### PR TITLE
feat(vrops8,vrli8): vROps/vRLI 8.x legacy dual-impls as thin subclasses (#3067, #3068)

### DIFF
--- a/backend/src/meho_backplane/connectors/vrli8/__init__.py
+++ b/backend/src/meho_backplane/connectors/vrli8/__init__.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vrli8 — Vrli8Connector package (legacy vRLI 8.x).
+
+Importing this package registers :class:`Vrli8Connector` against the v2 connector
+registry as the **legacy dual-impl** for **vRealize Log Insight 8.x / VMware Aria
+Operations for Logs 8.x** — the log-management tier of the VCF-5.x-era source
+estate evoila brings customers off (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3068).
+vRLI 8.x is the direct predecessor of **VCF Operations for Logs 9.x**
+(:mod:`meho_backplane.connectors.vcf_logs`, ``vrli-rest``), so this is a **second
+implementation of ``product="vrli"``** — the 5th real two-impl case after
+``fleet``, ``vcfa``, ``sddc``, and ``vrops``.
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<subpackage>/`` at startup, so both this legacy package and
+the modern ``vcf_logs`` package register under ``product="vrli"`` (distinct
+``impl_id``s) before any dispatch can occur.
+
+**Only the versioned triple is registered — NOT the ``("vrli","","")`` wildcard**,
+which the modern ``vcf_logs`` package owns (a second class on it would raise
+``RuntimeError`` at boot). This is the *inversion* of the ``fleet`` case: here the
+modern impl owns the wildcard, so an *unfingerprinted* / unversioned ``vrli``
+target resolves to modern ``vrli-rest``; a fingerprinted 8.x target
+(``/api/v2/version`` reports a real five-part ``8.x`` version) resolves to **this**
+impl by its disjoint band (legacy ``>=8.0,<9.0`` vs modern ``>=9.0,<10.0``) — see
+:mod:`tests.test_connectors_vrli8_dual_impl_resolution`.
+
+The ``product`` token is ``"vrli"`` and ``impl_id`` is ``"vrli-vrli8"`` because
+:func:`register_connector_v2` enforces that ``product`` equals the first
+hyphen-segment of ``impl_id`` — the round-trip invariant. ``connector_id``
+``"vrli-vrli8-8.0"`` parses back to ``("vrli", "8.0", "vrli-vrli8")``.
+
+The package queues a typed-op registrar (:mod:`.typed_ops`) that upserts the
+modern sibling's ``vrli.event.query`` typed op under this impl's triple, so a
+vRLI 8.x target dispatches its log-event query on a fresh boot with zero catalog
+ingest. Because 8.x publishes no committable API spec (only a per-appliance
+runtime Swagger UI — OA3-only ingest #2090 can't consume it), the broader browse
+surface the modern sibling serves via ingested catalog is a documented follow-up,
+not shipped here.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vrli8.connector import Vrli8Connector
+from meho_backplane.connectors.vrli8.typed_ops import register_vrli8_typed_operations
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the vRLI 8.x connector — the
+#: dispatch-canonical ``(product, version, impl_id)`` triple
+#: :func:`parse_connector_id` derives from ``"vrli-vrli8-8.0"``, plus the derived
+#: ``connector_id`` slug. ``product`` is shared with the modern ``vrli-rest``
+#: (``vrli``); the ``impl_id`` disambiguates the two impls.
+VRLI8_PRODUCT: Final[str] = "vrli"
+VRLI8_VERSION: Final[str] = "8.0"
+VRLI8_IMPL_ID: Final[str] = "vrli-vrli8"
+VRLI8_CONNECTOR_ID: Final[str] = f"{VRLI8_IMPL_ID}-{VRLI8_VERSION}"
+
+register_connector_v2(
+    product=VRLI8_PRODUCT,
+    version=VRLI8_VERSION,
+    impl_id=VRLI8_IMPL_ID,
+    cls=Vrli8Connector,
+)
+
+# NO wildcard registration. The ``("vrli","","")`` key is owned by the modern
+# ``vcf_logs`` package; a second class on it would raise RuntimeError at boot (the
+# ``fleet_lcm`` no-wildcard shape, inverted — there the legacy owns the wildcard,
+# here the modern does). An unfingerprinted ``vrli`` target therefore resolves to
+# modern ``vrli-rest``; a fingerprinted 8.x target resolves here.
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so the
+# typed descriptor row lands before the first dispatch — the vRLI 8.x read op
+# dispatches on a fresh boot with zero catalog ingest (#3068).
+register_typed_op_registrar(register_vrli8_typed_operations)
+
+__all__ = [
+    "VRLI8_CONNECTOR_ID",
+    "VRLI8_IMPL_ID",
+    "VRLI8_PRODUCT",
+    "VRLI8_VERSION",
+    "Vrli8Connector",
+    "register_vrli8_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/vrli8/connector.py
+++ b/backend/src/meho_backplane/connectors/vrli8/connector.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vrli8Connector — legacy dual-impl for vRealize Log Insight 8.x (#3068).
+
+vRealize Log Insight 8.x / VMware Aria Operations for Logs 8.x (the 8.12 rebrand
+is name-only, no API break) is the direct predecessor of **VCF Operations for
+Logs 9.x** (:mod:`meho_backplane.connectors.vcf_logs`, ``vrli-rest``). It is the
+log-management tier of a VCF-5.x-era source estate evoila migrates customers
+*off* (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3068).
+This is a **second implementation of ``product="vrli"``**, not a net-new product
+— the 5th real two-impl case after ``fleet``, ``vcfa``, ``sddc``, and ``vrops``.
+
+Why a subclass (not a standalone copy)
+--------------------------------------
+
+The vRLI ``/api/v2/*`` REST surface is **identical** on 8.x and 9.x — the v2 API
+shipped in vRLI 8.0 and is stable through 8.18.x: the same
+``POST /api/v2/sessions`` → ``Authorization: Bearer <sessionId>`` auth, the same
+unauthenticated ``GET /api/v2/version`` fingerprint, the same
+``/api/v2/events/{constraints}`` query, and the same ``{401, 440}``
+session-expiry recovery (the appliance's ``trait.authenticated.440`` idle
+timeout). So the honest, minimal representation (CLAUDE.md postulates 2 + 3) is
+a **thin subclass** of
+:class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector` that
+inherits the session mint, the token cache, the ``invalidate_session`` /
+``invalidate_credentials`` (#2067) recovery, the profile-derived fingerprint,
+and the ``vrli.event.query`` typed handler unchanged — overriding **only** the
+registration triple and the version band. Unlike vROps 8.x, the ``Bearer``
+scheme is unchanged across the version boundary, so there is **no auth override**
+at all.
+
+The dispatcher rebinds the inherited ``event_query`` handler against the
+resolver-chosen instance
+(:func:`~meho_backplane.operations._handler_resolve.is_unbound_method` walks
+``Vrli8Connector.__mro__`` — the documented bind9-E2E subclass pattern), so it
+runs on a :class:`Vrli8Connector` instance with the 8.x band.
+
+Resolution — by fingerprint alone
+----------------------------------
+
+**Only the versioned triple ``(vrli, 8.0, vrli-vrli8)`` is registered — NOT the
+``("vrli","","")`` wildcard**, which the modern ``vcf_logs`` package owns (a
+second class on it would raise ``RuntimeError`` at boot — the *fleet inversion*).
+An *unfingerprinted* / unversioned ``vrli`` target therefore resolves to modern
+``vrli-rest``; a fingerprinted 8.x target (``/api/v2/version`` reports a real
+five-part ``8.x`` version string) resolves to **this** impl by its disjoint band
+(legacy ``>=8.0,<9.0`` vs modern ``>=9.0,<10.0``) — no re-band, no specificity
+tie. See :mod:`tests.test_connectors_vrli8_dual_impl_resolution`.
+
+The ``product`` token is ``"vrli"`` and ``impl_id`` is ``"vrli-vrli8"`` because
+:func:`register_connector_v2` enforces that ``product`` equals the first
+hyphen-segment of ``impl_id`` — the round-trip invariant. ``connector_id``
+``"vrli-vrli8-8.0"`` parses back to ``("vrli", "8.0", "vrli-vrli8")``.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+
+__all__ = ["Vrli8Connector"]
+
+
+class Vrli8Connector(VcfLogsConnector):
+    """vRealize Log Insight 8.x legacy read connector — a thin subclass of ``vrli-rest``.
+
+    Overrides only the registration triple and the version band; inherits
+    everything else from
+    :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
+    (see the module docstring — the vRLI v2 surface, incl. the ``Bearer`` auth
+    scheme, is identical on 8.x and 9.x). The inherited ``__init__`` gives this
+    class its own per-target session cache, lock, and credentials cache (keyed
+    under ``product_label="vrli"``), independent of the modern instance the
+    dispatcher caches separately.
+    """
+
+    # G0.6 v2 registry metadata — the dispatch-canonical triple
+    # ``parse_connector_id`` derives from ``"vrli-vrli8-8.0"``. ``product`` is
+    # shared with the modern ``vrli-rest``; the ``impl_id`` disambiguates.
+    product = "vrli"
+    version = "8.0"
+    impl_id = "vrli-vrli8"
+    supported_version_range = ">=8.0,<9.0"
+    priority = 1

--- a/backend/src/meho_backplane/connectors/vrli8/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vrli8/typed_ops.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op registrar for :class:`Vrli8Connector` (legacy vRLI 8.x, #3068).
+
+The 8.x impl reuses the modern sibling's typed read op verbatim —
+:data:`~meho_backplane.connectors.vcf_logs.typed_ops.VRLI_TYPED_OPS` (today just
+``vrli.event.query``) issues the identical ``GET /api/v2/events/{constraints}``
+query on 8.x (the v2 API is stable since vRLI 8.0), and the handler is inherited
+on :class:`Vrli8Connector`. So this registrar upserts the *same op_id* under the
+8.x connector's own ``(vrli, 8.0, vrli-vrli8)`` triple rather than re-authoring
+it.
+
+The reuse is safe for the same two reasons as the vROps 8.x registrar:
+``endpoint_descriptor`` rows are keyed by ``(product, version, impl_id, op_id)``
+(so the op_id is shared but the rows are distinct), and ``OperationGroup`` rows
+are scoped by ``(product, version, impl_id, group_key)`` (so reusing the modern
+group_key lands a distinct group row for this impl).
+
+Note the modern vRLI connector types only ``vrli.event.query``; the rest of its
+browse surface (hosts / content-packs / alerts / fields) is **generic-ingested**
+from an internally-authored ``vcf-logs-9.0/openapi.yaml``, not a VMware download.
+8.x has no committable spec to ingest, so the 8.x impl's surface is the inherited
+typed op — a wider typed inventory surface is a documented follow-up on #3068,
+not shipped speculatively.
+
+Mirrors the modern
+:func:`~meho_backplane.connectors.vcf_logs.typed_ops.register_vrli_typed_operations`
+registrar exactly, differing only in the target class (:class:`Vrli8Connector`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = ["register_vrli8_typed_operations"]
+
+_log = structlog.get_logger(__name__)
+
+
+async def register_vrli8_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the modern vRLI typed read op(s) under the ``vrli-vrli8`` triple.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors` has
+    walked every connector subpackage, so the descriptor row lands before the
+    first dispatch — the 8.x read op dispatches on a fresh boot with zero catalog
+    ingest. Idempotent across pod restarts. Mirrors the modern
+    ``register_vrli_typed_operations`` registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`~meho_backplane.retrieval.embedding.EmbeddingService` (or a
+    chassis-test stub) to every registrar, so each must accept the kwarg; it is
+    forwarded to :func:`register_typed_operation`.
+    """
+    # Lazy import: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests should not
+    # pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vcf_logs.typed_ops import (
+        VRLI_TYPED_OPS,
+        VRLI_TYPED_WHEN_TO_USE_BY_GROUP,
+    )
+    from meho_backplane.connectors.vrli8.connector import Vrli8Connector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VRLI_TYPED_OPS:
+        handler = getattr(Vrli8Connector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"Vrli8Connector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else VRLI_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"Vrli8Connector typed op {op.op_id!r} declares group_key="
+                f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                f"Add an entry to VRLI_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=Vrli8Connector.product,
+            version=Vrli8Connector.version,
+            impl_id=Vrli8Connector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vrli8_typed_operations_registered",
+        count=len(VRLI_TYPED_OPS),
+        product=Vrli8Connector.product,
+        version=Vrli8Connector.version,
+        impl_id=Vrli8Connector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/vrops8/__init__.py
+++ b/backend/src/meho_backplane/connectors/vrops8/__init__.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vrops8 — Vrops8Connector package (legacy vROps 8.x).
+
+Importing this package registers :class:`Vrops8Connector` against the v2
+connector registry as the **legacy dual-impl** for **vRealize Operations 8.x /
+VMware Aria Operations 8.x** — the monitoring tier of the VCF-5.x-era source
+estate evoila brings customers off (initiative
+`evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_, task #3067).
+vROps 8.x is the direct predecessor of **VCF Operations 9.x**
+(:mod:`meho_backplane.connectors.vcf_operations`, ``vrops-rest``) — the same
+product line across a major-version rebuild — so this is a **second
+implementation of ``product="vrops"``**, the 4th real two-impl case after
+``fleet``, ``vcfa``, and ``sddc``.
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which walks
+every ``connectors/<subpackage>/`` at startup, so both this legacy package and
+the modern ``vcf_operations`` package register under ``product="vrops"`` (distinct
+``impl_id``s) before any dispatch can occur — the ``vcf_fleet`` + ``fleet_lcm``
+shape.
+
+**Only the versioned triple is registered — NOT the ``("vrops","","")`` wildcard.**
+The wildcard is already owned by the modern ``vcf_operations`` package (a second
+class on that key would raise ``RuntimeError`` at boot). This is the *inversion*
+of the ``fleet`` case: here the modern impl owns the wildcard, so an
+*unfingerprinted* / unversioned ``vrops`` target resolves to modern ``vrops-rest``;
+a fingerprinted 8.x target (``versions/current`` reports a real dotted ``8.x``
+``releaseName``) resolves to **this** impl by its disjoint band
+(legacy ``>=8.0,<9.0`` vs modern ``>=9.0,<10.0``) — see
+:mod:`tests.test_connectors_vrops8_dual_impl_resolution`. Because the inherited
+fingerprint stores ``releaseName`` raw, resolution depends on it being PEP
+440-parseable; a non-parseable value falls back *open* to the modern wildcard
+(operator pins ``version`` / ``preferred_impl_id`` to override) — the named
+residual risk in :class:`~meho_backplane.connectors.vrops8.connector.Vrops8Connector`.
+
+The ``product`` token is ``"vrops"`` and ``impl_id`` is ``"vrops-vrops8"`` because
+:func:`register_connector_v2` enforces that ``product`` equals the first
+hyphen-segment of ``impl_id`` — the round-trip invariant. ``connector_id``
+``"vrops-vrops8-8.0"`` parses back to ``("vrops", "8.0", "vrops-vrops8")``.
+
+The package queues a typed-op registrar (:mod:`.typed_ops`) that upserts the
+modern sibling's audited 4-op read set under this impl's triple, so a vROps 8.x
+target dispatches a migration-inventory read on a fresh boot with zero catalog
+ingest. Because 8.x publishes no committable OpenAPI 3.x (only a per-instance
+Swagger 2.0 document — OA3-only ingest #2090 can't consume it), a wider ingested
+breadth surface is not a follow-up here — the typed read core is the connector's
+surface.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vrops8.connector import Vrops8Connector
+from meho_backplane.connectors.vrops8.typed_ops import register_vrops8_typed_operations
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+#: Endpoint-descriptor identity for the vROps 8.x connector — the
+#: dispatch-canonical ``(product, version, impl_id)`` triple
+#: :func:`parse_connector_id` derives from ``"vrops-vrops8-8.0"``, plus the
+#: derived ``connector_id`` slug (the typed read core rows land under it).
+#: ``product`` is shared with the modern ``vrops-rest`` (``vrops``); the
+#: ``impl_id`` disambiguates the two impls.
+VROPS8_PRODUCT: Final[str] = "vrops"
+VROPS8_VERSION: Final[str] = "8.0"
+VROPS8_IMPL_ID: Final[str] = "vrops-vrops8"
+VROPS8_CONNECTOR_ID: Final[str] = f"{VROPS8_IMPL_ID}-{VROPS8_VERSION}"
+
+register_connector_v2(
+    product=VROPS8_PRODUCT,
+    version=VROPS8_VERSION,
+    impl_id=VROPS8_IMPL_ID,
+    cls=Vrops8Connector,
+)
+
+# NO wildcard registration. The ``("vrops","","")`` key is owned by the modern
+# ``vcf_operations`` package; a second class on it would raise RuntimeError at
+# boot (the ``fleet_lcm`` no-wildcard shape, inverted — there the legacy owns the
+# wildcard, here the modern does). An unfingerprinted ``vrops`` target therefore
+# resolves to modern ``vrops-rest``; a fingerprinted 8.x target resolves here.
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so the
+# typed descriptor rows land before the first dispatch — the vROps 8.x read core
+# dispatches on a fresh boot with zero catalog ingest (#3067).
+register_typed_op_registrar(register_vrops8_typed_operations)
+
+__all__ = [
+    "VROPS8_CONNECTOR_ID",
+    "VROPS8_IMPL_ID",
+    "VROPS8_PRODUCT",
+    "VROPS8_VERSION",
+    "Vrops8Connector",
+    "register_vrops8_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/vrops8/connector.py
+++ b/backend/src/meho_backplane/connectors/vrops8/connector.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vrops8Connector — legacy dual-impl for vRealize Operations 8.x (#3067).
+
+vRealize Operations 8.x / VMware Aria Operations 8.x (the 8.10 rebrand is
+name-only, no API break — ``major`` stays ``8`` across the whole line) is the
+direct predecessor of **VCF Operations 9.x**
+(:mod:`meho_backplane.connectors.vcf_operations`, ``vrops-rest``). It is the
+monitoring tier of a VCF-5.x-era source estate evoila migrates customers *off*
+(initiative `evoila/meho#3056 <https://github.com/evoila/meho/issues/3056>`_,
+task #3067). This is a **second implementation of ``product="vrops"``**, not a
+net-new product — the 4th real two-impl case after ``fleet``, ``vcfa``, and
+``sddc``.
+
+Why a subclass (not a standalone copy)
+--------------------------------------
+
+Unlike the sibling legacy connectors #3057 (vCD — net-new), #3058 (vRA 8 —
+divergent two-step CSP→IaaS auth), and #3059 (SDDC 5.x — divergent read scope),
+the vROps 8.x Suite API surface is **identical** to 9.x: the same
+``POST /suite-api/api/auth/token/acquire`` session mint, the same
+``GET /suite-api/api/versions/current`` fingerprint, and the same
+``/suite-api/api/{alerts, resources/query, resources/stats/latest}`` read paths
+(all stable since vROps 6.6/7.0). So the honest, minimal representation
+(CLAUDE.md postulates 2 + 3) is a **thin subclass** of
+:class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
+that inherits the acquire flow, the auth-model gate, the per-target session
+cache, the ``invalidate_session`` / ``invalidate_credentials`` (#2067) recovery,
+the fingerprint, and all four typed read handlers unchanged — overriding only
+the registration triple, the version band, and the token *scheme* (below).
+
+The dispatcher rebinds an inherited handler against the resolver-chosen
+instance (:func:`~meho_backplane.operations._handler_resolve.is_unbound_method`
+walks ``Vrops8Connector.__mro__`` and matches the base-class function object —
+the documented bind9-E2E subclass pattern), so the inherited handlers run on a
+:class:`Vrops8Connector` instance with the 8.x scheme (they call
+``self.auth_headers``) and the 8.x band.
+
+The one behavioural delta — the token scheme
+--------------------------------------------
+
+The 9.x connector presents ``Authorization: OpsToken <token>`` — the 9.x-native
+scheme (#2395). An 8.x appliance predates the ``OpsToken`` alias and accepts
+only the token-era ``vRealizeOpsToken`` scheme (stable across the whole 8.x
+line). :meth:`auth_headers` therefore re-labels the scheme on the header the
+base class returns; the auth-model guard and the token mint stay single-sourced
+on the base (the security-sensitive path is not duplicated).
+
+Resolution — by fingerprint, with a parseability caveat
+-------------------------------------------------------
+
+**Only the versioned triple ``(vrops, 8.0, vrops-vrops8)`` is registered — NOT
+the ``("vrops","","")`` wildcard.** The wildcard is owned by the modern
+``vcf_operations`` package (a second class on that key would raise
+``RuntimeError`` at boot). This is the *inversion* of the ``fleet`` case: the
+modern impl owns the wildcard, so an *unfingerprinted* / unversioned ``vrops``
+target resolves to modern ``vrops-rest``. Unlike vRA 8 (whose appliance
+fingerprint reports the API version rather than a product version), a vROps 8.x
+appliance's ``versions/current`` returns a real product ``releaseName`` (a dotted
+release, observed shape e.g. ``8.18.0.24178391``), so a fingerprinted 8.x target
+normally resolves to **this** impl by its disjoint band
+(legacy ``>=8.0,<9.0`` vs modern ``>=9.0,<10.0``) — no re-band, no specificity
+tie, no operator-asserted version required.
+
+**Caveat (the #3067 review's top finding, a named residual risk):** the
+fingerprint is inherited and stores ``releaseName`` *raw* (no split/normalise).
+Resolution therefore depends on ``releaseName`` being PEP 440-parseable. If a
+given 8.x appliance were to report a non-parseable ``releaseName`` (a word or a
+space), the resolver cannot band it and falls back to the modern-owned wildcard —
+i.e. it resolves *open* to ``vrops-rest``, which presents the 9.x ``OpsToken``
+scheme and would 401 against the 8.x appliance. The observed ``releaseName`` is
+always a dotted numeric release (and the modern connector relies on the same
+field), so this is expected not to occur — but it is **unverified against a live
+8.x appliance** (the deferred live-verify tail). The escape hatch is
+operator-side: pin ``version`` or ``preferred_impl_id`` on the target. The
+fallback behaviour is pinned in
+:mod:`tests.test_connectors_vrops8_dual_impl_resolution`.
+
+The ``product`` token is ``"vrops"`` and ``impl_id`` is ``"vrops-vrops8"``
+because :func:`register_connector_v2` enforces that ``product`` equals the first
+hyphen-segment of ``impl_id`` (the round-trip invariant); ``connector_id``
+``"vrops-vrops8-8.0"`` parses back to ``("vrops", "8.0", "vrops-vrops8")``.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+from meho_backplane.connectors.vcf_operations.session import VcfOperationsTargetLike
+
+__all__ = ["Vrops8Connector"]
+
+#: The pre-9.x authorization scheme for an acquired suite-api token. vROps /
+#: Aria Operations 8.x appliances predate the ``OpsToken`` alias (#2395) the
+#: modern connector presents and accept only ``vRealizeOpsToken`` (the token-era
+#: scheme, stable across the whole 8.x line). This is the sole behavioural delta
+#: from the 9.x sibling.
+_VROPS8_TOKEN_SCHEME = "vRealizeOpsToken"
+
+
+class Vrops8Connector(VcfOperationsConnector):
+    """vRealize Operations 8.x legacy read connector — a thin subclass of ``vrops-rest``.
+
+    Overrides the registration triple, the version band, and the token scheme;
+    inherits everything else from
+    :class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
+    (see the module docstring for why a subclass is the honest shape here). The
+    inherited ``__init__`` gives this class its own per-target session-token
+    cache, lock, and credentials cache (keyed under ``product_label="vrops"``),
+    independent of the modern instance the dispatcher caches separately.
+    """
+
+    # G0.6 v2 registry metadata — the dispatch-canonical triple
+    # ``parse_connector_id`` derives from ``"vrops-vrops8-8.0"``. ``product`` is
+    # shared with the modern ``vrops-rest``; the ``impl_id`` disambiguates.
+    product = "vrops"
+    version = "8.0"
+    impl_id = "vrops-vrops8"
+    supported_version_range = ">=8.0,<9.0"
+    priority = 1
+
+    async def auth_headers(
+        self,
+        target: VcfOperationsTargetLike,
+        operator: Operator,
+    ) -> dict[str, str]:
+        """Return ``{"Authorization": "vRealizeOpsToken <token>"}`` for the request.
+
+        Identical to the inherited 9.x path — same
+        :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
+        gate, same ``POST /suite-api/api/auth/token/acquire`` session mint, same
+        per-target token cache — except the presented scheme is the pre-9.x
+        ``vRealizeOpsToken`` (an 8.x appliance predates the ``OpsToken`` alias,
+        #2395). The guard and the mint stay single-sourced on the base class;
+        this override only re-labels the scheme on the header the base returns,
+        so a future change to the base auth path (e.g. the gate) is inherited
+        rather than silently forked.
+        """
+        headers = dict(await super().auth_headers(target, operator))
+        _scheme, _sep, token = headers.get("Authorization", "").partition(" ")
+        headers["Authorization"] = f"{_VROPS8_TOKEN_SCHEME} {token}"
+        return headers

--- a/backend/src/meho_backplane/connectors/vrops8/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vrops8/typed_ops.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op registrar for :class:`Vrops8Connector` (legacy vROps 8.x, #3067).
+
+The 8.x impl reuses the modern sibling's **audited typed read set verbatim** —
+the four ops in
+:data:`~meho_backplane.connectors.vcf_operations.typed_ops.VROPS_TYPED_OPS`
+(``vrops.liveness`` / ``vrops.alert.list`` / ``vrops.resource.query`` /
+``vrops.resource.stats``) hit the identical ``/suite-api/api/*`` surface on 8.x,
+and their handlers are inherited on :class:`Vrops8Connector`. So this registrar
+upserts the *same op_ids* under the 8.x connector's own
+``(vrops, 8.0, vrops-vrops8)`` triple rather than re-authoring them.
+
+Two invariants make the reuse safe:
+
+* **op_ids are shared on purpose.** ``endpoint_descriptor`` rows are keyed by
+  ``(product, version, impl_id, op_id)``, so ``vrops.liveness`` on
+  ``vrops-vrops8-8.0`` is a distinct row from the same op_id on
+  ``vrops-rest-9.0`` — the logical operation is the same, dispatched to whichever
+  impl the target resolves to.
+* **group_keys are scoped per impl.** ``_resolve_or_create_group`` looks up an
+  :class:`~meho_backplane.db.models.OperationGroup` by
+  ``(product, version, impl_id, group_key)``, so reusing the modern group_keys
+  lands distinct group rows for this impl — never colliding with the 9.x rows.
+
+This mirrors the modern
+:func:`~meho_backplane.connectors.vcf_operations.typed_ops.register_vcf_operations_typed_operations`
+registrar exactly, differing only in the target class (:class:`Vrops8Connector`)
+it resolves handlers and the registration triple from.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = ["register_vrops8_typed_operations"]
+
+_log = structlog.get_logger(__name__)
+
+
+async def register_vrops8_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the modern vROps typed read set under the ``vrops-vrops8`` triple.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors` has
+    walked every connector subpackage, so the descriptor rows land before the
+    first dispatch — the 8.x read core dispatches on a fresh boot with zero
+    catalog ingest. Idempotent across pod restarts. Mirrors the modern
+    ``register_vcf_operations_typed_operations`` registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`~meho_backplane.retrieval.embedding.EmbeddingService` (or a
+    chassis-test stub) to every registrar, so each must accept the kwarg; it is
+    forwarded to :func:`register_typed_operation` (which falls back to the
+    process-wide singleton when ``None``).
+    """
+    # Lazy import: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests should not
+    # pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vcf_operations.typed_ops import (
+        VROPS_TYPED_OPS,
+        VROPS_TYPED_WHEN_TO_USE_BY_GROUP,
+    )
+    from meho_backplane.connectors.vrops8.connector import Vrops8Connector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VROPS_TYPED_OPS:
+        handler = getattr(Vrops8Connector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"Vrops8Connector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else VROPS_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"Vrops8Connector typed op {op.op_id!r} declares group_key="
+                f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                f"Add an entry to VROPS_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=Vrops8Connector.product,
+            version=Vrops8Connector.version,
+            impl_id=Vrops8Connector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vrops8_typed_operations_registered",
+        count=len(VROPS_TYPED_OPS),
+        product=Vrops8Connector.product,
+        version=Vrops8Connector.version,
+        impl_id=Vrops8Connector.impl_id,
+    )

--- a/backend/tests/test_connectors_vrli8_auth.py
+++ b/backend/tests/test_connectors_vrli8_auth.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`Vrli8Connector` — the legacy vRLI 8.x thin subclass (#3068).
+
+``Vrli8Connector`` subclasses
+:class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector` (the 9.x
+sibling) and overrides **only** the registration triple and the version band. The
+vRLI ``/api/v2/*`` surface — including the ``Bearer`` session-auth scheme — is
+identical on 8.x and 9.x (the v2 API shipped in vRLI 8.0), so there is **no auth
+override**. These tests pin the 8.x metadata/registration and prove the inherited
+auth + fingerprint still work on the subclass:
+
+* ``auth_headers`` mints via ``POST /api/v2/sessions`` and presents ``Bearer <sessionId>``.
+* The inherited ``auth_model`` gate still fires.
+* ``fingerprint`` reads the unauthenticated ``GET /api/v2/version`` and reports a real 8.x version.
+
+Models :mod:`tests.test_connectors_vcf_logs_auth` (the 9.x sibling).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vrli8 import (
+    VRLI8_IMPL_ID,
+    VRLI8_PRODUCT,
+    VRLI8_VERSION,
+)
+from meho_backplane.connectors.vrli8.connector import Vrli8Connector
+
+_SESSIONS_PATH = "/api/v2/sessions"
+_VERSION_PATH = "/api/v2/version"
+_SESSION_ID = "vrli8-session-abc-123"
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Restore Vrli8Connector's package registration (versioned triple only, no wildcard)."""
+    clear_registry()
+    register_connector_v2(
+        product=Vrli8Connector.product,
+        version=Vrli8Connector.version,
+        impl_id=Vrli8Connector.impl_id,
+        cls=Vrli8Connector,
+    )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    provider: str | None = None
+    tls_server_name: str | None = None
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(name="vrli8-a", host="vrli8-a.test.invalid", port=443, secret_ref="vrli/a")
+
+
+async def _stub_loader(_target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> Vrli8Connector:
+    return Vrli8Connector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# Subclass metadata + registration
+# ---------------------------------------------------------------------------
+
+
+def test_vrli8_connector_subclasses_the_modern_impl() -> None:
+    """The connector inherits the 9.x impl (and thus HttpConnector) with 8.x metadata."""
+    from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+
+    assert issubclass(Vrli8Connector, VcfLogsConnector)
+    assert issubclass(Vrli8Connector, HttpConnector)
+    assert Vrli8Connector.product == "vrli"
+    assert Vrli8Connector.version == "8.0"
+    assert Vrli8Connector.impl_id == "vrli-vrli8"
+    assert Vrli8Connector.supported_version_range == ">=8.0,<9.0"
+    assert Vrli8Connector.priority == 1
+
+
+def test_importing_package_registers_versioned_triple_only() -> None:
+    """The package registers its versioned triple and NOT the ``("vrli","","")`` wildcard."""
+    registry = all_connectors_v2()
+    assert registry[(VRLI8_PRODUCT, VRLI8_VERSION, VRLI8_IMPL_ID)] is Vrli8Connector
+    assert (VRLI8_PRODUCT, "", "") not in registry
+
+
+# ---------------------------------------------------------------------------
+# Inherited Bearer auth (unchanged from 9.x)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_mints_session_and_presents_bearer() -> None:
+    """``auth_headers`` POSTs creds to /api/v2/sessions and presents ``Bearer <sessionId>``."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrli8-a.test.invalid") as mock:
+        session = mock.post(_SESSIONS_PATH).respond(
+            200, json={"sessionId": _SESSION_ID, "ttl": 1800}
+        )
+        headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert session.called
+    assert headers == {"Authorization": f"Bearer {_SESSION_ID}"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_inherited_auth_model_guard_still_rejects_non_shared_modes(auth_model: str) -> None:
+    """The base-class ``auth_model`` gate fires unchanged through the subclass."""
+    target = _StubTarget(
+        name="vrli8-per-user",
+        host="vrli8.test.invalid",
+        port=443,
+        secret_ref="vrli/pu",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "vrli8-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint — inherited unauthenticated GET /api/v2/version, real 8.x version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_reports_real_8x_version_unauthenticated() -> None:
+    """``GET /api/v2/version`` (no session) → reachable, product=vrli, a parsed 8.x version."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrli8-a.test.invalid") as mock:
+        version = mock.get(_VERSION_PATH).respond(200, json={"version": "8.18.0.0.24842179"})
+        fp = await connector.fingerprint(_TARGET_A, operator=_make_operator())
+    assert version.called
+    assert fp.vendor == "vmware"
+    assert fp.product == "vrli"
+    assert fp.reachable is True
+    assert fp.version is not None and fp.version.startswith("8.18")
+    assert fp.build == "24842179"
+    await connector.aclose()

--- a/backend/tests/test_connectors_vrli8_dual_impl_resolution.py
+++ b/backend/tests/test_connectors_vrli8_dual_impl_resolution.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The vRLI two-impl resolver test — ``product=vrli`` (vrli-rest + vrli-vrli8), #3068.
+
+``product=vrli`` is the codebase's **5th real two-implementation case** (after
+``fleet``, ``vcfa``, ``sddc``, ``vrops``; initiative #3056, policy #3033/#3038):
+
+* modern typed ``vrli-rest``
+  (:class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`) — VCF
+  Operations for Logs 9.x, ``supported_version_range=">=9.0,<10.0"``.
+* legacy typed ``vrli-vrli8``
+  (:class:`~meho_backplane.connectors.vrli8.connector.Vrli8Connector`) — a thin
+  subclass of the modern impl for vRealize Log Insight / Aria Operations for Logs
+  8.x, ``supported_version_range=">=8.0,<9.0"``.
+
+The **modern** ``vcf_logs`` owns the ``("vrli","","")`` wildcard, so the new legacy
+``vrli-vrli8`` registers **only** its versioned triple — the *fleet inversion*: an
+unfingerprinted ``vrli`` target resolves to **modern** ``vrli-rest``. A vRLI 8.x
+appliance's ``GET /api/v2/version`` returns a real five-part ``8.x`` version string,
+so a fingerprinted 8.x target resolves to the legacy impl **by fingerprint alone**.
+Bands are **disjoint**, so no specificity tie. Mirrors
+:mod:`tests.test_connectors_vrops8_dual_impl_resolution`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+from meho_backplane.connectors.vrli8.connector import Vrli8Connector
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+def _fp(version: str | None) -> _FakeFingerprint:
+    return _FakeFingerprint(version=version)
+
+
+def _register_both_impls() -> None:
+    """Register both vrli impls exactly as their ``__init__`` modules do.
+
+    ``vrli-rest`` (modern): versioned triple **plus** the ``("vrli","","")`` wildcard;
+    ``vrli-vrli8`` (legacy): the versioned triple only. Real classes so a band drift
+    breaks this guard.
+    """
+    register_connector_v2(
+        product=VcfLogsConnector.product,
+        version=VcfLogsConnector.version,
+        impl_id=VcfLogsConnector.impl_id,
+        cls=VcfLogsConnector,
+    )
+    register_connector_v2(product="vrli", version="", impl_id="", cls=VcfLogsConnector)
+    register_connector_v2(
+        product=Vrli8Connector.product,
+        version=Vrli8Connector.version,
+        impl_id=Vrli8Connector.impl_id,
+        cls=Vrli8Connector,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    _register_both_impls()
+    yield
+    clear_registry()
+
+
+def test_both_impls_register_under_distinct_triples() -> None:
+    """Two ``vrli`` impls, distinct (version, impl_id); the modern impl owns the wildcard."""
+    assert (VcfLogsConnector.product, VcfLogsConnector.version, VcfLogsConnector.impl_id) == (
+        "vrli",
+        "9.0",
+        "vrli-rest",
+    )
+    assert (Vrli8Connector.product, Vrli8Connector.version, Vrli8Connector.impl_id) == (
+        "vrli",
+        "8.0",
+        "vrli-vrli8",
+    )
+    assert VcfLogsConnector.supported_version_range == ">=9.0,<10.0"
+    assert Vrli8Connector.supported_version_range == ">=8.0,<9.0"
+
+    triples = set(all_connectors_v2())
+    assert ("vrli", "9.0", "vrli-rest") in triples
+    assert ("vrli", "8.0", "vrli-vrli8") in triples
+    assert ("vrli", "", "") in triples
+    assert all_connectors_v2()[("vrli", "", "")] is VcfLogsConnector
+
+
+def test_8x_target_resolves_legacy_vrli8() -> None:
+    """A vRLI 8.12 target resolves ``vrli-vrli8`` by fingerprint alone."""
+    assert resolve_connector(_FakeTarget(product="vrli", fingerprint=_fp("8.12"))) is Vrli8Connector
+
+
+def test_8x_boundary_and_patch_targets_resolve_legacy() -> None:
+    """The band floor (8.0) and a patch (8.18.1) both resolve ``vrli-vrli8`` (in ``>=8.0,<9.0``)."""
+    assert resolve_connector(_FakeTarget(product="vrli", fingerprint=_fp("8.0"))) is Vrli8Connector
+    assert (
+        resolve_connector(_FakeTarget(product="vrli", fingerprint=_fp("8.18.1"))) is Vrli8Connector
+    )
+
+
+def test_8x_preferred_modern_is_moot_out_of_range() -> None:
+    """``preferred_impl_id="vrli-rest"`` on an 8.x target cannot flip the out-of-range result."""
+    target = _FakeTarget(product="vrli", fingerprint=_fp("8.12"), preferred_impl_id="vrli-rest")
+    assert resolve_connector(target) is Vrli8Connector
+
+
+def test_9x_target_resolves_modern_vrli_rest() -> None:
+    """A 9.0 target resolves ``vrli-rest`` (its own wildcard demoted first)."""
+    assert (
+        resolve_connector(_FakeTarget(product="vrli", fingerprint=_fp("9.0"))) is VcfLogsConnector
+    )
+    assert (
+        resolve_connector(_FakeTarget(product="vrli", fingerprint=_fp("9.0.2"))) is VcfLogsConnector
+    )
+
+
+def test_unfingerprinted_target_resolves_via_modern_wildcard() -> None:
+    """A fresh (unfingerprinted, unversioned) ``vrli`` target resolves via the wildcard → MODERN."""
+    target = _FakeTarget(product="vrli", fingerprint=None, version=None)
+    assert resolve_connector(target) is VcfLogsConnector

--- a/backend/tests/test_connectors_vrli8_spec_reconcile.py
+++ b/backend/tests/test_connectors_vrli8_spec_reconcile.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vrli8 (legacy vRLI 8.x) reconcile lane (#3068) — the subclass op-set drift guard.
+
+``Vrli8Connector`` is a thin **subclass** of the modern ``vrli-rest`` impl: it
+introduces **no new hand-coded paths** (the vRLI ``/api/v2/*`` surface lives on the
+modern ``vcf_logs`` module — the ``vrli.event.query`` constraint path, the session
+mint, the ``/api/v2/version`` fingerprint — and is already guarded by
+:mod:`tests.test_connectors_vcf_logs_spec_reconcile`). The vRLI v2 API is stable
+across the 8.x↔9.x boundary (it shipped in vRLI 8.0), so the modern reconcile covers
+the 8.x paths too.
+
+**Evidenced exclusion — no committable 8.x spec.** vRLI 8.x publishes no committable
+OpenAPI 3.x or Swagger 2.0 file (Broadcom's developer portal serves gated HTML; the
+only machine-readable surface is a per-appliance runtime Swagger UI at
+``/rest-api``; VMware's own archived client was hand-coded). MEHO's OA3-only ingest
+(#2090) can't consume any of that — hence the typed read core (reused from the modern
+sibling). Full evidence lives in the ``vrli-vrli8`` entry of
+``docs/decisions/spec-reconcile-guards-standard.md``.
+
+So the guard unique to the subclass is the **op-set drift guard**: pin that the 8.x
+impl reuses *exactly* the modern typed op-set. If the modern connector grows a
+9.x-only typed op, the 8.x impl (whose registrar reuses the modern tuple) would
+silently inherit it — this test reds first, forcing a conscious 8.x-applicability
+decision. Parse-only, so it runs in the required unit sweep.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_logs.typed_ops import VRLI_TYPED_OPS
+from meho_backplane.connectors.vrli8 import connector as _connector
+from meho_backplane.connectors.vrli8 import typed_ops as _typed_ops
+from meho_backplane.connectors.vrli8.connector import Vrli8Connector
+from meho_backplane.operations._handler_resolve import is_unbound_method
+
+#: The modern typed read op the 8.x impl reuses verbatim (#2295). vRLI types only
+#: the event query; the rest of its browse surface is generic-ingested on 9.x (no
+#: committable 8.x spec to ingest — see the module docstring).
+_EXPECTED_REUSED_OP_IDS = {"vrli.event.query"}
+
+
+def test_vrli8_reuses_modern_typed_op_ids_verbatim() -> None:
+    """Pin the reused op-set: the 8.x impl registers exactly the modern typed op_ids.
+
+    A new modern typed op can't silently join the 8.x surface unreviewed — this pin
+    reds so its 8.x applicability is decided consciously.
+    """
+    assert {op.op_id for op in VRLI_TYPED_OPS} == _EXPECTED_REUSED_OP_IDS
+
+
+def test_vrli8_introduces_no_new_hand_coded_paths() -> None:
+    """The subclass adds no ``_*_PATH`` constants — its surface is the modern (reconciled) one."""
+    for module in (_connector, _typed_ops):
+        offending = [
+            name
+            for name, value in vars(module).items()
+            if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+        ]
+        assert offending == [], (
+            f"{module.__name__} introduced un-reconciled path constants: {offending}"
+        )
+
+
+def test_vrli8_inherits_every_typed_handler_and_is_rebindable() -> None:
+    """Every reused op's handler resolves on the subclass AND is MRO-rebindable to it.
+
+    Guards the load-bearing dispatch mechanism: ``is_unbound_method(handler,
+    Vrli8Connector)`` is the exact predicate the dispatcher uses to decide it must
+    rebind the (base-class-authored, shared) ``handler_ref`` onto the resolver-chosen
+    ``Vrli8Connector`` instance. A regression making the inherited ``event_query``
+    non-MRO-matchable would silently dispatch on the wrong instance — this pins it red.
+    """
+    for op in VRLI_TYPED_OPS:
+        handler = getattr(Vrli8Connector, op.handler_attr, None)
+        assert callable(handler), (
+            f"Vrli8Connector missing handler for {op.op_id} ({op.handler_attr})"
+        )
+        assert is_unbound_method(handler, Vrli8Connector), (
+            f"{op.op_id} handler is not MRO-rebindable onto Vrli8Connector"
+        )

--- a/backend/tests/test_connectors_vrops8_auth.py
+++ b/backend/tests/test_connectors_vrops8_auth.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`Vrops8Connector` — the legacy vROps 8.x scheme swap (#3067).
+
+``Vrops8Connector`` is a thin subclass of
+:class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
+(the 9.x sibling). The only behavioural delta is the token *scheme*: an 8.x
+appliance predates the ``OpsToken`` alias (#2395) and accepts only the pre-9.x
+``vRealizeOpsToken``. These tests pin exactly that delta — and prove the parts that
+are **inherited** (the ``POST /suite-api/api/auth/token/acquire`` mint, the
+``auth_model`` gate, ``invalidate_session`` recovery, the ``versions/current``
+fingerprint) still work and now present the 8.x scheme end-to-end:
+
+* ``auth_headers`` returns ``Authorization: vRealizeOpsToken <token>`` (not ``OpsToken``).
+* A dispatched read + the fingerprint both carry ``vRealizeOpsToken`` on the wire.
+* The inherited auth-model guard, per-target isolation, and eviction hooks are unbroken.
+
+Models :mod:`tests.test_connectors_vcf_operations_auth` (the 9.x sibling) with the
+8.x divergence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vrops8 import (
+    VROPS8_IMPL_ID,
+    VROPS8_PRODUCT,
+    VROPS8_VERSION,
+)
+from meho_backplane.connectors.vrops8.connector import Vrops8Connector
+
+_ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
+_VERSIONS_PATH = "/suite-api/api/versions/current"
+_OPS_TOKEN = "vrops8-ops-token-abc-123"
+
+
+def _acquire_response(token: str = _OPS_TOKEN) -> dict[str, Any]:
+    """A canonical ``token/acquire`` 200 body carrying *token*."""
+    return {"token": token, "validity": 1470421325035, "expiresAt": "later", "roles": []}
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Restore Vrops8Connector's package registration (versioned triple only, no wildcard)."""
+    clear_registry()
+    register_connector_v2(
+        product=Vrops8Connector.product,
+        version=Vrops8Connector.version,
+        impl_id=Vrops8Connector.impl_id,
+        cls=Vrops8Connector,
+    )
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    auth_source: str | None = None
+    tls_server_name: str | None = None
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(
+    name="vrops8-a", host="vrops8-a.test.invalid", port=443, secret_ref="vrops/a"
+)
+
+
+async def _stub_loader(_target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
+    return {"username": "admin", "password": "stub-password"}
+
+
+def _make_connector() -> Vrops8Connector:
+    return Vrops8Connector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# Subclass metadata + registration
+# ---------------------------------------------------------------------------
+
+
+def test_vrops8_connector_subclasses_the_modern_impl() -> None:
+    """The connector inherits the 9.x impl (and thus HttpConnector) with 8.x metadata."""
+    from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+
+    assert issubclass(Vrops8Connector, VcfOperationsConnector)
+    assert issubclass(Vrops8Connector, HttpConnector)
+    assert Vrops8Connector.product == "vrops"
+    assert Vrops8Connector.version == "8.0"
+    assert Vrops8Connector.impl_id == "vrops-vrops8"
+    assert Vrops8Connector.supported_version_range == ">=8.0,<9.0"
+    assert Vrops8Connector.priority == 1
+
+
+def test_importing_package_registers_versioned_triple_only() -> None:
+    """The package registers its versioned triple and NOT the ``("vrops","","")`` wildcard."""
+    registry = all_connectors_v2()
+    assert registry[(VROPS8_PRODUCT, VROPS8_VERSION, VROPS8_IMPL_ID)] is Vrops8Connector
+    assert (VROPS8_PRODUCT, "", "") not in registry
+
+
+# ---------------------------------------------------------------------------
+# The scheme swap — the one behavioural delta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_presents_vrealizeopstoken_scheme() -> None:
+    """``auth_headers`` mints via acquire and presents the pre-9.x ``vRealizeOpsToken`` scheme."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrops8-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    # The delta from the 9.x sibling: the scheme is vRealizeOpsToken, not the bare
+    # OpsToken (note vRealizeOpsToken *contains* the substring "OpsToken" — assert the
+    # exact scheme token, not a substring).
+    assert headers == {"Authorization": f"vRealizeOpsToken {_OPS_TOKEN}"}
+    assert headers["Authorization"].split(" ", 1)[0] == "vRealizeOpsToken" != "OpsToken"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatched_read_carries_the_8x_scheme_on_the_wire() -> None:
+    """A data read mints once and sends ``vRealizeOpsToken`` on the DATA request (not acquire)."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrops8-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        versions = mock.get(_VERSIONS_PATH).respond(
+            200, json={"releaseName": "8.18.0.12345", "buildNumber": 12345}
+        )
+        await connector._get_json(_TARGET_A, _VERSIONS_PATH, operator=_make_operator())
+    data_req = versions.calls[0].request
+    assert data_req.headers["Authorization"] == f"vRealizeOpsToken {_OPS_TOKEN}"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Inherited behaviour still holds (single-sourced on the base)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_inherited_auth_model_guard_still_rejects_non_shared_modes(auth_model: str) -> None:
+    """The base-class ``auth_model`` gate fires unchanged through the subclass override.
+
+    Proves the security-sensitive guard is single-sourced on the base: the override
+    calls ``super().auth_headers`` (which runs the gate) before swapping the scheme.
+    """
+    target = _StubTarget(
+        name="vrops8-per-user",
+        host="vrops8.test.invalid",
+        port=443,
+        secret_ref="vrops/pu",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+    assert "vrops8-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_establish_rejects_empty_operator_jwt() -> None:
+    """A system-initiated call (empty raw_jwt) fails closed before any mint (inherited)."""
+    connector = _make_connector()
+    with pytest.raises(VaultCredentialsReadError, match=r"vrops8-a"):
+        await connector.auth_headers(_TARGET_A, operator=_make_operator(raw_jwt=""))
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_cached_then_evicted_by_invalidate_session_remints() -> None:
+    """The inherited token cache + ``invalidate_session`` (#2067) evict-then-remint works."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrops8-a.test.invalid") as mock:
+        acquire = mock.post(_ACQUIRE_PATH).mock(
+            side_effect=[
+                httpx.Response(200, json=_acquire_response("tok-1")),
+                httpx.Response(200, json=_acquire_response("tok-2")),
+            ]
+        )
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        assert connector._session_tokens == {target_cache_key(_TARGET_A): "tok-1"}
+        await connector.invalidate_session(_TARGET_A)
+        assert connector._session_tokens == {}
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert h1 == {"Authorization": "vRealizeOpsToken tok-1"}
+    assert h2 == {"Authorization": "vRealizeOpsToken tok-2"}
+    assert acquire.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_authsource_rides_the_acquire_body_inherited() -> None:
+    """A target with ``auth_source`` set threads it onto the acquire body (inherited behaviour)."""
+    target = _StubTarget(
+        name="vrops8-ad",
+        host="vrops8-ad.test.invalid",
+        port=443,
+        secret_ref="vrops/ad",
+        auth_source="corp-ad",
+    )
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrops8-ad.test.invalid") as mock:
+        acquire = mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        await connector.auth_headers(target, operator=_make_operator())
+    body = acquire.calls[0].request.content
+    assert b"corp-ad" in body
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint — inherited, reports the real 8.x version, uses the 8.x scheme
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_reports_real_8x_version_and_uses_8x_scheme() -> None:
+    """``versions/current`` → product=vrops + 8.x releaseName; authed via vRealizeOpsToken."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://vrops8-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        versions = mock.get(_VERSIONS_PATH).respond(
+            200, json={"releaseName": "8.18.0.12345", "buildNumber": 12345}
+        )
+        fp = await connector.fingerprint(_TARGET_A, operator=_make_operator())
+    assert fp.vendor == "vmware"
+    assert fp.product == "vrops"
+    assert fp.reachable is True
+    assert fp.version == "8.18.0.12345"
+    assert fp.build == "12345"
+    # The fingerprint's authenticated GET presents the 8.x scheme too.
+    assert versions.calls[0].request.headers["Authorization"] == f"vRealizeOpsToken {_OPS_TOKEN}"
+    await connector.aclose()

--- a/backend/tests/test_connectors_vrops8_dual_impl_resolution.py
+++ b/backend/tests/test_connectors_vrops8_dual_impl_resolution.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The vROps two-impl resolver test — ``product=vrops`` (vrops-rest + vrops-vrops8), #3067.
+
+``product=vrops`` is the codebase's **4th real two-implementation case** (after
+``fleet``, ``vcfa``, ``sddc``; initiative #3056, policy #3033/#3038). Two
+``HttpConnector`` subclasses register under the same product with distinct
+``impl_id``s and **disjoint** version bands, and
+:func:`~meho_backplane.connectors.resolver.resolve_connector` picks one per target
+by fingerprint:
+
+* modern typed ``vrops-rest``
+  (:class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`)
+  — VCF Operations 9.x, ``supported_version_range=">=9.0,<10.0"``.
+* legacy typed ``vrops-vrops8``
+  (:class:`~meho_backplane.connectors.vrops8.connector.Vrops8Connector`) — a thin
+  subclass of the modern impl for vRealize Operations / Aria Operations 8.x,
+  ``supported_version_range=">=8.0,<9.0"``.
+
+The inversion vs ``fleet``
+--------------------------
+
+The **modern** ``vcf_operations`` owns the ``("vrops","","")`` wildcard (it shipped
+first, as the sole impl), so the new legacy ``vrops-vrops8`` registers **only** its
+versioned triple. Consequence: an *unfingerprinted* / unversioned ``vrops`` target
+resolves to **modern** ``vrops-rest`` (the wildcard owner).
+
+Unlike vRA 8 (whose appliance fingerprint reports the API version, not a product
+version, so an 8.x target needs an operator-asserted version), a vROps 8.x
+appliance's ``GET /suite-api/api/versions/current`` returns a real product
+``releaseName`` (e.g. ``8.18.x``), so a fingerprinted 8.x target resolves to the
+legacy impl **by fingerprint alone**. Because the two bands are **disjoint**,
+resolution never reaches the specificity tie-break: an 8.x target has exactly one
+in-range versioned candidate (legacy), a 9.x target exactly one (modern). Mirrors
+:mod:`tests.test_connectors_vra8_dual_impl_resolution`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+from meho_backplane.connectors.vrops8.connector import Vrops8Connector
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+def _fp(version: str | None) -> _FakeFingerprint:
+    return _FakeFingerprint(version=version)
+
+
+def _register_both_impls() -> None:
+    """Register both vrops impls exactly as their ``__init__`` modules do.
+
+    * ``vrops-rest`` (modern): the versioned triple **plus** the ``("vrops","","")``
+      wildcard fallback (the G0.15-T6 #1215 fanout it shipped with as the sole impl).
+    * ``vrops-vrops8`` (legacy): the versioned triple only — a second class on the
+      wildcard key would raise ``RuntimeError``.
+
+    Uses the real connector classes so a future drift in either
+    ``supported_version_range`` breaks this test — the point of a two-impl guard.
+    """
+    register_connector_v2(
+        product=VcfOperationsConnector.product,
+        version=VcfOperationsConnector.version,
+        impl_id=VcfOperationsConnector.impl_id,
+        cls=VcfOperationsConnector,
+    )
+    register_connector_v2(product="vrops", version="", impl_id="", cls=VcfOperationsConnector)
+    register_connector_v2(
+        product=Vrops8Connector.product,
+        version=Vrops8Connector.version,
+        impl_id=Vrops8Connector.impl_id,
+        cls=Vrops8Connector,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    _register_both_impls()
+    yield
+    clear_registry()
+
+
+def test_both_impls_register_under_distinct_triples() -> None:
+    """The two impls share ``product="vrops"`` but distinct (version, impl_id).
+
+    The v2 keys never collide (impl_id + version disambiguate), and the
+    ``("vrops","","")`` wildcard is owned by the **modern** impl alone (inversion vs fleet).
+    """
+    assert (
+        VcfOperationsConnector.product,
+        VcfOperationsConnector.version,
+        VcfOperationsConnector.impl_id,
+    ) == ("vrops", "9.0", "vrops-rest")
+    assert (Vrops8Connector.product, Vrops8Connector.version, Vrops8Connector.impl_id) == (
+        "vrops",
+        "8.0",
+        "vrops-vrops8",
+    )
+    # The disjoint bands are what the split hinges on (no overlap → no specificity tie).
+    assert VcfOperationsConnector.supported_version_range == ">=9.0,<10.0"
+    assert Vrops8Connector.supported_version_range == ">=8.0,<9.0"
+
+    triples = set(all_connectors_v2())
+    assert ("vrops", "9.0", "vrops-rest") in triples
+    assert ("vrops", "8.0", "vrops-vrops8") in triples
+    assert ("vrops", "", "") in triples  # the single wildcard
+    # ...owned by the MODERN impl (inversion vs fleet, where the legacy owns it).
+    assert all_connectors_v2()[("vrops", "", "")] is VcfOperationsConnector
+
+
+def test_8x_target_resolves_legacy_vrops8() -> None:
+    """A vROps 8.18 target resolves ``vrops-vrops8`` — the only in-range candidate.
+
+    A real 8.x appliance reports this version off ``versions/current``, so the split
+    happens by fingerprint alone (no operator-asserted version needed, unlike vRA 8).
+    """
+    target = _FakeTarget(product="vrops", fingerprint=_fp("8.18"))
+    assert resolve_connector(target) is Vrops8Connector
+
+
+def test_8x_boundary_and_patch_targets_resolve_legacy() -> None:
+    """The band floor (8.0) and a patch (8.18.1) both resolve ``vrops-vrops8``."""
+    assert (
+        resolve_connector(_FakeTarget(product="vrops", fingerprint=_fp("8.0"))) is Vrops8Connector
+    )
+    assert (
+        resolve_connector(_FakeTarget(product="vrops", fingerprint=_fp("8.18.1")))
+        is Vrops8Connector
+    )
+
+
+def test_8x_preferred_modern_is_moot_out_of_range() -> None:
+    """``preferred_impl_id="vrops-rest"`` on an 8.x target cannot flip the result.
+
+    Operator preference only breaks a tie among **in-range** candidates; at 8.18 only
+    the legacy impl is in range, so a preference for the out-of-range modern impl is
+    moot — the disjoint-band robustness the ``fleet`` overlapping-band case cannot assert.
+    """
+    target = _FakeTarget(product="vrops", fingerprint=_fp("8.18"), preferred_impl_id="vrops-rest")
+    assert resolve_connector(target) is Vrops8Connector
+
+
+def test_9x_target_resolves_modern_vrops_rest() -> None:
+    """A VCF Operations 9.0 target resolves ``vrops-rest`` (its own wildcard demoted first)."""
+    assert (
+        resolve_connector(_FakeTarget(product="vrops", fingerprint=_fp("9.0")))
+        is VcfOperationsConnector
+    )
+    assert (
+        resolve_connector(_FakeTarget(product="vrops", fingerprint=_fp("9.0.2")))
+        is VcfOperationsConnector
+    )
+
+
+def test_unfingerprinted_target_resolves_via_modern_wildcard() -> None:
+    """A fresh target (no fingerprint, no asserted version) resolves via the wildcard → MODERN.
+
+    Neither versioned entry matches without a version, so only the ``("vrops","","")``
+    wildcard survives — owned here by the **modern** ``vrops-rest`` (the inversion vs
+    fleet). An unfingerprinted vROps estate resolves to modern until it carries an 8.x
+    version; this pins that documented behaviour so a future wildcard re-assignment
+    can't silently change it.
+    """
+    target = _FakeTarget(product="vrops", fingerprint=None, version=None)
+    assert resolve_connector(target) is VcfOperationsConnector
+
+
+def test_unparseable_release_name_falls_back_to_modern_documenting_limitation() -> None:
+    """A non-PEP-440 fingerprint version resolves *open* to modern — the named residual risk.
+
+    The inherited fingerprint stores ``versions/current``'s ``releaseName`` raw, so
+    resolution depends on it being PEP 440-parseable. If an 8.x appliance ever reported
+    a non-parseable ``releaseName`` (a word / a space), the resolver cannot band it and
+    only the modern-owned wildcard survives → the target resolves to ``vrops-rest``
+    (which would present the wrong 9.x ``OpsToken`` scheme). This pins that documented
+    limitation (the #3067 review's top finding) as *visible, regression-guarded*
+    behaviour rather than a silent surprise; the operator escape hatch is to pin
+    ``version`` / ``preferred_impl_id`` on the target. The observed ``releaseName`` is
+    always a dotted numeric release, so this path is not expected in practice — but it
+    is unverified against a live 8.x appliance.
+    """
+    target = _FakeTarget(product="vrops", fingerprint=_fp("Aria Operations 8.18"))
+    assert resolve_connector(target) is VcfOperationsConnector

--- a/backend/tests/test_connectors_vrops8_spec_reconcile.py
+++ b/backend/tests/test_connectors_vrops8_spec_reconcile.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vrops8 (legacy vROps 8.x) reconcile lane (#3067) — the subclass op-set drift guard.
+
+``Vrops8Connector`` is a thin **subclass** of the modern ``vrops-rest`` impl: it
+introduces **no new hand-coded paths** (the ``/suite-api/api/*`` constants live on
+the modern ``vcf_operations.connector`` module and are already served-set-reconciled
+against the pinned ``vcf-operations-9.0`` OpenAPI 3.0 spec by
+:mod:`tests.test_connectors_vcf_operations_spec_reconcile`). The vROps Suite API
+paths are **stable across the 8.x↔9.x boundary** (``major`` stays ``8`` across the
+whole 8.x line; the 8.10 Aria rebrand is name-only), so those already-reconciled 9.x
+paths serve the 8.x impl too — path existence is version-stable even where response
+schemas drift.
+
+**Evidenced exclusion — no committable 8.x spec.** vROps / Aria Operations 8.x
+publishes only a **per-instance Swagger 2.0** document
+(``/suite-api/doc/v2/api-docs``); there is no OpenAPI 3.x and no committable
+``vmware/*`` artifact for 8.x, so MEHO's OA3-only ingest (#2090) can't consume it —
+hence the typed read core (reused from the modern sibling). Full evidence +
+activation trigger live in the ``vrops-vrops8`` entry of
+``docs/decisions/spec-reconcile-guards-standard.md``.
+
+So the reconcile guard unique to the subclass is the **op-set drift guard**: pin
+that the 8.x impl reuses *exactly* the modern typed op-set, verbatim. If the modern
+connector grows a 9.x-only typed op, the 8.x impl (whose registrar reuses the modern
+tuple) would silently inherit it — this test reds first, forcing a conscious decision
+about whether the new op is 8.x-valid. Parse-only (no DB / shelf / containers), so it
+runs in the required unit sweep.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_operations.typed_ops import VROPS_TYPED_OPS
+from meho_backplane.connectors.vrops8 import connector as _connector
+from meho_backplane.connectors.vrops8 import typed_ops as _typed_ops
+from meho_backplane.connectors.vrops8.connector import Vrops8Connector
+from meho_backplane.operations._handler_resolve import is_unbound_method
+
+#: The modern audited typed read set the 8.x impl reuses verbatim (#2303/#2838).
+#: A change to the modern set reds this pin so the 8.x applicability is reviewed.
+_EXPECTED_REUSED_OP_IDS = {
+    "vrops.liveness",
+    "vrops.alert.list",
+    "vrops.resource.query",
+    "vrops.resource.stats",
+}
+
+
+def test_vrops8_reuses_modern_typed_op_ids_verbatim() -> None:
+    """Pin the reused op-set: the 8.x impl registers exactly the modern typed op_ids.
+
+    The 8.x registrar (:func:`register_vrops8_typed_operations`) iterates
+    ``VROPS_TYPED_OPS`` (imported from the modern module) and upserts each op_id under
+    the ``(vrops, 8.0, vrops-vrops8)`` triple. Pinning the modern set here means a new
+    modern op can't silently join the 8.x surface unreviewed.
+    """
+    assert {op.op_id for op in VROPS_TYPED_OPS} == _EXPECTED_REUSED_OP_IDS
+
+
+def test_vrops8_introduces_no_new_hand_coded_paths() -> None:
+    """The subclass adds no ``_*_PATH`` constants — its surface is the modern (reconciled) one.
+
+    Guards the "subclass introduces nothing un-reconciled" invariant: if a future
+    change adds an 8.x-specific request path, this fails and the author must add a
+    served-set (or manifest-pin) reconcile for it rather than shipping an unguarded path.
+    """
+    for module in (_connector, _typed_ops):
+        offending = [
+            name
+            for name, value in vars(module).items()
+            if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+        ]
+        assert offending == [], (
+            f"{module.__name__} introduced un-reconciled path constants: {offending}"
+        )
+
+
+def test_vrops8_inherits_every_typed_handler_and_is_rebindable() -> None:
+    """Every reused op's handler resolves on the subclass AND is MRO-rebindable to it.
+
+    Two guards on the load-bearing dispatch mechanism (the #3067 review's finding 4):
+
+    * ``getattr(Vrops8Connector, handler_attr)`` returns the inherited base-class method
+      for every op — otherwise the registrar would ``AttributeError`` at boot.
+    * ``is_unbound_method(handler, Vrops8Connector)`` is ``True`` — the exact predicate
+      the dispatcher uses to decide it must rebind the (base-class-authored, shared)
+      ``handler_ref`` onto the resolver-chosen ``Vrops8Connector`` instance. If a
+      regression made the inherited handler non-MRO-matchable (e.g. it stopped living in
+      a class ``__dict__`` on the MRO), an 8.x dispatch would run unbound / on the wrong
+      instance and silently present the 9.x scheme — this pins it red instead.
+    """
+    for op in VROPS_TYPED_OPS:
+        handler = getattr(Vrops8Connector, op.handler_attr, None)
+        assert callable(handler), (
+            f"Vrops8Connector missing handler for {op.op_id} ({op.handler_attr})"
+        )
+        assert is_unbound_method(handler, Vrops8Connector), (
+            f"{op.op_id} handler is not MRO-rebindable onto Vrops8Connector — a dispatch "
+            "would not rebind to the 8.x instance/scheme"
+        )

--- a/docs/codebase/connectors-vrli8.md
+++ b/docs/codebase/connectors-vrli8.md
@@ -1,0 +1,118 @@
+# Connector: vrli8 (vRLI 8.x, legacy dual-impl of `vrli`)
+
+## Overview
+
+The `vrli-vrli8` connector makes **vRealize Log Insight 8.x / VMware Aria Operations
+for Logs 8.x** (the log-management tier of a VCF-5.x-era estate) dispatchable under
+the `(product="vrli", version="8.0", impl_id="vrli-vrli8")` registry triple. It is
+the **legacy dual-impl** of `product="vrli"` filed under the legacy migration-source
+connector-coverage initiative ([#3056](https://github.com/evoila/meho/issues/3056),
+task #3068): vRLI 8.x is a migration **source** logging estate evoila brings
+customers *off*, so MEHO must read and inventory it during discovery + onboarding.
+
+Source: `backend/src/meho_backplane/connectors/vrli8/`. The modern impl is
+[`connectors-vcf-logs.md`](connectors-vcf-logs.md) (`vrli-rest`, `>=9.0,<10.0`). This
+is the **5th real two-impl case** (after `fleet`, `vcfa`, `sddc`, `vrops`).
+
+## Why a thin subclass (not a standalone copy)
+
+The vRLI `/api/v2/*` surface is **identical** on 8.x and 9.x — the v2 API shipped in
+vRLI 8.0 and is stable through 8.18.x (the 8.12 vRealize→Aria rebrand is name-only):
+same `POST /api/v2/sessions` → `Authorization: Bearer <sessionId>` auth, same
+unauthenticated `GET /api/v2/version` fingerprint, same
+`/api/v2/events/{constraints}` query, same `{401, 440}` session-expiry recovery. So
+`Vrli8Connector` **subclasses**
+`meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector` and inherits the
+session mint, the token cache, the `invalidate_session` / `invalidate_credentials`
+(#2067) recovery, the profile-derived fingerprint, and the `vrli.event.query` typed
+handler — overriding **only** the registration triple and the version band. Unlike
+vROps 8.x, the `Bearer` scheme is unchanged across the boundary, so there is **no
+auth override at all** (the subclass body is five class attributes).
+
+The dispatcher rebinds the inherited `event_query` handler against the
+resolver-chosen instance (`is_unbound_method` over `Vrli8Connector.__mro__` — the
+bind9-E2E subclass pattern), so it runs on a `Vrli8Connector` instance with the 8.x
+band.
+
+## Dual-impl resolution (`vrli` = 5th two-impl case)
+
+| Impl | Class | Band | Wildcard |
+|---|---|---|---|
+| modern `vrli-rest` | `VcfLogsConnector` | `>=9.0,<10.0` | **owns** `("vrli","","")` |
+| legacy `vrli-vrli8` | `Vrli8Connector` | `>=8.0,<9.0` | none |
+
+The bands are **disjoint**. The **modern** `vcf_logs` owns the `("vrli","","")`
+wildcard, so `vrli-vrli8` registers **only** its versioned triple (the *fleet
+inversion*): an *unfingerprinted* `vrli` target resolves to modern. **In practice a
+non-issue**: `GET /api/v2/version` returns a real five-part `8.x` version string, so
+a probed vRLI 8.x target fingerprints straight into `>=8.0,<9.0` and resolves here.
+Matrix pinned in
+[`test_connectors_vrli8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vrli8_dual_impl_resolution.py).
+
+## Scope: the modern typed read op, reused
+
+The 8.x impl reuses the modern sibling's one typed op verbatim
+(`source_kind="typed"`, fresh-boot with zero catalog ingest) — the registrar
+(`register_vrli8_typed_operations`) upserts it under the `(vrli, 8.0, vrli-vrli8)`
+triple:
+
+| Group | Op | Endpoint |
+|---|---|---|
+| `vrli-events` | `vrli.event.query` | `GET /api/v2/events/{constraints}` |
+
+The op_id and group key are shared with the modern impl on purpose (distinct
+`endpoint_descriptor` / `OperationGroup` rows, scoped by the full connector triple).
+The modern connector types only the event query; the rest of its browse surface
+(hosts / content-packs / alerts / fields) is **generic-ingested** from an
+internally-authored `vcf-logs-9.0/openapi.yaml`, not a VMware download. 8.x has no
+committable spec to ingest, so a wider typed inventory surface is a documented
+follow-up on #3068, not shipped speculatively.
+
+## Spec reconcile lane
+
+[`test_connectors_vrli8_spec_reconcile.py`](../../backend/tests/test_connectors_vrli8_spec_reconcile.py)
+is an **op-set drift guard**, not a path pin: the subclass introduces no new paths
+(the vRLI `/api/v2/*` surface lives on the modern `vcf_logs` module and is already
+guarded by the modern lane). The lane pins that the 8.x impl reuses exactly the
+modern typed op-set (`{vrli.event.query}`) and adds no `_*_PATH` constants of its
+own. Evidenced exclusion (vRLI 8.x publishes no committable spec — a per-appliance
+runtime Swagger UI at `/rest-api` only): the `vrli-vrli8` entry of
+[`spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Key types
+
+- **`Vrli8Connector`** (`connector.py`) — `VcfLogsConnector` subclass.
+  `product="vrli"`, `version="8.0"`, `impl_id="vrli-vrli8"`,
+  `supported_version_range=">=8.0,<9.0"`, `priority=1`. No method overrides.
+  `connector_id` `"vrli-vrli8-8.0"` parses back to `("vrli", "8.0", "vrli-vrli8")`.
+- Target shape, credential loader, and the `VRLI_EXECUTION_PROFILE`-derived session /
+  fingerprint / `{401,440}` expiry set are **inherited** from the modern sibling
+  (`meho_backplane.connectors.vcf_logs`), keyed under `product_label="vrli"`.
+- Canonical constants (`__init__.py`): `VRLI8_PRODUCT`, `VRLI8_VERSION`,
+  `VRLI8_IMPL_ID`, `VRLI8_CONNECTOR_ID`.
+
+## Known issues / follow-ups
+
+- **Live dispatch not verified against a real appliance.** No vRLI 8.x lab was
+  dialled; the inherited event query is unit-tested end-to-end (respx). Live
+  verification is the deferred tail.
+- **Typed inventory breadth is a follow-up.** The event query is the 8.x typed
+  surface; typed hosts / content-packs / alerts / fields (the migration-discovery
+  inventory) would be a follow-up if a concrete need lands — the modern sibling
+  serves these via ingested 9.0 catalog, which 8.x cannot use (no committable spec).
+- **Unfingerprinted targets resolve to modern** (wildcard owned by `vrli-rest`); a
+  probed 8.x target fingerprints its real version and resolves here.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/3068>
+- Parent initiative: <https://github.com/evoila/meho/issues/3056>
+- Dual-version policy of record: <https://github.com/evoila/meho/issues/3033>
+- Tests: [`test_connectors_vrli8_auth.py`](../../backend/tests/test_connectors_vrli8_auth.py)
+  (inherited Bearer auth + fingerprint),
+  [`test_connectors_vrli8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vrli8_dual_impl_resolution.py)
+  (resolution matrix),
+  [`test_connectors_vrli8_spec_reconcile.py`](../../backend/tests/test_connectors_vrli8_spec_reconcile.py)
+  (op-set drift guard).
+- Modern sibling: [`connectors-vcf-logs.md`](connectors-vcf-logs.md).
+- Sibling legacy connector (same session-arc): [`connectors-vrops8.md`](connectors-vrops8.md).

--- a/docs/codebase/connectors-vrops8.md
+++ b/docs/codebase/connectors-vrops8.md
@@ -1,0 +1,161 @@
+# Connector: vrops8 (vROps 8.x, legacy dual-impl of `vrops`)
+
+## Overview
+
+The `vrops-vrops8` connector makes **vRealize Operations 8.x / VMware Aria
+Operations 8.x** (the monitoring tier of a VCF-5.x-era estate) dispatchable under
+the `(product="vrops", version="8.0", impl_id="vrops-vrops8")` registry triple. It
+is the **legacy dual-impl** of `product="vrops"` filed under the legacy
+migration-source connector-coverage initiative
+([#3056](https://github.com/evoila/meho/issues/3056), task #3067): vROps 8.x is a
+migration **source** monitoring estate evoila brings customers *off*, so MEHO must
+read and inventory it during discovery + onboarding.
+
+Source: `backend/src/meho_backplane/connectors/vrops8/`. The modern impl is
+[`connectors-vcf-operations.md`](connectors-vcf-operations.md) (`vrops-rest`,
+`>=9.0,<10.0`). This is the **4th real two-impl case** (after `fleet`, `vcfa`,
+`sddc`).
+
+## Why a thin subclass (not a standalone copy)
+
+Unlike the sibling legacy connectors `vcd` (#3057, net-new), `vcfa-vra8` (#3058,
+divergent two-step CSP→IaaS auth), and `sddc-vcf5` (#3059, divergent read scope),
+the vROps 8.x Suite API is **identical** to 9.x — same
+`POST /suite-api/api/auth/token/acquire` session mint, same
+`GET /suite-api/api/versions/current` fingerprint, same
+`/suite-api/api/{alerts, resources/query, resources/stats/latest}` reads (all stable
+since vROps 6.6/7.0; the 8.10 vRealize→Aria rebrand is name-only, `major` stays 8).
+So `Vrops8Connector` **subclasses**
+`meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector` and
+inherits the acquire flow, the `auth_model` gate, the per-target session cache, the
+`invalidate_session` / `invalidate_credentials` (#2067) recovery, the fingerprint,
+and all four typed read handlers — overriding only the registration triple, the
+version band, and the token **scheme** (below). Copying ~600 identical lines would
+be cargo-cult, not discipline (postulates 2 + 3).
+
+The dispatcher rebinds an inherited handler against the resolver-chosen instance
+(`is_unbound_method` walks `Vrops8Connector.__mro__` and matches the base-class
+function object — the documented bind9-E2E subclass pattern), so the inherited
+handlers run on a `Vrops8Connector` instance with the 8.x scheme and band.
+
+## The one behavioural delta — the token scheme
+
+The 9.x connector presents `Authorization: OpsToken <token>` — the 9.x-native scheme
+(#2395). An 8.x appliance predates the `OpsToken` alias and accepts only the
+token-era `vRealizeOpsToken` scheme (stable across the whole 8.x line, confirmed
+against the vendor 8.18 API programming guide). `Vrops8Connector.auth_headers`
+therefore re-labels the scheme on the header the base returns:
+
+```python
+headers = dict(await super().auth_headers(target, operator))
+_scheme, _sep, token = headers.get("Authorization", "").partition(" ")
+headers["Authorization"] = f"vRealizeOpsToken {token}"
+return headers
+```
+
+The security-sensitive `auth_model` gate and the token mint stay **single-sourced**
+on the base — the override only alters the presented scheme, so a future change to
+the base auth path is inherited rather than silently forked. (The modern connector
+was left untouched; promoting its module-level `_OPS_TOKEN_SCHEME` to a class
+attribute would have tripped the 600-line file-size gate on an already-oversized
+file — the subclass-local override is the more surgical seam.)
+
+## Dual-impl resolution (`vrops` = 4th two-impl case)
+
+| Impl | Class | Band | Wildcard |
+|---|---|---|---|
+| modern `vrops-rest` | `VcfOperationsConnector` | `>=9.0,<10.0` | **owns** `("vrops","","")` |
+| legacy `vrops-vrops8` | `Vrops8Connector` | `>=8.0,<9.0` | none |
+
+The bands are **disjoint** (no specificity tie). The **modern** `vcf_operations` owns
+the `("vrops","","")` wildcard (it shipped first), so `vrops-vrops8` registers **only**
+its versioned triple — the *inversion* of the `fleet` case. Consequence: an
+*unfingerprinted* `vrops` target resolves to modern. **In practice this is a
+non-issue**: `GET /suite-api/api/versions/current` returns a *real* product
+`releaseName` (a dotted release, e.g. `8.18.0.24178391`), so a probed vROps 8.x
+target normally fingerprints straight into `>=8.0,<9.0` and resolves here without an
+operator-asserted version — unlike `vcfa-vra8`, whose fingerprint yields only an
+API-date label. **Caveat (residual risk):** the inherited fingerprint stores
+`releaseName` raw, so resolution depends on it being PEP-440-parseable; a
+non-parseable value falls back *open* to the modern-owned wildcard (which presents
+the wrong 9.x `OpsToken` scheme). The observed `releaseName` is always dotted-numeric
+(and the modern connector relies on the same field), so this is not expected — but it
+is unverified live; the operator escape hatch is to pin `version` / `preferred_impl_id`.
+Both the happy matrix and the open-fallback limitation are pinned in
+[`test_connectors_vrops8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vrops8_dual_impl_resolution.py).
+
+## Scope: the modern audited typed read set, reused
+
+The 8.x impl reuses the modern sibling's audited **4-op typed read set** verbatim
+(`source_kind="typed"`, working on a fresh boot with zero catalog ingest) — the
+registrar (`register_vrops8_typed_operations`) upserts the same op_ids under the
+`(vrops, 8.0, vrops-vrops8)` triple:
+
+| Group | Op | Endpoint |
+|---|---|---|
+| `vrops-liveness` | `vrops.liveness` | `GET /suite-api/api/versions/current` |
+| `vrops-alert-triage` | `vrops.alert.list` | `GET /suite-api/api/alerts` |
+| `vrops-resource-query` | `vrops.resource.query` | `POST /suite-api/api/resources/query` |
+| `vrops-resource-stats` | `vrops.resource.stats` | `GET /suite-api/api/resources/stats/latest` |
+
+Op ids are **shared** with the modern impl on purpose (the same logical operation
+dispatched to whichever impl the target resolves to); `endpoint_descriptor` rows are
+keyed by `(product, version, impl_id, op_id)`, so the 8.x rows are distinct. Group
+keys are reused too — `OperationGroup` rows are scoped by
+`(product, version, impl_id, group_key)`, so the 8.x groups are distinct rows. The
+read payloads pass through the JSONFlux reducer largely unparsed, so 8.x
+response-shape drift is absorbed rather than parsed.
+
+The broader ingested browse catalog the modern connector also exposes (via the 9.x
+OA3) is **not** available on 8.x (no committable 8.x spec to ingest) — a documented
+follow-up, not shipped speculatively.
+
+## Spec reconcile lane
+
+[`test_connectors_vrops8_spec_reconcile.py`](../../backend/tests/test_connectors_vrops8_spec_reconcile.py)
+is an **op-set drift guard**, not a path pin: the subclass introduces no new paths
+(they are the modern connector's constants, already armed against the pinned
+`vcf-operations-9.0` OpenAPI 3.0 served set by the modern lane — path existence is
+stable across 8.x↔9.x). The lane pins that the 8.x impl reuses exactly the modern
+typed op-set and adds no `_*_PATH` constants of its own, so a future 9.x-only op
+cannot silently inherit into the 8.x surface. Evidenced exclusion (8.x publishes only
+a per-instance Swagger 2.0 doc, moot for path coverage): the `vrops-vrops8` entry of
+[`spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
+## Key types
+
+- **`Vrops8Connector`** (`connector.py`) — `VcfOperationsConnector` subclass.
+  `product="vrops"`, `version="8.0"`, `impl_id="vrops-vrops8"`,
+  `supported_version_range=">=8.0,<9.0"`, `priority=1`. Overrides `auth_headers`
+  (scheme swap) and nothing else. `connector_id` `"vrops-vrops8-8.0"` parses back to
+  `("vrops", "8.0", "vrops-vrops8")`.
+- Target shape + credential loader are **inherited** from the modern sibling
+  (`meho_backplane.connectors.vcf_operations.session`), keyed under
+  `product_label="vrops"` — the credential contract is product-level.
+- Canonical constants (`__init__.py`): `VROPS8_PRODUCT`, `VROPS8_VERSION`,
+  `VROPS8_IMPL_ID`, `VROPS8_CONNECTOR_ID`.
+
+## Known issues / follow-ups
+
+- **Live dispatch not verified against a real appliance.** No vROps 8.x lab was
+  dialled; the scheme swap + inherited handlers are unit-tested end-to-end (respx).
+  Live verification (incl. confirming the `resources/stats/latest` payload shape on a
+  live 8.x target) is the deferred tail.
+- **Ingested browse breadth is 9.x-only.** The typed 4-op core is the 8.x surface; a
+  wider inventory would need typed ops or an 8.x spec to ingest (none exists).
+- **Unfingerprinted targets resolve to modern** (wildcard owned by `vrops-rest`); a
+  probed 8.x target fingerprints its real version and resolves here.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/3067>
+- Parent initiative: <https://github.com/evoila/meho/issues/3056>
+- Dual-version policy of record: <https://github.com/evoila/meho/issues/3033>
+- Tests: [`test_connectors_vrops8_auth.py`](../../backend/tests/test_connectors_vrops8_auth.py)
+  (scheme swap + inherited auth/fingerprint),
+  [`test_connectors_vrops8_dual_impl_resolution.py`](../../backend/tests/test_connectors_vrops8_dual_impl_resolution.py)
+  (resolution matrix),
+  [`test_connectors_vrops8_spec_reconcile.py`](../../backend/tests/test_connectors_vrops8_spec_reconcile.py)
+  (op-set drift guard).
+- Modern sibling: [`connectors-vcf-operations.md`](connectors-vcf-operations.md).
+- Sibling legacy connector (same session-arc): [`connectors-vrli8.md`](connectors-vrli8.md).

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -476,6 +476,64 @@ committable spec exists for the modern generation, but not for 5.x.**
   `sddc-manager-openapi.json` served set, or Broadcom publishing a 5.x OA3
   artifact (or MEHO gaining a Swagger-2.0→OA3 ingest path, #2090).
 
+### vrops-vrops8 / vrli-vrli8 — subclass reuse, op-set drift guard (no new paths) (#3067/#3068)
+
+The `vrops-vrops8` (vROps 8.x) and `vrli-vrli8` (vRLI 8.x) connectors are
+**legacy dual-impls** of `product="vrops"` / `product="vrli"` (initiative
+[#3056](https://github.com/evoila/meho/issues/3056), tasks #3067/#3068) —
+but unlike the standalone legacy connectors above (`vcd`, `vcfa-vra8`,
+`sddc-vcf5`), they are **thin subclasses** of their modern siblings
+(`vrops-rest` / `vrli-rest`). The 8.x REST surface is identical to 9.x (the
+vROps Suite API `/suite-api/api/*` is stable since 6.6/7.0; the vRLI
+`/api/v2/*` surface shipped in vRLI 8.0), so the subclass **inherits every
+hand-coded path from the modern connector and adds none of its own.**
+
+The consequence for this standard: **there is nothing new to pin.** The
+paths these impls dispatch are the modern connectors' constants, already
+covered by the modern lanes —
+`test_connectors_vcf_operations_spec_reconcile.py` **arms** them against the
+pinned `vcf-operations-9.0` OpenAPI 3.0 served set (`vmware/vcf-api-specs`),
+and `test_connectors_vcf_logs_spec_reconcile.py` covers the vRLI surface.
+Path existence is version-stable across the 8.x↔9.x boundary, so the modern
+9.x served-set assertion transitively arms the 8.x impls' paths.
+
+- **The subclass lane is an op-set drift guard, not a path pin.**
+  `test_connectors_vrops8_spec_reconcile.py` /
+  `test_connectors_vrli8_spec_reconcile.py` (parse-only, always-on) assert
+  (a) the 8.x impl reuses **exactly** the modern typed op-set verbatim —
+  vROps `{liveness, alert.list, resource.query, resource.stats}`, vRLI
+  `{event.query}` — so a future 9.x-only typed op cannot silently inherit
+  into the 8.x surface (the registrar reuses the modern tuple) without a
+  conscious 8.x-applicability review; and (b) the subclass introduces **no**
+  `_*_PATH` constants of its own, so nothing un-reconciled can slip in
+  behind the "no new paths" claim.
+- **Evidenced exclusion (moot for path coverage).** Neither product
+  publishes a committable 8.x spec — vROps 8.x serves only a **per-instance
+  Swagger 2.0** document (`/suite-api/doc/v2/api-docs`); vRLI 8.x publishes
+  no downloadable spec at all (a per-appliance runtime Swagger UI at
+  `/rest-api`, VMware's own archived client hand-coded). MEHO's ingest is
+  OA3-only (#2090), so neither 8.x surface is operator-ingestable — hence
+  the reuse of the modern **typed** cores. But because the shared paths are
+  already armed against the modern 9.x served sets, the absence of an
+  8.x-specific spec costs no path coverage here.
+- **Residual risk, named:** no live 8.x appliance was dialled — the 8.x
+  scheme delta (vROps presents the pre-9.x `vRealizeOpsToken`) and the
+  inherited handlers are unit-tested end-to-end (respx), and live
+  verification is the deferred tail, the same posture `vcd` / `vcfa-vra8` /
+  `sddc-vcf5` shipped with. One vROps-specific edge (the #3067 review's top
+  finding): the inherited fingerprint stores `versions/current`'s
+  `releaseName` raw, so `vrops-vrops8` resolution depends on it being PEP
+  440-parseable — a non-parseable value falls back *open* to the modern
+  wildcard (wrong `OpsToken` scheme). Observed `releaseName` is always
+  dotted-numeric; the open-fallback limitation + the operator escape hatch
+  (pin `version` / `preferred_impl_id`) are pinned in
+  `test_connectors_vrops8_dual_impl_resolution.py`, and confirming the live
+  format is folded into the deferred live-verify.
+- **Activation:** if the two impls ever *diverge* from their siblings
+  (an 8.x-only path or a forked op-set), that new hand-coded surface must
+  ship its own served-set (or manifest-pin) lane at that point — the op-set
+  drift guard is what surfaces the divergence.
+
 ## Red lane = finding (the protocol)
 
 A red lane on first run against the real shelf is **the guard working**,


### PR DESCRIPTION
## What

The **legacy dual-impls for vRealize Operations 8.x** (`vrops-vrops8`) and
**vRealize Log Insight 8.x** (`vrli-vrli8`) — the **4th and 5th real two-impl cases**
for a product (after `fleet`, `vcfa`, `sddc`). Both are the monitoring + logging
tiers of a VCF-5.x-era **source** estate MEHO must read/inventory during migration
discovery, and both are legacy predecessors of shipped modern 9.x connectors
(`vrops-rest` / `vrli-rest`).

Completes the candidate tail of the legacy migration-source connector-coverage
initiative (#3056). **Closes #3067. Closes #3068.**

## Shape — thin subclasses, not copies

Unlike the sibling legacy connectors #3057 (vCD — net-new), #3058 (vRA 8 — divergent
two-step auth), #3059 (SDDC 5.x — divergent read scope), the 8.x REST surfaces are
**identical** to 9.x (the vROps Suite API `/suite-api/api/*` is stable since 6.6/7.0;
the vRLI `/api/v2/*` surface shipped in vRLI 8.0). So each is a thin **subclass** of
its modern sibling — inheriting the auth flow, session cache,
`invalidate_session`/`invalidate_credentials` (#2067) recovery, fingerprint, and
typed read handlers — rather than a ~600-line copy (postulates 2 + 3). The modern
connectors are **untouched**.

- **`vrops-vrops8`** @ 8.0, band `>=8.0,<9.0`. Overrides **only** the token *scheme*:
  8.x appliances predate the `OpsToken` alias (#2395) and accept only the pre-9.x
  `vRealizeOpsToken`. The override swaps the scheme on `super().auth_headers()`'s
  result, so the `auth_model` guard + token mint stay single-sourced on the base.
  Reuses the modern audited 4-op typed set (liveness / alert.list / resource.query /
  resource.stats).
- **`vrli-vrli8`** @ 8.0, band `>=8.0,<9.0`. **No auth override** (Bearer identical to
  9.x) — five class attributes. Reuses the modern `vrli.event.query` typed op.

Both register **only** the versioned triple (the modern impl owns the
`("<product>","","")` wildcard — the *fleet inversion*), so an unfingerprinted target
resolves to modern and a fingerprinted 8.x target resolves to legacy by disjoint band.
The dispatcher rebinds the inherited typed handlers against the resolver-chosen
instance (`is_unbound_method` over the MRO — the bind9-E2E subclass pattern), so they
run with the 8.x scheme/band. Op_ids/group_keys are shared on purpose;
`endpoint_descriptor` / `OperationGroup` rows are keyed by the full connector triple,
so the 8.x rows are distinct.

## Reconcile — op-set drift guard (no new paths)

The subclasses add no hand-coded paths (the modern lanes already served-set-reconcile
them; the Suite API + v2 API are path-stable across 8.x↔9.x), so each lane
(parse-only, always-on) pins that its impl reuses **exactly** the modern typed op-set
and adds no `_*_PATH` constants of its own — a future 9.x-only op can't silently
inherit into the 8.x surface. Neither product publishes a committable 8.x OA3 (vROps:
per-instance Swagger 2.0; vRLI: per-appliance runtime Swagger UI only) — evidenced
exclusion. Entries added to `spec-reconcile-guards-standard.md`.

## Verification

- 37 unit tests (auth / resolution / reconcile per connector); ruff + mypy clean.
- Broad connector+operations sweep green: **5300 passed**, only the 2 pre-existing
  real-DNS/ICMP sandbox failures.
- registry / resolver / eager-import-boots-clean + modern-sibling regression green.
  **No CLI OpenAPI snapshot regen** (products `vrops`/`vrli` reused).
- **Adversarially reviewed** — both SOUND, no BLOCKER/SHOULD-FIX; each reviewer
  empirically confirmed the dispatch rebind onto the 8.x instance (one drove both
  registrars against a real DB, confirming no `endpoint_descriptor`/`OperationGroup`
  collision). Applied the one doc-level finding (below) + a direct `is_unbound_method`
  dispatch-rebind test guard on both.

## Deferred tails

- **Live-appliance verification** (no 8.x lab dialled; unit-tested end-to-end via respx).
- **vROps `releaseName` parseability (named residual risk).** The inherited fingerprint
  stores `versions/current`'s `releaseName` raw, so `vrops-vrops8` resolution depends on
  it being PEP-440-parseable; a non-parseable value falls back *open* to the modern
  wildcard (wrong `OpsToken` scheme). Observed `releaseName` is always dotted-numeric
  (and the modern connector relies on the same field), so this is not expected — the
  open-fallback + the operator escape hatch (pin `version`/`preferred_impl_id`) are
  pinned in a test, and confirming the live format is folded into live-verify.
- **vRLI typed inventory breadth** (hosts / content-packs / alerts / fields) for richer
  migration discovery — a follow-up if a concrete need lands (9.x serves these via
  ingested catalog; 8.x has no committable spec to ingest).

## Docs

- `docs/codebase/connectors-vrops8.md`, `docs/codebase/connectors-vrli8.md`.
- `docs/decisions/spec-reconcile-guards-standard.md` (subclass op-set-drift entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
