### PR TITLE
feat(connectors): k8s connector supports vSphere Supervisor (WCP) SSO targets (#2905)

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/__init__.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/__init__.py
@@ -40,12 +40,23 @@ from meho_backplane.connectors.kubernetes.connector import (
     product_from_git_version,
 )
 from meho_backplane.connectors.kubernetes.kubeconfig import (
+    CredentialLoader,
+    KubeconfigCredential,
     KubeconfigLoader,
+    KubernetesCredential,
     KubernetesTargetLike,
+    WcpSsoCredential,
     load_kubeconfig_from_vault,
+    load_kubernetes_credential,
     parse_kubeconfig_yaml,
 )
 from meho_backplane.connectors.kubernetes.ops import KUBERNETES_OPS, KubernetesOp
+from meho_backplane.connectors.kubernetes.wcp import (
+    WcpLoginError,
+    WcpToken,
+    build_wcp_api_configuration,
+    wcp_login,
+)
 from meho_backplane.connectors.registry import (
     register_connector,
     register_connector_v2,
@@ -88,14 +99,23 @@ async def register_kubernetes_typed_operations(
 
 __all__ = [
     "KUBERNETES_OPS",
+    "CredentialLoader",
+    "KubeconfigCredential",
     "KubeconfigLoader",
     "KubernetesConnector",
+    "KubernetesCredential",
     "KubernetesOp",
     "KubernetesTargetLike",
+    "WcpLoginError",
+    "WcpSsoCredential",
+    "WcpToken",
+    "build_wcp_api_configuration",
     "load_kubeconfig_from_vault",
+    "load_kubernetes_credential",
     "parse_kubeconfig_yaml",
     "product_from_git_version",
     "register_kubernetes_typed_operations",
+    "wcp_login",
 ]
 
 # v1 entry -- retained for ``get_connector("k8s")`` callers (the

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -69,9 +69,13 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.kubernetes.kubeconfig import (
+    CredentialLoader,
+    KubeconfigCredential,
     KubeconfigLoader,
+    KubernetesCredential,
     KubernetesTargetLike,
-    load_kubeconfig_from_vault,
+    WcpSsoCredential,
+    load_kubernetes_credential,
 )
 from meho_backplane.connectors.kubernetes.ops import KUBERNETES_OPS
 from meho_backplane.connectors.kubernetes.ops_core import (
@@ -80,6 +84,7 @@ from meho_backplane.connectors.kubernetes.ops_core import (
     namespace_row,
     node_row,
 )
+from meho_backplane.connectors.kubernetes.wcp import build_wcp_api_configuration
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
@@ -279,6 +284,22 @@ def product_from_git_version(git_version: str) -> str:
     return "vanilla"
 
 
+def _adapt_kubeconfig_loader(loader: KubeconfigLoader) -> CredentialLoader:
+    """Adapt a legacy kubeconfig-dict loader onto the credential-loader contract.
+
+    Preserves the ``kubeconfig_loader=`` injection every existing test
+    uses: the dict the loader returns is wrapped in a
+    :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubeconfigCredential`,
+    so the static path is byte-identical and only vSphere Supervisor
+    (WCP) targets ever take the new SSO branch.
+    """
+
+    async def _wrapped(target: KubernetesTargetLike, operator: Operator) -> KubernetesCredential:
+        return KubeconfigCredential(await loader(target, operator))
+
+    return _wrapped
+
+
 class KubernetesConnector(Connector):
     """Kubernetes connector -- reads kubeconfig per target, caches the client."""
 
@@ -302,10 +323,30 @@ class KubernetesConnector(Connector):
         self,
         *,
         kubeconfig_loader: KubeconfigLoader | None = None,
+        credential_loader: CredentialLoader | None = None,
     ) -> None:
-        self._kubeconfig_loader: KubeconfigLoader = (
-            kubeconfig_loader if kubeconfig_loader is not None else load_kubeconfig_from_vault
-        )
+        """Wire the credential seam.
+
+        ``credential_loader`` (new) resolves a target to a discriminated
+        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubernetesCredential`
+        — a static kubeconfig or a vSphere Supervisor (WCP) SSO pair —
+        and defaults to
+        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubernetes_credential`.
+        ``kubeconfig_loader`` is the legacy kubeconfig-dict seam kept for
+        the existing test injections; its dict result is adapted onto the
+        credential contract as a
+        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubeconfigCredential`,
+        so the static path stays byte-identical and only WCP targets take
+        the new branch. Passing both is a wiring error.
+        """
+        if kubeconfig_loader is not None and credential_loader is not None:
+            raise ValueError("pass at most one of kubeconfig_loader / credential_loader")
+        if credential_loader is not None:
+            self._credential_loader: CredentialLoader = credential_loader
+        elif kubeconfig_loader is not None:
+            self._credential_loader = _adapt_kubeconfig_loader(kubeconfig_loader)
+        else:
+            self._credential_loader = load_kubernetes_credential
         self._api_clients: dict[str, client.ApiClient] = {}
         # Parallel cache of websocket-transport clients, keyed the same
         # way as ``_api_clients`` (``secret_ref``). Only ``k8s.exec``
@@ -347,7 +388,7 @@ class KubernetesConnector(Connector):
 
         G0.16-T4 (#1306) converged this path with the dispatch surface
         — both now flow the operator through the same
-        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
+        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubernetes_credential`
         helper. See :doc:`docs/codebase/connectors-kubernetes.md`.
         """
         eff_operator = operator if operator is not None else synthesise_system_operator()
@@ -1717,36 +1758,46 @@ class KubernetesConnector(Connector):
         """Resolve (and cache) the :class:`ApiClient` for *target*.
 
         The single lock serialises concurrent first-use for any target;
-        in practice the second caller hits the cache fast-path. The
-        slow kubeconfig read happens under the lock so two concurrent
-        callers for the same target don't both pay the cost.
+        in practice the second caller hits the cache fast-path. The slow
+        credential read + client build happens under the lock so two
+        concurrent callers for the same target don't both pay the cost.
 
         ``operator`` is forwarded to the injected
-        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubeconfigLoader`
+        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.CredentialLoader`
         so the default
-        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
-        can read the per-target kubeconfig under the operator's identity
-        (``vault_client_for_operator(operator)``). An injected test
-        loader receives the same ``(target, operator)`` pair so the
-        wiring is exercised by both the default and the injected path.
+        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubernetes_credential`
+        reads the per-target secret under the operator's identity
+        (``vault_client_for_operator(operator)``) and discriminates a
+        static kubeconfig from a vSphere Supervisor (WCP) SSO pair. An
+        injected test loader receives the same ``(target, operator)``
+        pair so the wiring is exercised by both the default and the
+        injected path.
 
         Cache-hit fast path: when the :class:`ApiClient` is already
         cached for this target's :meth:`_cache_key`, the operator
-        argument is ignored (the kubeconfig has already been resolved
+        argument is ignored (the credential has already been resolved
         under a prior operator's identity). This is the v0.2 design
-        choice: kubeconfigs are tied to ``target.secret_ref`` (the
-        shared service account) rather than the acting operator, so the
-        client is shareable across operators. A future per-operator
-        auth model (impersonation) would re-key the cache on operator
-        identity; until then ``secret_ref`` is sufficient.
+        choice: credentials are tied to ``target.secret_ref`` (the shared
+        service account) rather than the acting operator, so the client
+        is shareable across operators. For a WCP target the cached
+        client's short-lived Supervisor token refreshes transparently via
+        the :class:`Configuration`'s ``refresh_api_key_hook`` — the client
+        object stays cached, only its bearer rotates. A future
+        per-operator auth model (impersonation) would re-key the cache on
+        operator identity; until then ``secret_ref`` is sufficient.
         """
         key = self._cache_key(target)
         async with self._lock:
             cached = self._api_clients.get(key)
             if cached is not None:
                 return cached
-            kubeconfig_dict = await self._kubeconfig_loader(target, operator)
-            api_client = await config.new_client_from_config_dict(kubeconfig_dict)
+            credential = await self._credential_loader(target, operator)
+            if isinstance(credential, WcpSsoCredential):
+                api_client = client.ApiClient(
+                    configuration=await self._wcp_configuration(target, credential)
+                )
+            else:
+                api_client = await config.new_client_from_config_dict(credential.config)
             self._api_clients[key] = api_client
             _log.info(
                 "kubernetes_api_client_built",
@@ -1754,6 +1805,34 @@ class KubernetesConnector(Connector):
                 host=target.host,
             )
             return api_client
+
+    async def _wcp_configuration(
+        self,
+        target: KubernetesTargetLike,
+        credential: WcpSsoCredential,
+    ) -> client.Configuration:
+        """Build a self-refreshing :class:`Configuration` for a WCP Supervisor.
+
+        Delegates to
+        :func:`~meho_backplane.connectors.kubernetes.wcp.build_wcp_api_configuration`,
+        which performs the ``/wcp/login`` SSO exchange, takes the
+        Supervisor CA from the response, dials the operator-reachable
+        ``target.host`` (never the internal-VIP ``server`` the login
+        returns), and installs the token-refresh hook. The TLS knobs are
+        read defensively (``verify_tls`` defaults on, ``tls_ca_pin`` is
+        optional) so the narrow :class:`KubernetesTargetLike` Protocol
+        stays unchanged while the concrete ``Target`` model's fields are
+        honoured.
+        """
+        port = target.port if target.port is not None else _DEFAULT_K8S_PORT
+        return await build_wcp_api_configuration(
+            host=target.host,
+            api_port=port,
+            username=credential.username,
+            password=credential.password,
+            verify_tls=bool(getattr(target, "verify_tls", True)),
+            ca_pem=getattr(target, "tls_ca_pin", None),
+        )
 
     async def _get_ws_api_client(
         self,
@@ -1764,7 +1843,7 @@ class KubernetesConnector(Connector):
 
         Mirrors :meth:`_get_api_client` exactly -- same lock, same
         :meth:`_cache_key` (``secret_ref``), same operator-identity
-        kubeconfig load -- but builds a
+        credential load -- but builds a
         :class:`~kubernetes_asyncio.stream.WsApiClient` instead of an
         ordinary :class:`~kubernetes_asyncio.client.ApiClient`. The ws
         client is the only transport that can speak the
@@ -1772,14 +1851,17 @@ class KubernetesConnector(Connector):
         (only ``k8s.exec`` touches it) so read-only targets never pay
         for a second client.
 
-        The kubeconfig is loaded the same way
-        :func:`~kubernetes_asyncio.config.new_client_from_config_dict`
+        For a static-kubeconfig target the kubeconfig is loaded the same
+        way :func:`~kubernetes_asyncio.config.new_client_from_config_dict`
         does -- a fresh :class:`~kubernetes_asyncio.client.Configuration`
         populated by
         :func:`~kubernetes_asyncio.config.load_kube_config_from_dict` --
-        then handed to the ``WsApiClient`` constructor. Separate
-        ``Configuration`` instances keep the REST and ws clients from
-        sharing mutable auth state.
+        then handed to the ``WsApiClient`` constructor. A vSphere
+        Supervisor (WCP) target instead gets the self-refreshing
+        :class:`Configuration` from :meth:`_wcp_configuration`, so exec
+        over a Supervisor rides the same token-refresh hook the read path
+        uses. Separate ``Configuration`` instances keep the REST and ws
+        clients from sharing mutable auth state.
         """
         # Local import: pulled only on the exec path so the read-only
         # ops don't drag the stream sub-package into every import.
@@ -1791,12 +1873,15 @@ class KubernetesConnector(Connector):
             cached = self._ws_api_clients.get(key)
             if cached is not None:
                 return cached
-            kubeconfig_dict = await self._kubeconfig_loader(target, operator)
-            ws_config = type.__call__(Configuration)
-            await load_kube_config_from_dict(
-                config_dict=kubeconfig_dict,
-                client_configuration=ws_config,
-            )
+            credential = await self._credential_loader(target, operator)
+            if isinstance(credential, WcpSsoCredential):
+                ws_config = await self._wcp_configuration(target, credential)
+            else:
+                ws_config = type.__call__(Configuration)
+                await load_kube_config_from_dict(
+                    config_dict=credential.config,
+                    client_configuration=ws_config,
+                )
             ws_client = WsApiClient(configuration=ws_config)
             self._ws_api_clients[key] = ws_client
             _log.info(

--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
@@ -66,6 +66,7 @@ durable artifact.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, Protocol, cast, runtime_checkable
 
 import structlog
@@ -81,9 +82,16 @@ from meho_backplane.connectors._shared.vault_creds import (
 __all__ = [
     "DEFAULT_KUBECONFIG_FIELD",
     "DEFAULT_KUBECONFIG_KV_MOUNT",
+    "WCP_PASSWORD_FIELD",
+    "WCP_USERNAME_FIELD",
+    "CredentialLoader",
+    "KubeconfigCredential",
     "KubeconfigLoader",
+    "KubernetesCredential",
     "KubernetesTargetLike",
+    "WcpSsoCredential",
     "load_kubeconfig_from_vault",
+    "load_kubernetes_credential",
     "parse_kubeconfig_yaml",
 ]
 
@@ -98,6 +106,15 @@ DEFAULT_KUBECONFIG_KV_MOUNT: str = "secret"
 #: operator stores the kubeconfig at ``<secret_ref>`` with this single
 #: field; the loader reads exactly this key.
 DEFAULT_KUBECONFIG_FIELD: str = "kubeconfig"
+
+#: KV-v2 field names a vSphere Supervisor (WCP) target's secret carries
+#: instead of ``kubeconfig``: the vSphere SSO ``{username, password}`` the
+#: connector performs the ``/wcp/login`` exchange with. The username is
+#: the fully-qualified SSO principal (e.g. ``administrator@vsphere.local``
+#: or a scoped read-only namespace user), so no separate realm field is
+#: needed.
+WCP_USERNAME_FIELD: str = "username"
+WCP_PASSWORD_FIELD: str = "password"
 
 
 @runtime_checkable
@@ -135,6 +152,52 @@ reads the per-target secret under the operator's identity via
 :doc:`docs/architecture/connector-auth.md`. An injected test loader
 receives the same ``(target, operator)`` pair so the wiring is
 exercised by both the default and the injected path.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class KubeconfigCredential:
+    """A resolved static kubeconfig — the durable-credential k8s target path.
+
+    ``config`` is the parsed kubeconfig in the dict shape
+    ``kubernetes_asyncio.config.new_client_from_config_dict`` /
+    ``load_kube_config_from_dict`` accept.
+    """
+
+    config: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class WcpSsoCredential:
+    """Resolved vSphere SSO ``{username, password}`` for a WCP Supervisor.
+
+    A vSphere Supervisor issues no static/durable credential; the
+    connector holds this SSO pair and performs the ``/wcp/login`` token
+    exchange (mint -> cache -> refresh) itself. See
+    :mod:`meho_backplane.connectors.kubernetes.wcp`.
+    """
+
+    username: str
+    password: str
+
+
+#: Discriminated credential the connector resolves per target. The
+#: variant selects the client-build path: a static kubeconfig
+#: (:class:`KubeconfigCredential`) or the WCP SSO token exchange
+#: (:class:`WcpSsoCredential`).
+KubernetesCredential = KubeconfigCredential | WcpSsoCredential
+
+
+CredentialLoader = Callable[[KubernetesTargetLike, Operator], Awaitable[KubernetesCredential]]
+"""Async callable resolving a (target, operator) pair to a discriminated credential.
+
+The connector's credential seam. Production passes
+:func:`load_kubernetes_credential` (payload-shape discrimination over the
+operator-context Vault read); tests inject a callable returning a
+pre-built :class:`KubernetesCredential`. The legacy
+:data:`KubeconfigLoader` injection is adapted onto this contract by the
+connector (its dict result is wrapped in a :class:`KubeconfigCredential`),
+so existing kubeconfig-only injections keep working unchanged.
 """
 
 
@@ -185,6 +248,29 @@ def _extract_kubeconfig_text(
             "expected a YAML string"
         )
     return kubeconfig_text
+
+
+def _require_str_field(
+    secret_data: dict[str, object],
+    field: str,
+    *,
+    target_name: str,
+    secret_ref: str,
+) -> str:
+    """Extract a required non-empty string field, whitespace-stripped.
+
+    Missing / wrong-type / blank all raise
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    naming the target + field — never a bare ``KeyError`` and never
+    echoing the value.
+    """
+    value = secret_data.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise VaultCredentialsReadError(
+            f"vault secret for target {target_name!r} (secret_ref={secret_ref!r}) "
+            f"has field {field!r} that is empty or not a string"
+        )
+    return value.strip()
 
 
 async def load_kubeconfig_from_vault(
@@ -299,3 +385,85 @@ async def load_kubeconfig_from_vault(
     )
 
     return parse_kubeconfig_yaml(kubeconfig_text)
+
+
+async def load_kubernetes_credential(
+    target: KubernetesTargetLike,
+    operator: Operator,
+    *,
+    mount: str = DEFAULT_KUBECONFIG_KV_MOUNT,
+) -> KubernetesCredential:
+    """Resolve a target's credential, discriminating kubeconfig vs WCP SSO.
+
+    Reads ``target.secret_ref`` **once** through the shared
+    backend-dispatch seam
+    (:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`)
+    and routes on the payload's field shape — the same
+    credential-protocol discrimination the GitHub connector uses for its
+    App-vs-PAT split (``connectors/github/session.py``), rather than
+    overloading the target's ``auth_model`` (which is the *identity*
+    model — ``shared_service_account`` etc. — not a credential protocol):
+
+    * a ``kubeconfig`` field -> :class:`KubeconfigCredential` (the static
+      durable-credential path, checked **first** so an existing
+      kubeconfig secret is never re-interpreted);
+    * else ``username`` + ``password`` fields ->
+      :class:`WcpSsoCredential` (the vSphere Supervisor / WCP
+      token-exchange path,
+      :mod:`~meho_backplane.connectors.kubernetes.wcp`);
+    * neither ->
+      :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`.
+
+    A vSphere Supervisor target thus differs from a normal k8s target
+    only in the shape of the credential its ``secret_ref`` holds; it
+    still fingerprints as ``product="k8s"`` and needs no target-schema
+    change (the connector's resolution / target model are untouched).
+
+    The rubric **State 2** wiring (`shared_service_account`) and the
+    operator-context read identity are inherited verbatim from
+    :func:`load_vault_secret_data`; see
+    :doc:`docs/architecture/connector-auth.md`.
+    """
+    secret_data = await load_vault_secret_data(
+        cast(BasicCredentialsTargetLike, target), operator, mount=mount
+    )
+
+    if DEFAULT_KUBECONFIG_FIELD in secret_data:
+        kubeconfig_text = _extract_kubeconfig_text(
+            secret_data,
+            target_name=target.name,
+            secret_ref=target.secret_ref,
+            field=DEFAULT_KUBECONFIG_FIELD,
+        )
+        # Non-secret attribution only — never the kubeconfig content.
+        structlog.get_logger(__name__).info(
+            "kubernetes_credential_resolved",
+            target=target.name,
+            host=target.host,
+            secret_ref=target.secret_ref,
+            mode="kubeconfig",
+        )
+        return KubeconfigCredential(parse_kubeconfig_yaml(kubeconfig_text))
+
+    if WCP_USERNAME_FIELD in secret_data and WCP_PASSWORD_FIELD in secret_data:
+        username = _require_str_field(
+            secret_data, WCP_USERNAME_FIELD, target_name=target.name, secret_ref=target.secret_ref
+        )
+        password = _require_str_field(
+            secret_data, WCP_PASSWORD_FIELD, target_name=target.name, secret_ref=target.secret_ref
+        )
+        # Non-secret attribution only — never the SSO username/password.
+        structlog.get_logger(__name__).info(
+            "kubernetes_credential_resolved",
+            target=target.name,
+            host=target.host,
+            secret_ref=target.secret_ref,
+            mode="vsphere-supervisor",
+        )
+        return WcpSsoCredential(username=username, password=password)
+
+    raise VaultCredentialsReadError(
+        f"vault secret for target {target.name!r} (secret_ref={target.secret_ref!r}) "
+        f"carries neither a {DEFAULT_KUBECONFIG_FIELD!r} field (static kubeconfig) nor "
+        f"{WCP_USERNAME_FIELD!r}+{WCP_PASSWORD_FIELD!r} fields (vSphere Supervisor SSO)"
+    )

--- a/backend/src/meho_backplane/connectors/kubernetes/wcp.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/wcp.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vSphere Supervisor (WCP) SSO auth mode for the Kubernetes connector.
+
+A vSphere Supervisor (the WCP "Supervisor cluster" fronting a vSphere
+workload domain) is a real Kubernetes cluster, but it **cannot mint a
+static/durable credential**: WCP owns the cluster RBAC and even
+``administrator@vsphere.local`` is not cluster-admin, so the read-only
+ServiceAccount + non-expiring-token approach a normal appliance cluster
+allows is unavailable. The only credential a Supervisor issues is the
+**short-lived vSphere-SSO token** returned by the ``POST /wcp/login``
+exchange (it expires with the SSO session). The static-kubeconfig path
+in :mod:`~meho_backplane.connectors.kubernetes.kubeconfig` cannot consume
+that durably.
+
+This module is the connector-held equivalent of what ``kubectl vsphere
+login`` / ``kubelogin`` do: the connector holds the vSphere SSO
+``{username, password}`` and performs the login exchange itself to
+**mint -> cache -> refresh** the Supervisor bearer token transparently.
+
+Key mechanism — ``kubernetes_asyncio`` token refresh
+====================================================
+
+``kubernetes_asyncio.client.Configuration`` exposes an async-capable
+``refresh_api_key_hook``: :meth:`Configuration.get_api_key_with_prefix`
+awaits it before reading ``api_key["BearerToken"]`` on **every** request.
+We attach a hook that re-mints the Supervisor token once the cached one
+is inside a refresh margin of its expiry, so the cached
+:class:`~kubernetes_asyncio.client.ApiClient` keeps working across the
+token's lifetime with no per-op login round-trip. This is the seam the
+static kubeconfig path lacks (its token never refreshes), which is the
+exact gap that blocked registering a Supervisor as a ``k8s-1.x`` target.
+
+Two field-note behaviours this module honours
+=============================================
+
+* **Internal-VIP redirect avoidance.** The ``/wcp/login`` response
+  carries a ``kube_config`` whose ``server`` is the Supervisor's *raw
+  internal VIP* — unreachable when the Supervisor is dialed over a NAT'd
+  alias (a lab / operator-VPN norm). We take the CA from that
+  ``kube_config`` but **override the host to the operator-reachable
+  ``target.host``** (the top-level Supervisor kube-API context) and never
+  follow the internal-VIP workload-session redirects. Because we
+  deliberately dial the reachable alias rather than the cert's VIP SAN,
+  hostname assertion is disabled while the Supervisor CA chain stays
+  verified.
+* **Least privilege.** The SSO super-admin works but the recommended
+  long-term credential is a scoped read-only vSphere SSO user granted a
+  read-only vSphere-Namespace role. This module is credential-agnostic —
+  it uses whatever SSO ``{username, password}`` the target's secret
+  stages; the scoping is an operator-side choice.
+
+TLS trust bootstrap
+===================
+
+The login POST needs a trust anchor *before* the CA-bearing
+``kube_config`` exists, so its TLS follows the target's knobs exactly
+like the shared HTTP transport (``adapters/http.py``): a
+``tls_ca_pin`` (the Supervisor CA, staged out-of-band) is verified
+against; otherwise ``verify_tls`` toggles system-CA verification on/off.
+A self-signed Supervisor therefore needs either the CA pinned on the
+target (recommended) or ``verify_tls=false`` (lab) — the same trust
+bootstrap ``kubectl vsphere login`` needs a thumbprint or
+``--insecure-skip-tls-verify`` for.
+
+No secret material is ever logged: structlog events carry host / port /
+mode only, never the SSO credentials or the minted token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+import ssl
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import structlog
+import yaml
+from kubernetes_asyncio.client.configuration import Configuration
+from kubernetes_asyncio.config import load_kube_config_from_dict
+
+__all__ = [
+    "DEFAULT_WCP_LOGIN_TIMEOUT_SECONDS",
+    "DEFAULT_WCP_TOKEN_TTL_SECONDS",
+    "WCP_LOGIN_PATH",
+    "WCP_LOGIN_PORT",
+    "WCP_TOKEN_REFRESH_MARGIN_SECONDS",
+    "WcpLoginError",
+    "WcpToken",
+    "build_wcp_api_configuration",
+    "wcp_login",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The Supervisor auth endpoint. WCP serves the SSO token exchange on the
+#: control-plane HTTPS front (port 443), distinct from the Kubernetes API
+#: server on 6443 that the returned kubeconfig points at.
+WCP_LOGIN_PATH: str = "/wcp/login"
+
+#: Port the ``/wcp/login`` exchange listens on. The Supervisor front-end
+#: (auth + downloads UI) is on 443; the Kubernetes API server the minted
+#: token authenticates to is a separate port (``target.port``, default
+#: 6443). A non-default login port is a documented refinement (extras
+#: override) if a NAT alias remaps it — the standard WCP port is 443.
+WCP_LOGIN_PORT: int = 443
+
+#: httpx timeout for the login POST.
+DEFAULT_WCP_LOGIN_TIMEOUT_SECONDS: float = 15.0
+
+#: Fallback token lifetime when the minted token is not a decodable JWT
+#: (so no ``exp`` claim is readable). Deliberately short: a Supervisor
+#: SSO token is normally a JWT and its real ``exp`` drives refresh, so
+#: this fallback rarely triggers; keeping it short bounds how long a
+#: silently-shorter-than-assumed SSO session could serve a stale token.
+DEFAULT_WCP_TOKEN_TTL_SECONDS: float = 600.0
+
+#: Re-mint this many seconds before the token's stamped expiry, absorbing
+#: clock skew and in-flight request latency.
+WCP_TOKEN_REFRESH_MARGIN_SECONDS: float = 60.0
+
+
+class WcpLoginError(RuntimeError):
+    """The ``/wcp/login`` SSO exchange failed or returned an unusable body.
+
+    Raised on a non-200 status, a body missing ``session_id`` /
+    ``kube_config``, or a ``kube_config`` that does not parse to a
+    mapping. The message never echoes the SSO credentials or the response
+    body (which carries the token).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class WcpToken:
+    """A minted Supervisor bearer token plus its monotonic expiry.
+
+    ``expires_at_monotonic`` is stamped against :func:`time.monotonic`
+    (not wall-clock) so a system clock jump cannot make a live token look
+    expired or vice versa — the same discipline the GitHub App
+    installation-token cache uses.
+    """
+
+    token: str
+    expires_at_monotonic: float
+
+
+def _apply_bearer(configuration: Configuration, token: WcpToken) -> None:
+    """Write *token* as ``api_key['BearerToken']`` on *configuration*.
+
+    ``load_kube_config_from_dict`` bakes the ``"Bearer "`` prefix into the
+    api_key value with an empty ``api_key_prefix``; match that shape so
+    the ``authorization`` header renders identically whether the bearer
+    came from a kubeconfig or from a WCP re-mint.
+    """
+    configuration.api_key["BearerToken"] = f"Bearer {token.token}"
+
+
+class _WcpTokenRefresher:
+    """Async ``refresh_api_key_hook`` that re-mints the Supervisor token.
+
+    Holds the login parameters and the current token behind a
+    single-flight lock. ``kubernetes_asyncio`` calls (and awaits) the hook
+    before every request; it re-mints only once the cached token is inside
+    :data:`WCP_TOKEN_REFRESH_MARGIN_SECONDS` of expiry, writing the fresh
+    bearer straight into the live :class:`Configuration` so the cached
+    client keeps working with no rebuild.
+    """
+
+    def __init__(self, host: str, initial: WcpToken, **login_kwargs: Any) -> None:
+        self._host = host
+        self._login_kwargs = login_kwargs
+        self._token = initial
+        self._lock = asyncio.Lock()
+
+    @property
+    def token(self) -> WcpToken:
+        return self._token
+
+    def _fresh_enough(self) -> bool:
+        margin = WCP_TOKEN_REFRESH_MARGIN_SECONDS
+        return time.monotonic() < self._token.expires_at_monotonic - margin
+
+    async def __call__(self, configuration: Configuration) -> None:
+        if self._fresh_enough():
+            return
+        async with self._lock:
+            # Re-check under the lock: a single-flight winner may already
+            # have re-minted while this coroutine waited.
+            if self._fresh_enough():
+                return
+            self._token, _ = await wcp_login(self._host, **self._login_kwargs)
+            _apply_bearer(configuration, self._token)
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """Decode a base64url JWT segment, restoring stripped ``=`` padding."""
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _jwt_exp(token: str) -> float | None:
+    """Best-effort read of a JWT ``exp`` claim — no signature verification.
+
+    The Supervisor token is our own credential; we decode its ``exp``
+    purely to schedule proactive refresh, never for an auth decision, so
+    an unverified read is sound (the same pattern client-go's exec
+    plugins use). Returns ``None`` for any non-JWT / unreadable token so
+    the caller falls back to :data:`DEFAULT_WCP_TOKEN_TTL_SECONDS`.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        payload = json.loads(_b64url_decode(parts[1]))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    exp = payload.get("exp") if isinstance(payload, dict) else None
+    if isinstance(exp, (int, float)) and not isinstance(exp, bool):
+        return float(exp)
+    return None
+
+
+def _token_expiry_monotonic(token: str, *, now_wall: float, now_monotonic: float) -> float:
+    """Map a token's wall-clock ``exp`` onto the monotonic clock.
+
+    Prefers the JWT ``exp`` claim (accurate to the SSO session's real
+    lifetime); falls back to a short fixed TTL when the token carries no
+    readable ``exp``. The refresh margin is applied by the consumer at
+    check time, not baked in here.
+    """
+    exp_wall = _jwt_exp(token)
+    if exp_wall is not None:
+        remaining = exp_wall - now_wall
+        if remaining > 0:
+            return now_monotonic + remaining
+    return now_monotonic + DEFAULT_WCP_TOKEN_TTL_SECONDS
+
+
+def _login_tls(verify_tls: bool, ca_pem: str | None) -> ssl.SSLContext | bool:
+    """TLS setting for the login POST — ``tls_ca_pin`` wins, else ``verify_tls``.
+
+    Mirrors the shared HTTP transport's precedence
+    (``adapters/http.py``): a pinned CA is verified against with hostname
+    checking on; otherwise ``verify_tls`` toggles default system-CA
+    verification. Returned as an :class:`ssl.SSLContext` (pinned CA) or a
+    ``bool`` — both accepted by ``httpx``'s ``verify=``.
+    """
+    if ca_pem:
+        ctx = ssl.create_default_context(cadata=ca_pem)
+        return ctx
+    return verify_tls
+
+
+def _coerce_kube_config(raw: object) -> dict[str, Any]:
+    """Normalise the response ``kube_config`` (YAML string or mapping) to a dict."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            raise WcpLoginError(f"/wcp/login kube_config failed to parse as YAML: {exc}") from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise WcpLoginError(
+        f"/wcp/login response kube_config is not a kubeconfig mapping (got {type(raw).__name__})"
+    )
+
+
+async def wcp_login(
+    host: str,
+    *,
+    username: str,
+    password: str,
+    verify_tls: bool,
+    ca_pem: str | None,
+    login_port: int = WCP_LOGIN_PORT,
+    timeout: float = DEFAULT_WCP_LOGIN_TIMEOUT_SECONDS,
+    now_wall: float | None = None,
+    now_monotonic: float | None = None,
+) -> tuple[WcpToken, dict[str, Any]]:
+    """Perform the ``POST /wcp/login`` SSO exchange for the Supervisor.
+
+    Sends HTTP Basic ``{username, password}`` (the vSphere SSO
+    credential) to ``https://{host}:{login_port}/wcp/login`` — no body,
+    which selects the **top-level Supervisor context** (a
+    ``guest_cluster_*`` body would select a per-workload sub-session, the
+    internal-VIP redirect the field note says to avoid). Returns the
+    minted :class:`WcpToken` (expiry stamped from the JWT ``exp`` when
+    present) and the response ``kube_config`` mapping (the source of the
+    Supervisor CA the caller builds TLS trust from).
+    """
+    verify = _login_tls(verify_tls, ca_pem)
+    url = f"https://{host}:{login_port}{WCP_LOGIN_PATH}"
+    try:
+        async with httpx.AsyncClient(verify=verify, timeout=timeout) as http:
+            resp = await http.post(
+                url,
+                auth=(username, password),
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+            )
+    except (httpx.HTTPError, ssl.SSLError, OSError) as exc:
+        raise WcpLoginError(
+            f"/wcp/login exchange to {host!r} failed: {type(exc).__name__}"
+        ) from exc
+
+    if resp.status_code != 200:
+        raise WcpLoginError(
+            f"/wcp/login exchange to {host!r} returned HTTP {resp.status_code} "
+            "(check the SSO credential and that the target is a vSphere Supervisor)"
+        )
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise WcpLoginError(f"/wcp/login response from {host!r} was not JSON") from exc
+    session_id = body.get("session_id") if isinstance(body, dict) else None
+    if not isinstance(session_id, str) or not session_id:
+        raise WcpLoginError(f"/wcp/login response from {host!r} carried no session_id")
+    kube_config = _coerce_kube_config(body.get("kube_config"))
+
+    wall = now_wall if now_wall is not None else time.time()
+    mono = now_monotonic if now_monotonic is not None else time.monotonic()
+    token = WcpToken(
+        token=session_id,
+        expires_at_monotonic=_token_expiry_monotonic(session_id, now_wall=wall, now_monotonic=mono),
+    )
+    _log.info("wcp_login_minted", host=host, login_port=login_port)
+    return token, kube_config
+
+
+async def build_wcp_api_configuration(
+    *,
+    host: str,
+    api_port: int,
+    username: str,
+    password: str,
+    verify_tls: bool,
+    ca_pem: str | None,
+    login_port: int = WCP_LOGIN_PORT,
+    timeout: float = DEFAULT_WCP_LOGIN_TIMEOUT_SECONDS,
+) -> Configuration:
+    """Build a Supervisor-authenticated ``Configuration`` with self-refresh.
+
+    Performs the initial :func:`wcp_login`, takes the Supervisor CA from
+    the returned ``kube_config``, then **overrides the host to the
+    operator-reachable ``host:api_port``** (never the internal-VIP
+    ``server`` in the kube_config) and installs an async
+    ``refresh_api_key_hook`` that re-mints the token before expiry. The
+    returned ``Configuration`` drives an ordinary
+    :class:`~kubernetes_asyncio.client.ApiClient` (read/inventory ops) or
+    a :class:`~kubernetes_asyncio.stream.ws_client.WsApiClient` (exec).
+    """
+    login_kwargs: dict[str, Any] = {
+        "username": username,
+        "password": password,
+        "verify_tls": verify_tls,
+        "ca_pem": ca_pem,
+        "login_port": login_port,
+        "timeout": timeout,
+    }
+    token, kube_config = await wcp_login(host, **login_kwargs)
+
+    cfg: Configuration = type.__call__(Configuration)
+    # Reuse the kubeconfig loader purely to lift the Supervisor CA (and
+    # write it to the temp CA file ``ssl_ca_cert`` points at); host and
+    # bearer are overridden immediately below.
+    await load_kube_config_from_dict(config_dict=kube_config, client_configuration=cfg)
+
+    cfg.host = f"https://{host}:{api_port}"
+    if not verify_tls:
+        cfg.verify_ssl = False
+    else:
+        # We deliberately dial the reachable alias, not the Supervisor
+        # cert's internal-VIP SAN, so skip hostname assertion while
+        # keeping CA-chain verification (the field-note requirement).
+        cfg.assert_hostname = False
+
+    _apply_bearer(cfg, token)
+    cfg.refresh_api_key_hook = _WcpTokenRefresher(host, token, **login_kwargs)
+    return cfg

--- a/backend/tests/test_connectors_k8s_wcp.py
+++ b/backend/tests/test_connectors_k8s_wcp.py
@@ -1,0 +1,639 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the vSphere Supervisor (WCP) SSO auth mode (#2905).
+
+Covers the three layers the WCP mode adds to the ``k8s-1.x`` connector:
+
+* :mod:`meho_backplane.connectors.kubernetes.wcp` — the ``/wcp/login``
+  SSO exchange, JWT-``exp``-aware token expiry, the TLS bootstrap, and
+  the self-refreshing :class:`Configuration` (mint -> cache -> refresh).
+* :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubernetes_credential`
+  — the payload-shape discriminator (kubeconfig vs SSO ``{username,
+  password}``).
+* :class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+  — routing a WCP credential to the self-refreshing client and dialing
+  the reachable alias, not the Supervisor's internal VIP.
+
+``kubernetes_asyncio`` / ``httpx`` are mocked (``respx``) so the gate
+runs in every CI lane regardless of a live Supervisor.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.kubernetes import wcp
+from meho_backplane.connectors.kubernetes.connector import _DEFAULT_K8S_PORT, KubernetesConnector
+from meho_backplane.connectors.kubernetes.kubeconfig import (
+    KubeconfigCredential,
+    KubernetesTargetLike,
+    WcpSsoCredential,
+    load_kubernetes_credential,
+)
+from meho_backplane.connectors.kubernetes.wcp import (
+    DEFAULT_WCP_TOKEN_TTL_SECONDS,
+    WcpLoginError,
+    WcpToken,
+    build_wcp_api_configuration,
+    wcp_login,
+)
+from meho_backplane.settings import get_settings
+
+_WCP_MODULE = "meho_backplane.connectors.kubernetes.wcp"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires (mirrors the k8s auth suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    """Structural :class:`KubernetesTargetLike` + the TLS knobs the WCP
+    path reads via ``getattr``."""
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    verify_tls: bool = True
+    tls_ca_pin: str | None = None
+
+
+_WCP_TARGET = _StubTarget(
+    name="wcp-supervisor",
+    host="supervisor.alias.test",
+    port=6443,
+    secret_ref="k8s/wcp-supervisor",
+)
+
+
+def _make_operator(*, raw_jwt: str = "op.test.jwt") -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _kube_config(
+    *, server: str = "https://10.99.99.99:6443", insecure: bool = True, ca_data: str | None = None
+) -> dict[str, Any]:
+    """A minimal but valid kubeconfig dict for ``load_kube_config_from_dict``.
+
+    ``server`` defaults to a raw internal-VIP address so the host-override
+    assertion (dial the reachable alias, not the VIP) is meaningful.
+    """
+    cluster: dict[str, Any] = {"server": server}
+    if ca_data is not None:
+        cluster["certificate-authority-data"] = ca_data
+    elif insecure:
+        cluster["insecure-skip-tls-verify"] = True
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [{"name": "sup", "cluster": cluster}],
+        "users": [{"name": "u", "user": {"token": "kubeconfig-embedded-token"}}],
+        "contexts": [{"name": "ctx", "context": {"cluster": "sup", "user": "u"}}],
+        "current-context": "ctx",
+    }
+
+
+def _make_jwt(*, exp: float) -> str:
+    """A structurally-valid JWT carrying only an ``exp`` claim (unsigned)."""
+
+    def _seg(obj: dict[str, Any]) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{_seg({'alg': 'none'})}.{_seg({'exp': exp})}.sig"
+
+
+# ---------------------------------------------------------------------------
+# Token expiry — JWT exp vs fallback TTL
+# ---------------------------------------------------------------------------
+
+
+def test_jwt_exp_reads_exp_claim() -> None:
+    assert wcp._jwt_exp(_make_jwt(exp=1_900_000_000.0)) == 1_900_000_000.0
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "opaque-not-a-jwt",
+        "only.two",
+        "a.b.c.d",
+        f"{base64.urlsafe_b64encode(b'{bad json').decode().rstrip('=')}.x.y",
+    ],
+)
+def test_jwt_exp_returns_none_for_non_jwt(token: str) -> None:
+    assert wcp._jwt_exp(token) is None
+
+
+def test_jwt_exp_rejects_bool_exp() -> None:
+    # ``True`` is an int subclass — must not be read as a 1-second expiry.
+    seg = base64.urlsafe_b64encode(json.dumps({"exp": True}).encode()).decode().rstrip("=")
+    assert wcp._jwt_exp(f"h.{seg}.s") is None
+
+
+def test_token_expiry_prefers_jwt_exp() -> None:
+    token = _make_jwt(exp=1000.0)
+    got = wcp._token_expiry_monotonic(token, now_wall=400.0, now_monotonic=50.0)
+    # remaining wall seconds (600) projected onto the monotonic clock.
+    assert got == pytest.approx(650.0)
+
+
+def test_token_expiry_falls_back_to_default_ttl_for_opaque_token() -> None:
+    got = wcp._token_expiry_monotonic("opaque", now_wall=400.0, now_monotonic=50.0)
+    assert got == pytest.approx(50.0 + DEFAULT_WCP_TOKEN_TTL_SECONDS)
+
+
+def test_token_expiry_falls_back_when_jwt_already_expired() -> None:
+    # exp in the past -> remaining <= 0 -> fallback rather than an
+    # immediately-stale stamp.
+    token = _make_jwt(exp=100.0)
+    got = wcp._token_expiry_monotonic(token, now_wall=400.0, now_monotonic=50.0)
+    assert got == pytest.approx(50.0 + DEFAULT_WCP_TOKEN_TTL_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Login-POST TLS bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_login_tls_toggles_on_verify_tls_without_ca() -> None:
+    assert wcp._login_tls(True, None) is True
+    assert wcp._login_tls(False, None) is False
+
+
+def test_login_tls_pins_ca_when_present() -> None:
+    sentinel = object()
+    with patch(f"{_WCP_MODULE}.ssl.create_default_context", return_value=sentinel) as ctx:
+        assert wcp._login_tls(True, "PEM-DATA") is sentinel
+    ctx.assert_called_once_with(cadata="PEM-DATA")
+
+
+# ---------------------------------------------------------------------------
+# wcp_login — the /wcp/login exchange
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_success_top_level_context() -> None:
+    session = _make_jwt(exp=time.time() + 36_000)
+    route = respx.route(method="POST").mock(
+        return_value=httpx.Response(
+            200, json={"session_id": session, "kube_config": _kube_config()}
+        )
+    )
+    token, kube_config = await wcp_login(
+        "supervisor.alias.test",
+        username="administrator@vsphere.local",
+        password="s3cr3t",
+        verify_tls=False,
+        ca_pem=None,
+    )
+
+    assert token.token == session
+    assert kube_config["clusters"][0]["cluster"]["server"] == "https://10.99.99.99:6443"
+
+    request = route.calls.last.request
+    # Endpoint: the WCP front on 443, path /wcp/login. httpx elides the
+    # default https port, so ``port`` reads None (i.e. 443) — never the
+    # kube-API 6443 (a non-default login port is exercised separately).
+    assert request.url.host == "supervisor.alias.test"
+    assert request.url.path == "/wcp/login"
+    assert request.url.port in (None, 443)
+    # HTTP Basic with the SSO credential.
+    scheme, _, encoded = request.headers["authorization"].partition(" ")
+    assert scheme == "Basic"
+    assert base64.b64decode(encoded).decode() == "administrator@vsphere.local:s3cr3t"
+    # No body -> the top-level Supervisor context, never a
+    # guest_cluster_* per-workload sub-session (internal-VIP redirect).
+    assert request.content == b""
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_honours_custom_login_port() -> None:
+    route = respx.route(method="POST").mock(
+        return_value=httpx.Response(200, json={"session_id": "sess", "kube_config": _kube_config()})
+    )
+    await wcp_login(
+        "sup.test",
+        username="u",
+        password="p",
+        verify_tls=False,
+        ca_pem=None,
+        login_port=8443,
+    )
+    assert route.calls.last.request.url.port == 8443
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_accepts_yaml_string_kube_config() -> None:
+    yaml_cfg = (
+        "apiVersion: v1\nkind: Config\n"
+        "clusters:\n- name: sup\n  cluster:\n    server: https://10.0.0.5:6443\n"
+        "    insecure-skip-tls-verify: true\n"
+        "users:\n- name: u\n  user:\n    token: t\n"
+        "contexts:\n- name: c\n  context:\n    cluster: sup\n    user: u\n"
+        "current-context: c\n"
+    )
+    respx.route(method="POST").mock(
+        return_value=httpx.Response(200, json={"session_id": "sess", "kube_config": yaml_cfg})
+    )
+    _token, kube_config = await wcp_login(
+        "sup.test", username="u", password="p", verify_tls=False, ca_pem=None
+    )
+    assert kube_config["clusters"][0]["cluster"]["server"] == "https://10.0.0.5:6443"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_raises_on_non_200() -> None:
+    respx.route(method="POST").mock(return_value=httpx.Response(401, json={"error": "bad creds"}))
+    with pytest.raises(WcpLoginError, match="HTTP 401"):
+        await wcp_login("sup.test", username="u", password="p", verify_tls=False, ca_pem=None)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_raises_on_missing_session_id() -> None:
+    respx.route(method="POST").mock(
+        return_value=httpx.Response(200, json={"kube_config": _kube_config()})
+    )
+    with pytest.raises(WcpLoginError, match="no session_id"):
+        await wcp_login("sup.test", username="u", password="p", verify_tls=False, ca_pem=None)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_raises_on_unusable_kube_config() -> None:
+    respx.route(method="POST").mock(
+        return_value=httpx.Response(200, json={"session_id": "sess", "kube_config": 12345})
+    )
+    with pytest.raises(WcpLoginError, match="kube_config"):
+        await wcp_login("sup.test", username="u", password="p", verify_tls=False, ca_pem=None)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_wraps_transport_error() -> None:
+    respx.route(method="POST").mock(side_effect=httpx.ConnectError("refused"))
+    with pytest.raises(WcpLoginError, match="failed"):
+        await wcp_login("sup.test", username="u", password="p", verify_tls=False, ca_pem=None)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_wcp_login_message_never_echoes_credentials() -> None:
+    respx.route(method="POST").mock(return_value=httpx.Response(403, json={}))
+    with pytest.raises(WcpLoginError) as exc:
+        await wcp_login(
+            "sup.test",
+            username="administrator@vsphere.local",
+            password="TOPSECRET",
+            verify_tls=False,
+            ca_pem=None,
+        )
+    assert "TOPSECRET" not in str(exc.value)
+    assert "administrator@vsphere.local" not in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# build_wcp_api_configuration — self-refreshing Configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_configuration_dials_alias_not_internal_vip() -> None:
+    login = AsyncMock(return_value=(WcpToken("sess-tok", time.monotonic() + 9000), _kube_config()))
+    with patch(f"{_WCP_MODULE}.wcp_login", login):
+        cfg = await build_wcp_api_configuration(
+            host="supervisor.alias.test",
+            api_port=6443,
+            username="u",
+            password="p",
+            verify_tls=True,
+            ca_pem=None,
+        )
+    # The reachable alias, never the internal VIP from the kube_config.
+    assert cfg.host == "https://supervisor.alias.test:6443"
+    assert cfg.api_key["BearerToken"] == "Bearer sess-tok"
+    assert cfg.refresh_api_key_hook is not None
+
+
+@pytest.mark.asyncio
+async def test_build_configuration_tls_knobs() -> None:
+    async def _fake_lkcfd(*, config_dict: dict[str, Any], client_configuration: Any) -> None:
+        del config_dict
+        client_configuration.host = "https://10.99.99.99:6443"
+        client_configuration.verify_ssl = True
+        client_configuration.api_key["BearerToken"] = "Bearer kubeconfig-embedded-token"
+
+    login = AsyncMock(return_value=(WcpToken("sess", time.monotonic() + 9000), _kube_config()))
+    with (
+        patch(f"{_WCP_MODULE}.wcp_login", login),
+        patch(f"{_WCP_MODULE}.load_kube_config_from_dict", _fake_lkcfd),
+    ):
+        secure = await build_wcp_api_configuration(
+            host="alias.test",
+            api_port=6443,
+            username="u",
+            password="p",
+            verify_tls=True,
+            ca_pem=None,
+        )
+        insecure = await build_wcp_api_configuration(
+            host="alias.test",
+            api_port=6443,
+            username="u",
+            password="p",
+            verify_tls=False,
+            ca_pem=None,
+        )
+    # verify_tls on: CA chain stays verified, hostname assertion off
+    # (we dial the alias, not the cert's internal-VIP SAN).
+    assert secure.verify_ssl is True
+    assert secure.assert_hostname is False
+    # verify_tls off: full insecure override.
+    assert insecure.verify_ssl is False
+
+
+@pytest.mark.asyncio
+async def test_configuration_refreshes_token_past_expiry() -> None:
+    kube = _kube_config()
+    login = AsyncMock(
+        side_effect=[
+            (WcpToken("tok1", 100.0), kube),
+            (WcpToken("tok2", 100_000.0), kube),
+        ]
+    )
+    mono = MagicMock(return_value=0.0)
+    with patch(f"{_WCP_MODULE}.wcp_login", login), patch(f"{_WCP_MODULE}.time.monotonic", mono):
+        cfg = await build_wcp_api_configuration(
+            host="alias.test",
+            api_port=6443,
+            username="u",
+            password="p",
+            verify_tls=False,
+            ca_pem=None,
+        )
+        assert login.await_count == 1
+
+        # Within the refresh margin (100 - 60 = 40): no re-mint.
+        assert await cfg.get_api_key_with_prefix("BearerToken") == "Bearer tok1"
+        assert login.await_count == 1
+
+        # Past expiry - margin: the hook re-mints transparently.
+        mono.return_value = 50.0
+        assert await cfg.get_api_key_with_prefix("BearerToken") == "Bearer tok2"
+        assert login.await_count == 2
+
+        # tok2 is long-lived: no further re-mint on the next use.
+        assert await cfg.get_api_key_with_prefix("BearerToken") == "Bearer tok2"
+        assert login.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_configuration_refresh_is_single_flight() -> None:
+    kube = _kube_config()
+    login = AsyncMock(
+        side_effect=[
+            (WcpToken("tok1", 100.0), kube),
+            (WcpToken("tok2", 100_000.0), kube),
+            (WcpToken("tok3", 100_000.0), kube),
+        ]
+    )
+    mono = MagicMock(return_value=50.0)  # already past the refresh margin
+    with patch(f"{_WCP_MODULE}.wcp_login", login), patch(f"{_WCP_MODULE}.time.monotonic", mono):
+        cfg = await build_wcp_api_configuration(
+            host="alias.test",
+            api_port=6443,
+            username="u",
+            password="p",
+            verify_tls=False,
+            ca_pem=None,
+        )
+        import asyncio
+
+        results = await asyncio.gather(
+            cfg.get_api_key_with_prefix("BearerToken"),
+            cfg.get_api_key_with_prefix("BearerToken"),
+            cfg.get_api_key_with_prefix("BearerToken"),
+        )
+    # Exactly one re-mint (initial login + one refresh), not three.
+    assert login.await_count == 2
+    assert set(results) == {"Bearer tok2"}
+
+
+# ---------------------------------------------------------------------------
+# load_kubernetes_credential — payload-shape discriminator
+# ---------------------------------------------------------------------------
+
+
+async def _resolve(secret: dict[str, Any]) -> Any:
+    with patch(
+        "meho_backplane.connectors.kubernetes.kubeconfig.load_vault_secret_data",
+        new=AsyncMock(return_value=secret),
+    ):
+        return await load_kubernetes_credential(_WCP_TARGET, _make_operator())
+
+
+@pytest.mark.asyncio
+async def test_discriminator_picks_kubeconfig() -> None:
+    cred = await _resolve({"kubeconfig": "apiVersion: v1\nkind: Config\nclusters: []\n"})
+    assert isinstance(cred, KubeconfigCredential)
+    assert cred.config["kind"] == "Config"
+
+
+@pytest.mark.asyncio
+async def test_discriminator_picks_wcp_sso() -> None:
+    cred = await _resolve({"username": " admin@vsphere.local ", "password": " pw "})
+    assert isinstance(cred, WcpSsoCredential)
+    # Whitespace-stripped.
+    assert cred.username == "admin@vsphere.local"
+    assert cred.password == "pw"
+
+
+@pytest.mark.asyncio
+async def test_discriminator_prefers_kubeconfig_when_both_present() -> None:
+    cred = await _resolve(
+        {"kubeconfig": "apiVersion: v1\nkind: Config\n", "username": "u", "password": "p"}
+    )
+    assert isinstance(cred, KubeconfigCredential)
+
+
+@pytest.mark.asyncio
+async def test_discriminator_errors_on_neither_shape() -> None:
+    with pytest.raises(VaultCredentialsReadError, match="neither"):
+        await _resolve({"apitoken": "nope"})
+
+
+@pytest.mark.asyncio
+async def test_discriminator_errors_on_blank_sso_field() -> None:
+    with pytest.raises(VaultCredentialsReadError, match="empty or not a string"):
+        await _resolve({"username": "  ", "password": "pw"})
+
+
+# ---------------------------------------------------------------------------
+# Connector integration
+# ---------------------------------------------------------------------------
+
+
+def _wcp_loader(credential: WcpSsoCredential) -> Any:
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> Any:
+        del target, operator
+        return credential
+
+    return _loader
+
+
+@pytest.mark.asyncio
+async def test_connector_builds_wcp_client_from_sso_credential() -> None:
+    connector = KubernetesConnector(
+        credential_loader=_wcp_loader(
+            WcpSsoCredential(username="admin@vsphere.local", password="pw")
+        )
+    )
+    login = AsyncMock(return_value=(WcpToken("sess-tok", time.monotonic() + 9000), _kube_config()))
+    with patch(f"{_WCP_MODULE}.wcp_login", login):
+        api_client = await connector._get_api_client(_WCP_TARGET, _make_operator())
+
+    cfg = api_client.configuration
+    assert cfg.host == "https://supervisor.alias.test:6443"
+    assert cfg.api_key["BearerToken"] == "Bearer sess-tok"
+    # The login ran against the reachable alias with the SSO credential.
+    assert login.await_args.args[0] == "supervisor.alias.test"
+    assert login.await_args.kwargs["username"] == "admin@vsphere.local"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connector_defaults_port_and_forwards_tls_knobs() -> None:
+    target = _StubTarget(
+        name="wcp",
+        host="sup.test",
+        port=None,  # -> _DEFAULT_K8S_PORT
+        secret_ref="k8s/wcp",
+        verify_tls=False,
+        tls_ca_pin="CA-PEM",
+    )
+    connector = KubernetesConnector(
+        credential_loader=_wcp_loader(WcpSsoCredential(username="u", password="p"))
+    )
+    login = AsyncMock(return_value=(WcpToken("t", time.monotonic() + 9000), _kube_config()))
+    with patch(f"{_WCP_MODULE}.wcp_login", login):
+        api_client = await connector._get_api_client(target, _make_operator())
+
+    assert api_client.configuration.host == f"https://sup.test:{_DEFAULT_K8S_PORT}"
+    assert login.await_args.kwargs["verify_tls"] is False
+    assert login.await_args.kwargs["ca_pem"] == "CA-PEM"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connector_fingerprint_over_wcp() -> None:
+    connector = KubernetesConnector(
+        credential_loader=_wcp_loader(WcpSsoCredential(username="u", password="p"))
+    )
+    login = AsyncMock(return_value=(WcpToken("t", time.monotonic() + 9000), _kube_config()))
+    version = MagicMock()
+    version.git_version = "v1.28.5+vmware.wcp.1"
+    version.build_date = "2024-01-04T15:00:00Z"
+    version.major = "1"
+    version.minor = "28"
+    version.platform = "linux/amd64"
+    version.go_version = "go1.20"
+    version.git_commit = "abc"
+    version.git_tree_state = "clean"
+    with (
+        patch(f"{_WCP_MODULE}.wcp_login", login),
+        patch("meho_backplane.connectors.kubernetes.connector.client.VersionApi") as version_api,
+    ):
+        version_api.return_value.get_code = AsyncMock(return_value=version)
+        result = await connector.fingerprint(_WCP_TARGET, _make_operator())
+    assert result.vendor == "kubernetes"
+    assert result.reachable is True
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connector_ws_client_over_wcp() -> None:
+    connector = KubernetesConnector(
+        credential_loader=_wcp_loader(WcpSsoCredential(username="u", password="p"))
+    )
+    login = AsyncMock(return_value=(WcpToken("sess-tok", time.monotonic() + 9000), _kube_config()))
+    with patch(f"{_WCP_MODULE}.wcp_login", login):
+        ws_client = await connector._get_ws_api_client(_WCP_TARGET, _make_operator())
+    assert ws_client.configuration.host == "https://supervisor.alias.test:6443"
+    assert ws_client.configuration.api_key["BearerToken"] == "Bearer sess-tok"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connector_rejects_both_loaders() -> None:
+    async def _cred(target: KubernetesTargetLike, operator: Operator) -> Any:
+        del target, operator
+        return KubeconfigCredential({})
+
+    async def _kube(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del target, operator
+        return {}
+
+    with pytest.raises(ValueError, match="at most one"):
+        KubernetesConnector(kubeconfig_loader=_kube, credential_loader=_cred)
+
+
+@pytest.mark.asyncio
+async def test_legacy_kubeconfig_loader_still_works() -> None:
+    # The legacy kubeconfig_loader= injection is adapted onto the
+    # credential contract; the static path stays a KubeconfigCredential.
+    async def _kube(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del target, operator
+        return _kube_config()
+
+    connector = KubernetesConnector(kubeconfig_loader=_kube)
+    with patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new=AsyncMock(return_value=MagicMock(close=AsyncMock())),
+    ) as ctor:
+        await connector._get_api_client(_WCP_TARGET, _make_operator())
+    ctor.assert_awaited_once()
+    assert ctor.await_args.args[0]["kind"] == "Config"
+    await connector.aclose()

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -102,6 +102,105 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
   rubric **State 2** wiring (`shared_service_account` only). Decision:
   [`docs/architecture/connector-auth.md`](../architecture/connector-auth.md).
 
+## vSphere Supervisor (WCP) SSO auth mode (#2905)
+
+A **vSphere Supervisor** (the WCP "Supervisor cluster" fronting a
+vSphere workload domain) is a real Kubernetes cluster people want to
+observe, but it **issues no static/durable credential**: WCP owns the
+cluster RBAC and even `administrator@vsphere.local` is not cluster-admin,
+so the read-only-ServiceAccount + non-expiring-token recipe every normal
+appliance/kubeadm cluster allows is unavailable. The only credential a
+Supervisor hands out is the **short-lived vSphere-SSO token** from its
+`POST /wcp/login` exchange (it expires with the SSO session). The static
+`kubeconfig` path can't consume that durably — so the Supervisor was the
+one k8s tier the connector couldn't register.
+
+The WCP mode makes the connector hold the SSO credential and run the
+login dance itself — the same shape `kubectl vsphere login` /
+`kubelogin` implement — to **mint → cache → refresh** the Supervisor
+token transparently.
+
+### Credential-protocol discrimination (not `auth_model`)
+
+`load_kubernetes_credential`
+(`connectors/kubernetes/kubeconfig.py`) reads `target.secret_ref` **once**
+through the same `load_vault_secret_data` seam the kubeconfig path uses,
+then routes on the payload's **field shape** — the same pattern the
+GitHub connector uses for its App-vs-PAT split, deliberately **not**
+overloading the target's `auth_model` (that is the *identity* model —
+`shared_service_account` etc. — not a credential protocol):
+
+- a `kubeconfig` field → `KubeconfigCredential` (today's static path,
+  checked **first** so an existing kubeconfig secret is never
+  re-interpreted);
+- else `username` + `password` fields → `WcpSsoCredential` (the WCP SSO
+  path — the username is the fully-qualified SSO principal, e.g.
+  `administrator@vsphere.local` or a scoped read-only namespace user, so
+  no separate realm field is needed);
+- neither → `VaultCredentialsReadError`.
+
+A Supervisor target therefore differs from a normal k8s target **only**
+in the shape of the credential its `secret_ref` holds. It still
+registers as `product="k8s"`, still resolves through the single
+`("k8s","1.x","k8s")` connector, and needs **no target-schema change** —
+the fingerprint/resolver/target model are untouched (a whole sibling
+connector class would be the wrong altitude for an auth-only difference).
+
+### Mint → cache → refresh (`connectors/kubernetes/wcp.py`)
+
+`build_wcp_api_configuration` performs the initial
+`wcp_login` (`POST https://{host}:443/wcp/login`, HTTP Basic, **no body**
+— which selects the top-level Supervisor context, not a
+`guest_cluster_*` per-workload sub-session), takes the Supervisor CA from
+the response's `kube_config`, and builds a
+`kubernetes_asyncio.client.Configuration` whose bearer refreshes itself.
+The refresh rides `kubernetes_asyncio`'s async-capable
+`refresh_api_key_hook`: `Configuration.get_api_key_with_prefix` awaits it
+before reading `api_key["BearerToken"]` on **every** request, so the hook
+re-mints once the cached token is inside `WCP_TOKEN_REFRESH_MARGIN_SECONDS`
+of expiry (single-flight under a lock). Expiry is stamped from the
+token's JWT `exp` claim (read unverified — it's our own token, used only
+to schedule refresh) with a short `DEFAULT_WCP_TOKEN_TTL_SECONDS` fallback
+for a non-JWT token. The cached `ApiClient` (keyed on `secret_ref` like
+the static path) stays put across the token's lifetime — only its bearer
+rotates — so both the read `ApiClient` and the exec `WsApiClient` get the
+self-refreshing client with no per-op login round-trip.
+
+### Internal-VIP redirect avoidance + TLS bootstrap
+
+The `/wcp/login` response's `kube_config` points its `server` at the
+Supervisor's **raw internal VIP**, which is unreachable when the
+Supervisor is dialed over a NAT'd alias (a lab / operator-VPN norm). The
+connector keeps that CA but **overrides the host to the
+operator-reachable `target.host`** (the top-level Supervisor kube-API
+context) and never follows the internal-VIP workload-session redirects.
+Because it deliberately dials the alias rather than the cert's VIP SAN,
+hostname assertion is disabled while the Supervisor **CA chain stays
+verified**.
+
+TLS for the login POST itself follows the target's knobs exactly like the
+shared HTTP transport: a `tls_ca_pin` (the Supervisor CA, staged
+out-of-band) is verified against; otherwise `verify_tls` toggles
+system-CA verification. A self-signed Supervisor therefore needs either
+the CA pinned on the target (recommended) or `verify_tls=false` (lab) —
+the same trust bootstrap `kubectl vsphere login` needs a thumbprint or
+`--insecure-skip-tls-verify` for. No SSO credential or minted token is
+ever logged (structlog events carry host / port / mode only).
+
+### Operator staging
+
+Register the Supervisor as an ordinary k8s target (`product: k8s`,
+`host:` the reachable Supervisor address, `port:` the kube-API port,
+default 6443) and stage its `secret_ref` with **`username` + `password`**
+fields (vSphere SSO) instead of a `kubeconfig` field. Pin the Supervisor
+CA via the target's `tls_ca_pin` (recommended) or set `verify_tls=false`
+for a lab. **Least privilege:** the SSO super-admin works but the
+recommended long-term credential is a scoped read-only vSphere SSO user
+granted a read-only vSphere-Namespace role; the connector is
+credential-agnostic and uses whatever SSO pair is staged. Sibling
+issue #2902 (operator-CLI login-token longevity) is a different surface
+(Keycloak OIDC) and shares no implementation with this WCP token dance.
+
 ## Probe ↔ dispatch convergence on the route operator (G0.16-T4 #1306)
 
 The `Connector.fingerprint(target, operator=None)` ABC signature


### PR DESCRIPTION
## Summary

- A **vSphere Supervisor (WCP)** issues no static/durable credential — WCP owns the cluster RBAC and even `administrator@vsphere.local` is not cluster-admin, so the only credential is the short-lived vSphere-SSO token from `POST /wcp/login`. The k8s connector's static-kubeconfig path could not consume that durably, so a Supervisor could not be a first-class `k8s-1.x` target even though it is a real cluster people want to observe.
- Adds a **WCP SSO auth mode**: the connector holds the vSphere SSO `{username, password}` and performs the `/wcp/login` exchange itself to **mint → cache → refresh** the Supervisor bearer token transparently, via `kubernetes_asyncio`'s async `refresh_api_key_hook` (proactive, JWT-`exp`-aware with a short TTL fallback + single-flight locking). The cached `ApiClient` stays put; only its bearer rotates.
- **Fits the target/fingerprint model, no special-casing**: the credential protocol is discriminated by Vault **payload shape** (`kubeconfig` vs `username`+`password`), mirroring the in-repo GitHub App-vs-PAT precedent. The Supervisor still fingerprints as `product="k8s"`, resolves through the single `("k8s","1.x","k8s")` connector, and needs **no target-schema change**. `auth_model` (the identity enum) is untouched; the agent surface is unchanged.
- Honours the two field notes: dials the operator-reachable `target.host` (never the login response's **internal-VIP** `server`, and no `guest_cluster_*` per-workload sub-sessions), and threads `verify_tls` / `tls_ca_pin` through the login TLS + the kube-API `Configuration` (CA-chain verified; hostname assertion relaxed only because the alias, not the cert's VIP SAN, is dialed). No SSO credential or token is ever logged.

New module `connectors/kubernetes/wcp.py` (login + expiry-stamped token + self-refreshing `Configuration`); discriminator `load_kubernetes_credential` in `kubeconfig.py`; connector branches in `_get_api_client` / `_get_ws_api_client`. Legacy `kubeconfig_loader=` injection is preserved (adapted onto the new credential contract), so the static path is byte-identical.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (5 files)
- [x] `mypy` — clean (19 source files)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_connectors_k8s_wcp.py` — **34 passed** (new suite)
- [x] `pytest -k "k8s or kubernetes or typed_connectors_metadata"` — **453 passed, 1 skipped** (no regressions; legacy `kubeconfig_loader=` path intact)
- [x] AC — connector performs `/wcp/login` and dispatches with the minted token: `test_connector_builds_wcp_client_from_sso_credential`, `test_connector_fingerprint_over_wcp`
- [x] AC — mint→cache→refresh of the short-lived token: `test_configuration_refreshes_token_past_expiry`, `test_configuration_refresh_is_single_flight`, JWT-`exp` vs TTL-fallback expiry tests
- [x] AC — top-level Supervisor context (HTTP Basic, no body), not the internal-VIP redirect: `test_wcp_login_success_top_level_context`, `test_build_configuration_dials_alias_not_internal_vip`
- [x] AC — payload-shape discrimination fits the target model: `test_discriminator_*`

## Out of scope

- **Reactive 401 re-mint** via the dispatcher's `invalidate_session` recovery arm: k8s ops raise `kubernetes_asyncio.ApiException` (not `ConnectorAuthError`), which does not route to that arm today — wiring it is a larger dispatcher change. The proactive refresh (with a safety margin) covers normal SSO-session expiry; a token rejected earlier than its `exp` is a documented follow-up.
- **Least-privilege scoped SSO user**: the connector is credential-agnostic (uses whatever SSO pair is staged); the first cut accepts the SSO admin, and a scoped read-only vSphere-Namespace user is the recommended operator-side credential (documented).
- Sibling **#2902** (operator-CLI login-token longevity) is a different surface (Keycloak OIDC) with no shared implementation.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2905
