### PR TITLE
feat(obs): background-loop liveness gauge family + staleness alert

### DIFF
--- a/backend/src/meho_backplane/agent/reaper.py
+++ b/backend/src/meho_backplane/agent/reaper.py
@@ -121,6 +121,7 @@ from meho_backplane.db.models import (
     AuditLog,
     ScheduledTriggerInFlightPolicy,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.operations.agent_run import (
     IllegalTransitionError,
     release_lease,
@@ -445,6 +446,7 @@ async def _reaper_loop() -> None:
                 "agent_run_reaper_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("agent_run_reaper", get_settings().agent_run_reaper_tick_interval_seconds)
 
 
 def start_agent_run_reaper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/agents/grant_expiry.py
+++ b/backend/src/meho_backplane/agents/grant_expiry.py
@@ -60,6 +60,7 @@ from meho_backplane.memory.audit import (
     SYSTEM_OPERATOR_SUB,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 if TYPE_CHECKING:
@@ -172,6 +173,7 @@ async def _sweeper_loop() -> None:
                 "grant_expiry_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("grant_expiry", get_settings().grant_expiry_tick_interval_seconds)
 
 
 def start_grant_expiry_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/broadcast/announcement_retention.py
+++ b/backend/src/meho_backplane/broadcast/announcement_retention.py
@@ -72,6 +72,7 @@ from meho_backplane.memory.audit import (
     INTERNAL_METHOD,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -247,6 +248,10 @@ async def _prune_loop() -> None:
                 "broadcast_announcement_retention_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick(
+            "announcement_retention",
+            get_settings().broadcast_announcement_prune_interval_seconds,
+        )
 
 
 def start_announcement_retention_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/checks/evidence_retention.py
+++ b/backend/src/meho_backplane/checks/evidence_retention.py
@@ -61,6 +61,7 @@ from meho_backplane.memory.audit import (
     INTERNAL_METHOD,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -219,6 +220,7 @@ async def _prune_loop() -> None:
                 "checks_evidence_retention_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("evidence_retention", get_settings().checks_evidence_prune_interval_seconds)
 
 
 def start_evidence_retention_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -148,6 +148,7 @@ from meho_backplane.checks.watchdog import note_tick_completed, reset_watchdog_s
 from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Sensor
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.operations.meta_tools import _resolve_target_or_error
 from meho_backplane.scheduler.cron import (
@@ -652,6 +653,7 @@ async def _runner_loop() -> None:
             raise
         except Exception:
             _log().warning("sensor_runner_tick_failed", exc_info=True)
+        note_loop_tick("sensor_runner", get_settings().sensor_runner_tick_interval_seconds)
 
 
 def start_sensor_runner() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/checks/watchdog.py
+++ b/backend/src/meho_backplane/checks/watchdog.py
@@ -108,6 +108,7 @@ from meho_backplane.checks.broadcast import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Sensor, SensorStatus
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -393,6 +394,9 @@ async def _watchdog_loop() -> None:
             raise
         except Exception:
             _log().warning("checks_watchdog_check_failed", exc_info=True)
+        # Liveness gauge for the watchdog loop itself — complements, does not
+        # replace, its broadcast-plane stall detection for the runner.
+        note_loop_tick("sensor_watchdog", get_settings().sensor_runner_tick_interval_seconds)
 
 
 def start_checks_watchdog() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/events/drain.py
+++ b/backend/src/meho_backplane/events/drain.py
@@ -107,6 +107,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_engine, get_sessionmaker
 from meho_backplane.db.models import EVENT_OUTBOX_NOTIFY_CHANNEL, EventOutbox
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 if TYPE_CHECKING:
@@ -471,6 +472,7 @@ async def _drain_loop() -> None:
                 raise
             except Exception:
                 _log.warning("event_drain_tick_failed", exc_info=True)
+            note_loop_tick("event_drain", interval)
     finally:
         listener_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/backend/src/meho_backplane/gateway/deadman.py
+++ b/backend/src/meho_backplane/gateway/deadman.py
@@ -87,6 +87,7 @@ from meho_backplane.memory.audit import (
     SYSTEM_OPERATOR_SUB,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -324,6 +325,7 @@ async def _sweeper_loop() -> None:
                 "gateway_deadman_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("gateway_deadman", get_settings().gateway_deadman_tick_interval_seconds)
 
 
 def start_gateway_deadman_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/memory/expiry.py
+++ b/backend/src/meho_backplane/memory/expiry.py
@@ -90,6 +90,7 @@ from meho_backplane.memory.audit import (
     SYSTEM_OPERATOR_SUB,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 if TYPE_CHECKING:
@@ -251,6 +252,7 @@ async def _sweeper_loop() -> None:
                 "memory_expiry_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("memory_expiry", get_settings().memory_expiry_tick_interval_seconds)
 
 
 def start_memory_expiry_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/metrics.py
+++ b/backend/src/meho_backplane/metrics.py
@@ -21,6 +21,11 @@ seam or by the background schedulers:
   attempts, by ``outcome``.
 * ``advisory_lock_busy_total`` (Counter) — background-loop ticks
   skipped because a PG advisory lock was already held, by ``subsystem``.
+* ``background_loop_last_tick_timestamp_seconds`` (Gauge) — Unix
+  timestamp of each lifespan background loop's last completed tick, by
+  ``loop``; its companion ``background_loop_interval_seconds`` (Gauge)
+  publishes each loop's cadence so a staleness alert can threshold at
+  ``N x interval`` per loop (#2888).
 
 Further application counters — the ``broadcast_*_total`` family — live
 next to the code they measure in :mod:`meho_backplane.broadcast`.
@@ -51,10 +56,13 @@ Goal #11's acceptance criterion specifies.
 
 from __future__ import annotations
 
+import time
+
 from prometheus_client import (
     CONTENT_TYPE_PLAIN_0_0_4,
     REGISTRY,
     Counter,
+    Gauge,
     Histogram,
     generate_latest,
 )
@@ -120,6 +128,70 @@ ADVISORY_LOCK_BUSY_TOTAL: Counter = Counter(
     "Background-loop ticks skipped because the advisory lock was held.",
     labelnames=("subsystem",),
 )
+
+#: ``loop`` label vocabulary for the two background-loop liveness gauges
+#: below — one value per lifespan-owned loop started in
+#: :func:`meho_backplane.main._start_background_tasks`:
+#: ``topology_scheduler``, ``memory_expiry``, ``topology_history``,
+#: ``announcement_retention``, ``evidence_retention``, ``grant_expiry``,
+#: ``approval_expiry``, ``scheduler``, ``sensor_runner``,
+#: ``sensor_watchdog``, ``agent_run_reaper``, ``event_drain``,
+#: ``gateway_deadman``. A loop that never calls :func:`note_loop_tick` is
+#: invisible to the staleness alert — exactly the silent-stall class this
+#: family exists to catch — so any new lifespan loop must both stamp here
+#: and be added to this list.
+
+#: Unix timestamp (seconds) of the last completed tick per lifespan
+#: background loop, labelled by ``loop``. Stamped by :func:`note_loop_tick`
+#: at the end of every completed iteration, including no-op / heartbeat
+#: ticks — the same "a tick that did no work still proves the loop alive"
+#: semantics the sensor-runner watchdog uses (``checks/watchdog.py``). A
+#: wedged or dead loop stops advancing its stamp while healthy loops move
+#: on, so ``time() - background_loop_last_tick_timestamp_seconds`` is the
+#: staleness the ``MehoBackgroundLoopStalled`` alert trips on. The stamp is
+#: per process and scraped per pod, so a single wedged replica surfaces
+#: without a persisted fleet-level write masking it behind healthy
+#: siblings. Same module-level-singleton rationale as
+#: ``HTTP_REQUESTS_TOTAL``.
+BACKGROUND_LOOP_LAST_TICK: Gauge = Gauge(
+    "background_loop_last_tick_timestamp_seconds",
+    "Unix timestamp of the last completed tick, per lifespan background loop.",
+    labelnames=("loop",),
+)
+
+#: Configured tick interval (seconds) of each background loop, labelled by
+#: ``loop`` and re-published by :func:`note_loop_tick` every tick so it
+#: tracks a live settings change. It exists so the staleness alert can
+#: threshold *per loop* at ``N x this loop's interval`` without the chart
+#: enumerating loop names or baking in intervals that would drift from the
+#: deployment's settings: the alert is one rule,
+#: ``(time() - last_tick) > (N * interval)``, matched element-wise on the
+#: ``loop`` label. Same module-level-singleton rationale as
+#: ``HTTP_REQUESTS_TOTAL``.
+BACKGROUND_LOOP_INTERVAL_SECONDS: Gauge = Gauge(
+    "background_loop_interval_seconds",
+    "Configured tick interval in seconds, per lifespan background loop.",
+    labelnames=("loop",),
+)
+
+
+def note_loop_tick(loop: str, interval_seconds: float, *, now: float | None = None) -> None:
+    """Stamp a completed background-loop tick and (re)publish its interval.
+
+    Call at the end of every completed iteration of a lifespan-owned
+    background loop — including no-op / heartbeat iterations — so a wedged
+    loop's :data:`BACKGROUND_LOOP_LAST_TICK` stamp goes stale while healthy
+    loops keep advancing theirs. ``interval_seconds`` is the loop's current
+    sleep cadence; it feeds :data:`BACKGROUND_LOOP_INTERVAL_SECONDS` so the
+    staleness alert can threshold at ``N x interval`` per loop. Setting a
+    gauge is an in-memory dict write, so this never blocks and never raises
+    on its own — safe on the hot path of a loop that must not die. ``now``
+    (Unix seconds) is injectable for deterministic tests; it defaults to
+    the wall clock.
+    """
+    stamp = now if now is not None else time.time()
+    BACKGROUND_LOOP_LAST_TICK.labels(loop=loop).set(stamp)
+    BACKGROUND_LOOP_INTERVAL_SECONDS.labels(loop=loop).set(interval_seconds)
 
 
 def render_metrics() -> tuple[bytes, str]:

--- a/backend/src/meho_backplane/operations/approval_expiry.py
+++ b/backend/src/meho_backplane/operations/approval_expiry.py
@@ -66,6 +66,7 @@ from sqlalchemy import select
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Tenant
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.operations.approval_queue import (
     expire_stale_requests,
     publish_approval_event,
@@ -204,6 +205,7 @@ async def _sweeper_loop() -> None:
             raise
         except Exception:
             _log.warning("approval_expiry_tick_failed", exc_info=True)
+        note_loop_tick("approval_expiry", get_settings().approval_expiry_tick_interval_seconds)
 
 
 def start_approval_expiry_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -154,6 +154,7 @@ from meho_backplane.db.models import (
     ScheduledTriggerKind,
     ScheduledTriggerStatus,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.scheduler.credentials import (
     AgentCredentialsUnresolvedError,
     resolve_agent_credentials,
@@ -959,6 +960,7 @@ async def _scheduler_loop() -> None:
         if time.monotonic() - last_token_renew >= _TOKEN_RENEW_INTERVAL_SECONDS:
             last_token_renew = time.monotonic()
             await _renew_scheduler_vault_token(reason="periodic")
+        note_loop_tick("scheduler", get_settings().scheduler_tick_interval_seconds)
 
 
 def start_scheduler() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/topology/history_retention.py
+++ b/backend/src/meho_backplane/topology/history_retention.py
@@ -121,6 +121,7 @@ from meho_backplane.memory.audit import (
     INTERNAL_METHOD,
     write_internal_audit_row,
 )
+from meho_backplane.metrics import note_loop_tick
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -345,6 +346,7 @@ async def _prune_loop() -> None:
                 "topology_history_retention_tick_failed",
                 exc_info=True,
             )
+        note_loop_tick("topology_history", get_settings().topology_history_prune_interval_seconds)
 
 
 def start_topology_history_retention_sweeper() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/topology/scheduler.py
+++ b/backend/src/meho_backplane/topology/scheduler.py
@@ -65,7 +65,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Target, Tenant
-from meho_backplane.metrics import TOPOLOGY_REFRESH_TOTAL
+from meho_backplane.metrics import TOPOLOGY_REFRESH_TOTAL, note_loop_tick
 from meho_backplane.settings import get_settings
 from meho_backplane.topology.refresh import refresh_target_topology
 
@@ -274,6 +274,7 @@ async def _scheduler_loop() -> None:
             raise
         except Exception:
             _log.exception("topology_refresh_sweep_failed")
+        note_loop_tick("topology_scheduler", get_settings().topology_refresh_interval_seconds)
         await asyncio.sleep(get_settings().topology_refresh_interval_seconds)
 
 

--- a/backend/tests/test_chart_observability_scrape.py
+++ b/backend/tests/test_chart_observability_scrape.py
@@ -5,7 +5,7 @@
 
 Initiative #2884 ships the first Prometheus Operator resources in the
 chart: an optional ``ServiceMonitor`` that scrapes the backplane
-``/metrics`` endpoint and an optional starter ``PrometheusRule`` with two
+``/metrics`` endpoint and an optional starter ``PrometheusRule`` with three
 alerts. Both are **disabled by default** — a default install carries
 neither, so a cluster without the Prometheus Operator CRDs
 (``monitoring.coreos.com/v1``) is unaffected — and each is gated on its
@@ -19,10 +19,11 @@ These tests pin:
   ``/metrics``, same-namespace discovery);
 * the discovery-``labels`` merge both resources need so a Prometheus
   ``serviceMonitorSelector`` / ``ruleSelector`` actually picks them up;
-* the starter-alert contract (both alert names, the release-scoped
+* the starter-alert contract (the alert names, the release-scoped
   ``absent(up)`` scrape alert, the ``broadcast_publish_errors_total``
-  rate alert, the by-concern group split #2888 extends, and the tunable
-  ``for`` / ``severity`` knobs).
+  rate alert, the #2888 background-loop liveness alert in its own
+  ``meho.loops`` group, the by-concern group split, and the tunable
+  ``for`` / ``severity`` / ``missedTicks`` knobs).
 
 The authoritative chart gate is ``.github/workflows/chart.yml`` (lint +
 ``helm template`` + kubeconform + these render assertions). This test
@@ -209,6 +210,52 @@ def test_alert_for_and_severity_are_tunable() -> None:
     alerts = _alerts(pr)
     assert alerts["MehoMetricsScrapeAbsent"]["labels"]["severity"] == "warning"
     assert alerts["MehoBroadcastPublishErrors"]["for"] == "30m"
+
+
+def test_prometheus_rule_renders_loop_liveness_alert() -> None:
+    """The #2888 background-loop liveness alert lands as a NEW group.
+
+    ``meho.loops`` is added alongside ``meho.scrape`` / ``meho.broadcast``,
+    not by editing an existing group. The alert thresholds each loop's
+    staleness against its own published interval gauge (``N x interval``),
+    so the expr references both ``background_loop_last_tick_timestamp_seconds``
+    and ``background_loop_interval_seconds``, and the Prometheus
+    ``$labels.loop`` templating survives Helm rendering (so Alertmanager
+    gets the loop name, not a Helm parse error).
+    """
+    pr = _render_show_only("templates/prometheusrule.yaml", "--set", "prometheusRule.enabled=true")
+    group_names = {g["name"] for g in pr["spec"]["groups"]}
+    # New group, existing groups untouched.
+    assert "meho.loops" in group_names
+    assert {"meho.scrape", "meho.broadcast"} <= group_names
+
+    alert = _alerts(pr)["MehoBackgroundLoopStalled"]
+    expr = alert["expr"]
+    assert "background_loop_last_tick_timestamp_seconds" in expr
+    assert "background_loop_interval_seconds" in expr
+    # Per-loop threshold = default missedTicks (10) x each loop's interval.
+    assert "(10 * background_loop_interval_seconds)" in expr
+    # Backtick-escaped Prometheus templating renders through Helm intact.
+    assert "{{ $labels.loop }}" in alert["annotations"]["summary"]
+
+
+def test_loop_liveness_alert_knobs_are_tunable() -> None:
+    """``missedTicks`` / ``for`` / ``severity`` on loopLiveness flow through."""
+    pr = _render_show_only(
+        "templates/prometheusrule.yaml",
+        "--set",
+        "prometheusRule.enabled=true",
+        "--set",
+        "prometheusRule.loopLiveness.missedTicks=3",
+        "--set",
+        "prometheusRule.loopLiveness.for=1m",
+        "--set",
+        "prometheusRule.loopLiveness.severity=critical",
+    )
+    alert = _alerts(pr)["MehoBackgroundLoopStalled"]
+    assert "(3 * background_loop_interval_seconds)" in alert["expr"]
+    assert alert["for"] == "1m"
+    assert alert["labels"]["severity"] == "critical"
 
 
 def test_service_monitor_and_prometheus_rule_are_independent() -> None:

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -501,3 +501,60 @@ def test_unmatched_routes_collapse_to_single_metric_label() -> None:
         assert (
             REGISTRY.get_sample_value("http_request_duration_seconds_count", labels=literal) is None
         )
+
+
+# ---------------------------------------------------------------------------
+# background-loop liveness gauges (#2888)
+# ---------------------------------------------------------------------------
+
+
+def test_background_loop_last_tick_goes_stale_while_others_advance() -> None:
+    """A wedged loop's stamp stays behind while a healthy loop advances.
+
+    The load-bearing liveness property: a loop that stops ticking keeps its
+    old ``background_loop_last_tick_timestamp_seconds`` value while loops
+    that keep ticking move theirs forward, so ``time() - stamp`` crosses the
+    ``MehoBackgroundLoopStalled`` threshold for the stalled loop only. The
+    injectable clock (``now=``) makes the assertion deterministic — no
+    sleeps, no wall-clock flake.
+    """
+    from meho_backplane.metrics import note_loop_tick
+
+    # Test-only loop labels so the shared process registry cannot leak real
+    # loop series into (or out of) this test.
+    t0 = 1_000_000.0
+    note_loop_tick("test_loop_stalled", 10.0, now=t0)
+    note_loop_tick("test_loop_healthy", 10.0, now=t0)
+
+    # The healthy loop keeps ticking; the stalled one wedges after t0.
+    note_loop_tick("test_loop_healthy", 10.0, now=t0 + 30.0)
+
+    stalled = REGISTRY.get_sample_value(
+        "background_loop_last_tick_timestamp_seconds", labels={"loop": "test_loop_stalled"}
+    )
+    healthy = REGISTRY.get_sample_value(
+        "background_loop_last_tick_timestamp_seconds", labels={"loop": "test_loop_healthy"}
+    )
+    assert stalled == pytest.approx(t0)
+    assert healthy == pytest.approx(t0 + 30.0)
+    # The healthy stamp is 30 s ahead, so the stalled loop's staleness
+    # (``time() - stamp``) is strictly larger — exactly what the alert trips
+    # on while the healthy loop stays clear of the threshold.
+    assert healthy - stalled == pytest.approx(30.0)
+
+
+def test_note_loop_tick_publishes_interval_for_the_alert_threshold() -> None:
+    """``note_loop_tick`` re-publishes the loop's interval on every tick.
+
+    ``MehoBackgroundLoopStalled`` thresholds staleness at
+    ``N x background_loop_interval_seconds{loop}``, so the interval gauge
+    must carry each loop's current cadence for the per-loop threshold to
+    mean anything.
+    """
+    from meho_backplane.metrics import note_loop_tick
+
+    note_loop_tick("test_loop_interval", 42.0, now=1_000_000.0)
+
+    assert REGISTRY.get_sample_value(
+        "background_loop_interval_seconds", labels={"loop": "test_loop_interval"}
+    ) == pytest.approx(42.0)

--- a/deploy/charts/meho/templates/prometheusrule.yaml
+++ b/deploy/charts/meho/templates/prometheusrule.yaml
@@ -6,10 +6,12 @@ Optional and disabled by default: rendered only when
 `prometheusRule.enabled` is true, and requires the Prometheus Operator
 CRDs (`monitoring.coreos.com/v1`).
 
-Rules are split into groups BY CONCERN (`meho.scrape`, `meho.broadcast`)
-so sibling tasks can extend the rule without restructuring: the
-background-loop liveness alert lands with #2888 as a new `meho.loops`
-group rather than an edit to an existing group. Keep this shape.
+Rules are split into groups BY CONCERN (`meho.scrape`, `meho.broadcast`,
+`meho.loops`) so sibling tasks can extend the rule without restructuring:
+a new alert lands as a new group rather than an edit to an existing one.
+Keep this shape. `meho.loops` (#2888) carries the background-loop liveness
+alert, thresholding the `background_loop_last_tick_timestamp_seconds` and
+`background_loop_interval_seconds` gauges every lifespan loop stamps.
 */ -}}
 {{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
@@ -64,4 +66,32 @@ spec:
               the activity-broadcast publisher is failing to XADD events to
               Valkey (unreachable / XADD error / teardown race) and events
               are being lost. Check the broadcast subchart (Valkey) health.
+    - name: meho.loops
+      rules:
+        - alert: MehoBackgroundLoopStalled
+          # Every lifespan background loop stamps
+          # background_loop_last_tick_timestamp_seconds{loop} each completed
+          # tick; a wedged or dead loop stops advancing its stamp. The
+          # threshold is per-loop -- N x that loop's own published tick
+          # interval -- so one rule covers the 10s sensor runner and the
+          # weekly retention sweepers alike without enumerating loop names:
+          # the companion background_loop_interval_seconds{loop} gauge carries
+          # each loop's cadence and the comparison matches element-wise on the
+          # loop label. Per process, so a single wedged replica fires without
+          # healthy siblings masking it.
+          expr: '(time() - background_loop_last_tick_timestamp_seconds) > ({{ .Values.prometheusRule.loopLiveness.missedTicks }} * background_loop_interval_seconds)'
+          for: {{ .Values.prometheusRule.loopLiveness.for }}
+          labels:
+            severity: {{ .Values.prometheusRule.loopLiveness.severity }}
+          annotations:
+            summary: MEHO background loop {{`{{ $labels.loop }}`}} has stalled
+            description: >-
+              The {{`{{ $labels.loop }}`}} lifespan background loop has not
+              completed a tick in over {{ .Values.prometheusRule.loopLiveness.missedTicks }}x
+              its configured interval: its
+              background_loop_last_tick_timestamp_seconds stamp has gone stale
+              while healthy loops keep advancing. The loop coroutine is wedged
+              or dead, so the sweeps / drains it owns are silently not running.
+              Check the pod logs for that loop's task and restart the replica
+              if it does not recover.
 {{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -180,6 +180,28 @@
               "description": "`severity` label attached to the alert."
             }
           }
+        },
+        "loopLiveness": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Tuning for the `MehoBackgroundLoopStalled` alert (a lifespan background loop stopped stamping background_loop_last_tick_timestamp_seconds for longer than missedTicks x its background_loop_interval_seconds).",
+          "properties": {
+            "missedTicks": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Stall threshold as a multiple of each loop's tick interval: the alert trips when a loop has not completed a tick for missedTicks x its interval. Keep conservative; the sensor runner also has a faster in-process watchdog."
+            },
+            "for": {
+              "type": "string",
+              "pattern": "^([0-9]+(ms|s|m|h|d|w|y))+$",
+              "description": "How long the staleness must persist before firing (Prometheus duration); an anti-flap debounce on top of the missedTicks threshold."
+            },
+            "severity": {
+              "type": "string",
+              "minLength": 1,
+              "description": "`severity` label attached to the alert."
+            }
+          }
         }
       }
     },

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -209,6 +209,25 @@ prometheusRule:
     for: 15m
     # -- `severity` label attached to the alert.
     severity: warning
+  # `MehoBackgroundLoopStalled`: fires when a lifespan background loop stops
+  # stamping `background_loop_last_tick_timestamp_seconds{loop}` for longer
+  # than `missedTicks` x that loop's own tick interval (published as
+  # `background_loop_interval_seconds{loop}`). One rule covers every loop —
+  # from the 10s sensor runner to the weekly retention sweepers — because the
+  # threshold is relative to each loop's published cadence. Per process, so a
+  # single wedged replica surfaces without healthy siblings masking it.
+  loopLiveness:
+    # -- Stall threshold as a multiple of each loop's tick interval: the alert
+    # trips when a loop has not completed a tick for `missedTicks` x its
+    # interval. This is the fleet-wide backstop for every loop; the sensor
+    # runner additionally has a faster in-process watchdog (broadcast plane),
+    # so keep this conservative to avoid duplicate noise.
+    missedTicks: 10
+    # -- How long the staleness must persist before firing (Prometheus
+    # duration) — an anti-flap debounce on top of the `missedTicks` threshold.
+    for: 5m
+    # -- `severity` label attached to the alert.
+    severity: warning
 
 ingress:
   enabled: true

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -383,7 +383,7 @@ Operator resources close that gap (Initiative #2884, #2885):
   The broadcast subchart's Service carries a different
   `app.kubernetes.io/name`, so it is not matched.
 - `prometheusRule` (`prometheusRule.enabled`, default `false`) renders a
-  starter `PrometheusRule` with two conservative alerts:
+  starter `PrometheusRule` with three conservative alerts:
   - `MehoMetricsScrapeAbsent` — `absent(up{job=<fullname>, namespace=<ns>})`;
     fires when Prometheus has **no** target series for this release at
     all (the ServiceMonitor was never picked up, the selector drifted, or
@@ -393,11 +393,26 @@ Operator resources close that gap (Initiative #2884, #2885):
     the fail-open broadcast publisher swallows dropped events by design
     (`broadcast/publisher.py`), so a sustained nonzero rate is the only
     signal that the activity feed is silently losing events.
+  - `MehoBackgroundLoopStalled` (#2888) —
+    `(time() - background_loop_last_tick_timestamp_seconds) > (N * background_loop_interval_seconds)`;
+    every one of the 13 lifespan background loops stamps
+    `background_loop_last_tick_timestamp_seconds{loop}` on each completed
+    tick (via `metrics.note_loop_tick`, called at the end of every loop
+    body incl. no-op/heartbeat ticks) and re-publishes its cadence as
+    `background_loop_interval_seconds{loop}`. That companion gauge lets one
+    rule threshold each loop at `N x its own interval`
+    (`N = prometheusRule.loopLiveness.missedTicks`) — matched element-wise
+    on the `loop` label — without the chart enumerating loop names or baking
+    in intervals that would drift from settings. A wedged or dead loop stops
+    advancing its stamp while healthy loops move on; the stamp is
+    per-process (scraped per-pod), so a single stalled replica fires without
+    healthy siblings masking it. Complements — does not replace — the
+    sensor-runner watchdog's faster in-process broadcast stall detection
+    (`checks/watchdog.py`), which is unchanged.
 
   The rules are split into groups **by concern** (`meho.scrape`,
-  `meho.broadcast`) so follow-up tasks extend them cleanly — the
-  background-loop liveness alert (#2888) lands as a new `meho.loops`
-  group, not an edit to an existing group.
+  `meho.broadcast`, `meho.loops`) so follow-up tasks extend them cleanly —
+  a new alert lands as a new group, not an edit to an existing group.
 
 Both resources require the Prometheus Operator CRDs
 (`monitoring.coreos.com/v1`) to be installed in the cluster; a default
@@ -410,7 +425,9 @@ install that selector defaults to `release: <prometheus-release>`, so
 `release: kube-prometheus-stack` (or the site's equivalent) or the scrape
 config / rules are silently never generated. The alert `for` durations
 and `severity` labels are operator-tunable under
-`prometheusRule.scrapeAbsent` / `prometheusRule.broadcastPublishErrors`.
+`prometheusRule.scrapeAbsent` / `prometheusRule.broadcastPublishErrors` /
+`prometheusRule.loopLiveness` — the last also exposes `missedTicks`, the
+per-loop staleness multiplier `N`.
 
 Render assertions live in `backend/tests/test_chart_observability_scrape.py`
 (unit layer, skips where `helm` is absent) and in the `chart.yml`


### PR DESCRIPTION
## Summary
- Adds a `background_loop_last_tick_timestamp_seconds{loop}` gauge (plus a companion `background_loop_interval_seconds{loop}`) that **every one of the 13 lifespan-owned background loops** stamps on each completed tick — including no-op / heartbeat ticks — via a new `metrics.note_loop_tick` helper. A wedged or dead loop stops advancing its stamp while healthy loops move on, so a silent stall is visible on `/metrics`. Previously only the sensor runner had this (via its broadcast-plane watchdog); the other 12 loops were dark (verified: only `topology_refresh_total` existed).
- Wires a `MehoBackgroundLoopStalled` alert into the #2885 starter PrometheusRule as a **new `meho.loops` group** (the by-concern split #2885 reserved for exactly this), not an edit to an existing group. Expr `(time() - last_tick) > (N * interval)` matched element-wise on the `loop` label gives a true **per-loop threshold = N × that loop's own cadence** (10 s sensor runner → weekly retention sweepers) without the chart enumerating loop names or baking in intervals that would drift from settings. `missedTicks` / `for` / `severity` are tunable under `prometheusRule.loopLiveness` (values + JSON schema).
- The sensor-runner watchdog's broadcast-plane stall detection is **unchanged** — the gauge complements, not replaces it (AC #2). The stamp is per-process (scraped per-pod), so a single wedged replica fires without healthy siblings masking it — matching the watchdog's own "don't persist a fleet-level stamp" rationale.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` (strict) — clean for changed files; the only remaining error is a pre-existing darwin-only `connectors/net/icmp.py:205` `socket.MSG_ERRQUEUE` note that resolves on Linux CI (not in this diff)
- [x] `pytest` loop-coverage batch (observability, chart-render, watchdog, sensor_runner, topology_scheduler, event matcher/outbox, agent_run_reaper, approval/grant expiry, announcement/evidence/memory retention, scheduler) — **261 passed, 1 skipped** (Linux-only process-metric test)
- [x] **AC #1** — every loop started in `_start_background_tasks` stamps its gauge each tick; the `loop` label vocabulary is documented in `metrics.py` and `docs/codebase/devops.md`
- [x] **AC #2** — sensor-runner watchdog unchanged; `checks/watchdog.py` only gains a `note_loop_tick` for the watchdog loop itself, leaving the stall/broadcast logic intact
- [x] **AC #3** — staleness alert added to #2885's PrometheusRule as `meho.loops` (per-loop threshold = N × tick interval); validated with `helm template` + `helm lint` + `kubeconform`, render-tested at default and tuned (`missedTicks`/`for`/`severity`) knobs, and the safe-by-default posture (nothing renders without opt-in) preserved
- [x] **AC #4** — `test_background_loop_last_tick_goes_stale_while_others_advance` proves a deliberately-stalled loop's gauge goes stale while another advances (deterministic via injectable `now=`)

## Out of scope
- Distributed tracing — explicitly parked by Initiative #2884.
- Pre-existing function/file-size warnings in the touched loop modules (`scheduler/loop.py` file-size, `_run_one_tick`/`_listen_for_notify`/etc.) — reported by the diff quality gate as **warnings, not blockers**, and not introduced here (each loop gains only a one-line `note_loop_tick(...)` at the loop body).
- The `icmp.py` darwin-only mypy note above.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2888
