### PR TITLE
fix(connectors): bind9 record.add/remove view-qualified resolution + view-aware verify

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -783,11 +783,15 @@ def _zonestatus_serial_verify(zone_name: str, view: str, serial: int) -> str:
     # Anchored, whitespace-tolerant so ``serial: <N>`` matches whatever
     # indentation the rndc build emits and never a ``signed serial:`` line.
     serial_re = f"^[[:space:]]*serial: {serial}[[:space:]]*$"
+    # ``if ... then exit 0; fi`` rather than ``... && exit 0`` so the
+    # predicate is unambiguously safe under the pipeline's ``set -e``:
+    # a grep miss must fall through to the next poll and, after the
+    # loop, to the diagnostic -- never abort the script early.
     return (
         "STATUS=''; "
         "for _ in 1 2 3 4 5; do "
         f"STATUS=$({zonestatus} 2>&1) || true; "
-        f'printf "%s\\n" "$STATUS" | grep -qE "{serial_re}" && exit 0; '
+        f'if printf "%s\\n" "$STATUS" | grep -qE "{serial_re}"; then exit 0; fi; '
         "sleep 0.3; "
         "done; "
         'printf "zone %s view %s not at staged serial '
@@ -809,9 +813,11 @@ def _dig_add_verify(fqdn: str, ip: str, record_type: str) -> str:
     """
     quoted_fqdn = shlex.quote(fqdn)
     quoted_ip = shlex.quote(ip)
+    # ``if ... then exit 0; fi`` so a grep miss falls through to the
+    # diagnostic under the pipeline's ``set -e`` (not an early abort).
     return (
         f"ANSWER=$(dig @localhost {quoted_fqdn} {record_type} +short 2>&1) || true; "
-        f'printf "%s\\n" "$ANSWER" | grep -qxF {quoted_ip} && exit 0; '
+        f'if printf "%s\\n" "$ANSWER" | grep -qxF {quoted_ip}; then exit 0; fi; '
         f'printf "expected {record_type} %s in the answer for %s; dig +short returned:'
         f'\\n%s\\n" {quoted_ip} {quoted_fqdn} "$ANSWER"; '
         "exit 1"

--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -14,20 +14,33 @@
 G3.4-T2 (#588) of Initiative #367 landed the read op (``dig @localhost
 <fqdn> [<type>]``). G3.4-T3 (#589) adds the symmetric write ops:
 
-* ``bind9.record.add <fqdn> <ip> [--zone <name>] [--type A|AAAA]`` --
-  atomic stage-validate-commit-reload-verify-rollback against the
-  affected zonefile via :mod:`._atomic`. Verify predicate runs ``dig
-  @localhost <fqdn>`` and asserts the new IP appears in the answer.
-  ``safety_level=caution`` (mutation; the production-path gate is
-  G7/G10 policy territory).
-* ``bind9.record.remove <fqdn> [--zone <name>]`` -- symmetric remove
-  with verify predicate = ``dig`` no longer resolves the FQDN.
+* ``bind9.record.add <fqdn> <ip> [--zone <name>] [--type A|AAAA]
+  [--view <name>]`` -- atomic stage-validate-commit-reload-verify-
+  rollback against the affected zonefile via :mod:`._atomic`. Verify
+  predicate runs ``dig @localhost <fqdn>`` and asserts the new IP
+  appears in the answer. ``safety_level=caution`` (mutation; the
+  production-path gate is G7/G10 policy territory).
+* ``bind9.record.remove <fqdn> [--zone <name>] [--view <name>]`` --
+  symmetric remove with verify predicate = ``dig`` no longer resolves
+  the FQDN.
 
 ``--zone`` is optional. When omitted, the handler resolves the owning
 zone from ``named-checkconf -p`` (the T2 zone parser) by longest-suffix
 match against the FQDN; ambiguous (the FQDN matches two zones equally
 deep) or unresolvable (no zone is a suffix of the FQDN) inputs raise
 :class:`ZoneResolutionError` **before** any staging.
+
+Split-horizon (#2897)
+---------------------
+
+On a nameserver that declares the same zone in more than one ``view``,
+:func:`resolve_zone_target` disambiguates on the optional ``--view``
+param: without it a multi-view zone is rejected ``ambiguous_view`` (the
+error names the candidate views); with it the matching view's zonefile
+is edited. A caller-supplied ``view`` also switches the verify predicate
+from ``dig @localhost`` (view-blind -- answered by whichever view the
+loopback source matches) to ``rndc zonestatus <zone> IN <view>``, which
+confirms the staged serial loaded into *that* view.
 
 Why ``dig @localhost`` rather than zonefile lookup
 --------------------------------------------------
@@ -96,6 +109,7 @@ __all__ = [
     "bind9_record_remove",
     "parse_dig_answer",
     "resolve_zone_for_fqdn",
+    "resolve_zone_target",
 ]
 
 
@@ -402,27 +416,53 @@ BIND9_RECORD_GET_LLM_INSTRUCTIONS: dict[str, Any] = {
 class ZoneResolutionError(ValueError):
     """Owning zone could not be resolved for the requested FQDN.
 
-    Two flavours:
+    Four flavours:
 
-    * **unresolvable** -- no configured zone is a suffix of the FQDN.
-      The operator named a record outside any zone bind9 serves.
-    * **ambiguous** -- two (or more) configured zones tie for the
-      longest-suffix match. Should never happen with a real bind9
-      config (zones are unique within a view), but the parser handles
-      arbitrary input and the check is cheap defence-in-depth.
+    * **unresolvable** -- no configured zone is a suffix of the FQDN
+      (or the matched zone carries no ``file`` directive). The operator
+      named a record outside any writable zone bind9 serves.
+    * **ambiguous** -- two (or more) *distinct* configured zone names
+      tie for the longest-suffix match. Should never happen with a real
+      bind9 config, but the parser handles arbitrary input and the
+      check is cheap defence-in-depth.
+    * **ambiguous_view** -- the FQDN resolves to a single zone name,
+      but that zone is declared in more than one ``view`` (split-horizon
+      DNS) and no ``view`` was supplied to disambiguate. ``candidates``
+      carries the view names. The caller passes ``view`` to pick one.
+    * **view_not_found** -- a ``view`` was supplied but the zone is not
+      declared in it. ``candidates`` carries the views the zone *is*
+      declared in.
 
     The handler raises this **before** any staging, so the dispatcher's
     ``invalid_params`` envelope reports the rejection with zero side
     effects on the remote tree. The :class:`ValueError` base lets the
     dispatcher's ``connector_error`` branch use its standard exception-
-    class extras path without a custom shim.
+    class extras path without a custom shim. ``str(exc)`` is a
+    human-actionable sentence (not the bare reason code) so the
+    surfaced ``exception_message`` tells the operator what to do next.
     """
 
     def __init__(self, reason: str, fqdn: str, candidates: list[str] | None = None) -> None:
-        super().__init__(reason)
         self.reason: str = reason
         self.fqdn: str = fqdn
         self.candidates: list[str] = candidates or []
+        super().__init__(self._describe())
+
+    def _describe(self) -> str:
+        joined = ", ".join(self.candidates)
+        if self.reason == "ambiguous_view":
+            return (
+                f"the zone owning {self.fqdn!r} is declared in multiple views "
+                f"({joined}); pass ``view`` to pick the split-horizon copy to edit"
+            )
+        if self.reason == "view_not_found":
+            return (
+                f"no zone owning {self.fqdn!r} is declared in the requested view; "
+                f"the zone is declared in view(s): {joined or '<none>'}"
+            )
+        if self.reason == "ambiguous":
+            return f"multiple configured zones tie as the longest suffix of {self.fqdn!r}: {joined}"
+        return f"no writable bind9 zone resolves for {self.fqdn!r}"
 
 
 def resolve_zone_for_fqdn(zones: list[str], fqdn: str) -> str:
@@ -485,44 +525,73 @@ def resolve_zone_for_fqdn(zones: list[str], fqdn: str) -> str:
     return best_match
 
 
-async def _resolve_zone_via_checkconf(
-    connector: Bind9Connector,
-    target: Any,
+def resolve_zone_target(
+    rows: list[dict[str, Any]],
+    *,
     fqdn: str,
-    operator: Operator | None = None,
-) -> tuple[str, str]:
-    """Locate (zone_name, zonefile_path) for *fqdn* via ``named-checkconf -p``.
+    explicit_zone: str | None,
+    explicit_view: str | None,
+) -> tuple[str, str, str | None]:
+    """Resolve ``(zone_name, zonefile_path, view)`` for a write target.
 
-    Lazy-imports the zone parser to avoid a circular import (T2's
-    ``ops_zone`` imports from ``ops`` which (transitively) imports
-    from this module). The lazy-import shape mirrors the registration
-    walk in the connector class.
+    Pure function over the parsed ``named-checkconf -p`` rows (T2's
+    :func:`~meho_backplane.connectors.bind9.ops_zone.parse_named_checkconf_zones`
+    shape ``{name, file, type, view}``). Split-horizon aware: the same
+    zone name may appear once per ``view``.
 
-    Raises :class:`ZoneResolutionError` if the FQDN doesn't resolve to
-    a unique zone, or if the matched zone has no ``file`` directive.
+    Zone selection:
+
+    * ``explicit_zone`` set -> that zone name (trailing-dot / case
+      normalised).
+    * otherwise -> longest-suffix match via :func:`resolve_zone_for_fqdn`
+      over the **distinct** zone names, so a zone declared in N views no
+      longer ties with itself and spuriously reports ``ambiguous`` (the
+      #2897 failure mode).
+
+    View disambiguation, over the rows whose name matches the zone and
+    that carry a ``file`` directive:
+
+    * ``explicit_view`` set -> restrict to that view; no match raises
+      ``view_not_found``.
+    * ``explicit_view`` unset and the zone lives in exactly one view
+      (or none) -> that row.
+    * ``explicit_view`` unset and the zone lives in >1 view -> raise
+      ``ambiguous_view`` (the caller must pass ``view``).
+
+    ``view`` in the returned tuple is the enclosing view name, or
+    ``None`` for a zone declared outside any view (a no-views
+    deployment). It drives the view-aware verify predicate the handlers
+    build.
     """
-    from meho_backplane.connectors.bind9.ops_zone import (
-        parse_named_checkconf_zones,
-    )
 
-    cmd = "named-checkconf -p"
-    proc = await connector._run_command(target, cmd, operator=operator)
-    output = _require_zero_exit(proc, command=cmd)
-    rows = parse_named_checkconf_zones(output)
-    zone_names = [row["name"] for row in rows]
-    zone_name = resolve_zone_for_fqdn(zone_names, fqdn)
-    # Pull the zonefile path back out of the parsed rows.
-    matching_row = next(
-        (row for row in rows if row["name"].rstrip(".") == zone_name),
-        None,
-    )
-    if matching_row is None or not matching_row.get("file"):
-        # Best-suffix matched a zone with no ``file`` directive (a
-        # hint or forward zone, typically). The write ops only operate
-        # on master zonefiles; treat as unresolvable so the
-        # ``invalid_params`` envelope carries a coherent message.
+    def _name(row: dict[str, Any]) -> str:
+        return str(row["name"]).rstrip(".").lower()
+
+    if explicit_zone is not None:
+        zone_name = explicit_zone.rstrip(".").lower()
+    else:
+        zone_name = resolve_zone_for_fqdn(sorted({_name(row) for row in rows}), fqdn)
+
+    candidates = [row for row in rows if _name(row) == zone_name and row.get("file")]
+    if not candidates:
+        # No matching zone with a writable ``file`` directive -- a hint /
+        # forward zone, an unconfigured explicit ``zone``, or an FQDN
+        # outside every served zone.
         raise ZoneResolutionError("unresolvable", fqdn=fqdn)
-    return zone_name, str(matching_row["file"])
+
+    declared_views = sorted({str(r["view"]) for r in candidates if r.get("view")})
+    if explicit_view is not None:
+        matched = [row for row in candidates if row.get("view") == explicit_view]
+        if not matched:
+            raise ZoneResolutionError("view_not_found", fqdn=fqdn, candidates=declared_views)
+        chosen = matched[0]
+    elif len({row.get("view") for row in candidates}) > 1:
+        raise ZoneResolutionError("ambiguous_view", fqdn=fqdn, candidates=declared_views)
+    else:
+        chosen = candidates[0]
+
+    view = chosen.get("view")
+    return zone_name, str(chosen["file"]), (str(view) if view is not None else None)
 
 
 # ---------------------------------------------------------------------------
@@ -669,28 +738,138 @@ def _validate_ip_for_type(ip: str, record_type: str) -> None:
         raise ValueError(f"record type AAAA expects an IPv6 address; got {ip!r}")
 
 
+# bind9 master zonefiles the write ops edit are Internet (IN) class.
+# ``rndc`` requires the class token *before* a view name
+# (``rndc reload <zone> IN <view>`` / ``rndc zonestatus <zone> IN <view>``);
+# CH / HS zones are exotic and out of scope for record writes.
+_ZONE_CLASS = "IN"
+
+
+def _soa_serial_from_text(zonefile_text: str, zone_name: str) -> int:
+    """Return the SOA serial of the rendered *zonefile_text*.
+
+    The write transforms bump the serial in place; the view-aware verify
+    predicate asserts the running daemon loaded *this* revision into the
+    target view. Re-parsing with dnspython (rather than a regex over the
+    multi-form SOA grammar) reuses the same round-trip the transform
+    used, so the serial we assert on is exactly the one named reports.
+    """
+    origin = zone_name if zone_name.endswith(".") else zone_name + "."
+    zone = dns.zone.from_text(zonefile_text, origin=origin, relativize=False, check_origin=False)
+    zone_origin = zone.origin
+    assert zone_origin is not None, "zone parsed from text must carry an origin"
+    return int(zone.find_rdataset(zone_origin, dns.rdatatype.SOA)[0].serial)
+
+
+def _zonestatus_serial_verify(zone_name: str, view: str, serial: int) -> str:
+    """View-precise verify predicate for a write into a named ``view``.
+
+    ``dig @localhost`` is view-*blind*: on a split-horizon server it is
+    answered by whichever ``view`` matches the loopback source address,
+    which need not be the view whose zonefile we staged -- the #2897
+    verify-rollback failure. ``rndc zonestatus <zone> IN <view>`` names
+    the view explicitly and reports the serial it currently serves, so
+    asserting it equals the staged serial confirms named loaded our
+    revision into *that* view (``named-checkzone`` in the validate step
+    already proved the record is in the file). A bounded poll absorbs
+    the small window between ``rndc reload`` returning and the zone
+    being live. On failure the last ``zonestatus`` output is echoed so
+    the surfaced ``AtomicApplyError`` detail is diagnosable -- the
+    silent ``grep -q`` predicate is why #2897 saw an empty detail.
+    """
+    quoted_zone = shlex.quote(zone_name)
+    quoted_view = shlex.quote(view)
+    zonestatus = f"rndc zonestatus {quoted_zone} {_ZONE_CLASS} {quoted_view}"
+    # Anchored, whitespace-tolerant so ``serial: <N>`` matches whatever
+    # indentation the rndc build emits and never a ``signed serial:`` line.
+    serial_re = f"^[[:space:]]*serial: {serial}[[:space:]]*$"
+    return (
+        "STATUS=''; "
+        "for _ in 1 2 3 4 5; do "
+        f"STATUS=$({zonestatus} 2>&1) || true; "
+        f'printf "%s\\n" "$STATUS" | grep -qE "{serial_re}" && exit 0; '
+        "sleep 0.3; "
+        "done; "
+        'printf "zone %s view %s not at staged serial '
+        f'{serial} after reload; last rndc zonestatus:\\n%s\\n" '
+        f'{quoted_zone} {quoted_view} "$STATUS"; '
+        "exit 1"
+    )
+
+
+def _dig_add_verify(fqdn: str, ip: str, record_type: str) -> str:
+    """Record-level verify predicate for a no-views / single-view add.
+
+    ``dig @localhost <fqdn> <type> +short`` emits one rdata per line;
+    ``grep -qxF`` (literal, whole-line) asserts the new IP is present
+    without false-matching a substring. On mismatch the observed
+    ``dig`` output is echoed so the ``AtomicApplyError`` detail carries
+    the real reason (#2897 -- the prior silent predicate surfaced an
+    empty detail).
+    """
+    quoted_fqdn = shlex.quote(fqdn)
+    quoted_ip = shlex.quote(ip)
+    return (
+        f"ANSWER=$(dig @localhost {quoted_fqdn} {record_type} +short 2>&1) || true; "
+        f'printf "%s\\n" "$ANSWER" | grep -qxF {quoted_ip} && exit 0; '
+        f'printf "expected {record_type} %s in the answer for %s; dig +short returned:'
+        f'\\n%s\\n" {quoted_ip} {quoted_fqdn} "$ANSWER"; '
+        "exit 1"
+    )
+
+
+def _dig_remove_verify(fqdn: str) -> str:
+    """Record-level verify predicate for a no-views / single-view remove.
+
+    The FQDN must resolve to neither an A nor an AAAA answer. ``+short``
+    exits 0 on empty output, so emptiness is asserted explicitly. On
+    failure the residual answers are echoed for a diagnosable detail
+    (#2897).
+    """
+    quoted_fqdn = shlex.quote(fqdn)
+    return (
+        f"A=$(dig @localhost {quoted_fqdn} A +short 2>&1) || true; "
+        f"AAAA=$(dig @localhost {quoted_fqdn} AAAA +short 2>&1) || true; "
+        'if [ -z "$A" ] && [ -z "$AAAA" ]; then exit 0; fi; '
+        'printf "%s still resolves after remove (A: %s AAAA: %s)\\n" '
+        f'{quoted_fqdn} "$A" "$AAAA"; '
+        "exit 1"
+    )
+
+
 async def _resolve_zone_and_path(
     connector: Bind9Connector,
     target: Any,
     *,
     fqdn: str,
     explicit_zone: str | None,
+    explicit_view: str | None = None,
     operator: Operator | None = None,
-) -> tuple[str, str]:
-    """Return ``(zone_name, zonefile_path)`` for *fqdn*.
+) -> tuple[str, str, str | None]:
+    """Return ``(zone_name, zonefile_path, view)`` for *fqdn*.
 
-    Branches on ``explicit_zone``: when provided, looks up the
-    zonefile path directly; otherwise resolves via longest-suffix
-    match against ``named-checkconf -p``. Shared by the add / remove
-    handlers so the two paths cannot drift.
+    Runs ``named-checkconf -p`` once, parses the zone rows with T2's
+    view-attributing parser, and delegates the split-horizon-aware
+    selection to the pure :func:`resolve_zone_target`. Shared by the
+    add / remove handlers so the two paths cannot drift. ``view`` is
+    the enclosing view name (``None`` on a no-views deployment) and is
+    what the handlers thread into the view-aware verify predicate.
+
+    Lazy-imports the zone parser to avoid a circular import (T2's
+    ``ops_zone`` imports from ``ops`` which transitively imports this
+    module); the lazy shape mirrors the connector's registration walk.
     """
-    if explicit_zone is not None:
-        zone_name = explicit_zone.rstrip(".")
-        zonefile_path = await _resolve_zonefile_path_for_zone(
-            connector, target, zone_name, operator
-        )
-        return zone_name, zonefile_path
-    return await _resolve_zone_via_checkconf(connector, target, fqdn, operator)
+    from meho_backplane.connectors.bind9.ops_zone import (
+        parse_named_checkconf_zones,
+    )
+
+    cmd = "named-checkconf -p"
+    proc = await connector._run_command(target, cmd, operator=operator)
+    output = _require_zero_exit(proc, command=cmd)
+    rows = parse_named_checkconf_zones(output)
+    return resolve_zone_target(
+        rows, fqdn=fqdn, explicit_zone=explicit_zone, explicit_view=explicit_view
+    )
 
 
 async def _read_zonefile_text(
@@ -727,32 +906,37 @@ async def bind9_record_add(
 
     Sequence:
 
-    1. Resolve owning zone (via ``--zone`` param, or longest-suffix
-       match against ``named-checkconf -p``).
+    1. Resolve owning zone (via ``zone`` param, or longest-suffix
+       match against ``named-checkconf -p``) and its ``view`` --
+       split-horizon aware, so a zone declared in multiple views is
+       disambiguated by the optional ``view`` param.
     2. Validate the IP matches the requested record type.
     3. Read the current zonefile (``cat <path>``).
     4. Transform via :func:`_add_record_to_zonefile` (dnspython
        parse + add + SOA bump + render).
     5. :func:`atomic_apply` stages the new zonefile, runs
        ``named-checkzone <zone> <path>``, ``rndc reload``, and the
-       dig-verify predicate; rolls back on any failure.
+       view-aware verify predicate; rolls back on any failure.
 
-    Returns ``{fqdn, ip, type, zone, file, op_class, result_state_before,
-    result_state_after}``. ``op_class="write"`` is set explicitly even
-    though :func:`~meho_backplane.broadcast.events.classify_op`
-    derives the same value from the op-id suffix -- the dual signal
-    is what the audit-replay path (G8.2) reads to reconstruct the
-    change without re-parsing the op-id namespace.
+    Returns ``{fqdn, ip, type, zone, file, view, op_class,
+    result_state_before, result_state_after}``. ``op_class="write"`` is
+    set explicitly even though
+    :func:`~meho_backplane.broadcast.events.classify_op` derives the
+    same value from the op-id suffix -- the dual signal is what the
+    audit-replay path (G8.2) reads to reconstruct the change without
+    re-parsing the op-id namespace.
 
-    Raises :class:`ZoneResolutionError` if ``--zone`` is omitted and
-    the FQDN can't be uniquely resolved (pre-stage; no remote IO past
-    the ``named-checkconf -p`` lookup itself). Raises
+    Raises :class:`ZoneResolutionError` when the FQDN can't be uniquely
+    resolved -- including ``ambiguous_view`` when the zone is declared in
+    multiple views and no ``view`` was supplied (pre-stage; no remote IO
+    past the ``named-checkconf -p`` lookup). Raises
     :class:`AtomicApplyError` on any rollback path.
     """
     fqdn: str = params["fqdn"]
     ip: str = params["ip"]
     record_type: str = params.get("type", "A").upper()
     explicit_zone: str | None = params.get("zone")
+    explicit_view: str | None = params.get("view")
 
     if record_type not in _WRITE_SUPPORTED_TYPES:
         raise ValueError(
@@ -762,8 +946,13 @@ async def bind9_record_add(
     _validate_ip_for_type(ip, record_type)
 
     sudo_password = await _sudo_password_from_target(connector, target, operator)
-    zone_name, zonefile_path = await _resolve_zone_and_path(
-        connector, target, fqdn=fqdn, explicit_zone=explicit_zone, operator=operator
+    zone_name, zonefile_path, view = await _resolve_zone_and_path(
+        connector,
+        target,
+        fqdn=fqdn,
+        explicit_zone=explicit_zone,
+        explicit_view=explicit_view,
+        operator=operator,
     )
     current_text = await _read_zonefile_text(connector, target, zonefile_path, operator)
 
@@ -780,14 +969,17 @@ async def bind9_record_add(
             f"failed to parse / transform zonefile for zone {zone_name!r}: {exc}"
         ) from exc
 
-    # Dig-verify predicate: the new IP must appear in the answer.
-    # ``dig +short`` emits one rdata per line with no decoration, so
-    # ``grep -qxF`` (literal, full-line, quiet) is the right shape for
-    # an exact-match assertion that doesn't false-match a substring of
-    # another row.
-    quoted_fqdn = shlex.quote(fqdn)
-    quoted_ip = shlex.quote(ip)
-    verify_cmd = f"dig @localhost {quoted_fqdn} {record_type} +short | grep -qxF {quoted_ip}"
+    # A caller-supplied ``view`` means split-horizon disambiguation:
+    # ``dig @localhost`` may be answered by a different view than the one
+    # we edited (#2897), so assert the staged serial loaded into the
+    # named view via ``rndc zonestatus``. On a no-views / single-view
+    # target keep the stronger record-level dig check.
+    if explicit_view is not None:
+        verify_cmd = _zonestatus_serial_verify(
+            zone_name, explicit_view, _soa_serial_from_text(new_text, zone_name)
+        )
+    else:
+        verify_cmd = _dig_add_verify(fqdn, ip, record_type)
 
     apply_result = await atomic_apply(
         connector,
@@ -816,6 +1008,7 @@ async def bind9_record_add(
         "type": record_type,
         "zone": zone_name,
         "file": zonefile_path,
+        "view": view,
         "op_class": "write",
         "result_state_before": apply_result.state_before,
         "result_state_after": apply_result.state_after,
@@ -831,18 +1024,28 @@ async def bind9_record_remove(
     """Handler for ``bind9.record.remove`` -- atomic A/AAAA record remove.
 
     Sequence: same as :func:`bind9_record_add` but the zonefile
-    transform deletes the FQDN's A and AAAA rdatasets, and the
-    verify predicate asserts the FQDN no longer resolves
-    (``dig @localhost <fqdn> +short`` returns empty stdout).
+    transform deletes the FQDN's A and AAAA rdatasets, and the verify
+    predicate asserts the FQDN no longer resolves. Split-horizon aware:
+    the optional ``view`` param disambiguates a zone declared in
+    multiple views, and a caller-supplied ``view`` switches verify to
+    the view-precise ``rndc zonestatus`` serial check (``dig @localhost``
+    is view-blind -- #2897).
 
-    Returns the same envelope shape as ``record.add``.
+    Returns the same envelope shape as ``record.add`` (minus ``ip`` /
+    ``type``), including the resolved ``view``.
     """
     fqdn: str = params["fqdn"]
     explicit_zone: str | None = params.get("zone")
+    explicit_view: str | None = params.get("view")
 
     sudo_password = await _sudo_password_from_target(connector, target, operator)
-    zone_name, zonefile_path = await _resolve_zone_and_path(
-        connector, target, fqdn=fqdn, explicit_zone=explicit_zone, operator=operator
+    zone_name, zonefile_path, view = await _resolve_zone_and_path(
+        connector,
+        target,
+        fqdn=fqdn,
+        explicit_zone=explicit_zone,
+        explicit_view=explicit_view,
+        operator=operator,
     )
     current_text = await _read_zonefile_text(connector, target, zonefile_path, operator)
 
@@ -857,14 +1060,16 @@ async def bind9_record_remove(
             f"failed to parse / transform zonefile for zone {zone_name!r}: {exc}"
         ) from exc
 
-    # Verify: dig must return no answer rows for either A or AAAA.
-    # ``+short`` exits 0 even on empty output, so we explicitly assert
-    # zero lines via ``[ -z "$(dig ...)" ]``.
-    quoted_fqdn = shlex.quote(fqdn)
-    verify_cmd = (
-        f'[ -z "$(dig @localhost {quoted_fqdn} A +short)" ] '
-        f'&& [ -z "$(dig @localhost {quoted_fqdn} AAAA +short)" ]'
-    )
+    # View-aware verify -- see bind9_record_add for the rationale. For a
+    # targeted view the removal is confirmed by the staged serial being
+    # loaded into that view; otherwise the FQDN must resolve to neither
+    # an A nor an AAAA answer via the local resolver.
+    if explicit_view is not None:
+        verify_cmd = _zonestatus_serial_verify(
+            zone_name, explicit_view, _soa_serial_from_text(new_text, zone_name)
+        )
+    else:
+        verify_cmd = _dig_remove_verify(fqdn)
 
     apply_result = await atomic_apply(
         connector,
@@ -886,38 +1091,11 @@ async def bind9_record_remove(
         "fqdn": fqdn,
         "zone": zone_name,
         "file": zonefile_path,
+        "view": view,
         "op_class": "write",
         "result_state_before": apply_result.state_before,
         "result_state_after": apply_result.state_after,
     }
-
-
-async def _resolve_zonefile_path_for_zone(
-    connector: Bind9Connector,
-    target: Any,
-    zone_name: str,
-    operator: Operator | None = None,
-) -> str:
-    """Look up the zonefile path for an explicit ``--zone`` arg.
-
-    Lazy-imports T2's ``_resolve_zonefile_path`` to avoid a cycle
-    (T2's ``ops_zone`` imports the shared ``ops`` module that imports
-    this module). Same shape as the longest-suffix path.
-    """
-    from meho_backplane.connectors.bind9.ops_zone import (
-        ZonefileReadError,
-        _resolve_zonefile_path,
-    )
-
-    cmd = "named-checkconf -p"
-    proc = await connector._run_command(target, cmd, operator=operator)
-    output = _require_zero_exit(proc, command=cmd)
-    try:
-        return _resolve_zonefile_path(output, zone_name)
-    except ZonefileReadError as exc:
-        # Map the missing-zone case to the same structured error the
-        # auto-resolve path uses, so callers see a uniform shape.
-        raise ZoneResolutionError("unresolvable", fqdn=zone_name) from exc
 
 
 async def _sudo_password_from_target(
@@ -956,12 +1134,13 @@ async def _sudo_password_from_target(
 _WRITE_WARNING = (
     "WARNING: this change is global and atomic. The atomic-apply "
     "primitive stages the new zonefile, runs ``named-checkzone``, "
-    "``rndc reload``, and a dig-verify predicate; on any failure "
-    "the pre-op ``/etc/bind/`` tree is restored byte-identical. On "
-    "success the change is live for every consumer of this "
-    "nameserver -- DNS has no per-caller scoping. ``safety_level`` "
-    "is ``caution`` (the production-path gate is G7/G10 policy "
-    "territory keyed on this value)."
+    "``rndc reload``, and a verify predicate (a ``dig`` record check, "
+    "or a view-precise ``rndc zonestatus`` serial check when a ``view`` "
+    "is given); on any failure the pre-op ``/etc/bind/`` tree is "
+    "restored byte-identical. On success the change is live for every "
+    "consumer of this nameserver -- DNS has no per-caller scoping. "
+    "``safety_level`` is ``caution`` (the production-path gate is "
+    "G7/G10 policy territory keyed on this value)."
 )
 
 
@@ -1012,6 +1191,21 @@ BIND9_RECORD_ADD_PARAMETER_SCHEMA: dict[str, Any] = {
                 "``invalid_params``."
             ),
         },
+        "view": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. The ``view`` block that owns the zone on a "
+                "split-horizon nameserver, e.g. ``internal``. Required "
+                "only when the zone is declared in more than one view "
+                "(otherwise the resolve step rejects it with "
+                "``ambiguous_view`` and lists the candidate views). "
+                "Selects which view's zonefile is edited and switches "
+                "verification to a view-precise ``rndc zonestatus`` "
+                "check, since ``dig @localhost`` cannot target a view."
+            ),
+        },
     },
     "required": ["fqdn", "ip"],
     "additionalProperties": False,
@@ -1022,6 +1216,7 @@ _WRITE_RESPONSE_SCHEMA_PROPERTIES: dict[str, Any] = {
     "fqdn": {"type": "string"},
     "zone": {"type": "string"},
     "file": {"type": "string"},
+    "view": {"type": ["string", "null"]},
     "op_class": {"type": "string", "enum": ["write"]},
     "result_state_before": {"type": "string"},
     "result_state_after": {"type": "string"},
@@ -1041,6 +1236,7 @@ _BIND9_RECORD_ADD_RESPONSE_SCHEMA: dict[str, Any] = {
         "type",
         "zone",
         "file",
+        "view",
         "op_class",
         "result_state_before",
         "result_state_after",
@@ -1066,11 +1262,20 @@ BIND9_RECORD_ADD_LLM_INSTRUCTIONS: dict[str, Any] = {
             "Optional. Owning zone. Omit to let the handler pick "
             "the longest-suffix-matching zone automatically."
         ),
+        "view": (
+            "Optional. Split-horizon view that owns the zone. Needed "
+            "only when the zone is declared in multiple views; the "
+            "resolve step rejects a multi-view zone with "
+            "``ambiguous_view`` and names the candidate views to pass "
+            "here."
+        ),
     },
     "output_shape": (
-        "{'fqdn', 'ip', 'type', 'zone', 'file', 'op_class': 'write', "
+        "{'fqdn', 'ip', 'type', 'zone', 'file', 'view', "
+        "'op_class': 'write', "
         "'result_state_before': <prior-zonefile-text>, "
         "'result_state_after': <post-write-zonefile-text>}. "
+        "``view`` is the resolved view (``null`` outside any view). "
         "``result_state_*`` is the full zonefile content for audit "
         "replay; the staged change is the diff between the two."
     ),
@@ -1100,6 +1305,16 @@ BIND9_RECORD_REMOVE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "does."
             ),
         },
+        "view": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. Split-horizon view that owns the zone, the "
+                "same way ``record.add`` uses it. Required only when the "
+                "zone is declared in more than one view."
+            ),
+        },
     },
     "required": ["fqdn"],
     "additionalProperties": False,
@@ -1113,6 +1328,7 @@ _BIND9_RECORD_REMOVE_RESPONSE_SCHEMA: dict[str, Any] = {
         "fqdn",
         "zone",
         "file",
+        "view",
         "op_class",
         "result_state_before",
         "result_state_after",
@@ -1136,11 +1352,16 @@ BIND9_RECORD_REMOVE_LLM_INSTRUCTIONS: dict[str, Any] = {
             "Optional. Owning zone. Omit to let the handler pick "
             "the longest-suffix-matching zone automatically."
         ),
+        "view": (
+            "Optional. Split-horizon view that owns the zone. Needed "
+            "only when the zone is declared in multiple views."
+        ),
     },
     "output_shape": (
-        "{'fqdn', 'zone', 'file', 'op_class': 'write', "
+        "{'fqdn', 'zone', 'file', 'view', 'op_class': 'write', "
         "'result_state_before': <prior-zonefile-text>, "
-        "'result_state_after': <post-remove-zonefile-text>}."
+        "'result_state_after': <post-remove-zonefile-text>}. "
+        "``view`` is the resolved view (``null`` outside any view)."
     ),
 }
 
@@ -1183,7 +1404,10 @@ RECORD_OPS: tuple[Bind9Op, ...] = (
             "write of a forward A/AAAA record. Resolves the owning "
             "zone via ``named-checkconf -p`` longest-suffix match "
             "when ``zone`` is omitted; ambiguous or unresolvable "
-            "FQDNs are rejected pre-staging. " + _WRITE_WARNING
+            "FQDNs are rejected pre-staging. Split-horizon aware: on a "
+            "zone declared in multiple views, pass ``view`` to pick the "
+            "copy to edit (verification then targets that view via "
+            "``rndc zonestatus``). " + _WRITE_WARNING
         ),
         parameter_schema=BIND9_RECORD_ADD_PARAMETER_SCHEMA,
         response_schema=_BIND9_RECORD_ADD_RESPONSE_SCHEMA,
@@ -1201,7 +1425,9 @@ RECORD_OPS: tuple[Bind9Op, ...] = (
             "Atomic stage-validate-commit-reload-verify-rollback "
             "remove of every A and AAAA record at the given FQDN. "
             "Idempotent when the records are already absent (verify "
-            "passes -- the FQDN doesn't resolve before or after). " + _WRITE_WARNING
+            "passes -- the FQDN doesn't resolve before or after). "
+            "Split-horizon aware: pass ``view`` to disambiguate a zone "
+            "declared in multiple views. " + _WRITE_WARNING
         ),
         parameter_schema=BIND9_RECORD_REMOVE_PARAMETER_SCHEMA,
         response_schema=_BIND9_RECORD_REMOVE_RESPONSE_SCHEMA,

--- a/backend/tests/test_connectors_bind9_atomic.py
+++ b/backend/tests/test_connectors_bind9_atomic.py
@@ -52,10 +52,15 @@ from meho_backplane.connectors.bind9.ops_record import (
     RemoteCommandError,
     ZoneResolutionError,
     _add_record_to_zonefile,
+    _dig_add_verify,
+    _dig_remove_verify,
     _remove_record_from_zonefile,
+    _soa_serial_from_text,
+    _zonestatus_serial_verify,
     bind9_record_add,
     bind9_record_remove,
     resolve_zone_for_fqdn,
+    resolve_zone_target,
 )
 from meho_backplane.settings import get_settings
 from tests._ssh_vault_stub import stub_ssh_vault_secrets
@@ -140,6 +145,51 @@ mail IN AAAA 2001:db8::1
 _CHECKCONF_OUTPUT = 'zone "evba.lab" {\n\ttype master;\n\tfile "/etc/bind/db.evba.lab";\n};\n'
 
 
+# Split-horizon `named-checkconf -p`: the same zone declared once per
+# view (#2897). Parses to two `evba.lab` rows attributed internal /
+# external.
+_MULTIVIEW_CHECKCONF_OUTPUT = (
+    'view "internal" {\n'
+    "\tmatch-clients { 10.0.0.0/8; localhost; };\n"
+    '\tzone "evba.lab" {\n'
+    "\t\ttype master;\n"
+    '\t\tfile "/etc/bind/internal/db.evba.lab";\n'
+    "\t};\n"
+    "};\n"
+    'view "external" {\n'
+    "\tmatch-clients { any; };\n"
+    '\tzone "evba.lab" {\n'
+    "\t\ttype master;\n"
+    '\t\tfile "/etc/bind/external/db.evba.lab";\n'
+    "\t};\n"
+    "};\n"
+)
+
+# Parsed-row shapes for the pure `resolve_zone_target` tests -- the
+# `{name, file, type, view}` shape T2's `parse_named_checkconf_zones`
+# emits.
+_MULTIVIEW_ROWS: list[dict[str, Any]] = [
+    {
+        "name": "evba.lab",
+        "file": "/etc/bind/internal/db.evba.lab",
+        "type": "master",
+        "view": "internal",
+    },
+    {
+        "name": "evba.lab",
+        "file": "/etc/bind/external/db.evba.lab",
+        "type": "master",
+        "view": "external",
+    },
+]
+_SINGLE_EXPLICIT_VIEW_ROWS: list[dict[str, Any]] = [
+    {"name": "evba.lab", "file": "/etc/bind/db.evba.lab", "type": "master", "view": "default"},
+]
+_NO_VIEW_ROWS: list[dict[str, Any]] = [
+    {"name": "evba.lab", "file": "/etc/bind/db.evba.lab", "type": "master", "view": None},
+]
+
+
 # ---------------------------------------------------------------------------
 # resolve_zone_for_fqdn (pure)
 # ---------------------------------------------------------------------------
@@ -191,6 +241,139 @@ class TestResolveZoneForFqdn:
         assert resolve_zone_for_fqdn(["EVBA.LAB"], "api.evba.lab") == "evba.lab"
         # Mixed case on both sides.
         assert resolve_zone_for_fqdn(["EvBa.LaB"], "Api.EvBa.lAb") == "evba.lab"
+
+
+# ---------------------------------------------------------------------------
+# resolve_zone_target (pure) -- split-horizon / multi-view resolution (#2897)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveZoneTarget:
+    """Pure-function tests for the view-aware write-target resolver."""
+
+    def test_no_view_deployment_resolves_with_null_view(self) -> None:
+        zone, path, view = resolve_zone_target(
+            _NO_VIEW_ROWS, fqdn="api.evba.lab", explicit_zone=None, explicit_view=None
+        )
+        assert (zone, path, view) == ("evba.lab", "/etc/bind/db.evba.lab", None)
+
+    def test_single_view_resolves_and_returns_view(self) -> None:
+        zone, path, view = resolve_zone_target(
+            _SINGLE_EXPLICIT_VIEW_ROWS,
+            fqdn="api.evba.lab",
+            explicit_zone=None,
+            explicit_view=None,
+        )
+        assert (zone, path, view) == ("evba.lab", "/etc/bind/db.evba.lab", "default")
+
+    def test_multi_view_without_view_raises_ambiguous_view(self) -> None:
+        """The #2897 first failure: same zone in two views, no view given."""
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                _MULTIVIEW_ROWS, fqdn="api.evba.lab", explicit_zone=None, explicit_view=None
+            )
+        assert exc_info.value.reason == "ambiguous_view"
+        assert exc_info.value.candidates == ["external", "internal"]
+        # The rendered message is actionable, not the bare reason code.
+        assert "pass ``view``" in str(exc_info.value)
+
+    def test_multi_view_with_view_selects_that_views_file(self) -> None:
+        zone, path, view = resolve_zone_target(
+            _MULTIVIEW_ROWS,
+            fqdn="api.evba.lab",
+            explicit_zone=None,
+            explicit_view="internal",
+        )
+        assert (zone, path, view) == ("evba.lab", "/etc/bind/internal/db.evba.lab", "internal")
+
+    def test_explicit_zone_multi_view_without_view_raises_ambiguous_view(self) -> None:
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                _MULTIVIEW_ROWS,
+                fqdn="api.evba.lab",
+                explicit_zone="evba.lab",
+                explicit_view=None,
+            )
+        assert exc_info.value.reason == "ambiguous_view"
+
+    def test_view_not_declared_raises_view_not_found(self) -> None:
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                _MULTIVIEW_ROWS,
+                fqdn="api.evba.lab",
+                explicit_zone=None,
+                explicit_view="dmz",
+            )
+        assert exc_info.value.reason == "view_not_found"
+        assert exc_info.value.candidates == ["external", "internal"]
+
+    def test_unresolvable_when_no_zone_suffixes_fqdn(self) -> None:
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                _NO_VIEW_ROWS,
+                fqdn="host.other.example",
+                explicit_zone=None,
+                explicit_view=None,
+            )
+        assert exc_info.value.reason == "unresolvable"
+
+    def test_zone_without_file_is_unresolvable(self) -> None:
+        """A hint / forward zone (no ``file``) is not a writable target."""
+        rows = [{"name": "evba.lab", "file": None, "type": "forward", "view": None}]
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(rows, fqdn="api.evba.lab", explicit_zone=None, explicit_view=None)
+        assert exc_info.value.reason == "unresolvable"
+
+
+# ---------------------------------------------------------------------------
+# View-aware verify predicate builders (#2897)
+# ---------------------------------------------------------------------------
+
+
+class TestViewAwareVerifyBuilders:
+    """The handler-built verify commands: view-precise vs record-level."""
+
+    def test_soa_serial_round_trips_from_rendered_text(self) -> None:
+        # _SAMPLE_ZONEFILE carries SOA serial 2026051801; after an add it
+        # bumps to 2026051802.
+        assert _soa_serial_from_text(_SAMPLE_ZONEFILE, "evba.lab") == 2026051801
+        bumped = _add_record_to_zonefile(
+            _SAMPLE_ZONEFILE,
+            zone_name="evba.lab",
+            fqdn="api.evba.lab",
+            ip="10.5.50.99",
+            record_type="A",
+        )
+        assert _soa_serial_from_text(bumped, "evba.lab") == 2026051802
+
+    def test_zonestatus_verify_names_view_and_asserts_serial(self) -> None:
+        cmd = _zonestatus_serial_verify("evba.lab", "internal", 2026051802)
+        # Names the view explicitly (class token before the view).
+        assert "rndc zonestatus evba.lab IN internal" in cmd
+        # Anchored serial match avoids a substring false-positive; the
+        # optional leading whitespace tolerates any rndc indentation.
+        assert "^[[:space:]]*serial: 2026051802[[:space:]]*$" in cmd
+        # Echoes diagnostics on failure (fixes the #2897 empty detail).
+        assert "last rndc zonestatus" in cmd
+
+    def test_zonestatus_verify_quotes_metacharacters(self) -> None:
+        cmd = _zonestatus_serial_verify("evba.lab", "in;rm -rf", 1)
+        # The view is shlex-quoted so a metachar cannot break out.
+        assert "'in;rm -rf'" in cmd
+        assert "; rm -rf" not in cmd.replace("'in;rm -rf'", "")
+
+    def test_dig_add_verify_is_record_level_with_diagnostics(self) -> None:
+        cmd = _dig_add_verify("api.evba.lab", "10.5.50.99", "A")
+        assert "dig @localhost api.evba.lab A +short" in cmd
+        assert "grep -qxF 10.5.50.99" in cmd
+        assert "expected A" in cmd  # failure diagnostic
+
+    def test_dig_remove_verify_asserts_both_families_absent(self) -> None:
+        cmd = _dig_remove_verify("api.evba.lab")
+        assert "dig @localhost api.evba.lab A +short" in cmd
+        assert "dig @localhost api.evba.lab AAAA +short" in cmd
+        assert '[ -z "$A" ] && [ -z "$AAAA" ]' in cmd
+        assert "still resolves after remove" in cmd  # failure diagnostic
 
 
 # ---------------------------------------------------------------------------
@@ -1389,7 +1572,7 @@ class TestRecordAddHandler:
         ):
             # api.other.lab matches other.lab; api.evba.lab matches evba.lab.
             # No ambiguity; this assertion proves a non-ambiguous resolve works.
-            result_zone, _ = await _resolve_helper(connector, _TARGET, "api.other.lab")
+            result_zone, _, _ = await _resolve_helper(connector, _TARGET, "api.other.lab")
         assert result_zone == "other.lab"
         assert sudo_mock.await_count == 0
 
@@ -1537,6 +1720,139 @@ class TestRecordRemoveHandler:
 
 
 # ---------------------------------------------------------------------------
+# Split-horizon handler behaviour (#2897)
+# ---------------------------------------------------------------------------
+
+
+_SUDO_SUCCESS = (
+    "===STATE_BEFORE_BEGIN===\nold\n===STATE_BEFORE_END===\n"
+    "===STATE_AFTER_BEGIN===\nnew\n===STATE_AFTER_END===\n"
+    "===SUCCESS===\n"
+)
+
+
+class TestRecordViewHandling:
+    """`view` param end-to-end through the add / remove handlers (#2897)."""
+
+    async def test_add_multi_view_without_view_raises_ambiguous_view(self) -> None:
+        """The zone in two views + no ``view`` -> rejected pre-staging."""
+        connector = Bind9Connector()
+        run_mock = AsyncMock(return_value=_completed_process(stdout=_MULTIVIEW_CHECKCONF_OUTPUT))
+        sudo_mock = AsyncMock()
+        with (
+            patch.object(connector, "_run_command", run_mock),
+            patch.object(connector, "_remote_bash_with_sudo", sudo_mock),
+            pytest.raises(ZoneResolutionError) as exc_info,
+        ):
+            await bind9_record_add(
+                connector,
+                _TARGET,
+                {"fqdn": "host.evba.lab", "ip": "10.5.50.9"},
+            )
+        assert exc_info.value.reason == "ambiguous_view"
+        assert exc_info.value.candidates == ["external", "internal"]
+        assert sudo_mock.await_count == 0
+
+    async def test_add_view_not_found_rejects_pre_staging(self) -> None:
+        connector = Bind9Connector()
+        run_mock = AsyncMock(return_value=_completed_process(stdout=_MULTIVIEW_CHECKCONF_OUTPUT))
+        sudo_mock = AsyncMock()
+        with (
+            patch.object(connector, "_run_command", run_mock),
+            patch.object(connector, "_remote_bash_with_sudo", sudo_mock),
+            pytest.raises(ZoneResolutionError) as exc_info,
+        ):
+            await bind9_record_add(
+                connector,
+                _TARGET,
+                {"fqdn": "host.evba.lab", "ip": "10.5.50.9", "view": "dmz"},
+            )
+        assert exc_info.value.reason == "view_not_found"
+        assert sudo_mock.await_count == 0
+
+    async def test_add_with_view_selects_file_and_uses_zonestatus_verify(self) -> None:
+        connector = Bind9Connector()
+        run_mock = AsyncMock(
+            side_effect=[
+                _completed_process(stdout=_MULTIVIEW_CHECKCONF_OUTPUT),
+                _completed_process(stdout=_SAMPLE_ZONEFILE),
+            ]
+        )
+        sudo_mock = AsyncMock(return_value=_completed_process(stdout=_SUDO_SUCCESS))
+        with (
+            patch.object(connector, "_run_command", run_mock),
+            patch.object(connector, "_remote_bash_with_sudo", sudo_mock),
+        ):
+            result = await bind9_record_add(
+                connector,
+                _TARGET,
+                {"fqdn": "host.evba.lab", "ip": "10.5.50.9", "view": "internal"},
+            )
+        # The internal view's zonefile was the staging target.
+        assert result["view"] == "internal"
+        assert result["file"] == "/etc/bind/internal/db.evba.lab"
+        # The verify predicate baked into the sudo script is the
+        # view-precise zonestatus serial check (not a view-blind dig),
+        # asserting the staged serial (2026051801 + 1).
+        staged_script = sudo_mock.await_args.args[1]
+        assert "rndc zonestatus host.evba.lab IN internal" not in staged_script
+        assert "rndc zonestatus evba.lab IN internal" in staged_script
+        assert "2026051802" in staged_script
+        # The record-level dig predicate for this FQDN is NOT used (the
+        # bare ``dig @localhost <zone> SOA`` in the rollback comment is a
+        # different, literal-``<zone>`` string).
+        assert "dig @localhost host.evba.lab" not in staged_script
+
+    async def test_add_no_view_deployment_uses_dig_verify(self) -> None:
+        connector = Bind9Connector()
+        run_mock = AsyncMock(
+            side_effect=[
+                _completed_process(stdout=_CHECKCONF_OUTPUT),
+                _completed_process(stdout=_SAMPLE_ZONEFILE),
+            ]
+        )
+        sudo_mock = AsyncMock(return_value=_completed_process(stdout=_SUDO_SUCCESS))
+        with (
+            patch.object(connector, "_run_command", run_mock),
+            patch.object(connector, "_remote_bash_with_sudo", sudo_mock),
+        ):
+            result = await bind9_record_add(
+                connector,
+                _TARGET,
+                {"fqdn": "api.evba.lab", "ip": "10.5.50.99"},
+            )
+        assert result["view"] is None
+        staged_script = sudo_mock.await_args.args[1]
+        assert "dig @localhost api.evba.lab A +short" in staged_script
+        assert "rndc zonestatus" not in staged_script
+
+    async def test_remove_with_view_uses_zonestatus_verify(self) -> None:
+        connector = Bind9Connector()
+        run_mock = AsyncMock(
+            side_effect=[
+                _completed_process(stdout=_MULTIVIEW_CHECKCONF_OUTPUT),
+                _completed_process(stdout=_SAMPLE_ZONEFILE),
+            ]
+        )
+        sudo_mock = AsyncMock(return_value=_completed_process(stdout=_SUDO_SUCCESS))
+        with (
+            patch.object(connector, "_run_command", run_mock),
+            patch.object(connector, "_remote_bash_with_sudo", sudo_mock),
+        ):
+            result = await bind9_record_remove(
+                connector,
+                _TARGET,
+                {"fqdn": "mail.evba.lab", "view": "external"},
+            )
+        assert result["view"] == "external"
+        assert result["file"] == "/etc/bind/external/db.evba.lab"
+        staged_script = sudo_mock.await_args.args[1]
+        assert "rndc zonestatus evba.lab IN external" in staged_script
+        # The record-level dig predicate for this FQDN is NOT used.
+        assert "dig @localhost mail.evba.lab" not in staged_script
+
+
+# ---------------------------------------------------------------------------
 # Registration shape -- AC: ops carry the warning + caution + requires_approval
 # ---------------------------------------------------------------------------
 
@@ -1662,12 +1978,11 @@ class TestRemoteCommandExitStatus:
         assert "Permission denied" in exc_info.value.stderr
 
     async def test_explicit_zone_checkconf_failure_raises_remote_command_error(self) -> None:
-        """``_resolve_zonefile_path_for_zone`` (explicit --zone branch) checks exit too."""
+        """The explicit --zone branch checks the ``named-checkconf`` exit too."""
         connector = Bind9Connector()
-        # The explicit-zone path goes through
-        # ``_resolve_zonefile_path_for_zone`` which also runs
-        # named-checkconf -p. A non-zero exit must surface the typed
-        # error.
+        # The explicit-zone path goes through the unified
+        # ``_resolve_zone_and_path`` which runs named-checkconf -p. A
+        # non-zero exit must surface the typed error.
         run_mock = AsyncMock(
             return_value=_completed_process(
                 stdout="",
@@ -1702,9 +2017,9 @@ async def _resolve_helper(
     connector: Bind9Connector,
     target: Any,
     fqdn: str,
-) -> tuple[str, str]:
+) -> tuple[str, str, str | None]:
     from meho_backplane.connectors.bind9.ops_record import (
-        _resolve_zone_via_checkconf,
+        _resolve_zone_and_path,
     )
 
-    return await _resolve_zone_via_checkconf(connector, target, fqdn)
+    return await _resolve_zone_and_path(connector, target, fqdn=fqdn, explicit_zone=None)

--- a/cli/internal/cmd/bind9/record.go
+++ b/cli/internal/cmd/bind9/record.go
@@ -144,6 +144,7 @@ func newRecordAddCmd() *cobra.Command {
 	var (
 		targetName        string
 		zone              string
+		view              string
 		recordType        string
 		jsonOut           bool
 		backplaneOverride string
@@ -162,21 +163,29 @@ func newRecordAddCmd() *cobra.Command {
 			"`named-checkconf -p` output. --type accepts A or AAAA only\n" +
 			"(CNAME / MX / TXT writes are out of scope for v0.2; the\n" +
 			"consumer wrapper never wrote them either).\n\n" +
+			"--view disambiguates a split-horizon nameserver where the\n" +
+			"same zone is declared in more than one view; pass it when the\n" +
+			"handler rejects the write as `ambiguous_view` (the error\n" +
+			"names the candidate views). It also makes verification\n" +
+			"view-precise via `rndc zonestatus`.\n\n" +
 			"This verb is the 1:1 replacement for the consumer's\n" +
 			"`bind9-dns.sh --add-a-record <fqdn> <ip> --zone <zone>`.\n\n" +
 			"Exit codes mirror meho operation call.",
 		Example: "  meho bind9 record add esx-dc6.evba.lab 10.5.50.25 --zone evba.lab --target vcf-router-bind9\n" +
-			"  meho bind9 record add v6.evba.lab 2001:db8::25 --type AAAA --target vcf-router-bind9",
+			"  meho bind9 record add v6.evba.lab 2001:db8::25 --type AAAA --target vcf-router-bind9\n" +
+			"  meho bind9 record add host.evba.lab 10.5.50.9 --view internal --target vcf-router-bind9",
 		Args:          cobra.ExactArgs(2),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRecordAdd(cmd, args[0], args[1], zone, recordType, targetName, jsonOut, backplaneOverride)
+			return runRecordAdd(cmd, args[0], args[1], zone, view, recordType, targetName, jsonOut, backplaneOverride)
 		},
 	}
 	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
 	cmd.Flags().StringVar(&zone, "zone", "",
 		"owning zone (e.g. evba.lab). Omitted → handler resolves via longest-suffix match.")
+	cmd.Flags().StringVar(&view, "view", "",
+		"split-horizon view owning the zone. Required only when the zone is in multiple views.")
 	cmd.Flags().StringVar(&recordType, "type", "",
 		"record type (A / AAAA). Omitted → handler default (A).")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
@@ -185,7 +194,7 @@ func newRecordAddCmd() *cobra.Command {
 	return cmd
 }
 
-func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
+func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, view, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
 	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
@@ -196,6 +205,9 @@ func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, recordType, targetName str
 	}
 	if zone != "" {
 		params["zone"] = zone
+	}
+	if view != "" {
+		params["view"] = view
 	}
 	if recordType != "" {
 		params["type"] = recordType
@@ -214,6 +226,7 @@ func newRecordRemoveCmd() *cobra.Command {
 	var (
 		targetName        string
 		zone              string
+		view              string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -228,25 +241,31 @@ func newRecordRemoveCmd() *cobra.Command {
 			"consumer wrapper never removed them either; use\n" +
 			"`meho bind9 config apply-file` for fine-grained zonefile\n" +
 			"edits in the meantime).\n\n" +
+			"--view disambiguates a split-horizon nameserver where the\n" +
+			"same zone is declared in more than one view (same semantics\n" +
+			"as `record add`).\n\n" +
 			"Exit codes mirror meho operation call.",
-		Example:       "  meho bind9 record remove esx-dc6.evba.lab --zone evba.lab --target vcf-router-bind9",
+		Example: "  meho bind9 record remove esx-dc6.evba.lab --zone evba.lab --target vcf-router-bind9\n" +
+			"  meho bind9 record remove host.evba.lab --view internal --target vcf-router-bind9",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRecordRemove(cmd, args[0], zone, targetName, jsonOut, backplaneOverride)
+			return runRecordRemove(cmd, args[0], zone, view, targetName, jsonOut, backplaneOverride)
 		},
 	}
 	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
 	cmd.Flags().StringVar(&zone, "zone", "",
 		"owning zone (e.g. evba.lab). Omitted → handler resolves via longest-suffix match.")
+	cmd.Flags().StringVar(&view, "view", "",
+		"split-horizon view owning the zone. Required only when the zone is in multiple views.")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
 }
 
-func runRecordRemove(cmd *cobra.Command, fqdn, zone, targetName string, jsonOut bool, backplaneOverride string) error {
+func runRecordRemove(cmd *cobra.Command, fqdn, zone, view, targetName string, jsonOut bool, backplaneOverride string) error {
 	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
@@ -254,6 +273,9 @@ func runRecordRemove(cmd *cobra.Command, fqdn, zone, targetName string, jsonOut 
 	params := map[string]any{"fqdn": fqdn}
 	if zone != "" {
 		params["zone"] = zone
+	}
+	if view != "" {
+		params["view"] = view
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.record.remove", targetName, params)
 	if err != nil {
@@ -283,7 +305,7 @@ func printWriteResult(w io.Writer, r *CallResult) {
 	if opClass, ok := body["op_class"].(string); ok && opClass != "" {
 		fmt.Fprintf(w, "  op_class: %s\n", opClass)
 	}
-	for _, key := range []string{"fqdn", "zone", "file", "type", "ip"} {
+	for _, key := range []string{"fqdn", "zone", "view", "file", "type", "ip"} {
 		if v, ok := body[key]; ok && v != nil {
 			fmt.Fprintf(w, "  %-9s %v\n", key+":", v)
 		}

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -54,8 +54,10 @@ Source: `backend/src/meho_backplane/connectors/bind9/`.
 - **`ops_record.py`** -- T2 record-read + T3 record-write op module.
   Pure parser (`parse_dig_answer`), read handler (`bind9_record_get`),
   T3 (#589) write handlers (`bind9_record_add`, `bind9_record_remove`)
-  with longest-suffix zone resolution + pure dnspython zonefile
-  transforms, and the `RECORD_OPS` registration table.
+  with split-horizon-aware zone resolution (`resolve_zone_target`, an
+  optional `view` param disambiguating multi-view zones -- #2897) +
+  pure dnspython zonefile transforms + view-aware verify predicate
+  builders, and the `RECORD_OPS` registration table.
 - **`_atomic.py`** -- T3 (#589) atomic-apply primitive. One async
   `atomic_apply()` helper that runs the seven-step bash pipeline
   (snapshot, capture state_before, stage, validate, rndc reload,
@@ -194,8 +196,8 @@ reason.
 | `bind9.zone.list` | `Bind9Connector.bind9_zone_list` | `safe` | Parse `named-checkconf -p` into zone rows: `{name, file, type, view}` per declared zone (`view` is the enclosing `view "<name>"` block, or `null` outside any view — disambiguates split-horizon) |
 | `bind9.zone.read` | `Bind9Connector.bind9_zone_read` | `safe` | Resolve zonefile via `named-checkconf -p`, read + parse via dnspython; row per rrset member `{name, ttl, class, type, rdata}` |
 | `bind9.record.get` | `Bind9Connector.bind9_record_get` | `safe` | `dig @localhost <fqdn> <type>` parsed into structured rows; defaults to A; supports A / AAAA / CNAME / MX / TXT |
-| `bind9.record.add` | `Bind9Connector.bind9_record_add` | `caution` | Atomic A/AAAA record write with snapshot rollback; resolves owning zone via longest-suffix match when `zone` omitted; verify predicate = `dig` returns the new IP |
-| `bind9.record.remove` | `Bind9Connector.bind9_record_remove` | `caution` | Atomic remove of A + AAAA at the given FQDN with snapshot rollback; verify predicate = `dig` no longer resolves the FQDN |
+| `bind9.record.add` | `Bind9Connector.bind9_record_add` | `caution` | Atomic A/AAAA record write with snapshot rollback; resolves owning zone via longest-suffix match when `zone` omitted; optional `view` disambiguates split-horizon zones (#2897); verify predicate = `dig` returns the new IP, or `rndc zonestatus` serial-match when a `view` is given |
+| `bind9.record.remove` | `Bind9Connector.bind9_record_remove` | `caution` | Atomic remove of A + AAAA at the given FQDN with snapshot rollback; same `view` disambiguation as `record.add`; verify predicate = `dig` no longer resolves the FQDN, or `rndc zonestatus` serial-match when a `view` is given |
 | `bind9.config.show` | `Bind9Connector.bind9_config_show` | `safe` | Read named.conf or an included fragment under the bind config root; path-safety filter refuses traversal with no content leaked |
 | `bind9.config.apply_file` | `Bind9Connector.bind9_config_apply_file` | `dangerous` | Atomic single-fragment write via T3's primitive; validate = `named-checkconf -p`; verify = config still parses after live reload |
 | `bind9.config.apply_views` | `Bind9Connector.bind9_config_apply_views` | `dangerous` | Atomic multi-file tree write (tar mode of T3's primitive); validate = `named-checkconf -p`; verify = caller-supplied `dig` or fallback parse check |
@@ -256,23 +258,66 @@ POV; the bash body is generated entirely by `_atomic.py` (no
 caller-supplied substring lands in shell), so the safe-sudo
 helper's invariants extend uninjured.
 
-### Zone resolution when `--zone` is omitted
+### Zone resolution + split-horizon views (#2897)
 
-`bind9.record.add` / `bind9.record.remove` accept an optional
-`zone` parameter. When omitted, the handler resolves the owning
-zone from `named-checkconf -p` (T2's zone parser) by longest-suffix
-match against the FQDN:
+`bind9.record.add` / `bind9.record.remove` accept optional `zone` and
+`view` parameters. The pure `resolve_zone_target(rows, fqdn,
+explicit_zone, explicit_view)` (in `ops_record.py`) walks the
+`{name, file, type, view}` rows T2's `parse_named_checkconf_zones`
+emits and returns `(zone_name, zonefile_path, view)`:
 
-* The FQDN's label sequence must end with the zone's label sequence
-  -- label boundaries are atomic, so `api.evba.lab` matches
-  `evba.lab` but not `ba.lab`.
-* The root zone (`.`) is excluded from candidates.
-* On a tie at the longest suffix, raises `ZoneResolutionError(reason="ambiguous", candidates=[...])`.
-* On no match, raises `ZoneResolutionError(reason="unresolvable", fqdn=...)`.
+* **Zone name** -- `explicit_zone` when given, else longest-suffix match
+  (`resolve_zone_for_fqdn`) over the **distinct** zone names. The FQDN's
+  label sequence must end with the zone's (`api.evba.lab` matches
+  `evba.lab`, not `ba.lab`); the root zone (`.`) is excluded.
+* **View** -- the candidate rows are the zone's rows that carry a `file`
+  directive:
+  * `view` given -> restrict to that view; no match raises
+    `ZoneResolutionError(reason="view_not_found", candidates=[views])`.
+  * `view` omitted and the zone lives in one view (or none) -> that row;
+    the returned `view` is the enclosing view name, or `None` outside
+    any view.
+  * `view` omitted and the zone lives in **>1 view** -> raises
+    `ZoneResolutionError(reason="ambiguous_view", candidates=[views])`.
+    This is the #2897 fix: pre-#2897 the flat zone-name list made the
+    same zone tie with itself and report the opaque `ambiguous`; now the
+    error names the views and tells the caller to pass `view`.
+* No suffix match / no writable `file` -> `reason="unresolvable"`.
 
-Both errors raise **before** any staging, so the dispatcher's
-`invalid_params` envelope reports the rejection with zero side
-effects on the remote tree.
+`ZoneResolutionError` renders a human-actionable `str(exc)` (not the
+bare reason code) so the surfaced `exception_message` says what to do.
+All flavours raise **before** any staging, so the dispatcher's
+`invalid_params` envelope reports the rejection with zero side effects
+on the remote tree.
+
+### View-aware verify (#2897)
+
+The atomic-apply verify command is built by the handler (§ primitive
+step 6). `dig @localhost` is **view-blind**: on a split-horizon server
+it is answered by whichever `view` matches the loopback source address,
+which need not be the view whose zonefile we staged -- so a targeted
+write into a non-loopback view failed verify and rolled back even though
+the edit was correct. The handler therefore switches predicate on
+whether the caller passed `view`:
+
+* **`view` given** (`_zonestatus_serial_verify`) -- polls
+  `rndc zonestatus <zone> IN <view>` and asserts the served serial
+  equals the staged (SOA-bumped) serial. This names the view explicitly,
+  so it confirms named loaded our revision into *that* view;
+  `named-checkzone` (validate step) already proved the record is in the
+  file.
+* **`view` omitted** (`_dig_add_verify` / `_dig_remove_verify`) -- the
+  record-level `dig @localhost` check, unchanged for no-views /
+  single-view targets.
+
+Both predicates **echo their observed state on failure** so the
+`AtomicApplyError` detail is diagnosable -- the pre-#2897 silent
+`grep -q` / `[ -z … ]` predicates surfaced an empty `exception_message`.
+
+The commit-path reload is a whole-server `rndc reload`, which reloads
+every view from disk and is unchanged by #2897 (a full reload was the
+consumer's working workaround); the multi-view fix is in resolution and
+verify, not the reload.
 
 ### Audit integration
 


### PR DESCRIPTION
## Summary

- Fixes `bind9.record.add` / `record.remove` on split-horizon nameservers where the same zone is declared in more than one `view` block (#2897). Two failures were happening in sequence: zone auto-resolution flattened the per-view rows and reported the single zone name as `ambiguous`; and with an explicit `zone`, the atomic-apply verify used a view-blind `dig @localhost`, which is answered by whichever view matches the loopback source — potentially a different view than the one whose zonefile was staged — so verify failed and the change rolled back even though the edit was correct.
- Adds an optional `view` param (op params + CLI `--view` on `record add` / `record remove`) threaded through a new pure `resolve_zone_target`: it dedupes zone names (so a zone in N views no longer ties with itself), rejects a multi-view zone with an actionable `ambiguous_view` / `view_not_found` that **names the candidate views**, and otherwise edits the named view's zonefile. `ZoneResolutionError` now renders a human-readable sentence rather than the bare reason code (the issue flagged the opaque `"ambiguous"`).
- Makes verify **view-aware**: when the caller passes `view`, verification switches to a view-precise `rndc zonestatus <zone> IN <view>` serial-match (poll-bounded) — `dig` cannot target a view by name. On a no-views / single-view target the record-level `dig` check is kept. Both predicates now **echo their observed state on failure**, so the `AtomicApplyError` detail is no longer empty (the second #2897 complaint).
- The commit-path reload stays a whole-server `rndc reload` — it already reloads every view from disk, and a full reload was the reporter's working workaround; the multi-view fix is in resolution + verify, so the `_atomic.py` pipeline is untouched.

## Test plan

- [x] `ruff check` / `ruff format --check` (`src/`, `tests/`) — clean
- [x] `mypy src/meho_backplane/connectors/bind9/` — clean (repo-wide mypy shows one **pre-existing, macOS-only** `net/icmp.py` `MSG_ERRQUEUE` false positive — Linux-only socket constant, untouched by this PR, passes in CI)
- [x] `pytest tests/test_connectors_bind9_*` — **231 passed**. New: `TestResolveZoneTarget` (all resolution branches incl. `ambiguous_view` / `view_not_found`), `TestViewAwareVerifyBuilders` (verify-command shapes + serial round-trip + metachar quoting), `TestRecordViewHandling` (view param end-to-end through add/remove: pre-stage rejection, view-file selection, zonestatus-vs-dig verify choice)
- [x] Broader sweep `-k "bind9 or classify_op or typed_op or broadcast"` — 371 passed; `test_broadcast_events.py` — 95 passed
- [x] Go CLI `go build / vet / test ./internal/cmd/bind9/` — pass
- [x] `code-quality.py --diff` — 0 blockers (size warnings only, under the hard limit; module carries an existing `code-quality-allow`)
- [x] `rndc reload <zone> IN <view>` and `rndc zonestatus <zone> IN <view>` syntax + the un-indented `serial:` output line verified against ISC/BIND docs (grep anchor excludes the DNSSEC `signed serial:` line)

## Acceptance criteria (#2897)

- [x] Multi-view zone no longer resolves as spurious `ambiguous`; `view` disambiguates, or a clear `ambiguous_view` error names the views.
- [x] Atomic-apply verify is view-aware, so `record.add` works on multi-view zones.
- [x] Empty `exception_message` fixed — verify predicates emit diagnostics on failure.

## Out of scope / follow-ups

- A containerised split-horizon **integration** lane: the existing `tests/integration/test_connectors_bind9_container.py` fixture is single-view. The logic is fully unit-tested and the `rndc` syntax verified against ISC docs, but a real multi-view container test couldn't be validated in this sandbox (no Docker) — sensible follow-up.
- Pre-existing code-quality size warnings on `parse_dig_answer` (untouched) and the record handlers (already covered by the module's `code-quality-allow` header).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2897
