### PR TITLE
feat(sddc-vcf5): VCF 5.x SDDC Manager legacy dual-impl read core (7 ops) (#3059)

### DIFF
--- a/backend/src/meho_backplane/connectors/sddc_vcf5/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_vcf5/__init__.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.sddc_vcf5 — SddcVcf5Connector package.
+
+Importing this package registers :class:`SddcVcf5Connector` against the v2 connector
+registry as the **legacy dual-impl** for **VCF 5.x SDDC Manager** — the
+migration-source estate evoila brings customers off (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3059). It is
+a **second implementation of ``product="sddc"``** (sibling to the modern 9.x
+:mod:`meho_backplane.connectors.sddc_manager`, ``sddc-rest``), fingerprint-resolved
+per target — the same ``vcf_fleet`` + ``fleet_lcm`` shape.
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<subpackage>/`` at startup, so both this legacy package and the
+modern ``sddc_manager`` package register under ``product="sddc"`` (distinct
+``impl_id``s) before any dispatch can occur.
+
+**Only the versioned triple is registered — NOT the ``("sddc","","")`` wildcard.**
+The wildcard is already owned by the modern ``sddc_manager`` package (a second class
+on that key would raise ``RuntimeError`` at boot). This is the *inversion* of the
+``fleet`` case: here the modern impl owns the wildcard, so an *unfingerprinted* /
+unversioned ``sddc`` target resolves to modern ``sddc-rest``. In practice a VCF 5.x
+target fingerprints straight into the ``>=5.0,<9.0`` band (SDDC Manager exposes a
+real product version at ``GET /v1/sddc-managers``), so it resolves to this legacy
+impl without needing an operator-asserted version. The bands are **disjoint** (legacy
+``>=5.0,<9.0`` vs modern ``>=9.0,<10.0``), so no specificity tie — see
+:mod:`tests.test_connectors_sddc_vcf5_dual_impl_resolution`.
+
+The ``product`` token is ``"sddc"`` and ``impl_id`` is ``"sddc-vcf5"`` because
+``register_connector_v2`` enforces that ``product`` equals the first hyphen-segment
+of ``impl_id`` — the round-trip invariant. ``connector_id`` ``"sddc-vcf5-5.0"``
+parses back to ``("sddc", "5.0", "sddc-vcf5")``.
+
+This package registers a curated **7-op typed read core** (#3059, :mod:`.typed_ops`)
+via :func:`register_typed_op_registrar`, so a VCF 5.x target dispatches a
+migration-inventory read on a fresh boot with zero catalog ingest. Because 5.x
+publishes only a Swagger 2.0 definition (OA3-only ingest can't consume it — typed,
+not ingested), a wider ingested breadth surface is not a follow-up here — the read
+core is the connector's surface.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.sddc_manager.session import (
+    SddcCredentialsLoader,
+    SddcTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.sddc_vcf5.connector import SddcVcf5Connector
+from meho_backplane.connectors.sddc_vcf5.typed_ops import (
+    SDDC_VCF5_TYPED_OPS,
+    SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP,
+    SddcVcf5TypedOp,
+    register_sddc_vcf5_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the VCF 5.x SDDC Manager connector — the
+#: dispatch-canonical ``(product, version, impl_id)`` triple :func:`parse_connector_id`
+#: derives from ``"sddc-vcf5-5.0"``, plus the derived ``connector_id`` slug. ``product``
+#: is shared with the modern ``sddc-rest`` (``sddc``); the ``impl_id`` disambiguates.
+SDDC_VCF5_PRODUCT: Final[str] = "sddc"
+SDDC_VCF5_VERSION: Final[str] = "5.0"
+SDDC_VCF5_IMPL_ID: Final[str] = "sddc-vcf5"
+SDDC_VCF5_CONNECTOR_ID: Final[str] = f"{SDDC_VCF5_IMPL_ID}-{SDDC_VCF5_VERSION}"
+
+
+register_connector_v2(
+    product=SDDC_VCF5_PRODUCT,
+    version=SDDC_VCF5_VERSION,
+    impl_id=SDDC_VCF5_IMPL_ID,
+    cls=SddcVcf5Connector,
+)
+
+# NO wildcard registration. The ``("sddc","","")`` key is owned by the modern
+# ``sddc_manager`` package; a second class on it would raise RuntimeError at boot (the
+# ``fleet_lcm`` no-wildcard shape, inverted — there the legacy owns the wildcard, here
+# the modern does). An unfingerprinted ``sddc`` target resolves to modern
+# ``sddc-rest``; a fingerprinted 5.x target resolves here.
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# iterates after ``_eager_import_connectors`` so the typed descriptor rows land before
+# the first dispatch — the VCF 5.x read core dispatches on a fresh boot with zero
+# catalog ingest (#3059).
+register_typed_op_registrar(register_sddc_vcf5_typed_operations)
+
+__all__ = [
+    "SDDC_VCF5_CONNECTOR_ID",
+    "SDDC_VCF5_IMPL_ID",
+    "SDDC_VCF5_PRODUCT",
+    "SDDC_VCF5_TYPED_OPS",
+    "SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP",
+    "SDDC_VCF5_VERSION",
+    "SddcCredentialsLoader",
+    "SddcTargetLike",
+    "SddcVcf5Connector",
+    "SddcVcf5TypedOp",
+    "load_credentials_from_vault",
+    "register_sddc_vcf5_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/sddc_vcf5/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_vcf5/connector.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""SddcVcf5Connector — hand-rolled HttpConnector subclass for VCF 5.x SDDC Manager.
+
+The **legacy dual-impl** for **SDDC Manager 5.x** (the SDDC Manager tier of a VMware
+Cloud Foundation 5.x estate) — the migration-source estate evoila brings customers
+*off* (initiative `evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_,
+task #3059). It is a ``product="sddc"`` **second implementation**
+(``impl_id="sddc-vcf5"``, band ``>=5.0,<9.0``), sibling to the modern
+:mod:`~meho_backplane.connectors.sddc_manager` (``sddc-rest``, ``>=9.0,<10.0``) — the
+resolver picks this legacy impl for a VCF 5.x target by fingerprint and the modern
+one for a 9.x target. The bands are **disjoint**, so no re-band and no specificity
+tie; the ``("sddc","","")`` wildcard is owned by the **modern** package (the ``fleet``
+inversion), so an unfingerprinted ``sddc`` target resolves to modern.
+
+Why a separate impl (not just widen the modern band)
+----------------------------------------------------
+
+SDDC Manager's REST *path* surface is stable since VCF 4.0 — the ``/v1/*`` reads here
+are the same shapes the modern connector reads. The split is driven by **spec format
++ schema drift**: 5.x publishes only a Swagger 2.0 definition (appliance-served,
+non-conformant), while OpenAPI 3.x is a VCF-9.0-net-new deliverable (the
+``vmware/vcf-api-specs`` repo is tagged 9.0/9.1 only). So 5.x cannot be operator-
+ingested (MEHO's parser is OA3-only, #2090) — hence a **typed** read core (like
+``vcd`` / ``vcfa-vra8``) — and its response schemas differ enough by point release
+(e.g. ``ipAddress`` deprecated in 5.2) that the 9.x connector cannot faithfully serve
+a 5.x target.
+
+Auth — token session (``POST /v1/tokens``)
+------------------------------------------
+
+Identical to the modern 9.x flow (token auth is VCF 4.0+): SDDC Manager rejects HTTP
+Basic outright and mints a bearer via ``POST /v1/tokens`` with a ``{username,
+password}`` JSON body, returning ``accessToken`` (sent as ``Authorization: Bearer
+<accessToken>``). The login round-trip reuses the shared
+:func:`~meho_backplane.connectors._shared.vcf_auth.vcf_session_login` helper (a
+non-2xx / token-less 2xx raises the target-named :exc:`SessionLoginError`), the same
+helper the modern ``sddc_manager`` connector uses. The per-target token is cached
+under a lock and minted lazily on first use; an empty ``operator.raw_jwt`` fails
+closed **before** the cache lookup (a system-initiated call cannot read per-target
+vendor credentials). On a downstream ``401`` the dispatcher's session-recovery arm
+calls :meth:`invalidate_session` (#2067) and re-dispatches once; the fingerprint,
+which the dispatcher does not drive, has its own :meth:`_get_json_with_session_retry`.
+
+Fingerprint
+-----------
+
+SDDC Manager has **no unauthenticated version endpoint**, so :meth:`fingerprint`
+reads ``GET /v1/sddc-managers`` on the token session (via the session-retry helper)
+and takes ``elements[0]``. ``version`` carries the full VCF version string (e.g.
+``"5.2.0.0-24276214"``) — a *real* product version (unlike ``vcfa-vra8``'s API-date
+label), so a VCF 5.x target fingerprints straight into the ``>=5.0,<9.0`` band and
+resolves to this impl without an operator-asserted version. An operator-less probe
+(no JWT) fails closed and reports unreachable.
+
+Operations
+----------
+
+A curated **7-op typed read core** — the VCF 5.x migration-inventory surface:
+domains / clusters / hosts / vCenters / NSX-T clusters / SDDC Manager (inventory
+group) and tasks. All read-only, ``safety_level=safe``, ungated; registered as
+``source_kind="typed"`` (:mod:`.typed_ops` / :mod:`.typed_reads`) so they dispatch on
+a fresh boot with zero catalog ingest. The modern connector's credential-read
+(secret-bearing) and network-pool host-commissioning reads are out of scope — this
+inventories a migration *source*, it does not operate it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.system_operator import is_system_operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import (
+    SessionLoginError,
+    is_acceptable_auth_model,
+    vcf_session_login,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.sddc_manager.session import (
+    SddcCredentialsLoader,
+    SddcTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.sddc_vcf5.typed_reads import _SDDC_MANAGERS_PATH, _TOKENS_PATH
+
+# Re-export ``SessionLoginError`` so callers that catch the login helper's structured
+# failure don't have to reach into the shared module.
+__all__ = ["SddcVcf5Connector", "SessionLoginError"]
+
+_log = structlog.get_logger(__name__)
+
+# The static headers the login POST carries (JSON in/out).
+_SESSION_REQUEST_HEADERS: dict[str, str] = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+# Downstream statuses meaning "the cached session token is no longer accepted;
+# re-login and retry once". SDDC Manager signals an expired token with a plain 401.
+_SESSION_EXPIRED_STATUSES: frozenset[int] = frozenset({401})
+
+# Reachability/version surface — the same authenticated read exposed as
+# ``sddc.vcf5.manager.list``. Named here so the reconcile lane links the probe method.
+_SDDC_VCF5_PROBE_METHOD = "GET /v1/sddc-managers (VCF SDDC Manager appliance inventory)"
+
+
+def _sddc5_login_body(username: str, password: str) -> dict[str, Any]:
+    """Build SDDC Manager's ``{username, password}`` login body (the ``/v1/tokens`` shape)."""
+    return {"username": username, "password": password}
+
+
+def _extract_access_token(resp: httpx.Response) -> str | None:
+    """Pull ``accessToken`` out of the SDDC Manager token-response body.
+
+    Returns ``None`` for a missing / non-string / empty token (or a non-JSON body);
+    the shared :func:`vcf_session_login` helper then raises the consistent
+    target-named :exc:`SessionLoginError`.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    token = payload.get("accessToken")
+    return token if isinstance(token, str) and token else None
+
+
+class SddcVcf5Connector(HttpConnector):
+    """VCF 5.x SDDC Manager REST connector — ``POST /v1/tokens`` token-session auth.
+
+    Per-target minted bearers cached in :attr:`_session_tokens` (keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple) under :attr:`_session_lock`, so
+    two same-named targets in different tenants never share a token
+    (evoila/meho#1642). :meth:`auth_headers` returns ``Authorization: Bearer
+    <accessToken>``.
+
+    :attr:`priority` is ``1`` — the shim-tie-break convention. The
+    ``(product, version, impl_id)`` triple ``("sddc", "5.0", "sddc-vcf5")`` round-trips
+    through ``parse_connector_id`` from the ``connector_id`` ``"sddc-vcf5-5.0"``
+    (``product`` = first hyphen-segment of ``impl_id`` = ``"sddc"``).
+    """
+
+    # G0.6 v2 registry metadata. Legacy dual-impl of product ``sddc``: distinct
+    # impl_id ``sddc-vcf5`` and a DISJOINT band ``>=5.0,<9.0`` (modern ``sddc-rest`` is
+    # ``>=9.0,<10.0``). Registers only the versioned triple — the modern
+    # ``sddc_manager`` package owns the ``("sddc","","")`` wildcard.
+    product = "sddc"
+    version = "5.0"
+    impl_id = "sddc-vcf5"
+    supported_version_range = ">=5.0,<9.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: SddcCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._credentials_loader: SddcCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+        # Per-target minted-bearer cache, keyed on ``target_cache_key`` so the
+        # tenant-isolation invariant holds; a single lock serialises concurrent
+        # first-use callers so they don't double-POST /v1/tokens.
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
+
+    async def auth_headers(self, target: SddcTargetLike, operator: Operator) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <accessToken>"}``, minting on first use.
+
+        Lazily establishes the session on first call against *target*
+        (``POST /v1/tokens``); subsequent calls reuse the cached token. ``operator``
+        is threaded to the credential loader so the first-use Vault read runs under
+        the operator's identity.
+
+        Raises :exc:`NotImplementedError` for any ``target.auth_model`` other than
+        ``shared_service_account`` / ``None`` — the shared VCF-family gate.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"SddcVcf5Connector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: SddcTargetLike, operator: Operator) -> str:
+        """Return the cached session token, establishing it (``POST /v1/tokens``) on first use.
+
+        ``operator.raw_jwt`` must be non-empty: the credential read runs under the
+        operator's Vault identity, and a system-initiated call (empty JWT) cannot
+        resolve per-target vendor credentials. The guard is enforced **before** the
+        cache lookup so a token primed by an authenticated caller can never be handed
+        to an unauthenticated one — the defense-in-depth cache-scoping contract the
+        VCF-family connectors established.
+
+        The cache fast-path + write are additionally closed to the synthesised system
+        operator (``is_system_operator``): a system/operator-less caller can neither be
+        served a warm token a real operator primed nor poison the cache for one (#1008)
+        — the modern ``sddc_manager`` posture. Today this is belt-and-suspenders (the
+        empty-``raw_jwt`` guard already rejects the operator-less fingerprint's
+        placeholder before this point); it guards a future refactor that threads a
+        non-empty system-operator placeholder through instead.
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read per-target vendor credentials)"
+            )
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None and not is_system_operator(operator):
+                return cached
+            creds = await self._credentials_loader(target, operator)
+            try:
+                username = creds["username"]
+                password = creds["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"sddc-vcf5 credentials loader for target {target.name!r} returned a "
+                    f"dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            client = await self._http_client(target)
+            token = await vcf_session_login(
+                client,
+                _TOKENS_PATH,
+                username=username,
+                password=password,
+                target_name=target.name,
+                payload_builder=_sddc5_login_body,
+                token_extractor=_extract_access_token,
+                request_headers=dict(_SESSION_REQUEST_HEADERS),
+                request_extensions=self._request_extensions(target),
+            )
+            if not is_system_operator(operator):
+                self._session_tokens[cache_key] = token
+            _log.info("sddc_vcf5_session_established", target=target.name, host=target.host)
+            return token
+
+    async def _get_json_with_session_retry(
+        self,
+        target: SddcTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET *path* with single session-expiry → re-login → retry-once recovery.
+
+        Wraps the inherited :meth:`HttpConnector._get_json` (which carries tenacity's
+        connection-error + 5xx retry). On a ``401`` from the inherited call,
+        invalidates the cached token and retries once — the cached token is stale, not
+        the credential, so a re-login recovers it. A second ``401`` raises
+        :exc:`RuntimeError`. Serves the fingerprint/probe path, which the dispatcher
+        does not drive (the data path recovers via the :meth:`invalidate_session`
+        dispatch hook instead); the modern ``sddc_manager`` posture.
+        """
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in _SESSION_EXPIRED_STATUSES:
+                raise
+            await self._evict_session_token(target)
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in _SESSION_EXPIRED_STATUSES:
+                raise RuntimeError(
+                    f"sddc-vcf5 session re-login failed for target {target.name!r}: "
+                    f"GET {path} returned HTTP {status_code} after refresh"
+                ) from exc
+            raise
+
+    async def fingerprint(
+        self,
+        target: SddcTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /v1/sddc-managers`` (authenticated).
+
+        Reads ``elements[0]`` from the pagination envelope on the token session (SDDC
+        Manager has no unauthenticated version endpoint), via
+        :meth:`_get_json_with_session_retry` so an idle-expired token is recovered
+        with one re-login rather than surfacing as unreachable. ``version`` carries
+        the full VCF version string (e.g. ``"5.2.0.0-24276214"``) — a real product
+        version, so a VCF 5.x target resolves to this impl by fingerprint alone.
+        ``build`` is taken from a ``build`` field when present. On transport / status
+        / credential failure (including an operator-less probe, whose empty JWT fails
+        closed) returns a non-reachable result whose ``extras["error"]`` names the
+        exception.
+
+        ``operator`` (optional) is the request-scoped operator forwarded from the
+        probe routes; when ``None`` an empty-JWT placeholder is used, which fails
+        closed at the credential read (an operator-less probe cannot authenticate).
+        """
+        probed_at = datetime.now(UTC)
+        eff_operator = operator if operator is not None else _placeholder_operator()
+        try:
+            payload = await self._get_json_with_session_retry(
+                target, _SDDC_MANAGERS_PATH, operator=eff_operator
+            )
+        except (httpx.HTTPError, OSError, RuntimeError, VaultCredentialsReadError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="sddc",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_SDDC_VCF5_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        elements = payload.get("elements") or []
+        sddc = elements[0] if isinstance(elements, list) and elements else {}
+        domain = sddc.get("domain") or sddc.get("managementDomain") or {}
+        return FingerprintResult(
+            vendor="vmware",
+            product="sddc",
+            version=sddc.get("version"),
+            build=sddc.get("build"),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_SDDC_VCF5_PROBE_METHOD,
+            extras={
+                "id": sddc.get("id"),
+                "fqdn": sddc.get("fqdn"),
+                "management_domain": domain.get("name") if isinstance(domain, dict) else None,
+                "product_lineage": "vmware-cloud-foundation",
+                "api_surface": "sddc-manager-vcf5",
+            },
+        )
+
+    async def probe(self, target: SddcTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check — delegates to :meth:`fingerprint`.
+
+        One authenticated request covers both reachability and auth-challenge, the
+        modern ``sddc_manager`` / NSX posture.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: SddcTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Post-G0.6 callers construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly. The connector's natural
+        key is encoded as the dispatcher's ``connector_id`` per ``parse_connector_id``:
+        ``"sddc-vcf5-5.0"`` → (product=``"sddc"``, version=``"5.0"``,
+        impl_id=``"sddc-vcf5"``).
+        """
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:sddc-vcf5-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (#3059, initiative #3056)
+    #
+    # Thin bound-method shims for the migration-inventory read core. Each delegates to
+    # the module-level ``_impl`` body in ``.typed_reads`` (lazy import). Reads issue a
+    # plain ``self._get_json`` on the token session; a raw 401 propagates to the
+    # dispatcher's #2067 recovery arm, which calls ``invalidate_session`` and
+    # re-dispatches once. All read-only.
+    # ------------------------------------------------------------------
+
+    async def domain_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.domain.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_domain_list_impl
+
+        return await sddc5_domain_list_impl(self, operator, target, params)
+
+    async def cluster_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.cluster.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_cluster_list_impl
+
+        return await sddc5_cluster_list_impl(self, operator, target, params)
+
+    async def host_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.host.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_host_list_impl
+
+        return await sddc5_host_list_impl(self, operator, target, params)
+
+    async def vcenter_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.vcenter.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_vcenter_list_impl
+
+        return await sddc5_vcenter_list_impl(self, operator, target, params)
+
+    async def nsxt_cluster_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.nsxt_cluster.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_nsxt_cluster_list_impl
+
+        return await sddc5_nsxt_cluster_list_impl(self, operator, target, params)
+
+    async def manager_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.manager.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_manager_list_impl
+
+        return await sddc5_manager_list_impl(self, operator, target, params)
+
+    async def task_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf5.task.list`` shim (#3059)."""
+        from meho_backplane.connectors.sddc_vcf5.typed_reads import sddc5_task_list_impl
+
+        return await sddc5_task_list_impl(self, operator, target, params)
+
+    # ------------------------------------------------------------------
+    # Dispatch-path session-recovery hooks (#2067 / #2396)
+    # ------------------------------------------------------------------
+
+    async def invalidate_session(self, target: SddcTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path (#2067).
+
+        **The load-bearing 401-recovery hook.** On an auth-class status (SDDC
+        Manager's ``401`` from an expired token), the dispatcher's data-path recovery
+        arm calls this hook — keyed on ``invalidate_session``, *not*
+        ``invalidate_credentials`` — then re-dispatches the op once. Dropping the
+        cached token here makes the retry's :meth:`auth_headers` cache-miss and
+        re-mint via ``POST /v1/tokens``, so a mid-session token expiry self-heals on
+        the next dispatch without a backplane restart — the modern ``sddc_manager`` /
+        NSX precedent (a connector *without* this hook wedges on the stale token).
+        """
+        await self._evict_session_token(target)
+
+    async def invalidate_credentials(self, target: SddcTargetLike) -> None:
+        """Establish-auth-failure companion hook (#2396).
+
+        The dispatcher calls this on an establish-time login failure. This connector
+        re-reads Vault on every mint, so it keeps no separate credential-bytes cache;
+        the only per-target state is the token, so this also drops it. Kept so the
+        connector advertises both dispatch-path recovery hooks.
+        """
+        await self._evict_session_token(target)
+
+    async def _evict_session_token(self, target: SddcTargetLike) -> None:
+        """Drop the cached session token for *target* under the session lock."""
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens, then tear down the httpx pool.
+
+        No DELETE-revoke — SDDC Manager's session has a server-side lifetime and a
+        per-target network call during lifespan shutdown is more risk than benefit
+        (the modern ``sddc_manager`` posture). The cache is cleared so a post-aclose
+        reuse of the same instance re-mints cleanly.
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await super().aclose()
+
+
+def _placeholder_operator() -> Operator:
+    """An empty-JWT operator for an operator-less fingerprint — fails closed at the read.
+
+    The probe routes pass a real operator (G0.16-T4); when they do not, this
+    placeholder's empty ``raw_jwt`` trips the fail-closed guard in
+    :meth:`SddcVcf5Connector._session_token`, so an operator-less fingerprint reports
+    unreachable rather than authenticating as no-one.
+    """
+    return Operator(
+        sub="system:sddc-vcf5-fingerprint",
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )

--- a/backend/src/meho_backplane/connectors/sddc_vcf5/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_vcf5/typed_ops.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`SddcVcf5Connector` (#3059).
+
+The VCF 5.x SDDC Manager migration-inventory read set is registered as typed ops
+(``source_kind="typed"``) so it dispatches on a fresh boot with **zero catalog
+ingest** — the read core is live the moment the connector loads (part of initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, legacy
+migration-source connector coverage; this is the **legacy dual-impl** of
+``product="sddc"``, sibling to the modern 9.x ``sddc-rest``).
+
+The op bodies live in :mod:`meho_backplane.connectors.sddc_vcf5.typed_reads`; thin
+bound-method shims on
+:class:`~meho_backplane.connectors.sddc_vcf5.connector.SddcVcf5Connector` expose
+them under the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk recovers
+each callable from its persisted ``module.ClassName.method`` path. The dataclass +
+tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.sddc_manager.typed_ops`.
+
+Op ids are namespaced ``sddc.vcf5.*`` (distinct from the modern impl's ``sddc.*``):
+the two impls publish read surfaces for different VCF generations and the resolver
+picks one per target by fingerprint, so an agent only ever sees the set matching the
+target's version. A tight **migration-inventory** subset ships — domains / clusters
+/ hosts / vCenters / NSX-T clusters / SDDC Manager + tasks. The modern connector's
+credential-read (secret-bearing) and network-pool host-commissioning reads are
+deliberately out of scope: this core inventories a migration *source*, it does not
+operate it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "SDDC_VCF5_TYPED_OPS",
+    "SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP",
+    "SddcVcf5TypedOp",
+    "register_sddc_vcf5_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys — distinct from the modern ``sddc-*`` keys so the
+# (product, impl_id, group_key) rows never collide across the two impls of product
+# ``sddc``. Ordered by the migration operator's drill: what exists (inventory) ->
+# what is running (tasks).
+_GROUP_INVENTORY = "sddc-vcf5-inventory"
+_GROUP_TASKS = "sddc-vcf5-tasks"
+
+
+@dataclass(frozen=True)
+class SddcVcf5TypedOp:
+    """Metadata for one VCF 5.x SDDC Manager typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_sddc_vcf5_typed_operations` can splat the dataclass
+    into the helper without per-op boilerplate. ``handler_attr`` is the attribute
+    name on :class:`SddcVcf5Connector` exposing the async handler; the registrar
+    resolves the bound method against the class at registration time. Mirrors
+    :class:`~meho_backplane.connectors.sddc_manager.typed_ops.SddcTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set.
+SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_INVENTORY: (
+        "Use to inventory the VCF 5.x infrastructure a migration is moving off: the "
+        "workload + management domains (sddc.vcf5.domain.list), their vSphere "
+        "clusters (sddc.vcf5.cluster.list), ESXi hosts (sddc.vcf5.host.list), the "
+        "managed vCenters (sddc.vcf5.vcenter.list), the NSX-T manager clusters that "
+        "front them (sddc.vcf5.nsxt_cluster.list), and the SDDC Manager appliance "
+        "itself with its version (sddc.vcf5.manager.list). The right group for 'what "
+        "does this VCF 5.x stack contain and how big is it' — the physical + logical "
+        "footprint a migration must re-home. Read-only."
+    ),
+    _GROUP_TASKS: (
+        "Use to read VCF workflow tasks (sddc.vcf5.task.list) — in-flight or recently "
+        "completed operations, optionally filtered by status. The right group for "
+        "confirming the source estate is quiescent before a migration cutover, or "
+        "triaging a workflow that failed. Read-only."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The empty parameter object shared by the no-argument reads.
+_NO_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+
+def _instructions(
+    *,
+    when_to_use: str,
+    output_shape: str,
+    parameter_hints: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the per-op ``llm_instructions`` blob with the canonical SDDC keys."""
+    blob: dict[str, Any] = {"when_to_use": when_to_use, "output_shape": output_shape}
+    if parameter_hints is not None:
+        blob["parameter_hints"] = parameter_hints
+    return blob
+
+
+# ---------------------------------------------------------------------------
+# Inventory group
+# ---------------------------------------------------------------------------
+
+_DOMAIN_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.domain.list",
+    handler_attr="domain_list",
+    summary="VCF 5.x domains (management + workload) SDDC Manager governs.",
+    description=(
+        "Lists every VCF domain the SDDC Manager governs via GET /v1/domains — the "
+        "management domain plus any workload domains — the top of the VCF tenancy "
+        "tree and the entry point for a migration inventory. Works with zero catalog "
+        "ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "domain", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call first when inventorying a VCF 5.x source estate — the management "
+            "domain and any workload domains are the top of the tree and the anchor "
+            "for domain-scoped cluster / host / vCenter reads."
+        ),
+        output_shape=(
+            "{elements: [{id, name, type (MANAGEMENT/WORKLOAD), vcenters, "
+            "nsxtCluster}, ...], pageMetadata}."
+        ),
+    ),
+)
+
+_CLUSTER_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.cluster.list",
+    handler_attr="cluster_list",
+    summary="vSphere clusters across all or one VCF 5.x domain.",
+    description=(
+        "Lists vSphere clusters across all VCF domains via GET /v1/clusters, or "
+        "narrowed to one domain via the optional domainId filter — cluster count, "
+        "datastore type, and host membership a migration must re-home. Works with "
+        "zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "cluster", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use="Call to list vSphere clusters; pass domainId to scope to one domain.",
+        output_shape=(
+            "{elements: [{id, name, primaryDatastoreType, domainId, hosts}, ...], pageMetadata}."
+        ),
+        parameter_hints={"domainId": "VCF domain id from sddc.vcf5.domain.list; omit for all."},
+    ),
+)
+
+_HOST_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.host.list",
+    handler_attr="host_list",
+    summary="ESXi hosts across the VCF 5.x estate, optionally filtered.",
+    description=(
+        "Enumerates ESXi hosts across all VCF domains via GET /v1/hosts, or narrowed "
+        "by the optional domainId / clusterId / status filters — the physical "
+        "footprint (host count, FQDN, ESXi version, assignment status) a migration "
+        "must size. Large estates return hundreds of hosts, reduced to a JSONFlux "
+        "handle. Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+            "clusterId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional cluster id filter. Omit for all clusters.",
+            },
+            "status": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Optional host status filter (e.g. ASSIGNED, UNASSIGNED_USEABLE). "
+                    "Omit for all statuses."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "host", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to enumerate ESXi hosts — the migration's physical footprint. "
+            "Narrow with domainId / clusterId / status when the operator named one; "
+            "aggregate over the handle for host/version counts."
+        ),
+        output_shape=(
+            "{elements: [{id, fqdn, esxiVersion, ipAddresses, domain, cluster, "
+            "status}, ...], pageMetadata}."
+        ),
+        parameter_hints={
+            "domainId": "VCF domain id; omit for all.",
+            "clusterId": "cluster id; omit for all.",
+            "status": "ASSIGNED / UNASSIGNED_USEABLE; omit for all.",
+        },
+    ),
+)
+
+_VCENTER_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.vcenter.list",
+    handler_attr="vcenter_list",
+    summary="vCenter Server instances the VCF 5.x SDDC Manager manages.",
+    description=(
+        "Lists the vCenter Server instances SDDC Manager manages via GET /v1/vcenters, "
+        "or narrowed to one domain via the optional domainId filter. Cross the "
+        "returned fqdn against the vSphere connector for VM-level migration inventory. "
+        "Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "vcenter", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to list managed vCenters, then cross each fqdn against the vSphere "
+            "connector to inventory the VMs a migration will move."
+        ),
+        output_shape="{elements: [{id, fqdn, domain}, ...], pageMetadata}.",
+        parameter_hints={"domainId": "VCF domain id; omit for all."},
+    ),
+)
+
+_NSXT_CLUSTER_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.nsxt_cluster.list",
+    handler_attr="nsxt_cluster_list",
+    summary="NSX-T manager clusters the VCF 5.x SDDC Manager manages.",
+    description=(
+        "Lists the NSX-T manager clusters SDDC Manager manages via GET /v1/nsxt-clusters "
+        "and the domains each one backs — the network fabric a migration must re-home. "
+        "Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "nsxt", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to map the NSX-T fabric — which NSX-T cluster fronts each workload "
+            "domain — so the target-side network design covers every domain."
+        ),
+        output_shape="{elements: [{id, vipFqdn, domainIds}, ...], pageMetadata}.",
+    ),
+)
+
+_MANAGER_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.manager.list",
+    handler_attr="manager_list",
+    summary="SDDC Manager appliance inventory + version.",
+    description=(
+        "Lists the SDDC Manager appliances via GET /v1/sddc-managers — their FQDN, "
+        "IP, version, and management domain. Confirms which SDDC Manager fronts the "
+        "VCF stack and its exact 5.x build; the same surface the connector's "
+        "fingerprint reads, exposed as an operator-callable typed op. Works with zero "
+        "catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "manager", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to identify the SDDC Manager appliance(s) and read the exact VCF "
+            "version/build — the anchor for the migration source record."
+        ),
+        output_shape="{elements: [{id, fqdn, ipAddress, version, domain}, ...], pageMetadata}.",
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Tasks group
+# ---------------------------------------------------------------------------
+
+_TASK_LIST = SddcVcf5TypedOp(
+    op_id="sddc.vcf5.task.list",
+    handler_attr="task_list",
+    summary="In-flight or recent VCF 5.x workflow tasks, optionally filtered.",
+    description=(
+        "Lists in-flight or recently completed VCF workflow tasks via GET /v1/tasks, "
+        "optionally narrowed by the status filter (Successful / Failed / In_Progress "
+        "/ Pending / Cancelled). The read for confirming the source estate is "
+        "quiescent before a migration cutover, or triaging a workflow that failed. "
+        "Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["Successful", "Failed", "In_Progress", "Pending", "Cancelled"],
+                "description": "Optional task status filter. Omit for all statuses.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_TASKS,
+    tags=("read-only", "sddc", "vcf", "task", "workflow"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to confirm no VCF workflow is in flight before a migration cutover "
+            "(quiescence), or narrow with status='Failed' when triaging."
+        ),
+        output_shape=(
+            "{elements: [{id, name, status, type, subtasks, errors}, ...], "
+            "pageMetadata}. For a failed task surface errors[].message."
+        ),
+        parameter_hints={
+            "status": "Successful / Failed / In_Progress / Pending / Cancelled; omit for all.",
+        },
+    ),
+)
+
+
+#: The typed ops :class:`SddcVcf5Connector` registers at lifespan startup — the 7-op
+#: VCF 5.x migration-inventory read core (#3059). Ordered domains -> compute ->
+#: network -> appliance -> tasks to match the operator's inventory path.
+SDDC_VCF5_TYPED_OPS: tuple[SddcVcf5TypedOp, ...] = (
+    _DOMAIN_LIST,
+    _CLUSTER_LIST,
+    _HOST_LIST,
+    _VCENTER_LIST,
+    _NSXT_CLUSTER_LIST,
+    _MANAGER_LIST,
+    _TASK_LIST,
+)
+
+
+async def register_sddc_vcf5_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`SDDC_VCF5_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar` in
+    this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after every connector subpackage has been imported, so the descriptor
+    rows land before the first dispatch — the VCF 5.x read core is live on a fresh
+    boot. Idempotent across pod restarts. Mirrors
+    :func:`~meho_backplane.connectors.sddc_manager.typed_ops.register_sddc_typed_operations`.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so each
+    registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide singleton
+    when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline (ONNX
+    # runtime + model), which pure connector/handler unit tests should not pay.
+    from meho_backplane.connectors.sddc_vcf5.connector import SddcVcf5Connector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in SDDC_VCF5_TYPED_OPS:
+        handler = getattr(SddcVcf5Connector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"SddcVcf5Connector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        if when_to_use is None:
+            raise ValueError(
+                f"SddcVcf5Connector typed op {op.op_id!r} declares group_key="
+                f"{op.group_key!r} but no curated when_to_use exists for that key. Add "
+                f"an entry to SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=SddcVcf5Connector.product,
+            version=SddcVcf5Connector.version,
+            impl_id=SddcVcf5Connector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "sddc_vcf5_typed_operations_registered",
+        count=len(SDDC_VCF5_TYPED_OPS),
+        product=SddcVcf5Connector.product,
+        version=SddcVcf5Connector.version,
+        impl_id=SddcVcf5Connector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/sddc_vcf5/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/sddc_vcf5/typed_reads.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`SddcVcf5Connector`.
+
+The vRealize / VCF 5.x SDDC Manager migration-inventory read set (#3059, initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_) is registered as
+typed ops (``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog state** — no operator ``meho connector ingest`` + ``enable_reads`` step.
+Each function here is the body a thin bound-method shim on
+:class:`~meho_backplane.connectors.sddc_vcf5.connector.SddcVcf5Connector` delegates
+to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.sddc_vcf5.typed_ops`.
+
+This is the **legacy dual-impl** of ``product="sddc"`` — the migration-source VCF
+5.x estate evoila brings customers *off* (the modern 9.x sibling is
+:mod:`meho_backplane.connectors.sddc_manager`, ``sddc-rest``). SDDC Manager's REST
+path surface is **stable since VCF 4.0**, so these ``/v1/*`` paths are the same
+shapes the modern connector reads; the 5.x split exists because 5.x publishes only
+Swagger 2.0 (OA3 is VCF-9.0-net-new — not ingestable) and its response *schemas*
+drift by point release. The read core is therefore **typed** (hand-coded), the
+``vcd`` / ``vcfa-vra8`` migration-source posture.
+
+Every read is issued directly on the connector's own authenticated token session
+via :meth:`HttpConnector._get_json` — no ``dispatch_child``, no ingested descriptor.
+A raw ``401`` from a downstream call (SDDC Manager's expired-token signal)
+propagates as :class:`httpx.HTTPStatusError` to the dispatcher's #2067 recovery arm,
+which evicts the cached session token via the connector's public
+:meth:`SddcVcf5Connector.invalidate_session` hook and re-dispatches once. The
+handlers therefore do **not** wrap calls in the connector's internal
+``_get_json_with_session_retry`` helper (that helper serves the fingerprint/probe
+path, which the dispatcher does not drive) — the modern ``sddc_manager`` posture.
+
+The 7-read migration-inventory surface (each path pinned by
+:mod:`tests.test_connectors_sddc_vcf5_spec_reconcile`), all ``{elements: [...],
+pageMetadata}`` envelopes:
+
+* ``sddc.vcf5.domain.list`` — ``GET /v1/domains`` (management + workload domains).
+* ``sddc.vcf5.cluster.list`` — ``GET /v1/clusters`` (optional ``domainId``).
+* ``sddc.vcf5.host.list`` — ``GET /v1/hosts`` (optional ``domainId`` / ``clusterId`` / ``status``).
+* ``sddc.vcf5.vcenter.list`` — ``GET /v1/vcenters`` (optional ``domainId``).
+* ``sddc.vcf5.nsxt_cluster.list`` — ``GET /v1/nsxt-clusters``.
+* ``sddc.vcf5.manager.list`` — ``GET /v1/sddc-managers`` (also the fingerprint surface).
+* ``sddc.vcf5.task.list`` — ``GET /v1/tasks`` (optional ``status``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.sddc_manager.session import SddcTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.sddc_vcf5.connector import SddcVcf5Connector
+
+__all__ = [
+    "sddc5_cluster_list_impl",
+    "sddc5_domain_list_impl",
+    "sddc5_host_list_impl",
+    "sddc5_manager_list_impl",
+    "sddc5_nsxt_cluster_list_impl",
+    "sddc5_task_list_impl",
+    "sddc5_vcenter_list_impl",
+]
+
+# Spec-relative SDDC Manager endpoints. Every SDDC Manager REST path begins with
+# ``/v1/`` and is stable since VCF 4.0; the connector's pooled per-target client
+# carries the ``Authorization: Bearer <accessToken>`` header the token session
+# primed. The reconcile lane introspects these ``_*_PATH`` constants.
+# ``_TOKENS_PATH`` is the POST session-mint endpoint (see ``.connector``); the rest
+# are GET reads.
+_TOKENS_PATH = "/v1/tokens"
+_DOMAINS_PATH = "/v1/domains"
+_CLUSTERS_PATH = "/v1/clusters"
+_HOSTS_PATH = "/v1/hosts"
+_VCENTERS_PATH = "/v1/vcenters"
+_NSXT_CLUSTERS_PATH = "/v1/nsxt-clusters"
+_TASKS_PATH = "/v1/tasks"
+_SDDC_MANAGERS_PATH = "/v1/sddc-managers"
+
+
+def _optional_query(params: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any] | None:
+    """Build a query dict from the truthy *keys* present in *params*, or ``None``.
+
+    Mirrors the modern ``sddc_manager`` filter-forwarding shape: only keys the
+    caller supplied a truthy value for are forwarded, and an empty result collapses
+    to ``None`` so :meth:`HttpConnector._get_json` omits the query string entirely.
+    """
+    query: dict[str, Any] = {}
+    for key in keys:
+        val = params.get(key)
+        if val:
+            query[key] = val
+    return query or None
+
+
+async def sddc5_domain_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.domain.list`` — ``GET /v1/domains``.
+
+    Lists every VCF domain the SDDC Manager governs — the management domain plus any
+    workload domains — as a paginated ``{elements: [...], pageMetadata}`` envelope.
+    The entry point for a migration inventory: the top of the VCF tenancy tree and
+    the anchor for domain-scoped cluster / host / vCenter reads.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _DOMAINS_PATH, operator=operator)
+
+
+async def sddc5_cluster_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.cluster.list`` — ``GET /v1/clusters``.
+
+    Lists vSphere clusters across all VCF domains, or narrowed to one domain via the
+    optional ``domainId`` filter. The primary inventory read for cluster count,
+    datastore type, and host membership a migration must re-home.
+    """
+    query = _optional_query(params, ("domainId",))
+    return await connector._get_json(target, _CLUSTERS_PATH, operator=operator, params=query)
+
+
+async def sddc5_host_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.host.list`` — ``GET /v1/hosts``.
+
+    Enumerates ESXi hosts across all VCF domains, or narrowed by the optional
+    ``domainId`` / ``clusterId`` / ``status`` filters — the physical footprint (host
+    count, FQDN, ESXi version, assignment status) a migration must size. Large VCF
+    estates return dozens or hundreds of hosts; a big list is reduced to a JSONFlux
+    handle.
+    """
+    query = _optional_query(params, ("domainId", "clusterId", "status"))
+    return await connector._get_json(target, _HOSTS_PATH, operator=operator, params=query)
+
+
+async def sddc5_vcenter_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.vcenter.list`` — ``GET /v1/vcenters``.
+
+    Lists the vCenter Server instances SDDC Manager manages, or narrowed to one
+    domain via the optional ``domainId`` filter. Cross the returned ``fqdn`` against
+    the vSphere connector for VM-level migration inventory.
+    """
+    query = _optional_query(params, ("domainId",))
+    return await connector._get_json(target, _VCENTERS_PATH, operator=operator, params=query)
+
+
+async def sddc5_nsxt_cluster_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.nsxt_cluster.list`` — ``GET /v1/nsxt-clusters``.
+
+    Lists the NSX-T manager clusters SDDC Manager manages and the domains each one
+    backs — the network fabric a migration must re-home. ``{elements: [{id, vipFqdn,
+    domainIds}, ...], pageMetadata}``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _NSXT_CLUSTERS_PATH, operator=operator)
+
+
+async def sddc5_manager_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.manager.list`` — ``GET /v1/sddc-managers``.
+
+    Lists the SDDC Manager appliances — their FQDN, IP, version, and management
+    domain. The primary 'which SDDC Manager fronts this VCF stack, and what version'
+    read, and the same surface :meth:`SddcVcf5Connector.fingerprint` reads, exposed
+    as an operator-callable typed op.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SDDC_MANAGERS_PATH, operator=operator)
+
+
+async def sddc5_task_list_impl(
+    connector: SddcVcf5Connector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf5.task.list`` — ``GET /v1/tasks``.
+
+    Lists in-flight or recently completed VCF workflow tasks, optionally narrowed by
+    the ``status`` filter. The read for confirming the source estate is quiescent
+    before a migration cutover, or triaging a workflow that failed.
+    """
+    query = _optional_query(params, ("status",))
+    return await connector._get_json(target, _TASKS_PATH, operator=operator, params=query)

--- a/backend/tests/test_connectors_sddc_vcf5_auth.py
+++ b/backend/tests/test_connectors_sddc_vcf5_auth.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`SddcVcf5Connector` token-session mint + authenticated fingerprint.
+
+Exercises the VCF 5.x SDDC Manager auth contract (identical to the modern 9.x flow):
+
+* ``POST /v1/tokens`` with ``{username, password}`` returns ``{accessToken}``, cached
+  and sent as ``Authorization: Bearer <accessToken>`` on every read.
+* Per-target token caching + tenant-unique isolation.
+* Login failure (non-2xx / token-less 2xx) → target-named ``SessionLoginError``.
+* Both dispatch-path eviction hooks (``invalidate_session`` #2067 /
+  ``invalidate_credentials`` #2396) → re-mint.
+* ``auth_model`` gating + empty-``raw_jwt`` fail-closed.
+* **Authenticated fingerprint** ``GET /v1/sddc-managers`` (SDDC Manager has no
+  unauth version endpoint) — real version string, its 401 self-heal, and the
+  operator-less fail-closed path.
+
+Adapts :mod:`tests.test_connectors_vcd_auth` to the token (body) flow + auth fingerprint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.sddc_manager.session import SddcTargetLike
+from meho_backplane.connectors.sddc_vcf5 import (
+    SDDC_VCF5_IMPL_ID,
+    SDDC_VCF5_PRODUCT,
+    SDDC_VCF5_VERSION,
+    SddcVcf5Connector,
+)
+from meho_backplane.connectors.sddc_vcf5.connector import SessionLoginError
+from meho_backplane.settings import get_settings
+
+_TOKENS_PATH = "/v1/tokens"
+_DOMAINS_PATH = "/v1/domains"
+_MANAGERS_PATH = "/v1/sddc-managers"
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    """Return a minimal :class:`Operator`; non-empty ``raw_jwt`` passes the fail-closed gate."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _chassis_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env the shared credential loader reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Restore SddcVcf5Connector's package registration (versioned triple only, no wildcard)."""
+    clear_registry()
+    register_connector_v2(
+        product=SddcVcf5Connector.product,
+        version=SddcVcf5Connector.version,
+        impl_id=SddcVcf5Connector.impl_id,
+        cls=SddcVcf5Connector,
+    )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    """Target satisfying :class:`SddcTargetLike` structurally."""
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(name="sddc-a", host="sddc-a.test.invalid", port=443, secret_ref="sddc/a")
+_TARGET_B = _StubTarget(name="sddc-b", host="sddc-b.test.invalid", port=443, secret_ref="sddc/b")
+
+
+async def _stub_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target / operator."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> SddcVcf5Connector:
+    """Build a connector wired with the stub loader."""
+    return SddcVcf5Connector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_sddc_vcf5_connector_subclasses_http_connector() -> None:
+    """The connector inherits from HttpConnector with the legacy-dual-impl metadata."""
+    assert issubclass(SddcVcf5Connector, HttpConnector)
+    assert SddcVcf5Connector.product == "sddc"
+    assert SddcVcf5Connector.version == "5.0"
+    assert SddcVcf5Connector.impl_id == "sddc-vcf5"
+    assert SddcVcf5Connector.supported_version_range == ">=5.0,<9.0"
+    assert SddcVcf5Connector.priority == 1
+
+
+def test_importing_package_registers_versioned_triple_only() -> None:
+    """The package registers its versioned triple and NOT the ``("sddc","","")`` wildcard."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    assert registry[(SDDC_VCF5_PRODUCT, SDDC_VCF5_VERSION, SDDC_VCF5_IMPL_ID)] is SddcVcf5Connector
+    assert (SDDC_VCF5_PRODUCT, "", "") not in registry
+
+
+# ---------------------------------------------------------------------------
+# Token-session mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_mints_token_and_sends_bearer() -> None:
+    """A read mints the token via POST /v1/tokens and sends it as Bearer on the data GET."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        tokens = mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "tok-1"})
+        domains = mock.get(_DOMAINS_PATH).respond(200, json={"elements": []})
+        result = await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+
+    assert result == {"elements": []}
+    assert tokens.called
+    data_req = domains.calls[0].request
+    assert data_req.headers["Authorization"] == "Bearer tok-1"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_cached_across_calls() -> None:
+    """Two reads against the same target mint the token once."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        tokens = mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "tok-c"})
+        mock.get(_DOMAINS_PATH).respond(200, json={"elements": []})
+        mock.get("/v1/clusters").respond(200, json={"elements": []})
+        await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+        await connector._get_json(_TARGET_A, "/v1/clusters", operator=_make_operator())
+
+    assert tokens.call_count == 1
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "tok-c"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached token (#1642)."""
+    connector = _make_connector()
+    tenant_one = _StubTarget(
+        name="sddc-shared",
+        host="sddc-shared.test.invalid",
+        port=443,
+        secret_ref="sddc/shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="sddc-shared",
+        host="sddc-shared.test.invalid",
+        port=443,
+        secret_ref="sddc/shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://sddc-shared.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"accessToken": "tok-one"}),
+                httpx.Response(200, json={"accessToken": "tok-two"}),
+            ]
+        )
+        mock.get(_DOMAINS_PATH).respond(200, json={"elements": []})
+        await connector._get_json(tenant_one, _DOMAINS_PATH, operator=_make_operator())
+        await connector._get_json(tenant_two, _DOMAINS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {
+        target_cache_key(tenant_one): "tok-one",
+        target_cache_key(tenant_two): "tok-two",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Login failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_401_raises_session_login_error_naming_target() -> None:
+    """401 from POST /v1/tokens raises the target-named SessionLoginError."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(401)
+        with pytest.raises(SessionLoginError, match=r"sddc-a"):
+            await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_missing_access_token_raises_naming_target() -> None:
+    """A 2xx token response with no accessToken raises the target-named SessionLoginError."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"not_a_token": "x"})
+        with pytest.raises(SessionLoginError, match=r"sddc-a"):
+            await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_raises_clear_error() -> None:
+    """A loader returning a dict without ``password`` raises naming the target."""
+
+    async def _bad_loader(_t: SddcTargetLike, _o: Operator) -> dict[str, str]:
+        return {"username": "svc-meho"}  # missing 'password' on purpose
+
+    connector = SddcVcf5Connector(credentials_loader=_bad_loader)
+    async with respx.mock(base_url="https://sddc-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating + fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation / unknown modes raise NotImplementedError naming target + mode."""
+    target = _StubTarget(
+        name="sddc-per-user",
+        host="sddc.test.invalid",
+        port=443,
+        secret_ref="sddc/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "sddc-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model() -> None:
+    """``auth_model=None`` (pre-G0.3) is accepted."""
+    target = _StubTarget(
+        name="sddc-pre", host="sddc.test.invalid", port=443, secret_ref="sddc/pre", auth_model=None
+    )
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "pre-tok"})
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer pre-tok"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_establish_rejects_empty_operator_jwt() -> None:
+    """A system-initiated call (empty raw_jwt) cannot mint — fail-closed before the cache."""
+    connector = _make_connector()
+    with pytest.raises(VaultCredentialsReadError, match=r"sddc-a"):
+        await connector.auth_headers(_TARGET_A, operator=_make_operator(raw_jwt=""))
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-path eviction hooks → re-mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hook_name", ["invalidate_session", "invalidate_credentials"])
+@pytest.mark.asyncio
+async def test_eviction_hook_drops_token_forcing_remint(hook_name: str) -> None:
+    """Both dispatch-path eviction hooks drop the cached token so the next auth_headers re-mints.
+
+    ``invalidate_session`` is the data-path 401 arm (#2067 — proven end-to-end in the
+    typed-reads test); ``invalidate_credentials`` is the establish-failure companion
+    (#2396). This connector keeps only the token cache, so both evict it — pinning that
+    ``invalidate_session`` exists (its absence would be a latent permanent-wedge bug).
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        tokens = mock.post(_TOKENS_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"accessToken": "tok-1"}),
+                httpx.Response(200, json={"accessToken": "tok-2"}),
+            ]
+        )
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        await getattr(connector, hook_name)(_TARGET_A)
+        assert connector._session_tokens == {}
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == {"Authorization": "Bearer tok-1"}
+    assert h2 == {"Authorization": "Bearer tok-2"}
+    assert tokens.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_tokens_and_pool() -> None:
+    """aclose() drops the token cache and tears down the httpx pool."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "tok"})
+        mock.get(_DOMAINS_PATH).respond(200, json={"elements": []})
+        await connector._get_json(_TARGET_A, _DOMAINS_PATH, operator=_make_operator())
+
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "tok"}
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe() — authenticated GET /v1/sddc-managers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_reads_real_version() -> None:
+    """A 2xx on /v1/sddc-managers → reachable, version = the full VCF version string."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "fp-tok"})
+        mock.get(_MANAGERS_PATH).respond(
+            200,
+            json={
+                "elements": [
+                    {
+                        "id": "sddc-1",
+                        "fqdn": "sddc-a.vcf.local",
+                        "version": "5.2.0.0-24276214",
+                        "domain": {"name": "MGMT"},
+                    }
+                ]
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A, operator=_make_operator())
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "sddc"
+    assert fp.reachable is True
+    assert fp.version == "5.2.0.0-24276214"
+    assert fp.extras["management_domain"] == "MGMT"
+    assert fp.extras["api_surface"] == "sddc-manager-vcf5"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_401_reretries_then_succeeds() -> None:
+    """A 401 on the fingerprint GET self-heals via the internal session-retry helper."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        tokens = mock.post(_TOKENS_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"accessToken": "stale"}),
+                httpx.Response(200, json={"accessToken": "fresh"}),
+            ]
+        )
+        managers = mock.get(_MANAGERS_PATH).mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(200, json={"elements": [{"version": "5.1.1.0-11111111"}]}),
+            ]
+        )
+        fp = await connector.fingerprint(_TARGET_A, operator=_make_operator())
+
+    assert fp.reachable is True
+    assert fp.version == "5.1.1.0-11111111"
+    assert tokens.call_count == 2
+    assert managers.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_5xx() -> None:
+    """A 5xx on /v1/sddc-managers → reachable=False with a structured error."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "tok"})
+        mock.get(_MANAGERS_PATH).respond(503)
+        fp = await connector.fingerprint(_TARGET_A, operator=_make_operator())
+    assert fp.reachable is False
+    assert "HTTPStatusError" in fp.extras["error"] or "503" in fp.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_operator_less_fails_closed_unreachable() -> None:
+    """An operator-less fingerprint (no JWT) fails closed → unreachable, never authenticating."""
+    connector = _make_connector()
+    # No respx routes: the empty-JWT fail-closed trips before any HTTP call.
+    fp = await connector.fingerprint(_TARGET_A)
+    assert fp.reachable is False
+    assert "VaultCredentialsReadError" in fp.extras["error"]
+    assert connector._session_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_without_operator_is_not_ok() -> None:
+    """``probe(target)`` takes no operator, so on the auth-only SDDC surface it fails closed.
+
+    SDDC Manager has no unauthenticated endpoint, so ``probe(target)`` — which has no
+    operator to authenticate with — delegates to ``fingerprint(target)`` (empty-JWT
+    placeholder), fails closed, and reports not-ok. The real reachability check is
+    ``fingerprint(target, operator)`` via the probe routes (tested above). This matches
+    the modern ``sddc_manager`` sibling, whose probe likewise cannot authenticate
+    without an operator. No respx routes: the fail-closed trips before any HTTP call.
+    """
+    connector = _make_connector()
+    result = await connector.probe(_TARGET_A)
+    assert result.ok is False
+    # Pin the *fail-closed* reason specifically (not just any not-ok) so removing the
+    # empty-JWT guard — which would let this fall through to a transport error — is
+    # caught here too, not only by the two stronger operator-less tests above.
+    assert result.reason is not None and "VaultCredentialsReadError" in result.reason
+    assert connector._session_tokens == {}
+    await connector.aclose()

--- a/backend/tests/test_connectors_sddc_vcf5_dual_impl_resolution.py
+++ b/backend/tests/test_connectors_sddc_vcf5_dual_impl_resolution.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The third two-impl resolver test — ``product=sddc`` (sddc-rest + sddc-vcf5), #3059.
+
+``product=sddc`` becomes a two-implementation case (after ``fleet`` and ``vcfa``;
+initiative #3056, policy #3033/#3038). Two hand-rolled ``HttpConnector`` subclasses
+register under the same product with distinct ``impl_id``s and **disjoint** version
+bands, and :func:`~meho_backplane.connectors.resolver.resolve_connector` picks one per
+target by fingerprint:
+
+* modern ``sddc-rest``
+  (:class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`) —
+  VCF 9.x, ``supported_version_range=">=9.0,<10.0"``.
+* legacy ``sddc-vcf5``
+  (:class:`~meho_backplane.connectors.sddc_vcf5.connector.SddcVcf5Connector`) — VCF
+  5.x, ``supported_version_range=">=5.0,<9.0"``.
+
+The inversion vs ``fleet``: the **modern** ``sddc_manager`` owns the ``("sddc","","")``
+wildcard (it shipped first), so the legacy ``sddc-vcf5`` registers **only** its
+versioned triple. An unfingerprinted ``sddc`` target resolves to modern — but in
+practice a VCF 5.x target fingerprints straight into the ``>=5.0,<9.0`` band (SDDC
+Manager exposes a real product version at ``GET /v1/sddc-managers``, e.g.
+``"5.2.0.0-24276214"``), so it resolves to the legacy impl without an operator-asserted
+version. Mirrors :mod:`tests.test_connectors_vra8_dual_impl_resolution`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+from meho_backplane.connectors.sddc_vcf5.connector import SddcVcf5Connector
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+def _fp(version: str | None) -> _FakeFingerprint:
+    return _FakeFingerprint(version=version)
+
+
+def _register_both_impls() -> None:
+    """Register both sddc impls exactly as their ``__init__`` modules do.
+
+    * ``sddc-rest`` (modern): the versioned triple **plus** the ``("sddc","","")``
+      wildcard fallback.
+    * ``sddc-vcf5`` (legacy): the versioned triple only — a second class on the
+      wildcard key would raise ``RuntimeError``.
+    """
+    register_connector_v2(
+        product=SddcManagerConnector.product,
+        version=SddcManagerConnector.version,
+        impl_id=SddcManagerConnector.impl_id,
+        cls=SddcManagerConnector,
+    )
+    register_connector_v2(product="sddc", version="", impl_id="", cls=SddcManagerConnector)
+    register_connector_v2(
+        product=SddcVcf5Connector.product,
+        version=SddcVcf5Connector.version,
+        impl_id=SddcVcf5Connector.impl_id,
+        cls=SddcVcf5Connector,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    _register_both_impls()
+    yield
+    clear_registry()
+
+
+def test_both_impls_register_under_distinct_triples() -> None:
+    """Two impls share ``product="sddc"`` with distinct (version, impl_id); modern owns wildcard."""
+    assert (
+        SddcManagerConnector.product,
+        SddcManagerConnector.version,
+        SddcManagerConnector.impl_id,
+    ) == ("sddc", "9.0", "sddc-rest")
+    assert (SddcVcf5Connector.product, SddcVcf5Connector.version, SddcVcf5Connector.impl_id) == (
+        "sddc",
+        "5.0",
+        "sddc-vcf5",
+    )
+    # Disjoint bands (no overlap → no specificity tie).
+    assert SddcManagerConnector.supported_version_range == ">=9.0,<10.0"
+    assert SddcVcf5Connector.supported_version_range == ">=5.0,<9.0"
+
+    triples = set(all_connectors_v2())
+    assert ("sddc", "9.0", "sddc-rest") in triples
+    assert ("sddc", "5.0", "sddc-vcf5") in triples
+    assert ("sddc", "", "") in triples
+    # ...owned by the MODERN impl (inversion vs fleet).
+    assert all_connectors_v2()[("sddc", "", "")] is SddcManagerConnector
+
+
+def test_vcf5_full_version_string_resolves_legacy() -> None:
+    """A realistic VCF 5.2 fingerprint (``"5.2.0.0-24276214"``) resolves ``sddc-vcf5``.
+
+    This is the load-bearing case: the connector's fingerprint reads the full VCF
+    version string with a build suffix off ``GET /v1/sddc-managers``, so resolution
+    must accept it into ``>=5.0,<9.0`` — a VCF 5.x source resolves to the legacy impl
+    on fingerprint alone (no operator-asserted version needed).
+    """
+    target = _FakeTarget(product="sddc", fingerprint=_fp("5.2.0.0-24276214"))
+    assert resolve_connector(target) is SddcVcf5Connector
+
+
+def test_5x_boundary_and_patch_targets_resolve_legacy() -> None:
+    """The band floor (5.0) and a 5.1/5.2 target resolve ``sddc-vcf5`` (in ``>=5.0,<9.0``)."""
+    assert (
+        resolve_connector(_FakeTarget(product="sddc", fingerprint=_fp("5.0"))) is SddcVcf5Connector
+    )
+    assert (
+        resolve_connector(_FakeTarget(product="sddc", fingerprint=_fp("5.1.1.0")))
+        is SddcVcf5Connector
+    )
+
+
+def test_9x_target_resolves_modern_sddc_rest() -> None:
+    """A VCF 9.0 target resolves ``sddc-rest`` (``>=9.0,<10.0``; legacy excludes it)."""
+    target = _FakeTarget(product="sddc", fingerprint=_fp("9.0.0.0-24000000"))
+    assert resolve_connector(target) is SddcManagerConnector
+
+
+def test_5x_preferred_modern_is_moot_out_of_range() -> None:
+    """``preferred_impl_id="sddc-rest"`` on a 5.x target cannot flip the result (out of range)."""
+    target = _FakeTarget(
+        product="sddc", fingerprint=_fp("5.2.0.0-24276214"), preferred_impl_id="sddc-rest"
+    )
+    assert resolve_connector(target) is SddcVcf5Connector
+
+
+def test_unfingerprinted_target_resolves_via_modern_wildcard() -> None:
+    """A fresh target (no fingerprint / version) resolves via the MODERN-owned wildcard.
+
+    The inversion vs fleet: an unfingerprinted ``sddc`` estate resolves to modern
+    ``sddc-rest`` until it carries a 5.x version. Pins the documented behaviour so a
+    future wildcard re-assignment can't silently change it.
+    """
+    target = _FakeTarget(product="sddc", fingerprint=None, version=None)
+    assert resolve_connector(target) is SddcManagerConnector

--- a/backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py
+++ b/backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""sddc-vcf5 (VCF 5.x SDDC Manager) hand-coded-surface reconcile lane (#3059) — #2980 harness.
+
+Pins the exact ``METHOD:/path`` surface the ``sddc-vcf5`` connector hand-codes, swept
+from the connector's **live** module constants (the #2944 introspect-live-constants
+pattern — never a hardcoded mirror that can drift). Parse-only, no DB / embeddings /
+containers, so it lives in the required unit sweep.
+
+**Evidenced exclusion — manifest pin, no served-op-id compare.** SDDC Manager 5.x
+publishes only a **Swagger 2.0** API definition (appliance-served, non-conformant:
+missing ``info.version``); OpenAPI 3.x is a VCF-9.0-net-new deliverable
+(``vmware/vcf-api-specs`` is tagged 9.0/9.1 only — no 5.x). MEHO's ingest parser
+accepts OpenAPI 3.0/3.1 only (#2090), so the 5.x surface is not operator-ingestable
+(hence the typed read core). So this lane is the **manifest pin** half of the
+standard — it runs unconditionally, proves the enumeration on every sweep, and a new
+hand-coded path / renamed constant / method change must update the manifest
+consciously.
+
+**Strengthening (available, deferred):** SDDC Manager's ``/v1/*`` path surface is
+**stable since VCF 4.0**, so these 5.x paths are the same shapes the modern
+``sddc_manager`` (9.x) connector reads and reconciles against the vendored OA3
+``vmware/vcf-api-specs`` ``sddc-manager-openapi.json`` (9.1). A served-set check could
+therefore arm these 5.x *paths* against that 9.x OA3 (path existence is
+version-stable even though response schemas drift) — deferred in favour of the
+tested always-on manifest pin. Full evidence + activation trigger live in the
+``sddc-vcf5`` entry of ``docs/decisions/spec-reconcile-guards-standard.md``.
+
+Dispatch-fidelity of each path is proven live-mocked in
+:mod:`tests.test_connectors_sddc_vcf5_typed_reads` /
+:mod:`tests.test_connectors_sddc_vcf5_auth`.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.sddc_vcf5 import connector as _connector
+from meho_backplane.connectors.sddc_vcf5 import typed_reads as _typed_reads_module
+
+#: HTTP method per hand-coded path constant. ``_TOKENS_PATH`` is POSTed (the token
+#: session mint); every other constant — the ``/v1/sddc-managers`` fingerprint probe
+#: and the six migration-inventory reads — is GET. A new ``*_PATH`` constant not
+#: listed here fails the sweep loudly so its method is mapped consciously.
+_METHOD_BY_CONSTANT = {
+    "_TOKENS_PATH": "POST",
+    "_DOMAINS_PATH": "GET",
+    "_CLUSTERS_PATH": "GET",
+    "_HOSTS_PATH": "GET",
+    "_VCENTERS_PATH": "GET",
+    "_NSXT_CLUSTERS_PATH": "GET",
+    "_TASKS_PATH": "GET",
+    "_SDDC_MANAGERS_PATH": "GET",
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` string constants of the ``sddc_vcf5.typed_reads`` module."""
+    return {
+        name: value
+        for name, value in vars(_typed_reads_module).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the sddc-vcf5 connector dispatches.
+
+    Swept from the live ``typed_reads`` constants (never a hardcoded mirror); the
+    method for each is taken from :data:`_METHOD_BY_CONSTANT`. A constant with no
+    method mapping fails loudly so the reconcile keeps covering it.
+    """
+    declared: set[str] = set()
+    for name, path in _path_constants().items():
+        method = _METHOD_BY_CONSTANT.get(name)
+        if method is None:
+            raise AssertionError(
+                f"sddc_vcf5.typed_reads.{name} has no entry in _METHOD_BY_CONSTANT — map "
+                "the new constant's HTTP method there consciously so the reconcile keeps "
+                "covering it."
+            )
+        declared.add(f"{method}:{path}")
+    return declared
+
+
+def test_path_constant_names_are_pinned() -> None:
+    """Guard: the introspection finds exactly the hand-coded path-constant set."""
+    assert sorted(_path_constants()) == [
+        "_CLUSTERS_PATH",
+        "_DOMAINS_PATH",
+        "_HOSTS_PATH",
+        "_NSXT_CLUSTERS_PATH",
+        "_SDDC_MANAGERS_PATH",
+        "_TASKS_PATH",
+        "_TOKENS_PATH",
+        "_VCENTERS_PATH",
+    ]
+
+
+def test_sddc_vcf5_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept ``METHOD:/path`` manifest so drift can't silently change the surface.
+
+    Runs unconditionally (no shelf / spec needed). Because 5.x publishes only Swagger
+    2.0 (OA3-only ingest can't consume it — evidenced exclusion, see the module
+    docstring), this manifest pin is the whole reconcile: a new hand-coded path, a
+    renamed constant, or a method change must update it consciously.
+    """
+    assert _declared_op_ids() == {
+        "POST:/v1/tokens",
+        "GET:/v1/domains",
+        "GET:/v1/clusters",
+        "GET:/v1/hosts",
+        "GET:/v1/vcenters",
+        "GET:/v1/nsxt-clusters",
+        "GET:/v1/tasks",
+        "GET:/v1/sddc-managers",
+    }
+
+
+def test_probe_constant_links_to_sddc_managers_path() -> None:
+    """The fingerprint probe reads the same ``/v1/sddc-managers`` the manifest pins."""
+    assert _typed_reads_module._SDDC_MANAGERS_PATH == "/v1/sddc-managers"
+    assert "/v1/sddc-managers" in _connector._SDDC_VCF5_PROBE_METHOD

--- a/backend/tests/test_connectors_sddc_vcf5_typed_reads.py
+++ b/backend/tests/test_connectors_sddc_vcf5_typed_reads.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the VCF 5.x SDDC Manager typed read core (#3059, initiative #3056).
+
+The appliance-free proof that a VCF 5.x SDDC Manager target dispatches a
+migration-inventory read end-to-end on a fresh boot. Coverage:
+
+* **Zero-catalog typed dispatch.** Each of the 7 reads dispatches through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked SDDC Manager (the
+  ``POST /v1/tokens`` login + the data GET) with **only** the typed registrar run and
+  returns ``status="ok"``, carrying the minted Bearer.
+* **Data-path 401 self-heal.** A 401 on the data read re-mints via the dispatcher's
+  ``invalidate_session`` arm and retries once (the load-bearing #2067 proof).
+* **Registration-shape invariants.** All 7 reads persist as ``source_kind="typed"``,
+  ``is_enabled=True``, ``safe`` / ungated / ``read-only``; their 2 groups land
+  ``review_status="enabled"``; no write op is registered.
+
+Mirrors :mod:`tests.test_connectors_vcd_typed_reads`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.sddc_vcf5 import (
+    SDDC_VCF5_CONNECTOR_ID,
+    SDDC_VCF5_IMPL_ID,
+    SDDC_VCF5_PRODUCT,
+    SDDC_VCF5_TYPED_OPS,
+    SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP,
+    SDDC_VCF5_VERSION,
+    SddcVcf5Connector,
+    register_sddc_vcf5_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_SDDC_HOST = "sddc-typed.test.invalid"
+_SDDC_BASE_URL = f"https://{_SDDC_HOST}"
+_TOKENS_PATH = "/v1/tokens"
+
+_EXPECTED_OP_IDS = {
+    "sddc.vcf5.domain.list",
+    "sddc.vcf5.cluster.list",
+    "sddc.vcf5.host.list",
+    "sddc.vcf5.vcenter.list",
+    "sddc.vcf5.nsxt_cluster.list",
+    "sddc.vcf5.manager.list",
+    "sddc.vcf5.task.list",
+}
+
+_EXPECTED_GROUPS = {"sddc-vcf5-inventory", "sddc-vcf5-tasks"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=SDDC_VCF5_PRODUCT,
+        version=SDDC_VCF5_VERSION,
+        impl_id=SDDC_VCF5_IMPL_ID,
+        cls=SddcVcf5Connector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _Sddc5ReadTarget:
+    """Target satisfying both ``SddcTargetLike`` and the resolver shape.
+
+    ``fingerprint.version="5.2.0.0-24276214"`` is in the ``sddc-vcf5`` band
+    ``">=5.0,<9.0"``, so a VCF 5.x target resolves to this legacy impl.
+    """
+
+    def __init__(self) -> None:
+        self.product = SDDC_VCF5_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "5.2.0.0-24276214"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-0000000000f0")
+        self.name = "sddc-typed"
+        self.host = _SDDC_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/sddc-typed"
+        self.auth_model = "shared_service_account"
+        self.extras: dict[str, Any] = {}
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-sddc",
+        name="SDDC Reads Operator",
+        email=None,
+        raw_jwt="op.reads.sddc.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000f4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _stub_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Username/password for the token login."""
+    return {"username": "sddc-svc", "password": "sddc-pw"}
+
+
+async def _register_and_resolve() -> SddcVcf5Connector:
+    """Run the typed registrar (only) and return a credentials-stubbed instance."""
+    await register_sddc_vcf5_typed_operations()
+    instance = get_or_create_connector_instance(SddcVcf5Connector)
+    instance._credentials_loader = _stub_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Zero-catalog typed dispatch
+# ---------------------------------------------------------------------------
+
+# (op_id, wire path, payload)
+_DISPATCH_CASES: list[tuple[str, str, Any]] = [
+    ("sddc.vcf5.domain.list", "/v1/domains", {"elements": [{"id": "d1", "name": "MGMT"}]}),
+    ("sddc.vcf5.cluster.list", "/v1/clusters", {"elements": [{"id": "c1"}]}),
+    ("sddc.vcf5.host.list", "/v1/hosts", {"elements": [{"id": "h1"}]}),
+    ("sddc.vcf5.vcenter.list", "/v1/vcenters", {"elements": [{"id": "vc1"}]}),
+    ("sddc.vcf5.nsxt_cluster.list", "/v1/nsxt-clusters", {"elements": [{"id": "n1"}]}),
+    ("sddc.vcf5.manager.list", "/v1/sddc-managers", {"elements": [{"version": "5.2.0.0"}]}),
+    ("sddc.vcf5.task.list", "/v1/tasks", {"elements": [{"id": "t1", "status": "Successful"}]}),
+]
+
+
+@pytest.mark.parametrize(("op_id", "path", "payload"), _DISPATCH_CASES, ids=lambda v: v)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+    payload: Any,
+) -> None:
+    """Each read dispatches typed (zero ingested catalog), minting the token session."""
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        tokens = mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "disp-tok"})
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_VCF5_CONNECTOR_ID,
+            op_id=op_id,
+            target=_Sddc5ReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert tokens.called
+    assert route.called and route.call_count == 1
+    assert route.calls[0].request.headers["Authorization"] == "Bearer disp-tok"
+
+
+@pytest.mark.asyncio
+async def test_data_path_401_remints_via_dispatcher(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """A data-path 401 (expired token) self-heals via the dispatcher's session-recovery arm.
+
+    A stale token gets a 401 on the data read; the dispatcher evicts it via the
+    connector's ``invalidate_session`` hook and re-dispatches once; the retry re-mints
+    a fresh token and the op succeeds. Without ``invalidate_session`` this would fall
+    through to ``connector_auth_failed`` and wedge (dispatcher #2067) — so a green here
+    proves the hook is wired to the arm the 401 path actually calls, not the
+    establish-only ``invalidate_credentials``.
+    """
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL) as mock:
+        tokens = mock.post(_TOKENS_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json={"accessToken": "tok-stale"}),
+                httpx.Response(200, json={"accessToken": "tok-fresh"}),
+            ]
+        )
+        domains = mock.get("/v1/domains").mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(200, json={"elements": [{"id": "d1"}]}),
+            ]
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_VCF5_CONNECTOR_ID,
+            op_id="sddc.vcf5.domain.list",
+            target=_Sddc5ReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"elements": [{"id": "d1"}]}
+    assert tokens.call_count == 2
+    assert domains.call_count == 2
+    assert domains.calls[0].request.headers["Authorization"] == "Bearer tok-stale"
+    assert domains.calls[1].request.headers["Authorization"] == "Bearer tok-fresh"
+
+
+@pytest.mark.asyncio
+async def test_host_list_forwards_optional_filters(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """``sddc.vcf5.host.list`` forwards the optional domainId / clusterId / status filters."""
+    await _register_and_resolve()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKENS_PATH).respond(200, json={"accessToken": "tok"})
+        hosts = mock.get("/v1/hosts").respond(200, json={"elements": []})
+        await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_VCF5_CONNECTOR_ID,
+            op_id="sddc.vcf5.host.list",
+            target=_Sddc5ReadTarget(),
+            params={"domainId": "dom-1", "status": "ASSIGNED"},
+        )
+
+    req = hosts.calls[0].request
+    assert req.url.params["domainId"] == "dom-1"
+    assert req.url.params["status"] == "ASSIGNED"
+    assert "clusterId" not in req.url.params
+
+
+# ---------------------------------------------------------------------------
+# Registration-shape invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_typed_and_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 7 reads persist as source_kind='typed', is_enabled=True (live on fresh boot)."""
+    await register_sddc_vcf5_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == SDDC_VCF5_PRODUCT,
+                    EndpointDescriptor.impl_id == SDDC_VCF5_IMPL_ID,
+                    EndpointDescriptor.op_id.in_(list(_EXPECTED_OP_IDS)),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == _EXPECTED_OP_IDS
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.is_enabled is True for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+    assert all(r.method is None and r.path is None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_groups_are_enabled(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The 2 read-core groups land review_status='enabled' with a curated when_to_use."""
+    await register_sddc_vcf5_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(OperationGroup).where(
+                    OperationGroup.product == SDDC_VCF5_PRODUCT,
+                    OperationGroup.impl_id == SDDC_VCF5_IMPL_ID,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {g.group_key for g in rows} == _EXPECTED_GROUPS
+    assert all(g.review_status == "enabled" for g in rows)
+    assert all(g.when_to_use.strip() for g in rows)
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed reads are retrievable via search_operations."""
+    await register_sddc_vcf5_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {
+            "connector_id": SDDC_VCF5_CONNECTOR_ID,
+            "query": "vcf sddc manager domain cluster host vcenter nsxt inventory migration",
+            "limit": 25,
+        },
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    assert found >= _EXPECTED_OP_IDS, f"missing from search: {_EXPECTED_OP_IDS - found}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-dataclass invariants (no DB, no async)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_table_is_exactly_the_read_core() -> None:
+    assert {op.op_id for op in SDDC_VCF5_TYPED_OPS} == _EXPECTED_OP_IDS
+    assert len(SDDC_VCF5_TYPED_OPS) == 7
+
+
+def test_every_group_key_has_a_when_to_use() -> None:
+    assert set(SDDC_VCF5_TYPED_WHEN_TO_USE_BY_GROUP) == _EXPECTED_GROUPS
+    used_groups = {op.group_key for op in SDDC_VCF5_TYPED_OPS}
+    assert used_groups == _EXPECTED_GROUPS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in SDDC_VCF5_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_canonical_keys(op_id: str) -> None:
+    op = next(o for o in SDDC_VCF5_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    for key in ("when_to_use", "output_shape"):
+        value = op.llm_instructions.get(key)
+        assert isinstance(value, str) and value.strip(), f"{op_id}: {key}"
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in SDDC_VCF5_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only core: no create/write op and no credential-read op ships here."""
+    for op in SDDC_VCF5_TYPED_OPS:
+        assert not any(
+            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
+        )
+        assert "write" not in op.tags
+        assert "credential-read" not in op.tags

--- a/docs/codebase/connectors-sddc-vcf5.md
+++ b/docs/codebase/connectors-sddc-vcf5.md
@@ -1,0 +1,214 @@
+# Connector: sddc-vcf5 (VCF 5.x SDDC Manager, legacy dual-impl of `sddc`)
+
+## Overview
+
+The `sddc-vcf5` connector is the hand-rolled `HttpConnector` subclass that makes
+**VCF 5.x SDDC Manager** (the SDDC Manager tier of a VMware Cloud Foundation 5.x
+estate) dispatchable under the `(product="sddc", version="5.0", impl_id="sddc-vcf5")`
+registry triple. It is the **legacy dual-impl** of `product="sddc"` filed under the
+legacy migration-source connector-coverage initiative
+([#3056](https://github.com/evoila/meho/issues/3056), task #3059): VCF 5.x is a
+migration **source** estate evoila brings customers *off*, so MEHO must be able to
+read and inventory it during discovery + onboarding.
+
+Source: `backend/src/meho_backplane/connectors/sddc_vcf5/`.
+
+**VCF 5.x is the same product line as VCF 9.x, one major generation back.** The
+modern impl is [`connectors-sddc-manager.md`](connectors-sddc-manager.md)
+(`sddc-rest`, `>=9.0,<10.0`); this is a second implementation of `product="sddc"`,
+fingerprint-resolved per target — the third real two-impl case (after `fleet` and
+`vcfa`).
+
+## Dual-impl resolution (`sddc` = third two-impl case)
+
+| Impl | Class | Band | Wildcard |
+|---|---|---|---|
+| modern `sddc-rest` | `SddcManagerConnector` | `>=9.0,<10.0` | **owns** `("sddc","","")` |
+| legacy `sddc-vcf5` | `SddcVcf5Connector` | `>=5.0,<9.0` | none |
+
+The bands are **disjoint**, so resolution never reaches a specificity tie-break. The
+**modern** `sddc_manager` owns the `("sddc","","")` wildcard (it shipped first), so
+`sddc-vcf5` registers **only** its versioned triple — the *inversion* of the `fleet`
+case. Consequence: an *unfingerprinted* `sddc` target resolves to modern. **In
+practice this is a non-issue**: SDDC Manager exposes a *real* product version at
+`GET /v1/sddc-managers` (e.g. `"5.2.0.0-24276214"`), so a VCF 5.x target fingerprints
+straight into `>=5.0,<9.0` and resolves to the legacy impl without an
+operator-asserted version — unlike `vcfa-vra8`, whose fingerprint yields only an
+API-date label. The matrix is pinned in
+[`test_connectors_sddc_vcf5_dual_impl_resolution.py`](../../backend/tests/test_connectors_sddc_vcf5_dual_impl_resolution.py).
+
+## Why a separate impl (not just widen the modern band)
+
+SDDC Manager's REST *path* surface is **stable since VCF 4.0** — the `/v1/*` reads
+here are the same shapes the modern connector reads. The split is driven by **spec
+format + schema drift**:
+
+- **Spec format.** VCF 5.x publishes only a **Swagger 2.0** definition
+  (appliance-served at `/ui/assets/spec/external/swagger.json`, non-conformant —
+  missing `info.version`). OpenAPI 3.x is a **VCF-9.0-net-new** deliverable
+  (`vmware/vcf-api-specs` is tagged 9.0/9.1 only — no 5.x). MEHO's ingest parser is
+  OA3-only (#2090), so 5.x cannot be operator-ingested — hence a **typed** read core
+  (the `vcd` / `vcfa-vra8` posture), not a generic spec-ingested connector.
+- **Schema drift.** Response fields differ by point release (e.g. `ipAddress`
+  deprecated in 5.2 in favour of `fqdn`), so the 9.x connector's schemas cannot
+  faithfully serve a 5.x target.
+
+## Scope: typed read core (#3059)
+
+A curated **7-op typed read core** — the VCF 5.x migration-inventory surface —
+registered as `source_kind="typed"` and enabled at register time, so a VCF 5.x
+target dispatches an inventory read on a **fresh boot with zero catalog ingest**.
+
+| Group | Ops |
+|---|---|
+| `sddc-vcf5-inventory` | `sddc.vcf5.domain.list`, `.cluster.list`, `.host.list`, `.vcenter.list`, `.nsxt_cluster.list`, `.manager.list` |
+| `sddc-vcf5-tasks` | `sddc.vcf5.task.list` |
+
+Op ids are namespaced `sddc.vcf5.*` (distinct from the modern impl's `sddc.*`); the
+resolver picks one impl per target, so an agent only sees the set matching the
+target's version. The set covers the physical + logical VCF footprint a migration
+must re-home (domains → clusters → hosts → vCenters → NSX-T fabric → the SDDC Manager
+appliance itself) plus workflow tasks (the pre-cutover quiescence check).
+
+**Deliberately out of scope** (vs the modern connector's 14 ops): the credential-read
+(`GET /v1/credentials`, secret-bearing) and the network-pool host-commissioning
+reads — this core inventories a migration *source*, it does not operate it.
+
+## Key types
+
+- **`SddcVcf5Connector`** (`connector.py`) — `HttpConnector` subclass.
+  `product="sddc"`, `version="5.0"`, `impl_id="sddc-vcf5"`,
+  `supported_version_range=">=5.0,<9.0"`, `priority=1`. `connector_id`
+  `"sddc-vcf5-5.0"` parses back to `("sddc", "5.0", "sddc-vcf5")`.
+- Target shape + credential loader are **reused from the modern sibling**
+  (`meho_backplane.connectors.sddc_manager.session`: `SddcTargetLike`,
+  `SddcCredentialsLoader`, `load_credentials_from_vault`) — the credential contract
+  is product-level and version-agnostic, so a bespoke duplicate would only drift.
+- Canonical constants (`__init__.py`): `SDDC_VCF5_PRODUCT`, `SDDC_VCF5_VERSION`,
+  `SDDC_VCF5_IMPL_ID`, `SDDC_VCF5_CONNECTOR_ID`.
+
+## Control flow
+
+### Registration
+
+Importing `meho_backplane.connectors.sddc_vcf5` registers **only** the versioned
+triple — **not** a wildcard (the modern `sddc_manager` owns `("sddc","","")`; a
+second class on that key would crash `_eager_import_connectors` at boot). Both the
+legacy and modern packages register under `product="sddc"` at eager-import — the
+`vcf_fleet` + `fleet_lcm` shape.
+
+### Auth (token session, identical to the modern 9.x flow)
+
+Token auth is VCF 4.0+, so 5.x and 9.x share it. SDDC Manager rejects HTTP Basic
+outright and mints a bearer via `POST /v1/tokens` with a `{username, password}` JSON
+body, returning `accessToken`. On first use `auth_headers`:
+
+1. Rejects any `target.auth_model` other than `shared_service_account` / `None`.
+2. Fails closed on an empty `operator.raw_jwt` (a system-initiated call cannot read
+   per-target vendor credentials) — enforced **before** the token-cache lookup so a
+   primed token can never leak to an unauthenticated caller.
+3. Mints the session via the shared
+   `meho_backplane.connectors._shared.vcf_auth.vcf_session_login` helper (the same
+   helper the modern `sddc_manager` connector uses) — a non-2xx / token-less 2xx
+   raises the target-named `SessionLoginError`.
+4. Caches the token per tenant-unique `(tenant_id, target.id)` key and returns
+   `Authorization: Bearer <accessToken>`.
+
+A raw 401 on a **data** read propagates to the dispatcher's session-recovery arm,
+which — because the connector advertises an `invalidate_session` hook (#2067) —
+evicts the cached token and re-dispatches once, so the retry re-mints. The base
+transport's tenacity retry (5xx / connection) stays intact. (`invalidate_credentials`
+is also implemented — the #2396 establish-failure companion.) The 401 self-heal is
+proven end-to-end in `test_data_path_401_remints_via_dispatcher`.
+
+### Fingerprint / probe
+
+SDDC Manager has **no unauthenticated version endpoint**, so `fingerprint` reads
+`GET /v1/sddc-managers` **on the token session** (via `_get_json_with_session_retry`,
+which the dispatcher does not drive — so it evicts + re-mints + retries once on its
+own 401) and takes `elements[0]`. `version` carries the full VCF version string
+(e.g. `"5.2.0.0-24276214"`) — a *real* product version, so a VCF 5.x target resolves
+to this impl by fingerprint alone. An operator-less probe (no JWT) fails closed and
+reports unreachable; the ABC `probe(target)` — which has no operator — therefore
+always reports not-ok, and the real reachability check is `fingerprint(target,
+operator)` via the probe routes (the modern `sddc_manager` posture).
+
+### Dispatch
+
+The typed read ops dispatch through `meho_backplane.operations.dispatch`; the handler
+issues a plain `self._get_json` on the token session (dispatcher-hook 401 recovery).
+`execute()` is the G0.6 ABC-compatibility shim.
+
+## Typed read core internals
+
+Follows the modern `sddc_manager` layout:
+
+- **`typed_ops.py`** — the `SddcVcf5TypedOp` dataclass table, the per-group
+  `when_to_use` map, inline per-op `llm_instructions` (`when_to_use` / `output_shape`
+  / `parameter_hints`, the SDDC-family key shape), and the
+  `register_sddc_vcf5_typed_operations` registrar.
+- **`typed_reads.py`** — the op bodies (`async def sddc5_*_impl(...)`), each issuing
+  `connector._get_json(...)`; the filtered reads forward `domainId` / `clusterId` /
+  `status` via `_optional_query`. Holds the `_*_PATH` constants (incl. `_TOKENS_PATH`
+  for the mint) the reconcile lane introspects.
+- **`connector.py`** — the connector class + auth helpers + 7 bound-method shims.
+
+## Spec reconcile lane
+
+[`backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py`](../../backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py)
+is a **manifest pin + evidenced exclusion**: 5.x publishes only Swagger 2.0
+(OA3-only ingest can't consume it, and OA3 is VCF-9.0-net-new — no 5.x artifact). The
+lane sweeps the connector's live `_*_PATH` constants and pins the exact hand-coded
+surface unconditionally. **Strengthening (deferred):** the `/v1/*` paths are stable
+since VCF 4.0, so these 5.x paths could be armed against the modern connector's
+vendored 9.x OA3 (`vmware/vcf-api-specs` `sddc-manager-openapi.json`) — path existence
+is version-stable even though response schemas drift. Full evidence + activation
+trigger are in the `sddc-vcf5` entry of
+[`spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` — pooled per-target client,
+  tenacity 5xx/connection retry, `_get_json`.
+- `meho_backplane.connectors._shared.vcf_auth` — `vcf_session_login`,
+  `SessionLoginError`, `is_acceptable_auth_model`.
+- `meho_backplane.connectors.sddc_manager.session` — `SddcTargetLike`,
+  `SddcCredentialsLoader`, `load_credentials_from_vault` (reused).
+- `meho_backplane.connectors._shared.{cache_key,vault_creds}`,
+  `meho_backplane.connectors.schemas`.
+- `httpx`, `respx` (test-only). No new runtime deps.
+
+## Known issues / follow-ups
+
+- **Live dispatch not verified against a real appliance.** No VCF 5.x lab was dialled
+  during the build; the read core is unit-tested end-to-end (dispatch through the
+  token-mint seam against a respx mock) and manifest-pinned. Live verification
+  against a VCF 5.x source appliance (and confirming the 5.2 `ipAddress`→`fqdn`
+  schema drift in the returned records) is the deferred tail.
+- **List-focused inventory core.** Deep by-id reads, the credential-read surface, and
+  any write surface are out of scope — a source-inventory core, not an operations
+  surface.
+- **Unfingerprinted targets resolve to modern.** Because the modern impl owns the
+  wildcard, a `sddc` target with no fingerprint/version resolves to `sddc-rest`. In
+  practice a probed VCF 5.x target fingerprints its real version and resolves here.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/3059>
+- Parent initiative (legacy migration-source coverage):
+  <https://github.com/evoila/meho/issues/3056>
+- Dual-version / coverage policy of record:
+  <https://github.com/evoila/meho/issues/3033>
+- Read-core tests:
+  [`test_connectors_sddc_vcf5_auth.py`](../../backend/tests/test_connectors_sddc_vcf5_auth.py)
+  (token mint + authenticated fingerprint),
+  [`test_connectors_sddc_vcf5_typed_reads.py`](../../backend/tests/test_connectors_sddc_vcf5_typed_reads.py)
+  (dispatch + registration + 401 self-heal),
+  [`test_connectors_sddc_vcf5_dual_impl_resolution.py`](../../backend/tests/test_connectors_sddc_vcf5_dual_impl_resolution.py)
+  (the two-impl resolution matrix), and
+  [`test_connectors_sddc_vcf5_spec_reconcile.py`](../../backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py)
+  (manifest pin).
+- Modern sibling impl (same `product="sddc"`):
+  [`connectors-sddc-manager.md`](connectors-sddc-manager.md)
+- Migration-source typed read-core exemplars:
+  [`connectors-vra8.md`](connectors-vra8.md), [`connectors-vcd.md`](connectors-vcd.md)

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -438,6 +438,44 @@ committable spec _does_ exist — it just isn't ingestable.**
   Swagger-2.0→OA3 ingest path (#2090) that makes the surface
   operator-ingestable as a generic connector.
 
+### sddc-vcf5 — manifest-pin, Swagger-2.0-only (OA3 is VCF-9.0-net-new) (#3059)
+
+The `sddc-vcf5` (VCF 5.x SDDC Manager) connector is the **legacy dual-impl**
+of `product="sddc"` (initiative
+[#3056](https://github.com/evoila/meho/issues/3056), task #3059; the modern
+`sddc-rest` 9.x lane reconciles against the vendored OA3
+`vmware/vcf-api-specs` `sddc-manager-openapi.json`). Its lane
+(`backend/tests/test_connectors_sddc_vcf5_spec_reconcile.py`) is a
+**manifest pin only** — it sweeps the eight hand-coded op_ids
+unconditionally, no served-op-id compare. **Same shape as `vcfa-vra8`: a
+committable spec exists for the modern generation, but not for 5.x.**
+
+- **Excluded (8 op_ids: `POST:/v1/tokens` + `GET:/v1/{domains, clusters,
+  hosts, vcenters, nsxt-clusters, tasks, sddc-managers}`).** What was
+  checked: SDDC Manager 5.x publishes **only a Swagger 2.0** definition
+  (appliance-served at `/ui/assets/spec/external/swagger.json`,
+  non-conformant — missing `info.version`); **OpenAPI 3.x is a
+  VCF-9.0-net-new deliverable** — `vmware/vcf-api-specs` is tagged
+  `9.0.0.0` / `9.1.0.0` only (verified via the GitHub tags API), with **no
+  5.x branch, tag, or file**. MEHO's ingest parser is OA3-only (#2090), so
+  the 5.x surface is not operator-ingestable — hence the typed read core.
+  There is no pinnable 5.x artifact (the only 5.x spec lives on each
+  appliance, Swagger 2.0), so a served-op-id compare would have nothing to
+  reconcile against. **Residual risk, named** (the nsx lesson): this task
+  ran no live probe of a VCF 5.x appliance — live end-to-end verification
+  (incl. the 5.2 `ipAddress`→`fqdn` schema drift) is the deferred tail, the
+  same unit-tested-first posture `vcd` / `vcfa-vra8` shipped with.
+- **Strengthening (available, deferred):** SDDC Manager's `/v1/*` **path**
+  surface is stable since VCF 4.0, so these 5.x paths are the same shapes
+  the modern `sddc_manager` (9.x) connector reads. A served-set check could
+  arm the 5.x *paths* against the modern connector's already-vendored 9.x
+  OA3 (`sddc-manager-openapi.json`) — path existence is version-stable even
+  though the response *schemas* drift by point release. Deferred in favour
+  of the tested always-on manifest pin.
+- **Activation:** arming the shared `/v1/*` paths against the 9.x
+  `sddc-manager-openapi.json` served set, or Broadcom publishing a 5.x OA3
+  artifact (or MEHO gaining a Swagger-2.0→OA3 ingest path, #2090).
+
 ## Red lane = finding (the protocol)
 
 A red lane on first run against the real shelf is **the guard working**,


### PR DESCRIPTION
## What

The **legacy dual-impl for VCF 5.x SDDC Manager** — the **third real two-impl case** for a product (after `fleet` and `vcfa`). VCF 5.x SDDC Manager is the legacy predecessor of the modern VCF 9.x `sddc-rest`; this registers a second implementation of `product="sddc"` (`impl_id="sddc-vcf5"`, band `>=5.0,<9.0`), fingerprint-resolved against the modern `sddc-rest` (`>=9.0,<10.0`).

Completes the legacy migration-source connector-coverage initiative (#3056): VCF 5.x is a migration **source** estate MEHO must read/inventory during discovery + onboarding.

Closes #3059. With this, the #3056 register is fully green (VCD #3057, vRA 8 #3058, SDDC 5.x #3059).

## Shape

- **Typed read core, 7 ops** — `sddc.vcf5.domain.list` / `.cluster.list` / `.host.list` / `.vcenter.list` / `.nsxt_cluster.list` / `.manager.list` (inventory) + `.task.list` (tasks). Registered `source_kind="typed"`, enabled at register time → **dispatches on a fresh boot with zero catalog ingest.** Typed because 5.x publishes only **Swagger 2.0** (OA3 is a VCF-9.0-net-new deliverable — `vmware/vcf-api-specs` is tagged 9.0/9.1 only), and MEHO's ingest is OA3-only (#2090).
- **Dual-impl resolution.** Disjoint bands (no re-band, no specificity tie). Registers **only** the versioned triple — the modern `sddc_manager` owns the `("sddc","","")` wildcard (the *fleet inversion*). Unlike vRA 8, a VCF 5.x target fingerprints a **real** product version off `GET /v1/sddc-managers` (e.g. `5.2.0.0-24276214`), so it resolves to the legacy impl by fingerprint alone — pinned in `test_connectors_sddc_vcf5_dual_impl_resolution.py`.
- **Auth.** Token flow identical to modern 9.x (`POST /v1/tokens` → `accessToken` → Bearer), via the shared `vcf_session_login` helper. A data-path 401 self-heals via the dispatcher's `invalidate_session` arm (negative-control validated). SDDC Manager has no unauth endpoint, so the fingerprint is authenticated with its own session-retry; an operator-less probe fails closed; `is_system_operator` cache-scoping matches the sibling.
- **Scope:** a source-inventory core. The modern connector's credential-read (secret-bearing) and network-pool host-commissioning reads are deliberately excluded.
- **Reconcile:** manifest-pin + honest evidenced-exclusion (5.x is Swagger-2.0-only, no vendored 5.x OA3). Entry added to `spec-reconcile-guards-standard.md`.

## Verification

- 66 unit tests (auth / typed-reads dispatch / dual-impl resolution / reconcile); ruff + mypy clean.
- 4397-test broad connector sweep green (only the 2 pre-existing real-DNS/ICMP sandbox failures).
- Connector-id round-trip + product-enum meta-tests pass — **no CLI OpenAPI snapshot regen** (product `sddc` reused).
- Adversarially reviewed: no BLOCKER/SHOULD-FIX; two NITs fixed before this PR (`is_system_operator` cache-scoping to match the sibling; a fail-closed test strengthened to pin the reason).

## Deferred tails (documented in `connectors-sddc-vcf5.md`)

- Live-appliance verification (no VCF 5.x lab was dialled; incl. the 5.2 `ipAddress`→`fqdn` schema drift).
- Shelf-armed served-set reconcile against the modern 9.x OA3 (the `/v1/*` paths are VCF-4.0-stable).

## Docs

- `docs/codebase/connectors-sddc-vcf5.md` (full connector doc).
- `docs/decisions/spec-reconcile-guards-standard.md` (`sddc-vcf5` evidenced-exclusion entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
