### PR TITLE
fix(connectors): guard datastore.usage against global-VM-list enrichment (#2975)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -609,7 +609,13 @@ async def datastore_usage_composite(
         VM-placement enrichment errors, ``vm_count`` and ``vm_names``
         are ``None`` and the row carries an ``enrichment_note`` string
         describing the skipped enrichment; on success the row has no
-        ``enrichment_note`` key.
+        ``enrichment_note`` key. The same null + ``enrichment_note``
+        treatment is applied to every enriched row when the per-row VM
+        sets come back identical across all datastores -- the symptom of
+        an upstream per-datastore filter that was silently ignored and
+        returned the whole-inventory VM list on each row (#2975) -- so a
+        populated-but-wrong global list is never emitted as per-datastore
+        placement.
 
         ``vm_count`` is the exact VM total; ``vm_names`` is bounded to a
         sample of at most
@@ -635,6 +641,9 @@ async def datastore_usage_composite(
         )
 
     aggregated: list[dict[str, Any]] = []
+    # Each successfully-enriched row paired with the full (pre-cap) set of VM
+    # names on it, for the cross-row identical-sets guard after the loop (#2975).
+    enriched: list[tuple[dict[str, Any], frozenset[str]]] = []
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -707,7 +716,35 @@ async def datastore_usage_composite(
             # vm_count > len(vm_names) is the truncation signal.
             row["vm_count"] = len(vm_names)
             row["vm_names"] = vm_names[:DATASTORE_USAGE_MAX_VM_NAMES]
+            enriched.append((row, frozenset(vm_names)))
         aggregated.append(row)
+
+    # Cross-row identical-sets guard (#2975). A VM's working directory lives on
+    # exactly one datastore, so genuinely-distinct datastores never share a
+    # non-empty VM set. An identical non-empty set across *every* enriched row
+    # is therefore not real placement data -- it is the global-list symptom of
+    # an upstream per-datastore filter that was silently ignored, returning the
+    # whole-inventory VM list on every row. Emitting that populated-but-wrong
+    # answer is worse than emitting none, so treat it as failed enrichment:
+    # null vm_count/vm_names and record why, the same best-effort contract used
+    # for a transport error above (#1908). The all-empty case (every datastore
+    # legitimately has zero VMs) is excluded by the non-empty check.
+    if len(enriched) > 1:
+        vm_sets = [vm_set for _, vm_set in enriched]
+        shared = vm_sets[0]
+        if shared and all(vm_set == shared for vm_set in vm_sets[1:]):
+            note = (
+                "vm-placement enrichment discarded: the VM set was identical "
+                f"across all {len(enriched)} enriched datastores, so the "
+                "upstream per-datastore filter was not applied (the "
+                "whole-inventory VM list was returned on every row); "
+                "vm_count/vm_names are unreliable and have been nulled."
+            )
+            for row, _ in enriched:
+                row["vm_count"] = None
+                row["vm_names"] = None
+                row["enrichment_note"] = note
+
     return {"datastores": aggregated}
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -489,8 +489,8 @@ DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
                         "minimum": 0,
                         "description": (
                             "Number of VMs placed on this datastore; ``null`` when "
-                            "the best-effort VM-placement enrichment was skipped "
-                            "because its sub-call errored (see ``enrichment_note``)."
+                            "the best-effort VM-placement enrichment was skipped or "
+                            "discarded (see ``enrichment_note``)."
                         ),
                     },
                     "vm_names": {
@@ -511,9 +511,12 @@ DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "description": (
                             "Present only when the VM-placement enrichment was "
-                            "skipped; records the failing sub-op, its status, and "
-                            "the underlying error (status code + URL where the "
-                            "sub-op carried them)."
+                            "skipped or discarded. For a failing sub-op it records "
+                            "the sub-op, its status, and the underlying error "
+                            "(status code + URL where the sub-op carried them); for "
+                            "the identical-sets guard it records that the VM set was "
+                            "identical across every datastore, so the upstream "
+                            "per-datastore filter was not applied (#2975)."
                         ),
                     },
                 },

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -391,6 +391,16 @@ _DATASTORE_DETAIL: dict[str, dict[str, Any]] = {
     "datastore-22": {"capacity": 5000, "free_space": 2500, "type": "NFS"},
 }
 
+#: Per-datastore ``GET /vcenter/vm`` placement bodies. Distinct per datastore
+#: (a VM's working directory lives on exactly one datastore), so the composite's
+#: cross-row identical-sets guard (#2975) sees real placement rather than the
+#: global-list symptom it discards -- a single VM shared across every datastore
+#: would trip that guard.
+_DATASTORE_VMS: dict[str, list[dict[str, str]]] = {
+    "datastore-11": [{"name": "vm-x"}],
+    "datastore-22": [{"name": "vm-y"}],
+}
+
 
 def _register_datastore_composite_routes(
     mock: respx.MockRouter, *, mount: str, reject_prefixed_filter: bool = False
@@ -413,6 +423,16 @@ def _register_datastore_composite_routes(
     mock.get(f"{mount}/vcenter/datastore").respond(200, json=_DATASTORE_LISTING)
     for ds_id, detail in _DATASTORE_DETAIL.items():
         mock.get(f"{mount}/vcenter/datastore/{ds_id}").respond(200, json=detail)
+
+    def _vms_for(request: httpx.Request) -> list[dict[str, str]]:
+        # Serve this datastore's own VMs, keyed off the placement filter the
+        # composite sends (bare ``datastores`` on /api, ``filter.datastores``
+        # on legacy /rest). Distinct per-datastore sets keep the cross-row
+        # identical-sets guard (#2975) from tripping on the fixture.
+        params = request.url.params
+        ds_id = params.get("datastores") or params.get("filter.datastores") or ""
+        return _DATASTORE_VMS.get(ds_id, [])
+
     if reject_prefixed_filter:
 
         def _vm_route(request: httpx.Request) -> httpx.Response:
@@ -420,13 +440,15 @@ def _register_datastore_composite_routes(
             # and 400s the legacy ``filter.``-prefixed form.
             if "filter." in request.url.query.decode():
                 return httpx.Response(400, json={"messages": ["unknown query parameter"]})
-            return httpx.Response(200, json=[{"name": "vm-x"}])
+            return httpx.Response(200, json=_vms_for(request))
 
         mock.get(f"{mount}/vcenter/vm").mock(side_effect=_vm_route)
     else:
-        # A single VM-placement stub serves every per-datastore query; the
-        # composite only counts names, so one VM per datastore is enough.
-        mock.get(f"{mount}/vcenter/vm").respond(200, json=[{"name": "vm-x"}])
+
+        def _vm_route_legacy(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_vms_for(request))
+
+        mock.get(f"{mount}/vcenter/vm").mock(side_effect=_vm_route_legacy)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -811,6 +811,106 @@ async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() ->
 
 
 @pytest.mark.asyncio
+async def test_datastore_usage_identical_vm_sets_across_rows_trip_guard() -> None:
+    """Identical VM sets on every row = the upstream per-datastore filter was
+    ignored (whole-inventory list returned per row); the guard nulls
+    vm_count/vm_names and records why on every enriched row (#2975)."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+        {"datastore": "datastore-3", "name": "ds-3", "type": "vSAN"},
+    ]
+    # Every per-datastore VM leg returns the SAME whole-inventory list.
+    global_vms = [{"name": "vm-a"}, {"name": "vm-b"}, {"name": "vm-c"}]
+    sequence: list[Any] = [listing]
+    for _ in listing:
+        sequence.append({"capacity": 100, "free_space": 40})
+        sequence.append(global_vms)
+    conn = _RecordingConnector(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    rows = out["datastores"]
+    assert len(rows) == 3
+    for row in rows:
+        # Core capacity data is preserved; only the wrong enrichment is dropped.
+        assert row["capacity"] == 100
+        assert row["free_space"] == 40
+        assert row["vm_count"] is None
+        assert row["vm_names"] is None
+        note = row["enrichment_note"]
+        assert "identical" in note
+        assert "3 enriched datastores" in note
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_distinct_vm_sets_across_rows_left_populated() -> None:
+    """Genuinely-distinct per-datastore VM sets are real placement data: the
+    identical-sets guard does not fire and the rows stay populated (#2975)."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+        {"datastore": "datastore-3", "name": "ds-3", "type": "vSAN"},
+    ]
+    vms_by_ds: dict[str, list[dict[str, Any]]] = {
+        "datastore-1": [{"name": "vm-a"}, {"name": "vm-b"}],
+        "datastore-2": [{"name": "vm-c"}],
+        "datastore-3": [{"name": "vm-d"}, {"name": "vm-e"}],
+    }
+    sequence: list[Any] = [listing]
+    for entry in listing:
+        sequence.append({"capacity": 100, "free_space": 40})
+        sequence.append(vms_by_ds[entry["datastore"]])
+    conn = _RecordingConnector(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    rows = out["datastores"]
+    assert [r["vm_count"] for r in rows] == [2, 1, 2]
+    assert rows[0]["vm_names"] == ["vm-a", "vm-b"]
+    assert rows[1]["vm_names"] == ["vm-c"]
+    assert rows[2]["vm_names"] == ["vm-d", "vm-e"]
+    assert all("enrichment_note" not in r for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_all_empty_vm_sets_do_not_trip_guard() -> None:
+    """Every datastore legitimately having zero VMs is real data, not the
+    global-list symptom; the guard's non-empty check excludes it (#2975)."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+    ]
+    sequence: list[Any] = [listing]
+    for _ in listing:
+        sequence.append({"capacity": 100, "free_space": 40})
+        sequence.append([])  # no VMs on this datastore
+    conn = _RecordingConnector(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    rows = out["datastores"]
+    assert [r["vm_count"] for r in rows] == [0, 0]
+    assert [r["vm_names"] for r in rows] == [[], []]
+    assert all("enrichment_note" not in r for r in rows)
+
+
+@pytest.mark.asyncio
 async def test_datastore_usage_listing_error_propagates() -> None:
     """A load-bearing listing failure propagates; no per-DS calls fire."""
     conn = _RecordingConnector(

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -914,6 +914,28 @@ recording the failing sub-op, its status, and the underlying error.
 The response schema marks `vm_count`/`vm_names` as nullable and adds the
 optional `enrichment_note` key (present only on a skipped row).
 
+The same null + `enrichment_note` treatment is extended to a second,
+subtler failure mode by the **cross-row identical-sets guard** (#2975).
+A per-datastore VM leg can *succeed* (HTTP 200) yet still be wrong: if
+the target silently ignores the per-datastore filter, `GET:/vcenter/vm`
+returns the whole-inventory VM list, so every datastore row is
+enriched with the identical global list — `vm_count` equal to the
+cluster-wide VM total and an identical `vm_names` sample on all rows.
+That poisons the classic "which VMs live on this filling-up datastore?"
+triage question with the same wrong answer on every row. Because a VM's
+working directory lives on exactly one datastore, genuinely-distinct
+datastores never share a non-empty VM set; so an identical **non-empty**
+set across *every* enriched row is treated as failed enrichment — all
+those rows are nulled and carry an `enrichment_note` explaining the
+filter was not applied — rather than emitting the populated-but-wrong
+global list. The non-empty condition excludes the legitimate all-empty
+case (every datastore really has zero VMs), and the guard needs at least
+two enriched rows to compare, so a single-datastore result is never
+touched. The guard is defence-in-depth: it stands regardless of *why*
+the filter was ignored (the upstream root cause is diagnosed separately
+from the dispatch audit row), so it protects the data even when a target
+build mishandles the filter param.
+
 ### Per-entity capacity sensing (`filter_names`, #2758)
 
 `datastore.usage` takes an exact-match `filter_names` param (array of


### PR DESCRIPTION
## Summary

- `vmware.composite.datastore.usage` populated each datastore row's `vm_count`/`vm_names` directly from `GET:/vcenter/vm` with **no cross-row identity check** (`_read.py` `datastore_usage_composite`). When the target silently ignores the per-datastore filter, that sub-op returns the whole-inventory VM list, so every row carries the **identical global list** — the reported symptom (#2975): `vm_count` = cluster-wide total, identical `vm_names` on all 50 rows, poisoning the "which VMs live on this filling-up datastore?" triage question with the same wrong answer everywhere.
- Adds a **cross-row identical-sets guard**: a VM's working directory lives on exactly one datastore, so genuinely-distinct datastores never share a non-empty VM set. An identical **non-empty** set across *every* enriched row is treated as failed enrichment — `vm_count`/`vm_names` nulled + an `enrichment_note` — reusing the existing best-effort null+note contract (#1908), instead of emitting a populated-but-wrong global list.
- The guard's non-empty condition excludes the legitimate all-empty case (every datastore really has zero VMs), and it needs ≥2 enriched rows to compare, so a single-datastore result is never touched.
- Schema (`enrichment_note`/`vm_count` descriptions) and `docs/codebase/connectors-vmware-rest.md` updated to document the guard alongside the existing best-effort-error path.

## Scope split — guard-half only (param root-cause deferred, human-gated)

Per @damir-topic's grounding comment on #2975, the work splits cleanly and **only the guard-half is implemented here** — it "stands regardless of root cause":

- **Done (this PR):** the identical-sets guard, which protects the data on any target no matter *why* the filter was ignored.
- **Deferred (NOT in this PR):** the `GET:/vcenter/vm` filter-param / root-cause fix. The actual cause is **undetermined from code** — either the session mounted legacy `/rest`, or the 8.0.3 target ignores the bare `datastores=` param — and per the grounding comment it **must be diagnosed from the dispatch audit row's request URL/params by a human before the param-half is coded**. The param path is left exactly as-is (`{"filter.datastores": [ds_id]}` through `adapt_op_query`, the #2298 seam). Diff confirms zero changes to the param path.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `mypy` on the changed module (`connectors/vmware_rest/composites/`) — clean (6 files, no issues). Full-tree `mypy src/` shows one pre-existing, platform-specific error in the untouched `net/icmp.py` — `socket.MSG_ERRQUEUE` is Linux-only and absent on the local macOS box; it resolves on Linux CI.
- [x] `pytest` composites-read + register + datastore sensor — **52 passed**
- [x] New tests (acceptance criteria):
  - `test_datastore_usage_identical_vm_sets_across_rows_trip_guard` — identical non-empty sets on every row → all rows nulled + `enrichment_note`.
  - `test_datastore_usage_distinct_vm_sets_across_rows_left_populated` — genuinely-distinct per-row sets → unchanged, no note.
  - `test_datastore_usage_all_empty_vm_sets_do_not_trip_guard` — all-empty (zero VMs everywhere) → unchanged (false-positive boundary).
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing warnings on untouched functions / the 2700-line `schemas.py`).

## Out of scope

- The `GET:/vcenter/vm` filter-param / root-cause fix — deferred pending the audit-row diagnosis described above.
- Sibling initiative tasks (#3020): `vm.migrate` relocate body (#2973), sensor evidence identity (#2976), catalog dedupe (#2977), advisory-lock leak (#3010).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2975
