### PR TITLE
fix(connectors): reject epoch-version ingests + reap stale probe rows (#2977)

### DIFF
--- a/backend/alembic/versions/0075_reap_epoch_versioned_connector_registrations.py
+++ b/backend/alembic/versions/0075_reap_epoch_versioned_connector_registrations.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reap epoch-versioned connector registrations (#2977).
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-08-19
+
+Task #2977 under Initiative #3020 (G0.40 hardening wave 2). The consumer
+catalog on a v0.28.0 deploy accumulated 9-10 stale
+``fleet-rest-probe-<epoch>`` connector rows that grew one-per-probe-run
+with nothing to reap them. Mechanism (per the issue's grounding pass):
+the probe-then-ingest glue on the consumer side stamped the probe run's
+**Unix epoch as the connector ``version``**, so every run rendered a
+fresh ``(product, version, impl_id)`` triple. The ingest upsert
+(:mod:`meho_backplane.operations.ingest._upsert`) dedups on that exact
+triple, so a changed ``version`` never matched an existing row — it
+INSERTed a brand-new connector each time, and no TTL / reaper / GC
+exists anywhere for ``endpoint_descriptor`` / ``operation_group`` rows.
+
+The paired ingest-time guard
+(:meth:`meho_backplane.operations.ingest.api_schemas.IngestRequest._reject_epoch_version`)
+now rejects an epoch ``version`` at the source on every surface
+(REST / MCP / CLI all construct the same ``IngestRequest``), so this
+class cannot recur. This migration is the one-time cleanup of the rows
+that already leaked in before that guard existed.
+
+What counts as an "epoch version"
+---------------------------------
+
+A bare integer of at least 9 digits. Unix-epoch **seconds** have been 10
+digits since 2001-09 (crossed 1e9) and stay 10 until 2286; a 9-digit
+floor catches any epoch while never matching a real connector version,
+which always carries dots / letters / dashes (``9.0`` / ``2.x`` /
+``2026-04``). This is the same rule the ingest-time guard applies, so the
+prevention and the cleanup target one identical shape. The bundled
+``net-probe-1.x`` typed connector (``version="1.x"``) and every ingested
+connector with a genuine product-line version are untouched.
+
+Tenant-scope-inclusive (the #2977 sharpening)
+---------------------------------------------
+
+Unlike migrations ``0049`` / ``0052`` (which retire *built-in*
+``tenant_id IS NULL`` product-spelling twins only), the epoch rows are
+consumer-side **tenant** ingests, so this cleanup deliberately spans
+**every** scope — it does not filter on ``tenant_id``. An epoch version
+is illegitimate regardless of scope, so a blanket predicate is correct
+and there is no tenant row worth preserving.
+
+``endpoint_descriptor`` additionally guards on ``source_kind =
+'ingested'`` — typed / composite connectors are hand-coded and can never
+carry an epoch version, but the guard makes the blast radius provably
+ingest-only. ``operation_group`` has no ``source_kind`` column; the
+epoch-version predicate alone is diagnostic there (no legitimate group
+carries one). Descriptors are retired before groups so the two row
+surfaces the dispatch / review layer reads are cleared together, same
+ordering as ``0049`` / ``0052``.
+
+Portability
+-----------
+
+The "bare integer >= 9 digits" test is dialect-branched: PostgreSQL uses
+a POSIX regex (``version ~ '^[0-9]{9,}$'``); SQLite — which has no regex
+operator without a registered function — expresses the identical set as
+"length >= 9 AND no non-digit character" via ``length()`` + ``NOT
+GLOB``. Both run inside the single migration transaction against the
+operator-scale catalog. No UUID bind params are threaded (the predicate
+keys only on the ``Text`` ``version`` / ``source_kind`` columns), so the
+``docs/codebase/migrations.md`` UUID-hex gotcha does not apply.
+
+Additive-only forward, no-op back
+---------------------------------
+
+``upgrade()`` runs no DDL — only two DML DELETEs — so it clears
+``scripts/ci/check_migration_compat.py`` (which bans destructive DDL,
+not row deletion) and an older image reading the post-cleanup schema is
+unaffected (the ``helm rollback`` = image-revert + forward-compat-schema
+contract, ``docs/codebase/migrations.md``, holds). ``downgrade()`` is a
+documented no-op: the reaped rows were non-idempotent debris that no
+dispatch / review probe wanted, and re-INSERTing fabricated epoch rows
+would re-introduce the unbounded growth this migration removes. Same
+shape as ``0049`` / ``0052``.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0075"
+down_revision: str | None = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _epoch_version_predicate(dialect_name: str) -> sa.sql.elements.TextClause:
+    """Return the dialect-portable "``version`` is a Unix-epoch integer" WHERE.
+
+    A bare integer of at least 9 digits. PostgreSQL uses a POSIX regex;
+    SQLite (no regex operator without a registered function) expresses
+    the same set as "length >= 9 AND no non-digit character present".
+    Both reference the bare ``version`` column, which resolves against
+    the single table of each ``DELETE`` this predicate is attached to.
+    """
+    if dialect_name == "postgresql":
+        return sa.text("version ~ '^[0-9]{9,}$'")
+    return sa.text("length(version) >= 9 AND version NOT GLOB '*[^0-9]*'")
+
+
+def upgrade() -> None:
+    """Delete every epoch-versioned ingested descriptor + group row, any scope."""
+    bind = op.get_bind()
+    epoch = _epoch_version_predicate(bind.dialect.name)
+
+    descriptor = sa.table(
+        "endpoint_descriptor",
+        sa.column("source_kind", sa.Text()),
+        sa.column("version", sa.Text()),
+    )
+    group = sa.table(
+        "operation_group",
+        sa.column("version", sa.Text()),
+    )
+
+    bind.execute(
+        sa.delete(descriptor).where(
+            descriptor.c.source_kind == "ingested",
+            epoch,
+        )
+    )
+    bind.execute(sa.delete(group).where(epoch))
+
+
+def downgrade() -> None:
+    """No-op by design.
+
+    The reaped rows were non-idempotent probe debris (a fresh connector
+    per probe run, the defect #2977 fixes) that no dispatch / review
+    probe wanted; re-INSERTing fabricated epoch rows would re-introduce
+    the unbounded growth. No DDL runs in ``upgrade()``, so there is
+    nothing to undo at the schema layer either. Same documented-no-op
+    shape as ``0049`` / ``0052``. The function stays defined so
+    ``alembic downgrade -1`` resolves the symbol cleanly.
+    """
+    # Intentionally empty -- see docstring.

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -128,6 +128,27 @@ class SpecSource(BaseModel):
     content: str | None = Field(default=None, max_length=20 * 1024 * 1024)
 
 
+#: Minimum digit count for a ``version`` to be treated as a Unix-epoch
+#: timestamp rather than a product-line label. Unix-epoch **seconds**
+#: have been 10 digits since 2001-09 (crossed 1e9) and stay 10 until
+#: 2286; a 9-digit floor catches any epoch while never matching a real
+#: version (which always carries dots / letters / dashes — ``9.0`` /
+#: ``2.x`` / ``2026-04``). See :meth:`IngestRequest._reject_epoch_version`.
+_EPOCH_VERSION_MIN_DIGITS = 9
+
+
+def _version_looks_like_epoch(version: str) -> bool:
+    """Return whether *version* is a bare Unix-epoch-magnitude integer.
+
+    ``True`` only for an all-ASCII-digit string of at least
+    :data:`_EPOCH_VERSION_MIN_DIGITS` characters — the shape a
+    consumer-side probe-then-ingest loop stamps when it uses the probe
+    run's epoch as the connector ``version`` (#2977). A legitimate
+    connector version never matches (they carry ``.`` / letters / ``-``).
+    """
+    return version.isascii() and version.isdigit() and len(version) >= _EPOCH_VERSION_MIN_DIGITS
+
+
 class IngestRequest(BaseModel):
     """POST body for ``/api/v1/connectors/ingest``.
 
@@ -465,6 +486,43 @@ class IngestRequest(BaseModel):
             _compatibility_pattern_to_specifier(pattern)
             normalized.append(pattern)
         return normalized
+
+    @field_validator("version")
+    @classmethod
+    def _reject_epoch_version(cls, value: str | None) -> str | None:
+        """Reject a ``version`` that is a bare Unix-epoch integer (#2977).
+
+        A connector version is a stable product-line label (``9.0`` /
+        ``2.x`` / ``2026-04``), never a per-run timestamp. The
+        consumer-side probe-then-ingest loop that filed #2977 stamped the
+        probe run's epoch as ``version`` (rendering ``fleet-rest-probe-<epoch>``),
+        so every run produced a fresh ``(product, version, impl_id)``
+        triple — a new catalog row per probe, accumulating without bound
+        because nothing reaps them (the dedup upsert is keyed on that
+        triple, so a changed ``version`` never matches an existing row).
+        Rejecting the epoch shape here — on the one :class:`IngestRequest`
+        both the REST route and the ``meho_connector_ingest`` MCP tool
+        construct through — stops the growth at the source on every
+        surface; the ``0075`` data migration reaps the rows already
+        leaked in.
+
+        ``None`` (the catalog-driven shape, where ``version`` is resolved
+        server-side from the packaged — and therefore never epoch —
+        catalog entry) passes untouched. The ``snake_case`` classifier
+        follows the T11 error-message-shape convention so callers branch
+        without re-parsing the prose.
+        """
+        if value is not None and _version_looks_like_epoch(value):
+            raise ValueError(
+                "connector_version_epoch_rejected: version "
+                f"{value!r} is a Unix-epoch-like integer, not a stable "
+                "connector version (e.g. '9.0', '2.x', '2026-04'). An "
+                "epoch version renders a fresh connector_id on every "
+                "ingest, minting the unbounded '<impl>-probe-<epoch>' "
+                "catalog rows #2977 fixes. Re-ingest under a stable "
+                "product-line version. See docs/codebase/error-message-shape.md."
+            )
+        return value
 
 
 class AffectedSensorModel(BaseModel):

--- a/backend/tests/migrations/test_migration_0075_reap_epoch_versioned_connector_registrations.py
+++ b/backend/tests/migrations/test_migration_0075_reap_epoch_versioned_connector_registrations.py
@@ -1,0 +1,470 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0075_reap_epoch_versioned_connector_registrations``.
+
+Initiative #3020 (G0.40 hardening wave 2), Task #2977. The migration
+reaps ``endpoint_descriptor`` / ``operation_group`` rows whose
+``version`` is a bare Unix-epoch integer (>= 9 digits) — the
+non-idempotent ``fleet-rest-probe-<epoch>`` catalog debris a consumer
+probe-then-ingest loop accumulated one-per-run.
+
+Two properties distinguish it from the ``0049`` / ``0052`` twin-retire
+migrations, and both are pinned here:
+
+* **Tenant-scope-inclusive.** The epoch rows are consumer-side *tenant*
+  ingests, so the cleanup spans every scope — a tenant-scoped epoch row
+  IS reaped (:func:`test_tenant_scoped_epoch_rows_reaped`), the opposite
+  of ``0049`` / ``0052`` which never touch tenant rows.
+* **Keyed on the epoch-version shape, not a product/impl_id list.** A
+  stable-version row survives regardless of impl_id
+  (:func:`test_stable_version_rows_preserved`); a short integer version
+  (< 9 digits) survives (:func:`test_short_integer_version_preserved`);
+  ``endpoint_descriptor`` additionally guards on ``source_kind =
+  'ingested'`` (:func:`test_typed_epoch_descriptor_preserved`).
+
+Revision pin: every test drives the forward pass with
+``command.upgrade(cfg, "0075")`` (this migration's own revision, NOT
+``head``) so future sibling migrations cannot leak into the contract.
+Sync-test constraint identical to
+:mod:`tests.migrations.test_migration_0052_retire_registered_stub_twin_vcf_logs_orphan`:
+``alembic.command`` drives env.py's async cookbook via ``asyncio.run``,
+so the test functions stay sync.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+#: This migration's own revision -- the forward-pass target (NOT ``head``).
+_THIS_REVISION: Final[str] = "0075"
+#: The immediately preceding head this migration revises.
+_DOWN_REVISION: Final[str] = "0074"
+
+#: A representative Unix-epoch-seconds ``version`` (10 digits) -- the
+#: shape the consumer probe-then-ingest loop stamped.
+_EPOCH_VERSION: Final[str] = "1699999999"
+#: A legitimate product-line version -- must always survive.
+_STABLE_VERSION: Final[str] = "9.0"
+
+#: Stable seed timestamp -- lets assertions tell "row untouched" apart.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as
+    :mod:`tests.migrations.test_migration_0052_retire_registered_stub_twin_vcf_logs_orphan`:
+    sync fixture (``alembic.command`` calls ``asyncio.run`` internally),
+    per-test SQLite file under ``tmp_path``, settings + engine caches
+    reset on both sides so the alembic env reads *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0075.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    op_id: str,
+    version: str,
+    source_kind: str = "ingested",
+) -> UUID:
+    """Insert one minimal ``endpoint_descriptor`` row at the migration base.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration runs against. UUID binds use ``.hex`` per
+    ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :op_id,
+                        :source_kind, :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "op_id": op_id,
+                    "source_kind": source_kind,
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _insert_group_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    group_key: str,
+    version: str,
+) -> UUID:
+    """Insert one minimal ``operation_group`` row at the migration base."""
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO operation_group (
+                        id, tenant_id, product, version, impl_id, group_key,
+                        name, when_to_use, review_status, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :group_key,
+                        :name, 'seeded for 0075 reap test', 'enabled', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "group_key": group_key,
+                    "name": group_key.title(),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _row_exists(sync_url: str, table: str, row_id: UUID) -> bool:
+    """Return whether a row with ``row_id`` is still present in ``table``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).scalar_one()
+            return int(count) == 1
+    finally:
+        sync_eng.dispose()
+
+
+def _read_updated_at(sync_url: str, table: str, row_id: UUID) -> str:
+    """Return ``updated_at`` for one row, as a string."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(f"SELECT updated_at FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).one()
+            return str(row.updated_at)
+    finally:
+        sync_eng.dispose()
+
+
+def test_epoch_versioned_ingested_rows_reaped(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A built-in ``fleet-rest-probe-<epoch>`` descriptor + group are reaped.
+
+    The signature #2977 defect: an ingested connector whose ``version``
+    is a Unix epoch. Both row surfaces the dispatch / review layer reads
+    are cleared.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    epoch_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        op_id="GET:/api/probe",
+        version=_EPOCH_VERSION,
+    )
+    epoch_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        group_key="system",
+        version=_EPOCH_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch_descriptor), (
+        "the epoch-versioned descriptor must be reaped"
+    )
+    assert not _row_exists(sync_url, "operation_group", epoch_group), (
+        "the epoch-versioned group must be reaped under the same predicate"
+    )
+
+
+def test_stable_version_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A legitimate stable-version connector survives untouched.
+
+    Same impl_id family as the epoch row, but a real product-line
+    ``version`` (``9.0``) -- proves the reap keys on the epoch shape, not
+    on impl_id or product.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    stable_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest",
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+    stable_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest",
+        group_key="inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    for table, row_id in (
+        ("endpoint_descriptor", stable_descriptor),
+        ("operation_group", stable_group),
+    ):
+        assert _row_exists(sync_url, table, row_id), f"the stable-version {table} row must survive"
+        assert _read_updated_at(sync_url, table, row_id) == _SEED_TS, (
+            f"the surviving {table} row must not be touched"
+        )
+
+
+def test_tenant_scoped_epoch_rows_reaped(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The #2977 sharpening: tenant-scoped epoch rows ARE reaped.
+
+    Unlike ``0049`` / ``0052`` (which never delete a tenant row), the
+    epoch debris is a consumer-side tenant ingest, so the cleanup is
+    tenant-scope-inclusive.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    tenant_id = uuid4()
+    tenant_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        op_id="GET:/api/probe",
+        version=_EPOCH_VERSION,
+    )
+    tenant_group = _insert_group_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        group_key="system",
+        version=_EPOCH_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", tenant_descriptor), (
+        "a tenant-scoped epoch descriptor must be reaped (tenant-inclusive)"
+    )
+    assert not _row_exists(sync_url, "operation_group", tenant_group), (
+        "a tenant-scoped epoch group must be reaped (tenant-inclusive)"
+    )
+
+
+def test_typed_epoch_descriptor_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``source_kind`` guard: a typed descriptor is never reaped.
+
+    Typed / composite connectors are hand-coded and can never carry an
+    epoch version, but the ``source_kind = 'ingested'`` guard makes the
+    ``endpoint_descriptor`` blast radius provably ingest-only even in the
+    impossible case a typed row's version were all-digits.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    typed_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        op_id="GET:/api/probe",
+        version=_EPOCH_VERSION,
+        source_kind="typed",
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", typed_descriptor), (
+        "a typed descriptor must survive the ingested-only reap guard"
+    )
+
+
+def test_short_integer_version_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A short integer version (< 9 digits) is not an epoch and survives.
+
+    A calendar-year-ish bare integer (``2026``) is well below the
+    9-digit epoch floor, so it is left alone -- the threshold does not
+    over-reach onto plausible integer versions.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    short_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="widget",
+        impl_id="widget-rest",
+        op_id="GET:/api/x",
+        version="2026",
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", short_descriptor), (
+        "a sub-9-digit integer version is not an epoch and must survive"
+    )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Replaying ``upgrade()`` on a cleaned DB deletes nothing further.
+
+    Stamp-back replay pinned to this migration's own revision
+    (``stamp("0074") -> upgrade("0075")``), never ``head``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    epoch = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe",
+        op_id="GET:/api/probe",
+        version=_EPOCH_VERSION,
+    )
+    survivor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest",
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch)
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor)
+
+    command.stamp(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch), (
+        "the epoch row stays gone on replay"
+    )
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor), (
+        "the stable survivor must persist across an idempotent replay"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", survivor) == _SEED_TS, (
+        "a no-op replay must not disturb the surviving row"
+    )
+
+
+def test_downgrade_is_a_clean_noop(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade()`` runs without error and touches nothing.
+
+    The reap is one-directional (the debris carried no operator value),
+    so the downgrade is a documented no-op -- a surviving row is
+    unchanged across the up/down cycle.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    survivor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest",
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+    command.downgrade(cfg, _DOWN_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor), (
+        "the no-op downgrade must leave the surviving row in place"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", survivor) == _SEED_TS, (
+        "the no-op downgrade must not disturb the surviving row"
+    )

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -3824,6 +3824,114 @@ paths:
 
 
 # ---------------------------------------------------------------------------
+# #2977 — reject epoch-versioned (non-idempotent probe) registrations
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_request_rejects_epoch_version() -> None:
+    """``IngestRequest`` rejects a bare Unix-epoch ``version`` (#2977).
+
+    The one validator both the REST route and the MCP tool construct
+    through — so the guard fires on every surface. A 10-digit epoch is
+    the signature of the consumer probe-then-ingest loop that minted the
+    unbounded ``fleet-rest-probe-<epoch>`` catalog rows.
+    """
+    from pydantic import ValidationError
+
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    with pytest.raises(ValidationError) as exc_info:
+        IngestRequest(
+            product="fleet",
+            version="1699999999",
+            impl_id="fleet-rest-probe",
+            specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+        )
+    assert "connector_version_epoch_rejected" in str(exc_info.value)
+
+
+def test_ingest_request_accepts_stable_version() -> None:
+    """A legitimate product-line ``version`` passes untouched."""
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    req = IngestRequest(
+        product="fleet",
+        version="9.0",
+        impl_id="fleet-rest",
+        specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+    )
+    assert req.version == "9.0"
+
+
+def test_ingest_request_catalog_shape_unaffected_by_epoch_guard() -> None:
+    """The catalog-driven shape (``version`` unset) is not touched.
+
+    ``version`` is resolved server-side from the packaged catalog after
+    validation, so the epoch guard has nothing to check here.
+    """
+    from meho_backplane.operations.ingest import IngestRequest
+
+    req = IngestRequest(catalog_entry="vmware/9.0")
+    assert req.version is None
+
+
+@pytest.mark.parametrize(
+    ("version", "rejected"),
+    [
+        ("1699999999", True),  # 10-digit epoch seconds
+        ("169999999", True),  # 9-digit — at the floor, still an epoch
+        ("16999999", False),  # 8-digit — below the floor
+        ("2026", False),  # calendar-year-ish short integer
+        ("9.0", False),  # dotted product-line version
+        ("2026-04", False),  # date-style version with a dash
+        ("2.x", False),  # glob-style version
+    ],
+)
+def test_ingest_request_epoch_version_boundary(version: str, rejected: bool) -> None:
+    """Lock the 9-digit epoch floor: >= 9 bare digits rejected, else accepted."""
+    from pydantic import ValidationError
+
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    def _build() -> IngestRequest:
+        return IngestRequest(
+            product="widget",
+            version=version,
+            impl_id="widget-rest",
+            specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+        )
+
+    if rejected:
+        with pytest.raises(ValidationError, match="connector_version_epoch_rejected"):
+            _build()
+    else:
+        assert _build().version == version
+
+
+def test_ingest_returns_422_on_epoch_version(client: TestClient) -> None:
+    """End-to-end: POST with an epoch ``version`` → 422 with the classifier.
+
+    Validation fails at body-parse (before the handler, so no spec is
+    fetched); the ``snake_case`` classifier surfaces in the 422 body.
+    """
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "fleet",
+                "version": "1699999999",
+                "impl_id": "fleet-rest-probe",
+                "specs": [{"uri": "https://specs.test/never-fetched.yaml"}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    assert "connector_version_epoch_rejected" in response.text
+
+
+# ---------------------------------------------------------------------------
 # G0.14-T9 (#1150) — catalog-driven REST ingest shape
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -696,6 +696,33 @@ async def test_inline_uncovered_version_maps_to_invalid_params(
     assert data["version"] == "7.0"
 
 
+async def test_inline_epoch_version_rejected_before_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP ingest tool rejects an epoch ``version`` (#2977).
+
+    The rejection fires in ``_build_ingest_request`` — the same
+    ``IngestRequest`` validator the REST route constructs through — so
+    the MCP surface fails closed identically, before any service work.
+    The dispatcher renders the resulting ``ValidationError`` as a
+    ``-32602`` invalid_params, the same path the closed-set
+    ``auth_scheme`` rejection takes.
+    """
+    from pydantic import ValidationError
+
+    op = build_operator(TenantRole.TENANT_ADMIN)
+    with pytest.raises(ValidationError, match="connector_version_epoch_rejected"):
+        await ci_mod._ingest_handler(
+            op,
+            {
+                "product": "fleet",
+                "version": "1699999999",
+                "impl_id": "fleet-rest-probe",
+                "specs": [{"uri": "docs:fleet/probe.yaml"}],
+            },
+        )
+
+
 async def test_inline_divergent_product_with_handrolled_impl_fails_closed() -> None:
     """The MCP ingest tool rejects a divergent product whose impl_id is hand-coded.
 

--- a/backend/tests/test_operations_ingest_review.py
+++ b/backend/tests/test_operations_ingest_review.py
@@ -311,6 +311,49 @@ async def test_get_review_payload_returns_groups_with_counts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_review_counts_do_not_bleed_across_duplicate_scope_registrations() -> None:
+    """A duplicate ``connector_id`` under two scopes keeps counts isolated (#2977).
+
+    The catalog can legitimately hold the same ``connector_id``
+    (``vmware-rest-9.0``) once per scope — the
+    ``(product, version, impl_id, tenant_id)`` partial-unique split makes
+    builtin+tenant and cross-tenant twins legal by design. The review's
+    ``load_groups`` / ``load_ops_in_groups`` / ``count_ops_in_scope``
+    helpers all key on that same scoped triple, so one scope's review
+    counts only its own rows and never bleeds a twin's operations in.
+
+    (The #2977 report read ``ungrouped_op_count > total_op_count`` as
+    cross-duplicate bleed; that is documented semantics — ``total``
+    counts only rendered-group ops, and ``total + ungrouped`` reconciles
+    to the listing's ``operation_count`` — so this test pins the real
+    scope-isolation invariant the symptom was mistaken for.)
+    """
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    # The same connector_id under two tenants, with different op counts.
+    await _seed_connector(tenant_id=tenant_a, group_count=2, ops_per_group=3)  # 6 ops
+    await _seed_connector(tenant_id=tenant_b, group_count=1, ops_per_group=4)  # 4 ops
+
+    payload_a = await ReviewService(_make_operator(tenant_id=tenant_a)).get_review_payload(
+        "vmware-rest-9.0",
+        tenant_a,
+    )
+    payload_b = await ReviewService(_make_operator(tenant_id=tenant_b)).get_review_payload(
+        "vmware-rest-9.0",
+        tenant_b,
+    )
+
+    # Each scope counts only its own operations — never the 10-op sum a
+    # bleed across the two registrations would produce.
+    assert payload_a.tenant_id == tenant_a
+    assert payload_a.total_op_count == 6
+    assert payload_a.ungrouped_op_count == 0
+    assert payload_b.tenant_id == tenant_b
+    assert payload_b.total_op_count == 4
+    assert payload_b.ungrouped_op_count == 0
+
+
+@pytest.mark.asyncio
 async def test_get_review_payload_raises_when_no_rows() -> None:
     """A connector triple with no rows yields :class:`ConnectorNotFoundError`."""
     tenant_id = uuid.uuid4()

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1211,6 +1211,53 @@ backstop), the boundary 422 in
 and the verb round-trip in
 `tests/test_operations_ingest_catalog.py::test_registered_next_step_verb_round_trips_to_dispatchable_ingest`.
 
+#### Version integrity at the ingest boundary — epoch rejection + reaper (#2977)
+
+A connector `version` is a stable product-line label (`9.0` / `2.x` /
+`2026-04`), never a per-run timestamp. A consumer-side probe-then-ingest
+loop stamped each probe run's Unix epoch as the `version`, so every run
+rendered a fresh `(product, version, impl_id)` triple. The ingest upsert
+dedups on that exact triple (`_upsert.upsert_one_operation`), so a
+changed `version` never matched an existing row — it INSERTed a new
+connector each time, and no reaper exists for `endpoint_descriptor` /
+`operation_group` rows, so the `fleet-rest-probe-<epoch>` catalog rows
+grew without bound (one per probe run).
+
+Two guards close it — the same prevention-plus-cleanup shape the product
+divergence above took:
+
+- **Prevention, at the source.** `IngestRequest._reject_epoch_version`
+  (`ingest/api_schemas.py`) rejects a `version` that is a bare integer of
+  ≥ 9 digits — the epoch shape — with a `422
+  connector_version_epoch_rejected`. It is a field validator on the one
+  `IngestRequest` both the REST route and the `meho_connector_ingest` MCP
+  tool construct through, so every surface fails closed identically (the
+  same all-surfaces posture #1817 took for the product round-trip). The
+  catalog-driven shape (`version` resolved server-side from the
+  packaged — and therefore never epoch — catalog) is unaffected. A
+  9-digit floor catches any Unix epoch (10 digits since 2001) while never
+  matching a real version, which always carries dots / letters / dashes.
+
+- **Cleanup, one-time.** Migration
+  `0075_reap_epoch_versioned_connector_registrations` deletes the
+  epoch-versioned rows that leaked in before the guard, from
+  `endpoint_descriptor` (guarded on `source_kind = 'ingested'`) and
+  `operation_group`. Unlike the `0049` / `0052` twin-retire migrations it
+  is **tenant-scope-inclusive** — the epoch debris is a consumer-side
+  tenant ingest — and keys on the epoch-version shape (dialect-branched:
+  PG POSIX regex, SQLite `length` + `NOT GLOB`), not a product/impl_id
+  allowlist. `downgrade()` is a documented no-op.
+
+Regression coverage:
+`tests/test_api_v1_connectors_ingest.py::test_ingest_request_epoch_version_boundary`
+(plus the REST 422 and schema cases),
+`tests/test_mcp_tools_connector_ingest.py::test_inline_epoch_version_rejected_before_service`,
+`tests/migrations/test_migration_0075_reap_epoch_versioned_connector_registrations.py`,
+and the scope-isolation invariant the "counts bleed across duplicates"
+symptom was mistaken for (documented semantics — `total` counts only
+rendered-group ops) in
+`tests/test_operations_ingest_review.py::test_review_counts_do_not_bleed_across_duplicate_scope_registrations`.
+
 #### Dispatchability postcondition on async jobs (claude-rdc-hetzner-dc#1136)
 
 A background pipeline coroutine that returns without raising is **not**


### PR DESCRIPTION
## Summary

The connector catalog accumulated unbounded `fleet-rest-probe-<epoch>` rows (8→10 in a week on the v0.28.0 consumer deploy). Root cause, per the issue's grounding pass: a consumer probe-then-ingest loop stamped each probe run's **Unix epoch as the connector `version`**, so every run rendered a fresh `(product, version, impl_id)` triple. The ingest upsert dedups on that exact triple, so a changed `version` never matched an existing row — it INSERTed a new connector each run, and **no reaper exists** for `endpoint_descriptor` / `operation_group` rows.

Closed at both ends, mirroring the #1817 product-round-trip guard shape:

- **Prevention (idempotent/deduped registration).** `IngestRequest._reject_epoch_version` rejects a `version` that is a bare ≥9-digit integer (the epoch shape) with `422 connector_version_epoch_rejected`. It is a field validator on the one `IngestRequest` the REST route **and** the `meho_connector_ingest` MCP tool both construct through, so every surface fails closed identically. A legitimate version never matches (they carry dots/letters/dashes); the catalog-driven shape (`version` resolved server-side) is unaffected.
- **Cleanup (GC).** Migration `0075` reaps the epoch-versioned rows already persisted, from `endpoint_descriptor` (guarded on `source_kind='ingested'`) and `operation_group`. **Tenant-scope-inclusive** — the epoch debris is a consumer-side tenant ingest, unlike the `0049`/`0052` builtin-only twin retires. Dialect-branched epoch predicate (PG POSIX regex / SQLite `length`+`NOT GLOB`); `downgrade()` is a documented no-op.
- **Review counts.** The grounding pass established the counts do **not** bleed: `load_groups` / `load_ops_in_groups` / `count_ops_in_scope` share one scoped `(product, version, impl_id, tenant_id)` predicate, and `ungrouped_op_count > total_op_count` is documented design (`total` counts only rendered-group ops; `total + ungrouped == operation_count`). Added a scope-isolation regression test that pins the invariant the "counts bleed" symptom was mistaken for. **The count arithmetic is left untouched** (no phantom-bleed fix).

## Test plan

- [x] `ruff check src/ tests/` + the migration — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` (strict) — clean (the one reported error, `icmp.py:205 MSG_ERRQUEUE`, is a pre-existing darwin-only platform issue outside this diff; Linux CI passes it)
- [x] `python scripts/ci/check_migration_compat.py` — passes (DELETE is DML; no destructive DDL)
- [x] `pytest` targeted (225 passed) + `tests/migrations/` reversibility probe & UUID drift guard + ingest-adjacent (515 passed)

Acceptance criteria (Initiative #3020 DoD for #2977):

- [x] **Probe rows reaped/reused** — migration `0075` reaps them; `tests/migrations/test_migration_0075_*` (7 cases: builtin + tenant reap, stable/short-integer/typed preservation, idempotent replay, no-op downgrade).
- [x] **Registration idempotent/deduped on the correct key** — epoch versions (the non-idempotent key) rejected at ingest; `test_ingest_request_epoch_version_boundary`, `test_ingest_returns_422_on_epoch_version`, `test_inline_epoch_version_rejected_before_service`. Stable-version re-ingest stays idempotent (existing upsert unchanged).
- [x] **Review counts accurate per connector, no cross-duplicate bleed** — `test_review_counts_do_not_bleed_across_duplicate_scope_registrations` proves scope isolation.
- [x] `docs/codebase/spec-ingestion.md` updated (new "Version integrity at the ingest boundary" subsection).

## Out of scope

- **Product-spelling / builtin+tenant twins + DELETE-reachability.** The grounding pass notes the surviving `sddc`/`sddc-manager` twins are tenant-scoped legacy rows unreachable by the DELETE route (`delete_connector.py` filters on the parse-derived product). These are **bounded and non-recurring** (#1817 blocks new spelled twins), a distinct class from the recurring epoch rows this task targets. Deferred as a follow-up per the "minimal & scoped" directive — worth a separate ticket for the DELETE-route product-reachability fix + a tenant-inclusive twin cleanup.
- Sibling #2973 (vmware `vm.migrate` composite) touches the op-dispatch layer, not the catalog/registry — no overlap.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2977
