### PR TITLE
fix(image): patch util-linux family for CVE-2026-53615 (fixable HIGH)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -156,6 +156,25 @@ RUN set -eux; \
 # ---------- Runtime ----------------------------------------------------------
 FROM python:3.14-slim@sha256:d3400aa122fa42cf0af0dbe8ec3091b047eac5c8f7e3539f7135e86d855dc015 AS runtime
 
+# ---------- Base-OS security patch: util-linux family (CVE-2026-53615) -------
+# The pinned base still carries util-linux 2.41-5, which Trivy flags as a
+# fixable HIGH (CVE-2026-53615). Debian trixie-security already serves the fix
+# (2.41.5-0+deb13u1), but the upstream python:3.14-slim manifest has not been
+# rebuilt against it yet, so the digest bump the Dependabot docker block would
+# normally carry cannot clear it. Rather than publish a release image with a
+# known fixable HIGH, upgrade just the util-linux binary family to the security
+# version in one apt layer (indexes dropped in the same RUN, so no apt metadata
+# persists in the image). This is a targeted --only-upgrade of packages already
+# present — no new package enters the image — and is the sibling in intent of
+# the pip uninstall below: keep the Trivy scan clean. Remove this layer once
+# the base-digest bump lands a rebuilt base already carrying util-linux
+# >= 2.41.5-0+deb13u1.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --only-upgrade \
+      util-linux libuuid1 libmount1 libblkid1 libsmartcols1 liblastlog2-2 \
+      mount bsdutils login \
+ && rm -rf /var/lib/apt/lists/*
+
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).
 RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nologin meho
 


### PR DESCRIPTION
## What

The runtime image's base still ships **`util-linux 2.41-5`**, which Trivy flags as a **fixable HIGH — `CVE-2026-53615`** (all 9 open Trivy code-scanning alerts on `main` are this one CVE). That has kept the `image` workflow red on `main` since before the v0.29.0 sprint, and it's the sole fixable HIGH/CRITICAL in the image.

This adds a targeted `--only-upgrade` of the util-linux binary family (9 packages) in the **runtime stage**, with apt indexes dropped in the same layer.

## Why a layer, not a base-digest bump

The Dependabot docker block would normally clear a base CVE by bumping the `FROM` digest — but **verified against the live registry, the latest `python:3.14-slim` (`sha256:ce407646…`) still ships `util-linux 2.41-5`**; Docker Library hasn't rebuilt against the Debian fix yet. The fix **is** published to `trixie-security` (`2.41.5-0+deb13u1`), so an in-image `--only-upgrade` is the only way to ship v0.29.0 without a known fixable HIGH.

This is the **sibling in intent of the existing pip uninstall** two lines below (`RUN python -m pip uninstall -y pip` — there precisely because "its CVEs accrue on every Trivy scan"). No new package enters the image; only already-present packages move to their security version.

## Verification (PR CI can't — trivy is `if: != pull_request`)

Ran the exact upgrade in the base image; all 9 reach the fixed version:

```
util-linux        2.41.5-0+deb13u1
libuuid1          2.41.5-0+deb13u1
libmount1         2.41.5-0+deb13u1
libblkid1         2.41.5-0+deb13u1
libsmartcols1     2.41.5-0+deb13u1
liblastlog2-2     2.41.5-0+deb13u1
mount             2.41.5-0+deb13u1
bsdutils        1:2.41.5-0+deb13u1
login           1:4.16.0-2+really2.41.5-0+deb13u1
```

Since `CVE-2026-53615` is the only fixable HIGH, the post-merge `image` run on `main` should go **green**.

## Lifecycle

Transient — **remove this layer** once the Dependabot base-digest bump lands a rebuilt `python:3.14-slim` already carrying `util-linux >= 2.41.5-0+deb13u1`. Flagged as the gate for the **v0.29.0** release cut (ship trivy-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
