### PR TITLE
fix(connectors): synchronous library-item deploy uses a long per-request timeout (#3076)

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -693,6 +693,7 @@ class HttpConnector(Connector):
         json: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> dict[str, Any]:
         """Non-retried request for a non-idempotent verb, returning parsed JSON.
 
@@ -715,6 +716,17 @@ class HttpConnector(Connector):
         win on a key clash). Retry on non-idempotent verbs is the caller's
         responsibility -- this seam deliberately stays outside the
         :meth:`_request_json` tenacity wrapper.
+
+        ``timeout`` overrides the pooled client's default timeout for this
+        one request only. It defaults to :data:`httpx.USE_CLIENT_DEFAULT`,
+        so every caller that omits it keeps the connector's 30s client
+        default byte-identically (httpx merges the sentinel to the client
+        timeout in ``build_request``). A caller passes an explicit
+        :class:`httpx.Timeout` only for a *synchronous* long-running POST
+        whose body transfer legitimately outlasts 30s -- the vCenter
+        library-item deploys, whose connection is held open for the whole
+        multi-GB disk copy (#3076). The global client default is left
+        untouched so ordinary reads/writes still fail fast on a dead target.
         """
         verb = verb.upper()
         if verb in _IDEMPOTENT_METHODS:
@@ -735,6 +747,7 @@ class HttpConnector(Connector):
             data=data,
             headers=headers,
             extensions=self._request_extensions(target),
+            timeout=timeout,
         )
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -477,12 +477,14 @@ class VcfAutomationConnector(HttpConnector):
         json: Mapping[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> dict[str, Any]:
         """Path-aware non-idempotent JSON request with per-plane 401 retry-once.
 
         Honours the *actual* non-idempotent verb (``POST``/``PUT``/``PATCH``/
-        ``DELETE``) and an optional form-encoded ``data=`` body, mirroring the
-        base :meth:`HttpConnector._post_json` contract (#1968) while keeping
+        ``DELETE``), an optional form-encoded ``data=`` body, and an optional
+        per-request ``timeout`` override, mirroring the base
+        :meth:`HttpConnector._post_json` contract (#1968, #3076) while keeping
         the per-plane 401 retry-once dance.
         """
         verb = verb.upper()
@@ -499,6 +501,7 @@ class VcfAutomationConnector(HttpConnector):
             json=json,
             data=data,
             extra_headers=extra_headers,
+            timeout=timeout,
         )
 
     async def _do_request_with_retry(
@@ -512,6 +515,7 @@ class VcfAutomationConnector(HttpConnector):
         json: Mapping[str, Any] | None,
         data: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> dict[str, Any]:
         """Shared per-plane 401 retry-once dance for _request_json + _post_json.
 
@@ -519,7 +523,9 @@ class VcfAutomationConnector(HttpConnector):
         plane's token, refresh headers, retry once. A second 401
         surfaces as :exc:`RuntimeError`. ``extra_headers`` (header-located
         op params) merge onto the plane auth headers; ``data`` carries a
-        form-encoded body.
+        form-encoded body. ``timeout`` overrides the pooled client's default
+        per-request timeout, defaulting to :data:`httpx.USE_CLIENT_DEFAULT`
+        so reads keep the client default unchanged (#3076).
         """
 
         # vhost routing is applied per-request (never baked into the pooled
@@ -540,6 +546,7 @@ class VcfAutomationConnector(HttpConnector):
                 data=data,
                 headers={**dict(headers), **vhost},
                 extensions=extensions,
+                timeout=timeout,
             )
 
         plane = plane_for_path(path)

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -193,6 +193,18 @@ _OP_DEPLOY_LIBRARY_VM = (
 # id strings and mutate nothing, so they run un-gated like the REST listing
 # reads.
 _OP_DEPLOY_OVF_LIBRARY_ITEM = "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy"
+# Per-request timeout for the two *synchronous* library-item deploys
+# (``_OP_DEPLOY_LIBRARY_VM`` / ``_OP_DEPLOY_OVF_LIBRARY_ITEM``). Both hold the
+# POST connection open for the entire multi-GB disk copy with no
+# ``vmw-task=true`` variant to poll (#2970), so a real appliance deploy runs
+# well past the connector's 30s client-default read timeout and used to fault
+# with a false ``deploy_error`` while vCenter finished the copy server-side
+# (#3076). This override grants only these two calls a generous read/write
+# ceiling (30 min); connect/pool stay at the fast client default so a dead
+# target still fails fast, and every *other* call on the connector keeps the
+# unchanged 30s default (raising the global client timeout would make ordinary
+# reads hang on a dead target).
+_LIBRARY_ITEM_DEPLOY_TIMEOUT = httpx.Timeout(connect=5.0, read=1800.0, write=1800.0, pool=5.0)
 _OP_FIND_LIBRARY = "POST:/content/library?action=find"
 _OP_FIND_LIBRARY_ITEM = "POST:/content/library/item?action=find"
 # Content-library item type discriminator for OVF/OVA templates — the find
@@ -706,6 +718,8 @@ async def _write_sub_op(
     operator: Operator,
     op_id: str,
     params: dict[str, Any],
+    *,
+    timeout: Any = httpx.USE_CLIENT_DEFAULT,
 ) -> tuple[OperationResult | None, Any]:
     """Gate then issue one *write* sub-call directly on the connector session.
 
@@ -724,6 +738,12 @@ async def _write_sub_op(
     JSON payload rides back as ``(None, payload)``. Transport failures raise
     :exc:`httpx.HTTPError` for the caller to catch (partial-failure legs) or
     let propagate (load-bearing legs).
+
+    ``timeout`` overrides the connector's default per-request timeout for
+    this one sub-op. It defaults to :data:`httpx.USE_CLIENT_DEFAULT`, so
+    every write sub-op keeps the connector's 30s client default unchanged;
+    only the two synchronous library-item deploys pass an explicit long
+    ceiling (:data:`_LIBRARY_ITEM_DEPLOY_TIMEOUT`, #3076).
     """
     gate = await enforce_subop_policy(
         operator=operator,
@@ -739,7 +759,7 @@ async def _write_sub_op(
     method, path, body = _split_sub_op(op_id, params)
     mounted = await connector.mount_op_path(target, path, operator)
     payload = await connector._post_json(
-        target, mounted, operator=operator, verb=method, json=body or None
+        target, mounted, operator=operator, verb=method, json=body or None, timeout=timeout
     )
     return None, payload
 
@@ -1137,6 +1157,8 @@ async def vm_clone_composite(
         operator,
         _OP_DEPLOY_LIBRARY_VM,
         {"templateLibraryItem": library_item, "spec": {"name": target_name}},
+        # Synchronous deploy — the POST is held open for the whole copy (#3076).
+        timeout=_LIBRARY_ITEM_DEPLOY_TIMEOUT,
     )
     if gate is not None:
         return gate
@@ -1482,7 +1504,7 @@ async def vm_deploy_from_library_composite(
                 _deploy_issue(
                     "resolve",
                     "error",
-                    f"content-library lookup faulted: {_vsphere_fault_detail(exc)}: {exc}",
+                    f"content-library lookup faulted: {_vsphere_fault_detail(exc)}",
                 )
             ],
         )
@@ -1495,7 +1517,13 @@ async def vm_deploy_from_library_composite(
     deploy_params = {"ovfLibraryItemId": item_id, **_build_ovf_deploy_body(params, eula_field)}
     try:
         gate, deploy_payload = await _write_sub_op(
-            connector, target, operator, _OP_DEPLOY_OVF_LIBRARY_ITEM, deploy_params
+            connector,
+            target,
+            operator,
+            _OP_DEPLOY_OVF_LIBRARY_ITEM,
+            deploy_params,
+            # Synchronous deploy — the POST is held open for the whole copy (#3076).
+            timeout=_LIBRARY_ITEM_DEPLOY_TIMEOUT,
         )
     except httpx.HTTPError as exc:
         return _deploy_failure(
@@ -1505,7 +1533,7 @@ async def vm_deploy_from_library_composite(
                 _deploy_issue(
                     "placement",
                     "error",
-                    f"OVF deploy call faulted: {_vsphere_fault_detail(exc)}: {exc}",
+                    f"OVF deploy call faulted: {_vsphere_fault_detail(exc)}",
                 )
             ],
         )
@@ -1904,12 +1932,20 @@ def _vsphere_fault_detail(exc: httpx.HTTPError) -> str:
     letting a bare :exc:`httpx.HTTPStatusError` escape as an opaque
     ``connector_error`` with no status, url, or vendor message (the regression
     #3071 fixes, sibling of #1649/#1804). A transport-level fault (connect /
-    read, no response) degrades to ``transport fault``. Body parsing is
+    read, no response) degrades to ``transport fault (<ExcType>)`` — the
+    exception *type* name is folded in because several transport faults
+    (notably :exc:`httpx.ReadTimeout`) stringify to the empty string, which
+    otherwise left the surfaced detail an empty ``transport fault:`` tail
+    (#3076); a non-empty ``str(exc)`` is appended after it. The helper owns
+    the whole rendered detail for both fault classes, so callers interpolate
+    it directly without a redundant ``: {exc}`` suffix. Body parsing is
     defensive — a non-JSON or unexpectedly-shaped body drops the missing parts,
     never raises.
     """
     if not isinstance(exc, httpx.HTTPStatusError):
-        return "transport fault"
+        base = f"transport fault ({type(exc).__name__})"
+        text = str(exc)
+        return f"{base}: {text}" if text else base
     detail = f"HTTP {exc.response.status_code}"
     try:
         body = exc.response.json()

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -423,6 +423,61 @@ async def test_post_json_extra_headers_merged() -> None:
 
 
 @pytest.mark.asyncio
+async def test_post_json_default_timeout_is_client_default() -> None:
+    """Omitting ``timeout`` keeps the pooled client's 30s default on the wire.
+
+    ``httpx.build_request`` folds ``USE_CLIENT_DEFAULT`` to the client's own
+    ``Timeout`` into ``request.extensions['timeout']``, so a caller that does
+    not pass ``timeout`` dispatches byte-identically to before the override
+    existed — the ``connect=5 / read=30 / write=30 / pool=5`` client default.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.post("/api/widget").respond(201, json={"id": 1})
+        await conn._post_json(target, "/api/widget", operator=_make_operator("t"), json={"n": 1})
+
+    req = route.calls[0].request
+    assert req.extensions["timeout"] == {"connect": 5.0, "read": 30.0, "write": 30.0, "pool": 5.0}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_timeout_override_reaches_wire_request() -> None:
+    """An explicit ``timeout`` overrides the client default for that one request.
+
+    Guards the #3076 seam: the synchronous library-item deploys pass a
+    generous read/write ceiling so a multi-GB appliance copy is not cut off
+    at the 30s client-default read timeout. The override rides
+    ``request.extensions['timeout']``; connect/pool stay fast so a dead
+    target still fails fast.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+    override = httpx.Timeout(connect=5.0, read=1800.0, write=1800.0, pool=5.0)
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.post("/api/widget").respond(201, json={"id": 1})
+        await conn._post_json(
+            target,
+            "/api/widget",
+            operator=_make_operator("t"),
+            json={"n": 1},
+            timeout=override,
+        )
+
+    req = route.calls[0].request
+    assert req.extensions["timeout"] == {
+        "connect": 5.0,
+        "read": 1800.0,
+        "write": 1800.0,
+        "pool": 5.0,
+    }
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("verb", ["GET", "HEAD", "OPTIONS", "get"])
 async def test_post_json_rejects_idempotent_verb(verb: str) -> None:
     """_post_json refuses idempotent verbs — they belong on the retried path."""

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -214,6 +214,7 @@ class _DepthRecordingConnector:
         json: Any = None,
         data: Any = None,
         extra_headers: Any = None,
+        timeout: Any = None,
     ) -> Any:
         self.depths.append(composite_depth_var.get())
         spec = self._spec(path)

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -146,7 +146,17 @@ class _RecordingConnector:
         operator: Operator,
         params: dict[str, Any] | None = None,
     ) -> Any:
-        self.calls.append({"method": "GET", "path": path, "query": params, "body": None})
+        # Reads have no per-request timeout override — they always ride the
+        # connector's fast client default, recorded here for call-uniformity.
+        self.calls.append(
+            {
+                "method": "GET",
+                "path": path,
+                "query": params,
+                "body": None,
+                "timeout": httpx.USE_CLIENT_DEFAULT,
+            }
+        )
         return self._serve(path)
 
     async def _post_json(
@@ -159,8 +169,11 @@ class _RecordingConnector:
         json: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> Any:
-        self.calls.append({"method": verb, "path": path, "query": None, "body": json})
+        self.calls.append(
+            {"method": verb, "path": path, "query": None, "body": json, "timeout": timeout}
+        )
         return self._serve(path)
 
     def _serve(self, path: str) -> Any:
@@ -501,6 +514,34 @@ async def test_vm_clone_happy_path_synchronous_deploy(gate: _GateRecorder) -> No
 
 
 @pytest.mark.asyncio
+async def test_vm_clone_deploy_issued_with_long_timeout(gate: _GateRecorder) -> None:
+    """The synchronous VMTX deploy rides the long per-request timeout (#3076).
+
+    The template deploy POST is held open for the whole copy, so it must
+    carry ``_LIBRARY_ITEM_DEPLOY_TIMEOUT``; the pre-flight source GET stays
+    on the connector's fast client default (``USE_CLIENT_DEFAULT``).
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-src": {"name": "src"},
+            "/api/vcenter/vm-template/library-items/li-7?action=deploy": "vm-clone-1",
+        }
+    )
+    out = await vm_clone_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"source_vm": "vm-src", "target_name": "vm-clone-1", "library_item": "li-7"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "completed"
+    source_get, deploy_post = conn.calls
+    assert source_get["method"] == "GET"
+    assert source_get["timeout"] is httpx.USE_CLIENT_DEFAULT
+    assert deploy_post["method"] == "POST"
+    assert deploy_post["timeout"] is _write._LIBRARY_ITEM_DEPLOY_TIMEOUT
+
+
+@pytest.mark.asyncio
 async def test_vm_clone_legacy_value_envelope_unwraps(gate: _GateRecorder) -> None:
     """A legacy ``{"value": ...}``-wrapped deploy response unwraps to the VM id."""
     conn = _RecordingConnector(
@@ -596,6 +637,66 @@ async def test_deploy_from_library_id_passthrough_deployed(gate: _GateRecorder) 
         ("POST", "/api/vcenter/ovf/library-item/li-ovf?action=deploy"),
     ]
     assert gate.gated_op_ids == [_DEPLOY_OVF_OP]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_deploy_issued_with_long_timeout(gate: _GateRecorder) -> None:
+    """A slow-but-successful OVF deploy returns ``deployed`` and rides the long timeout.
+
+    The synchronous OVF deploy POST is held open for the whole multi-GB copy,
+    so it must carry ``_LIBRARY_ITEM_DEPLOY_TIMEOUT`` rather than the 30s
+    client default that used to cut a real appliance deploy off at ~30s and
+    return a false ``deploy_error`` (#3076). The canned ``succeeded=true``
+    ``DeploymentResult`` stands in for the eventual success the long timeout
+    lets the composite wait for.
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=True, vm_id="vm-ovf-1"
+            ),
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deployed"
+    assert out["vm_id"] == "vm-ovf-1"
+    (deploy_post,) = conn.calls
+    assert deploy_post["method"] == "POST"
+    assert deploy_post["timeout"] is _write._LIBRARY_ITEM_DEPLOY_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_read_timeout_names_exception_type(gate: _GateRecorder) -> None:
+    """A client ``ReadTimeout`` on the deploy → ``deploy_error`` naming the exc type.
+
+    ``str(httpx.ReadTimeout())`` is empty, which used to leave the surfaced
+    detail an empty ``transport fault:`` tail. The fault detail now folds in
+    the exception *type* name so the operator sees ``transport fault
+    (ReadTimeout)`` (#3076). (This is the residual defect-2 guard; the long
+    timeout of defect-1 makes a real deploy no longer *hit* this path.)
+    """
+    conn = _RecordingConnector(
+        {"/api/vcenter/ovf/library-item/li-ovf?action=deploy": httpx.ReadTimeout("")}
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deploy_error"
+    assert out["library_item_id"] == "li-ovf"
+    assert len(out["issues"]) == 1
+    message = out["issues"][0]["message"]
+    assert "transport fault (ReadTimeout)" in message
+    # The empty-tail regression is gone — no dangling "transport fault: ".
+    assert "transport fault: " not in message
+    assert message == message.rstrip()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -255,6 +255,7 @@ class _RecordingVmwareConnector:
         json: Any = None,
         data: Any = None,
         extra_headers: Any = None,
+        timeout: Any = None,
     ) -> Any:
         spec = self._spec(path)
         self.calls.append((verb, spec))

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -151,6 +151,7 @@ class _RecordingConnector:
         json: Any = None,
         data: Any = None,
         extra_headers: Any = None,
+        timeout: Any = None,
     ) -> Any:
         self.writes.append({"verb": verb, "path": path, "body": json})
         return {"value": "vm-should-not-exist"}
@@ -622,6 +623,7 @@ class _DeployRecordingConnector:
         json: Any = None,
         data: Any = None,
         extra_headers: Any = None,
+        timeout: Any = None,
     ) -> Any:
         self.deploy_writes.append((path, json))
         return {"succeeded": True, "resource_id": {"type": "VirtualMachine", "id": "vm-ovf-1"}}

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -234,6 +234,7 @@ class _RecordingConnector:
         json: Any = None,
         data: Any = None,
         extra_headers: Any = None,
+        timeout: Any = None,
     ) -> Any:
         spec = self._spec(path)
         self.calls.append((verb, spec, None))

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -864,6 +864,31 @@ successful deploy; a power-on fault leaves `status='deployed'` with
 `powered_on=false` and a `power_on` warning issue (a deployed appliance
 is never rolled back over a power-on hiccup).
 
+**Synchronous-deploy long timeout (#3076).** Both library-item deploys —
+the OVF `POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy`
+and `vm.clone`'s VMTX
+`POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy`
+— are **synchronous** with no `vmw-task=true` variant to poll (#2970): the
+POST connection is held open for the entire multi-GB disk copy. The
+connector's pooled client bakes a 30s read/write default
+(`httpx.Timeout(read=30.0, write=30.0)` in `HttpConnector._http_client`),
+which any real appliance copy blows past — so the POST used to raise
+`httpx.ReadTimeout` at ~30s and surface a **false** `deploy_error`
+(`vm.clone`: a raw `connector_error`) while vCenter finished the copy
+server-side. The two deploy sub-ops now pass a per-request `timeout`
+override, `_LIBRARY_ITEM_DEPLOY_TIMEOUT`
+(`connect=5 / read=1800 / write=1800 / pool=5` — a 30-min read/write
+ceiling), threaded `composite → _write_sub_op → HttpConnector._post_json →
+client.request(timeout=)`. The override defaults to
+`httpx.USE_CLIENT_DEFAULT`, so **every other call keeps the unchanged 30s
+client default** — the global client timeout is deliberately *not* raised,
+so ordinary reads/gets still fail fast on a dead target; connect/pool stay
+fast on the deploy too, so only the body transfer gets the long window.
+When a deploy genuinely faults at the transport layer, the structured
+detail names the exception *type* — `transport fault (ReadTimeout)` — since
+`str(httpx.ReadTimeout())` is the empty string (the `_vsphere_fault_detail`
+helper, #3076).
+
 ### vim cluster / inventory writes (`cluster.drs_rule.create` + `folder.create`, #2895)
 
 Two more vim-only writes ride the #2893 substrate (Task E). Neither has a


### PR DESCRIPTION
## Summary

- The two **synchronous** vCenter library-item deploys — `vmware.composite.vm.deploy_from_library` (OVF `?action=deploy`) and `vmware.composite.vm.clone` (VMTX template `?action=deploy`) — hold the POST connection open for the entire multi-GB disk copy, with no `vmw-task=true` variant to poll (#2970). The connector's pooled client bakes a 30s read/write default (`HttpConnector._http_client`), so any real appliance deploy raised `httpx.ReadTimeout` at ~30s and surfaced a **false** `deploy_error` (`vm.clone`: a raw `connector_error`) while vCenter finished the copy server-side.
- **Fix 1 — per-request long timeout.** Thread an optional `timeout` override through `composite → _write_sub_op → HttpConnector._post_json → client.request(timeout=)`, defaulting to `httpx.USE_CLIENT_DEFAULT` so **every other call keeps the unchanged 30s client default**. The global client timeout is deliberately *not* raised (reads/gets must still fail fast on a dead target). The two deploy sub-ops pass `_LIBRARY_ITEM_DEPLOY_TIMEOUT` (`connect=5 / read=1800 / write=1800 / pool=5` — a 30-min read/write ceiling; connect/pool stay fast so a dead target still fails fast).
- **Fix 2 — actionable transport-fault detail.** `str(httpx.ReadTimeout())` is the empty string, which left the surfaced detail an empty `transport fault:` tail. `_vsphere_fault_detail` now folds in the exception *type* name (`transport fault (ReadTimeout)`) and owns the whole rendered detail, so the two call sites drop the now-redundant `: {exc}` suffix.
- Docs: `docs/codebase/connectors-vmware-rest.md` §Deploy documents the synchronous-deploy long-timeout behavior.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on `src/` + `tests/`
- [x] `mypy src/` — clean
- [x] **Adapter layer** (`tests/test_connectors_http_adapter.py`): a `timeout` override reaches the wire request's `extensions["timeout"]`; omitting it keeps the `connect=5 / read=30 / write=30 / pool=5` client default byte-identically.
- [x] **Both deploy arms** (`tests/test_connectors_vmware_rest_composites_write.py`): the OVF deploy and the VMTX clone deploy each issue their sub-op with `_LIBRARY_ITEM_DEPLOY_TIMEOUT`; the pre-flight source GET stays on the client default.
- [x] **Slow-but-successful deploy** returns `deployed` and rode the long timeout (canned `succeeded=true` `DeploymentResult`).
- [x] **`ReadTimeout` → `deploy_error`** whose detail names the exception type (`transport fault (ReadTimeout)`), with no empty tail.
- [x] Existing `#3071` HTTP-fault tests (status + error_type + vendor message) still pass; full vmware-rest / http-adapter / dispatcher sweep green.

## Out of scope

- An async submit-and-poll model for library-item deploys — the vendor REST deploy is synchronous with no task handle (#2970), so there is nothing to poll. This PR makes the synchronous path behave correctly for large deploys, as scoped by the issue.

Closes #3076
