### PR TITLE
feat(vra8): vRealize Automation 8.x legacy dual-impl read core (6 ops) (#3058)

### DIFF
--- a/backend/src/meho_backplane/connectors/vra8/__init__.py
+++ b/backend/src/meho_backplane/connectors/vra8/__init__.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vra8 — Vra8Connector package.
+
+Importing this package registers :class:`Vra8Connector` against the v2 connector
+registry as the **legacy dual-impl** for **vRealize Automation 8.x** (vRA 8) — the
+migration-source estate evoila brings customers off (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3058). vRA 8
+is the direct predecessor of **VCF Automation 9.x**
+(:mod:`meho_backplane.connectors.vcf_automation`, ``vcfa-rest``) — the same product
+line renamed across a major-version rebuild — so this is a **second implementation of
+``product="vcfa"``**, not a net-new product: the second real two-impl case after
+``fleet`` (policy #3033 / #3038).
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<subpackage>/`` at startup, so both this legacy package and the
+modern ``vcf_automation`` package register under ``product="vcfa"`` (distinct
+``impl_id``s) before any dispatch can occur — the ``vcf_fleet`` + ``fleet_lcm`` shape.
+
+**Only the versioned triple is registered — NOT the ``("vcfa","","")`` wildcard.**
+The wildcard is already owned by the **modern** ``vcf_automation`` package (a second
+class on that key would raise ``RuntimeError`` at boot). This is the *inversion* of
+the ``fleet`` case (there the *legacy* ``vcf_fleet`` owns the wildcard and the modern
+``fleet_lcm`` skips it): here the modern impl owns it, so an *unfingerprinted* /
+unversioned ``vcfa`` target resolves to modern ``vcfa-rest`` — a vRA 8 target must
+carry an 8.x product version **operator-asserted at onboarding** to resolve to this
+legacy impl (the fingerprint reports the API version, not a resolvable product
+version). The bands are **disjoint** (legacy ``>=8.0,<9.0`` vs
+modern ``>=9.0,<10.0``), so a versioned 8.x target resolves here and a 9.x target to
+modern, with no specificity tie — see
+:mod:`tests.test_connectors_vra8_dual_impl_resolution`.
+
+The ``product`` token is ``"vcfa"`` and ``impl_id`` is ``"vcfa-vra8"`` because
+``register_connector_v2`` enforces that ``product`` equals the first hyphen-segment
+of ``impl_id`` — the round-trip invariant. ``connector_id`` ``"vcfa-vra8-8.0"``
+parses back to ``("vcfa", "8.0", "vcfa-vra8")``.
+
+This package registers a curated **6-op typed read core** (#3058, :mod:`.typed_ops`)
+via :func:`register_typed_op_registrar`, so a vRA 8 target dispatches a
+migration-inventory read on a fresh boot with zero catalog ingest. Because vRA 8's
+vendor spec is Swagger 2.0 (OA3-only ingest can't consume it — typed, not ingested),
+a wider ingested breadth surface is not a follow-up here — the read core is the
+connector's surface.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vra8.connector import Vra8Connector
+from meho_backplane.connectors.vra8.session import (
+    Vra8CredentialsLoader,
+    Vra8TargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.vra8.typed_ops import (
+    VRA8_TYPED_OPS,
+    VRA8_TYPED_WHEN_TO_USE_BY_GROUP,
+    Vra8TypedOp,
+    register_vra8_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the vRA 8 connector — the dispatch-canonical
+#: ``(product, version, impl_id)`` triple :func:`parse_connector_id` derives from
+#: ``"vcfa-vra8-8.0"``, plus the derived ``connector_id`` slug. The typed read core
+#: rows land under :data:`VRA8_CONNECTOR_ID`. ``product`` is shared with the modern
+#: ``vcf-automation`` (``vcfa``); the ``impl_id`` disambiguates the two impls.
+VRA8_PRODUCT: Final[str] = "vcfa"
+VRA8_VERSION: Final[str] = "8.0"
+VRA8_IMPL_ID: Final[str] = "vcfa-vra8"
+VRA8_CONNECTOR_ID: Final[str] = f"{VRA8_IMPL_ID}-{VRA8_VERSION}"
+
+
+register_connector_v2(
+    product=VRA8_PRODUCT,
+    version=VRA8_VERSION,
+    impl_id=VRA8_IMPL_ID,
+    cls=Vra8Connector,
+)
+
+# NO wildcard registration. The ``("vcfa","","")`` key is owned by the modern
+# ``vcf_automation`` package; a second class on it would raise RuntimeError at boot
+# (the ``fleet_lcm`` no-wildcard shape, inverted — there the legacy owns the
+# wildcard, here the modern does). An unfingerprinted ``vcfa`` target therefore
+# resolves to modern ``vcfa-rest``; an 8.x-versioned target resolves here.
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so the
+# typed descriptor rows land before the first dispatch — the vRA 8 read core
+# dispatches on a fresh boot with zero catalog ingest (#3058).
+register_typed_op_registrar(register_vra8_typed_operations)
+
+__all__ = [
+    "VRA8_CONNECTOR_ID",
+    "VRA8_IMPL_ID",
+    "VRA8_PRODUCT",
+    "VRA8_TYPED_OPS",
+    "VRA8_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VRA8_VERSION",
+    "Vra8Connector",
+    "Vra8CredentialsLoader",
+    "Vra8TargetLike",
+    "Vra8TypedOp",
+    "load_credentials_from_vault",
+    "register_vra8_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/vra8/_auth.py
+++ b/backend/src/meho_backplane/connectors/vra8/_auth.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Two-step session-establish helper for the ``vra8`` connector.
+
+Split out from :mod:`.connector` to keep that module lean (the ``vcf-automation``
+/ ``vcd`` precedent). The helper takes the per-target httpx client + resolved
+credentials and returns the freshly-minted bearer token; cache ownership and lock
+discipline stay in the connector class so the mutual-exclusion contract is
+co-located with the cache it protects.
+
+vRA 8's token acquisition is a **two-step exchange** (confirmed against the
+Broadcom vRA 8.x API Programming Guide + the ``vmware/vra-sdk-go`` ``vra-iaas.json``
+Swagger 2.0 spec):
+
+1. **CSP identity** — ``POST /csp/gateway/am/api/login?access_token`` with a JSON
+   ``{username, password, domain?}`` body returns a long-lived (~90-day)
+   ``refresh_token`` (snake_case) in the response body. ``domain`` is optional
+   (read from ``target.extras["domain"]`` — the Target model has no dedicated
+   column): omitted for a local/basic vRA user, set to the directory/AD domain (or
+   the literal ``"System Domain"`` for local system users) otherwise. This CSP
+   identity endpoint is **not** part of ``vra-sdk-go``.
+2. **IaaS token exchange** — ``POST /iaas/api/login`` with a ``{refreshToken}``
+   (camelCase — note the case flip from step 1's ``refresh_token``) body returns a
+   short-lived (~8h) bearer ``token`` in a ``{tokenType, token}`` response body
+   (spec-confirmed).
+
+The one bearer authenticates every vRA 8 service (``/iaas``, ``/deployment``,
+``/blueprint``, ``/catalog``). A 401/403 at *either* step is an auth-class establish
+failure, mapped to the structured
+:class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError`
+(``connector_auth_failed``) via
+:func:`~meho_backplane.connectors._shared.vcf_auth.session_establish_auth_error`
+(the ``vcf-automation`` / #2329 precedent).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors._shared.vcf_auth import session_establish_auth_error
+from meho_backplane.connectors.vra8._paths import _CSP_LOGIN_PATH, _IAAS_LOGIN_PATH
+from meho_backplane.connectors.vra8.session import Vra8TargetLike
+
+__all__ = ["vra8_login"]
+
+_log = structlog.get_logger(__name__)
+
+_JSON_ACCEPT = "application/json"
+#: The literal valueless ``?access_token`` query flag the CSP login requires
+#: (per the vRA 8 Programming Guide). httpx renders ``{"access_token": ""}`` as
+#: ``?access_token=`` — accepted equivalently by the appliance; the exact bare-flag
+#: wire form is a documented live-verify tail (connector docstring).
+_CSP_ACCESS_TOKEN_FLAG = {"access_token": ""}
+
+
+def _require_username_password(creds: dict[str, str], target_name: str) -> tuple[str, str]:
+    """Extract ``username`` + ``password`` from *creds*, raising on a missing key."""
+    try:
+        return creds["username"], creds["password"]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"vra8 credentials loader for target {target_name!r} returned a dict "
+            f"missing required key {exc.args[0]!r}; need "
+            f"{{'username': str, 'password': str}}"
+        ) from exc
+
+
+async def _csp_refresh_token(
+    client: httpx.AsyncClient,
+    creds: dict[str, str],
+    target: Vra8TargetLike,
+    *,
+    request_extensions: dict[str, Any],
+) -> str:
+    """Step 1 — POST the CSP login and return the ``refresh_token``.
+
+    ``POST /csp/gateway/am/api/login?access_token`` with ``{username, password,
+    domain?}``. A 2xx carries ``{"refresh_token": ...}`` (snake_case); a missing /
+    empty field raises :exc:`RuntimeError`. 401/403 → structured auth error.
+    """
+    username, password = _require_username_password(creds, target.name)
+    body: dict[str, str] = {"username": username, "password": password}
+    # The optional CSP domain selector comes from the target's per-product
+    # ``extras`` (the Target model has no dedicated column): set ``extras["domain"]``
+    # to the AD/directory domain, or "System Domain" for a local vRA system user;
+    # omit it entirely for a plain local user. Reading a phantom ``target.domain``
+    # attribute would silently omit it for every real target (the model has none).
+    extras = getattr(target, "extras", None)
+    domain = extras.get("domain") if isinstance(extras, dict) else None
+    if domain:
+        body["domain"] = domain
+    try:
+        resp = await client.post(
+            _CSP_LOGIN_PATH,
+            params=_CSP_ACCESS_TOKEN_FLAG,
+            json=body,
+            headers={"Accept": _JSON_ACCEPT},
+            extensions=request_extensions,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        message = (
+            f"vra8 CSP identity login failed for target {target.name!r}: "
+            f"POST {_CSP_LOGIN_PATH} returned HTTP {exc.response.status_code}"
+        )
+        raise (
+            session_establish_auth_error(exc, message=message, target=target)
+            or RuntimeError(message)
+        ) from exc
+    payload: Any = resp.json()
+    refresh_token = payload.get("refresh_token") if isinstance(payload, dict) else None
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise RuntimeError(
+            f"vra8 CSP identity login for target {target.name!r}: "
+            f"POST {_CSP_LOGIN_PATH} returned 2xx with no 'refresh_token' "
+            "field in the response body"
+        )
+    return refresh_token
+
+
+async def _iaas_bearer_token(
+    client: httpx.AsyncClient,
+    refresh_token: str,
+    target: Vra8TargetLike,
+    *,
+    request_extensions: dict[str, Any],
+) -> str:
+    """Step 2 — exchange the refresh token for the IaaS bearer access token.
+
+    ``POST /iaas/api/login`` with ``{"refreshToken": ...}`` (camelCase). A 2xx
+    carries ``{"tokenType": "Bearer", "token": ...}``; a missing / empty ``token``
+    raises :exc:`RuntimeError`. 401/403 → structured auth error.
+    """
+    try:
+        resp = await client.post(
+            _IAAS_LOGIN_PATH,
+            json={"refreshToken": refresh_token},
+            headers={"Accept": _JSON_ACCEPT},
+            extensions=request_extensions,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        message = (
+            f"vra8 IaaS token exchange failed for target {target.name!r}: "
+            f"POST {_IAAS_LOGIN_PATH} returned HTTP {exc.response.status_code}"
+        )
+        raise (
+            session_establish_auth_error(exc, message=message, target=target)
+            or RuntimeError(message)
+        ) from exc
+    payload: Any = resp.json()
+    token = payload.get("token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token:
+        raise RuntimeError(
+            f"vra8 IaaS token exchange for target {target.name!r}: "
+            f"POST {_IAAS_LOGIN_PATH} returned 2xx with no 'token' field in the "
+            "response body"
+        )
+    return token
+
+
+async def vra8_login(
+    client: httpx.AsyncClient,
+    creds: dict[str, str],
+    target: Vra8TargetLike,
+    *,
+    request_extensions: dict[str, Any] | None = None,
+) -> str:
+    """Run the vRA 8 two-step token exchange and return the bearer access token.
+
+    Step 1 mints a ``refresh_token`` from the CSP identity service; step 2
+    exchanges it for the short-lived bearer the connector caches and sends as
+    ``Authorization: Bearer <token>`` on every subsequent read. The refresh token
+    is *not* cached separately — a cache eviction (401 recovery) re-runs both steps,
+    which is rare (only on the ~8h bearer's expiry) and keeps the connector state to
+    the single minted bearer.
+
+    ``request_extensions`` (evoila/meho#2398) carries the caller's
+    :meth:`HttpConnector._request_extensions` so both login POSTs honour a target's
+    ``tls_server_name`` SNI / cert-verify name; ``None`` normalises to ``{}``
+    (byte-identical when unset).
+    """
+    ext = request_extensions or {}
+    refresh_token = await _csp_refresh_token(client, creds, target, request_extensions=ext)
+    token = await _iaas_bearer_token(client, refresh_token, target, request_extensions=ext)
+    _log.info("vra8_session_established", target=target.name, host=target.host)
+    return token

--- a/backend/src/meho_backplane/connectors/vra8/_llm_instructions.py
+++ b/backend/src/meho_backplane/connectors/vra8/_llm_instructions.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-op ``llm_instructions`` blobs for the ``vra8`` typed read core.
+
+Split out of :mod:`~meho_backplane.connectors.vra8.typed_reads` (which holds the
+op bodies) to keep each module focused, the ``fleet-lcm`` #3047 / ``vcd`` #3057
+layout. Consumed by :mod:`meho_backplane.connectors.vra8.typed_ops`, which keys
+each op's metadata row to :data:`VRA8_READ_LLM_INSTRUCTIONS`.
+
+The canonical three-key shape (``when_to_call`` / ``output_shape`` / ``next_step``)
+is the same convention the harbor / fleet-lcm / vcd read cores use, so an agent
+crossing connector boundaries sees a stable structure. The framing is migration
+inventory: these reads enumerate a *source* vRA 8 estate an operator is bringing
+onto the platform.
+
+**Pagination.** The vRA 8 list surfaces are server-paged (a ``{content: [],
+totalElements, numberOfElements, ...}`` wrapper). Each list op's ``output_shape``
+tells the agent to check ``totalElements`` and page via ``$top`` / ``$skip`` — the
+default call returns the first page only, but the wrapper self-describes the total,
+so it is never a silent truncation.
+"""
+
+from __future__ import annotations
+
+__all__ = ["VRA8_READ_LLM_INSTRUCTIONS"]
+
+
+_PROJECT_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call first when inventorying a vRealize Automation 8 source estate — "
+        "projects are vRA 8's tenancy/quota boundary (members, zones, resource "
+        "constraints). Use to answer 'which projects/teams live on this vRA' before "
+        "drilling into their deployments and blueprints."
+    ),
+    "output_shape": (
+        "IaaS paged wrapper {content: [Project, ...], totalElements, "
+        "numberOfElements}. Each Project carries id, name, description, orgId, "
+        "administrators/members/viewers, zones (cloud zones), constraints, and "
+        "customProperties. Paged — check totalElements and page with $top / $skip."
+    ),
+    "next_step": (
+        "Filter vcfa.vra8.deployment.list by projectId to enumerate a project's "
+        "running workloads, or vcfa.vra8.blueprint.list by the project to see its "
+        "IaC definitions."
+    ),
+}
+
+_DEPLOYMENT_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the deployments — vRA 8's running workloads (the Service "
+        "Broker view). This is usually the highest-value migration read: what is "
+        "actually deployed, in which project, from which blueprint/catalog item. "
+        "Pass $top to raise the page size for a whole-estate count."
+    ),
+    "output_shape": (
+        "Service Broker paged wrapper {content: [Deployment, ...], totalElements, "
+        "totalPages, number, size}. Each Deployment carries id, name, projectId, "
+        "blueprintId/blueprintVersion, catalogItemId, status, createdAt/By, "
+        "ownedBy, leaseExpireAt, and (with expand) resources / lastRequest / "
+        "inprogressRequests. A large list is reduced to a JSONFlux handle — narrow "
+        "with result_query / result_aggregate (e.g. count by projectId or status)."
+    ),
+    "next_step": (
+        "Drill into one deployment via vcfa.vra8.deployment.get for its resources "
+        "and request state (lastRequest / inprogressRequests — the pre-cutover "
+        "quiescence signal). Map blueprintId back to vcfa.vra8.blueprint.list for "
+        "the definition to recreate."
+    ),
+}
+
+_DEPLOYMENT_GET_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call with a deployment_id (from vcfa.vra8.deployment.list) to read one "
+        "deployment's full detail — its resources and its request state. vRA 8 has "
+        "no top-level list-all-requests endpoint, so this is how you read a "
+        "deployment's lastRequest / inprogressRequests: the signal for whether an "
+        "operation is in flight before a migration cutover."
+    ),
+    "output_shape": (
+        "A single Deployment object: id, name, projectId, blueprintId, "
+        "catalogItemId, status, expense, inputs, resources[] (the provisioned "
+        "machines/networks/etc.), lastRequest (the most recent action + its "
+        "status), and inprogressRequests[] (empty when quiescent)."
+    ),
+    "next_step": (
+        "A non-empty inprogressRequests means the deployment is not quiescent — "
+        "hold the cutover. Correlate resources[] against the target-side capacity "
+        "plan, and blueprintId with vcfa.vra8.blueprint.list."
+    ),
+}
+
+_BLUEPRINT_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the Cloud Assembly blueprints — the infrastructure-as-code "
+        "definitions (YAML) a migration must recreate on the target. Use to "
+        "inventory what templates exist, which are released, and which project owns "
+        "each."
+    ),
+    "output_shape": (
+        "Blueprint paged wrapper {content: [Blueprint, ...], totalElements}. Each "
+        "Blueprint carries id, name, projectId/projectName, status, content (the "
+        "blueprint YAML), totalVersions / totalReleasedVersions, valid, and "
+        "contentSourceId/Type (a git-backed source, if any). Paged — page with "
+        "$top / $skip."
+    ),
+    "next_step": (
+        "Flag git-backed blueprints (contentSourceType) as external dependencies "
+        "the migration must re-point. Correlate a blueprint's id with "
+        "vcfa.vra8.deployment.list (blueprintId) to see which are in active use."
+    ),
+}
+
+_CATALOG_ITEM_LIST_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to list the Service Broker catalog items (admin view — every project, "
+        "not just the caller's) — the self-service offerings a migration must "
+        "republish on the target. Use to inventory what is offered and which "
+        "projects each item is shared to."
+    ),
+    "output_shape": (
+        "Service Broker paged wrapper {content: [CatalogItem, ...], totalElements}. "
+        "Each CatalogItem carries id, name, type (the source kind — blueprint / "
+        "workflow / etc.), sourceId/sourceName, projectIds/projects (entitlement "
+        "scope), iconId, and createdAt/By. Paged — page with $top / $skip."
+    ),
+    "next_step": (
+        "Map an item's sourceId back to its backing definition "
+        "(vcfa.vra8.blueprint.list for blueprint-typed items), and its projectIds "
+        "to vcfa.vra8.project.list to see who can request it."
+    ),
+}
+
+_ABOUT_INSTRUCTIONS: dict[str, object] = {
+    "when_to_call": (
+        "Call to read the vRA 8 appliance's IaaS API capabilities — the supported "
+        "API versions. Use to confirm the source is a vRA 8.x surface and gauge its "
+        "generation before the deeper inventory reads (the connector's fingerprint "
+        "reads the same endpoint for reachability)."
+    ),
+    "output_shape": (
+        "{latestApiVersion, supportedApis: [{apiVersion, deprecationPolicy, "
+        "documentationLink}, ...]}. Note: latestApiVersion is an API *date* label "
+        "(e.g. 2021-07-15), not the product build (8.11 vs 8.18) — the product "
+        "version is carried on the target, not this response."
+    ),
+    "next_step": (
+        "Proceed to vcfa.vra8.project.list and vcfa.vra8.deployment.list for the "
+        "actual estate inventory."
+    ),
+}
+
+
+#: Per-op ``llm_instructions`` keyed by the dot-form op id, consumed by
+#: :mod:`meho_backplane.connectors.vra8.typed_ops`.
+VRA8_READ_LLM_INSTRUCTIONS: dict[str, dict[str, object]] = {
+    "vcfa.vra8.project.list": _PROJECT_LIST_INSTRUCTIONS,
+    "vcfa.vra8.deployment.list": _DEPLOYMENT_LIST_INSTRUCTIONS,
+    "vcfa.vra8.deployment.get": _DEPLOYMENT_GET_INSTRUCTIONS,
+    "vcfa.vra8.blueprint.list": _BLUEPRINT_LIST_INSTRUCTIONS,
+    "vcfa.vra8.catalog-item.list": _CATALOG_ITEM_LIST_INSTRUCTIONS,
+    "vcfa.vra8.about": _ABOUT_INSTRUCTIONS,
+}

--- a/backend/src/meho_backplane/connectors/vra8/_paths.py
+++ b/backend/src/meho_backplane/connectors/vra8/_paths.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-coded vRealize Automation 8.x wire constants — the reconcile-lane surface.
+
+vRealize Automation 8.x (vRA 8) is the **legacy** VMware automation product evoila
+migrates customers *from* — the direct predecessor of the Broadcom-era **VCF
+Automation 9.x** (:mod:`~meho_backplane.connectors.vcf_automation`, ``vcfa-rest``).
+Both are the same product line, renamed across a major-version rebuild, so this
+connector is the **legacy dual-impl** of ``product="vcfa"`` (``impl_id="vcfa-vra8"``,
+band ``>=8.0,<9.0``), fingerprint-resolved against the modern ``vcfa-rest``
+(``>=9.0,<10.0``) — the second real two-impl case after ``fleet`` (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3058,
+policy #3033/#3038).
+
+Why typed (not generic / ingested)
+----------------------------------
+
+``vmware/vra-sdk-go`` (Apache-2.0) publishes machine-readable specs for the vRA 8
+services (IaaS / Service Broker / Blueprint / Project), but they are **Swagger
+2.0**, and MEHO's ingest parser accepts OpenAPI 3.0/3.1 only (#2090). So the
+surface cannot be operator-ingested as a generic connector; the read core is
+**typed** (CLAUDE.md postulate 1: "no *usable* spec → typed"), the same shape the
+sibling ``vcf-automation`` tenant plane, ``fleet-lcm`` (#3047), and ``vcd`` (#3057)
+ship with.
+
+Every request path the connector dispatches is declared here as a module-level
+``_*_PATH`` string constant, so the spec-reconcile lane
+(:mod:`tests.test_connectors_vra8_spec_reconcile`) introspects the **live**
+constants (the #2944 introspect-live-constants pattern — never a hardcoded mirror
+that can drift) and pins the exact hand-coded surface. Because the vendor spec is
+Swagger 2.0 (OA3-only ingest can't consume it), that lane is a **manifest pin +
+evidenced exclusion** (the ``vcd`` / ``vcf-automation``-provider precedent), not a
+served-op-id compare — see ``docs/decisions/spec-reconcile-guards-standard.md``.
+
+Auth surface (two-step token exchange)
+--------------------------------------
+
+vRA 8 mints a bearer via a **two-step** exchange (distinct from VCFA 9's
+``/cloudapi/1.0.0/sessions/provider`` + ``/oauth/*`` flow — the divergence that
+justifies a separate impl):
+
+1. :data:`_CSP_LOGIN_PATH` — ``POST /csp/gateway/am/api/login?access_token`` with a
+   JSON ``{username, password, domain?}`` body → a long-lived ``refresh_token``
+   (snake_case) in the response body.
+2. :data:`_IAAS_LOGIN_PATH` — ``POST /iaas/api/login`` with ``{refreshToken}``
+   (camelCase) → a short-lived (8h) bearer ``token`` in the response body.
+
+The one bearer authenticates **every** vRA 8 service (``/iaas``, ``/deployment``,
+``/blueprint``, ``/catalog``) uniformly via ``Authorization: Bearer <token>`` — all
+the service specs declare the same ``Authorization``-header security scheme. Reads
+send ``Accept: application/json``; no per-surface Accept negotiation is needed
+(unlike ``vcd``).
+
+Read paths (migration-inventory core)
+-------------------------------------
+
+All GET, all ``application/json``. The lists are server-paged (``$top`` / ``$skip``
+OData params, a self-describing ``{content, totalElements}`` wrapper), so the
+connector forwards those and the op ``llm_instructions`` tell the agent to page —
+never a silent truncation. Sorting/filtering is done through the JSONFlux result
+handle, not vendor query params (MEHO postulate 6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+__all__ = ["ODATA_LIST_PARAM_KEYS", "odata_list_query"]
+
+# -- Auth (two-step token exchange) -----------------------------------------
+# CSP identity service: username/password -> refresh_token. POSTed by
+# ``._auth.vra8_login`` with the literal valueless ``?access_token`` query flag
+# (added at the call site). Not in vra-sdk-go (CSP identity is outside the SDK),
+# so the reconcile lane pins it as an evidenced exclusion.
+_CSP_LOGIN_PATH = "/csp/gateway/am/api/login"
+# IaaS token exchange: {refreshToken} -> {tokenType, token}. The bearer authenticates
+# every vRA 8 service.
+_IAAS_LOGIN_PATH = "/iaas/api/login"
+
+# -- Fingerprint probe ------------------------------------------------------
+# IaaS about endpoint — {latestApiVersion, supportedApis}. Read unauthenticated for
+# reachability (the vcf-automation tenant-plane probe reads the same path); it
+# reports the *API* version (a date label, e.g. 2021-07-15), not the product build,
+# so the connector does not fabricate a product version from it. Doubles as the
+# ``vcfa.vra8.about`` op (collapses onto one GET:/iaas/api/about by value).
+_ABOUT_PATH = "/iaas/api/about"
+
+# -- Read paths (migration-inventory core) ----------------------------------
+# Projects — the tenancy/quota boundary. The IaaS surface (documented public API),
+# not the lower-level /project-service (which paginates page/size, not $top/$skip).
+_PROJECTS_PATH = "/iaas/api/projects"
+# Deployments — the running workloads. The Service Broker surface (rich record with
+# resources / lastRequest / inprogressRequests), not the thin /iaas/api/deployments.
+_DEPLOYMENTS_PATH = "/deployment/api/deployments"
+# One deployment's detail — carries the embedded lastRequest / inprogressRequests
+# (the quiescence signal) and resources. There is no top-level list-all-requests
+# endpoint in vRA 8, so request state is read here, per deployment.
+_DEPLOYMENT_DETAIL_PATH = "/deployment/api/deployments/{deployment_id}"
+# Blueprints — the Cloud Assembly IaC definitions a migration must recreate.
+_BLUEPRINTS_PATH = "/blueprint/api/blueprints"
+# Catalog items — the Service Broker self-service offerings. The admin view
+# (whole-estate, not caller-project-scoped) matches the operator migration-inventory
+# contract: see everything, like vCD's admin* query types.
+_CATALOG_ITEMS_PATH = "/catalog/api/admin/items"
+
+#: The OData pagination params the list reads forward — ``$top`` / ``$skip``, which
+#: every vRA 8 list surface accepts with identical (lowercase) casing and which bound
+#: the fetch size before the dispatcher reduces the result to a JSONFlux handle.
+#: **Sorting/filtering is deliberately NOT forwarded to the vendor:** MEHO postulate 6
+#: makes the result handle the canonical narrow surface (``result_query`` /
+#: ``result_aggregate``), so a vendor ``$orderby`` would be redundant — and vRA 8's
+#: casing for it is *not* uniform (IaaS ``/iaas/api/projects`` uses ``$orderBy``, the
+#: Service Broker / Blueprint services ``$orderby``), so forwarding one spelling would
+#: silently drop the sort on the other. The agent sorts through the handle instead.
+ODATA_LIST_PARAM_KEYS: tuple[str, ...] = ("$top", "$skip")
+
+
+def odata_list_query(params: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Extract the forwarded OData ``$top`` / ``$skip`` pagination query params.
+
+    Returns ``None`` when neither is present so the request carries no query string
+    and vRA 8 applies its appliance-default pagination (the first page). The response
+    wrapper self-describes ``totalElements`` / ``numberOfElements``, so a default
+    (unpaged) call is never a silent truncation — the op ``llm_instructions`` tell the
+    agent to page via these params; sorting/filtering is done through the dispatcher's
+    JSONFlux handle, not the vendor query (see :data:`ODATA_LIST_PARAM_KEYS`).
+    """
+    query = {key: params[key] for key in ODATA_LIST_PARAM_KEYS if params.get(key) is not None}
+    return query or None

--- a/backend/src/meho_backplane/connectors/vra8/connector.py
+++ b/backend/src/meho_backplane/connectors/vra8/connector.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vra8Connector — hand-rolled HttpConnector subclass for vRealize Automation 8.x.
+
+The **legacy dual-impl** for **vRealize Automation 8.x** (vRA 8) — the migration-
+source estate evoila brings customers *off* (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3058). vRA 8
+is the direct predecessor of the Broadcom-era **VCF Automation 9.x**
+(:mod:`~meho_backplane.connectors.vcf_automation`, ``vcfa-rest``): the same product
+line, renamed across a major-version rebuild. So this is a ``product="vcfa"``
+**second implementation** (``impl_id="vcfa-vra8"``, band ``>=8.0,<9.0``), not a
+net-new product — the **second real two-impl case after ``fleet``** (policy #3033 /
+#3038). The resolver picks this legacy impl for an 8.x target by fingerprint and the
+modern ``vcfa-rest`` for a 9.x target; the bands are **disjoint** (``>=9.0,<10.0``
+for modern), so no re-band of the modern impl is needed and no specificity tie
+arises. The ``("vcfa","","")`` wildcard is owned by the **modern** ``vcf_automation``
+package (the inversion vs ``fleet``, where the legacy owns it), so an *unfingerprinted*
+``vcfa`` target resolves to modern — a vRA 8 target must carry an 8.x product version
+**operator-asserted at onboarding** (e.g. ``--version 8.12``) to resolve here; the
+connector's fingerprint reports only the API version (a date label), not a resolvable
+product version, so it cannot auto-populate the resolution version (see Fingerprint
+below).
+
+Why typed (not generic / ingested)
+----------------------------------
+
+``vmware/vra-sdk-go`` (Apache-2.0) publishes machine-readable specs for the vRA 8
+services, but they are **Swagger 2.0**, and MEHO's ingest parser accepts OpenAPI
+3.0/3.1 only (#2090) — so the surface cannot be operator-ingested. The read core is
+**typed** (CLAUDE.md postulate 1), the ``vcf-automation`` tenant-plane / ``fleet-lcm``
+/ ``vcd`` posture. The spec-reconcile lane is therefore a **manifest pin + evidenced
+exclusion** (see ``docs/decisions/spec-reconcile-guards-standard.md``), not a
+served-op-id compare.
+
+Auth — two-step token exchange, single bearer
+---------------------------------------------
+
+vRA 8 mints a bearer via a **two-step** exchange (:mod:`._auth`), distinct from VCFA
+9's ``/cloudapi/1.0.0/sessions/provider`` + ``/oauth/*`` flow (the divergence that
+justifies a separate impl): ``POST /csp/gateway/am/api/login?access_token`` (CSP
+identity) → a ``refresh_token``, then ``POST /iaas/api/login`` (``{refreshToken}``) →
+a short-lived (~8h) bearer ``token`` in the response body. The one bearer
+authenticates **every** vRA 8 service (``/iaas`` / ``/deployment`` / ``/blueprint`` /
+``/catalog``) uniformly, so :meth:`auth_headers` is path-independent (returns
+``Authorization: Bearer <token>``) and reads send a constant ``Accept:
+application/json`` (:meth:`_vra_get`) — no per-surface negotiation (unlike ``vcd``).
+
+The bearer is minted lazily on first use, cached per tenant-unique
+``(tenant_id, target.id)`` key
+(:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`) under a lock,
+and re-minted on a 401 via the dispatcher's session-recovery arm
+(:meth:`invalidate_session`, #2067) — the SDDC Manager / NSX / vcd session-minting
+pattern, so no in-connector retry loop is needed and the base transport's tenacity
+retry (5xx / connection only) stays intact for the flaky-legacy-appliance-over-VPN
+case. A 401 eviction re-runs both login steps (the refresh token is not cached
+separately — simplest state, rare re-mint).
+
+The ``?access_token`` CSP query flag and the exact-wire-form of the CSP domain field
+are pinned from the vRA 8 Programming Guide (not the vra-sdk-go spec, which omits the
+CSP identity service); **live-appliance verification against a vRA 8 lab is a
+documented deferred tail** (no vRA 8 lab was dialled during the build).
+
+Fingerprint / probe
+-------------------
+
+``GET /iaas/api/about`` is vRA 8's IaaS API-capabilities endpoint (the same surface
+the ``vcf-automation`` tenant probe reads). The connector fingerprints against it
+**without minting a session** (pure reachability). ``version`` is left ``None``:
+``/iaas/api/about`` reports the *API* version (a date label, e.g. ``2021-07-15``),
+not the product build (8.11 vs 8.18), and the connector does not fabricate a
+resolvable product version from a date — dual-impl resolution relies on the
+operator-asserted target version (documented above). If a given appliance requires
+auth on ``/iaas/api/about``, the fingerprint reports unreachable; resolution via the
+asserted version is unaffected.
+
+Operations
+----------
+
+A curated **6-op typed read core** ships here — the vRA 8 migration-inventory
+surface: ``vcfa.vra8.project.list`` / ``.deployment.list`` / ``.deployment.get`` /
+``.about`` (inventory group) and ``.blueprint.list`` / ``.catalog-item.list``
+(content group). All read-only, ``safety_level=safe``, ungated; registered as
+``source_kind="typed"`` (:mod:`.typed_ops` / :mod:`.typed_reads`, per-op
+``llm_instructions`` in :mod:`._llm_instructions`) so they dispatch on a fresh boot
+with **zero catalog ingest**. Set-shaped results are reduced to a JSONFlux handle by
+the dispatcher. A write surface is deliberately out of scope for this read core.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vra8._paths import _ABOUT_PATH
+from meho_backplane.connectors.vra8.session import (
+    Vra8CredentialsLoader,
+    Vra8TargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["Vra8Connector"]
+
+_log = structlog.get_logger(__name__)
+
+# Reachability probe: vRA 8's IaaS API-capabilities endpoint. The reconcile lane
+# (test_connectors_vra8_spec_reconcile.py) introspects this constant and pins
+# GET:/iaas/api/about in the hand-coded manifest.
+_VRA8_PROBE_METHOD = "GET /iaas/api/about (vRA 8 IaaS supported-API-versions endpoint)"
+
+# Constant Accept for every read — one bearer, one media type across all vRA 8
+# services (unlike vcd's per-surface split).
+_JSON_ACCEPT = "application/json"
+
+
+class Vra8Connector(HttpConnector):
+    """vRealize Automation 8.x REST connector — two-step bearer session mint.
+
+    Per-target minted bearers cached in :attr:`_session_tokens` (keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple) under :attr:`_session_lock`, so
+    two same-named targets in different tenants never share a token
+    (evoila/meho#1642/#1672). :meth:`auth_headers` returns ``Authorization: Bearer
+    <token>``; :meth:`_vra_get` adds the constant ``Accept: application/json``.
+
+    :attr:`priority` is ``1`` — the shim-tie-break convention every hand-rolled
+    connector uses. The ``(product, version, impl_id)`` triple is ``("vcfa", "8.0",
+    "vcfa-vra8")``; the ``connector_id`` ``"vcfa-vra8-8.0"`` parses back to it via
+    ``parse_connector_id`` (``product`` = first hyphen-segment of ``impl_id`` =
+    ``"vcfa"``, the round-trip invariant ``register_connector_v2`` enforces).
+    """
+
+    # G0.6 v2 registry metadata. Legacy dual-impl of product ``vcfa``: distinct
+    # impl_id ``vcfa-vra8`` and a DISJOINT band ``>=8.0,<9.0`` (modern ``vcfa-rest``
+    # is ``>=9.0,<10.0``), so an 8.x target resolves here and a 9.x target to modern
+    # with no specificity tie. This impl does NOT register the ``("vcfa","","")``
+    # wildcard — the modern ``vcf_automation`` package owns it.
+    product = "vcfa"
+    version = "8.0"
+    impl_id = "vcfa-vra8"
+    supported_version_range = ">=8.0,<9.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: Vra8CredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._credentials_loader: Vra8CredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+        # Per-target minted-bearer cache, keyed on ``target_cache_key`` so the
+        # tenant-isolation invariant holds; a single lock serialises concurrent
+        # first-use callers so they don't double-run the two-step login.
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # auth_headers — ABC override (Bearer; Accept added per-read by _vra_get)
+    # ------------------------------------------------------------------
+
+    async def auth_headers(self, target: Vra8TargetLike, operator: Operator) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <token>"}``, minting the session on first use.
+
+        The minted bearer authenticates every vRA 8 service, so this header is
+        path-independent; the constant ``Accept: application/json`` is layered on by
+        :meth:`_vra_get`. ``operator`` is threaded to the credential loader so the
+        first-use Vault read runs under the operator's identity (reused on warm-path
+        calls without re-reading Vault).
+
+        Raises :exc:`NotImplementedError` for any ``target.auth_model`` other than
+        ``shared_service_account`` / ``None`` — the shared VCF-family gate.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"Vra8Connector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: Vra8TargetLike, operator: Operator) -> str:
+        """Return the cached bearer, establishing it (two-step login) on first use.
+
+        ``operator.raw_jwt`` must be non-empty: the credential read runs under the
+        operator's Vault identity, and a system-initiated call (empty JWT) cannot
+        resolve per-target vendor credentials. The guard is enforced **before** the
+        cache lookup so a token primed by an authenticated caller can never be handed
+        to an unauthenticated one — the defense-in-depth cache-scoping contract the
+        ``vcf-automation`` provider plane established
+        (``docs/architecture/connector-auth.md``).
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read per-target vendor credentials)"
+            )
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None:
+                return cached
+            creds = await self._credentials_loader(target, operator)
+            client = await self._http_client(target)
+            # Lazy import so pure fingerprint/probe unit tests don't pay the _auth
+            # module's import; the login helper owns the two-step wire POSTs.
+            from meho_backplane.connectors.vra8._auth import vra8_login
+
+            token = await vra8_login(
+                client,
+                creds,
+                target,
+                request_extensions=self._request_extensions(target),
+            )
+            self._session_tokens[cache_key] = token
+            return token
+
+    async def _vra_get(
+        self,
+        target: Vra8TargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Retried GET returning parsed JSON, with the bearer + constant JSON ``Accept``.
+
+        Layers ``Accept: application/json`` onto the connector's ``Authorization:
+        Bearer`` header via the base transport's ``extra_headers`` seam, so the base
+        tenacity retry (5xx / connection) and the ``auth_headers`` mint both stay in
+        force. A raw 401 (expired bearer) propagates as
+        :class:`httpx.HTTPStatusError` to the dispatcher's session-recovery arm,
+        which evicts the token via :meth:`invalidate_session` (#2067) and
+        re-dispatches once.
+        """
+        return await self._request_json(
+            target,
+            "GET",
+            path,
+            operator=operator,
+            params=params,
+            extra_headers={"Accept": _JSON_ACCEPT},
+        )
+
+    # ------------------------------------------------------------------
+    # fingerprint / probe — unauthenticated GET /iaas/api/about
+    # ------------------------------------------------------------------
+
+    async def fingerprint(
+        self,
+        target: Vra8TargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint from the unauthenticated ``GET /iaas/api/about`` probe.
+
+        Reads vRA 8's IaaS API-capabilities endpoint **without** minting a session
+        (pure reachability). On success returns a reachable
+        :class:`FingerprintResult` (``vendor="vmware"``, ``product="vcfa"``);
+        ``version`` is left ``None`` — ``/iaas/api/about`` reports an API date label,
+        not the product build, and the connector does not fabricate a resolvable
+        product version (dual-impl resolution uses the operator-asserted target
+        version). ``extras["latest_api_version"]`` carries the reported API label for
+        the operator's information. On transport / status failure returns a
+        non-reachable result whose ``extras["error"]`` names the exception — the vcd /
+        vcf-fleet pattern. ``operator`` is unused (the probe is unauthenticated) but
+        kept for signature parity with the credentialed connectors.
+        """
+        del operator  # the /iaas/api/about probe is unauthenticated
+        probed_at = datetime.now(UTC)
+        try:
+            client = await self._http_client(target)
+            resp = await client.get(
+                _ABOUT_PATH,
+                headers={"Accept": _JSON_ACCEPT},
+                extensions=self._request_extensions(target),
+            )
+            resp.raise_for_status()
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcfa",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_VRA8_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        try:
+            payload: Any = resp.json()
+        except ValueError:
+            payload = {}
+        latest_api_version = payload.get("latestApiVersion") if isinstance(payload, dict) else None
+        supported_apis = payload.get("supportedApis") if isinstance(payload, dict) else None
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcfa",
+            version=None,
+            build=None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_VRA8_PROBE_METHOD,
+            extras={
+                "about_status": resp.status_code,
+                "latest_api_version": latest_api_version,
+                "supported_apis_count": (
+                    len(supported_apis) if isinstance(supported_apis, list) else None
+                ),
+                "product_lineage": "vrealize-automation",
+                "api_surface": "vra-8",
+            },
+        )
+
+    async def probe(self, target: Vra8TargetLike) -> ProbeResult:
+        """Lightweight reachability check — delegates to :meth:`fingerprint`.
+
+        ``GET /iaas/api/about`` is the single unauthenticated reachability surface;
+        reusing the fingerprint result keeps probe + fingerprint pinned to one
+        round-trip, the vcd / vcf-fleet delegation shape.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: Vra8TargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Post-G0.6 callers (``/api/v1/operations/call``, MCP ``call_operation``, the
+        CLI verbs) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't reach this
+        method. The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``: ``"vcfa-vra8-8.0"`` ->
+        (product=``"vcfa"``, version=``"8.0"``, impl_id=``"vcfa-vra8"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vcfa-vra8-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (#3058, initiative #3056)
+    #
+    # Thin bound-method shims for the migration-inventory read core. Each delegates
+    # to the module-level ``_impl`` body in ``.typed_reads`` (lazy import so pure
+    # fingerprint/probe unit tests don't pay the operations package's
+    # embedding-pipeline import). The dispatcher resolves each persisted
+    # ``module.ClassName.method`` handler_ref back to the bound method and threads
+    # ``operator`` / ``target`` / ``params`` by name. All read-only.
+    # ------------------------------------------------------------------
+
+    async def project_list(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.project.list`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_project_list_impl
+
+        return await vra8_project_list_impl(self, operator, target, params)
+
+    async def deployment_list(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.deployment.list`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_deployment_list_impl
+
+        return await vra8_deployment_list_impl(self, operator, target, params)
+
+    async def deployment_get(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.deployment.get`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_deployment_get_impl
+
+        return await vra8_deployment_get_impl(self, operator, target, params)
+
+    async def blueprint_list(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.blueprint.list`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_blueprint_list_impl
+
+        return await vra8_blueprint_list_impl(self, operator, target, params)
+
+    async def catalog_item_list(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.catalog-item.list`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_catalog_item_list_impl
+
+        return await vra8_catalog_item_list_impl(self, operator, target, params)
+
+    async def about(
+        self, operator: Operator, target: Vra8TargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``vcfa.vra8.about`` shim (#3058)."""
+        from meho_backplane.connectors.vra8.typed_reads import vra8_about_impl
+
+        return await vra8_about_impl(self, operator, target, params)
+
+    # ------------------------------------------------------------------
+    # Dispatch-path session-recovery hooks (#2067 / #2396)
+    # ------------------------------------------------------------------
+
+    async def invalidate_session(self, target: Vra8TargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path (#2067).
+
+        **The load-bearing 401-recovery hook.** On an auth-class status (vRA 8's
+        ``401`` from an expired bearer), the dispatcher's data-path recovery arm calls
+        this hook — keyed on ``invalidate_session``, *not* ``invalidate_credentials``
+        — then re-dispatches the op once
+        (:func:`~meho_backplane.operations.dispatcher._retry_after_session_invalidation`).
+        Dropping the cached bearer here makes the retry's :meth:`auth_headers`
+        cache-miss and re-run the two-step login, so a mid-session token expiry
+        self-heals on the next dispatch without a backplane restart — the SDDC Manager
+        / NSX / vcd session-minting precedent (a connector *without* this hook falls
+        straight through to ``connector_auth_failed`` and wedges on the stale token,
+        dispatcher.py #2067). Holds :attr:`_session_lock` so a concurrent
+        re-establish doesn't race the eviction.
+        """
+        await self._evict_session_token(target)
+
+    async def invalidate_credentials(self, target: Vra8TargetLike) -> None:
+        """Establish-auth-failure companion hook (#2396).
+
+        The dispatcher calls this on an establish-time
+        :class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError` (a
+        login 401/403). vRA 8 re-reads Vault on every mint, so it keeps no separate
+        credential-bytes cache to evict; the only per-target state is the bearer, so
+        this also drops it — a no-op when the establish already failed before caching,
+        harmless otherwise. Kept so the connector advertises both dispatch-path
+        recovery hooks.
+        """
+        await self._evict_session_token(target)
+
+    async def _evict_session_token(self, target: Vra8TargetLike) -> None:
+        """Drop the cached bearer for *target* under the session lock."""
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens, then tear down the httpx pool.
+
+        No server-side session revoke — the Bearer header is sent per request. The
+        token cache is cleared so a post-aclose reuse of the same connector instance
+        re-mints cleanly.
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vra8/session.py
+++ b/backend/src/meho_backplane/connectors/vra8/session.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading + target shape for the ``vra8`` (vRealize Automation 8.x) connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.vra8.connector.Vra8Connector`
+authenticates against vRA 8's two-step token exchange (CSP identity →
+refresh_token → IaaS bearer, see :mod:`._auth`) and caches the minted bearer. The
+credential contract is the shared VCF-family one — a ``{"username": str,
+"password": str}`` pair — so this module reuses the shared
+:mod:`meho_backplane.connectors._shared.vcf_auth` scaffolding (the #841
+cross-cutting module) rather than growing a bespoke duplicate, exactly as the
+sibling ``vcf-automation`` and ``vcd`` connectors do:
+
+* :data:`Vra8TargetLike` — the minimum target shape the connector reads. Aliased
+  to the shared :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike`
+  Protocol (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model`` + the
+  ``id`` / ``tenant_id`` cache-key pair); the concrete ``Target`` model satisfies
+  it structurally. vRA 8's optional CSP ``domain`` is read via ``getattr`` in
+  :mod:`._auth` (local/basic users omit it), so it need not widen the Protocol.
+* :data:`Vra8CredentialsLoader` — the async ``(target, operator) -> dict[str, str]``
+  loader type. Injectable on connector construction so unit tests pass a stub and
+  production the default Vault read.
+* :func:`load_credentials_from_vault` — the shared operator-context KV-v2 read,
+  re-exported so the package's public API reads cohesively.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    VcfCredentialsLoader,
+    VcfTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = [
+    "Vra8CredentialsLoader",
+    "Vra8TargetLike",
+    "load_credentials_from_vault",
+]
+
+#: Minimum target shape :class:`Vra8Connector` reads. Aliased to the shared
+#: VCF-family Protocol — vRA 8 reads exactly the fields the sibling VCF connectors
+#: do (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model`` + the
+#: ``(tenant_id, id)`` cache key), plus an optional ``domain`` read via ``getattr``.
+Vra8TargetLike = VcfTargetLike
+
+#: Async ``(target, operator) -> dict[str, str]`` credential loader. Aliased to the
+#: shared VCF loader type; re-exported under a vRA-8-flavoured name so
+#: ``Vra8Connector(credentials_loader=...)`` reads cohesively without exposing the
+#: shared module at the boundary.
+Vra8CredentialsLoader = VcfCredentialsLoader

--- a/backend/src/meho_backplane/connectors/vra8/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vra8/typed_ops.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`Vra8Connector` (#3058).
+
+The vRealize Automation 8.x migration-inventory read core is registered as typed
+ops (``source_kind="typed"``) so it dispatches on a fresh boot with **zero catalog
+ingest** — the read core is live the moment the connector loads (part of
+initiative `evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_,
+legacy migration-source connector coverage; this is the vRA 8 legacy dual-impl of
+``product="vcfa"``).
+
+The op bodies live in :mod:`meho_backplane.connectors.vra8.typed_reads`; the per-op
+``llm_instructions`` in :mod:`meho_backplane.connectors.vra8._llm_instructions`;
+thin bound-method shims on
+:class:`~meho_backplane.connectors.vra8.connector.Vra8Connector` expose them under
+the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk recovers
+each callable from its persisted ``module.ClassName.method`` path.
+
+The dataclass + tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.vcd.typed_ops` (#3057) and
+:mod:`meho_backplane.connectors.fleet_lcm.typed_ops` (#3047) — the Task #2358
+convention: typed ops own the curated read core. A write surface (create
+deployment / request catalog item) is deliberately out of scope — this is a read
+core for inventorying a migration source.
+
+Op ids are namespaced ``vcfa.vra8.*`` (distinct from the modern sibling's
+``vcfa.provider.*`` / ``vcfa.tenant.*``): the two impls of ``product="vcfa"``
+publish different read surfaces (vRA 8's ``/deployment`` + ``/blueprint`` +
+``/catalog`` services vs VCFA 9's consolidated ``/iaas`` + ``/cloudapi`` surface),
+and the resolver picks the impl per target, so an agent only ever sees the set that
+matches the target's version.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+from meho_backplane.connectors.vra8._llm_instructions import VRA8_READ_LLM_INSTRUCTIONS
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VRA8_TYPED_OPS",
+    "VRA8_TYPED_WHEN_TO_USE_BY_GROUP",
+    "Vra8TypedOp",
+    "register_vra8_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys — the two curated groups the vRA 8 read core spans. Distinct
+# from the modern ``vcfa-rest`` group keys so the (product, impl_id, group_key)
+# rows never collide across the two impls of product ``vcfa``. Ordered by the
+# operator's migration drill: what is running (inventory) -> what defines it (content).
+_GROUP_INVENTORY = "vcfa-vra8-inventory"
+_GROUP_CONTENT = "vcfa-vra8-content"
+
+
+@dataclass(frozen=True)
+class Vra8TypedOp:
+    """Metadata for one vRA 8 typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_vra8_typed_operations` can splat the dataclass into
+    the helper without per-op boilerplate. ``handler_attr`` is the attribute name
+    on :class:`Vra8Connector` exposing the async handler; the registrar resolves
+    the bound method against the class at registration time. Mirrors
+    :class:`~meho_backplane.connectors.vcd.typed_ops.VcloudDirectorTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group. Every entry is a complete
+#: sentence the agent reads verbatim through ``list_operation_groups`` to pick a
+#: group to search within; ``register_typed_operation`` requires a non-empty string
+#: whenever ``group_key`` is set.
+VRA8_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_INVENTORY: (
+        "Use this group to inventory the running vRealize Automation 8 estate an "
+        "operator is migrating off: projects (the tenancy/quota boundary), "
+        "deployments (the running workloads, with their resources and request "
+        "state), and the appliance's API capabilities. This is the primary 'what is "
+        "deployed and where' surface for migration sizing and cutover quiescence "
+        "checks."
+    ),
+    _GROUP_CONTENT: (
+        "Use this group to read the vRA 8 design + catalog surface: Cloud Assembly "
+        "blueprints (the infrastructure-as-code definitions a migration must "
+        "recreate) and Service Broker catalog items (the self-service offerings to "
+        "republish). Use when mapping what the target platform must be able to "
+        "rebuild and re-offer."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared schema fragments
+# ---------------------------------------------------------------------------
+
+#: Empty parameter object — the ``about`` capability read takes no argument.
+_NO_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+#: The paged-list parameter object: the OData ``$top`` / ``$skip`` pagination params
+#: every vRA 8 list surface accepts (identical lowercase casing), both optional. The
+#: read forwards only what the caller sets (see ``._paths.odata_list_query``);
+#: sorting/filtering is done through the JSONFlux handle, not the vendor query (MEHO
+#: postulate 6 — and vRA 8's ``$orderby`` casing differs across services, so it is
+#: deliberately not exposed here).
+_ODATA_LIST_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "$top": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Max items to return (page size). Raise for a whole-estate count.",
+        },
+        "$skip": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of items to skip (pagination offset).",
+        },
+    },
+    "additionalProperties": False,
+}
+
+#: The by-id detail parameter object — a required deployment id.
+_DEPLOYMENT_GET_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "deployment_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The vRA 8 deployment id (UUID), from vcfa.vra8.deployment.list.",
+        },
+    },
+    "required": ["deployment_id"],
+    "additionalProperties": False,
+}
+
+#: Response schema shared by every vRA 8 read: the list surfaces return a
+#: ``{content: [], totalElements, ...}`` wrapper and the detail read a single
+#: object, so a permissive object schema fits both.
+_OBJECT_RESPONSE: dict[str, Any] = {"type": "object", "additionalProperties": True}
+
+_READ_TAGS = ("read-only", "vcfa", "vra8", "vra")
+
+
+#: The typed ops :class:`Vra8Connector` registers at lifespan startup — the 6-op
+#: vRA 8 migration-inventory read core (#3058). Every op is safe, read-only, and
+#: ungated; the wire path/type lives in the handler (see ``.typed_reads`` /
+#: ``._paths``), so the descriptor rows carry ``method=None`` / ``path=None`` (typed
+#: convention).
+VRA8_TYPED_OPS: tuple[Vra8TypedOp, ...] = (
+    # ---- Inventory ----
+    Vra8TypedOp(
+        op_id="vcfa.vra8.project.list",
+        handler_attr="project_list",
+        summary="List the vRA 8 projects (tenancy/quota boundary).",
+        description=(
+            "Lists projects via GET /iaas/api/projects — vRA 8's tenancy/quota "
+            "boundary and the entry point for a migration inventory. Returns the IaaS "
+            "paged {content: [Project], totalElements} wrapper; each Project carries "
+            "id, name, orgId, administrators/members, zones, constraints. Server-paged "
+            "($top/$skip). Dispatches with zero catalog ingest. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema=_ODATA_LIST_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "project"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.project.list"],
+    ),
+    Vra8TypedOp(
+        op_id="vcfa.vra8.deployment.list",
+        handler_attr="deployment_list",
+        summary="List the vRA 8 deployments (running workloads).",
+        description=(
+            "Lists deployments via GET /deployment/api/deployments (the Service Broker "
+            "surface) — vRA 8's running workloads, the core migration inventory. "
+            "Returns the paged {content: [Deployment], totalElements, totalPages} "
+            "wrapper; each Deployment carries id, name, projectId, blueprintId, "
+            "catalogItemId, status, ownedBy. A large list is reduced to a JSONFlux "
+            "handle. Server-paged ($top/$skip). Dispatches with zero catalog ingest. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_ODATA_LIST_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "deployment"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.deployment.list"],
+    ),
+    Vra8TypedOp(
+        op_id="vcfa.vra8.deployment.get",
+        handler_attr="deployment_get",
+        summary="Get one vRA 8 deployment's detail (resources + request state).",
+        description=(
+            "Reads one deployment via GET /deployment/api/deployments/{deployment_id} "
+            "— its resources[] and its request state (lastRequest / "
+            "inprogressRequests). vRA 8 has no list-all-requests endpoint, so this is "
+            "how request/quiescence state is read. Requires deployment_id (from "
+            "deployment.list). Dispatches with zero catalog ingest. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema=_DEPLOYMENT_GET_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "deployment"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.deployment.get"],
+    ),
+    Vra8TypedOp(
+        op_id="vcfa.vra8.about",
+        handler_attr="about",
+        summary="Read the vRA 8 IaaS API capabilities (supported versions).",
+        description=(
+            "Reads GET /iaas/api/about — {latestApiVersion, supportedApis}. Confirms "
+            "the source is a vRA 8.x surface and its API generation. latestApiVersion "
+            "is an API *date* label, not the product build. Dispatches with zero "
+            "catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_INVENTORY,
+        tags=(*_READ_TAGS, "about", "capabilities"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.about"],
+    ),
+    # ---- Content (design + catalog) ----
+    Vra8TypedOp(
+        op_id="vcfa.vra8.blueprint.list",
+        handler_attr="blueprint_list",
+        summary="List the vRA 8 Cloud Assembly blueprints (IaC definitions).",
+        description=(
+            "Lists blueprints via GET /blueprint/api/blueprints — the Cloud Assembly "
+            "infrastructure-as-code definitions a migration must recreate. Returns the "
+            "paged {content: [Blueprint], totalElements} wrapper; each Blueprint "
+            "carries id, name, projectId, status, content (YAML), totalVersions, "
+            "contentSourceType (git-backed source, if any). Server-paged ($top/$skip). "
+            "Dispatches with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_ODATA_LIST_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_CONTENT,
+        tags=(*_READ_TAGS, "blueprint"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.blueprint.list"],
+    ),
+    Vra8TypedOp(
+        op_id="vcfa.vra8.catalog-item.list",
+        handler_attr="catalog_item_list",
+        summary="List the vRA 8 Service Broker catalog items (admin view).",
+        description=(
+            "Lists catalog items via GET /catalog/api/admin/items (the whole-estate "
+            "admin view, not caller-project-scoped) — the self-service offerings a "
+            "migration must republish. Returns the paged {content: [CatalogItem], "
+            "totalElements} wrapper; each CatalogItem carries id, name, type, "
+            "sourceId/sourceName, projectIds. Server-paged ($top/$skip). Dispatches "
+            "with zero catalog ingest. safety_level=safe, read-only."
+        ),
+        parameter_schema=_ODATA_LIST_PARAMS,
+        response_schema=_OBJECT_RESPONSE,
+        group_key=_GROUP_CONTENT,
+        tags=(*_READ_TAGS, "catalog", "catalog-item"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VRA8_READ_LLM_INSTRUCTIONS["vcfa.vra8.catalog-item.list"],
+    ),
+)
+
+
+async def register_vra8_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`VRA8_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after every connector subpackage has been imported, so the
+    descriptor rows land before the first dispatch — the vRA 8 read core is live on
+    a fresh boot. Idempotent across pod restarts (the helper skips the embedding
+    recompute on unchanged summary / description / tags). Mirrors
+    :func:`register_vcd_typed_operations`.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so each
+    registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide singleton
+    when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline (ONNX
+    # runtime + model), which pure connector/handler unit tests should not pay.
+    # Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vra8.connector import Vra8Connector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VRA8_TYPED_OPS:
+        handler = getattr(Vra8Connector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"Vra8Connector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = VRA8_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        if when_to_use is None:
+            raise ValueError(
+                f"Vra8Connector typed op {op.op_id!r} declares group_key="
+                f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                f"Add an entry to VRA8_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=Vra8Connector.product,
+            version=Vra8Connector.version,
+            impl_id=Vra8Connector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vra8_typed_operations_registered",
+        count=len(VRA8_TYPED_OPS),
+        product=Vra8Connector.product,
+        version=Vra8Connector.version,
+        impl_id=Vra8Connector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/vra8/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/vra8/typed_reads.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`Vra8Connector`.
+
+The vRA 8 migration-inventory read core (#3058, initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_) is registered as
+typed ops (``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog state** — no operator ``meho connector ingest`` + ``enable_reads`` step.
+Each function here is the body a thin bound-method shim on
+:class:`~meho_backplane.connectors.vra8.connector.Vra8Connector` delegates to; the
+metadata + registrar live in :mod:`meho_backplane.connectors.vra8.typed_ops`, the
+per-op ``llm_instructions`` in
+:mod:`meho_backplane.connectors.vra8._llm_instructions`. This mirrors the ``vcd``
+(#3057) and ``fleet-lcm`` (#3047) read cores under the Task #2358 convention: typed
+ops own the curated read core.
+
+Every read is issued via :meth:`Vra8Connector._vra_get`, which applies the bearer
+header (minting the two-step session on first use) and ``Accept:
+application/json``. The one bearer authenticates every vRA 8 service, so the reads
+span ``/iaas`` (projects, about), ``/deployment`` (deployments), ``/blueprint``
+(blueprints), and ``/catalog`` (catalog items) uniformly.
+
+The 6-read set (each path pinned by :mod:`tests.test_connectors_vra8_spec_reconcile`):
+
+* ``vcfa.vra8.project.list`` — ``GET /iaas/api/projects``.
+* ``vcfa.vra8.deployment.list`` — ``GET /deployment/api/deployments``.
+* ``vcfa.vra8.deployment.get`` — ``GET /deployment/api/deployments/{deployment_id}``.
+* ``vcfa.vra8.blueprint.list`` — ``GET /blueprint/api/blueprints``.
+* ``vcfa.vra8.catalog-item.list`` — ``GET /catalog/api/admin/items``.
+* ``vcfa.vra8.about`` — ``GET /iaas/api/about``.
+
+**Pagination note.** The list surfaces return a ``{content: [], totalElements,
+numberOfElements, ...}`` wrapper that self-describes whether more pages exist (so a
+default call is not silent truncation); the read forwards the caller's ``$top`` /
+``$skip`` (:func:`._paths.odata_list_query`) and the agent narrows / sorts a large
+result through the dispatcher's JSONFlux handle (MEHO postulate 6).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vra8._paths import (
+    _ABOUT_PATH,
+    _BLUEPRINTS_PATH,
+    _CATALOG_ITEMS_PATH,
+    _DEPLOYMENT_DETAIL_PATH,
+    _DEPLOYMENTS_PATH,
+    _PROJECTS_PATH,
+    odata_list_query,
+)
+from meho_backplane.connectors.vra8.session import Vra8TargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vra8.connector import Vra8Connector
+
+__all__ = [
+    "vra8_about_impl",
+    "vra8_blueprint_list_impl",
+    "vra8_catalog_item_list_impl",
+    "vra8_deployment_get_impl",
+    "vra8_deployment_list_impl",
+    "vra8_project_list_impl",
+]
+
+
+async def vra8_project_list_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.project.list`` — ``GET /iaas/api/projects``.
+
+    Lists vRA 8 projects (the tenancy/quota boundary). Returns the IaaS paged
+    ``{content: [Project, ...], totalElements, numberOfElements}`` wrapper; forwards
+    the caller's ``$top`` / ``$skip``.
+    """
+    return await connector._vra_get(
+        target, _PROJECTS_PATH, operator=operator, params=odata_list_query(params)
+    )
+
+
+async def vra8_deployment_list_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.deployment.list`` — ``GET /deployment/api/deployments``.
+
+    Lists vRA 8 deployments (the running workloads, Service Broker surface). Returns
+    the paged ``{content: [Deployment, ...], totalElements, totalPages}`` wrapper;
+    forwards the caller's ``$top`` / ``$skip``. A large list is
+    reduced to a JSONFlux handle.
+    """
+    return await connector._vra_get(
+        target, _DEPLOYMENTS_PATH, operator=operator, params=odata_list_query(params)
+    )
+
+
+async def vra8_deployment_get_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.deployment.get`` — ``GET /deployment/api/deployments/{deployment_id}``.
+
+    Reads one deployment's full detail — resources[] and request state
+    (``lastRequest`` / ``inprogressRequests``, the pre-cutover quiescence signal).
+    ``params["deployment_id"]`` is guaranteed present by the dispatcher's JSON Schema
+    validation (``required: ["deployment_id"]``); it is percent-encoded with an empty
+    safe set (OpenAPI ``style: simple`` semantics, the ``vcf-automation``
+    ``deployment.get`` precedent) so an id carrying a reserved char can never
+    traverse out of the ``/deployment/api/deployments/`` segment.
+    """
+    path = _DEPLOYMENT_DETAIL_PATH.format(
+        deployment_id=quote(str(params["deployment_id"]), safe="")
+    )
+    return await connector._vra_get(target, path, operator=operator)
+
+
+async def vra8_blueprint_list_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.blueprint.list`` — ``GET /blueprint/api/blueprints``.
+
+    Lists the Cloud Assembly blueprints (the IaC definitions to recreate). Returns
+    the paged ``{content: [Blueprint, ...], totalElements}`` wrapper; forwards the
+    caller's ``$top`` / ``$skip``.
+    """
+    return await connector._vra_get(
+        target, _BLUEPRINTS_PATH, operator=operator, params=odata_list_query(params)
+    )
+
+
+async def vra8_catalog_item_list_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.catalog-item.list`` — ``GET /catalog/api/admin/items``.
+
+    Lists the Service Broker catalog items (admin / whole-estate view — the
+    self-service offerings to republish). Returns the paged ``{content:
+    [CatalogItem, ...], totalElements}`` wrapper; forwards the caller's ``$top`` /
+    ``$skip``.
+    """
+    return await connector._vra_get(
+        target, _CATALOG_ITEMS_PATH, operator=operator, params=odata_list_query(params)
+    )
+
+
+async def vra8_about_impl(
+    connector: Vra8Connector,
+    operator: Operator,
+    target: Vra8TargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``vcfa.vra8.about`` — ``GET /iaas/api/about``.
+
+    Reads the IaaS API capabilities ``{latestApiVersion, supportedApis}``. A
+    no-argument read; ``latestApiVersion`` is an API date label, not the product
+    build.
+    """
+    del params  # schema declares the param object empty
+    return await connector._vra_get(target, _ABOUT_PATH, operator=operator)

--- a/backend/tests/test_connectors_vra8_auth.py
+++ b/backend/tests/test_connectors_vra8_auth.py
@@ -1,0 +1,582 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`Vra8Connector` two-step session mint + fingerprint/probe.
+
+Exercises the load-bearing vRA 8 auth contract — the CSP-identity → IaaS
+token-exchange flow:
+
+* ``POST /csp/gateway/am/api/login?access_token`` with ``{username, password,
+  domain?}`` returns ``{"refresh_token": ...}`` (snake_case) in the body;
+* ``POST /iaas/api/login`` with ``{"refreshToken": ...}`` (camelCase) returns
+  ``{"tokenType": "Bearer", "token": ...}`` — the bearer the connector caches and
+  sends as ``Authorization: Bearer <token>`` with ``Accept: application/json`` on
+  every read (one bearer authenticates all vRA 8 services).
+* Per-target token caching + tenant-unique isolation.
+* Both dispatch-path eviction hooks (``invalidate_session`` #2067 /
+  ``invalidate_credentials`` #2396) → re-mint.
+* ``GET /iaas/api/about`` unauthenticated fingerprint/probe (version left ``None``).
+* ``auth_model`` gating + empty-``raw_jwt`` fail-closed.
+
+Adapts :mod:`tests.test_connectors_vcd_auth` to the two-step (body-token) flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vra8 import (
+    VRA8_IMPL_ID,
+    VRA8_PRODUCT,
+    VRA8_VERSION,
+    Vra8Connector,
+    Vra8TargetLike,
+)
+from meho_backplane.settings import get_settings
+
+_CSP_LOGIN_PATH = "/csp/gateway/am/api/login"
+_IAAS_LOGIN_PATH = "/iaas/api/login"
+_ABOUT_PATH = "/iaas/api/about"
+_PROJECTS_PATH = "/iaas/api/projects"
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    """Return a minimal :class:`Operator`; non-empty ``raw_jwt`` passes the fail-closed gate."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _chassis_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env the shared credential loader reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_vra8_registry() -> Iterator[None]:
+    """Restore Vra8Connector's package registration (the versioned triple only).
+
+    Sibling tests clear the shared registry between tests; this fixture restores
+    exactly what the ``vra8`` package's ``__init__`` registers — the versioned triple
+    and NO wildcard (the modern ``vcf_automation`` owns ``("vcfa","","")``).
+    """
+    clear_registry()
+    register_connector_v2(
+        product=Vra8Connector.product,
+        version=Vra8Connector.version,
+        impl_id=Vra8Connector.impl_id,
+        cls=Vra8Connector,
+    )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    """Target satisfying :data:`Vra8TargetLike` structurally."""
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(name="vra-a", host="vra-a.test.invalid", port=443, secret_ref="vra/vra-a")
+_TARGET_B = _StubTarget(name="vra-b", host="vra-b.test.invalid", port=443, secret_ref="vra/vra-b")
+
+
+async def _stub_loader(_target: Vra8TargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target / operator."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> Vra8Connector:
+    """Build a connector wired with the stub loader."""
+    return Vra8Connector(credentials_loader=_stub_loader)
+
+
+def _mock_two_step_login(
+    mock: respx.Router,
+    *,
+    refresh_token: str = "refresh-abc",
+    bearer: str = "bearer-xyz",
+) -> tuple[respx.Route, respx.Route]:
+    """Register the CSP + IaaS login routes returning the given tokens.
+
+    CSP returns ``{refresh_token}`` (snake_case), IaaS returns ``{tokenType, token}``.
+    """
+    csp = mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": refresh_token})
+    iaas = mock.post(_IAAS_LOGIN_PATH).respond(200, json={"tokenType": "Bearer", "token": bearer})
+    return csp, iaas
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vra8_connector_subclasses_http_connector() -> None:
+    """The connector inherits from HttpConnector with the legacy-dual-impl metadata."""
+    assert issubclass(Vra8Connector, HttpConnector)
+    assert Vra8Connector.product == "vcfa"
+    assert Vra8Connector.version == "8.0"
+    assert Vra8Connector.impl_id == "vcfa-vra8"
+    assert Vra8Connector.supported_version_range == ">=8.0,<9.0"
+    assert Vra8Connector.priority == 1
+
+
+def test_importing_package_registers_versioned_triple_only() -> None:
+    """The vra8 package registers its versioned triple and NOT the ``("vcfa","","")`` wildcard.
+
+    The modern ``vcf_automation`` owns the wildcard; the legacy impl registers only
+    its versioned triple (the autouse fixture restores exactly that).
+    """
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    assert registry[(VRA8_PRODUCT, VRA8_VERSION, VRA8_IMPL_ID)] is Vra8Connector
+    assert (VRA8_PRODUCT, "", "") not in registry
+
+
+# ---------------------------------------------------------------------------
+# Two-step session mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_mints_bearer_via_two_step_login() -> None:
+    """A read runs CSP login → refresh_token → IaaS exchange → bearer, then the data GET."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        csp, iaas = _mock_two_step_login(mock, refresh_token="rt-1", bearer="bt-1")
+        projects = mock.get(_PROJECTS_PATH).respond(200, json={"content": [], "totalElements": 0})
+        result = await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+
+    assert result == {"content": [], "totalElements": 0}
+    # Step 1 — CSP login: username/password body + the ?access_token flag.
+    csp_req = csp.calls[0].request
+    assert "access_token" in dict(csp_req.url.params)
+    import json as _json
+
+    csp_body = _json.loads(csp_req.content)
+    assert csp_body == {"username": "svc-meho", "password": "stub-password"}
+    # Step 2 — IaaS exchange: the refresh_token rides back as camelCase refreshToken.
+    iaas_body = _json.loads(iaas.calls[0].request.content)
+    assert iaas_body == {"refreshToken": "rt-1"}
+    # The data GET carried the minted bearer + the constant JSON Accept.
+    data_req = projects.calls[0].request
+    assert data_req.headers["Authorization"] == "Bearer bt-1"
+    assert data_req.headers["Accept"] == "application/json"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_csp_domain_forwarded_when_extras_set_it() -> None:
+    """``extras["domain"]`` is forwarded in the CSP login body (directory/AD users).
+
+    The production ``Target`` model has no ``domain`` column, so the selector rides
+    the per-product ``extras`` escape hatch (like ``vcd``'s ``vcd_api_version``);
+    the target here is shaped like production — no ``domain`` attribute.
+    """
+    target = _StubTarget(
+        name="vra-dom",
+        host="vra-dom.test.invalid",
+        port=443,
+        secret_ref="vra/dom",
+        extras={"domain": "corp.example"},
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-dom.test.invalid") as mock:
+        csp, _iaas = _mock_two_step_login(mock)
+        mock.get(_ABOUT_PATH).respond(200, json={"latestApiVersion": "2021-07-15"})
+        await connector._vra_get(target, _ABOUT_PATH, operator=_make_operator())
+
+    import json as _json
+
+    body = _json.loads(csp.calls[0].request.content)
+    assert body["domain"] == "corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_cached_across_calls_against_same_target() -> None:
+    """Two reads against the same target run the two-step login once."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        csp, iaas = _mock_two_step_login(mock, bearer="bt-cache")
+        mock.get(_PROJECTS_PATH).respond(200, json={"content": []})
+        mock.get(_ABOUT_PATH).respond(200, json={"latestApiVersion": "2021-07-15"})
+        await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+        await connector._vra_get(_TARGET_A, _ABOUT_PATH, operator=_make_operator())
+
+    assert csp.call_count == 1
+    assert iaas.call_count == 1
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "bt-cache"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_tokens_separate() -> None:
+    """Two targets get two distinct cached bearers."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        mock.post("https://vra-a.test.invalid" + _CSP_LOGIN_PATH).respond(
+            200, json={"refresh_token": "rt-a"}
+        )
+        mock.post("https://vra-a.test.invalid" + _IAAS_LOGIN_PATH).respond(
+            200, json={"token": "bt-a"}
+        )
+        mock.post("https://vra-b.test.invalid" + _CSP_LOGIN_PATH).respond(
+            200, json={"refresh_token": "rt-b"}
+        )
+        mock.post("https://vra-b.test.invalid" + _IAAS_LOGIN_PATH).respond(
+            200, json={"token": "bt-b"}
+        )
+        mock.get("https://vra-a.test.invalid" + _PROJECTS_PATH).respond(200, json={"content": []})
+        mock.get("https://vra-b.test.invalid" + _PROJECTS_PATH).respond(200, json={"content": []})
+        await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+        await connector._vra_get(_TARGET_B, _PROJECTS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {
+        target_cache_key(_TARGET_A): "bt-a",
+        target_cache_key(_TARGET_B): "bt-b",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached token (#1642/#1672)."""
+    connector = _make_connector()
+    tenant_one = _StubTarget(
+        name="vra-shared",
+        host="vra-shared.test.invalid",
+        port=443,
+        secret_ref="vra/shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="vra-shared",
+        host="vra-shared.test.invalid",
+        port=443,
+        secret_ref="vra/shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://vra-shared.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": "rt"})
+        mock.post(_IAAS_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"token": "bt-one"}),
+                httpx.Response(200, json={"token": "bt-two"}),
+            ]
+        )
+        mock.get(_PROJECTS_PATH).respond(200, json={"content": []})
+        await connector._vra_get(tenant_one, _PROJECTS_PATH, operator=_make_operator())
+        await connector._vra_get(tenant_two, _PROJECTS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {
+        target_cache_key(tenant_one): "bt-one",
+        target_cache_key(tenant_two): "bt-two",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Login failure modes — both steps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_csp_login_401_surfaces_connector_auth_error_naming_target() -> None:
+    """401 from the CSP login raises the structured ConnectorAuthError (#2329)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(401)
+        with pytest.raises(RuntimeError, match=r"vra-a") as exc_info:
+            await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+    err = exc_info.value
+    assert isinstance(err, ConnectorAuthError)
+    assert "401" in str(err)
+    assert "CSP" in str(err)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_iaas_exchange_403_surfaces_connector_auth_error_naming_target() -> None:
+    """403 from the IaaS token exchange raises the structured ConnectorAuthError (#2329)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": "rt"})
+        mock.post(_IAAS_LOGIN_PATH).respond(403)
+        with pytest.raises(RuntimeError, match=r"vra-a") as exc_info:
+            await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+    err = exc_info.value
+    assert isinstance(err, ConnectorAuthError)
+    assert "403" in str(err)
+    assert "IaaS" in str(err)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_csp_missing_refresh_token_raises() -> None:
+    """A 2xx CSP login with no ``refresh_token`` raises naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(200, json={"not_a_token": "x"})
+        with pytest.raises(RuntimeError, match=r"vra-a") as exc_info:
+            await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+    assert "refresh_token" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_iaas_missing_token_raises() -> None:
+    """A 2xx IaaS exchange with no ``token`` field raises naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": "rt"})
+        mock.post(_IAAS_LOGIN_PATH).respond(200, json={"tokenType": "Bearer"})
+        with pytest.raises(RuntimeError, match=r"vra-a") as exc_info:
+            await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+    assert "token" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_raises_clear_error() -> None:
+    """A loader returning a dict without ``password`` raises naming the target."""
+
+    async def _bad_loader(_t: Vra8TargetLike, _o: Operator) -> dict[str, str]:
+        return {"username": "svc-meho"}  # missing 'password' on purpose
+
+    connector = Vra8Connector(credentials_loader=_bad_loader)
+    async with respx.mock(base_url="https://vra-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating + fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation / unknown modes raise NotImplementedError naming target + mode."""
+    target = _StubTarget(
+        name="vra-per-user",
+        host="vra.test.invalid",
+        port=443,
+        secret_ref="vra/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "vra-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model() -> None:
+    """``auth_model=None`` (pre-G0.3) is accepted."""
+    target = _StubTarget(
+        name="vra-pre-g03", host="vra.test.invalid", port=443, secret_ref="vra/pre", auth_model=None
+    )
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vra.test.invalid") as mock:
+        _mock_two_step_login(mock, bearer="pre-bt")
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer pre-bt"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_establish_rejects_empty_operator_jwt() -> None:
+    """A system-initiated call (empty raw_jwt) cannot mint — fail-closed before the cache."""
+    connector = _make_connector()
+    with pytest.raises(VaultCredentialsReadError, match=r"vra-a"):
+        await connector.auth_headers(_TARGET_A, operator=_make_operator(raw_jwt=""))
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-path eviction hooks → re-mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hook_name", ["invalidate_session", "invalidate_credentials"])
+@pytest.mark.asyncio
+async def test_eviction_hook_drops_token_forcing_remint(hook_name: str) -> None:
+    """Both dispatch-path eviction hooks drop the cached bearer so the next auth_headers re-mints.
+
+    ``invalidate_session`` is the hook the dispatcher's data-path 401 recovery arm
+    calls (#2067 — proven end-to-end in
+    ``test_connectors_vra8_typed_reads::test_data_path_401_remints_via_dispatcher``);
+    ``invalidate_credentials`` is the establish-failure companion (#2396). vRA 8
+    keeps only the minted-bearer cache, so both evict it. This also pins that
+    ``invalidate_session`` exists — its absence would be a latent permanent-wedge bug
+    (the data-path 401 arm is keyed on ``invalidate_session``, not
+    ``invalidate_credentials``).
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": "rt"})
+        iaas = mock.post(_IAAS_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"token": "bt-1"}),
+                httpx.Response(200, json={"token": "bt-2"}),
+            ]
+        )
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        await getattr(connector, hook_name)(_TARGET_A)
+        assert connector._session_tokens == {}
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == {"Authorization": "Bearer bt-1"}
+    assert h2 == {"Authorization": "Bearer bt-2"}
+    assert iaas.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_tokens_and_pool() -> None:
+    """aclose() drops the token cache and tears down the httpx pool."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        _mock_two_step_login(mock, bearer="bt")
+        mock.get(_PROJECTS_PATH).respond(200, json={"content": []})
+        await connector._vra_get(_TARGET_A, _PROJECTS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "bt"}
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe() — unauthenticated GET /iaas/api/about
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_reachable_no_mint() -> None:
+    """A 2xx on /iaas/api/about → reachable, version=None, latest_api_version in extras, no mint."""
+    connector = _make_connector()
+
+    # assert_all_called=False: the login routes are registered to prove the probe
+    # does NOT call them (an unauthenticated fingerprint must not mint a session).
+    async with respx.mock(base_url="https://vra-a.test.invalid", assert_all_called=False) as mock:
+        about = mock.get(_ABOUT_PATH).respond(
+            200,
+            json={
+                "latestApiVersion": "2021-07-15",
+                "supportedApis": [{"apiVersion": "2021-07-15"}, {"apiVersion": "2020-08-25"}],
+            },
+        )
+        csp, iaas = _mock_two_step_login(mock)
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcfa"
+    assert fp.reachable is True
+    assert fp.version is None
+    assert fp.extras["latest_api_version"] == "2021-07-15"
+    assert fp.extras["supported_apis_count"] == 2
+    assert fp.extras["api_surface"] == "vra-8"
+    assert about.called
+    # The probe is unauthenticated — it must NOT trigger a login.
+    assert not csp.called
+    assert not iaas.called
+    assert connector._session_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_5xx() -> None:
+    """A 5xx on /iaas/api/about → reachable=False with a structured error."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.get(_ABOUT_PATH).respond(503)
+        fp = await connector.fingerprint(_TARGET_A)
+    assert fp.reachable is False
+    assert "HTTPStatusError" in fp.extras["error"] or "503" in fp.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_and_not_ok() -> None:
+    """probe() reflects fingerprint reachability."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vra-a.test.invalid") as mock:
+        mock.get(_ABOUT_PATH).respond(200, json={"latestApiVersion": "2021-07-15"})
+        ok = await connector.probe(_TARGET_A)
+    assert ok.ok is True and ok.reason is None
+
+    connector2 = _make_connector()
+    async with respx.mock(base_url="https://vra-b.test.invalid") as mock:
+        mock.get(_ABOUT_PATH).respond(503)
+        bad = await connector2.probe(_TARGET_B)
+    assert bad.ok is False and bad.reason is not None
+    await connector.aclose()
+    await connector2.aclose()
+
+
+def test_default_loader_fails_closed_for_system_initiated_call() -> None:
+    """The default Vault loader rejects an empty operator JWT (system-initiated call)."""
+    from meho_backplane.connectors.vra8.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        with pytest.raises(VaultCredentialsReadError, match=r"vra-a"):
+            await load_credentials_from_vault(_TARGET_A, _make_operator(raw_jwt=""))
+
+    asyncio.run(_check())

--- a/backend/tests/test_connectors_vra8_dual_impl_resolution.py
+++ b/backend/tests/test_connectors_vra8_dual_impl_resolution.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The second two-impl resolver test — ``product=vcfa`` (vcfa-rest + vcfa-vra8), #3058.
+
+``product=vcfa`` is the codebase's **second real two-implementation case** (after
+``fleet``; initiative #3056, policy #3033/#3038). Two hand-rolled ``HttpConnector``
+subclasses register under the same product with distinct ``impl_id``s and
+**disjoint** version bands, and
+:func:`~meho_backplane.connectors.resolver.resolve_connector` picks one per target by
+fingerprint:
+
+* modern typed ``vcfa-rest``
+  (:class:`~meho_backplane.connectors.vcf_automation.connector.VcfAutomationConnector`)
+  — VCF Automation 9.x, ``supported_version_range=">=9.0,<10.0"``.
+* legacy typed ``vcfa-vra8``
+  (:class:`~meho_backplane.connectors.vra8.connector.Vra8Connector`) — vRealize
+  Automation 8.x, ``supported_version_range=">=8.0,<9.0"``.
+
+The inversion vs ``fleet``
+--------------------------
+
+In the ``fleet`` case the **legacy** ``vcf_fleet`` owns the ``("fleet","","")``
+wildcard and the modern ``fleet_lcm`` skips it. Here it is inverted: the **modern**
+``vcf_automation`` owns ``("vcfa","","")`` (it shipped first, as the sole impl), so
+the new legacy ``vcfa-vra8`` registers **only** its versioned triple. Consequence:
+an *unfingerprinted* / unversioned ``vcfa`` target resolves to **modern**
+``vcfa-rest`` (the wildcard owner) — a vRA 8 target must carry an 8.x version
+(operator-asserted at onboarding) to resolve to the legacy impl.
+
+Because the two bands are **disjoint** (no overlap at any version), resolution never
+reaches the specificity tie-break the ``fleet`` case exercises: an 8.x target has
+exactly one in-range versioned candidate (legacy), a 9.x target exactly one (modern).
+This test constructs both registrations exactly as the two packages' ``__init__``
+modules do and asserts the resolution matrix — mirroring
+:mod:`tests.test_connectors_fleet_dual_impl_resolution`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.vcf_automation.connector import VcfAutomationConnector
+from meho_backplane.connectors.vra8.connector import Vra8Connector
+
+# ---------------------------------------------------------------------------
+# Duck-typed target — the resolver reads .product, .fingerprint.version,
+# .version, .preferred_impl_id (mirrors tests.test_connectors_resolver).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+def _fp(version: str | None) -> _FakeFingerprint:
+    return _FakeFingerprint(version=version)
+
+
+def _register_both_impls() -> None:
+    """Register both vcfa impls exactly as their ``__init__`` modules do.
+
+    * ``vcfa-rest`` (modern): the versioned triple **plus** the ``("vcfa","","")``
+      wildcard fallback (the G0.15-T6 #1215 fanout it shipped with as the sole impl).
+    * ``vcfa-vra8`` (legacy): the versioned triple only — a second class on the
+      wildcard key would raise ``RuntimeError``.
+
+    Uses the real connector classes (not stand-ins) so a future drift in either
+    ``supported_version_range`` breaks this test — the point of a two-impl guard.
+    """
+    register_connector_v2(
+        product=VcfAutomationConnector.product,
+        version=VcfAutomationConnector.version,
+        impl_id=VcfAutomationConnector.impl_id,
+        cls=VcfAutomationConnector,
+    )
+    register_connector_v2(product="vcfa", version="", impl_id="", cls=VcfAutomationConnector)
+    register_connector_v2(
+        product=Vra8Connector.product,
+        version=Vra8Connector.version,
+        impl_id=Vra8Connector.impl_id,
+        cls=Vra8Connector,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    _register_both_impls()
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Registration shape — the two impls coexist under distinct triples
+# ---------------------------------------------------------------------------
+
+
+def test_both_impls_register_under_distinct_triples() -> None:
+    """The two impls share ``product="vcfa"`` but distinct (version, impl_id).
+
+    The v2 keys never collide (impl_id + version disambiguate), and the
+    ``("vcfa","","")`` wildcard is owned by the **modern** impl alone (the inversion
+    vs fleet).
+    """
+    # Class attrs are the source of truth for the registration triples.
+    assert (
+        VcfAutomationConnector.product,
+        VcfAutomationConnector.version,
+        VcfAutomationConnector.impl_id,
+    ) == ("vcfa", "9.0", "vcfa-rest")
+    assert (Vra8Connector.product, Vra8Connector.version, Vra8Connector.impl_id) == (
+        "vcfa",
+        "8.0",
+        "vcfa-vra8",
+    )
+    # The disjoint bands are what the split hinges on (no overlap → no specificity tie).
+    assert VcfAutomationConnector.supported_version_range == ">=9.0,<10.0"
+    assert Vra8Connector.supported_version_range == ">=8.0,<9.0"
+
+    triples = set(all_connectors_v2())
+    assert ("vcfa", "9.0", "vcfa-rest") in triples
+    assert ("vcfa", "8.0", "vcfa-vra8") in triples
+    assert ("vcfa", "", "") in triples  # the single wildcard
+    # ...owned by the MODERN impl (inversion vs fleet, where the legacy owns it).
+    assert all_connectors_v2()[("vcfa", "", "")] is VcfAutomationConnector
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — an 8.x target resolves the legacy vcfa-vra8 (only in-range candidate)
+# ---------------------------------------------------------------------------
+
+
+def test_8x_target_resolves_legacy_vra8() -> None:
+    """A vRA 8.12 target resolves ``vcfa-vra8``.
+
+    ``vcfa-rest``'s ``>=9.0,<10.0`` excludes 8.12, so the legacy impl is the only
+    in-range versioned candidate; the modern-owned wildcard is demoted by step 1.
+    """
+    target = _FakeTarget(product="vcfa", fingerprint=_fp("8.12"))
+    assert resolve_connector(target) is Vra8Connector
+
+
+def test_8x_boundary_and_patch_targets_resolve_legacy() -> None:
+    """The band floor (8.0) and a patch (8.18.1) both resolve ``vcfa-vra8`` (in ``>=8.0,<9.0``)."""
+    assert resolve_connector(_FakeTarget(product="vcfa", fingerprint=_fp("8.0"))) is Vra8Connector
+    assert (
+        resolve_connector(_FakeTarget(product="vcfa", fingerprint=_fp("8.18.1"))) is Vra8Connector
+    )
+
+
+def test_8x_preferred_modern_is_moot_out_of_range() -> None:
+    """``preferred_impl_id="vcfa-rest"`` on an 8.x target cannot flip the result.
+
+    Operator preference only breaks a tie among **in-range** candidates. At 8.12
+    only the legacy impl is in range (modern's ``>=9.0,<10.0`` excludes it), so a
+    preference for the out-of-range modern impl is moot — the disjoint-band
+    robustness the ``fleet`` overlapping-band case cannot assert.
+    """
+    target = _FakeTarget(product="vcfa", fingerprint=_fp("8.12"), preferred_impl_id="vcfa-rest")
+    assert resolve_connector(target) is Vra8Connector
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — a 9.x target resolves the modern vcfa-rest (only in-range candidate)
+# ---------------------------------------------------------------------------
+
+
+def test_9x_target_resolves_modern_vcfa_rest() -> None:
+    """A VCF Automation 9.0 target resolves ``vcfa-rest``.
+
+    ``vcfa-vra8``'s ``>=8.0,<9.0`` excludes 9.0, so the modern impl is the only
+    in-range versioned candidate; its own wildcard is demoted first (step 1).
+    """
+    target = _FakeTarget(product="vcfa", fingerprint=_fp("9.0"))
+    assert resolve_connector(target) is VcfAutomationConnector
+
+
+def test_9_0_2_patch_target_resolves_modern() -> None:
+    """A patch-versioned 9.0.2 target resolves ``vcfa-rest`` too (in ``>=9.0,<10.0``)."""
+    target = _FakeTarget(product="vcfa", fingerprint=_fp("9.0.2"))
+    assert resolve_connector(target) is VcfAutomationConnector
+
+
+# ---------------------------------------------------------------------------
+# Wildcard fallback — an unfingerprinted target resolves to MODERN (the inversion)
+# ---------------------------------------------------------------------------
+
+
+def test_unfingerprinted_target_resolves_via_modern_wildcard() -> None:
+    """A fresh target (no fingerprint, no asserted version) resolves via the wildcard.
+
+    Neither versioned entry matches without a version (the specificity filter needs
+    one), so only the ``("vcfa","","")`` wildcard survives — and here that wildcard is
+    owned by the **modern** ``vcfa-rest`` (the inversion vs fleet). So an
+    unfingerprinted vRA-8 estate resolves to modern until it carries an 8.x version;
+    this pins that documented behaviour so a future wildcard re-assignment can't
+    silently change it.
+    """
+    target = _FakeTarget(product="vcfa", fingerprint=None, version=None)
+    assert resolve_connector(target) is VcfAutomationConnector

--- a/backend/tests/test_connectors_vra8_spec_reconcile.py
+++ b/backend/tests/test_connectors_vra8_spec_reconcile.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vra8 (vRealize Automation 8.x) hand-coded-surface reconcile lane (#3058) — #2980 harness.
+
+Pins the exact ``METHOD:/path`` surface the ``vra8`` connector hand-codes, swept
+from the connector's **live** module constants (the #2944 introspect-live-constants
+pattern — never a hardcoded mirror that can drift). Parse-only, no DB / embeddings /
+containers, so it lives in the required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``.
+
+**Evidenced exclusion — manifest pin, no served-op-id compare.** A committable
+vendor spec *does* exist for the vRA 8 read surface — ``vmware/vra-sdk-go``
+(Apache-2.0) ships Swagger 2.0 documents for the IaaS (``vra-iaas.json``), Service
+Broker (``vra-catalog-deployment.json``), and Blueprint (``vra-blueprint.json``)
+services — but:
+
+* MEHO's ingest parser accepts OpenAPI 3.0/3.1 only (#2090), so the Swagger 2.0
+  surface is **not operator-ingestable** — hence the typed read core (not generic).
+* The CSP identity endpoint (``POST /csp/gateway/am/api/login``) is **not** part of
+  vra-sdk-go at all (CSP identity is outside the SDK), so a served-op-id compare
+  could never cover the login surface.
+
+So this lane is the **manifest pin** half of the standard — it runs unconditionally,
+proves the enumeration on every sweep, and a new hand-coded path / renamed constant /
+method change must update the manifest consciously. **Strengthening (deferred):** the
+sibling ``vcf-automation`` tenant lane *does* shelf-arm its ``/iaas/*`` paths against
+the Swagger 2.0 ``vra-iaas.json`` (via ``tests._spec_shelf`` + a local Swagger-2.0
+served-set extractor); the same could arm this connector's ``/iaas`` + ``/deployment``
++ ``/blueprint`` + ``/catalog`` paths against the three vra-sdk-go swaggers once they
+are shelved under a ``vcfa-vra8-8.0/`` shelf dir. That layer skips when the shelf is
+unconfigured (the default sweep), so the always-on manifest pin below is the tested
+guard. Full evidence + activation trigger live in the ``vcfa-vra8`` entry of the
+standard doc's Evidenced-exclusions section.
+
+Dispatch-fidelity of each path is proven live-mocked in
+:mod:`tests.test_connectors_vra8_typed_reads` / :mod:`tests.test_connectors_vra8_auth`.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vra8 import _paths as _paths_module
+from meho_backplane.connectors.vra8 import connector as _connector
+
+#: HTTP method per hand-coded path constant. The two login endpoints are POSTed
+#: (``._auth.vra8_login``); every read path (the ``/iaas/api/about`` fingerprint
+#: probe + the five migration-inventory reads) is GET. A new ``*_PATH`` constant not
+#: listed here fails the sweep loudly so its method is mapped consciously.
+_METHOD_BY_CONSTANT = {
+    "_CSP_LOGIN_PATH": "POST",
+    "_IAAS_LOGIN_PATH": "POST",
+    "_ABOUT_PATH": "GET",
+    "_PROJECTS_PATH": "GET",
+    "_DEPLOYMENTS_PATH": "GET",
+    "_DEPLOYMENT_DETAIL_PATH": "GET",
+    "_BLUEPRINTS_PATH": "GET",
+    "_CATALOG_ITEMS_PATH": "GET",
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` string constants of the ``vra8._paths`` module."""
+    return {
+        name: value
+        for name, value in vars(_paths_module).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vra8 connector dispatches.
+
+    Swept from the live ``_paths`` constants (never a hardcoded mirror); the method
+    for each is taken from :data:`_METHOD_BY_CONSTANT`. A constant with no method
+    mapping fails loudly so the reconcile keeps covering it.
+    """
+    declared: set[str] = set()
+    for name, path in _path_constants().items():
+        method = _METHOD_BY_CONSTANT.get(name)
+        if method is None:
+            raise AssertionError(
+                f"vra8._paths.{name} has no entry in _METHOD_BY_CONSTANT — map the "
+                "new constant's HTTP method there consciously so the reconcile keeps "
+                "covering it."
+            )
+        declared.add(f"{method}:{path}")
+    return declared
+
+
+def test_path_constant_names_are_pinned() -> None:
+    """Guard: the introspection finds exactly the hand-coded path-constant set.
+
+    Pinning the exact ``_*_PATH`` constant-name set (the #2944 guard shape) means a
+    renamed or dropped constant — or a new one that skips the ``_PATH`` convention —
+    can't silently shrink the reconciled surface to a vacuous pass.
+    """
+    assert sorted(_path_constants()) == [
+        "_ABOUT_PATH",
+        "_BLUEPRINTS_PATH",
+        "_CATALOG_ITEMS_PATH",
+        "_CSP_LOGIN_PATH",
+        "_DEPLOYMENTS_PATH",
+        "_DEPLOYMENT_DETAIL_PATH",
+        "_IAAS_LOGIN_PATH",
+        "_PROJECTS_PATH",
+    ]
+
+
+def test_vra8_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept ``METHOD:/path`` manifest so drift can't silently change the surface.
+
+    Runs unconditionally (no shelf / spec needed), so the enumeration is proven on
+    every sweep. Because the vRA 8 vendor spec is Swagger 2.0 (OA3-only ingest can't
+    consume it) and omits the CSP login (evidenced exclusion — see the module
+    docstring), this manifest pin is the whole reconcile: a new hand-coded path, a
+    renamed constant, or a method change must update it consciously.
+    """
+    assert _declared_op_ids() == {
+        "POST:/csp/gateway/am/api/login",
+        "POST:/iaas/api/login",
+        "GET:/iaas/api/about",
+        "GET:/iaas/api/projects",
+        "GET:/deployment/api/deployments",
+        "GET:/deployment/api/deployments/{deployment_id}",
+        "GET:/blueprint/api/blueprints",
+        "GET:/catalog/api/admin/items",
+    }
+
+
+def test_probe_constant_links_to_about_path() -> None:
+    """The fingerprint probe reads the same ``/iaas/api/about`` the manifest pins.
+
+    The connector's fingerprint dispatches :data:`vra8._paths._ABOUT_PATH`; pin the
+    value and the probe-method string's reference to it so a change to one is forced
+    through the other (the vcd probe⇄versions link shape).
+    """
+    assert _paths_module._ABOUT_PATH == "/iaas/api/about"
+    assert "/iaas/api/about" in _connector._VRA8_PROBE_METHOD

--- a/backend/tests/test_connectors_vra8_typed_reads.py
+++ b/backend/tests/test_connectors_vra8_typed_reads.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the vRA 8 typed read core (#3058, initiative #3056).
+
+The appliance-free proof that a vRealize Automation 8 target dispatches a
+migration-inventory read end-to-end on a fresh boot. Coverage:
+
+* **Zero-catalog typed dispatch.** Each of the 6 reads dispatches through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked vRA 8 (the
+  two-step login + the data GET) with **only** the typed registrar run (no ingested
+  rows) and returns ``status="ok"``. The list reads hit their service path; the
+  by-id read templates the deployment id into the path.
+* **Session mint on the dispatch path.** The read rides
+  :meth:`Vra8Connector.auth_headers`, minting the bearer from the two-step exchange
+  and sending it as ``Authorization: Bearer`` with ``Accept: application/json``.
+* **Data-path 401 self-heal.** A 401 on the data read re-mints via the dispatcher's
+  ``invalidate_session`` arm and retries once (the load-bearing #2067 proof).
+* **Registration-shape invariants.** All 6 reads persist as ``source_kind="typed"``,
+  ``is_enabled=True``, ``safe`` / ungated / ``read-only``, with a canonical-key
+  ``llm_instructions`` blob; their 2 groups land ``review_status="enabled"``; no
+  write op is registered.
+
+Mirrors :mod:`tests.test_connectors_vcd_typed_reads`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vra8 import (
+    VRA8_CONNECTOR_ID,
+    VRA8_IMPL_ID,
+    VRA8_PRODUCT,
+    VRA8_TYPED_OPS,
+    VRA8_TYPED_WHEN_TO_USE_BY_GROUP,
+    VRA8_VERSION,
+    Vra8Connector,
+    register_vra8_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_VRA_HOST = "vra-typed.test.invalid"
+_VRA_BASE_URL = f"https://{_VRA_HOST}"
+_CSP_LOGIN_PATH = "/csp/gateway/am/api/login"
+_IAAS_LOGIN_PATH = "/iaas/api/login"
+
+_EXPECTED_OP_IDS = {
+    "vcfa.vra8.project.list",
+    "vcfa.vra8.deployment.list",
+    "vcfa.vra8.deployment.get",
+    "vcfa.vra8.blueprint.list",
+    "vcfa.vra8.catalog-item.list",
+    "vcfa.vra8.about",
+}
+
+_EXPECTED_GROUPS = {"vcfa-vra8-inventory", "vcfa-vra8-content"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=VRA8_PRODUCT,
+        version=VRA8_VERSION,
+        impl_id=VRA8_IMPL_ID,
+        cls=Vra8Connector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _Vra8ReadTarget:
+    """Target satisfying both ``Vra8TargetLike`` and the resolver shape.
+
+    ``fingerprint.version="8.12"`` is in the ``vcfa-vra8`` band ``">=8.0,<9.0"``, so
+    a vRA 8 target resolves to this legacy impl.
+    """
+
+    def __init__(self) -> None:
+        self.product = VRA8_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "8.12"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-0000000000e0")
+        self.name = "vra-typed"
+        self.host = _VRA_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/vra-typed"
+        self.auth_model = "shared_service_account"
+        self.extras: dict[str, Any] = {}
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-vra",
+        name="VRA Reads Operator",
+        email=None,
+        raw_jwt="op.reads.vra.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000e4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _stub_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Username/password for the two-step login."""
+    return {"username": "vra-svc", "password": "vra-pw"}
+
+
+async def _register_and_resolve() -> Vra8Connector:
+    """Run the typed registrar (only) and return a credentials-stubbed instance."""
+    await register_vra8_typed_operations()
+    instance = get_or_create_connector_instance(Vra8Connector)
+    instance._credentials_loader = _stub_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Zero-catalog typed dispatch
+# ---------------------------------------------------------------------------
+
+# (op_id, wire path, params, payload)
+_DISPATCH_CASES: list[tuple[str, str, dict[str, Any], Any]] = [
+    ("vcfa.vra8.project.list", "/iaas/api/projects", {}, {"content": [{"name": "proj-a"}]}),
+    (
+        "vcfa.vra8.deployment.list",
+        "/deployment/api/deployments",
+        {},
+        {"content": [{"id": "dep-a"}], "totalElements": 1},
+    ),
+    (
+        "vcfa.vra8.deployment.get",
+        "/deployment/api/deployments/dep-123",
+        {"deployment_id": "dep-123"},
+        {"id": "dep-123", "inprogressRequests": []},
+    ),
+    ("vcfa.vra8.blueprint.list", "/blueprint/api/blueprints", {}, {"content": [{"id": "bp-a"}]}),
+    (
+        "vcfa.vra8.catalog-item.list",
+        "/catalog/api/admin/items",
+        {},
+        {"content": [{"id": "ci-a"}]},
+    ),
+    ("vcfa.vra8.about", "/iaas/api/about", {}, {"latestApiVersion": "2021-07-15"}),
+]
+
+
+@pytest.mark.parametrize(("op_id", "path", "params", "payload"), _DISPATCH_CASES, ids=lambda v: v)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+    params: dict[str, Any],
+    payload: Any,
+) -> None:
+    """Each read dispatches typed (zero ingested catalog), minting the two-step session."""
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_VRA_BASE_URL, assert_all_called=False) as mock:
+        csp = mock.post(_CSP_LOGIN_PATH).respond(200, json={"refresh_token": "rt"})
+        iaas = mock.post(_IAAS_LOGIN_PATH).respond(200, json={"token": "disp-bt"})
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=VRA8_CONNECTOR_ID,
+            op_id=op_id,
+            target=_Vra8ReadTarget(),
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert csp.called and iaas.called
+    assert route.called and route.call_count == 1
+    data_req = route.calls[0].request
+    # The minted bearer + the constant JSON Accept rode the data call.
+    assert data_req.headers["Authorization"] == "Bearer disp-bt"
+    assert data_req.headers["Accept"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_data_path_401_remints_via_dispatcher(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """A data-path 401 (expired bearer) self-heals via the dispatcher's session-recovery arm.
+
+    The load-bearing 401-recovery proof — the coverage the isolated eviction tests
+    can't give. A stale bearer gets a 401 on the data read; the dispatcher evicts it
+    via the connector's ``invalidate_session`` hook and re-dispatches once; the retry
+    re-runs the two-step login and the op succeeds. Without ``invalidate_session`` on
+    the connector this would fall through to ``connector_auth_failed`` and wedge on
+    the stale token (dispatcher #2067) — so a green here proves the hook is wired to
+    the arm the 401 path actually calls, not the establish-only
+    ``invalidate_credentials``.
+    """
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_VRA_BASE_URL) as mock:
+        csp = mock.post(_CSP_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"refresh_token": "rt-1"}),
+                httpx.Response(200, json={"refresh_token": "rt-2"}),
+            ]
+        )
+        iaas = mock.post(_IAAS_LOGIN_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"token": "bt-stale"}),
+                httpx.Response(200, json={"token": "bt-fresh"}),
+            ]
+        )
+        projects = mock.get("/iaas/api/projects").mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(200, json={"content": [{"name": "proj-a"}]}),
+            ]
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=VRA8_CONNECTOR_ID,
+            op_id="vcfa.vra8.project.list",
+            target=_Vra8ReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"content": [{"name": "proj-a"}]}
+    # Minted once, 401'd, re-minted (both steps), retried once → 2 logins each + 2 GETs.
+    assert csp.call_count == 2
+    assert iaas.call_count == 2
+    assert projects.call_count == 2
+    # The first data GET carried the stale bearer; the retry carried the fresh one.
+    assert projects.calls[0].request.headers["Authorization"] == "Bearer bt-stale"
+    assert projects.calls[1].request.headers["Authorization"] == "Bearer bt-fresh"
+
+
+# ---------------------------------------------------------------------------
+# Registration-shape invariants — the "merge = fix" property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_typed_and_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 6 reads persist as source_kind='typed', is_enabled=True (live on fresh boot)."""
+    await register_vra8_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == VRA8_PRODUCT,
+                    EndpointDescriptor.impl_id == VRA8_IMPL_ID,
+                    EndpointDescriptor.op_id.in_(list(_EXPECTED_OP_IDS)),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == _EXPECTED_OP_IDS
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.is_enabled is True for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+    # Typed ops carry no wire method/path on the descriptor (path lives in the handler).
+    assert all(r.method is None and r.path is None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_groups_are_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 2 read-core groups land review_status='enabled' with a curated when_to_use."""
+    await register_vra8_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(OperationGroup).where(
+                    OperationGroup.product == VRA8_PRODUCT,
+                    OperationGroup.impl_id == VRA8_IMPL_ID,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {g.group_key for g in rows} == _EXPECTED_GROUPS
+    assert all(g.review_status == "enabled" for g in rows)
+    assert all(g.when_to_use.strip() for g in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed reads are retrievable via search_operations."""
+    await register_vra8_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {
+            "connector_id": VRA8_CONNECTOR_ID,
+            "query": "vra vrealize automation 8 project deployment blueprint catalog inventory",
+            "limit": 25,
+        },
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    assert found >= _EXPECTED_OP_IDS, f"missing from search: {_EXPECTED_OP_IDS - found}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-dataclass invariants (no DB, no async)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_table_is_exactly_the_read_core() -> None:
+    assert {op.op_id for op in VRA8_TYPED_OPS} == _EXPECTED_OP_IDS
+    assert len(VRA8_TYPED_OPS) == 6
+
+
+def test_every_group_key_has_a_when_to_use() -> None:
+    assert set(VRA8_TYPED_WHEN_TO_USE_BY_GROUP) == _EXPECTED_GROUPS
+    used_groups = {op.group_key for op in VRA8_TYPED_OPS}
+    assert used_groups == _EXPECTED_GROUPS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in VRA8_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_canonical_keys(op_id: str) -> None:
+    op = next(o for o in VRA8_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    for key in ("when_to_call", "output_shape", "next_step"):
+        value = op.llm_instructions.get(key)
+        assert isinstance(value, str) and value.strip(), f"{op_id}: {key}"
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in VRA8_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+def test_deployment_get_requires_deployment_id() -> None:
+    """The only by-id read declares deployment_id required; the rest take no required param."""
+    get_op = next(o for o in VRA8_TYPED_OPS if o.op_id == "vcfa.vra8.deployment.get")
+    assert get_op.parameter_schema.get("required") == ["deployment_id"]
+    for op in VRA8_TYPED_OPS:
+        if op.op_id != "vcfa.vra8.deployment.get":
+            assert "required" not in op.parameter_schema or op.parameter_schema["required"] == []
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only core: no create/write op ships here."""
+    for op in VRA8_TYPED_OPS:
+        assert not any(
+            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
+        )
+        assert "write" not in op.tags

--- a/docs/codebase/connectors-vra8.md
+++ b/docs/codebase/connectors-vra8.md
@@ -1,0 +1,294 @@
+# Connector: vra8 (vRealize Automation 8.x, legacy dual-impl of `vcfa`)
+
+## Overview
+
+The `vra8` connector is the hand-rolled `HttpConnector` subclass that makes
+**vRealize Automation 8.x** (vRA 8) dispatchable under the
+`(product="vcfa", version="8.0", impl_id="vcfa-vra8")` registry triple. It is the
+**legacy dual-impl** of `product="vcfa"` filed under the legacy migration-source
+connector-coverage initiative
+([#3056](https://github.com/evoila/meho/issues/3056), task #3058): vRA 8 is a
+migration **source** estate evoila brings customers *off*, so MEHO must be able to
+read and inventory it during discovery + onboarding.
+
+Source: `backend/src/meho_backplane/connectors/vra8/`.
+
+**vRA 8 is the same product line as VCF Automation 9, one major version back.**
+vRealize Automation 8 → Aria Automation → VCF Automation 9 is a rename lineage
+across a major-version rebuild. So this is a **second implementation of
+`product="vcfa"`** (the modern impl is
+[`connectors-vcf-automation.md`](connectors-vcf-automation.md), `vcfa-rest`),
+fingerprint-resolved per target — the **second real two-impl case after `fleet`**
+(policy [#3033](https://github.com/evoila/meho/issues/3033) / #3038). The auth
+flows and read surfaces diverge enough between the two versions (see below) that a
+single connector cannot cleanly serve both — exactly the bifurcation the
+dual-version policy exists for.
+
+## Dual-impl resolution (`vcfa` = second two-impl case)
+
+| Impl | Class | Band | Wildcard |
+|---|---|---|---|
+| modern `vcfa-rest` | `VcfAutomationConnector` | `>=9.0,<10.0` | **owns** `("vcfa","","")` |
+| legacy `vcfa-vra8` | `Vra8Connector` | `>=8.0,<9.0` | none |
+
+The two bands are **disjoint**, so resolution never reaches a specificity
+tie-break (unlike `fleet`, whose bands overlap): an 8.x target has exactly one
+in-range versioned candidate (legacy), a 9.x target exactly one (modern). No
+re-band of the modern impl was needed.
+
+**The wildcard inversion vs `fleet`.** In the `fleet` case the *legacy* `vcf_fleet`
+owns the `("fleet","","")` wildcard; here the *modern* `vcf_automation` owns
+`("vcfa","","")` (it shipped first, as the sole impl). So the new legacy `vcfa-vra8`
+registers **only** its versioned triple — a second class on the wildcard key would
+crash `_eager_import_connectors` at boot. Consequence: an *unfingerprinted* /
+unversioned `vcfa` target resolves to **modern** `vcfa-rest`, so a vRA 8 target
+**must carry an 8.x product version operator-asserted at onboarding** (e.g.
+`--version 8.12`) to resolve to this legacy impl — the fingerprint reports the API
+version, not a resolvable product version, so it cannot auto-populate it. The full
+resolution matrix is pinned in
+[`test_connectors_vra8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vra8_dual_impl_resolution.py).
+
+## Scope: typed read core (#3058)
+
+The connector ships a curated **6-op typed read core** — the migration-inventory
+surface — registered as `source_kind="typed"` and **enabled at register time**, so
+a vRA 8 target dispatches an inventory read on a **fresh boot with zero catalog
+ingest**.
+
+| Group | Ops |
+|---|---|
+| `vcfa-vra8-inventory` | `vcfa.vra8.project.list`, `.deployment.list`, `.deployment.get`, `.about` |
+| `vcfa-vra8-content` | `vcfa.vra8.blueprint.list`, `.catalog-item.list` |
+
+Op ids are namespaced `vcfa.vra8.*` (distinct from the modern impl's
+`vcfa.provider.*` / `vcfa.tenant.*`): the two impls publish different read surfaces
+and the resolver picks one per target, so an agent only ever sees the set matching
+the target's version.
+
+**Why typed, not ingested.** `vmware/vra-sdk-go` (Apache-2.0) *does* publish
+machine-readable specs for the vRA 8 services (IaaS / Service Broker / Blueprint /
+Project) — but they are **Swagger 2.0**, and MEHO's ingest parser accepts OpenAPI
+3.0/3.1 only (#2090). So the surface cannot be operator-ingested as a generic
+connector; the read core is **typed** (CLAUDE.md postulate 1), the
+`vcf-automation` tenant-plane / `fleet-lcm` / `vcd` posture. There is therefore no
+wider `source_kind="ingested"` breadth to follow up: the typed read core **is** the
+connector's surface.
+
+**Migration-relevant surface.** The read core covers projects (tenancy/quota),
+deployments (running workloads) with a by-id detail read, blueprints (IaC
+definitions), catalog items (self-service offerings), and the appliance's API
+capabilities. **Requests** are read via `deployment.get`'s embedded `lastRequest` /
+`inprogressRequests` (the pre-cutover quiescence signal) rather than a standalone
+op — vRA 8 has **no top-level list-all-requests endpoint** (confirmed by
+enumerating `vra-catalog-deployment.json`; only `/deployment/api/requests/{id}` and
+per-deployment `/requests` exist).
+
+**Live-appliance dispatch verification is the deferred tail.** No vRA 8 lab was
+dialled during the build; the read core is unit-tested end-to-end against a
+respx-mocked vRA 8 (dispatch `status="ok"` through the two-step session-mint seam)
+and manifest-pinned — the same unit-tested-first posture `vcd` / `fleet-lcm`
+shipped with.
+
+## Key types
+
+- **`Vra8Connector`** (`connector.py`) — `HttpConnector` subclass. Class
+  attributes: `product="vcfa"`, `version="8.0"`, `impl_id="vcfa-vra8"`,
+  `supported_version_range=">=8.0,<9.0"`, `priority=1`. `connector_id`
+  `"vcfa-vra8-8.0"` parses back to `("vcfa", "8.0", "vcfa-vra8")` (`product` = first
+  hyphen-segment of `impl_id`, the round-trip invariant `register_connector_v2`
+  enforces).
+- **`Vra8TargetLike`** / **`Vra8CredentialsLoader`** (`session.py`) — aliases of the
+  shared `VcfTargetLike` Protocol and `VcfCredentialsLoader` type. The loader is
+  injectable on construction (`Vra8Connector(credentials_loader=...)`) for unit /
+  integration tests. vRA 8's optional CSP `domain` is read via `getattr` (local
+  users omit it).
+- **`load_credentials_from_vault`** (`session.py`) — the shared operator-context
+  KV-v2 read, re-exported. Returns the `{username, password}` pair.
+- Canonical constants (`__init__.py`): `VRA8_PRODUCT`, `VRA8_VERSION`,
+  `VRA8_IMPL_ID`, `VRA8_CONNECTOR_ID`.
+
+The connector reuses `is_acceptable_auth_model`, `session_establish_auth_error`,
+and `ConnectorAuthError` from `meho_backplane.connectors._shared.vcf_auth`.
+
+## Control flow
+
+### Registration
+
+Importing `meho_backplane.connectors.vra8` registers **only** the versioned triple
+`register_connector_v2(product="vcfa", version="8.0", impl_id="vcfa-vra8", ...)` —
+**not** a wildcard (the modern `vcf_automation` owns `("vcfa","","")`; see the
+inversion above). Both the legacy `vra8` package and the modern `vcf_automation`
+package register under `product="vcfa"` at eager-import — the `vcf_fleet` +
+`fleet_lcm` shape.
+
+### Auth (two-step CSP → IaaS token exchange, single bearer)
+
+vRA 8 mints a bearer via a **two-step** exchange, distinct from VCFA 9's
+`/cloudapi/1.0.0/sessions/provider` + `/oauth/*` flow (the divergence that
+justifies a separate impl). On first use `auth_headers`:
+
+1. Rejects any `target.auth_model` other than `shared_service_account` / `None` via
+   the shared `is_acceptable_auth_model`.
+2. Fails closed on an empty `operator.raw_jwt` (a system-initiated call cannot read
+   per-target vendor credentials) — enforced **before** the token-cache lookup so a
+   primed token can never leak to an unauthenticated caller.
+3. Mints the session (`_auth.vra8_login`), two steps:
+   - **CSP identity** — `POST /csp/gateway/am/api/login?access_token` with
+     `{username, password, domain?}` → a long-lived `refresh_token` (snake_case) in
+     the response body.
+   - **IaaS token exchange** — `POST /iaas/api/login` with `{refreshToken}`
+     (camelCase — note the case flip) → a short-lived (~8h) bearer `token` in a
+     `{tokenType, token}` response body.
+   A 401/403 at *either* step maps to the structured `ConnectorAuthError`; a
+   missing token field on a 2xx raises.
+4. Caches the bearer per tenant-unique `(tenant_id, target.id)` key under a lock and
+   returns `Authorization: Bearer <token>` (path-independent — the one bearer
+   authenticates every vRA 8 service).
+
+Reads add a constant `Accept: application/json` via `_vra_get` (no per-surface
+negotiation, unlike `vcd`). A raw 401 (expired bearer) propagates to the
+dispatcher's session-recovery arm, which — because the connector advertises an
+`invalidate_session` hook (the SDDC Manager / NSX / vcd session-minting precedent,
+#2067) — evicts the cached bearer and re-dispatches once, so the retry re-runs the
+two-step login. No in-connector retry loop; the base transport's tenacity retry
+(5xx / connection only) stays intact for the flaky-legacy-appliance-over-VPN case.
+(`invalidate_credentials` is also implemented — the #2396 establish-failure
+companion — but the data-path 401 recovery is keyed on `invalidate_session`; a
+connector that implements only the former wedges permanently on an expired token,
+so the wiring is proven end-to-end in
+`test_data_path_401_remints_via_dispatcher`.) The refresh token is not cached
+separately — a 401 eviction re-runs both steps, which is rare (only on the ~8h
+bearer's expiry).
+
+### Fingerprint / probe
+
+`GET /iaas/api/about` is vRA 8's IaaS API-capabilities endpoint (the same surface
+the VCFA tenant probe reads). `fingerprint` reads it **without minting a session**
+(pure reachability) and returns a reachable `FingerprintResult` (`vendor="vmware"`,
+`product="vcfa"`). `version` is left `None`: `/iaas/api/about` reports the *API*
+version (a date label, e.g. `2021-07-15`), not the product build (8.11 vs 8.18),
+and the connector does not fabricate a resolvable product version from a date —
+dual-impl resolution relies on the **operator-asserted target version** (see
+above). `extras["latest_api_version"]` carries the reported label for information.
+On any transport/status failure it returns a non-reachable result carrying
+`extras["error"]`. `probe()` delegates to `fingerprint()`.
+
+### Dispatch
+
+The typed read-core ops dispatch through `meho_backplane.operations.dispatch`: the
+dispatcher resolves the persisted `module.ClassName.method` handler_ref to the
+connector's bound-method shim, threads `operator` / `target` / `params`, and the
+handler issues an authenticated `GET` via `_vra_get`. `execute()` is the G0.6
+ABC-compatibility shim.
+
+## Typed read core internals
+
+The read core follows the `vcd` / `fleet-lcm` layout:
+
+- **`typed_ops.py`** — the `Vra8TypedOp` dataclass table (`VRA8_TYPED_OPS`), the
+  per-group `when_to_use` map (`VRA8_TYPED_WHEN_TO_USE_BY_GROUP`), and the
+  module-level `register_vra8_typed_operations(*, embedding_service=None)`
+  registrar. The list ops declare optional `$top` / `$skip` pagination params;
+  `deployment.get` declares a required `deployment_id`.
+- **`typed_reads.py`** — the op bodies (`async def vra8_*_impl(connector, operator,
+  target, params)`), each issuing `connector._vra_get(...)`; the list reads forward
+  `odata_list_query(params)`, and `deployment.get` percent-encodes the id into the
+  path.
+- **`_llm_instructions.py`** — the per-op `llm_instructions` blobs (`when_to_call` /
+  `output_shape` / `next_step`), keyed by op id; framed around inventorying a
+  migration-source estate, with explicit pagination guidance.
+- **`_paths.py`** — the request-path constants (`_CSP_LOGIN_PATH`,
+  `_IAAS_LOGIN_PATH`, `_ABOUT_PATH`, `_PROJECTS_PATH`, `_DEPLOYMENTS_PATH`,
+  `_DEPLOYMENT_DETAIL_PATH`, `_BLUEPRINTS_PATH`, `_CATALOG_ITEMS_PATH`) and the
+  `odata_list_query` helper. The reconcile lane introspects the `_*_PATH` constants.
+- **`_auth.py`** — `vra8_login` (the two-step wire POSTs) + the CSP / IaaS step
+  helpers.
+- **`connector.py`** — 6 thin bound-method shims (`project_list`, `deployment_list`,
+  …) that lazily import and delegate to their `_impl` body.
+
+`register_typed_operation` creates each `OperationGroup` (`review_status=
+"enabled"`) and inserts each descriptor `source_kind="typed"`, `is_enabled=True`,
+`method=None` / `path=None`. So the read core needs no operator review — it is live
+the moment the connector loads.
+
+**Pagination.** vRA 8's list surfaces are server-paged (a `{content: [],
+totalElements, numberOfElements, ...}` wrapper). The reads forward `$top` / `$skip`
+and each list op's `output_shape` tells the agent to check `totalElements` and page
+— a default (first-page) call is never a *silent* truncation because the wrapper
+self-describes the total. Sorting/filtering is done through the JSONFlux result
+handle (`result_query` / `result_aggregate`), not vendor query params (MEHO
+postulate 6); `$orderby` is deliberately not forwarded — vRA 8's casing for it is
+not uniform across services (IaaS `$orderBy` vs `$orderby`).
+
+## Spec reconcile lane
+
+[`backend/tests/test_connectors_vra8_spec_reconcile.py`](../../backend/tests/test_connectors_vra8_spec_reconcile.py)
+is a **manifest pin + evidenced exclusion** (not a served-op-id compare). A
+committable spec *does* exist (`vra-sdk-go` Swagger 2.0), but MEHO's ingest is
+OA3-only (#2090) so it is not operator-ingestable, and the CSP login endpoint is
+not in the SDK at all. The lane sweeps the connector's live `_*_PATH` constants
+(the #2944 introspect-live-constants pattern) and pins the exact hand-coded surface
+unconditionally, so a new hand-coded path / renamed constant / method change must
+update the manifest consciously. **Strengthening (deferred):** the sibling
+`vcf-automation` tenant lane shelf-arms its `/iaas/*` paths against the Swagger 2.0
+`vra-iaas.json`; the same could arm this connector's `/iaas` + `/deployment` +
+`/blueprint` + `/catalog` paths against the three vra-sdk-go swaggers once shelved.
+Full evidence + activation trigger live in the `vcfa-vra8` entry of
+[`spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` — pooled
+  `httpx.AsyncClient` per target, retry-on-idempotent transport, base-URL
+  composition, `extra_headers` seam.
+- `meho_backplane.connectors._shared.vcf_auth` — `is_acceptable_auth_model`,
+  `session_establish_auth_error`, `ConnectorAuthError`, the `VcfTargetLike` /
+  `VcfCredentialsLoader` aliases, `load_credentials_from_vault`.
+- `meho_backplane.connectors._shared.cache_key.target_cache_key`,
+  `meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`.
+- `meho_backplane.connectors.schemas` — `AuthModel`, `FingerprintResult`,
+  `ProbeResult`, `OperationResult`.
+- `httpx`, `respx` (test-only). No new runtime deps.
+
+## Known issues / follow-ups
+
+- **Live dispatch not verified against a real appliance.** No vRA 8 lab was dialled
+  during the build; the read core is unit-tested end-to-end (dispatch through the
+  two-step session-mint seam against a respx mock) and manifest-pinned. Live
+  verification against a vRA 8.x source appliance (and confirming the exact
+  `?access_token` bare-flag wire form + the CSP `domain` value for the target
+  estate) is the deferred tail.
+- **API version is server-default.** The reads pass no `apiVersion` query param, so
+  the appliance uses its default (reads are backward-compatible). Pinning a
+  per-service `apiVersion` (IaaS `2021-07-15`, Service Broker `2020-08-25`,
+  Blueprint `2019-09-12`) is a robustness follow-up.
+- **List-focused read core.** Deep by-id reads beyond `deployment.get`, a
+  standalone requests surface (vRA 8 has no list-all-requests endpoint — read via
+  `deployment.get`), and any write surface are out of scope — a list-focused
+  inventory core for migration discovery.
+- **Unfingerprinted targets resolve to modern.** Because the modern impl owns the
+  `("vcfa","","")` wildcard, a `vcfa` target with no operator-asserted version
+  resolves to `vcfa-rest`, not this legacy impl. A vRA 8 source must be onboarded
+  with an 8.x `version`.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/3058>
+- Parent initiative (legacy migration-source coverage):
+  <https://github.com/evoila/meho/issues/3056>
+- Dual-version / coverage policy of record:
+  <https://github.com/evoila/meho/issues/3033>
+- Read-core tests:
+  [`test_connectors_vra8_auth.py`](../../backend/tests/test_connectors_vra8_auth.py)
+  (two-step mint + fingerprint),
+  [`test_connectors_vra8_typed_reads.py`](../../backend/tests/test_connectors_vra8_typed_reads.py)
+  (dispatch + registration + 401 self-heal),
+  [`test_connectors_vra8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vra8_dual_impl_resolution.py)
+  (the two-impl resolution matrix), and
+  [`test_connectors_vra8_spec_reconcile.py`](../../backend/tests/test_connectors_vra8_spec_reconcile.py)
+  (manifest pin).
+- Modern sibling impl (same `product="vcfa"`):
+  [`connectors-vcf-automation.md`](connectors-vcf-automation.md)
+- First two-impl case (the resolver-ladder precedent):
+  [`connectors-fleet-lcm.md`](connectors-fleet-lcm.md)
+- Typed read-core exemplar: [`connectors-vcd.md`](connectors-vcd.md)

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -387,6 +387,57 @@ is proven on every run, with no served-op-id compare.
   service being evidenced. The activating task runs the full extension
   mechanics and reconciles the four op_ids on first run.
 
+### vcfa-vra8 — manifest-pin, Swagger-2.0 spec exists but OA3-only ingest (#3058)
+
+The `vcfa-vra8` (vRealize Automation 8.x) connector is the **legacy
+dual-impl** of `product="vcfa"` (initiative
+[#3056](https://github.com/evoila/meho/issues/3056), task #3058; the
+modern `vcfa-rest` provider/tenant lane is `vcf-automation-9.0` above).
+Its lane (`backend/tests/test_connectors_vra8_spec_reconcile.py`) is a
+**manifest pin only** — it sweeps the eight hand-coded op_ids
+unconditionally so the enumeration is proven on every run, with no
+served-op-id compare. **This exclusion differs from `vcd` above: a
+committable spec _does_ exist — it just isn't ingestable.**
+
+- **Excluded (8 op_ids: `POST:/csp/gateway/am/api/login`,
+  `POST:/iaas/api/login`, `GET:/iaas/api/about`, `GET:/iaas/api/projects`,
+  `GET:/deployment/api/deployments`,
+  `GET:/deployment/api/deployments/{deployment_id}`,
+  `GET:/blueprint/api/blueprints`, `GET:/catalog/api/admin/items`).**
+  What was checked: (1) **the five `/iaas` + `/deployment` + `/blueprint`
+  + `/catalog` read paths** are served by the Apache-2.0
+  [`vmware/vra-sdk-go`](https://github.com/vmware/vra-sdk-go) swaggers
+  (`vra-iaas.json`, `vra-catalog-deployment.json`, `vra-blueprint.json`,
+  tag `v0.6.5`) — but those are **Swagger 2.0**, which the ingest parser
+  rejects by decision (#2090), so they are not operator-ingestable (hence
+  the typed read core) and there is no OA3 artifact to route through
+  `openapi_served_op_ids`. (2) **The two login endpoints** are outside
+  vra-sdk-go entirely: `POST /iaas/api/login` is the IaaS token exchange
+  (present in `vra-iaas.json`, but a POST the read-lane doesn't reconcile),
+  and `POST /csp/gateway/am/api/login` is the **CSP identity service**,
+  which no vra-sdk-go spec covers (CSP identity is a separate vIDM
+  surface). So no single artifact can serve a reconcile authority for the
+  full eight without false reds. **Residual risk, named** (the nsx
+  lesson): this task ran no live probe of a vRA 8 appliance — live
+  end-to-end verification against a vRA 8.x source appliance is the
+  deferred tail (the same unit-tested-first posture `vcd` / `fleet-lcm`
+  shipped with).
+- **Strengthening (available, deferred):** unlike `vcd`, the read paths
+  here _are_ served by a vendored Swagger 2.0 artifact, so the sibling
+  `vcf-automation-9.0` lane's shelf-armed pattern applies — a
+  `_swagger2_served_op_ids` extractor (the non-OpenAPI-artifact clause,
+  already used for the VCFA tenant plane against `vra-iaas.json`) crossing
+  the `/iaas` + `/deployment` + `/blueprint` + `/catalog` op_ids against
+  the three vra-sdk-go swaggers, shelved under `vcfa-vra8-8.0/`. That layer
+  skips when the shelf is unconfigured (the default sweep), so it was
+  deferred in favour of the tested always-on manifest pin; the CSP + IaaS
+  login POSTs stay excluded regardless.
+- **Activation:** shelving the three vra-sdk-go swaggers under
+  `vcfa-vra8-8.0/` and adding the served-set compare for the read paths
+  (the login POSTs remain evidenced exclusions), or MEHO gaining a
+  Swagger-2.0→OA3 ingest path (#2090) that makes the surface
+  operator-ingestable as a generic connector.
+
 ## Red lane = finding (the protocol)
 
 A red lane on first run against the real shelf is **the guard working**,


### PR DESCRIPTION
## What

The **legacy dual-impl for vRealize Automation 8.x** (vRA 8) — the **second real two-impl case** for a product (after `fleet`). vRA 8 is the direct predecessor of VCF Automation 9.x (`vcfa-rest`); the same product line, one major version back. So this registers a second implementation of `product="vcfa"` (`impl_id="vcfa-vra8"`, band `>=8.0,<9.0`), fingerprint-resolved against the modern `vcfa-rest` (`>=9.0,<10.0`).

Part of the legacy migration-source connector-coverage initiative (#3056): vRA 8 is a migration **source** estate MEHO must read/inventory during discovery + onboarding.

Closes #3058.

## Shape

- **Typed read core, 6 ops** across 2 groups — `vcfa.vra8.project.list` / `.deployment.list` / `.deployment.get` / `.about` (inventory) and `.blueprint.list` / `.catalog-item.list` (content). Registered `source_kind="typed"`, enabled at register time → **dispatches on a fresh boot with zero catalog ingest.** Typed because `vmware/vra-sdk-go` ships **Swagger 2.0** and MEHO's ingest is OA3-only (#2090).
- **Dual-impl resolution.** Bands are **disjoint** (no re-band of the modern impl, no specificity tie). This impl registers **only** its versioned triple — the modern `vcf_automation` owns the `("vcfa","","")` wildcard (the *inversion* of the `fleet` case), so an unfingerprinted target resolves to modern; a vRA 8 target must carry an 8.x operator-asserted version. Full matrix pinned in `test_connectors_vra8_dual_impl_resolution.py`.
- **Two-step token exchange.** `POST /csp/gateway/am/api/login` → `refresh_token`, then `POST /iaas/api/login` → bearer; one bearer authenticates all vRA 8 services. A data-path 401 self-heals via the dispatcher's `invalidate_session` arm (proven end-to-end, negative-control validated during review).
- **Reconcile lane:** manifest-pin + honest evidenced-exclusion (a Swagger-2.0 spec *exists* but is OA3-ingest-incompatible; CSP login is outside the SDK). Entry added to `spec-reconcile-guards-standard.md`.

## Verification

- 66 unit tests (auth / typed-reads dispatch / dual-impl resolution / reconcile); ruff + mypy clean.
- 4331-test broad connector sweep green (only the 2 pre-existing real-DNS/ICMP sandbox failures, unrelated to this additive change).
- Connector-id round-trip + product-enum meta-tests pass — **no CLI OpenAPI snapshot regen** (product `vcfa` reused, enum unchanged).
- Adversarially reviewed by an independent agent; two spec-confirmed correctness fixes applied before this PR: CSP `domain` now read from `extras["domain"]` (the model has no `domain` column), and the mis-cased vendor `$orderby` dropped in favour of JSONFlux-handle sorting (postulate 6).

## Deferred tails (documented in `connectors-vra8.md`)

- Live-appliance verification (no vRA 8 lab was dialled during the build).
- Per-service `apiVersion` pinning (reads use the server default today).
- Shelf-armed served-set reconcile against the vra-sdk-go swaggers (a strengthening over the manifest pin).

## Docs

- `docs/codebase/connectors-vra8.md` (full connector doc).
- `docs/decisions/spec-reconcile-guards-standard.md` (`vcfa-vra8` evidenced-exclusion entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
