### PR TITLE
feat(connectors): VCF Installer 9.1 governed bring-up composite (#3065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — VCF Installer 9.1 governed bring-up write (Initiative #2907, task #3065)
+
+- `installer.composite.sddc.bringup` — the governed VCF management-domain bring-up
+  write, a `dangerous` + `requires_approval` composite. Orchestrates as one
+  approved unit: `POST /v1/sddcs/validations` (non-mutating dry-run, polled to
+  terminal) *gates* `POST /v1/sddcs` (the deploy). Validation failures abort
+  **before** any mutation with the failed checks summarised; the deploy runs for
+  hours so the composite returns the `SddcTask` id the moment it is accepted and
+  the caller polls `installer.sddc.status` to terminal. The park-time approval
+  preview and the sub-op policy params echo SDDC identity + network blast-radius
+  only — **never a password** (redaction by construction, covered by the
+  whole-suite secret-leak guard). Direct-session dispatch (Goal #2247) — every
+  sub-call goes through the connector's own session (new
+  `_post_json_with_session_retry` write-path twin, safe single 401-retry), never
+  an ingested primitive. The composite's write/validate paths join the
+  spec-reconcile lane against the pinned `vcf-installer-9.1` shelf spec. Docs:
+  [`connectors-vcf-installer.md`](docs/codebase/connectors-vcf-installer.md).
+
 ### Added — VCF Installer 9.1 bring-up connector skeleton (Initiative #2907, task #3065)
 
 - New `vcf-installer` connector (`installer-rest-9.1`) — the governed dispatch

--- a/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
@@ -13,13 +13,18 @@ before any dispatch can occur.
 The bring-up status poll (``installer.sddc.status``) ships as a typed op
 (``source_kind="typed"``) via :mod:`.typed_ops` / :mod:`.typed_reads`,
 dispatchable on a fresh boot with zero catalog ingest. The governed bring-up
-write (validate → deploy → poll) arrives as a ``dangerous`` + ``requires_approval``
-composite in a following increment.
+write (``installer.composite.sddc.bringup`` — validate → deploy) ships as a
+``dangerous`` + ``requires_approval`` composite via :mod:`.bringup`; importing
+that module also registers its park-time approval preview builder.
 """
 
 from typing import Final
 
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_installer.bringup import (
+    INSTALLER_BRINGUP_OP_ID,
+    register_installer_composite_operations,
+)
 from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
 from meho_backplane.connectors.vcf_installer.profile import INSTALLER_EXECUTION_PROFILE
 from meho_backplane.connectors.vcf_installer.session import (
@@ -61,10 +66,14 @@ register_connector_v2(
     cls=InstallerConnector,
 )
 
-# Queue the typed-op upsert onto the lifespan-driven registrar list.
+# Queue the typed-op + composite-op upserts onto the lifespan-driven registrar
+# list. Importing ``.bringup`` above also registered the composite's park-time
+# approval preview builder as an import side-effect (#1608).
 register_typed_op_registrar(register_installer_typed_operations)
+register_typed_op_registrar(register_installer_composite_operations)
 
 __all__ = [
+    "INSTALLER_BRINGUP_OP_ID",
     "INSTALLER_CONNECTOR_ID",
     "INSTALLER_EXECUTION_PROFILE",
     "INSTALLER_IMPL_ID",
@@ -77,5 +86,6 @@ __all__ = [
     "InstallerTypedOp",
     "SessionCredentials",
     "load_credentials_from_vault",
+    "register_installer_composite_operations",
     "register_installer_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
@@ -355,8 +355,10 @@ async def installer_sddc_bringup_composite(
 
     # 2. DEPLOY — the single mutation, through the sub-op policy gate. The
     #    top-level composite is the approval gate (requires_approval=True on the
-    #    op); the sub-op passes requires_approval=False so an approved+resumed
-    #    dispatch isn't double-gated.
+    #    op); the sub-op passes requires_approval=False so the approved+resumed
+    #    dispatch AUTO_EXECUTEs for the non-agent operator/automation caller. (An
+    #    agent principal still hits the dangerous safety-ceiling here — see the
+    #    module docstring's "Approval gate"; agent bring-up is unsupported today.)
     gate = await enforce_subop_policy(
         operator=operator,
         connector_id=_connector_id(connector),

--- a/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed VCF management-domain bring-up composite for :class:`InstallerConnector`.
+
+``installer.composite.sddc.bringup`` is the highest-blast-radius write in the
+product — ``safety_level="dangerous"`` + ``requires_approval=True``. It
+orchestrates the two-step Installer bring-up as one governed, approved unit:
+
+1. **validate** — ``POST /v1/sddcs/validations`` with the ``SddcSpec`` body, then
+   poll ``GET /v1/sddcs/validations/{id}`` until the ``Validation``'s
+   ``executionStatus`` is terminal. Validation is a **non-mutating dry-run**, so
+   it is *ungated*. The deploy is gated on the ``resultStatus``: ``SUCCEEDED`` and
+   ``WARNING`` proceed (warnings surfaced in the return), anything else aborts
+   **before any mutation**.
+2. **deploy** — ``POST /v1/sddcs`` with the same ``SddcSpec`` body, through
+   :func:`~meho_backplane.operations.composite.enforce_subop_policy`. This is the
+   single state mutation and the single sub-op gate. Returns an ``SddcTask``.
+3. **hand off** — a real bring-up runs for *hours* on the appliance, so the
+   composite returns the ``SddcTask`` id the moment the deploy is accepted
+   (``status="deploying"``). The caller (an operator or the deploy-automation
+   add-on's durable workflow) polls ``installer.sddc.status`` to a terminal
+   ``COMPLETED_WITH_SUCCESS`` / ``ROLLBACK_SUCCESS`` / ``COMPLETED_WITH_FAILURE``.
+   Blocking a single dispatch call to a multi-hour terminal state would be wrong.
+
+**Approval gate.** The top-level composite carries ``requires_approval=True`` —
+the dispatcher parks it for approval *before* the handler runs, showing the
+approver the secret-hygienic preview. The deploy sub-op passes
+``requires_approval=False`` to :func:`enforce_subop_policy` so that for the
+intended **non-agent operator / automation service-account** caller (the add-on
+runs no LLM in its execute path) the top-level approval is the single gate and
+the resumed dispatch AUTO_EXECUTEs the deploy. Caveat, not a claim of
+double-gate-immunity for *every* principal: a run-bound **agent** calling this
+op directly is subject to the backplane's unconditional ``dangerous``
+safety-ceiling on the sub-op too, so it would re-park a second approval — a
+fleet-wide property of every ``dangerous`` composite (the vmware-rest #2301
+sub-op pattern), not specific to this op; agent callers of the bring-up are not
+a supported path today.
+
+**Direct-session dispatch (Goal #2247).** Every sub-call goes through the
+injected connector's own session helpers
+(:meth:`~InstallerConnector._post_json_with_session_retry` /
+:meth:`~InstallerConnector._get_json_with_session_retry`), never
+``dispatch_child`` into an ingested ``METHOD:/path`` primitive — so correctness
+never depends on mutable per-deploy catalog state.
+
+**Secret hygiene (#1503).** :func:`_blast_radius` reads only a whitelist of SDDC
+identity + network keys and *never* reads any ``*Password`` / ``credentials``
+field of the ``SddcSpec``. The park-time approval **preview** and the **sub-op
+policy params** — the two reviewer-facing surfaces — are built from it, redaction
+by construction. This does **not** cover ``ApprovalRequest.params``: when the
+top-level op parks, the dispatcher persists the raw dispatch ``params`` (i.e. the
+full ``SddcSpec`` including plaintext passwords) verbatim on that row for the
+approval TTL (#1503's store-verbatim). That column is never surfaced by any API /
+audit / broadcast read path (those carry only ``params_hash`` / the scrubbed
+preview), so exposure is at-rest-in-the-governance-table, gated by DB/row access
+control — the same posture as every ``requires_approval`` op that takes inline
+secrets (e.g. the GOSC composites). It is *not* redacted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.operations._preview import PreviewContext, register_preview_builder
+from meho_backplane.operations.composite import enforce_subop_policy
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "BRINGUP_DECLARED_OP_IDS",
+    "INSTALLER_BRINGUP_OP_ID",
+    "installer_sddc_bringup_composite",
+    "register_installer_composite_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The governed bring-up composite op_id (``<product>.composite.<noun>.<verb>``).
+INSTALLER_BRINGUP_OP_ID = "installer.composite.sddc.bringup"
+
+#: Governance key for the deploy sub-op fed to :func:`enforce_subop_policy` — the
+#: logical mutation identifier, not a wire path.
+_DEPLOY_SUBOP_OP_ID = "installer.sddc.deploy"
+
+#: Same operation group as the ``installer.sddc.status`` poll, so discovery
+#: co-locates "run a bring-up" with "track a bring-up".
+_GROUP_BRINGUP = "installer-bringup"
+
+# --- Hand-coded wire paths — the spec-reconcile lane's introspection source. ---
+#: ``POST`` — submit an ``SddcSpec`` for a non-mutating validation dry-run.
+_VALIDATE_PATH = "/v1/sddcs/validations"
+#: ``POST`` — start the bring-up (the single state mutation).
+_DEPLOY_PATH = "/v1/sddcs"
+#: ``GET`` — poll one validation's ``executionStatus`` to a terminal state.
+_VALIDATION_STATUS_PATH = "/v1/sddcs/validations/{id}"
+
+#: The exact ``METHOD:/path`` set this composite hand-codes. The reconcile lane
+#: (:mod:`tests.test_connectors_vcf_installer_spec_reconcile`) asserts each is
+#: served by the pinned 9.1 OpenAPI, and pins this set so it can't go vacuous.
+BRINGUP_DECLARED_OP_IDS: frozenset[str] = frozenset(
+    {
+        f"POST:{_VALIDATE_PATH}",
+        f"POST:{_DEPLOY_PATH}",
+        f"GET:{_VALIDATION_STATUS_PATH}",
+    }
+)
+
+# --- Validation poll bounds (module globals so tests monkeypatch to 0). ---
+#: Wall-clock ceiling for the validation poll. Validation is minutes, not hours.
+_VALIDATION_TIMEOUT_SECONDS = 1200.0
+#: Delay between validation-status polls.
+_VALIDATION_POLL_INTERVAL = 10.0
+
+# --- Validation status vocabulary (from the vendored 9.1 ``Validation`` schema). ---
+#: ``executionStatus`` values that mean "still running; keep polling".
+_VALIDATION_NONTERMINAL: frozenset[str] = frozenset({"IN_PROGRESS", "CANCELLATION_IN_PROGRESS"})
+#: ``resultStatus`` values that permit the deploy (``WARNING`` is non-fatal in
+#: VCF; its checks are surfaced in the return so the approver sees them).
+_VALIDATION_PASS_RESULTS: frozenset[str] = frozenset({"SUCCEEDED", "WARNING"})
+
+#: Cap on echoed validation-check summaries, so a large check list can't bloat
+#: the return envelope.
+_MAX_CHECK_SUMMARIES = 40
+
+
+@dataclass(frozen=True)
+class _ValidationVerdict:
+    """Outcome of classifying a terminal (or timed-out) ``Validation``."""
+
+    #: ``"pass"`` | ``"validation_failed"`` | ``"validation_timeout"``.
+    status: str
+    #: Non-fatal ``WARNING`` check summaries surfaced on a passing verdict.
+    warnings: list[dict[str, Any]]
+
+
+def _execution_status(validation: dict[str, Any]) -> str:
+    """Upper-cased ``executionStatus`` of a ``Validation`` (``""`` if absent)."""
+    return str(validation.get("executionStatus") or "").upper()
+
+
+def _result_status(validation: dict[str, Any]) -> str:
+    """Upper-cased ``resultStatus`` of a ``Validation`` (``""`` if absent)."""
+    return str(validation.get("resultStatus") or "").upper()
+
+
+def _collect_checks(validation: dict[str, Any], *, want: str) -> list[dict[str, Any]]:
+    """Flatten ``validationChecks`` (recursing ``nestedValidationChecks``) to the
+    leaf checks whose ``resultStatus`` equals *want*, as secret-free summaries.
+
+    Echoes only ``description`` / ``severity`` / ``resultStatus`` — never
+    ``errorResponse`` (which can be large and is not needed to triage), and never
+    any spec value. Capped at :data:`_MAX_CHECK_SUMMARIES`.
+    """
+    out: list[dict[str, Any]] = []
+
+    def _walk(checks: Any) -> None:
+        if not isinstance(checks, list):
+            return
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            if (
+                len(out) < _MAX_CHECK_SUMMARIES
+                and str(check.get("resultStatus") or "").upper() == want
+            ):
+                out.append(
+                    {
+                        "description": check.get("description"),
+                        "severity": check.get("severity"),
+                        "resultStatus": check.get("resultStatus"),
+                    }
+                )
+            _walk(check.get("nestedValidationChecks"))
+
+    _walk(validation.get("validationChecks"))
+    return out
+
+
+def _classify_validation(validation: dict[str, Any]) -> _ValidationVerdict:
+    """Map a terminal (or poll-exhausted) ``Validation`` to a deploy verdict."""
+    if _execution_status(validation) in _VALIDATION_NONTERMINAL:
+        # The poll loop returns a still-running validation only when it ran out
+        # of wall-clock budget.
+        return _ValidationVerdict(status="validation_timeout", warnings=[])
+    if (
+        _execution_status(validation) == "COMPLETED"
+        and _result_status(validation) in _VALIDATION_PASS_RESULTS
+    ):
+        warnings = (
+            _collect_checks(validation, want="WARNING")
+            if _result_status(validation) == "WARNING"
+            else []
+        )
+        return _ValidationVerdict(status="pass", warnings=warnings)
+    return _ValidationVerdict(status="validation_failed", warnings=[])
+
+
+async def _await_validation(
+    connector: InstallerConnector,
+    target: Any,
+    operator: Operator,
+    initial: dict[str, Any],
+) -> dict[str, Any]:
+    """Poll ``GET /v1/sddcs/validations/{id}`` until ``executionStatus`` is
+    terminal or the wall-clock budget is spent; return the last ``Validation``.
+
+    *initial* is the ``Validation`` the ``POST /v1/sddcs/validations`` returned;
+    if it is already terminal (a synchronous ``200``) no GET is issued. A missing
+    ``id`` mid-flight short-circuits (the caller classifies the still-running body
+    as a timeout) rather than looping forever against an unpollable validation.
+    """
+    validation = initial
+    deadline = time.monotonic() + _VALIDATION_TIMEOUT_SECONDS
+    while _execution_status(validation) in _VALIDATION_NONTERMINAL:
+        if time.monotonic() >= deadline:
+            return validation
+        validation_id = validation.get("id")
+        if not isinstance(validation_id, str) or not validation_id:
+            return validation
+        await asyncio.sleep(_VALIDATION_POLL_INTERVAL)
+        validation = await connector._get_json_with_session_retry(
+            target,
+            _VALIDATION_STATUS_PATH.replace("{id}", validation_id),
+            operator=operator,
+        )
+    return validation
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """*value* if it is a dict, else an empty dict (typed narrowing helper)."""
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    """*value* if it is a list, else an empty list (typed narrowing helper)."""
+    return value if isinstance(value, list) else []
+
+
+def _network_summary(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Secret-free per-network summary of ``networkSpecs`` (identity fields only)."""
+    networks = _as_list(spec.get("networkSpecs"))
+    return [
+        {
+            "networkType": net.get("networkType"),
+            "subnet": net.get("subnet"),
+            "gateway": net.get("gateway"),
+            "vlanId": net.get("vlanId"),
+            "mtu": net.get("mtu"),
+        }
+        for net in networks
+        if isinstance(net, dict)
+    ]
+
+
+def _blast_radius(spec: dict[str, Any]) -> dict[str, Any]:
+    """SDDC identity + network blast-radius, with **zero** secret exposure.
+
+    Reads only a fixed whitelist of identity / network keys. It never reads any
+    ``*Password`` (``rootVcenterPassword``, ``rootNsxtManagerPassword``,
+    ``nsxtAdminPassword``, ``sddcManagerSpec.rootPassword``, …) or ``credentials``
+    field of the ``SddcSpec`` — redaction by construction. Shared by the sub-op
+    policy params and the park-time preview so both echo exactly this and nothing
+    else.
+    """
+    vcenter = _as_dict(spec.get("vcenterSpec"))
+    nsxt = _as_dict(spec.get("nsxtSpec"))
+    dns = _as_dict(spec.get("dnsSpec"))
+    sddc_manager = _as_dict(spec.get("sddcManagerSpec"))
+    host_specs = _as_list(spec.get("hostSpecs"))
+    nsxt_managers = _as_list(nsxt.get("nsxtManagers"))
+    return {
+        "sddc_id": spec.get("sddcId"),
+        "vcf_instance_name": spec.get("vcfInstanceName") or spec.get("sddcId"),
+        "workflow_type": spec.get("workflowType"),
+        "vcenter_hostname": vcenter.get("vcenterHostname"),
+        "sso_domain": vcenter.get("ssoDomain"),
+        "nsxt_vip_fqdn": nsxt.get("vipFqdn"),
+        "nsxt_manager_count": len(nsxt_managers),
+        "nsxt_transport_vlan_id": nsxt.get("transportVlanId"),
+        "sddc_manager_hostname": sddc_manager.get("hostname"),
+        "dns_subdomain": dns.get("subdomain"),
+        "dns_nameservers": dns.get("nameservers"),
+        "ntp_servers": spec.get("ntpServers"),
+        "host_count": len(host_specs),
+        "host_names": [
+            h.get("hostname") for h in host_specs if isinstance(h, dict) and h.get("hostname")
+        ],
+        "networks": _network_summary(spec),
+    }
+
+
+def _require_spec(params: dict[str, Any]) -> dict[str, Any]:
+    """Return ``params['spec']`` as a dict or raise a clear :exc:`ValueError`."""
+    spec = params.get("spec")
+    if not isinstance(spec, dict):
+        raise ValueError(
+            f"{INSTALLER_BRINGUP_OP_ID} requires params['spec'] to be the SddcSpec "
+            f"object (a JSON object); got {type(spec).__name__}"
+        )
+    return spec
+
+
+def _connector_id(connector: InstallerConnector) -> str:
+    """The dispatch-canonical ``impl_id-version`` id, e.g. ``installer-rest-9.1``."""
+    return f"{connector.impl_id}-{connector.version}"
+
+
+async def installer_sddc_bringup_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: InstallerConnector,
+) -> dict[str, Any] | OperationResult:
+    """Handler for ``installer.composite.sddc.bringup`` — validate then deploy.
+
+    Returns a structured ``{"status": ...}`` envelope, or an ``OperationResult``
+    verbatim when the deploy sub-op gate parks/denies the write.
+    """
+    spec = _require_spec(params)
+
+    # 1. VALIDATE — non-mutating dry-run, ungated. Poll to terminal, then gate
+    #    the deploy on the result. Never deploy an invalid spec.
+    initial = await connector._post_json_with_session_retry(
+        target, _VALIDATE_PATH, operator=operator, json=spec
+    )
+    validation = await _await_validation(connector, target, operator, initial)
+    verdict = _classify_validation(validation)
+    if verdict.status != "pass":
+        _log.info(
+            "installer_bringup_validation_blocked",
+            target=getattr(target, "name", None),
+            sddc_id=spec.get("sddcId"),
+            status=verdict.status,
+            execution_status=validation.get("executionStatus"),
+            result_status=validation.get("resultStatus"),
+        )
+        return {
+            "status": verdict.status,
+            "validation_id": validation.get("id"),
+            "execution_status": validation.get("executionStatus"),
+            "result_status": validation.get("resultStatus"),
+            "failed_checks": _collect_checks(validation, want="FAILED"),
+        }
+
+    # 2. DEPLOY — the single mutation, through the sub-op policy gate. The
+    #    top-level composite is the approval gate (requires_approval=True on the
+    #    op); the sub-op passes requires_approval=False so an approved+resumed
+    #    dispatch isn't double-gated.
+    gate = await enforce_subop_policy(
+        operator=operator,
+        connector_id=_connector_id(connector),
+        op_id=_DEPLOY_SUBOP_OP_ID,
+        safety_level="dangerous",
+        requires_approval=False,
+        target=target,
+        params=_blast_radius(spec),
+    )
+    if gate is not None:
+        return gate
+
+    task = await connector._post_json_with_session_retry(
+        target, _DEPLOY_PATH, operator=operator, json=spec
+    )
+
+    # 3. HAND OFF — the bring-up runs for hours; return the task id for
+    #    installer.sddc.status polling rather than block on a terminal state.
+    _log.info(
+        "installer_bringup_deploy_accepted",
+        target=getattr(target, "name", None),
+        sddc_id=spec.get("sddcId"),
+        sddc_task_id=task.get("id"),
+        task_status=task.get("status"),
+    )
+    result: dict[str, Any] = {
+        "status": "deploying",
+        "sddc_task": {
+            "id": task.get("id"),
+            "status": task.get("status"),
+            "name": task.get("name"),
+            "vcfInstanceName": task.get("vcfInstanceName"),
+        },
+        "poll_with": "installer.sddc.status",
+        "validation_id": validation.get("id"),
+        # Always echo the validation verdict so a WARNING can never be silent:
+        # `validation_warnings` only carries leaf WARNING checks, which may be
+        # empty even when the overall resultStatus is WARNING (parent-encoded or
+        # non-literal leaf status). The approver/caller sees the verdict either way.
+        "validation_result_status": validation.get("resultStatus"),
+    }
+    if verdict.warnings:
+        result["validation_warnings"] = verdict.warnings
+    return result
+
+
+async def _sddc_bringup_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Park-time approval preview for ``installer.composite.sddc.bringup``.
+
+    Echoes SDDC identity + network blast-radius only (via :func:`_blast_radius`,
+    which never reads a secret field). Returns ``None`` if the spec is missing so
+    the dispatcher falls back to its identifier-only default.
+    """
+    spec = ctx.params.get("spec")
+    if not isinstance(spec, dict):
+        return None
+    br = _blast_radius(spec)
+    return {
+        "operation": "VCF management-domain bring-up",
+        "sddc_id": br["sddc_id"],
+        "vcf_instance_name": br["vcf_instance_name"],
+        "vcenter_hostname": br["vcenter_hostname"],
+        "sddc_manager_hostname": br["sddc_manager_hostname"],
+        "nsxt_vip_fqdn": br["nsxt_vip_fqdn"],
+        "host_count": br["host_count"],
+        "host_names": br["host_names"],
+        "management_networks": br["networks"],
+        "dns_nameservers": br["dns_nameservers"],
+    }
+
+
+# --- Registration metadata --------------------------------------------------
+
+_BRINGUP_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "spec": {
+            "type": "object",
+            "description": (
+                "The full VCF Installer SddcSpec bring-up body (as generated by the "
+                "deploy-automation factory from a resolved EnvSpec). POSTed verbatim "
+                "to /v1/sddcs/validations (dry-run) then, if valid, /v1/sddcs."
+            ),
+            "additionalProperties": True,
+        },
+    },
+    "required": ["spec"],
+    "additionalProperties": False,
+}
+
+_BRINGUP_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Bring-up outcome envelope. status='deploying' with sddc_task.id when the "
+        "deploy is accepted (poll installer.sddc.status to terminal); "
+        "status='validation_failed'/'validation_timeout' with failed_checks when "
+        "validation blocked the deploy."
+    ),
+    "additionalProperties": True,
+}
+
+_BRINGUP_WHEN_TO_USE = (
+    "Use to DEPLOY a new VCF management domain through the Installer: it validates "
+    "the SddcSpec (POST /v1/sddcs/validations, poll to terminal) and, only if "
+    "validation passes, starts the bring-up (POST /v1/sddcs) and returns the "
+    "SddcTask id. dangerous + requires_approval — the reviewer sees an SDDC "
+    "identity/network preview, never passwords. The deploy runs for hours; poll "
+    "installer.sddc.status with the returned id for terminal state. This is the "
+    "governed replacement for a Cloud Builder / Installer bring-up run by hand."
+)
+
+
+async def register_installer_composite_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the bring-up composite into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``. Mirrors
+    :func:`~meho_backplane.connectors.vmware_rest.composites._register.register_vmware_composite_operations`.
+    """
+    from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
+    from meho_backplane.operations.typed_register import register_composite_operation
+
+    await register_composite_operation(
+        product=InstallerConnector.product,
+        version=InstallerConnector.version,
+        impl_id=InstallerConnector.impl_id,
+        op_id=INSTALLER_BRINGUP_OP_ID,
+        handler=installer_sddc_bringup_composite,
+        summary="Govern a VCF management-domain bring-up (validate then deploy).",
+        description=(
+            "Orchestrates the two-step VCF Installer bring-up as one approved unit: "
+            "POST /v1/sddcs/validations (non-mutating dry-run, polled to terminal) "
+            "gates POST /v1/sddcs (the deploy). Returns the SddcTask id the moment "
+            "the deploy is accepted — the bring-up runs for hours, so poll "
+            "installer.sddc.status for terminal state. dangerous + requires_approval; "
+            "the approval preview echoes SDDC identity + network blast-radius only, "
+            "never passwords. Direct-session dispatch (Goal #2247)."
+        ),
+        parameter_schema=_BRINGUP_PARAM_SCHEMA,
+        response_schema=_BRINGUP_RESPONSE_SCHEMA,
+        group_key=_GROUP_BRINGUP,
+        when_to_use=_BRINGUP_WHEN_TO_USE,
+        tags=["vcf", "installer", "bringup", "deploy", "dangerous"],
+        safety_level="dangerous",
+        requires_approval=True,
+        embedding_service=embedding_service,
+    )
+    _log.info(
+        "installer_composite_operations_registered",
+        count=1,
+        product=InstallerConnector.product,
+        version=InstallerConnector.version,
+        impl_id=InstallerConnector.impl_id,
+    )
+
+
+# Side-effect: register the park-time preview builder at import time (#1608),
+# mirroring how ``connectors/vmware_rest/composites/_write_preview`` wires its
+# builders. This module is imported by the package ``__init__`` (which pulls in
+# ``register_installer_composite_operations``), so the builder is registered
+# before any dispatch can park.
+register_preview_builder(INSTALLER_BRINGUP_OP_ID, _sddc_bringup_preview)

--- a/backend/src/meho_backplane/connectors/vcf_installer/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/connector.py
@@ -4,8 +4,10 @@
 """InstallerConnector — hand-rolled HttpConnector subclass for VCF Installer 9.1.
 
 Auth + fingerprint + probe + the G0.6 dispatch shim + the bring-up status poll.
-The governed bring-up *write* (validate → deploy → poll) is a separate
-``dangerous`` + ``requires_approval`` composite (a following increment).
+The governed bring-up *write* (validate → deploy) is a separate ``dangerous`` +
+``requires_approval`` composite in :mod:`.bringup`; this connector supplies the
+session-auth POST twin (:meth:`_post_json_with_session_retry`) it dispatches
+through.
 
 Registered against the v2 registry at import time in
 :mod:`meho_backplane.connectors.vcf_installer.__init__` under
@@ -232,6 +234,41 @@ class InstallerConnector(HttpConnector):
                 raise RuntimeError(
                     f"vcf-installer session re-login failed for target {target.name!r}: "
                     f"GET {path} returned HTTP {status_code} after refresh"
+                ) from exc
+            raise
+
+    async def _post_json_with_session_retry(
+        self,
+        target: InstallerTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+        verb: str = "POST",
+    ) -> dict[str, Any]:
+        """POST *path* with single session-expiry → re-login → retry-once recovery.
+
+        The write-path twin of :meth:`_get_json_with_session_retry`, used by the
+        governed bring-up composite. Retrying a non-idempotent verb is safe *only*
+        for a session-expiry status: a ``401`` means the request was rejected at
+        auth **before** the server processed it, so the first attempt had no
+        effect and re-issuing once after a re-login cannot double-apply the write.
+        Any other status propagates unretried.
+        """
+        try:
+            return await self._post_json(target, path, operator=operator, verb=verb, json=json)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in _SESSION_EXPIRED_STATUSES:
+                raise
+            await self._invalidate_session(target)
+        try:
+            return await self._post_json(target, path, operator=operator, verb=verb, json=json)
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in _SESSION_EXPIRED_STATUSES:
+                raise RuntimeError(
+                    f"vcf-installer session re-login failed for target {target.name!r}: "
+                    f"{verb} {path} returned HTTP {status_code} after refresh"
                 ) from exc
             raise
 

--- a/backend/tests/test_connectors_vcf_installer_bringup.py
+++ b/backend/tests/test_connectors_vcf_installer_bringup.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the governed ``installer.composite.sddc.bringup`` composite.
+
+Exercises the validate → gate → deploy flow of
+:func:`~meho_backplane.connectors.vcf_installer.bringup.installer_sddc_bringup_composite`
+end to end against a respx-mocked Installer (``/v1/tokens``,
+``/v1/sddcs/validations``, ``/v1/sddcs/validations/{id}``, ``/v1/sddcs``), with
+:func:`enforce_subop_policy` monkeypatched by a recorder so the sub-op gate is
+asserted without a DB. Covers:
+
+* happy path (sync validation SUCCEEDED → gated deploy → ``deploying`` handle);
+* async validation polled to terminal;
+* ``FAILED`` validation aborts **before** any deploy;
+* ``WARNING`` validation proceeds and surfaces the warnings;
+* validation poll exhausting its wall-clock budget → ``validation_timeout``;
+* the deploy gate parking → the handler returns the ``OperationResult`` verbatim
+  and never fires the deploy;
+* the preview echoing identity/network only, never a password;
+* a missing ``spec`` raising a clear error;
+* the write-path ``_post_json_with_session_retry`` 401 → re-login → retry;
+* the handler satisfying the composite-registration signature contract.
+
+All respx-mocked — no network, no DB.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel, OperationResult
+from meho_backplane.connectors.vcf_installer import InstallerConnector, InstallerTargetLike
+from meho_backplane.connectors.vcf_installer import bringup as _bringup
+
+_TOKEN_PATH = "/v1/tokens"
+_VALIDATE_PATH = "/v1/sddcs/validations"
+_DEPLOY_PATH = "/v1/sddcs"
+_BASE_URL = "https://installer-a.test.invalid"
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _StubTarget:
+    name: str = "installer-a"
+    host: str = "installer-a.test.invalid"
+    port: int | None = 443
+    secret_ref: str = "installer/installer-a"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None
+    id: UUID = field(default_factory=lambda: UUID(int=1))
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET = _StubTarget()
+
+
+async def _stub_loader(_target: InstallerTargetLike, _operator: Operator) -> dict[str, str]:
+    return {"username": "admin@local", "password": "stub-password"}
+
+
+def _make_connector() -> InstallerConnector:
+    return InstallerConnector(credentials_loader=_stub_loader)
+
+
+@pytest.fixture(autouse=True)
+def _clean_installer_registry() -> Iterator[None]:
+    clear_registry()
+    register_connector_v2(
+        product=InstallerConnector.product,
+        version=InstallerConnector.version,
+        impl_id=InstallerConnector.impl_id,
+        cls=InstallerConnector,
+    )
+    yield
+    clear_registry()
+
+
+class _GateRecorder:
+    """Stand-in for :func:`enforce_subop_policy`; records calls, returns a verdict.
+
+    ``verdict=None`` models an ``AUTO_EXECUTE`` gate (the handler proceeds with
+    the write); an ``OperationResult`` models a parked/denied gate (the handler
+    must return it verbatim without writing).
+    """
+
+    def __init__(self, verdict: OperationResult | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._verdict = verdict
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {
+                "connector_id": connector_id,
+                "op_id": op_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
+                "params": params,
+            }
+        )
+        return self._verdict
+
+
+def _spec_with_secrets() -> dict[str, Any]:
+    """A representative SddcSpec carrying passwords in every credential slot."""
+    return {
+        "sddcId": "mgmt-domain",
+        "vcfInstanceName": "vcf-mgmt-01",
+        "workflowType": "VCF",
+        "vcenterSpec": {
+            "vcenterHostname": "vc01.evba.lab",
+            "ssoDomain": "vsphere.local",
+            "rootVcenterPassword": "SECRET-VC-ROOT",
+            "adminUserSsoPassword": "SECRET-SSO",
+        },
+        "nsxtSpec": {
+            "vipFqdn": "nsx.evba.lab",
+            "nsxtManagers": [{"hostname": "nsx-a.evba.lab"}],
+            "transportVlanId": 14,
+            "rootNsxtManagerPassword": "SECRET-NSX-ROOT",
+            "nsxtAdminPassword": "SECRET-NSX-ADMIN",
+        },
+        "sddcManagerSpec": {
+            "hostname": "sddcm.evba.lab",
+            "rootPassword": "SECRET-SDDCM-ROOT",
+            "sshPassword": "SECRET-SDDCM-SSH",
+        },
+        "dnsSpec": {"subdomain": "evba.lab", "nameservers": ["10.5.1.209"]},
+        "ntpServers": ["10.5.1.209"],
+        "networkSpecs": [
+            {"networkType": "MANAGEMENT", "subnet": "10.11.16.0/20", "vlanId": 4003, "mtu": 1400},
+        ],
+        "hostSpecs": [
+            {"hostname": "esx-dc13.evba.lab", "credentials": {"password": "SECRET-HOST"}},
+        ],
+    }
+
+
+# --------------------------------------------------------------- happy path
+
+
+@pytest.mark.asyncio
+async def test_bringup_happy_path_validates_then_deploys(monkeypatch: pytest.MonkeyPatch) -> None:
+    gate = _GateRecorder(verdict=None)  # AUTO_EXECUTE
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", gate)
+    connector = _make_connector()
+    spec = _spec_with_secrets()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        validate_route = mock.post(_VALIDATE_PATH).respond(
+            200, json={"id": "val-1", "executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"}
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(
+            202, json={"id": "sddc-1", "status": "IN_PROGRESS", "name": "bringup-mgmt"}
+        )
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(), target=_TARGET, params={"spec": spec}, connector=connector
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "deploying"
+    assert result["sddc_task"]["id"] == "sddc-1"
+    assert result["sddc_task"]["status"] == "IN_PROGRESS"
+    assert result["poll_with"] == "installer.sddc.status"
+    assert result["validation_id"] == "val-1"
+    assert result["validation_result_status"] == "SUCCEEDED"
+    assert "validation_warnings" not in result
+    # Validation and deploy both fired, each carrying the minted Bearer token.
+    assert validate_route.call_count == 1
+    assert deploy_route.call_count == 1
+    assert json.loads(validate_route.calls[0].request.content)["sddcId"] == "mgmt-domain"
+    assert json.loads(deploy_route.calls[0].request.content)["sddcId"] == "mgmt-domain"
+    assert deploy_route.calls[0].request.headers["authorization"] == "Bearer tok-abc"
+    # The deploy sub-op was gated with the right governance facts + secret-free params.
+    assert len(gate.calls) == 1
+    call = gate.calls[0]
+    assert call["op_id"] == "installer.sddc.deploy"
+    assert call["connector_id"] == "installer-rest-9.1"
+    assert call["safety_level"] == "dangerous"
+    assert call["requires_approval"] is False
+    assert "SECRET" not in json.dumps(call["params"])
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_polls_async_validation_to_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", _GateRecorder(verdict=None))
+    monkeypatch.setattr(_bringup, "_VALIDATION_POLL_INTERVAL", 0.0)
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.post(_VALIDATE_PATH).respond(
+            202, json={"id": "val-1", "executionStatus": "IN_PROGRESS"}
+        )
+        poll_route = mock.get("/v1/sddcs/validations/val-1").respond(
+            200, json={"id": "val-1", "executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"}
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(
+            202, json={"id": "sddc-9", "status": "IN_PROGRESS"}
+        )
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "deploying"
+    assert result["sddc_task"]["id"] == "sddc-9"
+    assert poll_route.call_count == 1
+    assert deploy_route.call_count == 1
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- validation gates the deploy
+
+
+@pytest.mark.asyncio
+async def test_bringup_aborts_on_validation_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    gate = _GateRecorder(verdict=None)
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", gate)
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.post(_VALIDATE_PATH).respond(
+            200,
+            json={
+                "id": "val-2",
+                "executionStatus": "COMPLETED",
+                "resultStatus": "FAILED",
+                "validationChecks": [
+                    {
+                        "description": "DNS forward/reverse mismatch for esx-dc13",
+                        "severity": "ERROR",
+                        "resultStatus": "FAILED",
+                    },
+                    {
+                        "description": "NTP reachable",
+                        "severity": "INFO",
+                        "resultStatus": "SUCCEEDED",
+                    },
+                ],
+            },
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(202, json={"id": "should-not-happen"})
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "validation_failed"
+    assert result["result_status"] == "FAILED"
+    assert result["validation_id"] == "val-2"
+    assert [c["description"] for c in result["failed_checks"]] == [
+        "DNS forward/reverse mismatch for esx-dc13"
+    ]
+    # The deploy never fired, and the gate was never consulted.
+    assert deploy_route.call_count == 0
+    assert gate.calls == []
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_proceeds_on_warning_surfacing_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", _GateRecorder(verdict=None))
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.post(_VALIDATE_PATH).respond(
+            200,
+            json={
+                "id": "val-3",
+                "executionStatus": "COMPLETED",
+                "resultStatus": "WARNING",
+                "validationChecks": [
+                    {
+                        "description": "Management network gateway ping skipped",
+                        "severity": "WARNING",
+                        "resultStatus": "WARNING",
+                    }
+                ],
+            },
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(
+            202, json={"id": "sddc-3", "status": "IN_PROGRESS"}
+        )
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "deploying"
+    assert deploy_route.call_count == 1
+    assert result["validation_warnings"][0]["resultStatus"] == "WARNING"
+    # The verdict is always echoed so a WARNING can never be silent (Finding 3).
+    assert result["validation_result_status"] == "WARNING"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_times_out_when_validation_never_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = _GateRecorder(verdict=None)
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", gate)
+    monkeypatch.setattr(_bringup, "_VALIDATION_TIMEOUT_SECONDS", 0.0)
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.post(_VALIDATE_PATH).respond(
+            202, json={"id": "val-4", "executionStatus": "IN_PROGRESS"}
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(202, json={"id": "should-not-happen"})
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "validation_timeout"
+    assert result["execution_status"] == "IN_PROGRESS"
+    assert deploy_route.call_count == 0
+    assert gate.calls == []
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- gate parks the deploy
+
+
+@pytest.mark.asyncio
+async def test_bringup_returns_gate_result_verbatim_when_parked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parked = OperationResult(status="pending", op_id="installer.sddc.deploy", duration_ms=0.0)
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", _GateRecorder(verdict=parked))
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.post(_VALIDATE_PATH).respond(
+            200, json={"id": "val-5", "executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"}
+        )
+        deploy_route = mock.post(_DEPLOY_PATH).respond(202, json={"id": "should-not-happen"})
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert result is parked  # returned verbatim, not wrapped
+    assert deploy_route.call_count == 0  # write never fired while awaiting approval
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- preview secret hygiene
+
+
+@pytest.mark.asyncio
+async def test_bringup_preview_echoes_identity_never_secrets() -> None:
+    spec = _spec_with_secrets()
+    ctx = SimpleNamespace(params={"spec": spec})
+    preview = await _bringup._sddc_bringup_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview is not None
+    assert preview["operation"] == "VCF management-domain bring-up"
+    assert preview["sddc_id"] == "mgmt-domain"
+    assert preview["vcenter_hostname"] == "vc01.evba.lab"
+    assert preview["nsxt_vip_fqdn"] == "nsx.evba.lab"
+    assert preview["host_count"] == 1
+    assert preview["management_networks"][0]["vlanId"] == 4003
+    # Not one password value or key from any credential slot leaks into the preview.
+    dumped = json.dumps(preview)
+    assert "SECRET" not in dumped
+    for secret_key in (
+        "rootVcenterPassword",
+        "adminUserSsoPassword",
+        "rootNsxtManagerPassword",
+        "nsxtAdminPassword",
+        "rootPassword",
+        "sshPassword",
+        "credentials",
+    ):
+        assert secret_key not in dumped
+
+
+@pytest.mark.asyncio
+async def test_bringup_preview_returns_none_without_spec() -> None:
+    ctx = SimpleNamespace(params={})
+    assert await _bringup._sddc_bringup_preview(ctx) is None  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------- guards / plumbing
+
+
+@pytest.mark.asyncio
+async def test_bringup_missing_spec_raises() -> None:
+    connector = _make_connector()
+    with pytest.raises(ValueError, match=r"params\['spec'\]"):
+        await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(), target=_TARGET, params={}, connector=connector
+        )
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_with_session_retry_relogins_on_401() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        token = mock.post(_TOKEN_PATH)
+        token.side_effect = [
+            respx.MockResponse(201, json={"accessToken": "tok-1"}),
+            respx.MockResponse(201, json={"accessToken": "tok-2"}),
+        ]
+        deploy = mock.post(_DEPLOY_PATH)
+        deploy.side_effect = [
+            respx.MockResponse(401, json={"message": "token expired"}),
+            respx.MockResponse(202, json={"id": "sddc-7", "status": "IN_PROGRESS"}),
+        ]
+        result = await connector._post_json_with_session_retry(
+            _TARGET, _DEPLOY_PATH, operator=_make_operator(), json={"sddcId": "x"}
+        )
+
+    assert result["id"] == "sddc-7"
+    assert deploy.call_count == 2  # first 401, retried after re-login
+    assert token.call_count == 2  # re-minted the token between attempts
+    # The retry carried the FRESH token, not the stale one that 401'd.
+    assert deploy.calls[0].request.headers["authorization"] == "Bearer tok-1"
+    assert deploy.calls[1].request.headers["authorization"] == "Bearer tok-2"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_deploy_recovers_from_mid_deploy_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a 401 on the deploy POST re-logs in and retries once — the
+    composite completes without a double-launch surfacing to the caller."""
+    monkeypatch.setattr(_bringup, "enforce_subop_policy", _GateRecorder(verdict=None))
+    connector = _make_connector()
+
+    async with respx.mock(base_url=_BASE_URL, assert_all_called=False) as mock:
+        token = mock.post(_TOKEN_PATH)
+        token.side_effect = [
+            respx.MockResponse(201, json={"accessToken": "tok-1"}),
+            respx.MockResponse(201, json={"accessToken": "tok-2"}),
+        ]
+        mock.post(_VALIDATE_PATH).respond(
+            200, json={"id": "val-8", "executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"}
+        )
+        deploy = mock.post(_DEPLOY_PATH)
+        deploy.side_effect = [
+            respx.MockResponse(401, json={"message": "token expired mid-deploy"}),
+            respx.MockResponse(202, json={"id": "sddc-8", "status": "IN_PROGRESS"}),
+        ]
+        result = await _bringup.installer_sddc_bringup_composite(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"spec": _spec_with_secrets()},
+            connector=connector,
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "deploying"
+    assert result["sddc_task"]["id"] == "sddc-8"
+    assert deploy.call_count == 2
+    assert deploy.calls[1].request.headers["authorization"] == "Bearer tok-2"
+    await connector.aclose()
+
+
+# --------------------------------------------------------------- classifier (fail-closed)
+
+
+@pytest.mark.parametrize(
+    ("validation", "expected"),
+    [
+        # Deploys only on COMPLETED + {SUCCEEDED, WARNING}.
+        ({"executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"}, "pass"),
+        ({"executionStatus": "COMPLETED", "resultStatus": "WARNING"}, "pass"),
+        # Every other combination must abort (fail-closed), NOT deploy.
+        ({"executionStatus": "COMPLETED", "resultStatus": "FAILED"}, "validation_failed"),
+        ({"executionStatus": "COMPLETED", "resultStatus": "UNKNOWN"}, "validation_failed"),
+        ({"executionStatus": "COMPLETED"}, "validation_failed"),  # missing resultStatus
+        ({"executionStatus": "FAILED", "resultStatus": "FAILED"}, "validation_failed"),
+        # A terminal execution FAILED must abort even if resultStatus reads SUCCEEDED.
+        ({"executionStatus": "FAILED", "resultStatus": "SUCCEEDED"}, "validation_failed"),
+        ({"executionStatus": "SKIPPED", "resultStatus": "SUCCEEDED"}, "validation_failed"),
+        ({"executionStatus": "CANCELLED", "resultStatus": "SUCCEEDED"}, "validation_failed"),
+        ({"executionStatus": "UNKNOWN", "resultStatus": "SUCCEEDED"}, "validation_failed"),
+        ({}, "validation_failed"),  # empty / malformed
+        # Still-running statuses map to timeout (poll budget spent).
+        ({"executionStatus": "IN_PROGRESS"}, "validation_timeout"),
+        ({"executionStatus": "CANCELLATION_IN_PROGRESS"}, "validation_timeout"),
+    ],
+)
+def test_classify_validation_is_fail_closed(validation: dict[str, Any], expected: str) -> None:
+    """Deploy only on COMPLETED+SUCCEEDED/WARNING; every other verdict aborts."""
+    assert _bringup._classify_validation(validation).status == expected
+
+
+# --------------------------------------------------------------- poll short-circuit
+
+
+class _RecordingReader:
+    """Minimal connector double recording ``_get_json_with_session_retry`` calls."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.get_calls = 0
+        self._response = response
+
+    async def _get_json_with_session_retry(
+        self, _target: Any, _path: str, *, operator: Any
+    ) -> dict[str, Any]:
+        self.get_calls += 1
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_await_validation_short_circuits_when_initial_has_no_id() -> None:
+    """An IN_PROGRESS initial with no ``id`` returns as-is — no unpollable GET loop."""
+    reader = _RecordingReader({"executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"})
+    result = await _bringup._await_validation(
+        reader,  # type: ignore[arg-type]
+        _TARGET,
+        _make_operator(),
+        {"executionStatus": "IN_PROGRESS"},  # no id
+    )
+    assert result == {"executionStatus": "IN_PROGRESS"}
+    assert reader.get_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_await_validation_polls_to_terminal_via_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An IN_PROGRESS initial WITH an id is polled once to its terminal state."""
+    monkeypatch.setattr(_bringup, "_VALIDATION_POLL_INTERVAL", 0.0)
+    reader = _RecordingReader({"executionStatus": "COMPLETED", "resultStatus": "SUCCEEDED"})
+    result = await _bringup._await_validation(
+        reader,  # type: ignore[arg-type]
+        _TARGET,
+        _make_operator(),
+        {"id": "val-x", "executionStatus": "IN_PROGRESS"},
+    )
+    assert result["executionStatus"] == "COMPLETED"
+    assert reader.get_calls == 1
+
+
+def test_bringup_handler_signature_is_valid_for_composite_registration() -> None:
+    """The handler declares ``connector`` so composite registration accepts it."""
+    from meho_backplane.operations.typed_register import validate_composite_handler_signature
+
+    validate_composite_handler_signature(_bringup.installer_sddc_bringup_composite)

--- a/backend/tests/test_connectors_vcf_installer_bringup_register.py
+++ b/backend/tests/test_connectors_vcf_installer_bringup_register.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""DB-backed registration test for the ``installer.composite.sddc.bringup`` composite.
+
+Runs :func:`register_installer_composite_operations` against the autouse-migrated
+SQLite engine (a deterministic embedding stub replaces the ONNX pipeline) and
+asserts the ``endpoint_descriptor`` row lands with the governed-write posture:
+``source_kind="composite"``, ``safety_level="dangerous"``, ``requires_approval=True``,
+a NULL tenant/method/path, and a resolvable handler ref. This catches a
+registration-time failure (bad schema, op_id convention, when_to_use pairing) in
+the fast unit lane instead of at integration-boot. Mirrors
+``test_connectors_vmware_rest_composites_register``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.vcf_installer import (
+    INSTALLER_BRINGUP_OP_ID,
+    register_installer_composite_operations,
+)
+from meho_backplane.connectors.vcf_installer import bringup as _bringup
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.typed_register import (
+    _TYPED_OP_REGISTRARS,
+    derive_handler_ref,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Snapshot + restore the process-global registrar list and reset caches."""
+    saved_registrars = list(_TYPED_OP_REGISTRARS)
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    _TYPED_OP_REGISTRARS[:] = saved_registrars
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so the upsert doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+async def _fetch_bringup_row() -> EndpointDescriptor | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        return (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.op_id == INSTALLER_BRINGUP_OP_ID
+                    )
+                )
+            )
+            .scalars()
+            .one_or_none()
+        )
+
+
+@pytest.mark.asyncio
+async def test_registrar_lands_the_bringup_composite_row(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The registrar upserts exactly the bring-up composite, embedded once."""
+    await register_installer_composite_operations(embedding_service=stub_embedding_service)
+    row = await _fetch_bringup_row()
+    assert row is not None
+    assert row.op_id == INSTALLER_BRINGUP_OP_ID
+    assert stub_embedding_service.encode_one.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_bringup_row_carries_governed_write_posture(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The row routes the composite branch and pops the approval queue."""
+    await register_installer_composite_operations(embedding_service=stub_embedding_service)
+    row = await _fetch_bringup_row()
+    assert row is not None
+    assert row.source_kind == "composite"
+    assert row.safety_level == "dangerous"
+    assert row.requires_approval is True
+    assert row.tenant_id is None
+    assert row.is_enabled is True
+    # A composite carries no wire method/path — it dispatches its own sub-calls.
+    assert row.method is None
+    assert row.path is None
+
+
+@pytest.mark.asyncio
+async def test_bringup_row_handler_ref_resolves_to_the_handler(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The persisted handler ref points at the module-level composite handler."""
+    await register_installer_composite_operations(embedding_service=stub_embedding_service)
+    row = await _fetch_bringup_row()
+    assert row is not None
+    assert row.handler_ref == derive_handler_ref(_bringup.installer_sddc_bringup_composite)

--- a/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
@@ -23,13 +23,15 @@ path:
   ``session_login_token`` scheme spec).
 * :mod:`~meho_backplane.connectors.vcf_installer.profile` — the declarative
   fingerprint recipe's ``GET /v1/system/appliance-info``.
-
-The governed bring-up composite's write paths (``POST /v1/sddcs``,
-``POST /v1/sddcs/validations``) join this set when that increment lands.
+* :mod:`~meho_backplane.connectors.vcf_installer.bringup` — the governed
+  composite's ``BRINGUP_DECLARED_OP_IDS`` (``POST /v1/sddcs/validations``,
+  ``POST /v1/sddcs``, ``GET /v1/sddcs/validations/{id}``), which carry their own
+  HTTP method, so they contribute the ``METHOD:`` verb directly.
 """
 
 from __future__ import annotations
 
+from meho_backplane.connectors.vcf_installer import bringup as _bringup
 from meho_backplane.connectors.vcf_installer import connector as _connector
 from meho_backplane.connectors.vcf_installer import typed_reads as _typed_reads
 from meho_backplane.connectors.vcf_installer.profile import INSTALLER_EXECUTION_PROFILE
@@ -58,6 +60,7 @@ def _declared_op_ids() -> set[str]:
     declared = {f"GET:{path}" for path in _typed_read_paths().values()}
     declared.add(f"POST:{_connector._SESSION_CREATE_PATH}")
     declared.add(f"GET:{INSTALLER_EXECUTION_PROFILE.fingerprint.path}")
+    declared |= set(_bringup.BRINGUP_DECLARED_OP_IDS)
     return declared
 
 
@@ -69,6 +72,24 @@ def test_typed_read_path_constants_are_all_discovered() -> None:
     shrink the reconciled set to a vacuous pass.
     """
     assert sorted(_typed_read_paths()) == ["_SDDC_STATUS_PATH"]
+
+
+def test_bringup_declared_op_ids_are_pinned() -> None:
+    """Guard: the composite's declared write/validate set can't go vacuous.
+
+    Pinning the exact ``METHOD:/path`` set means dropping or renaming a bring-up
+    path constant can't silently shrink the reconciled set to a passing subset.
+    """
+    assert (
+        frozenset(
+            {
+                "POST:/v1/sddcs/validations",
+                "POST:/v1/sddcs",
+                "GET:/v1/sddcs/validations/{id}",
+            }
+        )
+        == _bringup.BRINGUP_DECLARED_OP_IDS
+    )
 
 
 def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:

--- a/docs/codebase/connectors-vcf-installer.md
+++ b/docs/codebase/connectors-vcf-installer.md
@@ -14,11 +14,13 @@ binds its bring-up step to — it generates the `SddcSpec`, meho governs the POS
 Filed under Initiative [#2907](https://github.com/evoila/meho/issues/2907)
 (backplane-first coverage) as [#3065](https://github.com/evoila/meho/issues/3065),
 converting the register's "VCF stack / Cloud Builder bring-up — to file" row to
-the 9.x reality. This increment is the **skeleton**: token auth, fingerprint /
-probe, and the bring-up **status poll**. The governed bring-up **write**
-(validate → deploy → poll) lands as a `dangerous` + `requires_approval`
-composite in a following increment — the highest-blast-radius write in the
-product must carry the preview + sub-op-policy machinery a raw op cannot.
+the 9.x reality. Increment 1 (the **skeleton** — token auth, fingerprint / probe,
+and the bring-up **status poll**) shipped in
+[#3066](https://github.com/evoila/meho/issues/3066). Increment 2 adds the
+governed bring-up **write** `installer.composite.sddc.bringup` — a `dangerous` +
+`requires_approval` composite (validate → deploy) — because the
+highest-blast-radius write in the product must carry the preview + sub-op-policy
+machinery a raw op cannot.
 
 Source: `backend/src/meho_backplane/connectors/vcf_installer/`.
 
@@ -84,20 +86,56 @@ ingest; the body lives in `typed_reads.py`, a bound-method shim on the connector
 exposes it. This is the poll the automation add-on (or an operator) runs while a
 bring-up is in flight or to triage a failed one.
 
-### Governed bring-up write (following increment)
+### `installer.composite.sddc.bringup` — governed bring-up write (composite, `dangerous`)
 
-`installer.composite.sddc.bringup` — a `dangerous` + `requires_approval`
-composite orchestrating `POST /v1/sddcs/validations` (validate) → `POST /v1/sddcs`
-(deploy) → poll-to-terminal, with a secret-hygienic preview (SDDC identity /
-network blast-radius echoed, passwords never on reviewer surfaces) and every
-mutating sub-call through `enforce_subop_policy`. Not shipped in this increment.
+The highest-blast-radius write in the product, in `bringup.py`. A `dangerous` +
+`requires_approval` composite (`source_kind="composite"`) orchestrating, as one
+approved unit:
+
+1. **validate** — `POST /v1/sddcs/validations` with the `SddcSpec` body, then poll
+   `GET /v1/sddcs/validations/{id}` to a terminal `executionStatus`. Validation is
+   a **non-mutating dry-run**, so it is *ungated*. The deploy is gated on the
+   `resultStatus`: `SUCCEEDED`/`WARNING` proceed (warnings surfaced in the
+   return), anything else returns `validation_failed` / `validation_timeout`
+   **before any mutation**, with the failed checks summarised.
+2. **deploy** — `POST /v1/sddcs` with the same `SddcSpec` through
+   `enforce_subop_policy`. This is the single state mutation and the single sub-op
+   gate (the top-level composite is `requires_approval=True`; the deploy sub-op
+   passes `requires_approval=False` so an approved-and-resumed dispatch is not
+   double-gated).
+3. **hand off** — the bring-up runs for *hours*, so the composite returns
+   `{status: "deploying", sddc_task: {id, status, …}, poll_with:
+   "installer.sddc.status"}` the moment the deploy is accepted. The caller (an
+   operator or the deploy-automation add-on's durable workflow) polls
+   `installer.sddc.status` to a terminal `COMPLETED_WITH_SUCCESS` /
+   `ROLLBACK_SUCCESS` / `COMPLETED_WITH_FAILURE`. Blocking one dispatch on a
+   multi-hour terminal state would be wrong.
+
+**Secret hygiene (#1503).** The park-time approval preview and the sub-op policy
+params are both built by `_blast_radius(spec)`, which reads only a whitelist of
+SDDC identity + network keys and *never* reads any `*Password` /
+`credentials` field of the `SddcSpec` — redaction by construction. Covered by the
+whole-suite secret-leak guard.
+
+**Direct-session dispatch (Goal #2247).** Every sub-call goes through the injected
+connector's own session helpers (`_post_json_with_session_retry` /
+`_get_json_with_session_retry`) — never `dispatch_child` into an ingested
+`METHOD:/path` primitive — so correctness never depends on per-deploy catalog
+state. `_post_json_with_session_retry` is the write-path twin of the increment-1
+GET helper: a `401` means auth was rejected *before* the server processed the
+request, so re-issuing the non-idempotent POST once after a re-login cannot
+double-apply.
+
+Shipped as increment 2 of [#3065](https://github.com/evoila/meho/issues/3065).
 
 ## Spec-reconcile lane
 
 Every hand-coded `METHOD:/path` — `POST:/v1/tokens`,
-`GET:/v1/system/appliance-info` (fingerprint), `GET:/v1/sddcs/{id}` (status) — is
-asserted against the pinned `vcf-installer-9.1` shelf spec (vendored from
-`vmware/vcf-api-specs`) by
+`GET:/v1/system/appliance-info` (fingerprint), `GET:/v1/sddcs/{id}` (status), and
+the composite's `POST:/v1/sddcs/validations`, `POST:/v1/sddcs`,
+`GET:/v1/sddcs/validations/{id}` (introspected from
+`bringup.BRINGUP_DECLARED_OP_IDS`) — is asserted against the pinned
+`vcf-installer-9.1` shelf spec (vendored from `vmware/vcf-api-specs`) by
 [`backend/tests/test_connectors_vcf_installer_spec_reconcile.py`](../../backend/tests/test_connectors_vcf_installer_spec_reconcile.py)
 (the #2980 harness; parse-only, in the required unit sweep, uniform skip when the
 shelf is unconfigured). Standard:
@@ -114,8 +152,30 @@ shelf is unconfigured). Standard:
 
 ## Known issues
 
-- The bring-up write surface is not yet shipped (following increment) — a VCF
-  management-domain deployment cannot yet be dispatched, only its status polled.
+- The composite **kicks off** the bring-up and returns the `SddcTask` id; it does
+  not block on the multi-hour deployment. Terminal state (`COMPLETED_WITH_SUCCESS`
+  / `ROLLBACK_SUCCESS` / `COMPLETED_WITH_FAILURE`) is reached by polling
+  `installer.sddc.status`. Durable orchestration of that wait (retry, resume) is
+  the deploy-automation add-on's DBOS workflow, not this connector.
+- `WARNING`-result validations proceed to deploy (VCF treats them as non-fatal);
+  the return always echoes `validation_result_status` (and the leaf WARNING
+  checks when present), but the approver saw the preview *before* validation ran.
+  Blocking on `WARNING` would make most lab bring-ups unrunnable; revisit if a
+  stricter posture is needed.
+- **Secret at rest in the approval table.** The `_blast_radius` preview + sub-op
+  policy params never carry a password, but when the top-level op parks for
+  approval the dispatcher persists the raw dispatch `params` (the full `SddcSpec`,
+  including plaintext passwords) verbatim in `approval_request.params` for the
+  approval TTL (#1503 store-verbatim). That column is never surfaced by any API /
+  audit / broadcast read path — exposure is at-rest-in-the-governance-table,
+  gated by DB/row access control, the same posture as every `requires_approval`
+  op taking inline secrets (e.g. the GOSC composites). A Vault-ref-in-spec
+  redesign that keeps plaintext out of the row entirely is future work.
+- **Agent callers are not a supported path.** The intended caller is a non-agent
+  operator or the automation add-on's service account. A run-bound agent hits the
+  backplane's `dangerous` safety-ceiling on the deploy sub-op and would re-park a
+  second, currently un-resumable approval (fleet-wide `dangerous`-composite
+  behavior, not specific to this op).
 - The default credentials loader is the live State-2 read; a target must be
   `shared_service_account` with a `secret_ref` resolving to a
   `{username, password}` KV-v2 secret.


### PR DESCRIPTION
## What

Increment 2 of the VCF Installer 9.1 connector (#3065, under Initiative #2907): the governed bring-up **write** `installer.composite.sddc.bringup` — the highest-blast-radius operation in the product. A `dangerous` + `requires_approval` composite that turns the two-step Installer bring-up into one approved, governed unit.

Increment 1 (skeleton: auth, fingerprint/probe, status poll) shipped in #3066.

## Flow

1. **validate** — `POST /v1/sddcs/validations` with the `SddcSpec`, polled (`GET /v1/sddcs/validations/{id}`) to a terminal `executionStatus`. Non-mutating dry-run, so **ungated**. The deploy is gated on `resultStatus`: `SUCCEEDED`/`WARNING` proceed (verdict always echoed), anything else returns `validation_failed`/`validation_timeout` with the failed checks summarised — **before any mutation**.
2. **deploy** — `POST /v1/sddcs` through `enforce_subop_policy` (the single mutation, the single sub-op gate).
3. **hand off** — the bring-up runs for *hours*, so the composite returns `{status: "deploying", sddc_task: {id, …}, poll_with: "installer.sddc.status"}` the moment the deploy is accepted. Durable orchestration of the wait is the deploy-automation add-on's DBOS workflow, not this connector.

## Governance & safety

- **Secret hygiene by construction** — the park-time preview + sub-op policy params come from a `_blast_radius()` whitelist that never reads a `*Password`/`credentials` field. Passes the whole-suite secret-leak guard.
- **Direct-session dispatch (Goal #2247)** — new `_post_json_with_session_retry` write-path twin (safe single 401-retry: a 401 is rejected pre-processing); no `dispatch_child` into ingested primitives.
- **Spec-reconcile** — the three new write/validate paths are asserted against the pinned vendored 9.1 OpenAPI.

## Adversarial review — applied

A hostile review ran before this PR. Fixes applied: the deploying envelope now **always echoes `validation_result_status`** so a WARNING can't be silent; the docstrings/docs are corrected to be honest that (a) the single-approval-gate property holds for the intended **non-agent** operator/automation caller — an agent-principal direct caller hits the fleet-wide `dangerous` safety-ceiling on the sub-op (agent bring-up is not a supported path today), and (b) when the op parks, the raw `SddcSpec` (incl. passwords) is persisted at rest in `approval_request.params` for the TTL (never surfaced by any API/audit/broadcast path; the same posture as every `requires_approval` op with inline secrets). Added fail-closed classifier tests (every non-`COMPLETED+SUCCEEDED/WARNING` combo aborts), a missing-id poll short-circuit test, and an end-to-end mid-deploy-401 recovery test.

## Tests

37 unit tests (validate/gate/deploy flow, async poll, FAILED/WARNING/timeout, gate-parks-verbatim, preview secret-hygiene, session-retry, fail-closed classifier matrix, e2e 401 recovery) + a DB-backed registration test proving the row lands as `source_kind=composite` / `dangerous` / `requires_approval=True` with a resolvable `handler_ref`. Spec-reconcile lane green. ruff + `mypy src/` clean.

Part of #2907. Closes nothing (task #3065 stays open through its increments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)