### PR TITLE
fix(ui): wire both broadcast filter selects, not just the first (#229)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
@@ -45,7 +45,7 @@
   hx-get="/ui/broadcast/feed"
   hx-target="#broadcast-feed"
   hx-swap="outerHTML"
-  hx-trigger="change from:find select, input changed delay:300ms from:find input[name=principal]"
+  hx-trigger="change from:find select[name=op_class], change from:find select[name=target], input changed delay:300ms from:find input[name=principal]"
   hx-include="[name=op_class], [name=principal], [name=target]"
   hx-push-url="true"
   role="search"

--- a/backend/tests/test_ui_broadcast_filters.py
+++ b/backend/tests/test_ui_broadcast_filters.py
@@ -272,6 +272,14 @@ def test_page_renders_filter_bar_with_all_four_controls() -> None:
     # The filter bar HTMX-submits the three server filters to the fragment route.
     assert 'hx-get="/ui/broadcast/feed"' in body
     assert 'hx-target="#broadcast-feed"' in body
+    # #229: the hx-trigger must wire BOTH selects (op_class + target), not
+    # just the first. htmx `from:find select` binds only the first matching
+    # descendant, so `change from:find select` alone left the Target select
+    # dead. Each select is named explicitly; op_id stays client-side (no
+    # server trigger clause).
+    assert "change from:find select[name=op_class]" in body
+    assert "change from:find select[name=target]" in body
+    assert "from:find select," not in body  # the old first-select-only trigger is gone
 
 
 def test_page_op_class_options_cover_the_closed_vocabulary() -> None:


### PR DESCRIPTION
## Summary
- The broadcast live-feed **Target** filter did nothing when changed. The filter bar used `hx-trigger="change from:find select, …"`, and htmx's `from:find <sel>` binds only the **first** matching descendant — so only the **Op class** select triggered the refilter.
- Fixed by enumerating both selects by name: `change from:find select[name=op_class], change from:find select[name=target], input changed delay:300ms from:find input[name=principal]`.
- The `op_id` input keeps **no** server-trigger clause (it's deliberately client-side, excluded from `hx-include`), so the fix restores the Target filter without churning the SSE subscription on op_id blur. Same bug class as the connector-registry filter fix (#174).

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_broadcast_filters.py tests/test_ui_broadcast_feed.py` — 41 passed
- [x] **Target select refilters** — render-guard asserts `change from:find select[name=target]` is present and the old first-select-only `from:find select,` trigger is gone
- [x] **Op class still refilters** — `change from:find select[name=op_class]` present
- [x] **No regression** — principal debounced input + client-side op_id narrowing covered by the 41 passing tests

## Out of scope
- The filter bar's dead daisyUI-v4 `form-control` / `label-text` classes (cosmetic; noted on the issue as a follow-up).
- Sibling broadcast-view tasks evoila-bosnia/meho-internal#230 (event drawer) and #231 (overrides dialog) under initiative #228.

## Issue
Implements **evoila-bosnia/meho-internal#229** (subtask of initiative **evoila-bosnia/meho-internal#228**). Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#229