### PR TITLE
fix(connectors): deploy_from_library find body /api top-level, not /rest {spec} envelope (#3071)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -450,7 +450,9 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
             "placement validation returns succeeded=false and surfaces as "
             "status='deploy_failed' with per-issue messages, and an invalid / "
             "missing placement resource (HTTP 400/404) as status='deploy_error' "
-            "— structured statuses, never a raw vendor error. With power_on the "
+            "(a faulted content-library find during name resolution as "
+            "status='resolve_error') — structured statuses, never a raw vendor "
+            "error. With power_on the "
             "deployed VM is started best-effort. Equivalent of 'govc "
             "library.deploy' for operator-facing dispatch."
         ),

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1261,16 +1261,17 @@ async def _find_content_library_ids(
     return a bare array of id strings and mutate nothing, so they skip the
     :func:`enforce_subop_policy` seam like the REST listing reads — but they
     are POST-shaped, so they ride ``_post_json`` rather than :func:`_read_sub_op`
-    (which is GET-only). The ``FindSpec`` is wrapped in the ``{"spec": ...}``
-    envelope the ``/api`` protocol expects for a single structured input
-    parameter (the same wrapping the ``CreateSpec`` writes use). Transport
-    faults raise :exc:`httpx.HTTPError` for the caller.
+    (which is GET-only). The ``FindSpec`` is sent at the **top level** of the
+    request body -- the modern ``/api`` surface takes the ``FindSpec`` directly
+    (``Content.Library.FindSpec`` / ``Content.Library.Item.FindSpec``), not the
+    legacy ``/rest`` ``{"spec": {...}}`` envelope, which it rejects with
+    ``400 INVALID_ARGUMENT`` (#3071 — the resolution-step sibling of the
+    write-body envelope fix #2973). Transport faults raise
+    :exc:`httpx.HTTPError` for the caller.
     """
     method, _, path = op_id.partition(":")
     mounted = await connector.mount_op_path(target, path, operator)
-    payload = await connector._post_json(
-        target, mounted, operator=operator, verb=method, json={"spec": spec}
-    )
+    payload = await connector._post_json(target, mounted, operator=operator, verb=method, json=spec)
     ids = _unwrap_value(payload)
     if not isinstance(ids, list):
         raise RuntimeError(f"expected id list from {op_id!r}, got {type(ids).__name__}")
@@ -1445,9 +1446,25 @@ async def vm_deploy_from_library_composite(
     so a placement or network-mapping error is a structured status, never a
     raw vendor error. With ``power_on`` the deployed VM is started best-effort.
     """
-    item_id, resolution_error = await _resolve_deploy_library_item(
-        connector=connector, target=target, operator=operator, params=params
-    )
+    try:
+        item_id, resolution_error = await _resolve_deploy_library_item(
+            connector=connector, target=target, operator=operator, params=params
+        )
+    except httpx.HTTPError as exc:
+        # A content-library ``?action=find`` call faulted (e.g. a 4xx). Surface
+        # the vCenter status + message as a structured ``resolve_error`` instead
+        # of letting the raw ``httpx.HTTPStatusError`` escape as an opaque
+        # ``connector_error`` (#3071).
+        return _deploy_failure(
+            "resolve_error",
+            issues=[
+                _deploy_issue(
+                    "resolve",
+                    "error",
+                    f"content-library lookup faulted: {_vsphere_fault_detail(exc)}: {exc}",
+                )
+            ],
+        )
     if resolution_error is not None:
         return resolution_error
     assert item_id is not None  # resolution_error is None ⇒ item_id resolved
@@ -1458,15 +1475,15 @@ async def vm_deploy_from_library_composite(
             connector, target, operator, _OP_DEPLOY_OVF_LIBRARY_ITEM, deploy_params
         )
     except httpx.HTTPError as exc:
-        status, error_type = _parse_vsphere_error(exc)
-        detail = f"HTTP {status}" if status is not None else "transport fault"
-        if error_type:
-            detail += f" ({error_type})"
         return _deploy_failure(
             "deploy_error",
             library_item_id=item_id,
             issues=[
-                _deploy_issue("placement", "error", f"OVF deploy call faulted: {detail}: {exc}")
+                _deploy_issue(
+                    "placement",
+                    "error",
+                    f"OVF deploy call faulted: {_vsphere_fault_detail(exc)}: {exc}",
+                )
             ],
         )
     if gate is not None:
@@ -1852,6 +1869,40 @@ def _parse_vsphere_error(exc: httpx.HTTPError) -> tuple[int | None, str | None]:
         return status, None
     error_type = body.get("error_type") if isinstance(body, dict) else None
     return status, error_type if isinstance(error_type, str) else None
+
+
+def _vsphere_fault_detail(exc: httpx.HTTPError) -> str:
+    """Human-readable ``HTTP <status> (<error_type>): <message>`` from a sub-op fault.
+
+    The diagnosable form of an upstream fault (#3071): the HTTP status, the
+    machine ``error_type`` (e.g. ``INVALID_ARGUMENT`` / ``NOT_FOUND``), and the
+    first localized vAPI message (``messages[].default_message``) — so a
+    composite can fold a 4xx/5xx into its structured failure arm instead of
+    letting a bare :exc:`httpx.HTTPStatusError` escape as an opaque
+    ``connector_error`` with no status, url, or vendor message (the regression
+    #3071 fixes, sibling of #1649/#1804). A transport-level fault (connect /
+    read, no response) degrades to ``transport fault``. Body parsing is
+    defensive — a non-JSON or unexpectedly-shaped body drops the missing parts,
+    never raises.
+    """
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return "transport fault"
+    detail = f"HTTP {exc.response.status_code}"
+    try:
+        body = exc.response.json()
+    except (ValueError, httpx.HTTPError):
+        body = None
+    if isinstance(body, dict):
+        error_type = body.get("error_type")
+        if isinstance(error_type, str) and error_type:
+            detail += f" ({error_type})"
+        for message in body.get("messages") or []:
+            if isinstance(message, dict):
+                default = message.get("default_message")
+                if isinstance(default, str) and default:
+                    detail += f": {default}"
+                    break
+    return detail
 
 
 def _guest_tools_unavailable(status: int | None, error_type: str | None) -> bool:

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -2630,6 +2630,7 @@ VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
                 "ambiguous_library",
                 "item_not_found",
                 "ambiguous_item",
+                "resolve_error",
             ],
             "description": (
                 "``'deployed'`` — the OVF deploy report returned "
@@ -2643,9 +2644,12 @@ VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
                 "``library_item_name`` was supplied; ``'library_not_found'`` / "
                 "``'ambiguous_library'`` — the ``library_name`` lookup matched "
                 "zero / many libraries; ``'item_not_found'`` / ``'ambiguous_item'`` "
-                "— the ``library_item_name`` lookup matched zero / many items. "
-                "Every non-``deployed`` status is reached before or without a "
-                "successful mutation."
+                "— the ``library_item_name`` lookup matched zero / many items; "
+                "``'resolve_error'`` — a content-library ``?action=find`` "
+                "resolution call itself faulted (HTTP 4xx/5xx), surfaced as a "
+                "structured message with the vCenter status carried in ``issues`` "
+                "rather than a raw vendor error. Every non-``deployed`` status is "
+                "reached before or without a successful mutation."
             ),
         },
         "vm_id": {

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -670,10 +670,10 @@ async def test_deploy_from_library_name_resolution_scoped_by_library(gate: _Gate
         ("POST", _FIND_ITEM_PATH),
         ("POST", "/api/vcenter/ovf/library-item/li-resolved?action=deploy"),
     ]
-    assert conn.calls[0]["body"] == {"spec": {"name": "lab-templates"}}
-    assert conn.calls[1]["body"] == {
-        "spec": {"name": "holorouter-ova", "type": "ovf", "library_id": "lib-7"}
-    }
+    # The find bodies are the FindSpec at the top level of the /api body (#3071),
+    # NOT the legacy /rest {"spec": {...}} envelope vCenter 8.x 400s.
+    assert conn.calls[0]["body"] == {"name": "lab-templates"}
+    assert conn.calls[1]["body"] == {"name": "holorouter-ova", "type": "ovf", "library_id": "lib-7"}
     # The finds are un-gated reads; only the deploy hit the policy seam.
     assert gate.gated_op_ids == [_DEPLOY_OVF_OP]
 
@@ -796,7 +796,13 @@ async def test_deploy_from_library_deploy_error_on_http_fault(gate: _GateRecorde
         request=httpx.Request(
             "POST", "https://vc/api/vcenter/ovf/library-item/li-ovf?action=deploy"
         ),
-        response=httpx.Response(404, json={"error_type": "NOT_FOUND"}),
+        response=httpx.Response(
+            404,
+            json={
+                "error_type": "NOT_FOUND",
+                "messages": [{"default_message": "resource pool resgroup-missing not found"}],
+            },
+        ),
     )
     conn = _RecordingConnector({"/api/vcenter/ovf/library-item/li-ovf?action=deploy": fault})
     out = await vm_deploy_from_library_composite(
@@ -809,8 +815,55 @@ async def test_deploy_from_library_deploy_error_on_http_fault(gate: _GateRecorde
     assert out["library_item_id"] == "li-ovf"
     assert len(out["issues"]) == 1
     assert out["issues"][0]["category"] == "placement"
+    # The structured message carries the HTTP status, the vAPI error_type, and
+    # the localized vendor message (#3071 diagnosability, #1649/#1804 pattern).
     assert "404" in out["issues"][0]["message"]
     assert "NOT_FOUND" in out["issues"][0]["message"]
+    assert "resource pool resgroup-missing not found" in out["issues"][0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_resolve_error_on_find_http_fault(gate: _GateRecorder) -> None:
+    """A 4xx on the content-library find → structured resolve_error, not a bare fault.
+
+    Regression guard for #3071: the name-resolution find call sits before the
+    deploy gate, so a fault there used to escape the composite uncaught and
+    surface as an opaque ``connector_error: HTTPStatusError`` with no status,
+    url, or vendor message. It is now folded into the ``resolve_error`` arm
+    carrying the vCenter HTTP status + error_type + localized message.
+    """
+    fault = httpx.HTTPStatusError(
+        "bad request",
+        request=httpx.Request("POST", "https://vc/api/content/library/item?action=find"),
+        response=httpx.Response(
+            400,
+            json={
+                "error_type": "INVALID_ARGUMENT",
+                "messages": [{"default_message": "Invalid input for method: Find"}],
+            },
+        ),
+    )
+    conn = _RecordingConnector({_FIND_ITEM_PATH: fault})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item_name": "holorouter-ova", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "resolve_error"
+    assert out["vm_id"] is None
+    assert out["library_item_id"] is None
+    assert out["candidates"] is None
+    assert len(out["issues"]) == 1
+    issue = out["issues"][0]
+    assert issue["category"] == "resolve"
+    assert issue["severity"] == "error"
+    assert "400" in issue["message"]
+    assert "INVALID_ARGUMENT" in issue["message"]
+    assert "Invalid input for method: Find" in issue["message"]
+    # The fault happened during un-gated resolution; nothing hit the policy seam.
+    assert gate.calls == []
+    assert [c["path"] for c in conn.calls] == [_FIND_ITEM_PATH]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -505,7 +505,8 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         # #2970: the pinned deploy operation is synchronous, so the
         # pending/timeout task-wait statuses are gone.
         "vmware.composite.vm.clone": {"completed"},
-        # #2909: OVF/OVA content-library deploy — resolution + deploy-report statuses.
+        # #2909: OVF/OVA content-library deploy — resolution + deploy-report
+        # statuses; #3071 adds resolve_error (a content-library find fault).
         "vmware.composite.vm.deploy_from_library": {
             "deployed",
             "deploy_failed",
@@ -515,6 +516,7 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
             "ambiguous_library",
             "item_not_found",
             "ambiguous_item",
+            "resolve_error",
         },
         # #2970: the revert is a polled vim *_Task -> a poll timeout is a
         # legible status.

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -561,14 +561,16 @@ bodies with no envelope — lives in
 everywhere. The path-only reconcile lanes assert *which* endpoints exist;
 this pair asserts *what shape* their bodies take.
 
-**Not-yet-swept (adjacent findings).** The same envelope still rides three
+**Not-yet-swept (adjacent findings).** The same envelope still rides two
 non-VM write bodies that the pinned spec likewise declares flat, left for a
 follow-up because each carries a wrinkle beyond the mechanical flatten:
-`vm.clone`'s library-item deploy (`DeploySpec`), the content-library `find`
-reads (`FindSpec`, a distinct `_post_json` helper, not `_write_sub_op`), and
-`cluster.patch`'s vLCM software apply (`ApplySpec` — an all-optional spec
-whose empty body raises the `json=body or None` "send `{}` vs no body"
-question). Separately, the create/memory bodies still use vSphere's
+`vm.clone`'s library-item deploy (`DeploySpec`) and `cluster.patch`'s vLCM
+software apply (`ApplySpec` — an all-optional spec whose empty body raises
+the `json=body or None` "send `{}` vs no body" question). The content-library
+`find` reads (`FindSpec`, a distinct `_post_json` helper on
+`vm.deploy_from_library`'s resolution path) were the third such body; #3071
+swept them to the flat `/api` shape (see the OVF/OVA deploy section).
+Separately, the create/memory bodies still use vSphere's
 documented mixed-case field names (`guest_OS`, `size_MiB`) while the pinned
 spec keys them lowercase (`guest_os`, `size_mib`); that field-casing gap is
 independent of the envelope and untouched here.
@@ -584,7 +586,7 @@ enum) are:
 | --- | --- |
 | `vm.create` | `created`, `rolled_back` |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
-| `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error` with a structured message, and the name-resolution refusals are pre-deploy — so a placement/mapping error is a structured status, never a raw vendor fault) |
+| `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item`, `resolve_error` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error`, and a faulted content-library `find` during name resolution → `resolve_error` (#3071), both with a structured message carrying the vCenter status — so a placement/mapping/resolution error is a structured status, never a raw vendor fault) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
 | `vm.migrate` | `migrated`, `no_recommendation` |
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
@@ -810,17 +812,24 @@ through the generic `_SUB_OPS_VM_DEPLOY_FROM_LIBRARY` sweep (not a
 `library_item_name` is resolved to an id via
 `POST:/content/library/item?action=find` (a *read* — returns a bare id
 array — issued un-gated through the `_find_content_library_ids` helper,
-which rides `_post_json` since find is POST-shaped), filtered to
-`type=ovf` so a colliding non-OVF item name never matches. An optional
-`library_name` first resolves to a library id via
+which rides `_post_json` since find is POST-shaped). The `FindSpec` is sent
+at the **top level** of the `/api` body (`{name, type, library_id}`), not
+the legacy `/rest` `{"spec": {...}}` envelope vCenter 8.x `400`s (#3071); the
+item find is filtered to `type=ovf` so a colliding non-OVF item name never
+matches. An optional `library_name` first resolves to a library id via
 `POST:/content/library?action=find` to scope the item lookup. Zero
 matches → `item_not_found` / `library_not_found`; more than one →
 `ambiguous_item` / `ambiguous_library` with the candidate ids — every
-refusal is **pre-deploy**, so the operator re-dispatches by explicit id.
+refusal is **pre-deploy**, so the operator re-dispatches by explicit id. A
+find call that itself faults (HTTP 4xx/5xx) is caught and mapped to
+`resolve_error` with the vCenter status + message, never a raw
+`connector_error: HTTPStatusError` (#3071).
 
-**Deploy.** The body is `{deployment_spec, target}` (two top-level params
-— not the single-`spec` wrapper the `find` reads and `CreateSpec` writes
-use). `target.resource_pool_id` is the one **required** placement
+**Deploy.** The body is `{deployment_spec, target}` — two top-level named
+params, the flat `/api` shape. This deploy op takes two parameters, so its
+body never carried the single-`spec` envelope the single-parameter `find` /
+`CreateSpec` bodies did before #2973/#3071 flattened them.
+`target.resource_pool_id` is the one **required** placement
 (`host_id` / `folder_id` refine it); `deployment_spec` carries
 `accept_all_eula` (defaults true), `name`, the OVF-network-key →
 portgroup-moid **map** `network_mappings` (a map in the pinned 9.0 spec,


### PR DESCRIPTION
## Summary

- `vmware.composite.vm.deploy_from_library` `400`'d on a vCenter 8.0.3 target for **every** OVF item, while a direct `govc library.deploy` with identical inputs succeeded. **Root cause:** the composite's content-library `?action=find` resolution calls (`_find_content_library_ids`) sent the legacy `/rest` `{"spec": FindSpec}` envelope, which the modern `/api` surface rejects with `400 INVALID_ARGUMENT` — the **same class as #2973**, whose PR (#3043) explicitly deferred these content-library `find` bodies as an adjacent finding. The `Content.Library[.Item].find` ops take a single `spec` parameter, so `/api` wants the `FindSpec` flat at the top level. Flattened it.
- The OVF **deploy** body itself (`{deployment_spec, target}`) is a **two-parameter** op and was already the correct flat `/api` shape — verified against the pinned `vcenter.yaml` by the #3043 body-reconcile lane (which already covers `POST:/vcenter/ovf/library-item/{…}?action=deploy`) and guarded by `test_deploy_from_library_deploy_body_shape`. No change needed there; the envelope bug was isolated to the name-resolution `find` step.
- **Swallowed HTTP status (secondary, same ticket).** The find fault escaped the composite **uncaught** (the resolution path had no `try/except`), surfacing as a bare `connector_error: HTTPStatusError` with no status, url, or vendor message (also absent from logs). It is now caught and mapped to a new structured **`resolve_error`** status carrying the vCenter HTTP status + `error_type` + localized `messages[].default_message`, mirroring the existing `deploy_error` arm and the #1627/#1649/#1804 dispatch-error pattern. A shared `_vsphere_fault_detail` helper now enriches **both** the resolve and deploy error arms with the vAPI message, so the next 4xx is diagnosable from the result envelope alone.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — only the pre-existing macOS-only `socket.MSG_ERRQUEUE` in untouched `net/icmp.py` (green on Linux CI); the 3 touched composite files are clean
- [x] `pytest -k vmware_rest_composites` — **304 passed, 15 skipped** (skips are shelf-gated reconcile lanes, unprovisioned locally)
- [x] **(a)** `test_deploy_from_library_name_resolution_scoped_by_library` now asserts the find bodies are the **flat `FindSpec`** (`{"name": …}` / `{"name": …, "type": "ovf", "library_id": …}`), not `{"spec": {…}}` — the #2973-style regression guard
- [x] **(b)** new `test_deploy_from_library_resolve_error_on_find_http_fault` — a find `400` yields `status='resolve_error'` with the HTTP status + `error_type` + message in `issues`, **not** a bare `HTTPStatusError`
- [x] `test_deploy_from_library_deploy_error_on_http_fault` extended to assert the vendor `default_message` now surfaces on the deploy arm too
- [x] `code-quality.py --diff` — 0 blockers (10 pre-existing file/function-size warnings)

## Out of scope (adjacent findings — recorded, not edited)

The other two envelope bodies #3043 deferred remain deferred (separate ops, not entangled with `deploy_from_library`):

- `vm_clone_from_template_composite`'s VMTX deploy still sends `{"spec": {"name": …}}` (the "`vm.clone` `DeploySpec`" finding).
- `cluster.patch`'s vLCM `ApplySpec` (empty-body `json=body or None` wrinkle).

## Docs

`docs/codebase/connectors-vmware-rest.md`: the #2973 "not-yet-swept" note drops the content-library `find` bodies (now swept), the item-resolution and deploy sections describe the flat `/api` `FindSpec` + the `resolve_error` mapping, and the status alphabet carries `resolve_error`.

Closes #3071
