### PR TITLE
feat(vcd): net-new VMware Cloud Director typed read core (7 ops) (#3057)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcd/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcd/__init__.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcd — VcloudDirectorConnector package.
+
+Importing this package registers :class:`VcloudDirectorConnector` against the v2
+connector registry as the **net-new typed** connector for the legacy standalone
+**VMware Cloud Director** (vCD) product — the migration-source estate evoila
+brings customers off (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3057).
+vCD is a distinct product from the Broadcom-era successor: VCF Automation
+(:mod:`meho_backplane.connectors.vcf_automation`) absorbed only vCD's provider
+control plane, so this is its own ``product="vcd"`` connector, not a ``vcfa``
+dual-impl.
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<product>/`` subpackage at startup, so this registration
+lands before any dispatch can occur (no explicit wiring elsewhere).
+
+**Both a versioned triple and the ``("vcd", "", "")`` wildcard are registered.**
+Unlike ``fleet-lcm`` — which skips the wildcard because the legacy ``vcf_fleet``
+package already owns ``("fleet", "", "")`` — vCD is a brand-new product with no
+sibling, so it takes the wildcard itself (the harbor / nsx / keycloak /
+vcf-automation single-impl pattern). The wildcard makes an *unfingerprinted* vCD
+target still resolve; the versioned triple carries the real
+``(product, version, impl_id)`` coordinates the typed ops register under and the
+``connector_id`` (``"vcd-rest-10.6"``) parses to. The ``product`` token is
+``"vcd"`` (not ``"vcloud-director"``) because ``register_connector_v2`` enforces
+that ``product`` equals the first hyphen-segment of ``impl_id`` — a hyphenated
+product token would crash the round-trip check at boot.
+
+This package registers a curated **7-op typed read core** (#3057, :mod:`.typed_ops`)
+via :func:`register_typed_op_registrar`, so a vCD target dispatches a
+migration-inventory read on a fresh boot with zero catalog ingest. Because vCD
+publishes no committable OpenAPI (typed, not ingested), a wider ingested breadth
+surface is not a follow-up here — the read core is the connector's surface.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcd.connector import VcloudDirectorConnector
+from meho_backplane.connectors.vcd.session import (
+    VcloudDirectorCredentialsLoader,
+    VcloudDirectorTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.vcd.typed_ops import (
+    VCD_TYPED_OPS,
+    VCD_TYPED_WHEN_TO_USE_BY_GROUP,
+    VcloudDirectorTypedOp,
+    register_vcd_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the vCD connector — the dispatch-canonical
+#: ``(product, version, impl_id)`` triple :func:`parse_connector_id` derives from
+#: ``"vcd-rest-10.6"``, plus the derived ``connector_id`` slug. The typed read
+#: core rows land under :data:`VCD_CONNECTOR_ID`.
+VCD_PRODUCT: Final[str] = "vcd"
+VCD_VERSION: Final[str] = "10.6"
+VCD_IMPL_ID: Final[str] = "vcd-rest"
+VCD_CONNECTOR_ID: Final[str] = f"{VCD_IMPL_ID}-{VCD_VERSION}"
+
+
+register_connector_v2(
+    product=VCD_PRODUCT,
+    version=VCD_VERSION,
+    impl_id=VCD_IMPL_ID,
+    cls=VcloudDirectorConnector,
+)
+
+# Wildcard fallback so an unfingerprinted vCD target still resolves. vCD is a
+# net-new single-impl product with no sibling owning ``("vcd", "", "")`` (the
+# harbor / nsx / keycloak / vcf-automation pattern; contrast fleet-lcm, which
+# skips it because vcf_fleet owns ``("fleet", "", "")``).
+register_connector_v2(
+    product=VCD_PRODUCT,
+    version="",
+    impl_id="",
+    cls=VcloudDirectorConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so the
+# typed descriptor rows land before the first dispatch — the vCD read core
+# dispatches on a fresh boot with zero catalog ingest (#3057).
+register_typed_op_registrar(register_vcd_typed_operations)
+
+__all__ = [
+    "VCD_CONNECTOR_ID",
+    "VCD_IMPL_ID",
+    "VCD_PRODUCT",
+    "VCD_TYPED_OPS",
+    "VCD_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VCD_VERSION",
+    "VcloudDirectorConnector",
+    "VcloudDirectorCredentialsLoader",
+    "VcloudDirectorTargetLike",
+    "VcloudDirectorTypedOp",
+    "load_credentials_from_vault",
+    "register_vcd_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/vcd/_auth.py
+++ b/backend/src/meho_backplane/connectors/vcd/_auth.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Provider session-establish helper for the ``vcd`` connector.
+
+Split out from :mod:`.connector` to keep that module lean, the
+:mod:`~meho_backplane.connectors.vcf_automation._auth` precedent. The helper
+takes the per-target httpx client + resolved credentials and returns the
+freshly-minted Bearer JWT; cache ownership and lock discipline stay in the
+connector class so the mutual-exclusion contract is co-located with the cache
+it protects.
+
+vCD's provider login is the vCloud-Director-derived Basic→Bearer flow the
+``vcf-automation`` provider plane also speaks (they share the surface — VCFA
+absorbed vCD's provider control plane): ``POST /cloudapi/1.0.0/sessions/provider``
+with HTTP Basic (``<user>@System``) returns the JWT in the
+``X-VMWARE-VCLOUD-ACCESS-TOKEN`` **response header**, which every subsequent
+call sends as ``Authorization: Bearer <jwt>``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors._shared.vcf_auth import session_establish_auth_error
+from meho_backplane.connectors.vcd._paths import (
+    _SESSIONS_PROVIDER_PATH,
+    VCD_TOKEN_HEADER,
+    cloudapi_accept,
+)
+from meho_backplane.connectors.vcd.session import VcloudDirectorTargetLike
+
+__all__ = ["compose_provider_basic_user", "vcd_provider_login"]
+
+_log = structlog.get_logger(__name__)
+
+
+def _require_username_password(creds: dict[str, str], target_name: str) -> tuple[str, str]:
+    """Extract ``username`` + ``password`` from *creds*, raising on a missing key."""
+    try:
+        return creds["username"], creds["password"]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"vcd provider credentials loader for target {target_name!r} returned a "
+            f"dict missing required key {exc.args[0]!r}; need "
+            f"{{'username': str, 'password': str}}"
+        ) from exc
+
+
+def compose_provider_basic_user(username: str) -> str:
+    """Return the vCD provider Basic username — ``"<user>@System"``.
+
+    vCD provider (administrator) accounts always live in the built-in
+    ``System`` organization, so the Basic username is the credential
+    username suffixed with ``@System``. A non-System / SSO provider
+    identity (an explicit ``provider_username`` override) is a documented
+    follow-up; the System-org form covers the provider-account login every
+    vCD deployment ships with.
+    """
+    return f"{username}@System"
+
+
+async def vcd_provider_login(
+    client: httpx.AsyncClient,
+    creds: dict[str, str],
+    target: VcloudDirectorTargetLike,
+    *,
+    api_version: str,
+    request_extensions: dict[str, Any] | None = None,
+) -> str:
+    """POST the provider session-create endpoint and return the minted JWT.
+
+    Issues ``POST /cloudapi/1.0.0/sessions/provider`` with HTTP Basic
+    (``<user>@System``) and ``Accept: application/json;version=<api_version>``.
+    A 2xx response carries the JWT in the ``X-VMWARE-VCLOUD-ACCESS-TOKEN``
+    response header — it is returned to the caller (which writes the cache
+    under the session lock). Absence of the header on a 2xx response raises
+    :exc:`RuntimeError` rather than caching an empty token.
+
+    A 401/403 at login is an auth-class establish failure, mapped to the
+    structured :class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError`
+    (``connector_auth_failed``) via
+    :func:`~meho_backplane.connectors._shared.vcf_auth.session_establish_auth_error`,
+    the ``vcf-automation`` / #2329 precedent. ``request_extensions`` carries
+    the caller's :meth:`HttpConnector._request_extensions` so the login
+    handshake honours a target's ``tls_server_name`` SNI / cert-verify name
+    (``None`` normalises to ``{}``, byte-identical when unset).
+    """
+    username, password = _require_username_password(creds, target.name)
+    basic_user = compose_provider_basic_user(username)
+    try:
+        resp = await client.post(
+            _SESSIONS_PROVIDER_PATH,
+            auth=(basic_user, password),
+            headers={"Accept": cloudapi_accept(api_version)},
+            extensions=request_extensions or {},
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        message = (
+            f"vcd provider session establish failed for target {target.name!r}: "
+            f"POST {_SESSIONS_PROVIDER_PATH} returned HTTP {exc.response.status_code}"
+        )
+        raise (
+            session_establish_auth_error(exc, message=message, target=target)
+            or RuntimeError(message)
+        ) from exc
+    jwt: str | None = resp.headers.get(VCD_TOKEN_HEADER)
+    if not jwt:
+        raise RuntimeError(
+            f"vcd provider session establish for target {target.name!r}: "
+            f"POST {_SESSIONS_PROVIDER_PATH} returned 2xx with no "
+            f"{VCD_TOKEN_HEADER} response header"
+        )
+    _log.info("vcd_provider_session_established", target=target.name, host=target.host)
+    return jwt

--- a/backend/src/meho_backplane/connectors/vcd/_llm_instructions.py
+++ b/backend/src/meho_backplane/connectors/vcd/_llm_instructions.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-op ``llm_instructions`` blobs for the ``vcd`` typed read core.
+
+Split out of :mod:`~meho_backplane.connectors.vcd.typed_reads` (which holds the
+op bodies) to keep each module focused, the ``fleet-lcm`` #3047 layout. Consumed
+by :mod:`meho_backplane.connectors.vcd.typed_ops`, which keys each op's metadata
+row to :data:`VCD_READ_LLM_INSTRUCTIONS`.
+
+The canonical three-key shape (``when_to_call`` / ``output_shape`` /
+``next_step``) is the same convention the harbor / nsx / fleet-lcm read cores
+use, so an agent crossing connector boundaries sees a stable structure. The
+prose references the dot-form op ids the reads register under and the sibling
+ops an agent drills to next. The framing is migration inventory: these reads
+enumerate a *source* vCD estate an operator is bringing onto the platform.
+"""
+
+from __future__ import annotations
+
+__all__ = ["VCD_READ_LLM_INSTRUCTIONS"]
+
+
+_ORG_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call first when inventorying a VMware Cloud Director source estate — "
+        "the organizations are the top of the vCD tenancy tree. A provider "
+        "(System) session sees every org. Use to answer 'which tenants live on "
+        "this vCD' before drilling into their VDCs, vApps, and VMs."
+    ),
+    "output_shape": (
+        "Modern cloudapi paged envelope {resultTotal, pageCount, page, "
+        "pageSize, values: [Org, ...]}. Each Org carries id (a "
+        "urn:vcloud:org: URN), name, displayName, and isEnabled."
+    ),
+    "next_step": (
+        "Cross-reference an org's name against vcd.vdc.list (orgName) to see its "
+        "compute allocations, or vcd.catalog.list to see its templates. vApps "
+        "and VMs are reached the same way via vcd.vapp.list / vcd.vm.list."
+    ),
+}
+
+_VDC_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the organization VDCs — the per-org compute/storage "
+        "allocations backed by a provider VDC. The unit of capacity a migration "
+        "must re-home. Use to answer 'how much is allocated where' or to map "
+        "orgs to their backing provider VDCs."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [AdminOrgVdcRecord, ...], total, "
+        "page, pageSize}. Each record carries name, orgName, providerVdcName, "
+        "numberOfVApps / numberOfVMs, and CPU/memory/storage allocation figures."
+    ),
+    "next_step": (
+        "Filter vcd.vapp.list / vcd.vm.list by vdcName to enumerate the "
+        "workloads in a given VDC, or group by providerVdcName to size the "
+        "underlying vSphere resource the migration lands on."
+    ),
+}
+
+_VAPP_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the vApps — the deployable multi-VM units vCD groups "
+        "workloads into. Use when planning migration waves (a vApp is a natural "
+        "move-together boundary) or to find which vApp contains a given VM."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [AdminVAppRecord, ...], total, "
+        "page, pageSize}. Each record carries name, orgName, vdcName, status "
+        "(e.g. POWERED_ON / POWERED_OFF), numberOfVMs, and isDeployed. A large "
+        "list is reduced to a JSONFlux handle."
+    ),
+    "next_step": (
+        "Drill into a vApp's VMs by filtering vcd.vm.list on containerName (the "
+        "vApp name). Correlate status against vcd.task.list to see recent "
+        "power/deploy operations."
+    ),
+}
+
+_VM_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the virtual machines across the estate — the core "
+        "migration-workload inventory. This is usually the highest-value read: "
+        "the count, sizing, and guest OS of every VM the migration will move. A "
+        "provider session sees every org's VMs."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [AdminVMRecord, ...], total, "
+        "page, pageSize}. Each record carries name, containerName (the vApp), "
+        "vdc, org, status, numberOfCpus, memoryMB, and guestOs. A large "
+        "inventory is reduced to a JSONFlux handle — narrow it with result_query "
+        "/ result_aggregate (e.g. sum memoryMB by org)."
+    ),
+    "next_step": (
+        "Aggregate over the handle for capacity planning (count / vCPU / memory "
+        "by org or vdc), or group by guestOs to flag OSes needing special "
+        "migration handling. Map containerName back to vcd.vapp.list for the "
+        "move-together boundary."
+    ),
+}
+
+_CATALOG_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the catalogs — the vApp-template and media (ISO) libraries "
+        "each org publishes. Use to inventory the templates a migration must "
+        "recreate on the target, and to spot shared/published catalogs that "
+        "cross org boundaries."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [AdminCatalogRecord, ...], "
+        "total, page, pageSize}. Each record carries name, orgName, isShared / "
+        "isPublished, and numberOfVAppTemplates / numberOfMedia."
+    ),
+    "next_step": (
+        "Flag isPublished / isShared catalogs as cross-tenant dependencies for "
+        "the migration plan. Correlate an org's catalogs with its vApps "
+        "(vcd.vapp.list) to see which templates are in active use."
+    ),
+}
+
+_EDGE_GATEWAY_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the edge gateways — the org-VDC network egress + services "
+        "(NAT, firewall, VPN, load-balancing) boundary. The networking surface a "
+        "migration must re-home. Use to answer 'what network edges exist and "
+        "which VDCs do they serve'."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [EdgeGatewayRecord, ...], total, "
+        "page, pageSize}. Each record carries name, vdc, orgName, "
+        "numberOfExtNetworks, and numberOfOrgNetworks."
+    ),
+    "next_step": (
+        "Map each edge gateway's vdc back to vcd.vdc.list to associate network "
+        "boundaries with compute allocations, so the target-side network design "
+        "covers every VDC's egress."
+    ),
+}
+
+_TASK_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list recent asynchronous tasks — 'what is vCD doing / did it "
+        "just do'. Use to confirm the estate is quiescent before a migration "
+        "cutover, or to find the task behind a resource in an unexpected state."
+    ),
+    "output_shape": (
+        "Query-service record envelope {record: [TaskRecord, ...], total, page, "
+        "pageSize}. Each record carries name (the operation), status (running / "
+        "success / error), objectName (the affected entity), orgName, startDate "
+        "/ endDate, and ownerName. A large list is reduced to a JSONFlux handle."
+    ),
+    "next_step": (
+        "Filter the handle to status=error to surface recent failures, or to "
+        "status=running to confirm no operation is in flight before a cutover. "
+        "Correlate objectName with the matching inventory read."
+    ),
+}
+
+
+#: Per-op ``llm_instructions`` keyed by the dot-form op id, consumed by
+#: :mod:`meho_backplane.connectors.vcd.typed_ops`.
+VCD_READ_LLM_INSTRUCTIONS: dict[str, dict[str, object]] = {
+    "vcd.org.list": _ORG_LIST_INSTRUCTIONS,
+    "vcd.vdc.list": _VDC_LIST_INSTRUCTIONS,
+    "vcd.vapp.list": _VAPP_LIST_INSTRUCTIONS,
+    "vcd.vm.list": _VM_LIST_INSTRUCTIONS,
+    "vcd.catalog.list": _CATALOG_LIST_INSTRUCTIONS,
+    "vcd.edge-gateway.list": _EDGE_GATEWAY_LIST_INSTRUCTIONS,
+    "vcd.task.list": _TASK_LIST_INSTRUCTIONS,
+}

--- a/backend/src/meho_backplane/connectors/vcd/_llm_instructions.py
+++ b/backend/src/meho_backplane/connectors/vcd/_llm_instructions.py
@@ -145,7 +145,7 @@ _TASK_LIST_INSTRUCTIONS: dict[str, object] = {
         "cutover, or to find the task behind a resource in an unexpected state."
     ),
     "output_shape": (
-        "Query-service record envelope {record: [TaskRecord, ...], total, page, "
+        "Query-service record envelope {record: [AdminTaskRecord, ...], total, page, "
         "pageSize}. Each record carries name (the operation), status (running / "
         "success / error), objectName (the affected entity), orgName, startDate "
         "/ endDate, and ownerName. A large list is reduced to a JSONFlux handle."

--- a/backend/src/meho_backplane/connectors/vcd/_paths.py
+++ b/backend/src/meho_backplane/connectors/vcd/_paths.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-coded VMware Cloud Director wire constants — the reconcile-lane surface.
+
+VMware Cloud Director (vCD) is the legacy standalone product evoila migrates
+customers *from* (initiative `evoila/meho#3056
+<https://github.com/evoila/meho/issues/3056>`_, task #3057). Broadcom publishes
+**no committable OpenAPI** for vCD's full REST surface — the classic ``/api/*``
+query service is bundled into the UI JS at build time and the appliance serves
+no ``/cloudapi/1.0.0/openapi*`` (probed: 404) — so the connector is a **typed**
+read core (CLAUDE.md postulate 1: "no usable spec → typed"), the same shape the
+``fleet-lcm`` (#3047) and ``vcf-automation`` provider-plane cores ship with.
+
+Every request path the connector dispatches is declared here as a module-level
+``_*_PATH`` string constant, so the spec-reconcile lane
+(:mod:`tests.test_connectors_vcd_spec_reconcile`) can introspect the **live**
+constants (the #2944 introspect-live-constants pattern — never a hardcoded
+mirror that can drift) and pin the exact hand-coded surface. Because no vendor
+spec exists, that lane is a **manifest pin + evidenced exclusion** (the
+``vcf-automation-9.0`` provider-plane precedent), not a served-op-id compare.
+
+Surfaces
+--------
+
+vCD exposes two co-existing REST surfaces the connector reads, both
+authenticated by the one provider Bearer token minted at
+:data:`_SESSIONS_PROVIDER_PATH`:
+
+* **Modern ``/cloudapi/1.0.0/*``** — clean JSON collections
+  (:data:`_ORGS_PATH`). In-repo verified: the ``vcf-automation`` provider plane
+  reads ``GET /cloudapi/1.0.0/orgs`` against the same vCloud-Director-derived
+  surface.
+* **Classic ``/api/*`` query service** (:data:`_QUERY_PATH`) — the uniform,
+  provider/system-scoped inventory mechanism. One path, one paging model, a
+  ``type=`` selector per entity (:data:`_QT_ADMIN_VM` &c., the
+  ``go-vcloud-director`` SDK's canonical query-type constants). This is the
+  migration-inventory backbone: a provider session over the admin query types
+  sees the whole estate.
+
+The two surfaces need **different ``Accept`` media types** (vCD content
+negotiation): the classic ``/api/*`` paths take the versioned
+``application/*+json`` form, the modern ``/cloudapi/*`` paths the
+``application/json`` form. :func:`accept_for_path` picks by prefix — the
+``vcf-automation`` ``provider_accept_for_path`` split (#517).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "QUERY_RECORDS_FORMAT",
+    "VCD_TOKEN_HEADER",
+    "accept_for_path",
+    "classic_api_accept",
+    "cloudapi_accept",
+]
+
+# -- Request paths reconciled by the manifest lane --------------------------
+# Unauthenticated supported-versions probe (reachability + API surface). vCD
+# serves this without auth (it is the version-discovery entry point), so the
+# connector's fingerprint reads it without minting a session.
+_VERSIONS_PATH = "/api/versions"
+# Provider (System-org) session-create endpoint. POSTed with HTTP Basic; the
+# minted JWT rides back in the X-VMWARE-VCLOUD-ACCESS-TOKEN response header.
+_SESSIONS_PROVIDER_PATH = "/cloudapi/1.0.0/sessions/provider"
+# Modern cloudapi organization collection (clean JSON, provider sees all orgs).
+_ORGS_PATH = "/cloudapi/1.0.0/orgs"
+# Classic query service — the uniform inventory path; the entity is selected by
+# the ``type=`` query param (see the _QT_* constants), never by the path.
+_QUERY_PATH = "/api/query"
+
+# -- Query-service selectors (go-vcloud-director SDK canonical constants) ----
+# Admin variants so a provider/System session enumerates every org's resources
+# (the migration-inventory contract: see the whole estate, not one tenant).
+_QT_ADMIN_ORG_VDC = "adminOrgVdc"
+_QT_ADMIN_VAPP = "adminVApp"
+_QT_ADMIN_VM = "adminVM"
+_QT_ADMIN_CATALOG = "adminCatalog"
+_QT_EDGE_GATEWAY = "edgeGateway"
+_QT_TASK = "task"
+
+#: Query-service response format. ``records`` returns flattened attribute rows
+#: (names, status, hrefs) — the right shape for inventory + JSONFlux drill-in;
+#: ``references`` (the alternative) returns bare hrefs only.
+QUERY_RECORDS_FORMAT = "records"
+
+#: Provider-login response header carrying the session JWT. HTTP/2 lowercases
+#: header names on the wire; httpx indexing is case-insensitive, so the
+#: constant stays in the vendor's canonical mixed-case form (the
+#: ``vcf-automation`` ``PROVIDER_TOKEN_HEADER`` precedent).
+VCD_TOKEN_HEADER = "X-VMWARE-VCLOUD-ACCESS-TOKEN"
+
+#: Default vCD API version for the ``Accept`` header's ``version=`` token.
+#: 38.0 is served by vCD 10.5 and 10.6 (10.6 keeps back-compat for the prior
+#: ~3 API versions), so it covers the common migration-source range with the
+#: live 10.6 provider lab working out of the box. A target may override via
+#: ``extras["vcd_api_version"]``; version *negotiation* (read the max
+#: non-deprecated version from ``GET /api/versions`` and use it) is the
+#: documented robustness follow-up (see the connector docstring).
+_DEFAULT_VCD_API_VERSION = "38.0"
+
+
+def cloudapi_accept(api_version: str) -> str:
+    """``Accept`` for the modern ``/cloudapi/1.0.0/*`` JSON surface."""
+    return f"application/json;version={api_version}"
+
+
+def classic_api_accept(api_version: str) -> str:
+    """``Accept`` for the classic ``/api/*`` (query service) JSON surface."""
+    return f"application/*+json;version={api_version}"
+
+
+def accept_for_path(path: str, api_version: str) -> str:
+    """Return the vCD ``Accept`` media type for *path*.
+
+    Classic ``/api/*`` paths (including the query service) take the versioned
+    ``application/*+json`` form; everything else (the modern ``/cloudapi/*``
+    surface) takes ``application/json``. The one provider Bearer token
+    authenticates both. Mirrors ``vcf-automation``'s ``provider_accept_for_path``
+    (#517) — a genuine wire requirement, not cosmetic: the wrong ``Accept``
+    makes vCD answer XML (classic) or reject with a 406.
+    """
+    if path.startswith("/api/"):
+        return classic_api_accept(api_version)
+    return cloudapi_accept(api_version)

--- a/backend/src/meho_backplane/connectors/vcd/_paths.py
+++ b/backend/src/meho_backplane/connectors/vcd/_paths.py
@@ -8,7 +8,9 @@ customers *from* (initiative `evoila/meho#3056
 <https://github.com/evoila/meho/issues/3056>`_, task #3057). Broadcom publishes
 **no committable OpenAPI** for vCD's full REST surface — the classic ``/api/*``
 query service is bundled into the UI JS at build time and the appliance serves
-no ``/cloudapi/1.0.0/openapi*`` (probed: 404) — so the connector is a **typed**
+no ``/cloudapi/1.0.0/openapi*`` (evidenced 404 on the same vCloud-Director-derived
+surface via the VCFA 9.0.2 Holodeck probe; no vCD-specific probe run) — so the
+connector is a **typed**
 read core (CLAUDE.md postulate 1: "no usable spec → typed"), the same shape the
 ``fleet-lcm`` (#3047) and ``vcf-automation`` provider-plane cores ship with.
 
@@ -70,14 +72,17 @@ _ORGS_PATH = "/cloudapi/1.0.0/orgs"
 _QUERY_PATH = "/api/query"
 
 # -- Query-service selectors (go-vcloud-director SDK canonical constants) ----
-# Admin variants so a provider/System session enumerates every org's resources
-# (the migration-inventory contract: see the whole estate, not one tenant).
+# System-admin ("admin*") variants so a provider/System session enumerates every
+# org's resources (the migration-inventory contract: see the whole estate, not
+# one tenant). ``edgeGateway`` has no admin variant — a System admin sees all
+# edge gateways via the plain type — but ``task`` does, so tasks use ``adminTask``
+# (the cross-org, all-tenants view) to match the whole-estate contract.
 _QT_ADMIN_ORG_VDC = "adminOrgVdc"
 _QT_ADMIN_VAPP = "adminVApp"
 _QT_ADMIN_VM = "adminVM"
 _QT_ADMIN_CATALOG = "adminCatalog"
 _QT_EDGE_GATEWAY = "edgeGateway"
-_QT_TASK = "task"
+_QT_ADMIN_TASK = "adminTask"
 
 #: Query-service response format. ``records`` returns flattened attribute rows
 #: (names, status, hrefs) — the right shape for inventory + JSONFlux drill-in;

--- a/backend/src/meho_backplane/connectors/vcd/connector.py
+++ b/backend/src/meho_backplane/connectors/vcd/connector.py
@@ -17,7 +17,9 @@ Why typed (not generic / ingested)
 
 Broadcom publishes no committable OpenAPI for vCD's full REST surface — the
 classic ``/api/*`` query service is bundled into the UI JS at build time, and
-the appliance serves no ``/cloudapi/1.0.0/openapi*`` (probed: 404). This is the
+the appliance serves no ``/cloudapi/1.0.0/openapi*`` (evidenced 404 on the same
+vCloud-Director-derived surface via the VCFA 9.0.2 Holodeck probe — no
+vCD-specific appliance probe was run; live-verify is the deferred tail). This is the
 CLAUDE.md postulate-1 "no usable spec → typed" case, the same posture the
 ``fleet-lcm`` (#3047) and ``vcf-automation`` provider-plane cores ship with. The
 spec-reconcile lane is therefore a **manifest pin + evidenced exclusion** (see
@@ -34,10 +36,10 @@ the JWT in the ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` **response header**; every
 subsequent read sends ``Authorization: Bearer <jwt>``. The token is minted lazily
 on first use, cached per tenant-unique ``(tenant_id, target.id)`` key
 (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`) under a
-lock, and re-minted on a 401 via the dispatcher's credential-recovery arm
-(:meth:`invalidate_credentials`, #2396) — the ``fleet-lcm`` pattern, so no
-in-connector retry loop is needed and the base transport's tenacity retry (5xx /
-connection only) stays intact.
+lock, and re-minted on a 401 via the dispatcher's session-recovery arm
+(:meth:`invalidate_session`, #2067) — the SDDC Manager / NSX session-minting
+pattern, so no in-connector retry loop is needed and the base transport's
+tenacity retry (5xx / connection only) stays intact.
 
 The one provider token authenticates **both** REST surfaces vCD exposes; they
 differ only in the ``Accept`` media type, which :meth:`_vcd_get` derives from
@@ -75,7 +77,7 @@ provider/System-scoped so one session sees the whole estate:
   classic query service (``GET /api/query?type=adminOrgVdc|adminVApp|adminVM|
   adminCatalog&format=records``), the ``go-vcloud-director`` admin query types.
 * ``vcd.edge-gateway.list`` — ``GET /api/query?type=edgeGateway``.
-* ``vcd.task.list`` — ``GET /api/query?type=task``.
+* ``vcd.task.list`` — ``GET /api/query?type=adminTask``.
 
 All read-only, ``safety_level=safe``, ungated; registered as
 ``source_kind="typed"`` (:mod:`.typed_ops` / :mod:`.typed_reads`, per-op
@@ -269,8 +271,8 @@ class VcloudDirectorConnector(HttpConnector):
         transport's ``extra_headers`` seam, so the base tenacity retry (5xx /
         connection) and the ``auth_headers`` mint both stay in force. A raw 401
         (expired token) propagates as :class:`httpx.HTTPStatusError` to the
-        dispatcher's credential-recovery arm, which evicts the token via
-        :meth:`invalidate_credentials` (#2396) and re-dispatches once.
+        dispatcher's session-recovery arm, which evicts the token via
+        :meth:`invalidate_session` (#2067) and re-dispatches once.
         """
         accept = accept_for_path(path, self._api_version(target))
         return await self._request_json(
@@ -457,19 +459,42 @@ class VcloudDirectorConnector(HttpConnector):
 
         return await vcd_task_list_impl(self, operator, target, params)
 
-    async def invalidate_credentials(self, target: VcloudDirectorTargetLike) -> None:
-        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+    async def invalidate_session(self, target: VcloudDirectorTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path (#2067).
 
-        Drops the cached provider JWT for *target* so the next credential read
-        re-mints a fresh session. The dispatcher calls this hook on an
-        establish-auth failure (a data-path 401 from an expired token) and
-        re-dispatches once, so an out-of-band credential restage — or a simply
-        expired session — converges on the next dispatch without a backplane
-        restart. The ``fleet-lcm`` credential-recovery pattern.
+        **The load-bearing 401-recovery hook.** On an auth-class status (vCD's
+        ``401`` from an expired minted JWT), the dispatcher's data-path recovery
+        arm calls this hook — keyed on ``invalidate_session``, *not*
+        ``invalidate_credentials`` — then re-dispatches the op once
+        (:func:`~meho_backplane.operations.dispatcher._retry_after_session_invalidation`).
+        Dropping the cached JWT here makes the retry's
+        :meth:`auth_headers` cache-miss and re-mint a fresh session, so a
+        mid-session token expiry self-heals on the next dispatch without a
+        backplane restart — the SDDC Manager / NSX session-minting precedent (a
+        connector *without* this hook falls straight through to
+        ``connector_auth_failed`` and wedges on the stale token, dispatcher.py
+        #2067). Holds :attr:`_session_lock` so a concurrent re-establish doesn't
+        race the eviction.
         """
-        cache_key = target_cache_key(target)
+        await self._evict_session_token(target)
+
+    async def invalidate_credentials(self, target: VcloudDirectorTargetLike) -> None:
+        """Establish-auth-failure companion hook (#2396).
+
+        The dispatcher calls this on an establish-time
+        :class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError`
+        (a provider-login 401/403). vCD re-reads Vault on every mint, so it keeps
+        no separate credential-bytes cache to evict (contrast SDDC Manager); the
+        only per-target state is the JWT, so this also drops it — a no-op when
+        the establish already failed before caching, harmless otherwise. Kept so
+        the connector advertises both dispatch-path recovery hooks.
+        """
+        await self._evict_session_token(target)
+
+    async def _evict_session_token(self, target: VcloudDirectorTargetLike) -> None:
+        """Drop the cached provider JWT for *target* under the session lock."""
         async with self._session_lock:
-            self._session_tokens.pop(cache_key, None)
+            self._session_tokens.pop(target_cache_key(target), None)
 
     async def aclose(self) -> None:
         """Clear cached session tokens, then tear down the httpx pool.

--- a/backend/src/meho_backplane/connectors/vcd/connector.py
+++ b/backend/src/meho_backplane/connectors/vcd/connector.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VcloudDirectorConnector — hand-rolled HttpConnector subclass for VMware Cloud Director.
+
+The **net-new typed** connector for the legacy standalone **VMware Cloud
+Director** (vCD) product — the migration-source estate evoila brings customers
+*off* (initiative `evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_,
+task #3057). vCD is a *distinct product* from the Broadcom-era successor: VCF
+Automation (:mod:`~meho_backplane.connectors.vcf_automation`, ``--plane
+provider``) absorbed only vCD's *provider control plane*, so this is **not** a
+``vcfa`` dual-impl — it is its own ``product="vcd"`` connector, resolved by
+fingerprint like any other.
+
+Why typed (not generic / ingested)
+----------------------------------
+
+Broadcom publishes no committable OpenAPI for vCD's full REST surface — the
+classic ``/api/*`` query service is bundled into the UI JS at build time, and
+the appliance serves no ``/cloudapi/1.0.0/openapi*`` (probed: 404). This is the
+CLAUDE.md postulate-1 "no usable spec → typed" case, the same posture the
+``fleet-lcm`` (#3047) and ``vcf-automation`` provider-plane cores ship with. The
+spec-reconcile lane is therefore a **manifest pin + evidenced exclusion** (see
+``docs/decisions/spec-reconcile-guards-standard.md``), not a served-op-id
+compare.
+
+Auth — provider session mint
+----------------------------
+
+vCD's provider login is the vCloud-Director-derived Basic→Bearer flow (the same
+surface the ``vcf-automation`` provider plane speaks): ``POST
+/cloudapi/1.0.0/sessions/provider`` with HTTP Basic (``<user>@System``) returns
+the JWT in the ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` **response header**; every
+subsequent read sends ``Authorization: Bearer <jwt>``. The token is minted lazily
+on first use, cached per tenant-unique ``(tenant_id, target.id)`` key
+(:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`) under a
+lock, and re-minted on a 401 via the dispatcher's credential-recovery arm
+(:meth:`invalidate_credentials`, #2396) — the ``fleet-lcm`` pattern, so no
+in-connector retry loop is needed and the base transport's tenacity retry (5xx /
+connection only) stays intact.
+
+The one provider token authenticates **both** REST surfaces vCD exposes; they
+differ only in the ``Accept`` media type, which :meth:`_vcd_get` derives from
+the path (:func:`._paths.accept_for_path`): the classic ``/api/*`` query service
+takes the versioned ``application/*+json`` form, the modern ``/cloudapi/*``
+collections ``application/json``.
+
+The ``version=`` token in ``Accept`` defaults to
+:data:`._paths._DEFAULT_VCD_API_VERSION` (38.0 — served by vCD 10.5/10.6),
+overridable per target via ``extras["vcd_api_version"]``. **Version negotiation**
+(read the max non-deprecated version from ``GET /api/versions`` and use it, the
+way ``go-vcloud-director`` does) is the documented robustness follow-up.
+
+Fingerprint / probe
+-------------------
+
+``GET /api/versions`` is vCD's unauthenticated supported-versions endpoint — the
+same reachability surface the ``vcf-automation`` provider probe reads. The
+connector fingerprints against it **without minting a session** (pure
+reachability, works even when credentials are unavailable). ``version`` is left
+``None``: ``/api/versions`` reports *API* versions (37/38/39), not the *product*
+version (10.x), and the connector does not fabricate one — product-version
+fingerprinting via an authenticated call is a follow-up. Being single-impl, vCD
+resolves through its ``("vcd", "", "")`` wildcard registration regardless, so an
+absent product version never blocks dispatch.
+
+Operations
+----------
+
+A curated **7-op typed read core** ships here — the migration-inventory surface,
+provider/System-scoped so one session sees the whole estate:
+
+* ``vcd.org.list`` — ``GET /cloudapi/1.0.0/orgs`` (organizations, modern cloudapi).
+* ``vcd.vdc.list`` / ``.vapp.list`` / ``.vm.list`` / ``.catalog.list`` — the
+  classic query service (``GET /api/query?type=adminOrgVdc|adminVApp|adminVM|
+  adminCatalog&format=records``), the ``go-vcloud-director`` admin query types.
+* ``vcd.edge-gateway.list`` — ``GET /api/query?type=edgeGateway``.
+* ``vcd.task.list`` — ``GET /api/query?type=task``.
+
+All read-only, ``safety_level=safe``, ungated; registered as
+``source_kind="typed"`` (:mod:`.typed_ops` / :mod:`.typed_reads`, per-op
+``llm_instructions`` in :mod:`._llm_instructions`) so they dispatch on a fresh
+boot with **zero catalog ingest**. Set-shaped results are reduced to a JSONFlux
+handle by the dispatcher. By-id detail reads, non-``System`` provider identities,
+and any write surface are deliberately out of scope for this read core.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcd._paths import (
+    _DEFAULT_VCD_API_VERSION,
+    _VERSIONS_PATH,
+    accept_for_path,
+)
+from meho_backplane.connectors.vcd.session import (
+    VcloudDirectorCredentialsLoader,
+    VcloudDirectorTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["VcloudDirectorConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Reachability probe: vCD's unauthenticated supported-versions endpoint. The
+# reconcile lane (test_connectors_vcd_spec_reconcile.py) introspects this
+# constant and pins GET:/api/versions in the hand-coded manifest.
+_VCD_PROBE_METHOD = "GET /api/versions (VMware Cloud Director supported-versions endpoint)"
+
+
+class VcloudDirectorConnector(HttpConnector):
+    """VMware Cloud Director REST connector — provider Basic→Bearer session mint.
+
+    Per-target minted JWTs cached in :attr:`_session_tokens` (keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple) under :attr:`_session_lock`,
+    so two same-named targets in different tenants never share a token
+    (evoila/meho#1642/#1672). :meth:`auth_headers` returns
+    ``Authorization: Bearer <jwt>``; the per-surface ``Accept`` is added by
+    :meth:`_vcd_get` from the request path.
+
+    :attr:`priority` is ``1`` — the shim-tie-break convention every hand-rolled
+    connector uses, so a stray ``GenericRestConnector`` auto-shim that somehow
+    registered for the same triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple matches
+    # the dispatcher's parse_connector_id contract: ``"vcd-rest-10.6"`` ->
+    # (``"vcd"``, ``"10.6"``, ``"vcd-rest"``). ``product`` MUST be the first
+    # hyphen-segment of ``impl_id`` (the round-trip invariant register_connector_v2
+    # enforces), which is why the token is ``"vcd"`` and not ``"vcloud-director"``.
+    product = "vcd"
+    version = "10.6"
+    impl_id = "vcd-rest"
+    supported_version_range = ">=10.0,<11.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: VcloudDirectorCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._credentials_loader: VcloudDirectorCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+        # Per-target minted-JWT cache, keyed on ``target_cache_key`` so the
+        # tenant-isolation invariant holds; a single lock serialises concurrent
+        # first-use callers so they don't double-POST the login endpoint.
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # API-version negotiation (Accept header ``version=`` token)
+    # ------------------------------------------------------------------
+
+    def _api_version(self, target: VcloudDirectorTargetLike) -> str:
+        """Return the vCD API version for *target*'s ``Accept`` header.
+
+        A target may override the module default via
+        ``extras["vcd_api_version"]`` (e.g. ``"37.0"`` for a vCD 10.4 source);
+        absent / malformed falls back to :data:`._paths._DEFAULT_VCD_API_VERSION`.
+        Reading the max supported version from ``GET /api/versions`` is a
+        follow-up.
+        """
+        extras = getattr(target, "extras", None)
+        if isinstance(extras, dict):
+            override = extras.get("vcd_api_version")
+            if isinstance(override, str) and override.strip():
+                return override
+        return _DEFAULT_VCD_API_VERSION
+
+    # ------------------------------------------------------------------
+    # auth_headers — ABC override (Bearer; Accept added per-path by _vcd_get)
+    # ------------------------------------------------------------------
+
+    async def auth_headers(
+        self, target: VcloudDirectorTargetLike, operator: Operator
+    ) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <jwt>"}``, minting the session on first use.
+
+        The minted provider token authenticates both the ``/cloudapi/*`` and the
+        classic ``/api/*`` surfaces, so this header is path-independent; the
+        per-surface ``Accept`` is layered on by :meth:`_vcd_get` (via
+        ``_request_json``'s ``extra_headers``). ``operator`` is threaded to the
+        credential loader so the first-use Vault read runs under the operator's
+        identity (reused on warm-path calls without re-reading Vault).
+
+        Raises :exc:`NotImplementedError` for any ``target.auth_model`` other
+        than ``shared_service_account`` / ``None`` — the shared VCF-family gate.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VcloudDirectorConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: VcloudDirectorTargetLike, operator: Operator) -> str:
+        """Return the cached provider JWT, establishing it on first use.
+
+        ``operator.raw_jwt`` must be non-empty: the credential read runs under
+        the operator's Vault identity, and a system-initiated call (empty JWT)
+        cannot resolve per-target vendor credentials. The guard is enforced
+        **before** the cache lookup so a token primed by an authenticated caller
+        can never be handed to an unauthenticated one — the defense-in-depth
+        cache-scoping contract the ``vcf-automation`` provider plane established
+        (``docs/architecture/connector-auth.md``).
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read per-target vendor credentials)"
+            )
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None:
+                return cached
+            creds = await self._credentials_loader(target, operator)
+            client = await self._http_client(target)
+            # Lazy import so pure fingerprint/probe unit tests don't pay the
+            # _auth module's import; the login helper owns the wire POST.
+            from meho_backplane.connectors.vcd._auth import vcd_provider_login
+
+            jwt = await vcd_provider_login(
+                client,
+                creds,
+                target,
+                api_version=self._api_version(target),
+                request_extensions=self._request_extensions(target),
+            )
+            self._session_tokens[cache_key] = jwt
+            return jwt
+
+    async def _vcd_get(
+        self,
+        target: VcloudDirectorTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Retried GET returning parsed JSON, with the vCD per-surface ``Accept``.
+
+        Layers the path-derived ``Accept`` (:func:`._paths.accept_for_path`)
+        onto the connector's ``Authorization: Bearer`` header via the base
+        transport's ``extra_headers`` seam, so the base tenacity retry (5xx /
+        connection) and the ``auth_headers`` mint both stay in force. A raw 401
+        (expired token) propagates as :class:`httpx.HTTPStatusError` to the
+        dispatcher's credential-recovery arm, which evicts the token via
+        :meth:`invalidate_credentials` (#2396) and re-dispatches once.
+        """
+        accept = accept_for_path(path, self._api_version(target))
+        return await self._request_json(
+            target,
+            "GET",
+            path,
+            operator=operator,
+            params=params,
+            extra_headers={"Accept": accept},
+        )
+
+    # ------------------------------------------------------------------
+    # fingerprint / probe — unauthenticated GET /api/versions
+    # ------------------------------------------------------------------
+
+    async def fingerprint(
+        self,
+        target: VcloudDirectorTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint from the unauthenticated ``GET /api/versions`` probe.
+
+        Reads vCD's supported-versions endpoint **without** minting a session
+        (pure reachability). On success returns a reachable
+        :class:`FingerprintResult` (``vendor="vmware"``, ``product="vcd"``);
+        ``version`` is left ``None`` — ``/api/versions`` reports API versions,
+        not the product version, and the connector does not fabricate one. On
+        transport / status failure returns a non-reachable result whose
+        ``extras["error"]`` names the exception — the Harbor / NSX / vcf-fleet
+        pattern. ``operator`` is unused (the probe is unauthenticated) but kept
+        for signature parity with the credentialed connectors.
+        """
+        del operator  # the /api/versions probe is unauthenticated
+        probed_at = datetime.now(UTC)
+        try:
+            client = await self._http_client(target)
+            resp = await client.get(
+                _VERSIONS_PATH,
+                extensions=self._request_extensions(target),
+            )
+            resp.raise_for_status()
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcd",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_VCD_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcd",
+            version=None,
+            build=None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_VCD_PROBE_METHOD,
+            extras={
+                "versions_status": resp.status_code,
+                "product_lineage": "vmware-cloud-director",
+                "api_surface": "vcloud-director",
+            },
+        )
+
+    async def probe(self, target: VcloudDirectorTargetLike) -> ProbeResult:
+        """Lightweight reachability check — delegates to :meth:`fingerprint`.
+
+        ``GET /api/versions`` is the single unauthenticated reachability surface;
+        reusing the fingerprint result keeps probe + fingerprint pinned to one
+        round-trip, the SDDC Manager / NSX / vcf-fleet delegation shape.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: VcloudDirectorTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Post-G0.6 callers (``/api/v1/operations/call``, MCP ``call_operation``,
+        the CLI verbs) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't reach
+        this method. The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``: ``"vcd-rest-10.6"`` ->
+        (product=``"vcd"``, version=``"10.6"``, impl_id=``"vcd-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vcd-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (#3057, initiative #3056)
+    #
+    # Thin bound-method shims for the migration-inventory read core. Each
+    # delegates to the module-level ``_impl`` body in ``.typed_reads`` (lazy
+    # import so pure fingerprint/probe unit tests don't pay the operations
+    # package's embedding-pipeline import). The dispatcher resolves each
+    # persisted ``module.ClassName.method`` handler_ref back to the bound
+    # method and threads ``operator`` / ``target`` / ``params`` by name. All
+    # read-only — no write op ships here.
+    # ------------------------------------------------------------------
+
+    async def org_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.org.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_org_list_impl
+
+        return await vcd_org_list_impl(self, operator, target, params)
+
+    async def vdc_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.vdc.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_vdc_list_impl
+
+        return await vcd_vdc_list_impl(self, operator, target, params)
+
+    async def vapp_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.vapp.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_vapp_list_impl
+
+        return await vcd_vapp_list_impl(self, operator, target, params)
+
+    async def vm_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.vm.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_vm_list_impl
+
+        return await vcd_vm_list_impl(self, operator, target, params)
+
+    async def catalog_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.catalog.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_catalog_list_impl
+
+        return await vcd_catalog_list_impl(self, operator, target, params)
+
+    async def edge_gateway_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.edge-gateway.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_edge_gateway_list_impl
+
+        return await vcd_edge_gateway_list_impl(self, operator, target, params)
+
+    async def task_list(
+        self, operator: Operator, target: VcloudDirectorTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcd.task.list`` shim (#3057)."""
+        from meho_backplane.connectors.vcd.typed_reads import vcd_task_list_impl
+
+        return await vcd_task_list_impl(self, operator, target, params)
+
+    async def invalidate_credentials(self, target: VcloudDirectorTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached provider JWT for *target* so the next credential read
+        re-mints a fresh session. The dispatcher calls this hook on an
+        establish-auth failure (a data-path 401 from an expired token) and
+        re-dispatches once, so an out-of-band credential restage — or a simply
+        expired session — converges on the next dispatch without a backplane
+        restart. The ``fleet-lcm`` credential-recovery pattern.
+        """
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            self._session_tokens.pop(cache_key, None)
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens, then tear down the httpx pool.
+
+        No server-side session revoke — the Bearer header is sent per request.
+        The token cache is cleared so a post-aclose reuse of the same connector
+        instance re-mints cleanly.
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcd/session.py
+++ b/backend/src/meho_backplane/connectors/vcd/session.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading + target shape for the ``vcd`` (VMware Cloud Director) connector.
+
+The hand-rolled
+:class:`~meho_backplane.connectors.vcd.connector.VcloudDirectorConnector`
+authenticates against vCD's provider (System-org) session endpoint with HTTP
+Basic and caches the minted Bearer JWT (see :mod:`._auth`). The credential
+contract is the shared VCF-family one — a ``{"username": str, "password": str}``
+pair — so this module reuses the shared
+:mod:`meho_backplane.connectors._shared.vcf_auth` scaffolding (the #841
+cross-cutting module) rather than growing a bespoke duplicate:
+
+* :data:`VcloudDirectorTargetLike` — the minimum target shape the connector
+  reads. Aliased to the shared
+  :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike` Protocol
+  (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model`` + the
+  ``id`` / ``tenant_id`` cache-key pair); the concrete ``Target`` model in
+  :mod:`meho_backplane.targets` satisfies it structurally.
+* :data:`VcloudDirectorCredentialsLoader` — the async ``(target, operator) ->
+  dict[str, str]`` loader type. Injectable on connector construction so unit
+  tests pass a stub, integration tests a lab-account loader, and production the
+  default Vault read.
+* :func:`load_credentials_from_vault` — the shared operator-context KV-v2 read,
+  re-exported so the package's public API reads cohesively.
+
+The provider **Basic** username is composed as ``"<user>@System"`` — vCD
+provider accounts always live in the System org — inside :mod:`._auth`; the
+loader returns the raw ``username`` / ``password`` pair. A non-System /
+SSO provider identity is a documented follow-up (the connector docstring).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    VcfCredentialsLoader,
+    VcfTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = [
+    "VcloudDirectorCredentialsLoader",
+    "VcloudDirectorTargetLike",
+    "load_credentials_from_vault",
+]
+
+#: Minimum target shape :class:`VcloudDirectorConnector` reads. Aliased to the
+#: shared VCF-family Protocol — vCD reads exactly the fields the sibling VCF
+#: connectors do (``name`` / ``host`` / ``port`` / ``secret_ref`` /
+#: ``auth_model`` + the ``(tenant_id, id)`` cache key), so a bespoke duplicate
+#: Protocol would only drift.
+VcloudDirectorTargetLike = VcfTargetLike
+
+#: Async ``(target, operator) -> dict[str, str]`` credential loader. Aliased to
+#: the shared VCF loader type; re-exported under a vCD-flavoured name so
+#: ``VcloudDirectorConnector(credentials_loader=...)`` reads cohesively without
+#: exposing the shared module at the boundary.
+VcloudDirectorCredentialsLoader = VcfCredentialsLoader

--- a/backend/src/meho_backplane/connectors/vcd/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcd/typed_ops.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`VcloudDirectorConnector` (#3057).
+
+The VMware Cloud Director migration-inventory read core is registered as typed
+ops (``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog ingest** — the read core is live the moment the connector loads (part of
+initiative `evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_,
+legacy migration-source connector coverage).
+
+The op bodies live in :mod:`meho_backplane.connectors.vcd.typed_reads`; the
+per-op ``llm_instructions`` in
+:mod:`meho_backplane.connectors.vcd._llm_instructions`; thin bound-method shims
+on :class:`~meho_backplane.connectors.vcd.connector.VcloudDirectorConnector`
+expose them under the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk recovers
+each callable from its persisted ``module.ClassName.method`` path.
+
+The dataclass + tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.fleet_lcm.typed_ops` (#3047) and
+:mod:`meho_backplane.connectors.harbor.typed_ops` (#2856) — the Task #2358
+convention: typed ops own the curated read core. A write surface (create org /
+vApp / deploy) is deliberately out of scope — this is a read core for
+inventorying a migration source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+from meho_backplane.connectors.vcd._llm_instructions import VCD_READ_LLM_INSTRUCTIONS
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VCD_TYPED_OPS",
+    "VCD_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VcloudDirectorTypedOp",
+    "register_vcd_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys — the three curated groups the vCD read core spans,
+# ordered inventory -> networking -> tasks to match the operator's migration
+# drill path ("what workloads are here, how do they network, what's happening").
+_GROUP_INVENTORY = "vcd-inventory"
+_GROUP_NETWORKING = "vcd-networking"
+_GROUP_TASKS = "vcd-tasks"
+
+
+@dataclass(frozen=True)
+class VcloudDirectorTypedOp:
+    """Metadata for one vCD typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_vcd_typed_operations` can splat the dataclass into
+    the helper without per-op boilerplate. ``handler_attr`` is the attribute name
+    on :class:`VcloudDirectorConnector` exposing the async handler; the registrar
+    resolves the bound method against the class at registration time. Mirrors
+    :class:`~meho_backplane.connectors.fleet_lcm.typed_ops.FleetLcmTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group. Every entry is a complete
+#: sentence the agent reads verbatim through ``list_operation_groups`` to pick a
+#: group to search within; ``register_typed_operation`` requires a non-empty
+#: string whenever ``group_key`` is set.
+VCD_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_INVENTORY: (
+        "Use this group to inventory the VMware Cloud Director estate an operator "
+        "is migrating off: organizations, their org VDCs (compute/storage "
+        "allocations), vApps, virtual machines, and catalogs. A provider session "
+        "sees every org, so this is the primary 'what workloads exist and how "
+        "big are they' surface for migration sizing and wave planning."
+    ),
+    _GROUP_NETWORKING: (
+        "Use this group to read the vCD networking edges — the edge gateways that "
+        "provide each org VDC's egress and network services (NAT, firewall, VPN). "
+        "Use when mapping the source network topology a migration must re-home "
+        "onto the target."
+    ),
+    _GROUP_TASKS: (
+        "Use this group to read the vCD instance's recent asynchronous tasks — "
+        "what it is doing or just did. Use to confirm the estate is quiescent "
+        "before a migration cutover, or to find the task behind a resource in an "
+        "unexpected state."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared schema fragments
+# ---------------------------------------------------------------------------
+
+#: Empty parameter object shared by every read (all are no-argument list ops —
+#: the provider session is estate-wide, so no per-call selector is needed).
+_NO_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+#: Response schema shared by every vCD read: the cloudapi collection returns a
+#: ``{values: []}`` envelope and the query service a ``{record: []}`` envelope,
+#: so a permissive object schema fits both.
+_OBJECT_RESPONSE: dict[str, Any] = {"type": "object", "additionalProperties": True}
+
+_READ_TAGS = ("read-only", "vcd", "vcloud-director")
+
+
+#: The typed ops :class:`VcloudDirectorConnector` registers at lifespan startup —
+#: the 7-op migration-inventory read core (#3057). Every op is safe, read-only,
+#: and ungated; the wire path/type lives in the handler (see ``.typed_reads`` /
+#: ``._paths``), so the descriptor rows carry ``method=None`` / ``path=None``
+#: (typed convention).
+VCD_TYPED_OPS: tuple[VcloudDirectorTypedOp, ...] = (
+    # ---- Inventory ----
+    VcloudDirectorTypedOp(
+        op_id="vcd.org.list",
+        handler_attr="org_list",
+        summary="List the organizations in the vCD instance.",
+        description=(
+            "Lists organizations via GET /cloudapi/1.0.0/orgs — the top of the vCD "
+            "tenancy tree and the entry point for a migration inventory. A provider "
+            "session sees every org. Returns the cloudapi {resultTotal, values: []} "
+            "envelope; each Org carries a urn:vcloud:org: id, name, displayName, "
+            "isEnabled. Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "org"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.org.list"],
+    ),
+    VcloudDirectorTypedOp(
+        op_id="vcd.vdc.list",
+        handler_attr="vdc_list",
+        summary="List the organization VDCs (compute/storage allocations).",
+        description=(
+            "Lists org VDCs via GET /api/query?type=adminOrgVdc&format=records — the "
+            "per-org compute/storage allocations a migration must re-home. Returns the "
+            "query-service {record: []} envelope; each AdminOrgVdcRecord carries name, "
+            "orgName, providerVdcName, numberOfVApps/numberOfVMs, allocation figures. "
+            "Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "vdc"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.vdc.list"],
+    ),
+    VcloudDirectorTypedOp(
+        op_id="vcd.vapp.list",
+        handler_attr="vapp_list",
+        summary="List the vApps (deployable multi-VM units).",
+        description=(
+            "Lists vApps via GET /api/query?type=adminVApp&format=records — the "
+            "move-together boundary for migration waves. Returns the query-service "
+            "{record: []} envelope; each AdminVAppRecord carries name, orgName, vdcName, "
+            "status, numberOfVMs, isDeployed. A large list is reduced to a JSONFlux "
+            "handle. Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "vapp"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.vapp.list"],
+    ),
+    VcloudDirectorTypedOp(
+        op_id="vcd.vm.list",
+        handler_attr="vm_list",
+        summary="List the virtual machines across the estate.",
+        description=(
+            "Lists VMs via GET /api/query?type=adminVM&format=records — the core "
+            "migration-workload inventory (count, sizing, guest OS of every VM). Returns "
+            "the query-service {record: []} envelope; each AdminVMRecord carries name, "
+            "containerName (vApp), vdc, org, status, numberOfCpus, memoryMB, guestOs. A "
+            "large inventory is reduced to a JSONFlux handle. Dispatches with zero "
+            "catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "vm"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.vm.list"],
+    ),
+    VcloudDirectorTypedOp(
+        op_id="vcd.catalog.list",
+        handler_attr="catalog_list",
+        summary="List the catalogs (vApp-template + media libraries).",
+        description=(
+            "Lists catalogs via GET /api/query?type=adminCatalog&format=records — the "
+            "vApp-template and media libraries a migration must recreate on the target. "
+            "Returns the query-service {record: []} envelope; each AdminCatalogRecord "
+            "carries name, orgName, isShared/isPublished, numberOfVAppTemplates/"
+            "numberOfMedia. Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "catalog"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.catalog.list"],
+    ),
+    # ---- Networking ----
+    VcloudDirectorTypedOp(
+        op_id="vcd.edge-gateway.list",
+        handler_attr="edge_gateway_list",
+        summary="List the edge gateways (org-VDC network edges).",
+        description=(
+            "Lists edge gateways via GET /api/query?type=edgeGateway&format=records — the "
+            "org-VDC network egress + services (NAT, firewall, VPN) boundary a migration "
+            "must re-home. Returns the query-service {record: []} envelope; each "
+            "EdgeGatewayRecord carries name, vdc, orgName, numberOfExtNetworks, "
+            "numberOfOrgNetworks. Dispatches with zero catalog ingest. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_NETWORKING,
+        tags=(*_READ_TAGS, "edge-gateway", "network"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.edge-gateway.list"],
+    ),
+    # ---- Tasks ----
+    VcloudDirectorTypedOp(
+        op_id="vcd.task.list",
+        handler_attr="task_list",
+        summary="List recent asynchronous tasks.",
+        description=(
+            "Lists recent tasks via GET /api/query?type=task&format=records — 'what is "
+            "vCD doing / just did', used to confirm the estate is quiescent before a "
+            "migration cutover. Returns the query-service {record: []} envelope; each "
+            "TaskRecord carries name, status, objectName, orgName, startDate/endDate, "
+            "ownerName. A large list is reduced to a JSONFlux handle. Dispatches with "
+            "zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_TASKS,
+        tags=(*_READ_TAGS, "task"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VCD_READ_LLM_INSTRUCTIONS["vcd.task.list"],
+    ),
+)
+
+
+async def register_vcd_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`VCD_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after every connector subpackage has been imported, so the
+    descriptor rows land before the first dispatch — the vCD read core is live on
+    a fresh boot. Idempotent across pod restarts (the helper skips the embedding
+    recompute on unchanged summary / description / tags). Mirrors
+    :func:`register_fleet_lcm_typed_operations`.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so
+    each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests should not
+    # pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vcd.connector import VcloudDirectorConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VCD_TYPED_OPS:
+        handler = getattr(VcloudDirectorConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"VcloudDirectorConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = VCD_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        if when_to_use is None:
+            raise ValueError(
+                f"VcloudDirectorConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for that "
+                f"key. Add an entry to VCD_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=VcloudDirectorConnector.product,
+            version=VcloudDirectorConnector.version,
+            impl_id=VcloudDirectorConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vcd_typed_operations_registered",
+        count=len(VCD_TYPED_OPS),
+        product=VcloudDirectorConnector.product,
+        version=VcloudDirectorConnector.version,
+        impl_id=VcloudDirectorConnector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/vcd/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcd/typed_ops.py
@@ -253,10 +253,10 @@ VCD_TYPED_OPS: tuple[VcloudDirectorTypedOp, ...] = (
         handler_attr="task_list",
         summary="List recent asynchronous tasks.",
         description=(
-            "Lists recent tasks via GET /api/query?type=task&format=records — 'what is "
+            "Lists recent tasks via GET /api/query?type=adminTask&format=records — 'what is "
             "vCD doing / just did', used to confirm the estate is quiescent before a "
             "migration cutover. Returns the query-service {record: []} envelope; each "
-            "TaskRecord carries name, status, objectName, orgName, startDate/endDate, "
+            "AdminTaskRecord carries name, status, objectName, orgName, startDate/endDate, "
             "ownerName. A large list is reduced to a JSONFlux handle. Dispatches with "
             "zero catalog ingest. safety_level=safe, read-only."
         ),

--- a/backend/src/meho_backplane/connectors/vcd/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/vcd/typed_reads.py
@@ -27,7 +27,7 @@ The 7-read set (each path pinned by :mod:`tests.test_connectors_vcd_spec_reconci
   classic query service ``GET /api/query`` with ``type=adminOrgVdc`` /
   ``adminVApp`` / ``adminVM`` / ``adminCatalog`` and ``format=records``.
 * ``vcd.edge-gateway.list`` — ``GET /api/query?type=edgeGateway``.
-* ``vcd.task.list`` — ``GET /api/query?type=task``.
+* ``vcd.task.list`` — ``GET /api/query?type=adminTask``.
 
 **Pagination note.** The cloudapi collection returns ``{resultTotal, pageCount,
 page, pageSize, values: []}``; the query service returns ``{...QueryResultRecords,
@@ -46,10 +46,10 @@ from meho_backplane.connectors.vcd._paths import (
     _ORGS_PATH,
     _QT_ADMIN_CATALOG,
     _QT_ADMIN_ORG_VDC,
+    _QT_ADMIN_TASK,
     _QT_ADMIN_VAPP,
     _QT_ADMIN_VM,
     _QT_EDGE_GATEWAY,
-    _QT_TASK,
     _QUERY_PATH,
     QUERY_RECORDS_FORMAT,
 )
@@ -192,14 +192,17 @@ async def vcd_task_list_impl(
     target: VcloudDirectorTargetLike,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """``vcd.task.list`` — ``GET /api/query?type=task&format=records``.
+    """``vcd.task.list`` — ``GET /api/query?type=adminTask&format=records``.
 
     Lists recent asynchronous tasks across the instance — 'what is vCD doing /
-    just did'. Returns the query-service record envelope; each ``TaskRecord``
-    carries ``name``, ``status``, ``objectName``, ``orgName``, ``startDate`` /
-    ``endDate``, and ``ownerName``. A large list is reduced to a JSONFlux handle.
+    just did'. Uses the system-admin ``adminTask`` type (not the org-scoped
+    ``task``) so a provider session sees tasks across every org — the whole-estate
+    view the migration-quiescence check needs. Returns the query-service record
+    envelope; each ``AdminTaskRecord`` carries ``name``, ``status``,
+    ``objectName``, ``orgName``, ``startDate`` / ``endDate``, and ``ownerName``.
+    A large list is reduced to a JSONFlux handle.
     """
     del params  # schema declares the param object empty
     return await connector._vcd_get(
-        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_TASK)
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_ADMIN_TASK)
     )

--- a/backend/src/meho_backplane/connectors/vcd/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/vcd/typed_reads.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`VcloudDirectorConnector`.
+
+The migration-inventory read core (#3057, initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_) is registered
+as typed ops (``source_kind="typed"``) so it dispatches on a fresh boot with
+**zero catalog state** — no operator ``meho connector ingest`` + ``enable_reads``
+step. Each function here is the body a thin bound-method shim on
+:class:`~meho_backplane.connectors.vcd.connector.VcloudDirectorConnector`
+delegates to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.vcd.typed_ops`, the per-op ``llm_instructions``
+in :mod:`meho_backplane.connectors.vcd._llm_instructions`. This mirrors the
+``fleet-lcm`` (#3047) and Harbor (#2856) read cores under the Task #2358
+convention: typed ops own the curated read core.
+
+Every read is issued via :meth:`VcloudDirectorConnector._vcd_get`, which applies
+the provider Bearer header (minting the session on first use) plus the
+per-surface ``Accept`` derived from the path. The provider/System session sees
+the whole estate, so the classic-query reads use the ``admin*`` query types.
+
+The 7-read set (each path pinned by :mod:`tests.test_connectors_vcd_spec_reconcile`):
+
+* ``vcd.org.list`` — ``GET /cloudapi/1.0.0/orgs`` (modern cloudapi org collection).
+* ``vcd.vdc.list`` / ``.vapp.list`` / ``.vm.list`` / ``.catalog.list`` — the
+  classic query service ``GET /api/query`` with ``type=adminOrgVdc`` /
+  ``adminVApp`` / ``adminVM`` / ``adminCatalog`` and ``format=records``.
+* ``vcd.edge-gateway.list`` — ``GET /api/query?type=edgeGateway``.
+* ``vcd.task.list`` — ``GET /api/query?type=task``.
+
+**Pagination note.** The cloudapi collection returns ``{resultTotal, pageCount,
+page, pageSize, values: []}``; the query service returns ``{...QueryResultRecords,
+record: [], total, page, pageSize}`` — both self-describe whether more pages
+exist (so this is not silent truncation). Forwarding server-side ``page`` /
+``pageSize`` is a deferred enrichment; today the agent narrows a large result
+through the dispatcher's JSONFlux handle (``result_query``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vcd._paths import (
+    _ORGS_PATH,
+    _QT_ADMIN_CATALOG,
+    _QT_ADMIN_ORG_VDC,
+    _QT_ADMIN_VAPP,
+    _QT_ADMIN_VM,
+    _QT_EDGE_GATEWAY,
+    _QT_TASK,
+    _QUERY_PATH,
+    QUERY_RECORDS_FORMAT,
+)
+from meho_backplane.connectors.vcd.session import VcloudDirectorTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vcd.connector import VcloudDirectorConnector
+
+__all__ = [
+    "vcd_catalog_list_impl",
+    "vcd_edge_gateway_list_impl",
+    "vcd_org_list_impl",
+    "vcd_task_list_impl",
+    "vcd_vapp_list_impl",
+    "vcd_vdc_list_impl",
+    "vcd_vm_list_impl",
+]
+
+
+def _query_params(query_type: str) -> dict[str, str]:
+    """Build the query-service params for *query_type* (``type`` + ``format=records``)."""
+    return {"type": query_type, "format": QUERY_RECORDS_FORMAT}
+
+
+async def vcd_org_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.org.list`` — ``GET /cloudapi/1.0.0/orgs``.
+
+    Lists the organizations in the vCD instance (a provider session sees all).
+    Returns the cloudapi paged envelope ``{resultTotal, pageCount, page,
+    pageSize, values: [Org, ...]}``; each ``Org`` carries ``id`` (a
+    ``urn:vcloud:org:`` URN), ``name``, ``displayName``, and ``isEnabled``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(target, _ORGS_PATH, operator=operator)
+
+
+async def vcd_vdc_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.vdc.list`` — ``GET /api/query?type=adminOrgVdc&format=records``.
+
+    Lists the organization VDCs (the per-org compute/storage allocations) across
+    every org. Returns the query-service record envelope; each
+    ``AdminOrgVdcRecord`` carries ``name``, ``orgName``, ``providerVdcName``,
+    ``numberOfVApps`` / ``numberOfVMs``, and allocation figures.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_ADMIN_ORG_VDC)
+    )
+
+
+async def vcd_vapp_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.vapp.list`` — ``GET /api/query?type=adminVApp&format=records``.
+
+    Lists the vApps (the deployable multi-VM units) across every org. Returns the
+    query-service record envelope; each ``AdminVAppRecord`` carries ``name``,
+    ``orgName``, ``vdcName``, ``status``, ``numberOfVMs``, and ``isDeployed``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_ADMIN_VAPP)
+    )
+
+
+async def vcd_vm_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.vm.list`` — ``GET /api/query?type=adminVM&format=records``.
+
+    Lists the VMs across every org — the core migration-workload inventory.
+    Returns the query-service record envelope; each ``AdminVMRecord`` carries
+    ``name``, ``containerName`` (the vApp), ``vdc``, ``org``, ``status``,
+    ``numberOfCpus``, ``memoryMB``, and ``guestOs``. A large inventory is reduced
+    to a JSONFlux handle.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_ADMIN_VM)
+    )
+
+
+async def vcd_catalog_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.catalog.list`` — ``GET /api/query?type=adminCatalog&format=records``.
+
+    Lists the catalogs (vApp-template + media libraries) across every org.
+    Returns the query-service record envelope; each ``AdminCatalogRecord``
+    carries ``name``, ``orgName``, ``isShared`` / ``isPublished``, and
+    ``numberOfVAppTemplates`` / ``numberOfMedia``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_ADMIN_CATALOG)
+    )
+
+
+async def vcd_edge_gateway_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.edge-gateway.list`` — ``GET /api/query?type=edgeGateway&format=records``.
+
+    Lists the edge gateways (the org-VDC network egress + services boundary).
+    Returns the query-service record envelope; each ``EdgeGatewayRecord`` carries
+    ``name``, ``vdc``, ``orgName``, ``numberOfExtNetworks``, and
+    ``numberOfOrgNetworks`` — the networking surface a migration must re-home.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_EDGE_GATEWAY)
+    )
+
+
+async def vcd_task_list_impl(
+    connector: VcloudDirectorConnector,
+    operator: Operator,
+    target: VcloudDirectorTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcd.task.list`` — ``GET /api/query?type=task&format=records``.
+
+    Lists recent asynchronous tasks across the instance — 'what is vCD doing /
+    just did'. Returns the query-service record envelope; each ``TaskRecord``
+    carries ``name``, ``status``, ``objectName``, ``orgName``, ``startDate`` /
+    ``endDate``, and ``ownerName``. A large list is reduced to a JSONFlux handle.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vcd_get(
+        target, _QUERY_PATH, operator=operator, params=_query_params(_QT_TASK)
+    )

--- a/backend/tests/test_connectors_vcd_auth.py
+++ b/backend/tests/test_connectors_vcd_auth.py
@@ -1,0 +1,539 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VcloudDirectorConnector` provider session mint + fingerprint/probe.
+
+Exercises the load-bearing vCD auth contract (the vCloud-Director-derived
+Basic→Bearer flow the ``vcf-automation`` provider plane also speaks):
+
+* ``POST /cloudapi/1.0.0/sessions/provider`` with HTTP Basic (``<user>@System``);
+  the response header ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` is the JWT the connector
+  caches and sends as ``Authorization: Bearer <jwt>`` on subsequent calls.
+* Per-surface ``Accept``: the classic ``/api/*`` query service takes the
+  versioned ``application/*+json`` form, the modern ``/cloudapi/*`` collections
+  ``application/json`` — the one provider token authenticates both.
+* Per-target token caching + tenant-unique isolation.
+* ``invalidate_credentials`` eviction → re-mint (the dispatcher 401-recovery arm).
+* ``GET /api/versions`` unauthenticated fingerprint/probe.
+* ``auth_model`` gating + empty-``raw_jwt`` fail-closed.
+
+Single-plane simplification of :mod:`tests.test_connectors_vcf_automation_auth`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcd import (
+    VCD_IMPL_ID,
+    VCD_PRODUCT,
+    VCD_VERSION,
+    VcloudDirectorConnector,
+    VcloudDirectorTargetLike,
+)
+from meho_backplane.settings import get_settings
+
+_ORGS_PATH = "/cloudapi/1.0.0/orgs"
+_QUERY_PATH = "/api/query"
+_LOGIN_PATH = "/cloudapi/1.0.0/sessions/provider"
+_TOKEN_HEADER = "X-VMWARE-VCLOUD-ACCESS-TOKEN"
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    """Return a minimal :class:`Operator`; non-empty ``raw_jwt`` passes the fail-closed gate."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _chassis_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env the shared credential loader reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_vcd_registry() -> Iterator[None]:
+    """Restore VcloudDirectorConnector's package registration (both versioned + wildcard).
+
+    Sibling tests clear the shared registry between tests; this fixture restores
+    exactly what the ``vcd`` package's ``__init__`` registers — the versioned
+    triple *and* the ``("vcd", "", "")`` wildcard — so every test sees the real
+    registration shape.
+    """
+    clear_registry()
+    for version, impl_id in (
+        (VcloudDirectorConnector.version, VcloudDirectorConnector.impl_id),
+        ("", ""),
+    ):
+        register_connector_v2(
+            product=VcloudDirectorConnector.product,
+            version=version,
+            impl_id=impl_id,
+            cls=VcloudDirectorConnector,
+        )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    """Target satisfying :data:`VcloudDirectorTargetLike` structurally."""
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(name="vcd-a", host="vcd-a.test.invalid", port=443, secret_ref="vcd/vcd-a")
+_TARGET_B = _StubTarget(name="vcd-b", host="vcd-b.test.invalid", port=443, secret_ref="vcd/vcd-b")
+
+
+async def _stub_loader(_target: VcloudDirectorTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target / operator."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VcloudDirectorConnector:
+    """Build a connector wired with the stub loader."""
+    return VcloudDirectorConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vcd_connector_subclasses_http_connector() -> None:
+    """The connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(VcloudDirectorConnector, HttpConnector)
+    assert VcloudDirectorConnector.product == "vcd"
+    assert VcloudDirectorConnector.version == "10.6"
+    assert VcloudDirectorConnector.impl_id == "vcd-rest"
+    assert VcloudDirectorConnector.supported_version_range == ">=10.0,<11.0"
+    assert VcloudDirectorConnector.priority == 1
+
+
+def test_importing_package_registers_versioned_and_wildcard() -> None:
+    """The vcd package registers BOTH the versioned triple and the ``("vcd","","")`` wildcard.
+
+    The registration state is the package ``__init__``'s (restored verbatim by
+    the autouse fixture); a net-new single-impl product owns its own wildcard, so
+    an unfingerprinted vCD target still resolves.
+    """
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    assert registry[(VCD_PRODUCT, VCD_VERSION, VCD_IMPL_ID)] is VcloudDirectorConnector
+    assert registry[(VCD_PRODUCT, "", "")] is VcloudDirectorConnector
+
+
+# ---------------------------------------------------------------------------
+# Provider session mint + per-surface Accept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cloudapi_path_mints_bearer_and_sends_cloudapi_accept() -> None:
+    """A ``/cloudapi/*`` GET mints the provider JWT and sends the cloudapi Accept."""
+    connector = _make_connector()
+    jwt = "provider-jwt-abc-123"
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        login = mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: jwt})
+        orgs = mock.get(_ORGS_PATH).respond(200, json={"values": []})
+        result = await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+
+    assert result == {"values": []}
+    # Provider login used HTTP Basic with the <user>@System form.
+    basic_user, basic_password = _decode_basic_auth(login.calls[0].request.headers["Authorization"])
+    assert basic_user == "svc-meho@System"
+    assert basic_password == "stub-password"
+    # The data GET carried the Bearer + the cloudapi Accept.
+    data_req = orgs.calls[0].request
+    assert data_req.headers["Authorization"] == f"Bearer {jwt}"
+    assert data_req.headers["Accept"] == "application/json;version=38.0"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_classic_api_path_sends_versioned_classic_accept() -> None:
+    """A classic ``/api/*`` GET (query service) sends the versioned classic Accept."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "p-jwt"})
+        query = mock.get(_QUERY_PATH).respond(200, json={"record": []})
+        await connector._vcd_get(
+            _TARGET_A,
+            _QUERY_PATH,
+            operator=_make_operator(),
+            params={"type": "adminVM", "format": "records"},
+        )
+
+    req = query.calls[0].request
+    assert req.headers["Accept"] == "application/*+json;version=38.0"
+    assert req.headers["Authorization"] == "Bearer p-jwt"
+    # The query-service selector rode as query params (not path structure).
+    assert dict(req.url.params) == {"type": "adminVM", "format": "records"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_api_version_override_via_extras() -> None:
+    """``extras['vcd_api_version']`` overrides the module default in the Accept."""
+    target = _StubTarget(
+        name="vcd-v37",
+        host="vcd-v37.test.invalid",
+        port=443,
+        secret_ref="vcd/v37",
+        extras={"vcd_api_version": "37.0"},
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-v37.test.invalid") as mock:
+        # The login Accept also honours the override (cloudapi form).
+        login = mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "p-jwt"})
+        orgs = mock.get(_ORGS_PATH).respond(200, json={"values": []})
+        await connector._vcd_get(target, _ORGS_PATH, operator=_make_operator())
+
+    assert login.calls[0].request.headers["Accept"] == "application/json;version=37.0"
+    assert orgs.calls[0].request.headers["Accept"] == "application/json;version=37.0"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_cached_across_calls_against_same_target() -> None:
+    """Two calls against the same target mint the session once."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        login = mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "p-jwt"})
+        mock.get(_ORGS_PATH).respond(200, json={"values": []})
+        mock.get(_QUERY_PATH).respond(200, json={"record": []})
+        await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+        await connector._vcd_get(
+            _TARGET_A, _QUERY_PATH, operator=_make_operator(), params={"type": "task"}
+        )
+
+    assert login.call_count == 1
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "p-jwt"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        mock.post("https://vcd-a.test.invalid" + _LOGIN_PATH).respond(
+            200, headers={_TOKEN_HEADER: "p-a"}
+        )
+        mock.post("https://vcd-b.test.invalid" + _LOGIN_PATH).respond(
+            200, headers={_TOKEN_HEADER: "p-b"}
+        )
+        mock.get("https://vcd-a.test.invalid" + _ORGS_PATH).respond(200, json={"values": []})
+        mock.get("https://vcd-b.test.invalid" + _ORGS_PATH).respond(200, json={"values": []})
+        await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+        await connector._vcd_get(_TARGET_B, _ORGS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {
+        target_cache_key(_TARGET_A): "p-a",
+        target_cache_key(_TARGET_B): "p-b",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached token (#1642/#1672)."""
+    connector = _make_connector()
+    tenant_one = _StubTarget(
+        name="vcd-shared",
+        host="vcd-shared.test.invalid",
+        port=443,
+        secret_ref="vcd/shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="vcd-shared",
+        host="vcd-shared.test.invalid",
+        port=443,
+        secret_ref="vcd/shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://vcd-shared.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, headers={_TOKEN_HEADER: "p-one"}),
+                httpx.Response(200, headers={_TOKEN_HEADER: "p-two"}),
+            ]
+        )
+        mock.get(_ORGS_PATH).respond(200, json={"values": []})
+        await connector._vcd_get(tenant_one, _ORGS_PATH, operator=_make_operator())
+        await connector._vcd_get(tenant_two, _ORGS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {
+        target_cache_key(tenant_one): "p-one",
+        target_cache_key(tenant_two): "p-two",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Login failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_401_surfaces_connector_auth_error_naming_target() -> None:
+    """401 from provider login raises the structured ConnectorAuthError (#2329)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).respond(401)
+        with pytest.raises(RuntimeError, match=r"vcd-a") as exc_info:
+            await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+    err = exc_info.value
+    assert isinstance(err, ConnectorAuthError)
+    assert "401" in str(err)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_missing_token_header_raises() -> None:
+    """A 2xx login with no X-VMWARE-VCLOUD-ACCESS-TOKEN raises naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).respond(200)
+        with pytest.raises(RuntimeError, match=r"vcd-a") as exc_info:
+            await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+    assert _TOKEN_HEADER in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_raises_clear_error() -> None:
+    """A loader returning a dict without ``password`` raises naming the target."""
+
+    async def _bad_loader(_t: VcloudDirectorTargetLike, _o: Operator) -> dict[str, str]:
+        return {"username": "svc-meho"}  # missing 'password' on purpose
+
+    connector = VcloudDirectorConnector(credentials_loader=_bad_loader)
+    async with respx.mock(base_url="https://vcd-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating + fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation / unknown modes raise NotImplementedError naming target + mode."""
+    target = _StubTarget(
+        name="vcd-per-user",
+        host="vcd.test.invalid",
+        port=443,
+        secret_ref="vcd/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "vcd-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model() -> None:
+    """``auth_model=None`` (pre-G0.3) is accepted."""
+    target = _StubTarget(
+        name="vcd-pre-g03", host="vcd.test.invalid", port=443, secret_ref="vcd/pre", auth_model=None
+    )
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vcd.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "pre-jwt"})
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer pre-jwt"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_establish_rejects_empty_operator_jwt() -> None:
+    """A system-initiated call (empty raw_jwt) cannot mint — fail-closed before the cache."""
+    connector = _make_connector()
+    with pytest.raises(VaultCredentialsReadError, match=r"vcd-a"):
+        await connector.auth_headers(_TARGET_A, operator=_make_operator(raw_jwt=""))
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# invalidate_credentials → re-mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_credentials_evicts_token_forcing_remint() -> None:
+    """invalidate_credentials drops the cached token so the next call re-mints (dispatcher arm)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        login = mock.post(_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, headers={_TOKEN_HEADER: "jwt-1"}),
+                httpx.Response(200, headers={_TOKEN_HEADER: "jwt-2"}),
+            ]
+        )
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        await connector.invalidate_credentials(_TARGET_A)
+        assert connector._session_tokens == {}
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == {"Authorization": "Bearer jwt-1"}
+    assert h2 == {"Authorization": "Bearer jwt-2"}
+    assert login.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_tokens_and_pool() -> None:
+    """aclose() drops the token cache and tears down the httpx pool."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "jwt"})
+        mock.get(_ORGS_PATH).respond(200, json={"values": []})
+        await connector._vcd_get(_TARGET_A, _ORGS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "jwt"}
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe() — unauthenticated GET /api/versions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_reachable_no_mint() -> None:
+    """A 2xx on /api/versions → reachable=True, version=None, and NO session mint."""
+    connector = _make_connector()
+
+    # assert_all_called=False: the login route is registered to prove the probe
+    # does NOT call it (an unauthenticated fingerprint must not mint a session).
+    async with respx.mock(base_url="https://vcd-a.test.invalid", assert_all_called=False) as mock:
+        versions = mock.get("/api/versions").respond(
+            200,
+            content=b"<SupportedVersions><VersionInfo><Version>38.0</Version>"
+            b"</VersionInfo></SupportedVersions>",
+        )
+        login = mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "should-not-mint"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcd"
+    assert fp.reachable is True
+    assert fp.version is None
+    assert fp.extras["versions_status"] == 200
+    assert fp.extras["api_surface"] == "vcloud-director"
+    assert versions.called
+    # The probe is unauthenticated — it must NOT trigger a provider login.
+    assert not login.called
+    assert connector._session_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_5xx() -> None:
+    """A 5xx on /api/versions → reachable=False with a structured error."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.get("/api/versions").respond(503)
+        fp = await connector.fingerprint(_TARGET_A)
+    assert fp.reachable is False
+    assert "HTTPStatusError" in fp.extras["error"] or "503" in fp.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_and_not_ok() -> None:
+    """probe() reflects fingerprint reachability."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
+        mock.get("/api/versions").respond(200, content=b"<x/>")
+        ok = await connector.probe(_TARGET_A)
+    assert ok.ok is True and ok.reason is None
+
+    connector2 = _make_connector()
+    async with respx.mock(base_url="https://vcd-b.test.invalid") as mock:
+        mock.get("/api/versions").respond(503)
+        bad = await connector2.probe(_TARGET_B)
+    assert bad.ok is False and bad.reason is not None
+    await connector.aclose()
+    await connector2.aclose()
+
+
+def test_default_loader_fails_closed_for_system_initiated_call() -> None:
+    """The default Vault loader rejects an empty operator JWT (system-initiated call)."""
+    from meho_backplane.connectors.vcd.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        with pytest.raises(VaultCredentialsReadError, match=r"vcd-a"):
+            await load_credentials_from_vault(_TARGET_A, _make_operator(raw_jwt=""))
+
+    asyncio.run(_check())

--- a/backend/tests/test_connectors_vcd_auth.py
+++ b/backend/tests/test_connectors_vcd_auth.py
@@ -426,9 +426,19 @@ async def test_session_establish_rejects_empty_operator_jwt() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("hook_name", ["invalidate_session", "invalidate_credentials"])
 @pytest.mark.asyncio
-async def test_invalidate_credentials_evicts_token_forcing_remint() -> None:
-    """invalidate_credentials drops the cached token so the next call re-mints (dispatcher arm)."""
+async def test_eviction_hook_drops_token_forcing_remint(hook_name: str) -> None:
+    """Both dispatch-path eviction hooks drop the cached JWT so the next auth_headers re-mints.
+
+    ``invalidate_session`` is the hook the dispatcher's data-path 401 recovery arm
+    calls (#2067 — proven end-to-end in
+    ``test_data_path_401_remints_via_dispatcher``); ``invalidate_credentials`` is
+    the establish-failure companion (#2396). vCD keeps only the minted-JWT cache,
+    so both evict it. This also pins that ``invalidate_session`` exists — its
+    absence was a latent permanent-wedge bug (the data-path 401 arm is keyed on
+    ``invalidate_session``, not ``invalidate_credentials``).
+    """
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vcd-a.test.invalid") as mock:
@@ -439,7 +449,7 @@ async def test_invalidate_credentials_evicts_token_forcing_remint() -> None:
             ]
         )
         h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
-        await connector.invalidate_credentials(_TARGET_A)
+        await getattr(connector, hook_name)(_TARGET_A)
         assert connector._session_tokens == {}
         h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
 

--- a/backend/tests/test_connectors_vcd_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcd_spec_reconcile.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcd (VMware Cloud Director) hand-coded-surface reconcile lane (#3057) — #2980 harness.
+
+Pins the exact ``METHOD:/path`` surface the ``vcd`` connector hand-codes, swept
+from the connector's **live** module constants (the #2944 introspect-live-
+constants pattern — never a hardcoded mirror that can drift). Parse-only, no DB
+/ embeddings / containers, so it lives in the required unit sweep per the
+lane-placement rule in ``docs/decisions/spec-reconcile-guards-standard.md``.
+
+**Evidenced exclusion — no served-op-id compare.** Unlike the ``fleet-lcm`` lane
+(which reconciles against a pinned Apache-2.0 OpenAPI on the shelf), vCD is a
+*typed* connector precisely because Broadcom publishes **no committable spec**
+for its REST surface: the classic ``/api/*`` query service is bundled into the
+UI JS at build time, and the appliance serves no ``/cloudapi/1.0.0/openapi*``
+(the same evidence recorded for the ``vcf-automation`` provider plane, which
+speaks the same vCloud-Director-derived surface). So there is no artifact to
+reconcile against; this lane is the **manifest pin** half of the standard —
+runs unconditionally, proves the enumeration on every sweep, and a new
+hand-coded path / renamed constant / method change must update the manifest
+consciously. Dispatch-fidelity of each path is proven live-mocked in
+:mod:`tests.test_connectors_vcd_typed_reads` / :mod:`tests.test_connectors_vcd_auth`.
+
+The full evidence + activation trigger (if Broadcom ever ships a vCD OpenAPI)
+live in the ``vcd`` entry of the standard doc's Evidenced-exclusions section.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcd import _paths as _paths_module
+from meho_backplane.connectors.vcd import connector as _connector
+
+#: HTTP method per hand-coded path constant. The provider session-create
+#: endpoint is POSTed (``._auth.vcd_provider_login``); every other constant —
+#: the ``/api/versions`` fingerprint probe and the two read paths — is GET.
+#: A new ``*_PATH`` constant not listed here fails the sweep loudly so its
+#: method is mapped consciously.
+_METHOD_BY_CONSTANT = {
+    "_SESSIONS_PROVIDER_PATH": "POST",
+    "_VERSIONS_PATH": "GET",
+    "_ORGS_PATH": "GET",
+    "_QUERY_PATH": "GET",
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` string constants of the ``vcd._paths`` module."""
+    return {
+        name: value
+        for name, value in vars(_paths_module).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcd connector dispatches.
+
+    Swept from the live ``_paths`` constants (never a hardcoded mirror); the
+    method for each is taken from :data:`_METHOD_BY_CONSTANT`. A constant with
+    no method mapping fails loudly so the reconcile keeps covering it.
+    """
+    declared: set[str] = set()
+    for name, path in _path_constants().items():
+        method = _METHOD_BY_CONSTANT.get(name)
+        if method is None:
+            raise AssertionError(
+                f"vcd._paths.{name} has no entry in _METHOD_BY_CONSTANT — map the "
+                "new constant's HTTP method there consciously so the reconcile "
+                "keeps covering it."
+            )
+        declared.add(f"{method}:{path}")
+    return declared
+
+
+def test_path_constant_names_are_pinned() -> None:
+    """Guard: the introspection finds exactly the hand-coded path-constant set.
+
+    Pinning the exact ``_*_PATH`` constant-name set (the #2944 guard shape) means
+    a renamed or dropped constant — or a new one that skips the ``_PATH``
+    convention — can't silently shrink the reconciled surface to a vacuous pass.
+    """
+    assert sorted(_path_constants()) == [
+        "_ORGS_PATH",
+        "_QUERY_PATH",
+        "_SESSIONS_PROVIDER_PATH",
+        "_VERSIONS_PATH",
+    ]
+
+
+def test_vcd_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept ``METHOD:/path`` manifest so drift can't silently change the surface.
+
+    Runs unconditionally (no shelf / spec needed), so the enumeration is proven
+    on every sweep. Because vCD publishes no committable spec (evidenced
+    exclusion — see the module docstring), this manifest pin is the whole
+    reconcile: a new hand-coded path, a renamed constant, or a method change must
+    update it consciously.
+    """
+    assert _declared_op_ids() == {
+        "GET:/api/query",
+        "GET:/api/versions",
+        "GET:/cloudapi/1.0.0/orgs",
+        "POST:/cloudapi/1.0.0/sessions/provider",
+    }
+
+
+def test_probe_constant_links_to_versions_path() -> None:
+    """The fingerprint probe reads the same ``/api/versions`` the manifest pins.
+
+    The connector's fingerprint dispatches :data:`vcd._paths._VERSIONS_PATH`; pin
+    the value and the probe-method string's reference to it so a change to one is
+    forced through the other (the fleet-lcm health⇄probe link shape).
+    """
+    assert _paths_module._VERSIONS_PATH == "/api/versions"
+    assert "/api/versions" in _connector._VCD_PROBE_METHOD

--- a/backend/tests/test_connectors_vcd_typed_reads.py
+++ b/backend/tests/test_connectors_vcd_typed_reads.py
@@ -34,6 +34,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 from sqlalchemy import select
@@ -194,7 +195,7 @@ _DISPATCH_CASES: list[tuple[str, str, str | None, Any]] = [
     ("vcd.vm.list", "/api/query", "adminVM", {"record": [{"name": "vm-a"}]}),
     ("vcd.catalog.list", "/api/query", "adminCatalog", {"record": [{"name": "cat-a"}]}),
     ("vcd.edge-gateway.list", "/api/query", "edgeGateway", {"record": [{"name": "edge-a"}]}),
-    ("vcd.task.list", "/api/query", "task", {"record": [{"name": "task-a"}]}),
+    ("vcd.task.list", "/api/query", "adminTask", {"record": [{"name": "task-a"}]}),
 ]
 
 
@@ -237,6 +238,55 @@ async def test_each_typed_op_dispatches_zero_catalog(
         assert data_req.url.params["format"] == "records"
     else:
         assert data_req.headers["Accept"] == "application/json;version=38.0"
+
+
+@pytest.mark.asyncio
+async def test_data_path_401_remints_via_dispatcher(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """A data-path 401 (expired JWT) self-heals via the dispatcher's session-recovery arm.
+
+    The load-bearing 401-recovery proof — the coverage the isolated eviction
+    tests can't give. A stale minted JWT gets a 401 on the data read; the
+    dispatcher evicts it via the connector's ``invalidate_session`` hook and
+    re-dispatches once; the retry re-mints a fresh session and the op succeeds.
+    Without ``invalidate_session`` on the connector this would fall through to
+    ``connector_auth_failed`` and wedge on the stale token (dispatcher #2067) —
+    so a green here proves the hook is wired to the arm the 401 path actually
+    calls, not the establish-only ``invalidate_credentials``.
+    """
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_VCD_BASE_URL) as mock:
+        login = mock.post(_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, headers={_TOKEN_HEADER: "jwt-stale"}),
+                httpx.Response(200, headers={_TOKEN_HEADER: "jwt-fresh"}),
+            ]
+        )
+        orgs = mock.get("/cloudapi/1.0.0/orgs").mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(200, json={"values": [{"name": "System"}]}),
+            ]
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=VCD_CONNECTOR_ID,
+            op_id="vcd.org.list",
+            target=_VcdReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"values": [{"name": "System"}]}
+    # Minted once, 401'd, re-minted, retried once → exactly 2 logins + 2 data GETs.
+    assert login.call_count == 2
+    assert orgs.call_count == 2
+    # The first data GET carried the stale token; the retry carried the fresh one.
+    assert orgs.calls[0].request.headers["Authorization"] == "Bearer jwt-stale"
+    assert orgs.calls[1].request.headers["Authorization"] == "Bearer jwt-fresh"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vcd_typed_reads.py
+++ b/backend/tests/test_connectors_vcd_typed_reads.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the vCD typed read core (#3057, initiative #3056).
+
+The appliance-free proof that a VMware Cloud Director target dispatches a
+migration-inventory read end-to-end on a fresh boot. Coverage:
+
+* **Zero-catalog typed dispatch.** Each of the 7 reads dispatches through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked vCD (the
+  provider login POST + the data GET) with **only** the typed registrar run (no
+  ingested rows) and returns ``status="ok"``. The query-service reads carry the
+  right ``type=`` selector; the modern org read hits ``/cloudapi/1.0.0/orgs``.
+* **Session mint on the dispatch path.** The read rides
+  :meth:`VcloudDirectorConnector.auth_headers`, minting the provider Bearer JWT
+  from the ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` login-response header and sending it
+  as ``Authorization: Bearer`` with the per-surface ``Accept``.
+* **Registration-shape invariants.** All 7 reads persist as
+  ``source_kind="typed"``, ``is_enabled=True`` (enabled at register time — the
+  "merge = fix" property), ``safe`` / ungated / ``read-only``, with a
+  canonical-key ``llm_instructions`` blob; their 3 groups land
+  ``review_status="enabled"``; no write op is registered.
+
+Mirrors :mod:`tests.test_connectors_fleet_lcm_typed_reads`; the credential seam
+replaces the resolved instance's ``_credentials_loader`` (vCD mints a token from
+the loader creds, the ``vcf-automation`` shape), not a ``CredentialsCache``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vcd import (
+    VCD_CONNECTOR_ID,
+    VCD_IMPL_ID,
+    VCD_PRODUCT,
+    VCD_TYPED_OPS,
+    VCD_TYPED_WHEN_TO_USE_BY_GROUP,
+    VCD_VERSION,
+    VcloudDirectorConnector,
+    register_vcd_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_VCD_HOST = "vcd-typed.test.invalid"
+_VCD_BASE_URL = f"https://{_VCD_HOST}"
+_LOGIN_PATH = "/cloudapi/1.0.0/sessions/provider"
+_TOKEN_HEADER = "X-VMWARE-VCLOUD-ACCESS-TOKEN"
+
+_EXPECTED_OP_IDS = {
+    "vcd.org.list",
+    "vcd.vdc.list",
+    "vcd.vapp.list",
+    "vcd.vm.list",
+    "vcd.catalog.list",
+    "vcd.edge-gateway.list",
+    "vcd.task.list",
+}
+
+_EXPECTED_GROUPS = {"vcd-inventory", "vcd-networking", "vcd-tasks"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=VCD_PRODUCT,
+        version=VCD_VERSION,
+        impl_id=VCD_IMPL_ID,
+        cls=VcloudDirectorConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _VcdReadTarget:
+    """Target satisfying both ``VcloudDirectorTargetLike`` and the resolver shape.
+
+    ``fingerprint.version="10.6.1"`` is in the ``vcd-rest`` band ``">=10.0,<11.0"``,
+    so a vCD target resolves to this impl (single-impl; the versioned entry or the
+    wildcard both point at it).
+    """
+
+    def __init__(self) -> None:
+        self.product = VCD_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "10.6.1"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-0000000000d0")
+        self.name = "vcd-typed"
+        self.host = _VCD_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/vcd-typed"
+        self.auth_model = "shared_service_account"
+        self.extras: dict[str, Any] = {}
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-vcd",
+        name="VCD Reads Operator",
+        email=None,
+        raw_jwt="op.reads.vcd.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000d4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _stub_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Username/password for the provider Basic login."""
+    return {"username": "vcd-svc", "password": "vcd-pw"}
+
+
+async def _register_and_resolve() -> VcloudDirectorConnector:
+    """Run the typed registrar (only) and return a credentials-stubbed instance."""
+    await register_vcd_typed_operations()
+    instance = get_or_create_connector_instance(VcloudDirectorConnector)
+    instance._credentials_loader = _stub_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Zero-catalog typed dispatch
+# ---------------------------------------------------------------------------
+
+# (op_id, wire path, expected query ``type`` (None for the cloudapi org read), payload)
+_DISPATCH_CASES: list[tuple[str, str, str | None, Any]] = [
+    ("vcd.org.list", "/cloudapi/1.0.0/orgs", None, {"values": [{"name": "System"}]}),
+    ("vcd.vdc.list", "/api/query", "adminOrgVdc", {"record": [{"name": "vdc-a"}]}),
+    ("vcd.vapp.list", "/api/query", "adminVApp", {"record": [{"name": "vapp-a"}]}),
+    ("vcd.vm.list", "/api/query", "adminVM", {"record": [{"name": "vm-a"}]}),
+    ("vcd.catalog.list", "/api/query", "adminCatalog", {"record": [{"name": "cat-a"}]}),
+    ("vcd.edge-gateway.list", "/api/query", "edgeGateway", {"record": [{"name": "edge-a"}]}),
+    ("vcd.task.list", "/api/query", "task", {"record": [{"name": "task-a"}]}),
+]
+
+
+@pytest.mark.parametrize(
+    ("op_id", "path", "query_type", "payload"), _DISPATCH_CASES, ids=lambda v: v
+)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+    query_type: str | None,
+    payload: Any,
+) -> None:
+    """Each read dispatches typed (zero ingested catalog), minting the provider session."""
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_VCD_BASE_URL, assert_all_called=False) as mock:
+        login = mock.post(_LOGIN_PATH).respond(200, headers={_TOKEN_HEADER: "disp-jwt"})
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=VCD_CONNECTOR_ID,
+            op_id=op_id,
+            target=_VcdReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert login.called
+    assert route.called and route.call_count == 1
+    data_req = route.calls[0].request
+    # The minted provider Bearer + the per-surface Accept rode the data call.
+    assert data_req.headers["Authorization"] == "Bearer disp-jwt"
+    if path.startswith("/api/"):
+        assert data_req.headers["Accept"] == "application/*+json;version=38.0"
+        assert data_req.url.params["type"] == query_type
+        assert data_req.url.params["format"] == "records"
+    else:
+        assert data_req.headers["Accept"] == "application/json;version=38.0"
+
+
+# ---------------------------------------------------------------------------
+# Registration-shape invariants — the "merge = fix" property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_typed_and_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 7 reads persist as source_kind='typed', is_enabled=True (live on fresh boot)."""
+    await register_vcd_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == VCD_PRODUCT,
+                    EndpointDescriptor.impl_id == VCD_IMPL_ID,
+                    EndpointDescriptor.op_id.in_(list(_EXPECTED_OP_IDS)),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == _EXPECTED_OP_IDS
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.is_enabled is True for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+    # Typed ops carry no wire method/path on the descriptor (path lives in the handler).
+    assert all(r.method is None and r.path is None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_groups_are_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 3 read-core groups land review_status='enabled' with a curated when_to_use."""
+    await register_vcd_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(OperationGroup).where(
+                    OperationGroup.product == VCD_PRODUCT,
+                    OperationGroup.impl_id == VCD_IMPL_ID,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {g.group_key for g in rows} == _EXPECTED_GROUPS
+    assert all(g.review_status == "enabled" for g in rows)
+    assert all(g.when_to_use.strip() for g in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed reads are retrievable via search_operations."""
+    await register_vcd_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {
+            "connector_id": VCD_CONNECTOR_ID,
+            "query": "vcd cloud director org vdc vapp vm catalog edge gateway task inventory",
+            "limit": 25,
+        },
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    assert found >= _EXPECTED_OP_IDS, f"missing from search: {_EXPECTED_OP_IDS - found}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-dataclass invariants (no DB, no async)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_table_is_exactly_the_read_core() -> None:
+    assert {op.op_id for op in VCD_TYPED_OPS} == _EXPECTED_OP_IDS
+    assert len(VCD_TYPED_OPS) == 7
+
+
+def test_every_group_key_has_a_when_to_use() -> None:
+    assert set(VCD_TYPED_WHEN_TO_USE_BY_GROUP) == _EXPECTED_GROUPS
+    used_groups = {op.group_key for op in VCD_TYPED_OPS}
+    assert used_groups == _EXPECTED_GROUPS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in VCD_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_canonical_keys(op_id: str) -> None:
+    op = next(o for o in VCD_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    for key in ("when_to_call", "output_shape", "next_step"):
+        value = op.llm_instructions.get(key)
+        assert isinstance(value, str) and value.strip(), f"{op_id}: {key}"
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in VCD_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only core: no create/write op ships here."""
+    for op in VCD_TYPED_OPS:
+        assert not any(
+            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
+        )
+        assert "write" not in op.tags

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -29856,6 +29856,7 @@
               "sddc",
               "tempo",
               "vault",
+              "vcd",
               "vcfa",
               "vmware",
               "vrli",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -522,6 +522,7 @@ const (
 	TargetCreateProductSddc       TargetCreateProduct = "sddc"
 	TargetCreateProductTempo      TargetCreateProduct = "tempo"
 	TargetCreateProductVault      TargetCreateProduct = "vault"
+	TargetCreateProductVcd        TargetCreateProduct = "vcd"
 	TargetCreateProductVcfa       TargetCreateProduct = "vcfa"
 	TargetCreateProductVmware     TargetCreateProduct = "vmware"
 	TargetCreateProductVrli       TargetCreateProduct = "vrli"

--- a/docs/codebase/connectors-vcd.md
+++ b/docs/codebase/connectors-vcd.md
@@ -54,7 +54,8 @@ core reads, both authenticated by the one minted provider Bearer JWT:
 - **Classic `/api/query`** — the uniform, provider/System-scoped inventory
   mechanism. One path, one paging model, a `type=` selector per entity (the
   `go-vcloud-director` SDK's canonical `adminOrgVdc` / `adminVApp` / `adminVM` /
-  `adminCatalog` admin query types, plus `edgeGateway` / `task`), `format=records`.
+  `adminCatalog` / `adminTask` admin query types, plus `edgeGateway` — no admin
+  variant; a System admin sees all), `format=records`.
 
 The two surfaces need **different `Accept` media types** (vCD content
 negotiation): `accept_for_path` returns the versioned `application/*+json` form
@@ -124,10 +125,13 @@ served by vCD 10.5/10.6), overridable per target via `extras["vcd_api_version"]`
 version *negotiation* (read the max non-deprecated version from `/api/versions`)
 is a documented follow-up.
 
-A raw 401 (expired token) propagates to the dispatcher's credential-recovery arm,
-which calls `invalidate_credentials` (evicts the cached JWT) and re-dispatches
-once — the `fleet-lcm` pattern, so there is no in-connector retry loop and the
-base transport's tenacity retry (5xx / connection only) stays intact.
+A raw 401 (expired token) propagates to the dispatcher's session-recovery arm,
+which — because the connector advertises an `invalidate_session` hook (the
+SDDC Manager / NSX session-minting precedent, #2067) — evicts the cached JWT and
+re-dispatches once, so the retry re-mints. There is no in-connector retry loop,
+and the base transport's tenacity retry (5xx / connection only) stays intact.
+(`invalidate_credentials` is also implemented — the #2396 establish-failure
+companion — but the data-path 401 recovery is keyed on `invalidate_session`.)
 
 ### Fingerprint / probe
 

--- a/docs/codebase/connectors-vcd.md
+++ b/docs/codebase/connectors-vcd.md
@@ -1,0 +1,246 @@
+# Connector: vcd (VMware Cloud Director, net-new typed read core)
+
+## Overview
+
+The `vcd` connector is the hand-rolled `HttpConnector` subclass that makes
+**VMware Cloud Director** (vCD) — the legacy standalone product — dispatchable
+under the `(product="vcd", version="10.6", impl_id="vcd-rest")` registry triple.
+It is a **net-new typed** connector filed under the legacy migration-source
+connector-coverage initiative
+([#3056](https://github.com/evoila/meho/issues/3056), task #3057): vCD is a
+migration **source** estate evoila brings customers *off*, so MEHO must be able
+to read and inventory it during discovery + onboarding.
+
+Source: `backend/src/meho_backplane/connectors/vcd/`.
+
+**vCD is a distinct product from VCF Automation.** The Broadcom-era successor
+([`connectors-vcf-automation.md`](connectors-vcf-automation.md)) absorbed only
+vCD's *provider control plane* (reachable via `--plane provider`); vCD is its
+own product with the full org / VDC / vApp / VM / catalog tenancy model. So this
+is **not** a `vcfa` dual-impl — it is a separate `product="vcd"` connector,
+resolved by fingerprint like any other. The two do share the vCloud-Director-
+derived provider auth flow and cloudapi surface (which is why the auth here
+mirrors the VCFA provider plane).
+
+## Scope: typed read core (#3057)
+
+The connector ships a curated **7-op typed read core** — the migration-inventory
+surface — registered as `source_kind="typed"` and **enabled at register time**,
+so a vCD target dispatches an inventory read on a **fresh boot with zero catalog
+ingest**. A provider (System-org) session is estate-wide, so one session
+enumerates every org's resources — exactly what a migration discovery needs.
+
+| Group | Ops |
+|---|---|
+| `vcd-inventory` | `vcd.org.list`, `.vdc.list`, `.vapp.list`, `.vm.list`, `.catalog.list` |
+| `vcd-networking` | `vcd.edge-gateway.list` |
+| `vcd-tasks` | `vcd.task.list` |
+
+**Why typed, not ingested.** Broadcom publishes **no committable OpenAPI** for
+vCD's full REST surface: the classic `/api/*` query service is bundled into the
+UI JS at build time, and the appliance serves no `/cloudapi/1.0.0/openapi*`
+(the same evidence recorded for the VCFA provider plane, which speaks the same
+surface). This is the CLAUDE.md postulate-1 "no usable spec → typed" case — the
+`fleet-lcm` (#3047) / harbor (#2856) pattern. There is therefore no wider
+`source_kind="ingested"` breadth to follow up: the typed read core **is** the
+connector's surface.
+
+**Dual REST surface, one token.** vCD exposes two co-existing surfaces the read
+core reads, both authenticated by the one minted provider Bearer JWT:
+
+- **Modern `/cloudapi/1.0.0/*`** — the clean JSON org collection (`vcd.org.list`
+  → `GET /cloudapi/1.0.0/orgs`). In-repo verified: the VCFA provider plane reads
+  the same path.
+- **Classic `/api/query`** — the uniform, provider/System-scoped inventory
+  mechanism. One path, one paging model, a `type=` selector per entity (the
+  `go-vcloud-director` SDK's canonical `adminOrgVdc` / `adminVApp` / `adminVM` /
+  `adminCatalog` admin query types, plus `edgeGateway` / `task`), `format=records`.
+
+The two surfaces need **different `Accept` media types** (vCD content
+negotiation): `accept_for_path` returns the versioned `application/*+json` form
+for `/api/*` and `application/json` for `/cloudapi/*`.
+
+**Live-appliance dispatch verification is the deferred tail.** A vCD 10.6
+provider lab exists for end-to-end verification (needs lab Vault/VPN access);
+the read core is unit-tested end-to-end against a respx-mocked vCD (dispatch
+`status="ok"` through the session-mint seam) and manifest-pinned — the same
+unit-tested-first posture `fleet-lcm` shipped with.
+
+## Key types
+
+- **`VcloudDirectorConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="vcd"`, `version="10.6"`, `impl_id="vcd-rest"`,
+  `supported_version_range=">=10.0,<11.0"`, `priority=1`. The `product` token is
+  `"vcd"` (not `"vcloud-director"`) because `register_connector_v2` enforces that
+  `product` equals the first hyphen-segment of `impl_id` — a hyphenated token
+  would crash the round-trip check at boot.
+- **`VcloudDirectorTargetLike`** / **`VcloudDirectorCredentialsLoader`**
+  (`session.py`) — aliases of the shared `VcfTargetLike` Protocol and
+  `VcfCredentialsLoader` type. The loader is injectable on construction
+  (`VcloudDirectorConnector(credentials_loader=...)`) for unit / integration tests.
+- **`load_credentials_from_vault`** (`session.py`) — the shared operator-context
+  KV-v2 read, re-exported. Returns the `{username, password}` pair.
+- Canonical constants (`__init__.py`): `VCD_PRODUCT`, `VCD_VERSION`,
+  `VCD_IMPL_ID`, `VCD_CONNECTOR_ID`.
+
+The connector reuses `is_acceptable_auth_model`, `session_establish_auth_error`,
+and `ConnectorAuthError` from `meho_backplane.connectors._shared.vcf_auth`.
+
+## Control flow
+
+### Registration
+
+Importing `meho_backplane.connectors.vcd` registers **both** the versioned
+triple `register_connector_v2(product="vcd", version="10.6", impl_id="vcd-rest",
+...)` **and** the `("vcd","","")` wildcard. Unlike `fleet-lcm` — which skips the
+wildcard because the legacy `vcf_fleet` package already owns `("fleet","","")` —
+vCD is a net-new single-impl product with no sibling, so it takes the wildcard
+itself (the harbor / nsx / keycloak / vcf-automation single-impl pattern). The
+wildcard makes an *unfingerprinted* vCD target still resolve; the versioned
+triple carries the `(product, version, impl_id)` coordinates the typed ops
+register under and the `connector_id` (`"vcd-rest-10.6"`) parses to.
+
+### Auth (provider Basic → Bearer session mint)
+
+vCD's provider login is the vCloud-Director-derived Basic→Bearer flow. On first
+use `auth_headers`:
+
+1. Rejects any `target.auth_model` other than `shared_service_account` / `None`
+   via the shared `is_acceptable_auth_model`.
+2. Fails closed on an empty `operator.raw_jwt` (a system-initiated call cannot
+   read per-target vendor credentials) — enforced **before** the token-cache
+   lookup so a primed token can never leak to an unauthenticated caller.
+3. Mints the session (`_auth.vcd_provider_login`): `POST /cloudapi/1.0.0/sessions/provider`
+   with HTTP Basic (`<user>@System`) and the cloudapi `Accept`; the JWT rides
+   back in the `X-VMWARE-VCLOUD-ACCESS-TOKEN` **response header** (absence on a
+   2xx raises; a 401/403 maps to the structured `ConnectorAuthError`).
+4. Caches the JWT per tenant-unique `(tenant_id, target.id)` key under a lock
+   and returns `Authorization: Bearer <jwt>` (path-independent).
+
+The per-surface `Accept` is layered on by `_vcd_get` (via the base transport's
+`extra_headers` seam), so a data read carries both the Bearer and the right
+`Accept`. The `version=` token defaults to `_DEFAULT_VCD_API_VERSION` (`38.0` —
+served by vCD 10.5/10.6), overridable per target via `extras["vcd_api_version"]`;
+version *negotiation* (read the max non-deprecated version from `/api/versions`)
+is a documented follow-up.
+
+A raw 401 (expired token) propagates to the dispatcher's credential-recovery arm,
+which calls `invalidate_credentials` (evicts the cached JWT) and re-dispatches
+once — the `fleet-lcm` pattern, so there is no in-connector retry loop and the
+base transport's tenacity retry (5xx / connection only) stays intact.
+
+### Fingerprint / probe
+
+`GET /api/versions` is vCD's unauthenticated supported-versions endpoint (the
+same reachability surface the VCFA provider probe reads). `fingerprint` reads it
+**without minting a session** (pure reachability) and returns a reachable
+`FingerprintResult` (`vendor="vmware"`, `product="vcd"`). `version` is left
+`None`: `/api/versions` reports *API* versions (37/38/39), not the *product*
+version (10.x), and the connector does not fabricate one — being single-impl, vCD
+resolves through its wildcard regardless. On any transport/status failure it
+returns a non-reachable result carrying `extras["error"]`. `probe()` delegates to
+`fingerprint()`.
+
+### Dispatch
+
+The typed read-core ops dispatch through `meho_backplane.operations.dispatch`:
+the dispatcher resolves the persisted `module.ClassName.method` handler_ref to
+the connector's bound-method shim, threads `operator` / `target` / `params`, and
+the handler issues an authenticated `GET` via `_vcd_get`. `execute()` is the
+G0.6 ABC-compatibility shim (builds a synthetic `Operator` and forwards to
+`dispatch`).
+
+## Typed read core internals
+
+The read core follows the `fleet-lcm` / harbor layout:
+
+- **`typed_ops.py`** — the `VcloudDirectorTypedOp` dataclass table
+  (`VCD_TYPED_OPS`), the per-group `when_to_use` map
+  (`VCD_TYPED_WHEN_TO_USE_BY_GROUP`), and the module-level
+  `register_vcd_typed_operations(*, embedding_service=None)` registrar.
+- **`typed_reads.py`** — the op bodies (`async def vcd_*_impl(connector,
+  operator, target, params)`), each issuing `connector._vcd_get(...)`; the
+  query-service reads pass `{"type": <adminX>, "format": "records"}`.
+- **`_llm_instructions.py`** — the per-op `llm_instructions` blobs
+  (`when_to_call` / `output_shape` / `next_step`), keyed by op id; the prose is
+  framed around inventorying a migration-source estate.
+- **`_paths.py`** — the request-path constants (`_VERSIONS_PATH`,
+  `_SESSIONS_PROVIDER_PATH`, `_ORGS_PATH`, `_QUERY_PATH`), the query-type
+  selectors, the `VCD_TOKEN_HEADER`, and the `Accept`-media-type helpers. The
+  reconcile lane introspects the `_*_PATH` constants.
+- **`_auth.py`** — `vcd_provider_login` (the wire-level Basic→Bearer POST) +
+  `compose_provider_basic_user` (`<user>@System`).
+- **`connector.py`** — 7 thin bound-method shims (`org_list`, `vdc_list`, …) that
+  lazily import and delegate to their `_impl` body.
+
+`register_typed_operation` creates each `OperationGroup` (`review_status=
+"enabled"`) and inserts each descriptor `source_kind="typed"`, `is_enabled=True`,
+`method=None` / `path=None` (the wire path/type lives only in the handler). So
+the read core needs no operator review — it is live the moment the connector
+loads.
+
+## Spec reconcile lane
+
+[`backend/tests/test_connectors_vcd_spec_reconcile.py`](../../backend/tests/test_connectors_vcd_spec_reconcile.py)
+is a **manifest pin + evidenced exclusion** (not a served-op-id compare): vCD
+publishes no committable spec, so there is no artifact to reconcile against. The
+lane sweeps the connector's live `_*_PATH` constants (the #2944 introspect-live-
+constants pattern) and pins the exact hand-coded surface —
+`GET:/api/query`, `GET:/api/versions`, `GET:/cloudapi/1.0.0/orgs`,
+`POST:/cloudapi/1.0.0/sessions/provider` — unconditionally, so a new hand-coded
+path / renamed constant / method change must update the manifest consciously.
+Dispatch-fidelity of each path is proven live-mocked in the auth + typed-reads
+tests. The full evidence + activation trigger live in the `vcd` entry of
+[`spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` — pooled
+  `httpx.AsyncClient` per target, retry-on-idempotent transport, base-URL
+  composition, `extra_headers` seam.
+- `meho_backplane.connectors._shared.vcf_auth` — `is_acceptable_auth_model`,
+  `session_establish_auth_error`, `ConnectorAuthError`, the `VcfTargetLike` /
+  `VcfCredentialsLoader` aliases, `load_credentials_from_vault`.
+- `meho_backplane.connectors._shared.cache_key.target_cache_key`,
+  `meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`.
+- `meho_backplane.connectors.schemas` — `AuthModel`, `FingerprintResult`,
+  `ProbeResult`, `OperationResult`.
+- `httpx`, `respx` (test-only). No new runtime deps.
+
+## Known issues / follow-ups
+
+- **Live dispatch not verified against a real appliance.** The read core is
+  unit-tested end-to-end (dispatch through the session-mint seam against a respx
+  mock) and manifest-pinned; live end-to-end verification against the vCD 10.6
+  provider lab is the deferred tail (needs lab Vault/VPN access).
+- **Fixed API version.** The `Accept` `version=` token is a constant (`38.0`,
+  overridable via `extras["vcd_api_version"]`). Reading the max non-deprecated
+  version from `GET /api/versions` (the way `go-vcloud-director` negotiates) is
+  the robustness follow-up; a target on a version outside 10.5/10.6 needs the
+  override until then.
+- **List-only read core.** By-id detail reads (org / vApp / VM by URN or href),
+  non-`System` / SSO provider identities, and any write surface are out of scope
+  — a list-focused inventory core for migration discovery.
+- **Operator-side product-token alignment.** The operator `vcloud-director` skill
+  (rdc-hetzner-dc) emits `product: vcloud-director` on `--probe`; a target must
+  use the connector's canonical `product: vcd` token to resolve here. Realigning
+  the skill + `targets.yaml` token to `vcd` (the #1814 VCF-suite realignment
+  precedent) is a separate operator-repo follow-up.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/3057>
+- Parent initiative (legacy migration-source coverage):
+  <https://github.com/evoila/meho/issues/3056>
+- Dual-version / coverage policy of record:
+  <https://github.com/evoila/meho/issues/3033>
+- Read-core tests:
+  [`test_connectors_vcd_auth.py`](../../backend/tests/test_connectors_vcd_auth.py)
+  (session mint + fingerprint),
+  [`test_connectors_vcd_typed_reads.py`](../../backend/tests/test_connectors_vcd_typed_reads.py)
+  (dispatch + registration), and
+  [`test_connectors_vcd_spec_reconcile.py`](../../backend/tests/test_connectors_vcd_spec_reconcile.py)
+  (manifest pin).
+- Auth-family sibling (shares the vCloud-Director provider flow):
+  [`connectors-vcf-automation.md`](connectors-vcf-automation.md)
+- Typed read-core exemplar: [`connectors-fleet-lcm.md`](connectors-fleet-lcm.md)

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -345,6 +345,48 @@ split.
   form. Left as-is per "never invent a path"; the activation run
   reconciles it.
 
+### vcd — fully excluded, all-typed (no pinnable spec) (#3057)
+
+The `vcd` (VMware Cloud Director) connector is a **net-new typed**
+connector for the legacy standalone product (initiative
+[#3056](https://github.com/evoila/meho/issues/3056), task #3057). Unlike
+VCFA above there is no plane to arm: **all four** hand-coded op_ids are
+excluded, so the lane
+(`backend/tests/test_connectors_vcd_spec_reconcile.py`) is a **manifest
+pin only** — it sweeps the four op_ids unconditionally so the enumeration
+is proven on every run, with no served-op-id compare.
+
+- **Excluded (4 op_ids: `GET:/api/query`, `GET:/api/versions`,
+  `GET:/cloudapi/1.0.0/orgs`, `POST:/cloudapi/1.0.0/sessions/provider`).**
+  What was checked, per family: (1) **the modern `/cloudapi/1.0.0/*`
+  surface** is the same vCloud-Director-derived surface VCFA's provider
+  plane speaks (VCFA absorbed vCD's provider plane); the appliance serves
+  no `/cloudapi/1.0.0/openapi*` (the evidenced 404 recorded for the
+  `vcf-automation-9.0` provider plane above — live Holodeck VCFA 9.0.2,
+  2026-05-16, #501 — applies to the same endpoint family). A VMware Cloud
+  Director OpenAPI *is* published on the Broadcom developer portal
+  (`developer.broadcom.com/xapis/vmware-cloud-director-openapi`), but it
+  is not a pinnable vendored Apache-2.0 artifact and covers only the
+  cloudapi families — the same reason VCFA excludes `GET:/cloudapi/1.0.0/orgs`
+  rather than pin it. (2) **The classic `/api/*` query service +
+  `/api/versions`** are the legacy vCloud API, whose machine-readable
+  definition Broadcom bundles into the UI JS at build time: no vCD
+  directory in [`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs),
+  and `go-vcloud-director`'s hand-written `govcd/` endpoint map (the only
+  machine-readable surface) does not enumerate the query-service `type=`
+  catalog as an OpenAPI. So no artifact can serve a reconcile authority
+  for the four paths without false reds. **Residual risk, named** (the
+  nsx lesson): this task ran no live probe of a *vCD-specific* appliance's
+  spec-serving locations — live end-to-end verification against the vCD
+  10.6 provider lab is the deferred tail (needs lab Vault/VPN access), the
+  same unit-tested-first posture `fleet-lcm` shipped with; if a
+  vendor-documented spec-serving family emerges there, that falsifies this
+  exclusion and is the activation trigger.
+- **Activation:** `vmware/vcf-api-specs` gaining a vCD spec, or a
+  pinnable/appliance-served spec covering the classic `/api/*` query
+  service being evidenced. The activating task runs the full extension
+  mechanics and reconciles the four op_ids on first run.
+
 ## Red lane = finding (the protocol)
 
 A red lane on first run against the real shelf is **the guard working**,


### PR DESCRIPTION
## What

Net-new **typed** connector for legacy **VMware Cloud Director** (vCD) — the migration-source estate MEHO reads during discovery/onboarding. Closes #3057 (under initiative #3056, legacy migration-source connector coverage).

vCD is a *distinct product* from `vcf-automation`: VCFA absorbed only vCD's provider control plane, so this is its own `product="vcd"` connector, resolved by fingerprint — **not** a `vcfa` dual-impl. (It does share the vCloud-Director-derived provider auth flow, which is why the auth mirrors the VCFA provider plane.)

## Shape

- **Registration:** `product="vcd"`, `impl_id="vcd-rest"`. Registers the versioned triple **and** the `("vcd","","")` wildcard (a net-new single-impl product owns its wildcard). `"vcd"` is the only token that survives the `impl_id` round-trip invariant — `vcloud-director` would crash `register_connector_v2` at boot.
- **Auth — provider session mint:** `POST /cloudapi/1.0.0/sessions/provider` (HTTP Basic, `<user>@System`); the JWT rides back in the `X-VMWARE-VCLOUD-ACCESS-TOKEN` **response header**, is cached per tenant-unique target key, and re-mints on a 401 via the dispatcher's credential-recovery arm + `invalidate_credentials` (the `fleet-lcm` pattern — base tenacity retry stays intact).
- **7-op read core / 3 groups** (provider/System-scoped migration inventory):
  - `vcd-inventory`: `org.list` (`/cloudapi/1.0.0/orgs`) + `vdc`/`vapp`/`vm`/`catalog.list` (`/api/query?type=admin*&format=records`)
  - `vcd-networking`: `edge-gateway.list` · `vcd-tasks`: `task.list`
  - Dual surface, one token; `Accept` derived per-path (cloudapi `application/json` vs classic `application/*+json`).
- **Typed, not ingested:** Broadcom publishes no committable spec (classic `/api` query service bundled in UI JS; appliance serves no `/cloudapi/1.0.0/openapi*`). The reconcile lane is a **manifest pin + evidenced exclusion** (`spec-reconcile-guards-standard.md` updated).
- **Fingerprint:** unauthenticated `GET /api/versions` (no session mint).

## Tests / verification

- **59 unit tests** — session mint + per-surface Accept + per-target/per-tenant isolation + 401 recovery + auth-model gating + fail-closed (`test_connectors_vcd_auth.py`); zero-catalog dispatch of all 7 ops + registration-shape invariants + search visibility (`test_connectors_vcd_typed_reads.py`); manifest pin (`test_connectors_vcd_spec_reconcile.py`).
- ruff + mypy clean; the all-typed-connector metadata invariant + connector-id round-trip meta-tests pass locally.
- `docs/codebase/connectors-vcd.md` + the `vcd` evidenced-exclusion entry.

## Deferred tails (documented in the connector doc)

- **Live dispatch** against the vCD 10.6 provider lab (needs lab Vault/VPN) — the unit-tested-first posture `fleet-lcm` shipped with.
- **API-version negotiation:** the `Accept` `version=` token defaults to `38.0` (overridable via `extras["vcd_api_version"]`); reading the max non-deprecated version from `/api/versions` is a follow-up.
- **Operator-side token alignment:** the operator `vcloud-director` skill emits `product: vcloud-director`; realigning its probe + `targets` token to `vcd` (the #1814 VCF-suite realignment precedent) is a separate operator-repo follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
