### PR TITLE
feat(fleet-lcm): typed read core (13 ops) — restore 9.0 fleet dispatch (#3047)

### DIFF
--- a/backend/src/meho_backplane/connectors/fleet_lcm/__init__.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/__init__.py
@@ -33,14 +33,17 @@ target still resolves *something*; which concrete class it points at does
 not matter for the "resolve at all" guarantee, and the versioned entries
 carry the real per-band matching once a version is known.
 
-Operations for this connector arrive via **G0.7 spec ingestion** against
-the public Apache-2.0 ``fleet-lcm-openapi.yaml``
-(``vmware/vcf-api-specs``) as ``source_kind="ingested"``
-``endpoint_descriptor`` rows under ``connector_id="fleet-lcm-9.0"`` — they
-are not hand-coded. Registering this hand-rolled :class:`HttpConnector`
-subclass is the load-bearing prerequisite for those rows to become
-dispatchable (a bare ``GenericRestConnector`` auto-shim is
-non-dispatchable), the
+This package registers a curated **13-op typed read core** (#3047,
+:mod:`.typed_ops`) via :func:`register_typed_op_registrar`, so a VCF Fleet
+9.x target dispatches a modern ``/v1/*`` read on a fresh boot with zero
+catalog ingest — the read core that restores 9.0 fleet dispatch under the
+"modern default now" resolver decision. The wider surface (the full 51-op
+``fleet-lcm-openapi.yaml`` as ``source_kind="ingested"`` breadth plus the
+writes) is a follow-up, enabled operationally through the generic review
+flow (``ReviewService.enable_reads`` over ``meho connector ingest``);
+registering this hand-rolled :class:`HttpConnector` subclass is the
+load-bearing prerequisite for those ingested rows to become dispatchable
+(a bare ``GenericRestConnector`` auto-shim is non-dispatchable), the
 :class:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector`
 pattern.
 """
@@ -53,7 +56,14 @@ from meho_backplane.connectors.fleet_lcm.session import (
     FleetLcmTargetLike,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.fleet_lcm.typed_ops import (
+    FLEET_LCM_TYPED_OPS,
+    FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP,
+    FleetLcmTypedOp,
+    register_fleet_lcm_typed_operations,
+)
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 #: Endpoint-descriptor identity for the modern Fleet LCM connector — the
 #: dispatch-canonical ``(product, version, impl_id)`` triple
@@ -74,13 +84,26 @@ register_connector_v2(
     cls=FleetLcmConnector,
 )
 
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The
+# runner (``run_typed_op_registrars``) iterates after
+# ``_eager_import_connectors`` so the typed descriptor rows land before the
+# first dispatch — the modern 9.x fleet read core dispatches on a fresh boot
+# with zero catalog ingest (#3047). No wildcard sibling registration (see
+# the module docstring): the legacy ``vcf_fleet`` package owns the
+# ``("fleet", "", "")`` fallback.
+register_typed_op_registrar(register_fleet_lcm_typed_operations)
+
 __all__ = [
     "FLEET_LCM_CONNECTOR_ID",
     "FLEET_LCM_IMPL_ID",
     "FLEET_LCM_PRODUCT",
+    "FLEET_LCM_TYPED_OPS",
+    "FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP",
     "FLEET_LCM_VERSION",
     "FleetLcmConnector",
     "FleetLcmCredentialsLoader",
     "FleetLcmTargetLike",
+    "FleetLcmTypedOp",
     "load_credentials_from_vault",
+    "register_fleet_lcm_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/fleet_lcm/_llm_instructions.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/_llm_instructions.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-op ``llm_instructions`` blobs for the ``fleet-lcm`` typed read core.
+
+Split out of :mod:`~meho_backplane.connectors.fleet_lcm.typed_reads` (which
+holds the op bodies) purely to keep each module under the file-size budget;
+harbor (#2856) co-locates the equivalent ``HARBOR_READ_LLM_INSTRUCTIONS``
+with its read impls, but the 13-op fleet-lcm core is large enough to earn a
+dedicated module. Consumed by
+:mod:`meho_backplane.connectors.fleet_lcm.typed_ops`, which keys each op's
+metadata row to :data:`FLEET_LCM_READ_LLM_INSTRUCTIONS`.
+
+The canonical three-key shape (``when_to_call`` / ``output_shape`` /
+``next_step``) is the same convention the harbor / nsx / hetzner read cores
+use, so an agent crossing connector boundaries sees a stable structure. The
+prose references the dot-form op ids the reads register under and the
+sibling ops an agent drills to next.
+"""
+
+from __future__ import annotations
+
+__all__ = ["FLEET_LCM_READ_LLM_INSTRUCTIONS"]
+
+
+_HEALTH_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to check whether the VCF Fleet LCM Service is up before any "
+        "heavier fleet read, or when diagnosing a reachability issue. This "
+        "is the modern 9.x successor to the legacy fleet-rest about/health "
+        "probe (which returns HTTP 500 on 9.0 appliances) — on a 9.x fleet "
+        "target this endpoint answers cleanly."
+    ),
+    "output_shape": "Object with a single 'up' boolean.",
+    "next_step": (
+        "If up=true, proceed to fleet-lcm.system.info for the fleet summary "
+        "or fleet-lcm.component.list for the deployed inventory. If up=false "
+        "or the call errors, the service is unreachable — surface that to the "
+        "operator rather than retrying other fleet reads."
+    ),
+}
+
+_SYSTEM_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read the fleet-wide system summary: whether a system-level "
+        "upgrade is in flight and which software bundles are available to "
+        "the fleet. Use when answering 'is the fleet mid-upgrade' or 'what "
+        "bundles can the fleet deploy'."
+    ),
+    "output_shape": (
+        "Object with 'upgrade' ({taskId, status e.g. PENDING}) and "
+        "'bundles' [] — each bundle carries components[] with componentType, "
+        "publicName, bundleId, bundleType, version, and status (e.g. "
+        "REQUIRED)."
+    ),
+    "next_step": (
+        "If upgrade.taskId is set, pass it to fleet-lcm.task.info to track "
+        "the in-flight system upgrade. For per-component upgrade planning, "
+        "see fleet-lcm.upgrade-plan.list."
+    ),
+}
+
+_CONFIG_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read how the Fleet LCM service itself is configured: its "
+        "deployment flavor, the management cluster it is bound to, and its "
+        "overall health status. Use when confirming which SDDC the fleet "
+        "service runs against or diagnosing a service-config issue."
+    ),
+    "output_shape": (
+        "Object with deploymentFlavor (e.g. 'VCF'), vspCluster (fqdn, id, "
+        "type e.g. MANAGEMENT), id (uuid), version, and status (HEALTHY / "
+        "OFFLINE)."
+    ),
+    "next_step": (
+        "Cross-reference vspCluster.fqdn with fleet-lcm.component.list to "
+        "see the components deployed on that management cluster."
+    ),
+}
+
+_SDDC_LCM_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the SDDC lifecycle managers the fleet manages — the "
+        "entry point for 'what SDDCs does this fleet govern'. Each SDDC LCM "
+        "is the per-SDDC lifecycle authority the fleet coordinates."
+    ),
+    "output_shape": (
+        "Paged envelope {pageMetadata, sddcLcms: []}. Each SddcLcm carries "
+        "fqdn, sddcGroupFqdn, isPrimary (bool), and vspClusters[] (each with "
+        "fqdn, id, type). pageMetadata carries totalElements / totalPages so "
+        "you can tell whether more pages exist."
+    ),
+    "next_step": (
+        "Pick an SddcLcm's id for fleet-lcm.sddc-lcm.info for full detail, "
+        "or cross-reference its vspClusters against fleet-lcm.component.list "
+        "(the sddcLcmId field) to see the components under that SDDC."
+    ),
+}
+
+_SDDC_LCM_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read one SDDC lifecycle manager in full by its id. Requires "
+        "sddcLcmId (a UUID) obtained from fleet-lcm.sddc-lcm.list."
+    ),
+    "output_shape": (
+        "SddcLcm object with fqdn, sddcGroupFqdn, isPrimary (bool), and "
+        "vspClusters[] (each with fqdn, certificate, id, type)."
+    ),
+    "next_step": (
+        "Cross-reference this SDDC's components via fleet-lcm.component.list "
+        "and filter by the sddcLcmId, or check its managed status through "
+        "fleet-lcm.component.status on each component."
+    ),
+}
+
+_COMPONENT_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the components the fleet has deployed — the primary "
+        "'what is deployed' inventory read. Every managed product node "
+        "(Operations, Automation, …) surfaces here with its type, version, "
+        "and the SDDC LCM it belongs to."
+    ),
+    "output_shape": (
+        "Object {components: [Component, ...]}. Each Component carries "
+        "componentType, fqdn, version, sddcLcmId, deploymentType (e.g. OVA), "
+        "nodes[] (size, fqdn, ipAddress, name), and vspCluster. A large "
+        "inventory is reduced to a JSONFlux handle."
+    ),
+    "next_step": (
+        "Pick a component's id for fleet-lcm.component.info (full detail) or "
+        "fleet-lcm.component.status (is it Running). Group by sddcLcmId to "
+        "map components to their SDDC from fleet-lcm.sddc-lcm.list."
+    ),
+}
+
+_COMPONENT_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read one managed component in full by its id. Requires "
+        "componentId (a UUID) obtained from fleet-lcm.component.list. "
+        "Returns the same fields as the list plus any per-component detail "
+        "the list view omits."
+    ),
+    "output_shape": (
+        "Component object with componentType, fqdn, version, sddcLcmId, "
+        "deploymentType, nodes[], and vspCluster."
+    ),
+    "next_step": (
+        "Call fleet-lcm.component.status with the same componentId to confirm "
+        "the component is Running, or check fleet-lcm.upgrade-plan.list for "
+        "any planned upgrade that targets it."
+    ),
+}
+
+_COMPONENT_STATUS_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to check the runtime status of one managed component — 'is "
+        "component X running'. Requires componentId (a UUID) from "
+        "fleet-lcm.component.list."
+    ),
+    "output_shape": (
+        "Object with id (the componentId) and status — one of 'Unknown', "
+        "'NotRunning', or 'Running'."
+    ),
+    "next_step": (
+        "If status is NotRunning or Unknown, surface the component's fqdn "
+        "(from fleet-lcm.component.info) to the operator and check "
+        "fleet-lcm.task.list for a recent failed task on that resource."
+    ),
+}
+
+_TASK_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the fleet's async operation tasks — 'what is the fleet "
+        "doing / what did it just do'. Use to find in-flight or recently "
+        "completed upgrades, refreshes, and component actions."
+    ),
+    "output_shape": (
+        "Paged envelope {elements: [TaskSummary, ...], pageMetadata}. Each "
+        "TaskSummary carries resourceId, type, createTime / updateTime, "
+        "cancellable / retriable (bool), parentTaskId, and a description with "
+        "a localizedMessage. pageMetadata.totalElements tells you whether "
+        "more pages exist; a large list is reduced to a JSONFlux handle."
+    ),
+    "next_step": (
+        "Pick a task's id for fleet-lcm.task.info for the full task tree and "
+        "status. Correlate a task's resourceId with a componentId from "
+        "fleet-lcm.component.list to see which component it acted on."
+    ),
+}
+
+_TASK_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read one async task in full by its id — its status, timing, "
+        "and sub-task detail. Requires taskId (a UUID) from "
+        "fleet-lcm.task.list, or the upgrade.taskId from "
+        "fleet-lcm.system.info."
+    ),
+    "output_shape": (
+        "Task object with resourceId, type, status, createTime / updateTime, "
+        "createdBy / updatedBy, cancellable / retriable, parentTaskId, and a "
+        "description with a localizedMessage."
+    ),
+    "next_step": (
+        "If the task failed, surface its description.localizedMessage to the "
+        "operator. If retriable=true, a retry is available via the fleet's "
+        "task-retry action (a write op, outside this read core)."
+    ),
+}
+
+_UPGRADE_PLAN_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the fleet's upgrade plans — 'what upgrades are planned'. "
+        "Each plan pins a desired software set against a component filter."
+    ),
+    "output_shape": (
+        "Paged envelope {elements: [UpgradePlanSummary, ...], pageMetadata}. "
+        "Each summary carries id, createTime / updateTime, createdBy, and a "
+        "spec with componentsFilter[] and desiredSoftware.components[] "
+        "(publicName, type)."
+    ),
+    "next_step": (
+        "Pick a plan's id for fleet-lcm.upgrade-plan.info for the full plan, "
+        "or check fleet-lcm.release-version.list to see which target "
+        "versions the desiredSoftware could move to."
+    ),
+}
+
+_UPGRADE_PLAN_INFO_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read one upgrade plan in full by its id. Requires planId "
+        "(a UUID) obtained from fleet-lcm.upgrade-plan.list."
+    ),
+    "output_shape": (
+        "UpgradePlan object with id, createTime / updateTime, and a spec "
+        "carrying componentsFilter[] and desiredSoftware (the target "
+        "component versions)."
+    ),
+    "next_step": (
+        "Cross-reference the plan's componentsFilter ids against "
+        "fleet-lcm.component.list to see which deployed components the plan "
+        "targets. Applying / precheck-ing a plan is a write op outside this "
+        "read core."
+    ),
+}
+
+_RELEASE_VERSION_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the release versions the fleet can target — 'what can "
+        "we upgrade to'. Use when planning an upgrade or confirming a target "
+        "version is available."
+    ),
+    "output_shape": (
+        "Paged envelope {elements: [ReleaseVersion, ...], pageMetadata}. Each "
+        "ReleaseVersion carries a version string and components[] (publicName, "
+        "the available versions[], and type e.g. OPS)."
+    ),
+    "next_step": (
+        "Match a target version's components against a plan's desiredSoftware "
+        "in fleet-lcm.upgrade-plan.info, or against the currently-deployed "
+        "versions in fleet-lcm.component.list to compute the delta."
+    ),
+}
+
+
+#: Per-op ``llm_instructions`` keyed by the dot-form op id, consumed by
+#: :mod:`meho_backplane.connectors.fleet_lcm.typed_ops`.
+FLEET_LCM_READ_LLM_INSTRUCTIONS: dict[str, dict[str, object]] = {
+    "fleet-lcm.health": _HEALTH_INSTRUCTIONS,
+    "fleet-lcm.system.info": _SYSTEM_INFO_INSTRUCTIONS,
+    "fleet-lcm.config.info": _CONFIG_INFO_INSTRUCTIONS,
+    "fleet-lcm.sddc-lcm.list": _SDDC_LCM_LIST_INSTRUCTIONS,
+    "fleet-lcm.sddc-lcm.info": _SDDC_LCM_INFO_INSTRUCTIONS,
+    "fleet-lcm.component.list": _COMPONENT_LIST_INSTRUCTIONS,
+    "fleet-lcm.component.info": _COMPONENT_INFO_INSTRUCTIONS,
+    "fleet-lcm.component.status": _COMPONENT_STATUS_INSTRUCTIONS,
+    "fleet-lcm.task.list": _TASK_LIST_INSTRUCTIONS,
+    "fleet-lcm.task.info": _TASK_INFO_INSTRUCTIONS,
+    "fleet-lcm.upgrade-plan.list": _UPGRADE_PLAN_LIST_INSTRUCTIONS,
+    "fleet-lcm.upgrade-plan.info": _UPGRADE_PLAN_INFO_INSTRUCTIONS,
+    "fleet-lcm.release-version.list": _RELEASE_VERSION_LIST_INSTRUCTIONS,
+}

--- a/backend/src/meho_backplane/connectors/fleet_lcm/_paths.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/_paths.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-coded Fleet LCM Service ``/v1/*`` path templates — the reconcile-lane surface.
+
+Every request path the modern ``fleet-lcm`` typed read core dispatches is
+declared here as a module-level ``_*_PATH`` template constant, and every
+handler in :mod:`~meho_backplane.connectors.fleet_lcm.typed_reads` builds
+its concrete path from one of these templates via :func:`fill_path` (or
+uses a placeholder-free constant directly) — never from an inline
+f-string. Placeholder names are byte-for-byte the pinned spec's own
+path-parameter names (``docs/fleet-lcm-9.0/fleet-lcm-openapi.yaml`` on the
+operator's spec shelf): the by-id reads take ``{sddcLcmId}`` /
+``{componentId}`` / ``{taskId}`` / ``{planId}``.
+
+This lets the spec-reconcile lane
+(:mod:`tests.test_connectors_fleet_lcm_spec_reconcile`) introspect these
+live constants and assert each declared ``GET:/path`` is served by the
+pinned Apache-2.0 spec — the #2944 introspect-live-constants pattern
+(never a hardcoded mirror that can drift), the same shape
+:mod:`~meho_backplane.connectors.harbor._paths` and
+:mod:`~meho_backplane.connectors.keycloak._paths` established.
+
+All templates are the raw ``/v1/*`` form. The pinned spec's server url
+``https://vcf.broadcom.com/fleet-lcm`` is **absolute**, so ``parse_openapi``
+does not fold the ``/fleet-lcm`` base onto path keys (only *relative*
+server bases are folded, #1796) — the served op_ids and these constants
+are both the raw ``/v1/*`` path, and the ``/fleet-lcm`` base is an operator
+target-configuration concern (the connector's per-target client carries it
+in ``host``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["encode_segment", "fill_path"]
+
+# -- templates reconciled against the pinned Fleet LCM 9.0 spec -------------
+# System / service surface
+_HEALTH_PATH = "/v1/health"
+_SYSTEM_PATH = "/v1/system"
+_CONFIG_PATH = "/v1/config"
+# SDDC LCM inventory
+_SDDC_LCMS_PATH = "/v1/sddc-lcms"
+_SDDC_LCM_PATH = "/v1/sddc-lcms/{sddcLcmId}"
+# Managed components
+_COMPONENTS_PATH = "/v1/components"
+_COMPONENT_PATH = "/v1/components/{componentId}"
+_COMPONENT_STATUS_PATH = "/v1/components/{componentId}/status"
+# Async tasks
+_TASKS_PATH = "/v1/tasks"
+_TASK_PATH = "/v1/tasks/{taskId}"
+# Lifecycle — upgrade plans + release versions
+_UPGRADE_PLANS_PATH = "/v1/upgrade-plans"
+_UPGRADE_PLAN_PATH = "/v1/upgrade-plans/{planId}"
+_RELEASE_VERSIONS_PATH = "/v1/release-versions"
+
+
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
+
+
+def encode_segment(value: object) -> str:
+    """Percent-encode one URL path segment (OpenAPI ``style: simple``).
+
+    Empty safe set, so a reserved char in a caller-controlled value can
+    never leak path structure. The Fleet LCM by-id segments
+    (``sddcLcmId`` / ``componentId`` / ``taskId`` / ``planId``) are
+    server-issued UUIDs in practice, but encoding them is the safe default
+    the harbor / keycloak path helpers established — a defensive encode
+    costs nothing on an opaque id and forecloses path injection if a caller
+    ever passes a non-UUID value.
+    """
+    return quote(str(value), safe="")
+
+
+def fill_path(template: str, values: Mapping[str, str]) -> str:
+    """Substitute *values* into *template*'s ``{placeholder}`` segments.
+
+    Fail-loud contract, both directions: every placeholder in *template*
+    must have a value and every provided key must name a placeholder — a
+    typo'd key or a missing segment raises :exc:`ValueError` at the call
+    site instead of dispatching a malformed URL. Values are inserted
+    verbatim; callers pre-encode caller-controlled segments with
+    :func:`encode_segment`. Verbatim mirror of
+    :func:`meho_backplane.connectors.harbor._paths.fill_path` (per-connector
+    copy is the established convention — harbor and keycloak each ship
+    their own, with no shared module and no cross-connector import).
+    """
+    placeholders = set(_PLACEHOLDER_RE.findall(template))
+    provided = set(values)
+    if placeholders != provided:
+        raise ValueError(
+            f"fill_path template {template!r} declares placeholders "
+            f"{sorted(placeholders)} but got values for {sorted(provided)}"
+        )
+    return _PLACEHOLDER_RE.sub(lambda match: values[match.group(1)], template)

--- a/backend/src/meho_backplane/connectors/fleet_lcm/connector.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/connector.py
@@ -107,13 +107,29 @@ is not assumed from any single ``/v1/*`` field; ``version`` is left
 Operations
 ----------
 
-This module ships zero hand-coded operations — :meth:`execute` exists for
-ABC compatibility and delegates to the G0.6 dispatcher. The 51 ``/v1/*``
-ops land in ``endpoint_descriptor`` via spec ingestion; until an operator
-ingests the spec, the connector is registered and discoverable but
-``execute`` against any ``op_id`` resolves to "unknown operation" at the
-dispatcher — the correct behaviour for a registered-but-empty connector
-at this Task's stage.
+A curated **13-op typed read core** ships here (#3047): health, system,
+config, SDDC-LCM list/detail, component list/detail/status, task
+list/detail, and upgrade-plan list/detail + release-versions. They are
+registered as ``source_kind="typed"`` (:mod:`.typed_ops` /
+:mod:`.typed_reads`, per-op ``llm_instructions`` in
+:mod:`._llm_instructions`), enabled at register time, so a VCF Fleet 9.x
+target — which resolves to this impl by most-specific-version — dispatches
+a modern read op on a **fresh boot with zero catalog ingest**. This is what
+restores 9.0 fleet dispatch after the "modern default now" resolver
+decision (initiative #3033); the two typed ops the legacy ``fleet-rest``
+impl carries are its ``/lcm/*`` back-compat surface, distinct from these
+``/v1/*`` reads.
+
+The handler bodies build their ``/v1/*`` request paths from the templates
+in :mod:`._paths` (reconcile-lane-introspectable) and dispatch on this
+class's authenticated client, so the reads ride :meth:`auth_headers`
+(Bearer primary, Basic fallback) exactly as an ingested op would. The
+wider surface — the full 51-op spec as ``source_kind="ingested"`` breadth
+plus the component / upgrade / task **writes** — is a follow-up enabled
+operationally through the generic review flow
+(``ReviewService.enable_reads`` over ``meho connector ingest`` of the
+pinned ``fleet-lcm-openapi.yaml``); :meth:`execute` remains the G0.6
+dispatch shim for any such ingested ``op_id``.
 """
 
 from __future__ import annotations
@@ -360,6 +376,126 @@ class FleetLcmConnector(HttpConnector):
             target=target,
             params=params,
         )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (#3047, initiative #3033)
+    #
+    # Thin bound-method shims for the modern ``/v1/*`` read core. Each
+    # delegates to the module-level ``_impl`` body in ``.typed_reads`` (lazy
+    # import so pure fingerprint/probe unit tests don't pay the operations
+    # package's embedding-pipeline import). The dispatcher resolves each
+    # persisted ``module.ClassName.method`` handler_ref back to the bound
+    # method and threads ``operator`` / ``target`` / ``params`` by name (see
+    # ``dispatch_typed``); ``operator`` reaches ``_get_json`` so the
+    # credential loader reads under the operator's identity. All read-only —
+    # no write op ships here (writes are a follow-up).
+    # ------------------------------------------------------------------
+
+    async def health(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.health`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_health_impl
+
+        return await fleet_lcm_health_impl(self, operator, target, params)
+
+    async def system_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.system.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_system_info_impl
+
+        return await fleet_lcm_system_info_impl(self, operator, target, params)
+
+    async def config_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.config.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_config_info_impl
+
+        return await fleet_lcm_config_info_impl(self, operator, target, params)
+
+    async def sddc_lcm_list(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.sddc-lcm.list`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_sddc_lcm_list_impl
+
+        return await fleet_lcm_sddc_lcm_list_impl(self, operator, target, params)
+
+    async def sddc_lcm_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.sddc-lcm.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_sddc_lcm_info_impl
+
+        return await fleet_lcm_sddc_lcm_info_impl(self, operator, target, params)
+
+    async def component_list(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.component.list`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_component_list_impl
+
+        return await fleet_lcm_component_list_impl(self, operator, target, params)
+
+    async def component_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.component.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_component_info_impl
+
+        return await fleet_lcm_component_info_impl(self, operator, target, params)
+
+    async def component_status(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.component.status`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_component_status_impl
+
+        return await fleet_lcm_component_status_impl(self, operator, target, params)
+
+    async def task_list(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.task.list`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_task_list_impl
+
+        return await fleet_lcm_task_list_impl(self, operator, target, params)
+
+    async def task_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.task.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_task_info_impl
+
+        return await fleet_lcm_task_info_impl(self, operator, target, params)
+
+    async def upgrade_plan_list(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.upgrade-plan.list`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_upgrade_plan_list_impl
+
+        return await fleet_lcm_upgrade_plan_list_impl(self, operator, target, params)
+
+    async def upgrade_plan_info(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.upgrade-plan.info`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import fleet_lcm_upgrade_plan_info_impl
+
+        return await fleet_lcm_upgrade_plan_info_impl(self, operator, target, params)
+
+    async def release_version_list(
+        self, operator: Operator, target: FleetLcmTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``fleet-lcm.release-version.list`` shim (#3047)."""
+        from meho_backplane.connectors.fleet_lcm.typed_reads import (
+            fleet_lcm_release_version_list_impl,
+        )
+
+        return await fleet_lcm_release_version_list_impl(self, operator, target, params)
 
     async def invalidate_credentials(self, target: FleetLcmTargetLike) -> None:
         """Public duck-typed credential-eviction hook for the dispatch path (#2396).

--- a/backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`FleetLcmConnector` (#3047).
+
+The modern VCF 9 Fleet LCM Service ``/v1/*`` read core is registered as
+typed ops (``source_kind="typed"``) so it dispatches on a fresh boot with
+**zero catalog ingest** — the read core is live the moment the connector
+loads. This is what restores 9.0 fleet dispatch (initiative
+`evoila/meho#3033 <https://github.com/evoila/meho/issues/3033>`_): under
+the "modern default now" resolver decision a VCF Fleet 9.x target resolves
+to ``fleet-lcm`` by most-specific-version, and until this read core landed
+that impl was a skeleton with no dispatchable ops.
+
+The op bodies live in
+:mod:`meho_backplane.connectors.fleet_lcm.typed_reads`; the per-op
+``llm_instructions`` in
+:mod:`meho_backplane.connectors.fleet_lcm._llm_instructions`; thin
+bound-method shims on
+:class:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector`
+expose them under the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+recovers each callable from its persisted ``module.ClassName.method`` path.
+
+The dataclass + tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.harbor.typed_ops` (#2856) and
+:mod:`meho_backplane.connectors.nsx.typed_ops` (#2302) — the Task #2358
+convention: typed ops own the curated read core, generic review
+(``ReviewService.enable_reads`` over an operator ingest of the full 51-op
+``fleet-lcm-openapi.yaml``) owns the wider write / breadth surface as a
+follow-up. The wider surface (component / upgrade-plan / task **writes**)
+is deliberately out of scope here — this is a read core.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+from meho_backplane.connectors.fleet_lcm._llm_instructions import FLEET_LCM_READ_LLM_INSTRUCTIONS
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "FLEET_LCM_TYPED_OPS",
+    "FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP",
+    "FleetLcmTypedOp",
+    "register_fleet_lcm_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys — the five curated groups the fleet-lcm read core
+# spans, ordered system -> sddc -> components -> tasks -> lifecycle to match
+# the operator's typical "is it up, what's deployed, what's happening, what
+# can we upgrade to" drill path.
+_GROUP_SYSTEM = "fleet-lcm-system"
+_GROUP_SDDC = "fleet-lcm-sddc"
+_GROUP_COMPONENTS = "fleet-lcm-components"
+_GROUP_TASKS = "fleet-lcm-tasks"
+_GROUP_LIFECYCLE = "fleet-lcm-lifecycle"
+
+
+@dataclass(frozen=True)
+class FleetLcmTypedOp:
+    """Metadata for one Fleet LCM typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_fleet_lcm_typed_operations` can splat the
+    dataclass into the helper without per-op boilerplate. ``handler_attr``
+    is the attribute name on :class:`FleetLcmConnector` exposing the async
+    handler; the registrar resolves the bound method against the class at
+    registration time. Mirrors
+    :class:`~meho_backplane.connectors.harbor.typed_ops.HarborTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group. Every entry is a
+#: complete sentence the agent reads verbatim through ``list_operation_groups``
+#: to pick a group to search within; ``register_typed_operation`` requires a
+#: non-empty string whenever ``group_key`` is set.
+FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_SYSTEM: (
+        "Use this group to read the VCF Fleet LCM service itself: its "
+        "liveness (health), the fleet-wide system summary (in-flight upgrade "
+        "+ available bundles), and its service configuration. The probe "
+        "surface the agent calls first to confirm a 9.x fleet target is "
+        "reachable before heavier reads."
+    ),
+    _GROUP_SDDC: (
+        "Use this group to list or inspect the SDDC lifecycle managers the "
+        "fleet governs. Each SDDC LCM is the per-SDDC lifecycle authority the "
+        "fleet coordinates; use to answer 'what SDDCs does this fleet manage' "
+        "or to navigate from an SDDC to its deployed components."
+    ),
+    _GROUP_COMPONENTS: (
+        "Use this group to list or inspect the components the fleet has "
+        "deployed and their runtime status — the 'what is deployed and is it "
+        "running' inventory. Each component (Operations, Automation, …) "
+        "carries its type, version, nodes, and the SDDC LCM it belongs to."
+    ),
+    _GROUP_TASKS: (
+        "Use this group to list or inspect the fleet's async operation tasks "
+        "— what the fleet is doing or just did (upgrades, refreshes, "
+        "component actions). Use to track an in-flight task's status or to "
+        "find the failed task behind a component that is not running."
+    ),
+    _GROUP_LIFECYCLE: (
+        "Use this group to read the fleet's lifecycle surface: the planned "
+        "upgrades (upgrade plans) and the release versions the fleet can "
+        "target. Use when answering 'what upgrades are planned' or 'what can "
+        "we upgrade to', or to compute the delta between deployed and target "
+        "versions."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: Empty parameter object shared by the no-argument reads (health / list ops).
+_NO_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+#: Response schema shared by every fleet-lcm read: the by-id reads return a
+#: single object and the list reads return an object envelope
+#: (``{components: []}`` / ``{sddcLcms: []}`` / ``{elements: [], pageMetadata}``),
+#: so a permissive object schema fits both.
+_OBJECT_RESPONSE: dict[str, Any] = {"type": "object", "additionalProperties": True}
+
+_SDDC_LCM_ID_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "SDDC LCM UUID, from fleet-lcm.sddc-lcm.list.",
+}
+_COMPONENT_ID_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Managed component UUID, from fleet-lcm.component.list.",
+}
+_TASK_ID_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Async task UUID, from fleet-lcm.task.list.",
+}
+_PLAN_ID_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Upgrade plan UUID, from fleet-lcm.upgrade-plan.list.",
+}
+
+
+def _schema(properties: dict[str, Any], required: tuple[str, ...] = ()) -> dict[str, Any]:
+    """Build a closed (``additionalProperties=False``) object schema."""
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = list(required)
+    return schema
+
+
+#: The typed ops :class:`FleetLcmConnector` registers at lifespan startup —
+#: the 13-op modern read core (#3047). Every op is safe, read-only, and
+#: ungated; the wire path lives in the handler (see ``._paths``), so the
+#: descriptor rows carry ``method=None`` / ``path=None`` (typed convention).
+FLEET_LCM_TYPED_OPS: tuple[FleetLcmTypedOp, ...] = (
+    # ---- System / service ----
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.health",
+        handler_attr="health",
+        summary="Fleet LCM service liveness probe.",
+        description=(
+            "Returns the Fleet LCM Service liveness via GET /v1/health ({up: bool}). The "
+            "modern 9.x successor to the legacy fleet-rest about/health probe (which 500s "
+            "on 9.0). The same reachability surface the connector's probe reads, exposed "
+            "as a typed op. Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_SYSTEM,
+        tags=("read-only", "fleet-lcm", "vcf", "health"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.health"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.system.info",
+        handler_attr="system_info",
+        summary="Fleet-wide system summary: in-flight upgrade + available bundles.",
+        description=(
+            "Returns the fleet system summary via GET /v1/system: any in-flight system "
+            "upgrade (taskId + status) and the software bundles[] available to the fleet. "
+            "Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_SYSTEM,
+        tags=("read-only", "fleet-lcm", "vcf", "system"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.system.info"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.config.info",
+        handler_attr="config_info",
+        summary="Fleet LCM service configuration.",
+        description=(
+            "Returns the Fleet LCM service configuration via GET /v1/config: "
+            "deploymentFlavor, the management vspCluster it is bound to, config id / "
+            "version, and overall status (HEALTHY / OFFLINE). Dispatches with zero catalog "
+            "ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_SYSTEM,
+        tags=("read-only", "fleet-lcm", "vcf", "config"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.config.info"],
+    ),
+    # ---- SDDC LCM inventory ----
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.sddc-lcm.list",
+        handler_attr="sddc_lcm_list",
+        summary="List the SDDC lifecycle managers the fleet governs.",
+        description=(
+            "Lists SDDC lifecycle managers via GET /v1/sddc-lcms — the 'what SDDCs does "
+            "this fleet manage' entry point. Returns a paged {pageMetadata, sddcLcms: []} "
+            "envelope. Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_SDDC,
+        tags=("read-only", "fleet-lcm", "vcf", "sddc"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.sddc-lcm.list"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.sddc-lcm.info",
+        handler_attr="sddc_lcm_info",
+        summary="Full detail for one SDDC lifecycle manager.",
+        description=(
+            "Reads one SDDC lifecycle manager by id via GET /v1/sddc-lcms/{sddcLcmId}: "
+            "fqdn, sddcGroupFqdn, isPrimary, and vspClusters[]. Requires sddcLcmId from "
+            "fleet-lcm.sddc-lcm.list. Dispatches with zero catalog ingest. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema=_schema({"sddcLcmId": _SDDC_LCM_ID_PROP}, ("sddcLcmId",)),
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_SDDC,
+        tags=("read-only", "fleet-lcm", "vcf", "sddc"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.sddc-lcm.info"],
+    ),
+    # ---- Managed components ----
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.component.list",
+        handler_attr="component_list",
+        summary="List the components the fleet has deployed.",
+        description=(
+            "Lists managed components via GET /v1/components — the primary 'what is "
+            "deployed' inventory. Returns {components: []}; each carries componentType, "
+            "fqdn, version, sddcLcmId, deploymentType, nodes[]. A large inventory is "
+            "reduced to a JSONFlux handle. Dispatches with zero catalog ingest. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_COMPONENTS,
+        tags=("read-only", "fleet-lcm", "vcf", "component"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.component.list"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.component.info",
+        handler_attr="component_info",
+        summary="Full detail for one managed component.",
+        description=(
+            "Reads one managed component by id via GET /v1/components/{componentId}: "
+            "componentType, fqdn, version, sddcLcmId, deploymentType, nodes[], vspCluster. "
+            "Requires componentId from fleet-lcm.component.list. Dispatches with zero "
+            "catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_schema({"componentId": _COMPONENT_ID_PROP}, ("componentId",)),
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_COMPONENTS,
+        tags=("read-only", "fleet-lcm", "vcf", "component"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.component.info"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.component.status",
+        handler_attr="component_status",
+        summary="Runtime status of one managed component.",
+        description=(
+            "Reads the runtime status of one managed component via "
+            "GET /v1/components/{componentId}/status: {id, status} where status is "
+            "Unknown / NotRunning / Running. Requires componentId from "
+            "fleet-lcm.component.list. Dispatches with zero catalog ingest. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_schema({"componentId": _COMPONENT_ID_PROP}, ("componentId",)),
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_COMPONENTS,
+        tags=("read-only", "fleet-lcm", "vcf", "component", "status"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.component.status"],
+    ),
+    # ---- Async tasks ----
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.task.list",
+        handler_attr="task_list",
+        summary="List the fleet's async operation tasks.",
+        description=(
+            "Lists async operation tasks via GET /v1/tasks — 'what is the fleet doing / "
+            "just did'. Returns a paged {elements: [], pageMetadata} envelope; each task "
+            "carries resourceId, type, timing, and a localizedMessage. A large list is "
+            "reduced to a JSONFlux handle. Dispatches with zero catalog ingest. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_TASKS,
+        tags=("read-only", "fleet-lcm", "vcf", "task"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.task.list"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.task.info",
+        handler_attr="task_info",
+        summary="Full detail for one async task.",
+        description=(
+            "Reads one async task by id via GET /v1/tasks/{taskId}: status, timing, "
+            "createdBy / updatedBy, cancellable / retriable, parentTaskId, and a "
+            "localizedMessage. Requires taskId from fleet-lcm.task.list. Dispatches with "
+            "zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_schema({"taskId": _TASK_ID_PROP}, ("taskId",)),
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_TASKS,
+        tags=("read-only", "fleet-lcm", "vcf", "task"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.task.info"],
+    ),
+    # ---- Lifecycle — upgrade plans + release versions ----
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.upgrade-plan.list",
+        handler_attr="upgrade_plan_list",
+        summary="List the fleet's upgrade plans.",
+        description=(
+            "Lists upgrade plans via GET /v1/upgrade-plans — 'what upgrades are planned'. "
+            "Returns a paged {elements: [], pageMetadata} envelope; each plan pins a "
+            "desiredSoftware set against a componentsFilter. Dispatches with zero catalog "
+            "ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_LIFECYCLE,
+        tags=("read-only", "fleet-lcm", "vcf", "upgrade"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.upgrade-plan.list"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.upgrade-plan.info",
+        handler_attr="upgrade_plan_info",
+        summary="Full detail for one upgrade plan.",
+        description=(
+            "Reads one upgrade plan by id via GET /v1/upgrade-plans/{planId}: its spec "
+            "(componentsFilter + desiredSoftware) and timing. Requires planId from "
+            "fleet-lcm.upgrade-plan.list. Dispatches with zero catalog ingest. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_schema({"planId": _PLAN_ID_PROP}, ("planId",)),
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_LIFECYCLE,
+        tags=("read-only", "fleet-lcm", "vcf", "upgrade"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.upgrade-plan.info"],
+    ),
+    FleetLcmTypedOp(
+        op_id="fleet-lcm.release-version.list",
+        handler_attr="release_version_list",
+        summary="List the release versions the fleet can target.",
+        description=(
+            "Lists targetable release versions via GET /v1/release-versions — 'what can we "
+            "upgrade to'. Returns a paged {elements: [], pageMetadata} envelope; each entry "
+            "carries a version and per-component available versions. Dispatches with zero "
+            "catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_LIFECYCLE,
+        tags=("read-only", "fleet-lcm", "vcf", "release"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=FLEET_LCM_READ_LLM_INSTRUCTIONS["fleet-lcm.release-version.list"],
+    ),
+)
+
+
+async def register_fleet_lcm_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`FLEET_LCM_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after every connector subpackage has been imported, so the
+    descriptor rows land before the first dispatch — the 9.x fleet read core
+    is live on a fresh boot. Idempotent across pod restarts (the helper skips
+    the embedding recompute on unchanged summary / description / tags).
+    Mirrors :func:`register_harbor_typed_operations`.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so
+    each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests should
+    # not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.fleet_lcm.connector import FleetLcmConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in FLEET_LCM_TYPED_OPS:
+        handler = getattr(FleetLcmConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"FleetLcmConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        if when_to_use is None:
+            raise ValueError(
+                f"FleetLcmConnector typed op {op.op_id!r} declares group_key={op.group_key!r} "
+                f"but no curated when_to_use exists for that key. Add an entry to "
+                f"FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=FleetLcmConnector.product,
+            version=FleetLcmConnector.version,
+            impl_id=FleetLcmConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "fleet_lcm_typed_operations_registered",
+        count=len(FLEET_LCM_TYPED_OPS),
+        product=FleetLcmConnector.product,
+        version=FleetLcmConnector.version,
+        impl_id=FleetLcmConnector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/fleet_lcm/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/typed_reads.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`FleetLcmConnector`.
+
+The modern VCF 9 Fleet LCM Service ``/v1/*`` read core (#3047, initiative
+`evoila/meho#3033 <https://github.com/evoila/meho/issues/3033>`_) is
+registered as typed ops (``source_kind="typed"``) so it dispatches on a
+fresh boot with **zero catalog state** — the read core is live the moment
+the connector loads, no operator ``meho connector ingest`` +
+``enable_reads`` step. This is what restores 9.0 fleet dispatch: a VCF
+Fleet 9.0 target resolves to ``fleet-lcm`` by the resolver's
+most-specific-version tie-break (``>=9.0,<10.0`` vs the legacy
+``fleet-rest`` ``>=8.0,<10.0``), and these ops give it a dispatchable
+modern read surface.
+
+Each function here is the body a thin bound-method shim on
+:class:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector`
+delegates to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.fleet_lcm.typed_ops`, and the per-op
+``llm_instructions`` blobs in
+:mod:`meho_backplane.connectors.fleet_lcm._llm_instructions` (split out to
+keep this module under the file-size budget — the same three-key shape the
+harbor #2856 read core co-locates). This mirrors the Harbor (#2856) and NSX
+(#2302) conversions under Task #2358: typed ops own the curated read core,
+generic review (``ReviewService.enable_reads`` over an operator ingest of
+the full 51-op spec) owns the wider write / breadth surface as a follow-up.
+
+Every read is issued directly on the connector's own authenticated client
+via :meth:`HttpConnector._get_json`, which applies
+:meth:`FleetLcmConnector.auth_headers` per request — Bearer primary
+(``Authorization: Bearer <token>`` when the loaded credentials carry a
+``token``), HTTP-Basic fallback otherwise. A raw ``401`` propagates as
+:class:`httpx.HTTPStatusError` to the dispatcher's credential-recovery arm,
+which evicts the cached credentials via
+:meth:`FleetLcmConnector.invalidate_credentials` (#2396) and re-dispatches
+once.
+
+The 13-read set (each ``GET:/path`` reconciled against the pinned
+Apache-2.0 ``fleet-lcm-openapi.yaml`` on the operator's shelf by
+:mod:`tests.test_connectors_fleet_lcm_spec_reconcile`; the path templates
+live in :mod:`~meho_backplane.connectors.fleet_lcm._paths`):
+
+* ``fleet-lcm.health`` — ``GET /v1/health`` (service liveness; the same
+  surface :meth:`FleetLcmConnector.probe` reads, exposed as an
+  operator-callable typed op).
+* ``fleet-lcm.system.info`` — ``GET /v1/system`` (fleet system summary:
+  pending upgrade + available bundles).
+* ``fleet-lcm.config.info`` — ``GET /v1/config`` (Fleet LCM service
+  configuration).
+* ``fleet-lcm.sddc-lcm.list`` / ``.info`` — ``GET /v1/sddc-lcms`` and
+  ``/v1/sddc-lcms/{sddcLcmId}`` (registered SDDC lifecycle managers).
+* ``fleet-lcm.component.list`` / ``.info`` / ``.status`` —
+  ``GET /v1/components``, ``/v1/components/{componentId}`` and
+  ``/v1/components/{componentId}/status`` (managed component inventory +
+  per-component status).
+* ``fleet-lcm.task.list`` / ``.info`` — ``GET /v1/tasks`` and
+  ``/v1/tasks/{taskId}`` (async operation tracking).
+* ``fleet-lcm.upgrade-plan.list`` / ``.info`` — ``GET /v1/upgrade-plans``
+  and ``/v1/upgrade-plans/{planId}`` (planned upgrades).
+* ``fleet-lcm.release-version.list`` — ``GET /v1/release-versions``
+  (available target releases).
+
+**Pagination note.** ``sddc-lcms`` / ``tasks`` / ``upgrade-plans`` /
+``release-versions`` are server-paged: an un-parameterised call returns the
+first page under an ``sddcLcms`` / ``elements`` array plus a
+``pageMetadata`` object carrying ``totalElements`` / ``totalPages`` — the
+agent reads that to know whether more exist (so this is self-describing,
+not silent truncation). Forwarding server-side ``page`` / ``size`` / filter
+query params is a deferred enrichment; today the agent narrows large
+results through the dispatcher's JSONFlux handle (``result_query``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.fleet_lcm._paths import (
+    _COMPONENT_PATH,
+    _COMPONENT_STATUS_PATH,
+    _COMPONENTS_PATH,
+    _CONFIG_PATH,
+    _HEALTH_PATH,
+    _RELEASE_VERSIONS_PATH,
+    _SDDC_LCM_PATH,
+    _SDDC_LCMS_PATH,
+    _SYSTEM_PATH,
+    _TASK_PATH,
+    _TASKS_PATH,
+    _UPGRADE_PLAN_PATH,
+    _UPGRADE_PLANS_PATH,
+    encode_segment,
+    fill_path,
+)
+from meho_backplane.connectors.fleet_lcm.session import FleetLcmTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.fleet_lcm.connector import FleetLcmConnector
+
+__all__ = [
+    "fleet_lcm_component_info_impl",
+    "fleet_lcm_component_list_impl",
+    "fleet_lcm_component_status_impl",
+    "fleet_lcm_config_info_impl",
+    "fleet_lcm_health_impl",
+    "fleet_lcm_release_version_list_impl",
+    "fleet_lcm_sddc_lcm_info_impl",
+    "fleet_lcm_sddc_lcm_list_impl",
+    "fleet_lcm_system_info_impl",
+    "fleet_lcm_task_info_impl",
+    "fleet_lcm_task_list_impl",
+    "fleet_lcm_upgrade_plan_info_impl",
+    "fleet_lcm_upgrade_plan_list_impl",
+]
+
+
+# ---------------------------------------------------------------------------
+# System / service surface
+# ---------------------------------------------------------------------------
+
+
+async def fleet_lcm_health_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.health`` — ``GET /v1/health``.
+
+    Returns the Fleet LCM Service liveness object (``{"up": bool}``). The
+    same reachability surface :meth:`FleetLcmConnector.probe` /
+    :meth:`~FleetLcmConnector.fingerprint` read, exposed as an
+    operator-callable typed op. The spec marks the endpoint
+    ``security: []`` (unauthenticated), but the connector sends its auth
+    headers anyway so probe and dispatch stay on one auth path.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _HEALTH_PATH, operator=operator)
+
+
+async def fleet_lcm_system_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.system.info`` — ``GET /v1/system``.
+
+    Returns the fleet system summary: any in-flight system ``upgrade``
+    (``taskId`` + ``status``) and the ``bundles[]`` available to the fleet
+    (each with component type, version, and required/optional status).
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SYSTEM_PATH, operator=operator)
+
+
+async def fleet_lcm_config_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.config.info`` — ``GET /v1/config``.
+
+    Returns the Fleet LCM service configuration: ``deploymentFlavor`` (e.g.
+    ``VCF``), the management ``vspCluster`` it is bound to, the config
+    ``id`` / ``version``, and an overall ``status`` (``HEALTHY`` /
+    ``OFFLINE``).
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _CONFIG_PATH, operator=operator)
+
+
+# ---------------------------------------------------------------------------
+# SDDC LCM inventory
+# ---------------------------------------------------------------------------
+
+
+async def fleet_lcm_sddc_lcm_list_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.sddc-lcm.list`` — ``GET /v1/sddc-lcms``.
+
+    Lists the SDDC lifecycle managers the fleet manages. Returns a paged
+    envelope: ``{"pageMetadata": {...}, "sddcLcms": [SddcLcm, ...]}``. Each
+    entry carries ``fqdn``, ``sddcGroupFqdn``, ``isPrimary``, and its
+    ``vspClusters[]``. ``pageMetadata`` (``totalElements`` / ``totalPages``)
+    tells you whether more pages exist.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SDDC_LCMS_PATH, operator=operator)
+
+
+async def fleet_lcm_sddc_lcm_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.sddc-lcm.info`` — ``GET /v1/sddc-lcms/{sddcLcmId}``.
+
+    Reads one SDDC lifecycle manager by id. Requires ``sddcLcmId`` (a UUID
+    from ``fleet-lcm.sddc-lcm.list``). Returns the full ``SddcLcm`` object.
+    """
+    path = fill_path(_SDDC_LCM_PATH, {"sddcLcmId": encode_segment(params["sddcLcmId"])})
+    return await connector._get_json(target, path, operator=operator)
+
+
+# ---------------------------------------------------------------------------
+# Managed components
+# ---------------------------------------------------------------------------
+
+
+async def fleet_lcm_component_list_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.component.list`` — ``GET /v1/components``.
+
+    Lists the components the fleet manages ("what's deployed"). Returns
+    ``{"components": [Component, ...]}``; each entry carries
+    ``componentType``, ``fqdn``, ``version``, ``sddcLcmId``,
+    ``deploymentType``, ``nodes[]``, and its ``vspCluster``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _COMPONENTS_PATH, operator=operator)
+
+
+async def fleet_lcm_component_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.component.info`` — ``GET /v1/components/{componentId}``.
+
+    Reads one managed component by id. Requires ``componentId`` (a UUID
+    from ``fleet-lcm.component.list``). Returns the full ``Component``
+    object.
+    """
+    path = fill_path(_COMPONENT_PATH, {"componentId": encode_segment(params["componentId"])})
+    return await connector._get_json(target, path, operator=operator)
+
+
+async def fleet_lcm_component_status_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.component.status`` — ``GET /v1/components/{componentId}/status``.
+
+    Reads the runtime status of one managed component. Requires
+    ``componentId``. Returns ``{"id": <uuid>, "status": <Unknown |
+    NotRunning | Running>}``.
+    """
+    path = fill_path(
+        _COMPONENT_STATUS_PATH,
+        {"componentId": encode_segment(params["componentId"])},
+    )
+    return await connector._get_json(target, path, operator=operator)
+
+
+# ---------------------------------------------------------------------------
+# Async tasks
+# ---------------------------------------------------------------------------
+
+
+async def fleet_lcm_task_list_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.task.list`` — ``GET /v1/tasks``.
+
+    Lists the fleet's async operation tasks. Returns a paged envelope
+    ``{"elements": [TaskSummary, ...], "pageMetadata": {...}}``; each entry
+    carries ``resourceId``, ``type``, ``createTime`` / ``updateTime``,
+    ``cancellable`` / ``retriable``, ``parentTaskId``, and a
+    ``description`` with a ``localizedMessage``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _TASKS_PATH, operator=operator)
+
+
+async def fleet_lcm_task_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.task.info`` — ``GET /v1/tasks/{taskId}``.
+
+    Reads one async task by id. Requires ``taskId`` (a UUID from
+    ``fleet-lcm.task.list``). Returns the full ``Task`` object, including
+    its current status and any sub-task detail.
+    """
+    path = fill_path(_TASK_PATH, {"taskId": encode_segment(params["taskId"])})
+    return await connector._get_json(target, path, operator=operator)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle — upgrade plans + release versions
+# ---------------------------------------------------------------------------
+
+
+async def fleet_lcm_upgrade_plan_list_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.upgrade-plan.list`` — ``GET /v1/upgrade-plans``.
+
+    Lists the fleet's upgrade plans. Returns a paged envelope
+    ``{"elements": [UpgradePlanSummary, ...], "pageMetadata": {...}}``; each
+    entry carries ``id``, ``createTime`` / ``updateTime``, and a ``spec``
+    with the ``componentsFilter`` and ``desiredSoftware``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _UPGRADE_PLANS_PATH, operator=operator)
+
+
+async def fleet_lcm_upgrade_plan_info_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.upgrade-plan.info`` — ``GET /v1/upgrade-plans/{planId}``.
+
+    Reads one upgrade plan by id. Requires ``planId`` (a UUID from
+    ``fleet-lcm.upgrade-plan.list``). Returns the full ``UpgradePlan``
+    object.
+    """
+    path = fill_path(_UPGRADE_PLAN_PATH, {"planId": encode_segment(params["planId"])})
+    return await connector._get_json(target, path, operator=operator)
+
+
+async def fleet_lcm_release_version_list_impl(
+    connector: FleetLcmConnector,
+    operator: Operator,
+    target: FleetLcmTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``fleet-lcm.release-version.list`` — ``GET /v1/release-versions``.
+
+    Lists the release versions the fleet can target. Returns a paged
+    envelope ``{"elements": [ReleaseVersion, ...], "pageMetadata": {...}}``;
+    each entry carries a ``version`` and the per-``components[]`` public
+    names and available versions.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _RELEASE_VERSIONS_PATH, operator=operator)

--- a/backend/tests/test_connectors_fleet_lcm_spec_reconcile.py
+++ b/backend/tests/test_connectors_fleet_lcm_spec_reconcile.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""fleet-lcm (VCF 9 Fleet LCM Service) real-spec reconcile lane (#3036) — the #2980 harness.
+"""fleet-lcm (VCF 9 Fleet LCM Service) real-spec reconcile lane (#3036, #3047) — #2980 harness.
 
 Asserts every hand-coded ``METHOD:/path`` the modern ``fleet-lcm`` connector
 dispatches is served by the pinned ``fleet-lcm-9.0/fleet-lcm-openapi.yaml`` — the
@@ -21,15 +21,21 @@ reconciles the **modern** ``fleet-lcm`` impl's ``/v1/*`` surface. The two impls
 of ``product=fleet`` are resolved per target by fingerprint (see
 ``test_connectors_fleet_dual_impl_resolution.py``).
 
-Ingested ops are not reconciled here. The connector's 51 ``/v1/*`` operations
-arrive via G0.7 spec ingestion (``source_kind="ingested"``), so an operator
-ingest of the same pinned spec produces those op_ids **by construction** — a
-reconcile of ingested rows against the spec they were ingested from is
-tautological. What this lane guards is the connector's **hand-coded** surface:
-its ``_*_PATH`` probe/fingerprint constant(s), introspected from the live class
-constants (the #2944 pattern — never a hardcoded mirror), which a typo or a
-renamed endpoint would silently break. The connector hand-codes exactly one
-path — the ``GET /v1/health`` reachability probe — and dispatches it GET.
+What this lane guards (#3047). The connector's hand-coded surface is now the
+**13-op typed read core** (``source_kind="typed"``): its ``/v1/*`` request-path
+templates live as ``_*_PATH`` constants in
+:mod:`~meho_backplane.connectors.fleet_lcm._paths`, and every typed handler
+builds its concrete path from one via ``fill_path`` — so a typo, a renamed
+endpoint, or a placeholder-name drift would dispatch a URL the real service
+never serves. This lane introspects those live ``_paths`` constants (the #2944
+pattern — never a hardcoded mirror) plus the connector's
+``_FLEET_LCM_HEALTH_PATH`` reachability probe, and asserts each assembled
+``GET:/path`` is served by the pinned spec. The typed health op and the probe
+share ``/v1/health`` — the pin asserts that link so the two never drift apart.
+(The wider 51-op ``/v1/*`` surface arrives as ``source_kind="ingested"`` breadth
+via an operator ingest of *this same spec* — reconciling ingested rows against
+the spec they were ingested from is tautological, so only the hand-coded typed
+paths are guarded here.)
 
 No server-base fold. Unlike the vcf-operations lane (whose spec declares the
 *relative* server base ``/suite-api`` that ``parse_openapi`` folds onto every
@@ -40,9 +46,9 @@ server (scheme/authority present) — the ``/fleet-lcm`` base points at a
 spec-declared host meho does not dispatch against, so only the operator's
 target host carries it. The served op_ids are therefore the raw ``/v1/*`` path
 keys (verified: the pinned spec serves ``GET:/v1/health``, no ``/fleet-lcm``
-prefix), and the connector's ``_FLEET_LCM_HEALTH_PATH`` constant declares the
-same raw ``/v1/health`` — the comparison is byte-for-byte against what an
-operator ingest of the same spec would dispatch.
+prefix), and the ``_paths`` constants declare the same raw ``/v1/*`` — the
+comparison is byte-for-byte against what an operator ingest of the same spec
+would dispatch.
 
 A red lane here is the guard surfacing a real finding, not harness noise —
 triage per docs/decisions/spec-reconcile-guards-standard.md.
@@ -50,7 +56,9 @@ triage per docs/decisions/spec-reconcile-guards-standard.md.
 
 from __future__ import annotations
 
+from meho_backplane.connectors.fleet_lcm import _paths
 from meho_backplane.connectors.fleet_lcm import connector as _connector
+from meho_backplane.connectors.fleet_lcm.typed_ops import FLEET_LCM_TYPED_OPS
 from tests._spec_shelf import (
     assert_op_ids_served,
     openapi_served_op_ids,
@@ -61,39 +69,88 @@ _SPEC_DIR = "fleet-lcm-9.0"
 _SPEC_FILE = "fleet-lcm-openapi.yaml"
 _SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
 
+#: The exact ``_*_PATH`` template-constant name set the typed read core declares
+#: in :mod:`~meho_backplane.connectors.fleet_lcm._paths`. Pinned so a dropped or
+#: renamed template — or a new one that skips the convention — fails the guard
+#: consciously rather than silently shrinking the reconciled surface.
+_EXPECTED_PATH_CONSTANT_NAMES = frozenset(
+    {
+        "_HEALTH_PATH",
+        "_SYSTEM_PATH",
+        "_CONFIG_PATH",
+        "_SDDC_LCMS_PATH",
+        "_SDDC_LCM_PATH",
+        "_COMPONENTS_PATH",
+        "_COMPONENT_PATH",
+        "_COMPONENT_STATUS_PATH",
+        "_TASKS_PATH",
+        "_TASK_PATH",
+        "_UPGRADE_PLANS_PATH",
+        "_UPGRADE_PLAN_PATH",
+        "_RELEASE_VERSIONS_PATH",
+    }
+)
 
-def _path_constants() -> dict[str, str]:
-    """The live ``_*_PATH`` string constants of ``connector``, by constant name."""
+#: The full hand-coded ``GET:/path`` surface the typed read core dispatches, plus
+#: the connector's health probe (which reuses the ``/v1/health`` typed path).
+_EXPECTED_OP_IDS = frozenset(
+    {
+        "GET:/v1/health",
+        "GET:/v1/system",
+        "GET:/v1/config",
+        "GET:/v1/sddc-lcms",
+        "GET:/v1/sddc-lcms/{sddcLcmId}",
+        "GET:/v1/components",
+        "GET:/v1/components/{componentId}",
+        "GET:/v1/components/{componentId}/status",
+        "GET:/v1/tasks",
+        "GET:/v1/tasks/{taskId}",
+        "GET:/v1/upgrade-plans",
+        "GET:/v1/upgrade-plans/{planId}",
+        "GET:/v1/release-versions",
+    }
+)
+
+
+def _typed_path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` template constants of the ``_paths`` module."""
     return {
         name: value
-        for name, value in vars(_connector).items()
+        for name, value in vars(_paths).items()
         if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
     }
 
 
 def _declared_op_ids() -> set[str]:
-    """Every hand-coded ``METHOD:/path`` the fleet-lcm connector dispatches.
+    """Every hand-coded ``GET:/path`` the fleet-lcm connector dispatches.
 
-    Sweeps the live module constants (never a hardcoded mirror). The connector
-    hand-codes exactly one path — the ``GET /v1/health`` reachability probe —
-    and dispatches it GET (the 51 ``/v1/*`` operational ops are ingested, not
-    hand-coded, and are reconciled by ingestion itself, not this lane).
+    The 13 typed read-core path templates (:mod:`._paths`) union the connector's
+    ``GET /v1/health`` reachability probe (which reuses the typed health path).
+    All are dispatched GET. Swept from live module constants — never a hardcoded
+    mirror.
     """
-    return {f"GET:{path}" for path in _path_constants().values()}
+    paths = set(_typed_path_constants().values())
+    paths.add(_connector._FLEET_LCM_HEALTH_PATH)
+    return {f"GET:{path}" for path in paths}
 
 
 def test_hand_coded_path_surface_is_pinned() -> None:
-    """Guard: the introspection finds the hand-coded probe literal.
+    """Guard: the introspection finds exactly the typed read-core path surface.
 
-    Pinning the exact ``_*_PATH`` constant-name set, its value, and the
-    assembled op_id set (the #2944 guard shape) means a renamed or dropped
-    constant — or a new path that skips the convention — fails here until the
-    reconcile is updated consciously, so the declared set can never silently
-    shrink to a vacuous pass. Runs unconditionally (no shelf needed).
+    Pins the ``_*_PATH`` template-constant name set, the assembled op_id set (the
+    #2944 guard shape), the probe⇄typed-health link, and the one-path-per-typed-op
+    invariant — so the declared set can never silently shrink to a vacuous pass or
+    drift from the read core the connector actually ships. Runs unconditionally
+    (no shelf needed).
     """
-    assert sorted(_path_constants()) == ["_FLEET_LCM_HEALTH_PATH"]
-    assert _connector._FLEET_LCM_HEALTH_PATH == "/v1/health"
-    assert _declared_op_ids() == {"GET:/v1/health"}
+    assert set(_typed_path_constants()) == set(_EXPECTED_PATH_CONSTANT_NAMES)
+    # The typed health op and the connector's reachability probe are the same
+    # endpoint — pin the link so a change to one is forced through the other.
+    assert _paths._HEALTH_PATH == _connector._FLEET_LCM_HEALTH_PATH == "/v1/health"
+    assert _declared_op_ids() == set(_EXPECTED_OP_IDS)
+    # One dispatched path per typed op (health's path is shared with the probe,
+    # so the distinct-path count equals the typed-op count).
+    assert len(FLEET_LCM_TYPED_OPS) == len(_declared_op_ids()) == 13
 
 
 def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
@@ -105,7 +162,9 @@ def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
     OpenAPI 3.0.4 document whose ``securitySchemes`` are well-formed
     ``type: http`` schemes, so ``parse_openapi`` accepts it) with **no**
     server-base fold — see the module docstring for the absolute-server
-    reasoning.
+    reasoning. The by-id placeholders (``{sddcLcmId}`` / ``{componentId}`` /
+    ``{taskId}`` / ``{planId}``) are byte-for-byte the spec's own path-parameter
+    names, so the templated op_ids compare directly against the served keys.
     """
     spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
     served = openapi_served_op_ids(spec_path)

--- a/backend/tests/test_connectors_fleet_lcm_typed_reads.py
+++ b/backend/tests/test_connectors_fleet_lcm_typed_reads.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the modern fleet-lcm typed read core (#3047, initiative #3033).
+
+This is the appliance-free proof that restores 9.0 fleet dispatch: a VCF
+Fleet 9.x target resolves to ``fleet-lcm`` (most-specific-version) and now
+dispatches a modern ``/v1/*`` read op end-to-end. Coverage:
+
+* **Zero-catalog typed dispatch.** Each of the 13 reads dispatches through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked Fleet
+  LCM service with **only** the typed registrar run (no ingested rows) and
+  returns ``status="ok"``. By-id ops interpolate ``{sddcLcmId}`` /
+  ``{componentId}`` / ``{taskId}`` / ``{planId}`` into the path via
+  ``fill_path`` + ``encode_segment``.
+* **Both auth seams.** The reads ride :meth:`FleetLcmConnector.auth_headers`
+  per request — HTTP Basic when the loaded credentials carry only
+  username/password, and ``Authorization: Bearer <token>`` (the spec's
+  primary scheme) when they additionally carry a ``token``. The Bearer
+  *header shape* is exercised here against a mocked service; live-verify
+  against a real appliance is the #3047 follow-up (no reachable appliance,
+  #1002 / #995).
+* **Registration-shape invariants.** All 13 reads persist as
+  ``source_kind="typed"``, ``is_enabled=True`` (enabled at register time —
+  the "fresh boot, zero ingest" property), ``safe`` / ungated / ``read-only``,
+  with a canonical-key ``llm_instructions`` blob; their 5 groups land
+  ``review_status="enabled"``; no write op is registered.
+
+Mirrors :mod:`tests.test_connectors_harbor_typed_reads` for the
+dispatch-lifecycle + embedding-stub plumbing; the credential seam replaces
+the whole ``CredentialsCache`` on the resolved instance (the shared
+VCF-family pattern the vcf_fleet e2e / typed-read tests use), since
+``FleetLcmConnector`` holds its loader inside ``self._creds`` rather than a
+bare ``_credentials_loader``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.fleet_lcm import (
+    FLEET_LCM_CONNECTOR_ID,
+    FLEET_LCM_IMPL_ID,
+    FLEET_LCM_PRODUCT,
+    FLEET_LCM_TYPED_OPS,
+    FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP,
+    FLEET_LCM_VERSION,
+    FleetLcmConnector,
+    register_fleet_lcm_typed_operations,
+)
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_FLEET_HOST = "fleet-lcm-typed.test.invalid"
+_FLEET_BASE_URL = f"https://{_FLEET_HOST}"
+
+_EXPECTED_OP_IDS = {
+    "fleet-lcm.health",
+    "fleet-lcm.system.info",
+    "fleet-lcm.config.info",
+    "fleet-lcm.sddc-lcm.list",
+    "fleet-lcm.sddc-lcm.info",
+    "fleet-lcm.component.list",
+    "fleet-lcm.component.info",
+    "fleet-lcm.component.status",
+    "fleet-lcm.task.list",
+    "fleet-lcm.task.info",
+    "fleet-lcm.upgrade-plan.list",
+    "fleet-lcm.upgrade-plan.info",
+    "fleet-lcm.release-version.list",
+}
+
+_EXPECTED_GROUPS = {
+    "fleet-lcm-system",
+    "fleet-lcm-sddc",
+    "fleet-lcm-components",
+    "fleet-lcm-tasks",
+    "fleet-lcm-lifecycle",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=FLEET_LCM_PRODUCT,
+        version=FLEET_LCM_VERSION,
+        impl_id=FLEET_LCM_IMPL_ID,
+        cls=FleetLcmConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _FleetLcmReadTarget:
+    """Target satisfying both ``FleetLcmTargetLike`` and the resolver shape.
+
+    ``fingerprint.version="9.0.2"`` is in the ``fleet-lcm`` band
+    ``">=9.0,<10.0"``, so a fleet target resolves to this modern impl by the
+    resolver's most-specific-version tie-break (the "modern default now"
+    decision).
+    """
+
+    def __init__(self) -> None:
+        self.product = FLEET_LCM_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "9.0.2"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-0000000000e0")
+        self.name = "fleet-lcm-typed"
+        self.host = _FLEET_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/fleet-lcm-typed"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-fleet-lcm",
+        name="Fleet LCM Reads Operator",
+        email=None,
+        raw_jwt="op.reads.fleet-lcm.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000e4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _basic_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Username/password only — drives the ``basicAuth`` fallback path."""
+    return {"username": "fleet-lcm-svc", "password": "fleet-lcm-pw"}
+
+
+async def _bearer_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Adds a ``token`` — drives the primary ``bearerToken`` path."""
+    return {
+        "username": "fleet-lcm-svc",
+        "password": "fleet-lcm-pw",
+        "token": "fleet-lcm-bearer-tok",
+    }
+
+
+async def _register_and_resolve(loader: Any) -> FleetLcmConnector:
+    """Run the typed registrar (only) and return a credentials-stubbed instance.
+
+    ``FleetLcmConnector`` keeps its loader inside ``self._creds`` (a
+    ``CredentialsCache``), so the seam replaces the whole cache with one wired
+    to *loader* — the shared VCF-family injection the vcf_fleet e2e / typed
+    tests use.
+    """
+    await register_fleet_lcm_typed_operations()
+    instance = get_or_create_connector_instance(FleetLcmConnector)
+    instance._creds = type(instance._creds)(  # type: ignore[attr-defined]
+        loader,
+        product_label="fleet-lcm",
+    )
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Zero-catalog typed dispatch
+# ---------------------------------------------------------------------------
+
+_DISPATCH_CASES: list[tuple[str, str, dict[str, Any], Any]] = [
+    ("fleet-lcm.health", "/v1/health", {}, {"up": True}),
+    (
+        "fleet-lcm.system.info",
+        "/v1/system",
+        {},
+        {"upgrade": {"taskId": "t-1", "status": "PENDING"}, "bundles": []},
+    ),
+    ("fleet-lcm.config.info", "/v1/config", {}, {"deploymentFlavor": "VCF", "status": "HEALTHY"}),
+    (
+        "fleet-lcm.sddc-lcm.list",
+        "/v1/sddc-lcms",
+        {},
+        {"pageMetadata": {"totalElements": 1}, "sddcLcms": [{"fqdn": "sddc-a"}]},
+    ),
+    (
+        "fleet-lcm.sddc-lcm.info",
+        "/v1/sddc-lcms/sddc-1",
+        {"sddcLcmId": "sddc-1"},
+        {"fqdn": "sddc-a", "isPrimary": True},
+    ),
+    (
+        "fleet-lcm.component.list",
+        "/v1/components",
+        {},
+        {"components": [{"componentType": "OPS", "version": "9.0.0"}]},
+    ),
+    (
+        "fleet-lcm.component.info",
+        "/v1/components/comp-1",
+        {"componentId": "comp-1"},
+        {"componentType": "OPS", "fqdn": "ops-a"},
+    ),
+    (
+        "fleet-lcm.component.status",
+        "/v1/components/comp-1/status",
+        {"componentId": "comp-1"},
+        {"id": "comp-1", "status": "Running"},
+    ),
+    (
+        "fleet-lcm.task.list",
+        "/v1/tasks",
+        {},
+        {"elements": [{"resourceId": "r-1", "type": "UPGRADE"}], "pageMetadata": {}},
+    ),
+    (
+        "fleet-lcm.task.info",
+        "/v1/tasks/task-1",
+        {"taskId": "task-1"},
+        {"resourceId": "r-1", "type": "UPGRADE", "status": "COMPLETED"},
+    ),
+    (
+        "fleet-lcm.upgrade-plan.list",
+        "/v1/upgrade-plans",
+        {},
+        {"elements": [{"id": "plan-1"}], "pageMetadata": {}},
+    ),
+    (
+        "fleet-lcm.upgrade-plan.info",
+        "/v1/upgrade-plans/plan-1",
+        {"planId": "plan-1"},
+        {"id": "plan-1", "spec": {"componentsFilter": []}},
+    ),
+    (
+        "fleet-lcm.release-version.list",
+        "/v1/release-versions",
+        {},
+        {"elements": [{"version": "9.1.0"}], "pageMetadata": {}},
+    ),
+]
+
+
+@pytest.mark.parametrize(("op_id", "path", "params", "payload"), _DISPATCH_CASES, ids=lambda v: v)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+    params: dict[str, Any],
+    payload: Any,
+) -> None:
+    """Each read dispatches typed (zero ingested catalog); the Basic header is sent."""
+    await _register_and_resolve(_basic_loader)
+
+    async with respx.mock(base_url=_FLEET_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=FLEET_LCM_CONNECTOR_ID,
+            op_id=op_id,
+            target=_FleetLcmReadTarget(),
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert route.called and route.call_count == 1
+    # Basic loader (no token) → the spec's basicAuth fallback header is sent.
+    sent_auth = route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_bearer_when_token_present(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """When the loaded credentials carry a ``token``, the read sends Bearer (primary scheme)."""
+    await _register_and_resolve(_bearer_loader)
+
+    async with respx.mock(base_url=_FLEET_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/v1/components").respond(200, json={"components": []})
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=FLEET_LCM_CONNECTOR_ID,
+            op_id="fleet-lcm.component.list",
+            target=_FleetLcmReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    sent_auth = route.calls[0].request.headers.get("authorization")
+    assert sent_auth == "Bearer fleet-lcm-bearer-tok"
+
+
+@pytest.mark.asyncio
+async def test_by_id_op_percent_encodes_path_segment(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """A by-id param with a reserved char is percent-encoded (encode_segment), not injected."""
+    await _register_and_resolve(_basic_loader)
+
+    async with respx.mock(base_url=_FLEET_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/v1/components/a%2Fb/status").respond(200, json={"id": "a/b"})
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=FLEET_LCM_CONNECTOR_ID,
+            op_id="fleet-lcm.component.status",
+            target=_FleetLcmReadTarget(),
+            params={"componentId": "a/b"},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called and route.call_count == 1
+    # The "/" is encoded to %2F — a reserved char can never leak path structure.
+    assert route.calls[0].request.url.raw_path.decode().startswith("/v1/components/a%2Fb/status")
+
+
+# ---------------------------------------------------------------------------
+# Registration-shape invariants — the "merge = fix" property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_typed_and_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 13 reads persist as source_kind='typed', is_enabled=True (live on fresh boot)."""
+    await register_fleet_lcm_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == FLEET_LCM_PRODUCT,
+                    EndpointDescriptor.impl_id == FLEET_LCM_IMPL_ID,
+                    EndpointDescriptor.op_id.in_(list(_EXPECTED_OP_IDS)),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == _EXPECTED_OP_IDS
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.is_enabled is True for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+    # Typed ops carry no wire method/path on the descriptor (path lives in _paths).
+    assert all(r.method is None and r.path is None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_groups_are_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 5 read-core groups land review_status='enabled' (typed groups skip the queue)."""
+    await register_fleet_lcm_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(OperationGroup).where(
+                    OperationGroup.product == FLEET_LCM_PRODUCT,
+                    OperationGroup.impl_id == FLEET_LCM_IMPL_ID,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {g.group_key for g in rows} == _EXPECTED_GROUPS
+    assert all(g.review_status == "enabled" for g in rows)
+    assert all(g.when_to_use.strip() for g in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed reads are retrievable via search_operations."""
+    await register_fleet_lcm_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {
+            "connector_id": FLEET_LCM_CONNECTOR_ID,
+            "query": "fleet health system components sddc tasks upgrade release versions",
+            "limit": 25,
+        },
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    assert found >= _EXPECTED_OP_IDS, f"missing from search: {_EXPECTED_OP_IDS - found}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-dataclass invariants (no DB, no async)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_table_is_exactly_the_read_core() -> None:
+    assert {op.op_id for op in FLEET_LCM_TYPED_OPS} == _EXPECTED_OP_IDS
+    assert len(FLEET_LCM_TYPED_OPS) == 13
+
+
+def test_every_group_key_has_a_when_to_use() -> None:
+    assert set(FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP) == _EXPECTED_GROUPS
+    used_groups = {op.group_key for op in FLEET_LCM_TYPED_OPS}
+    assert used_groups == _EXPECTED_GROUPS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in FLEET_LCM_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_canonical_keys(op_id: str) -> None:
+    op = next(o for o in FLEET_LCM_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    for key in ("when_to_call", "output_shape", "next_step"):
+        value = op.llm_instructions.get(key)
+        assert isinstance(value, str) and value.strip(), f"{op_id}: {key}"
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in FLEET_LCM_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only core: no create/write op ships here (writes are a #3047 follow-up)."""
+    for op in FLEET_LCM_TYPED_OPS:
+        assert not any(
+            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
+        )
+        assert "write" not in op.tags

--- a/docs/codebase/connectors-fleet-lcm.md
+++ b/docs/codebase/connectors-fleet-lcm.md
@@ -23,22 +23,46 @@ impl dispatches; the legacy surface still answers on 9.0 appliances for
 back-compat, which is why both bands overlap at 9.0 and the resolver — not the
 connector — picks the surface per target.
 
-## Skeleton scope
+## Scope: typed read core (#3047)
 
-This Task (#3036) ships the connector **skeleton** — auth + fingerprint +
-probe + the G0.6 dispatch shim — the same shape the legacy `vcf_fleet`
-connector first shipped as (#831). The 51 `/v1/*` operations are **not**
-hand-coded: they arrive via G0.7 spec ingestion as `source_kind="ingested"`
-`endpoint_descriptor` rows under `connector_id="fleet-lcm-9.0"`. Registering
-this real `HttpConnector` subclass is the load-bearing prerequisite for those
-rows to become **dispatchable** — a bare `GenericRestConnector` auto-shim is
-non-dispatchable (its `auth_headers` / `execute` raise), so ingested ops ride
-*this* class's `auth_headers` on dispatch (the `VmwareRestConnector` pattern).
+The connector ships a curated **13-op typed read core** — the modern successor
+to the legacy `fleet-rest` read surface — registered as `source_kind="typed"`
+and **enabled at register time**, so a VCF Fleet 9.x target (which resolves
+here by most-specific-version) dispatches a modern `/v1/*` read op on a **fresh
+boot with zero catalog ingest**. This is what **restores 9.0 fleet dispatch**
+after the "modern default now" resolver decision (#3033): the #3036 skeleton
+left `fleet-lcm` registered but with no dispatchable ops, so a 9.0 target
+resolved to an impl that could not serve a call; the read core closes that gap.
 
-**Live-appliance dispatch verification is a non-goal** (#1002 / #995 — no
-reachable Fleet LCM appliance). The connector ships registered, spec-guarded
-(reconcile lane), and reconcile-armed; live Bearer-auth verification is a
-follow-up gated on a stood-up appliance (see "Auth" below).
+The read core covers the operator's "is it up, what's deployed, what's
+happening, what can we upgrade to" drill path across five groups:
+
+| Group | Ops |
+|---|---|
+| `fleet-lcm-system` | `fleet-lcm.health`, `.system.info`, `.config.info` |
+| `fleet-lcm-sddc` | `fleet-lcm.sddc-lcm.list`, `.sddc-lcm.info` |
+| `fleet-lcm-components` | `fleet-lcm.component.list`, `.component.info`, `.component.status` |
+| `fleet-lcm-tasks` | `fleet-lcm.task.list`, `.task.info` |
+| `fleet-lcm-lifecycle` | `fleet-lcm.upgrade-plan.list`, `.upgrade-plan.info`, `.release-version.list` |
+
+**Why typed, not ingested.** The connector *is* the modern generic impl and its
+51-op spec is pinnable, but the read core is hand-coded typed (the harbor / nsx
+#2358 pattern) precisely so it is live on a fresh boot with **no** operational
+`meho connector ingest` + `enable_reads` step — merging the read core *is* the
+9.0-restoration, not a runbook the operator must still run. The wider surface
+(the full 51-op spec as `source_kind="ingested"` breadth + the component /
+upgrade / task **writes**) remains a follow-up, enabled operationally through
+the generic review flow (`ReviewService.enable_reads` over an ingest of the same
+pinned `fleet-lcm-openapi.yaml`). Registering this real `HttpConnector` subclass
+is also the load-bearing prerequisite for those future ingested rows to become
+dispatchable (a bare `GenericRestConnector` auto-shim is non-dispatchable — the
+`VmwareRestConnector` pattern).
+
+**Live-appliance dispatch verification remains a non-goal** (#1002 / #995 — no
+reachable Fleet LCM appliance). The read core is unit-tested end-to-end against
+a respx-mocked service (dispatch `status="ok"` through **both** the Bearer and
+Basic auth seams) and reconcile-guarded; live Bearer-auth verification against
+real hardware is the #3047 follow-up (see "Auth" below).
 
 ## Key types
 
@@ -111,23 +135,62 @@ pattern). `probe()` delegates to `fingerprint()`.
 
 ### Dispatch
 
-`execute()` is the G0.6 ABC-compatibility shim (builds a synthetic `Operator`
-and forwards to `meho_backplane.operations.dispatch`). Ingested `/v1/*` ops
-route through the dispatcher via `POST /api/v1/operations/call` (or MCP
-`call_operation`) and ride this connector's `auth_headers`.
+The typed read-core ops dispatch through `meho_backplane.operations.dispatch`
+(via `POST /api/v1/operations/call` or MCP `call_operation`): the dispatcher
+resolves the persisted `module.ClassName.method` handler_ref to the connector's
+bound-method shim, threads `operator` / `target` / `params`, and the handler
+issues an authenticated `GET` on this connector's client — so the read rides
+`auth_headers` (Bearer primary, Basic fallback). `execute()` is the G0.6
+ABC-compatibility shim (builds a synthetic `Operator` and forwards to
+`dispatch`); it remains the path for any future `source_kind="ingested"` op.
+
+## Typed read core internals
+
+The read core follows the harbor #2856 layout:
+
+- **`typed_ops.py`** — the `FleetLcmTypedOp` dataclass table
+  (`FLEET_LCM_TYPED_OPS`), the per-group `when_to_use` map
+  (`FLEET_LCM_TYPED_WHEN_TO_USE_BY_GROUP`), and the module-level
+  `register_fleet_lcm_typed_operations(*, embedding_service=None)` registrar.
+- **`typed_reads.py`** — the op bodies (`async def fleet_lcm_*_impl(connector,
+  operator, target, params)`), each issuing an authenticated `GET` via
+  `HttpConnector._get_json` and returning the parsed payload.
+- **`_llm_instructions.py`** — the per-op `llm_instructions` blobs
+  (`when_to_call` / `output_shape` / `next_step`), keyed by op id (split out
+  for the file-size budget).
+- **`_paths.py`** — the `/v1/*` request-path templates + `fill_path` /
+  `encode_segment` (percent-encoded, fail-loud path substitution for the by-id
+  ops; the reconcile lane introspects these constants).
+- **`connector.py`** — 13 thin bound-method shims (`health`, `system_info`, …)
+  that lazily import and delegate to their `_impl` body; each typed op's
+  `handler_attr` names its shim.
+
+`register_fleet_lcm_typed_operations` is queued onto the lifespan registrar
+list via `register_typed_op_registrar` in `__init__.py`;
+`register_typed_operation` creates each `OperationGroup` (`review_status=
+"enabled"`) and inserts each descriptor `source_kind="typed"`, `is_enabled=
+True`, `method=None` / `path=None` (the wire path lives only in the handler).
+So the read core needs no operator review — it is live the moment the connector
+loads.
 
 ## Spec reconcile lane
 
 [`backend/tests/test_connectors_fleet_lcm_spec_reconcile.py`](../../backend/tests/test_connectors_fleet_lcm_spec_reconcile.py)
-asserts the connector's hand-coded probe path (`_FLEET_LCM_HEALTH_PATH`,
-introspected from the live constant — the #2944 pattern) is served by the
-pinned `fleet-lcm-9.0/fleet-lcm-openapi.yaml`. **No server-base fold** is
-applied: the spec's server url `https://vcf.broadcom.com/fleet-lcm` is
-*absolute*, so `parse_openapi` does not fold the `/fleet-lcm` base onto path
-keys (only *relative* server bases are folded, #1796) — the served op_id is the
-raw `GET:/v1/health`, matching the probe constant. The lane arms when the shelf
-provides the spec (`MEHO_CONSUMER_DOCS_ROOT`) and skips uniformly otherwise
-(`tests/_spec_shelf.py` contract).
+asserts every hand-coded `GET:/path` the typed read core dispatches — the 13
+`/v1/*` path templates in `_paths.py` plus the connector's
+`_FLEET_LCM_HEALTH_PATH` probe (introspected from the live constants — the
+#2944 pattern) — is served by the pinned `fleet-lcm-9.0/fleet-lcm-openapi.yaml`.
+The typed health op and the probe share `/v1/health`; the pin asserts that link
+so the two never drift. **No server-base fold** is applied: the spec's server
+url `https://vcf.broadcom.com/fleet-lcm` is *absolute*, so `parse_openapi` does
+not fold the `/fleet-lcm` base onto path keys (only *relative* server bases are
+folded, #1796) — the served op_ids are the raw `GET:/v1/*`, matching the
+templates (the by-id placeholders `{sddcLcmId}` / `{componentId}` / `{taskId}` /
+`{planId}` are byte-for-byte the spec's own path-parameter names). The lane arms
+when the shelf provides the spec (`MEHO_CONSUMER_DOCS_ROOT`) and skips uniformly
+otherwise (`tests/_spec_shelf.py` contract). (The wider ingested breadth is not
+reconciled here — reconciling ingested rows against the spec they were ingested
+from is tautological.)
 
 ## Dependencies
 
@@ -143,18 +206,28 @@ provides the spec (`MEHO_CONSUMER_DOCS_ROOT`) and skips uniformly otherwise
 ## Known issues / follow-ups
 
 - **Bearer auth not live-verified.** See "Auth" — the header shape ships and is
-  unit-tested; token provisioning + live dispatch are the follow-up gated on a
-  reachable appliance.
-- **Ops arrive by ingestion.** Until an operator ingests
-  `fleet-lcm-openapi.yaml`, the connector is registered and discoverable but
-  `execute` against any `op_id` resolves to "unknown operation" — correct for a
-  registered-but-empty connector at this stage.
+  unit-tested (dispatch through the Bearer seam against a respx mock); token
+  provisioning + live dispatch against a real appliance are the #3047 follow-up
+  gated on reachable hardware. Until then the live default is the Basic
+  alternative the appliance also accepts.
+- **Read core only; ingested breadth + writes are a follow-up.** The 13-op
+  typed read core dispatches on a fresh boot. The wider 51-op `/v1/*` surface
+  (as `source_kind="ingested"` breadth) and the component / upgrade / task
+  writes are enabled operationally through the generic review flow
+  (`meho connector ingest` of `fleet-lcm-openapi.yaml` → `ReviewService.enable_reads`),
+  not shipped here.
 
 ## References
 
-- Modern-impl Task: <https://github.com/evoila/meho/issues/3036>
+- Typed read-core Task: <https://github.com/evoila/meho/issues/3047>
+- Modern-impl skeleton Task: <https://github.com/evoila/meho/issues/3036>
 - Legacy re-band + resolution test Task: <https://github.com/evoila/meho/issues/3037>
 - Parent initiative: <https://github.com/evoila/meho/issues/3033>
+- Read-core tests:
+  [`test_connectors_fleet_lcm_typed_reads.py`](../../backend/tests/test_connectors_fleet_lcm_typed_reads.py)
+  (dispatch + registration) and
+  [`test_connectors_fleet_lcm_spec_reconcile.py`](../../backend/tests/test_connectors_fleet_lcm_spec_reconcile.py)
+  (13-path reconcile lane).
 - Legacy impl: [`connectors-vcf-fleet.md`](connectors-vcf-fleet.md)
 - Spec provenance: `vmware/vcf-api-specs@c3f3b52c` (Apache-2.0); shelf
   `docs/fleet-lcm-9.0/MANIFEST.md`.


### PR DESCRIPTION
## What & why

Ships a curated **13-op typed read core** for the modern `fleet-lcm` connector so a **VCF Fleet 9.x target dispatches a modern `/v1/*` read op on a fresh boot with zero catalog ingest** — restoring 9.0 fleet dispatch after the "modern default now" resolver decision (initiative #3033) left `fleet-lcm` registered but with no dispatchable ops.

This is the read-core portion of **#3047**. The **typed** read-core path was chosen (over generic ingest + `enable_reads`) precisely so that **merging this PR *is* the 9.0 restoration** — typed ops are `is_enabled=True` at register time, so there's no dangling operator `meho connector ingest` + `enable_reads` step.

## The read core (5 operator-reviewed groups)

| Group | Ops |
|---|---|
| `fleet-lcm-system` | `health`, `system.info`, `config.info` |
| `fleet-lcm-sddc` | `sddc-lcm.list`, `.info` |
| `fleet-lcm-components` | `component.list`, `.info`, `.status` |
| `fleet-lcm-tasks` | `task.list`, `.info` |
| `fleet-lcm-lifecycle` | `upgrade-plan.list`, `.info`, `release-version.list` |

Layout follows the harbor #2856 typed-read shape: `typed_ops.py` (dataclass table + `when_to_use` map + registrar), `typed_reads.py` (13 `_impl` bodies), `_llm_instructions.py` (per-op blobs), `_paths.py` (`/v1/*` templates + `fill_path`/`encode_segment`), 13 bound-method shims on the connector, and `register_typed_op_registrar` wiring (versioned-only — the legacy `vcf_fleet` package owns the `("fleet","","")` wildcard).

## Verification (appliance-free)

- **Dispatch end-to-end (`status="ok"`)** through the full dispatcher against a respx-mocked service — all 13 reads, plus **both auth seams**: HTTP Basic (default) and `Authorization: Bearer <token>` (the spec's primary scheme) when the loaded creds carry a `token`.
- **By-id path substitution + percent-encoding** (`fill_path` / `encode_segment` — a reserved char in a caller-supplied id can't leak path structure).
- **Registration invariants**: `source_kind="typed"`, `is_enabled=True`, `method`/`path=None`, groups `review_status="enabled"`, every op safe / read-only / ungated, no write op registered.
- **Spec-reconcile lane extended** from the single health probe to all 13 `/v1/*` path templates (incl. the `{sddcLcmId}` / `{componentId}` / `{taskId}` / `{planId}` placeholders) — **armed green against the pinned Apache-2.0 `fleet-lcm-openapi.yaml`**; the probe↔typed-health `/v1/health` link is pinned so the two can't drift.
- Local gates: `ruff` clean, `mypy --strict` clean (src scope), 60 new tests + 132-test fleet suite + cross-connector metadata/classifier/secret-leak suites all green.

## Explicitly out of scope — the documented follow-up tail of #3047

- **Ingested 51-op breadth + writes** — enabled operationally via `meho connector ingest` → `ReviewService.enable_reads` over the same pinned spec (registering this real `HttpConnector` subclass is the load-bearing prerequisite that makes those future ingested rows dispatchable).
- **Live Bearer verification against a real appliance** — no reachable Fleet LCM appliance (#1002 / #995); the Bearer *header shape* is unit-tested here, the live handshake is the gated tail. Until then the live default is the Basic alternative the appliance also accepts.

Advances #3047 (read core + 9.0 read dispatch restored — not fully closed while the Bearer/breadth tail remains). Part of initiative #3033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
