### PR TITLE
feat(connectors): VCF Installer 9.1 bring-up connector — skeleton (#3065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — VCF Installer 9.1 bring-up connector skeleton (Initiative #2907, task #3065)
+
+- New `vcf-installer` connector (`installer-rest-9.1`) — the governed dispatch
+  surface for VCF 9.x management-domain bring-up (the automation add-on generates
+  the `SddcSpec`, meho governs the POST). This increment ships the **skeleton**:
+  `session_login_token` auth (`POST /v1/tokens` → cached Bearer, reusing the SDDC
+  Manager scheme), fingerprint / probe via `GET /v1/system/appliance-info`, and
+  the `installer.sddc.status` bring-up status poll (`GET /v1/sddcs/{id}`; typed,
+  `safe`). Ships at rubric State 2 (`shared_service_account`, live operator-context
+  Vault read). A spec-reconcile lane pins every hand-coded path against the pinned
+  `vcf-installer-9.1` shelf spec. The governed bring-up **write** (validate →
+  deploy → poll — a `dangerous` + `requires_approval` composite) lands in a
+  following increment. Docs:
+  [`connectors-vcf-installer.md`](docs/codebase/connectors-vcf-installer.md).
+
 ## [0.29.0] - 2026-08-19
 
 ### Security — base image util-linux family patched for CVE-2026-53615 (PR #3053)

--- a/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcf_installer — InstallerConnector package.
+
+Importing this package registers :class:`InstallerConnector` against the v2
+connector registry under ``(product="installer", version="9.1",
+impl_id="installer-rest")``. The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<product>/`` subpackage at startup, so the registration lands
+before any dispatch can occur.
+
+The bring-up status poll (``installer.sddc.status``) ships as a typed op
+(``source_kind="typed"``) via :mod:`.typed_ops` / :mod:`.typed_reads`,
+dispatchable on a fresh boot with zero catalog ingest. The governed bring-up
+write (validate → deploy → poll) arrives as a ``dangerous`` + ``requires_approval``
+composite in a following increment.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
+from meho_backplane.connectors.vcf_installer.profile import INSTALLER_EXECUTION_PROFILE
+from meho_backplane.connectors.vcf_installer.session import (
+    InstallerCredentialsLoader,
+    InstallerTargetLike,
+    SessionCredentials,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.vcf_installer.typed_ops import (
+    INSTALLER_TYPED_OPS,
+    InstallerTypedOp,
+    register_installer_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the VCF Installer connector — the
+#: dispatch-canonical ``(product, version, impl_id)`` triple
+#: :func:`parse_connector_id` derives from ``"installer-rest-9.1"``.
+INSTALLER_PRODUCT: Final[str] = "installer"
+INSTALLER_VERSION: Final[str] = "9.1"
+INSTALLER_IMPL_ID: Final[str] = "installer-rest"
+INSTALLER_CONNECTOR_ID: Final[str] = f"{INSTALLER_IMPL_ID}-{INSTALLER_VERSION}"
+
+register_connector_v2(
+    product="installer",
+    version="9.1",
+    impl_id="installer-rest",
+    cls=InstallerConnector,
+)
+
+# Wildcard fallback: a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present.
+register_connector_v2(
+    product="installer",
+    version="",
+    impl_id="",
+    cls=InstallerConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_installer_typed_operations)
+
+__all__ = [
+    "INSTALLER_CONNECTOR_ID",
+    "INSTALLER_EXECUTION_PROFILE",
+    "INSTALLER_IMPL_ID",
+    "INSTALLER_PRODUCT",
+    "INSTALLER_TYPED_OPS",
+    "INSTALLER_VERSION",
+    "InstallerConnector",
+    "InstallerCredentialsLoader",
+    "InstallerTargetLike",
+    "InstallerTypedOp",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+    "register_installer_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/vcf_installer/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/connector.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""InstallerConnector — hand-rolled HttpConnector subclass for VCF Installer 9.1.
+
+Auth + fingerprint + probe + the G0.6 dispatch shim + the bring-up status poll.
+The governed bring-up *write* (validate → deploy → poll) is a separate
+``dangerous`` + ``requires_approval`` composite (a following increment).
+
+Registered against the v2 registry at import time in
+:mod:`meho_backplane.connectors.vcf_installer.__init__` under
+``(product="installer", version="9.1", impl_id="installer-rest")``.
+
+Auth — token session derived from the shipped ExecutionProfile
+--------------------------------------------------------------
+
+The Installer flow is the ``session_login_token`` named scheme (#2287), the same
+as SDDC Manager: ``POST /v1/tokens`` with a ``{username, password}`` body
+(``TokenCreationSpec``) returns ``accessToken`` (``TokenPair``), sent as
+``Authorization: Bearer <accessToken>`` on every subsequent request. The
+connector derives its login path, request headers, and session-expiry status set
+from :data:`~meho_backplane.connectors.vcf_installer.profile.INSTALLER_EXECUTION_PROFILE`
+via that scheme's spec, so the mechanics cannot drift.
+
+The per-target session token is cached (single-flight under a lock). On a
+downstream ``401`` the cached token is evicted and the login re-run once: the
+:meth:`_get_json_with_session_retry` helper covers the fingerprint/probe
+round-trip, and the public :meth:`invalidate_session` hook is the seam the
+generic dispatch path calls (#2067) before re-dispatching once. Credentials are
+loaded once per target from Vault (a ``401`` means the *token* expired, not the
+credential).
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or ``None``
+for pre-G0.3 targets); any other ``target.auth_model`` raises a clear
+:exc:`NotImplementedError`.
+
+Fingerprint
+-----------
+
+``GET /v1/system/appliance-info`` returns a flat ``ApplianceInfo`` object with a
+top-level ``version`` string and ``role`` — the Installer appliance's own version
+(it has no deployed inventory to fingerprint from). The GET authenticates via the
+token session, so it goes through :meth:`_get_json_with_session_retry`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.profile_auth import SESSION_SCHEME_SPECS
+from meho_backplane.connectors._shared.system_operator import (
+    is_system_operator,
+    synthesise_system_operator,
+)
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError, vcf_session_login
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcf_installer.profile import INSTALLER_EXECUTION_PROFILE
+from meho_backplane.connectors.vcf_installer.session import (
+    InstallerCredentialsLoader,
+    InstallerTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["InstallerConnector", "SessionLoginError"]
+
+_log = structlog.get_logger(__name__)
+
+# The ``session_login_token`` scheme spec (#2287), selected by the shipped
+# profile — supplies the login path, request headers, credential-body builder,
+# and token extractor from one declaration.
+_SESSION_SPEC = SESSION_SCHEME_SPECS[INSTALLER_EXECUTION_PROFILE.auth.scheme]
+
+# ``POST /v1/tokens`` — sourced from the scheme spec's login-path builder.
+_SESSION_CREATE_PATH = _SESSION_SPEC.login_path(INSTALLER_EXECUTION_PROFILE.auth)
+
+# Static headers the login POST carries (JSON Content-Type / Accept).
+_SESSION_REQUEST_HEADERS: dict[str, str] = dict(_SESSION_SPEC.request_headers)
+
+# Downstream statuses meaning "cached token no longer accepted; re-login once".
+_SESSION_EXPIRED_STATUSES: frozenset[int] = INSTALLER_EXECUTION_PROFILE.expiry_statuses
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """True iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset (``None``)."""
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+def _installer_login_body(username: str, password: str) -> dict[str, Any]:
+    """Build the Installer ``{username, password}`` login body via the scheme spec."""
+    return dict(
+        _SESSION_SPEC.build_body(
+            INSTALLER_EXECUTION_PROFILE.auth,
+            {"username": username, "password": password},
+        )
+    )
+
+
+def _extract_access_token(resp: httpx.Response) -> str | None:
+    """Pull ``accessToken`` out of the Installer ``TokenPair`` response via the scheme spec."""
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    token = _SESSION_SPEC.extract_token(payload)
+    return token.token if token is not None else None
+
+
+class InstallerConnector(HttpConnector):
+    """VCF Installer 9.1 REST connector with profile-derived token-session auth."""
+
+    # G0.6 v2 registry metadata. ``"installer-rest-9.1"`` ->
+    # (product="installer", version="9.1", impl_id="installer-rest").
+    product = "installer"
+    version = "9.1"
+    impl_id = "installer-rest"
+    supported_version_range = ">=9.1,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: InstallerCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
+        self._creds_lock = asyncio.Lock()
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
+        self._credentials_loader: InstallerCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: InstallerTargetLike, operator: Operator) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <accessToken>"}`` for the request.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
+        other than ``shared_service_account`` or ``None``.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"InstallerConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: InstallerTargetLike, operator: Operator) -> str:
+        """Return the cached session token for *target*, establishing on first use.
+
+        The lock serialises concurrent first-use callers so two don't both pay
+        the ``POST /v1/tokens`` round-trip. The cache fast-path is closed to the
+        synthesised system operator (``is_system_operator``): a system caller
+        always re-establishes and its token is never written to the shared cache
+        (#1008).
+        """
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None and not is_system_operator(operator):
+                return cached
+            creds = await self._load_credentials(target, operator)
+            client = await self._http_client(target)
+            token = await vcf_session_login(
+                client,
+                _SESSION_CREATE_PATH,
+                username=creds["username"],
+                password=creds["password"],
+                target_name=target.name,
+                payload_builder=_installer_login_body,
+                token_extractor=_extract_access_token,
+                request_headers=dict(_SESSION_REQUEST_HEADERS),
+                request_extensions=self._request_extensions(target),
+            )
+            if not is_system_operator(operator):
+                self._session_tokens[cache_key] = token
+            _log.info("installer_session_established", target=target.name, host=target.host)
+            return token
+
+    async def invalidate_session(self, target: InstallerTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path (#2067)."""
+        await self._invalidate_session(target)
+
+    async def _invalidate_session(self, target: InstallerTargetLike) -> None:
+        """Drop the cached session token for *target* (credential cache left intact)."""
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
+
+    async def invalidate_credentials(self, target: InstallerTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396)."""
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
+    async def _get_json_with_session_retry(
+        self,
+        target: InstallerTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET *path* with single session-expiry → re-login → retry-once recovery."""
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in _SESSION_EXPIRED_STATUSES:
+                raise
+            await self._invalidate_session(target)
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in _SESSION_EXPIRED_STATUSES:
+                raise RuntimeError(
+                    f"vcf-installer session re-login failed for target {target.name!r}: "
+                    f"GET {path} returned HTTP {status_code} after refresh"
+                ) from exc
+            raise
+
+    async def _load_credentials(
+        self, target: InstallerTargetLike, operator: Operator
+    ) -> dict[str, str]:
+        """Return the cached credentials for *target*, loading from Vault on first use.
+
+        The loaded dict must contain ``"username"`` and ``"password"``; a missing
+        key raises :exc:`RuntimeError` naming the target and key. The cache
+        fast-path is closed to the synthesised system operator (#1008).
+        """
+        cache_key = target_cache_key(target)
+        async with self._creds_lock:
+            cached = self._creds_cache.get(cache_key)
+            if cached is not None and not is_system_operator(operator):
+                return cached
+            raw = await self._credentials_loader(target, operator)
+            try:
+                _ = raw["username"]
+                _ = raw["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"vcf-installer credentials loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            self._creds_cache[cache_key] = raw
+            _log.info("installer_credentials_loaded", target=target.name, host=target.host)
+            return raw
+
+    async def fingerprint(
+        self,
+        target: InstallerTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /v1/system/appliance-info``.
+
+        Reads the flat ``ApplianceInfo`` object's top-level ``version`` and
+        ``role``. The GET authenticates via the token session through
+        :meth:`_get_json_with_session_retry`, so an idle-expired token is
+        recovered with one re-login. On transport/status failure returns a
+        non-reachable result whose ``extras["error"]`` carries the exception.
+        """
+        probed_at = datetime.now(UTC)
+        eff_operator = operator if operator is not None else synthesise_system_operator()
+        try:
+            payload = await self._get_json_with_session_retry(
+                target, "/v1/system/appliance-info", operator=eff_operator
+            )
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="installer",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /v1/system/appliance-info",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="vmware",
+            product="installer",
+            version=payload.get("version"),
+            build=None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /v1/system/appliance-info",
+            extras={
+                "role": payload.get("role"),
+                "dns_domain": payload.get("dnsDomain"),
+            },
+        )
+
+    async def probe(self, target: InstallerTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check — delegates to :meth:`fingerprint`."""
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: InstallerTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher. Post-G0.6 callers
+        construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly."""
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:installer-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def sddc_status(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.sddc.status`` shim — bring-up task poll."""
+        from meho_backplane.connectors.vcf_installer.typed_reads import installer_sddc_status_impl
+
+        return await installer_sddc_status_impl(self, operator, target, params)
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens + credentials, then tear down the httpx pool."""
+        async with self._session_lock:
+            self._session_tokens.clear()
+        async with self._creds_lock:
+            self._creds_cache.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcf_installer/profile.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/profile.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The reviewed ``installer`` ExecutionProfile for the VCF Installer connector.
+
+The declarative source of truth the typed
+:class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
+derives its session auth from — the same posture the sddc-manager connector
+takes against ``SDDC_EXECUTION_PROFILE``.
+
+Auth
+====
+
+The Installer's real flow is the ``session_login_token`` scheme (#2287), byte-
+for-byte the SDDC Manager token flow: ``POST /v1/tokens`` with a
+``{username, password}`` body (``TokenCreationSpec``), read ``accessToken`` out
+of the ``TokenPair`` response, send it as ``Authorization: Bearer <accessToken>``
+on every subsequent request. Reusing the named scheme means the login mechanics
+are declared once and cannot drift.
+
+Fingerprint
+===========
+
+``GET /v1/system/appliance-info`` returns ``ApplianceInfo`` with a literal
+top-level ``version`` string (and ``role``) — the Installer appliance's own
+version, served pre-bring-up (unlike a deployed SDDC Manager, an Installer has
+no inventory to fingerprint from). ``expiry_statuses`` defaults to ``{401}``: the
+Installer signals an expired token with a plain ``401`` (no vendor-specific
+expiry code; the refresh-token leg is a Non-goal here).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.profile import (
+    AuthSpec,
+    ExecutionProfile,
+    FingerprintSpec,
+    PaginationSpec,
+)
+
+__all__ = ["INSTALLER_EXECUTION_PROFILE"]
+
+
+#: The reviewed declarative profile for VCF Installer 9.1. The single source of
+#: truth for the connector's auth scheme; the typed
+#: :class:`InstallerConnector` derives its session-login path, request headers,
+#: and session-expiry status set from the named ``session_login_token`` scheme
+#: this profile selects.
+INSTALLER_EXECUTION_PROFILE = ExecutionProfile(
+    product="installer",
+    version="9.1",
+    auth=AuthSpec(scheme="session_login_token", secret_fields=("username", "password")),
+    fingerprint=FingerprintSpec(
+        path="/v1/system/appliance-info",
+        authenticated=True,
+        version_key="version",
+        version_splitter="none",
+    ),
+    probe="delegate",
+    pagination=PaginationSpec(strategy="none", items_key="elements"),
+)

--- a/backend/src/meho_backplane/connectors/vcf_installer/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/session.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the vcf-installer connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
+reads service-account credentials from the target's Vault path and exchanges
+them for a session token at ``POST /v1/tokens`` (the ``session_login_token``
+scheme — ``TokenCreationSpec`` in, ``TokenPair.accessToken`` out), sending it as
+``Authorization: Bearer <accessToken>`` on every subsequent request.
+
+The credential fetch (Vault path → ``{"username": ..., "password": ...}`` dict)
+is split behind a narrow :class:`InstallerCredentialsLoader` callable so
+production reuses the live operator-context KV-v2 read
+(:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`,
+rubric **State 2**, ``shared_service_account`` only) while unit / integration
+tests inject a loader returning a pre-built dict. This is the same split the
+sddc-manager connector uses — the Installer is the second member of the
+``session_login_token`` scheme.
+
+:class:`InstallerTargetLike` captures the minimum target shape read: ``name``
+(cache key), ``host``, ``port``, ``secret_ref`` (the Vault path), and
+``auth_model`` (boundary-checked). The concrete ``Target`` model in
+:mod:`meho_backplane.targets` (G0.3 #224) satisfies it structurally.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
+
+__all__ = [
+    "InstallerCredentialsLoader",
+    "InstallerTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`InstallerCredentialsLoader` returns — the
+    ``{username, password}`` pair POSTed to ``/v1/tokens``."""
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class InstallerTargetLike(Protocol):
+    """Minimum target shape :class:`InstallerConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` satisfies it unchanged. ``auth_model`` is
+    boundary-checked so a ``per_user`` / ``impersonation`` target raises a clear
+    error rather than silently authenticating as the shared service account.
+    ``secret_ref`` is the Vault path the loader resolves; ``str | None`` matches
+    the nullable column (an unset ref is rejected inside the loader, never a bare
+    ``KeyError``). ``id`` / ``tenant_id`` form the tenant-unique cache key so two
+    same-named targets in different tenants never share a cached credential.
+    """
+
+    id: object
+    tenant_id: object
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str | None
+    auth_model: str | None
+
+
+InstallerCredentialsLoader = Callable[[InstallerTargetLike, Operator], Awaitable[dict[str, str]]]
+"""Async callable resolving a (target, operator) pair to ``{"username", "password"}``.
+
+Invoked once per target (first-use) by
+:meth:`InstallerConnector._load_credentials`, caching the dict under the
+tenant-unique key. The ``operator`` carries the frozen
+:class:`~meho_backplane.auth.operator.Operator` so the live loader reads the
+per-target secret under the operator's identity via
+``vault_client_for_operator(operator)``.
+"""
+
+
+async def load_credentials_from_vault(
+    target: InstallerTargetLike,
+    operator: Operator,
+) -> dict[str, str]:
+    """Default credential loader — live operator-context Vault KV-v2 read.
+
+    Reads ``target.secret_ref`` as a KV-v2 secret under the operator's identity
+    and returns the service-account ``{"username", "password"}`` pair the
+    connector exchanges for a session token at ``POST /v1/tokens``. Delegates to
+    the shared :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper so the read, the no-secret-in-logs discipline, and the two-phase error
+    contract (``VaultCredentialsReadError`` for read-phase, ``VaultClientError``
+    for login-phase) are defined once. A custom
+    :class:`InstallerCredentialsLoader` can be injected via ``credentials_loader``
+    on :class:`InstallerConnector` (tests do exactly that); this default is what
+    production targets at rubric State 2 use.
+    """
+    return await load_basic_credentials(target, operator)

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`InstallerConnector`.
+
+The Installer's bring-up *status poll* (``GET /v1/sddcs/{id}`` → ``SddcTask``)
+ships as a typed op (``source_kind="typed"``) so it dispatches on a fresh boot
+with zero catalog ingest. The op body lives in
+:mod:`meho_backplane.connectors.vcf_installer.typed_reads`; a thin bound-method
+shim on :class:`InstallerConnector` exposes it under the ``handler_attr`` name so
+the dispatcher's ``import_handler`` walk recovers the callable.
+
+The governed bring-up *write* (validate → deploy → poll) is a separate
+``dangerous`` + ``requires_approval`` composite (a following increment), not a
+typed op — the highest-blast-radius write in the product must carry the preview
++ sub-op-policy machinery a raw op cannot. The dataclass + tuple + registrar
+shape mirrors :mod:`meho_backplane.connectors.sddc_manager.typed_ops`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "INSTALLER_TYPED_OPS",
+    "INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP",
+    "InstallerTypedOp",
+    "register_installer_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+_GROUP_BRINGUP = "installer-bringup"
+
+
+@dataclass(frozen=True)
+class InstallerTypedOp:
+    """Metadata for one Installer typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
+    exposing the async handler. Mirrors
+    :class:`~meho_backplane.connectors.sddc_manager.typed_ops.SddcTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group.
+INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_BRINGUP: (
+        "Use to track a VCF management-domain bring-up the Installer is running: "
+        "installer.sddc.status polls one bring-up task by id for its lifecycle "
+        "state (IN_PROGRESS / COMPLETED_WITH_SUCCESS / COMPLETED_WITH_FAILURE) "
+        "and per-stage sub-tasks. The right group while a bring-up submitted "
+        "through the governed installer.composite.sddc.bringup deploy is in "
+        "flight, or when triaging one that failed. Read-only."
+    ),
+}
+
+
+def _instructions(
+    *, when_to_use: str, output_shape: str, parameter_hints: dict[str, str]
+) -> dict[str, Any]:
+    return {
+        "when_to_use": when_to_use,
+        "output_shape": output_shape,
+        "parameter_hints": parameter_hints,
+    }
+
+
+_SDDC_STATUS = InstallerTypedOp(
+    op_id="installer.sddc.status",
+    handler_attr="sddc_status",
+    summary="Lifecycle status of one VCF bring-up task.",
+    description=(
+        "Reads one VCF management-domain bring-up task via GET /v1/sddcs/{id} — "
+        "the SddcTask object whose top-level status carries the "
+        "IN_PROGRESS / COMPLETED_WITH_SUCCESS / COMPLETED_WITH_FAILURE lifecycle "
+        "state, plus sddcSubTasks[] and milestones[] for per-stage progress. "
+        "Requires the bring-up id returned by the governed deploy. The poll an "
+        "operator (or the automation add-on) runs while a bring-up is in flight "
+        "or to triage a failed one. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The bring-up (SDDC) task id returned by the deploy.",
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_BRINGUP,
+    tags=("read-only", "vcf", "installer", "bringup", "status"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a bring-up id to check whether a VCF management-domain "
+            "deployment has completed, is still running, or failed."
+        ),
+        output_shape=(
+            "{id, name, status, vcfInstanceName, sddcSubTasks: [...], "
+            "milestones: [...]}. Surface the top-level status and any failed "
+            "sub-task."
+        ),
+        parameter_hints={"id": "The bring-up (SDDC) task id from the deploy."},
+    ),
+)
+
+
+#: The typed ops :class:`InstallerConnector` registers at lifespan startup.
+INSTALLER_TYPED_OPS: tuple[InstallerTypedOp, ...] = (_SDDC_STATUS,)
+
+
+async def register_installer_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`INSTALLER_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``. Mirrors
+    :func:`~meho_backplane.connectors.sddc_manager.typed_ops.register_sddc_typed_operations`.
+    """
+    from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in INSTALLER_TYPED_OPS:
+        handler = getattr(InstallerConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"InstallerConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"InstallerConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for that key."
+            )
+        await register_typed_operation(
+            product=InstallerConnector.product,
+            version=InstallerConnector.version,
+            impl_id=InstallerConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "installer_typed_operations_registered",
+        count=len(INSTALLER_TYPED_OPS),
+        product=InstallerConnector.product,
+        version=InstallerConnector.version,
+        impl_id=InstallerConnector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_reads.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`InstallerConnector`.
+
+The bring-up status poll is registered as a typed op
+(``source_kind="typed"``) so it dispatches on a fresh boot with zero catalog
+state. Each function here is the body a thin bound-method shim on
+:class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
+delegates to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.vcf_installer.typed_ops`.
+
+The read is issued directly on the connector's own authenticated token session
+via :meth:`HttpConnector._get_json`. A raw ``401`` (the Installer's expired-token
+signal) propagates as :class:`httpx.HTTPStatusError` to the dispatcher's #2067
+recovery arm, which evicts the cached session token via the connector's public
+:meth:`InstallerConnector.invalidate_session` hook and re-dispatches once — so
+the handler does not wrap the call in the internal
+``_get_json_with_session_retry`` helper (that helper serves the
+fingerprint/probe path, which the dispatcher does not drive).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
+    from meho_backplane.connectors.vcf_installer.session import InstallerTargetLike
+
+__all__ = ["installer_sddc_status_impl"]
+
+#: The bring-up status vendor path (``{id}`` substituted at call time). A module
+#: constant so the spec-reconcile lane introspects it by value — the #2944
+#: pattern — instead of mirroring a literal.
+_SDDC_STATUS_PATH = "/v1/sddcs/{id}"
+
+
+async def installer_sddc_status_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.sddc.status`` — read one bring-up task via ``GET /v1/sddcs/{id}``.
+
+    The ``id`` param is validated non-empty by the op's parameter schema before
+    dispatch; it is path-substituted into the vendor path. Returns the raw
+    ``SddcTask`` object (top-level ``status`` + ``sddcSubTasks`` / ``milestones``).
+    """
+    sddc_id = str(params["id"])
+    return await connector._get_json(
+        target, _SDDC_STATUS_PATH.replace("{id}", sddc_id), operator=operator
+    )

--- a/backend/tests/test_connectors_vcf_installer_auth.py
+++ b/backend/tests/test_connectors_vcf_installer_auth.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`InstallerConnector` auth + fingerprint/probe + status poll.
+
+Exercises the ``session_login_token`` flow (the same scheme SDDC Manager uses):
+the connector POSTs ``{username, password}`` to ``/v1/tokens``, reads
+``accessToken`` out of the ``TokenPair`` response, and sends it as
+``Authorization: Bearer <accessToken>`` on every subsequent request. Covers
+cached-token reuse, the auth_model boundary gate, a login failure, the
+fingerprint/probe shape against a mocked ``GET /v1/system/appliance-info``, the
+bring-up status poll, and cache tear-down. All respx-mocked — no network.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_installer import InstallerConnector, InstallerTargetLike
+
+_TOKEN_PATH = "/v1/tokens"
+_APPLIANCE_INFO_PATH = "/v1/system/appliance-info"
+
+
+def _make_operator(raw_jwt: str = "") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_installer_registry() -> Iterator[None]:
+    """Re-register InstallerConnector after sibling tests clear the registry."""
+    clear_registry()
+    register_connector_v2(
+        product=InstallerConnector.product,
+        version=InstallerConnector.version,
+        impl_id=InstallerConnector.impl_id,
+        cls=InstallerConnector,
+    )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None
+    id: UUID = field(default_factory=lambda: UUID(int=1))
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET = _StubTarget(
+    name="installer-a",
+    host="installer-a.test.invalid",
+    port=443,
+    secret_ref="installer/installer-a",
+)
+
+
+async def _stub_loader(_target: InstallerTargetLike, _operator: Operator) -> dict[str, str]:
+    return {"username": "admin@local", "password": "stub-password"}
+
+
+def _make_connector() -> InstallerConnector:
+    return InstallerConnector(credentials_loader=_stub_loader)
+
+
+# --------------------------------------------------------------- plumbing
+
+
+def test_installer_connector_subclasses_http_connector() -> None:
+    assert issubclass(InstallerConnector, HttpConnector)
+    assert InstallerConnector.product == "installer"
+    assert InstallerConnector.version == "9.1"
+    assert InstallerConnector.impl_id == "installer-rest"
+    assert InstallerConnector.supported_version_range == ">=9.1,<10.0"
+    assert InstallerConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    assert registry[("installer", "9.1", "installer-rest")] is InstallerConnector
+
+
+# --------------------------------------------------------------- auth
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_mints_and_sends_bearer_token() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(
+            201, json={"accessToken": "tok-abc", "refreshToken": {"id": "r"}}
+        )
+        headers = await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    assert headers == {"Authorization": "Bearer tok-abc"}
+    assert token_route.call_count == 1
+    login_request = token_route.calls[0].request
+    assert login_request.headers.get("authorization") is None  # no HTTP Basic
+    assert json.loads(login_request.content) == {
+        "username": "admin@local",
+        "password": "stub-password",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_token() -> None:
+    calls = {"n": 0}
+
+    async def _counting_loader(_t: InstallerTargetLike, _o: Operator) -> dict[str, str]:
+        calls["n"] += 1
+        return {"username": "admin@local", "password": "stub-password"}
+
+    connector = InstallerConnector(credentials_loader=_counting_loader)
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        h1 = await connector.auth_headers(_TARGET, operator=_make_operator())
+        h2 = await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    assert h1 == h2 == {"Authorization": "Bearer tok-abc"}
+    assert calls["n"] == 1
+    assert token_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model", [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"]
+)
+async def test_auth_headers_rejects_non_shared_service_account(auth_model: str) -> None:
+    target = _StubTarget(
+        name="installer-per-user",
+        host="installer.test.invalid",
+        port=443,
+        secret_ref="installer/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "installer-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_non_2xx_raises_session_login_error_naming_target() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(401, json={"message": "bad credentials"})
+        with pytest.raises(SessionLoginError, match=r"installer-a"):
+            await connector.auth_headers(_TARGET, operator=_make_operator())
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- fingerprint
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        info_route = mock.get(_APPLIANCE_INFO_PATH).respond(
+            200,
+            json={"role": "INSTALLER", "version": "9.1.0.0", "dnsDomain": "vcf.lab.local"},
+        )
+        fp = await connector.fingerprint(_TARGET)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "installer"
+    assert fp.version == "9.1.0.0"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /v1/system/appliance-info"
+    assert fp.extras["role"] == "INSTALLER"
+    assert fp.extras["dns_domain"] == "vcf.lab.local"
+    # The appliance-info GET carried the minted Bearer token — never HTTP Basic.
+    assert info_route.calls[0].request.headers.get("authorization") == "Bearer tok-abc"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_persistent_401() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.get(_APPLIANCE_INFO_PATH).respond(401, json={"message": "Unauthorized"})
+        fp = await connector.fingerprint(_TARGET)
+
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /v1/system/appliance-info"
+    assert "401" in fp.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_reachable() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.get(_APPLIANCE_INFO_PATH).respond(
+            200, json={"role": "INSTALLER", "version": "9.1.0.0"}
+        )
+        result = await connector.probe(_TARGET)
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- status poll
+
+
+@pytest.mark.asyncio
+async def test_sddc_status_reads_the_bringup_task() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        status_route = mock.get("/v1/sddcs/sddc-1").respond(
+            200,
+            json={
+                "id": "sddc-1",
+                "name": "bringup-mgmt",
+                "status": "IN_PROGRESS",
+                "vcfInstanceName": "vcf-mgmt-01",
+                "sddcSubTasks": [],
+            },
+        )
+        result = await connector.sddc_status(_make_operator(), _TARGET, {"id": "sddc-1"})
+
+    assert result["status"] == "IN_PROGRESS"
+    assert result["id"] == "sddc-1"
+    assert status_route.calls[0].request.headers.get("authorization") == "Bearer tok-abc"
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- aclose
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_caches_and_pool() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(_TARGET, operator=_make_operator())
+    assert target_cache_key(_TARGET) in connector._creds_cache
+    assert target_cache_key(_TARGET) in connector._session_tokens
+    await connector.aclose()
+    assert connector._creds_cache == {}
+    assert connector._session_tokens == {}
+    assert connector._clients == {}

--- a/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcf-installer real-spec reconcile lane — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the vcf-installer connector dispatches
+is served by the pinned ``vcf-installer-9.1`` spec on the shelf
+(``vmware/vcf-api-specs``' OpenAPI 3.0.1 document; provenance in the shelf's
+``MANIFEST.md``). Parse-only set compare — no DB, no embeddings, no containers —
+so it lives in the required unit sweep per
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when the shelf
+is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The declared set is introspected from the connector's live constants (the #2944
+pattern — never a hardcoded mirror), across the three surfaces that hand-code a
+path:
+
+* :mod:`~meho_backplane.connectors.vcf_installer.typed_reads` — the ``_*_PATH``
+  module constants (currently the bring-up status poll). Each typed read
+  dispatches through :meth:`HttpConnector._get_json`, so each declares ``GET:``.
+* :mod:`~meho_backplane.connectors.vcf_installer.connector` — the token mint
+  ``_SESSION_CREATE_PATH`` (``POST /v1/tokens``, sourced from the
+  ``session_login_token`` scheme spec).
+* :mod:`~meho_backplane.connectors.vcf_installer.profile` — the declarative
+  fingerprint recipe's ``GET /v1/system/appliance-info``.
+
+The governed bring-up composite's write paths (``POST /v1/sddcs``,
+``POST /v1/sddcs/validations``) join this set when that increment lands.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_installer import connector as _connector
+from meho_backplane.connectors.vcf_installer import typed_reads as _typed_reads
+from meho_backplane.connectors.vcf_installer.profile import INSTALLER_EXECUTION_PROFILE
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "vcf-installer-9.1"
+_SPEC_FILE = "vcf-installer-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+
+def _typed_read_paths() -> dict[str, str]:
+    """The live ``_*_PATH`` constants of ``typed_reads``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_typed_reads).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcf-installer connector dispatches."""
+    declared = {f"GET:{path}" for path in _typed_read_paths().values()}
+    declared.add(f"POST:{_connector._SESSION_CREATE_PATH}")
+    declared.add(f"GET:{INSTALLER_EXECUTION_PROFILE.fingerprint.path}")
+    return declared
+
+
+def test_typed_read_path_constants_are_all_discovered() -> None:
+    """Guard: the introspection finds every typed-read path constant.
+
+    Pinning the exact constant-name set means a renamed or dropped ``_*_PATH``
+    constant — or a new one that skips the suffix convention — can't silently
+    shrink the reconciled set to a vacuous pass.
+    """
+    assert sorted(_typed_read_paths()) == ["_SDDC_STATUS_PATH"]
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded op_id is served by the pinned vcf-installer-9.1 spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -29842,6 +29842,7 @@
               "harbor",
               "hetzner",
               "holodeck",
+              "installer",
               "k8s",
               "keycloak",
               "loki",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -508,6 +508,7 @@ const (
 	TargetCreateProductHarbor     TargetCreateProduct = "harbor"
 	TargetCreateProductHetzner    TargetCreateProduct = "hetzner"
 	TargetCreateProductHolodeck   TargetCreateProduct = "holodeck"
+	TargetCreateProductInstaller  TargetCreateProduct = "installer"
 	TargetCreateProductK8s        TargetCreateProduct = "k8s"
 	TargetCreateProductKeycloak   TargetCreateProduct = "keycloak"
 	TargetCreateProductLoki       TargetCreateProduct = "loki"

--- a/docs/codebase/connector-auth-coverage.md
+++ b/docs/codebase/connector-auth-coverage.md
@@ -40,6 +40,7 @@ naming one raises `ReservedAuthSchemeError` ("author a typed connector").
 | 13 | kubernetes | `kubernetes/connector.py` | kubeconfig loaded from Vault → cert/token embedded in `ApiClient` | kubeconfig payload | embedded in `ApiClient` | **RESERVED** `kubeconfig` |
 | 14 | nsx | `nsx/session.py` | Session create `POST /api/session/create` (form `j_username`/`j_password`) → `Set-Cookie JSESSIONID` jar + `X-XSRF-TOKEN` | `username`, `password` | mutated cookie jar + `dict[str,str]` | **RESERVED** `cookie_jar_session` |
 | 15 | vcf_automation | `vcf_automation/_auth.py` | Dual-plane: provider login (`/cloudapi/.../sessions/provider`) + tenant login (`/iaas/api/login`), token from header / body | `username`, `password`, `domain` | `dict[str,str]` (plane-specific Bearer) | **RESERVED** `dual_plane_session` |
+| 16 | vcf_installer | `vcf_installer/connector.py` `auth_headers` | Session login `POST /v1/tokens` (JSON `{username,password}` → `TokenPair.accessToken`) → cached Bearer; re-login once on `401`. Second member of the scheme (SDDC Manager shape) | `username`, `password` | `dict[str,str]` (Bearer) | **`session_login_token`** |
 
 > Row count note: the connectors directory ships 15 HTTP-family connector
 > packages; the issue's "14" excludes `vcf_automation`'s dual-plane shape

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -158,6 +158,7 @@ flow is the only auth_model; loader is live; consumer confirmed
 | `vcf-fleet-9.0` | 2 | Shared [`_shared/vcf_auth.load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py) — live operator-context Vault read (G3.10-T2 [#946](https://github.com/evoila/meho/issues/946)) | ✅ (`shared_service_account`) |
 | `nsx-4.2` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/nsx/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
 | `sddc-manager-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/sddc_manager/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
+| `installer-rest-9.1` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vcf_installer/session.py) — live operator-context Vault read (delegates to shared [`_shared/vcf_auth.load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py)) | ✅ (`shared_service_account`) |
 | `harbor-2.x` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/harbor/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
 | `kubernetes-asyncio-1.x` | 2 (shadow) | Same as `k8s-1.x` | ✅ (`shared_service_account`) |
 

--- a/docs/codebase/connectors-vcf-installer.md
+++ b/docs/codebase/connectors-vcf-installer.md
@@ -1,0 +1,131 @@
+# Connector: vcf-installer (VCF Installer 9.1)
+
+## Overview
+
+The `vcf-installer` connector is the hand-rolled `HttpConnector` subclass that
+dispatches VMware Cloud Foundation **Installer** operations under the
+`(product="installer", version="9.1", impl_id="installer-rest")` registry triple
+(`connector_id="installer-rest-9.1"`). The Installer is the VCF 9.x bring-up
+appliance (the successor to Cloud Builder); this connector is the governed
+dispatch surface the automation add-on
+([evoila-bosnia/meho-internal#223](https://github.com/evoila/meho/issues/2907))
+binds its bring-up step to — it generates the `SddcSpec`, meho governs the POST.
+
+Filed under Initiative [#2907](https://github.com/evoila/meho/issues/2907)
+(backplane-first coverage) as [#3065](https://github.com/evoila/meho/issues/3065),
+converting the register's "VCF stack / Cloud Builder bring-up — to file" row to
+the 9.x reality. This increment is the **skeleton**: token auth, fingerprint /
+probe, and the bring-up **status poll**. The governed bring-up **write**
+(validate → deploy → poll) lands as a `dangerous` + `requires_approval`
+composite in a following increment — the highest-blast-radius write in the
+product must carry the preview + sub-op-policy machinery a raw op cannot.
+
+Source: `backend/src/meho_backplane/connectors/vcf_installer/`.
+
+## Key types
+
+- **`InstallerConnector`** (`connector.py`) — `HttpConnector` subclass.
+  `product="installer"`, `version="9.1"`, `impl_id="installer-rest"`,
+  `supported_version_range=">=9.1,<10.0"`, `priority=1`.
+- **`INSTALLER_EXECUTION_PROFILE`** (`profile.py`) — the reviewed declarative
+  profile the connector derives its session auth from (the `session_login_token`
+  scheme) and its fingerprint recipe (`GET /v1/system/appliance-info` → literal
+  top-level `version`).
+- **`InstallerTargetLike`** / **`InstallerCredentialsLoader`** (`session.py`) —
+  the structural target Protocol and the injectable credential loader; the
+  default `load_credentials_from_vault` delegates to the shared
+  `_shared/vcf_auth.load_basic_credentials` live operator-context Vault read
+  (rubric State 2, `shared_service_account`).
+
+## Control flow
+
+### Registration
+
+Importing `meho_backplane.connectors.vcf_installer` calls
+`register_connector_v2(product="installer", version="9.1",
+impl_id="installer-rest", cls=InstallerConnector)` (plus a `("installer","","")`
+wildcard fallback for a fresh, unfingerprinted target), and queues
+`register_installer_typed_operations` onto the lifespan registrar list. The
+`(product, impl_id)` round-trip constraint requires `product="installer"` (the
+first hyphen-segment of `impl_id`), **not** `vcf-installer`.
+
+### Auth — token session (`session_login_token`)
+
+The Installer is token-only, the same scheme as SDDC Manager:
+`POST /v1/tokens` with a `{username, password}` body (`TokenCreationSpec`)
+returns `accessToken` (`TokenPair`), sent as `Authorization: Bearer <accessToken>`
+on every subsequent request. The connector derives the login path, request
+headers, and expiry status set from the profile's scheme spec, so the mechanics
+are declared once and cannot drift. The per-target token is cached (single-flight
+under a lock); a downstream `401` evicts it and re-logs in once (the
+`_get_json_with_session_retry` helper for the fingerprint path, the public
+`invalidate_session` hook for the dispatch path, #2067). Credentials load once
+per target from Vault. v0.2 locks the connector to
+`AuthModel.SHARED_SERVICE_ACCOUNT` (or `None` for pre-G0.3 targets); any other
+`auth_model` raises `NotImplementedError`.
+
+### Fingerprint + probe
+
+`fingerprint(target)` issues `GET /v1/system/appliance-info` through the token
+session and reads the flat `ApplianceInfo` object's top-level `version` and
+`role`. On transport/status failure it returns `reachable=False` with a
+structured `extras["error"]`. `probe(target)` delegates to `fingerprint` — one
+authenticated request covers reachability and auth-challenge.
+
+## Operations
+
+### `installer.sddc.status` — bring-up status poll (typed, `safe`)
+
+`GET /v1/sddcs/{id}` → the `SddcTask` object whose top-level `status` carries the
+`IN_PROGRESS` / `COMPLETED_WITH_SUCCESS` / `COMPLETED_WITH_FAILURE` lifecycle
+state, plus `sddcSubTasks[]` / `milestones[]`. Registered as a typed op
+(`source_kind="typed"`) so it dispatches on a fresh boot with zero catalog
+ingest; the body lives in `typed_reads.py`, a bound-method shim on the connector
+exposes it. This is the poll the automation add-on (or an operator) runs while a
+bring-up is in flight or to triage a failed one.
+
+### Governed bring-up write (following increment)
+
+`installer.composite.sddc.bringup` — a `dangerous` + `requires_approval`
+composite orchestrating `POST /v1/sddcs/validations` (validate) → `POST /v1/sddcs`
+(deploy) → poll-to-terminal, with a secret-hygienic preview (SDDC identity /
+network blast-radius echoed, passwords never on reviewer surfaces) and every
+mutating sub-call through `enforce_subop_policy`. Not shipped in this increment.
+
+## Spec-reconcile lane
+
+Every hand-coded `METHOD:/path` — `POST:/v1/tokens`,
+`GET:/v1/system/appliance-info` (fingerprint), `GET:/v1/sddcs/{id}` (status) — is
+asserted against the pinned `vcf-installer-9.1` shelf spec (vendored from
+`vmware/vcf-api-specs`) by
+[`backend/tests/test_connectors_vcf_installer_spec_reconcile.py`](../../backend/tests/test_connectors_vcf_installer_spec_reconcile.py)
+(the #2980 harness; parse-only, in the required unit sweep, uniform skip when the
+shelf is unconfigured). Standard:
+[`docs/decisions/spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Dependencies
+
+- **httpx** — per-target `AsyncClient` pool (inherited from `HttpConnector`);
+  Bearer token computed by the connector.
+- **respx** (test-only) — the unit-test module mocks every request shape without
+  a network call.
+- **structlog** — `installer_session_established` / `installer_credentials_loaded`
+  events, both carrying `target` and `host`.
+
+## Known issues
+
+- The bring-up write surface is not yet shipped (following increment) — a VCF
+  management-domain deployment cannot yet be dispatched, only its status polled.
+- The default credentials loader is the live State-2 read; a target must be
+  `shared_service_account` with a `secret_ref` resolving to a
+  `{username, password}` KV-v2 secret.
+
+## References
+
+- Task: [#3065](https://github.com/evoila/meho/issues/3065). Parent Initiative:
+  [#2907](https://github.com/evoila/meho/issues/2907). Parent Goal:
+  [#221](https://github.com/evoila/meho/issues/221).
+- Template precedent: `connectors/sddc_manager/` (identical `session_login_token`
+  auth), `connectors/vcf_fleet/` (skeleton wiring).
+- VCF Installer API reference:
+  <https://developer.broadcom.com/xapis/vcf-installer-api/latest/>.


### PR DESCRIPTION
## What

The **VCF Installer 9.1 bring-up connector** — the backplane dispatch surface the automation add-on's deploy path needs. The add-on now generates a schema-valid `SddcSpec` (meho-internal); this connector is where meho governs the POST. Closes the register's "VCF stack / Cloud Builder bring-up — to file" row under Initiative #2907, filed as #3065.

This PR is the **skeleton** (mirrors how `sddc-manager` shipped): token auth, fingerprint/probe, and the bring-up status poll. The governed bring-up **write** (validate → deploy → poll) is a following increment — it must be a `dangerous` + `requires_approval` composite with a preview + `enforce_subop_policy`, not a raw op, so it gets its own focused review.

## Identity & template

`product=installer`, `version=9.1`, `impl_id=installer-rest`, `connector_id=installer-rest-9.1` (the `(product, impl_id)` round-trip forces `installer`, not `vcf-installer`). Modeled on **`sddc-manager`** — same VCF family, the *exact* auth flow.

## Surface

| Endpoint | Surface |
|---|---|
| `POST /v1/tokens` | the `session_login_token` auth scheme (reuses `_shared/vcf_auth` + the profile scheme spec) — `{username,password}` → `TokenPair.accessToken` → cached Bearer, single re-login on 401 |
| `GET /v1/system/appliance-info` | fingerprint/probe → `ApplianceInfo.version`/`role` |
| `GET /v1/sddcs/{id}` | `installer.sddc.status` — typed `safe` poll → `SddcTask.status` |

Ships at **State 2** (`shared_service_account`, live operator-context Vault read via the shared loader).

## Validation

- **Spec-reconcile lane** pins every hand-coded path (`POST:/v1/tokens`, `GET:/v1/system/appliance-info`, `GET:/v1/sddcs/{id}`) against the pinned `vcf-installer-9.1` shelf — **green against the real vendored 9.1 OpenAPI** (`vmware/vcf-api-specs`).
- **13 respx-mocked unit tests**: auth mint/reuse, auth-model gate, login failure, fingerprint shape + unreachable, the status poll, aclose.
- ruff + mypy clean; the registry/boot enumeration tests (`test_connectors_registry_v2` / `_registry` / `_operations_boot_stamp`, 62 tests) pass with the connector added (29 connectors, round-trip + boot clean).

## Docs

`connectors-vcf-installer.md` (new); rows in `connector-auth-coverage.md` (2nd `session_login_token` member) and `connector-release-readiness.md` (State 2); CHANGELOG.

## Scope / next

Advances #2907 (#3065). No composite yet, no minimal-spec catalog ingest (not needed for the typed poll). Following increment: the governed `installer.composite.sddc.bringup` composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
