### PR TITLE
fix(connectors): 204/empty-body write acks return {} instead of JSONDecodeError

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -227,6 +227,31 @@ def _retryable(exc: BaseException) -> bool:
     return False
 
 
+def json_payload_or_empty(resp: httpx.Response) -> dict[str, Any]:
+    """Parse *resp*'s JSON body, mapping ``204`` / empty bodies to ``{}``.
+
+    Shared success-path tail for :meth:`HttpConnector._request_json` and
+    :meth:`HttpConnector._post_json` (and the contract-parity
+    ``VcfAutomationConnector`` transport override). Several vendor write
+    endpoints acknowledge success with ``204 No Content`` and no body —
+    vCenter's ``POST /vcenter/vm/{vm}/power?action=<verb>``, the guest
+    ``/guest/power`` actions, ``DELETE /vcenter/vm/{vm}``, and the
+    session-revoke ``DELETE`` — where an unconditional ``resp.json()``
+    raised :exc:`json.JSONDecodeError` *after the write had already taken
+    effect at the vendor*, so a succeeded write surfaced as
+    ``connector_error`` and envelope-driven automation retried an
+    operation that had executed (#3082). A ``204`` — or any empty body —
+    now returns a benign ``{}``; callers already treat the payload as
+    optional shape. A non-empty body parses exactly as before, so
+    200-with-JSON behaviour is byte-identical (including the pass-through
+    of non-dict JSON payloads such as vCenter's bare session-token
+    string).
+    """
+    if resp.status_code == httpx.codes.NO_CONTENT or not resp.content:
+        return {}
+    return resp.json()  # type: ignore[no-any-return]
+
+
 # Hard cap on the same-origin redirect chain followed by
 # :class:`_SameOriginRedirectClient`. Vendor canonicalisation never chains
 # more than one trailing-slash hop in practice; the cap is a cheap guard
@@ -650,6 +675,10 @@ class HttpConnector(Connector):
         credentials under the operator's identity. ``extra_headers`` are
         merged onto the connector-supplied :meth:`auth_headers` (e.g.
         header-located op params; per-call values win on a key clash).
+
+        A ``204 No Content`` — or any empty-body — response returns ``{}``
+        instead of raising from the JSON parse (#3082); see
+        :func:`json_payload_or_empty`.
         """
         method = method.upper()
         if method not in _IDEMPOTENT_METHODS:
@@ -670,7 +699,7 @@ class HttpConnector(Connector):
             extensions=self._request_extensions(target),
         )
         resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return json_payload_or_empty(resp)
 
     async def _get_json(
         self,
@@ -727,6 +756,12 @@ class HttpConnector(Connector):
         library-item deploys, whose connection is held open for the whole
         multi-GB disk copy (#3076). The global client default is left
         untouched so ordinary reads/writes still fail fast on a dead target.
+
+        A ``204 No Content`` — or any empty-body — response returns ``{}``
+        instead of raising from the JSON parse (#3082): vCenter power
+        actions and VM deletes acknowledge success with no body, and a
+        parse failure here surfaced *after* the write took effect at the
+        vendor. See :func:`json_payload_or_empty`.
         """
         verb = verb.upper()
         if verb in _IDEMPOTENT_METHODS:
@@ -750,7 +785,7 @@ class HttpConnector(Connector):
             timeout=timeout,
         )
         resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return json_payload_or_empty(resp)
 
     async def aclose(self) -> None:
         """Close all pooled clients. Called by lifespan or per-target cleanup."""

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -106,7 +106,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
-from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.adapters.http import HttpConnector, json_payload_or_empty
 from meho_backplane.connectors.schemas import (
     AuthModel,
     FingerprintResult,
@@ -525,7 +525,10 @@ class VcfAutomationConnector(HttpConnector):
         op params) merge onto the plane auth headers; ``data`` carries a
         form-encoded body. ``timeout`` overrides the pooled client's default
         per-request timeout, defaulting to :data:`httpx.USE_CLIENT_DEFAULT`
-        so reads keep the client default unchanged (#3076).
+        so reads keep the client default unchanged (#3076). A ``204 No
+        Content`` / empty-body response maps to ``{}`` via
+        :func:`~meho_backplane.connectors.adapters.http.json_payload_or_empty`
+        — contract parity with the base transport helpers (#3082).
         """
 
         # vhost routing is applied per-request (never baked into the pooled
@@ -567,7 +570,7 @@ class VcfAutomationConnector(HttpConnector):
                     "HTTP 401 after refresh"
                 )
         resp.raise_for_status()
-        payload = resp.json()
+        payload = json_payload_or_empty(resp)
         if not isinstance(payload, dict):
             raise RuntimeError(
                 f"vcf-automation {method} {path} for target {target.name!r} "

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -527,6 +527,87 @@ async def test_request_json_extra_headers_merged() -> None:
 
 
 # ---------------------------------------------------------------------------
+# 204 / empty-body responses return {} instead of raising (#3082)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verb", ["POST", "DELETE"])
+async def test_post_json_204_no_content_returns_empty_payload(verb: str) -> None:
+    """A 204-No-Content write ack returns ``{}`` — no JSONDecodeError.
+
+    Regression for #3082: vCenter acknowledges
+    ``POST /vcenter/vm/{vm}/power?action=<verb>`` (and
+    ``DELETE /vcenter/vm/{vm}``) with 204 and no body; the unconditional
+    ``resp.json()`` raised *after* the write took effect at the vendor,
+    reporting a succeeded write as ``connector_error``.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.request(verb, "/api/vcenter/vm/vm-1/power").respond(204)
+        result = await conn._post_json(
+            target,
+            "/api/vcenter/vm/vm-1/power",
+            operator=_make_operator("tok"),
+            verb=verb,
+        )
+
+    assert result == {}
+    assert route.called
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_200_empty_body_returns_empty_payload() -> None:
+    """A 200 with a zero-byte body returns ``{}`` — same guard, different status (#3082)."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.post("/api/widget").respond(200)
+        result = await conn._post_json(
+            target, "/api/widget", operator=_make_operator("tok"), json={"n": 1}
+        )
+
+    assert result == {}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_200_with_json_body_unchanged_by_empty_guard() -> None:
+    """A 200 with a JSON body parses exactly as before the #3082 guard."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.post("/api/widget").respond(200, json={"value": "vm-42"})
+        result = await conn._post_json(
+            target, "/api/widget", operator=_make_operator("tok"), json={"n": 1}
+        )
+
+    assert result == {"value": "vm-42"}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_204_no_content_returns_empty_payload() -> None:
+    """The retried idempotent path shares the empty-body guard (#3082 symmetry)."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.get("/api/ack-only").respond(204)
+        result = await conn._request_json(
+            target, "GET", "/api/ack-only", operator=_make_operator("tok")
+        )
+
+    assert result == {}
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
 # Retry behaviour — 5xx
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -947,6 +947,34 @@ async def test_request_json_rejects_non_idempotent_method() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_post_json_204_no_content_returns_empty_payload() -> None:
+    """A 204-No-Content write ack returns ``{}`` through the transport override.
+
+    Contract parity with the base :meth:`HttpConnector._post_json` empty-body
+    guard (#3082): the override re-implements the JSON tail inside its 401
+    retry-once dance, so a bodyless vendor ack must map to ``{}`` here too —
+    not raise ``json.JSONDecodeError`` after the write took effect.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        delete = mock.delete("/cloudapi/1.0.0/orgs/urn:org:1").respond(204)
+        result = await connector._post_json(
+            _TARGET_A,
+            "/cloudapi/1.0.0/orgs/urn:org:1",
+            operator=_make_operator(),
+            verb="DELETE",
+        )
+
+    assert result == {}
+    assert delete.called
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # fingerprint() + probe()
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1501,6 +1501,45 @@ async def test_vm_power_gated_short_circuits(monkeypatch: pytest.MonkeyPatch) ->
     assert conn.calls == []
 
 
+@pytest.mark.asyncio
+async def test_vm_power_vendor_204_no_content_reports_ok_respx(gate: _GateRecorder) -> None:
+    """respx-verified: a 204-No-Content power ack maps to the ``ok`` envelope (#3082).
+
+    vCenter acknowledges ``POST /vcenter/vm/{vm}/power?action=<verb>`` with
+    204 and **no body**. Observed live: the VM powered on at the vendor while
+    the dispatch surfaced ``connector_error: JSONDecodeError`` — a false
+    error on a succeeded write that makes envelope-driven automation retry
+    an operation that already executed. Drives the real handler through a
+    real :class:`VmwareRestConnector` over an httpx (respx) transport so the
+    adapter's empty-body guard — not a recording double — is what maps the
+    bodyless vendor ack to success.
+    """
+    connector = VmwareRestConnector(session_loader=_stub_loader)
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url="https://vc-grow.test.invalid") as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            power = mock.post("/api/vcenter/vm/vm-1/power", params={"action": "start"}).respond(204)
+            out = await vm_power_composite(
+                operator=_make_operator(),
+                target=_StubTarget(),
+                params={"vm": "vm-1", "verb": "on"},
+                connector=connector,
+            )
+        assert out == {
+            "vm": "vm-1",
+            "verb": "on",
+            "status": "ok",
+            "error": None,
+            "error_type": None,
+            "guest_tools": None,
+        }
+        assert power.called
+        assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}/power?action=start"]
+    finally:
+        await connector.aclose()
+
+
 # ===========================================================================
 # host.evacuate -- recursive composite (dispatch_child kept for vm.migrate)
 # ===========================================================================

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -889,6 +889,30 @@ detail names the exception *type* — `transport fault (ReadTimeout)` — since
 `str(httpx.ReadTimeout())` is the empty string (the `_vsphere_fault_detail`
 helper, #3076).
 
+**204 / empty-body write acks (#3082).** Several vCenter write endpoints
+acknowledge success with **204 No Content** and no body — the power actions
+(`POST:/vcenter/vm/{vm}/power?action=<verb>`), the Tools-mediated guest
+power actions (`POST:/vcenter/vm/{vm}/guest/power?action=<verb>`),
+`DELETE:/vcenter/vm/{vm}` (the `vm.delete` write and the `vm.create`
+rollback), and the session-revoke `DELETE`. The shared transport helpers
+(`HttpConnector._post_json` / `_request_json`) used to end in an
+unconditional `resp.json()`, so a 204 raised `json.JSONDecodeError` —
+wrapped by the dispatcher as `connector_error` — **after the write had
+already taken effect at the vendor** (observed live:
+`vmware.composite.vm.power` powered the VM on, then reported
+`connector_error: JSONDecodeError`; a false error on a succeeded write
+makes envelope-driven automation retry an executed operation). The guard
+lives at the adapter (`json_payload_or_empty` in
+`connectors/adapters/http.py`): a `204` — or any empty body — returns a
+benign `{}`, which the composites' success arms already accept
+(`vm_power_composite` / `vm_power_bulk_composite` / the delete legs discard
+the payload and build their own envelopes); a non-empty body parses exactly
+as before, so 200-with-JSON payload flows (`create` vm-id unwrap, deploy
+payloads) are byte-identical. Every `_write_sub_op` call site inherits the
+guard because `vmware_rest` does not override the transport helpers; the
+`vcf_automation` connector *does* override them and applies the same guard
+for contract parity.
+
 ### vim cluster / inventory writes (`cluster.drs_rule.create` + `folder.create`, #2895)
 
 Two more vim-only writes ride the #2893 substrate (Task E). Neither has a


### PR DESCRIPTION
## Summary

- `HttpConnector._post_json` / `_request_json` ended in an unconditional `resp.json()`; vCenter's power actions (`POST /vcenter/vm/{vm}/power?action=<verb>`) acknowledge with **204 No Content**, so a live `vmware.composite.vm.power` dispatch powered the VM on at the vendor and *then* failed with `connector_error: JSONDecodeError` — a false error on a succeeded write that makes envelope-driven automation retry an operation that already executed.
- New `json_payload_or_empty` at the adapter: a `204` — or any empty body — returns a benign `{}` (the composites' success arms already accept it — `vm_power_composite` discards the sub-op payload and builds its own envelope); a non-empty body parses exactly as before, so 200-with-JSON flows (create vm-id unwrap, deploy payloads, the bare session-token string) are byte-identical.
- `VcfAutomationConnector` re-implements the JSON tail inside its 401 retry-once transport override; it applies the same guard for contract parity (the #3076/#3075 override-drift lesson — full-tree `mypy src/` run locally).
- Bonus defect closed: `_rollback_created_vm` swallows only `httpx.HTTPError` on its best-effort rollback DELETE, so the `JSONDecodeError` (a `ValueError`) previously escaped the swallow and masked the original create failure.

## 204-returning call-site audit (acceptance criterion 3)

| Vendor endpoint | Reached via | Before | After |
|---|---|---|---|
| `POST /vcenter/vm/{vm}/power?action=start/stop/reset` | `vm_power_composite`, `vm_power_bulk_composite`, power-on legs of create/deploy/clone → `_write_sub_op` → base `_post_json` | `JSONDecodeError` **after** the write took effect (observed live) | `{}` → composite `ok` envelope |
| `POST /vcenter/vm/{vm}/guest/power?action=shutdown/reboot` | `vm_power_composite` (guest verbs) → same seam | same defect | `{}` → `ok` / typed Tools handling unchanged |
| `DELETE /vcenter/vm/{vm}` | ingested `vm.delete` dispatch (base `_post_json`) and `_rollback_created_vm` | same defect; rollback leg additionally leaked the error past its best-effort swallow | `{}`; rollback swallow now moot |
| `DELETE /api/session` (revoke in `aclose`) | raw `client.request`, no JSON parse | never affected | unchanged |
| Keycloak admin writes (204 on PUT) | own `_write_admin` → `KeycloakWriteResult` (status/location, no JSON parse) | never affected | unchanged |
| VCF Automation / vCD 204-returning writes | `VcfAutomationConnector._do_request_with_retry` (own parse) | same defect class | guarded via shared helper (contract parity) |
| gcloud `_post_json_abs` | separate GCP-specific helper with its own parse; the GCP ops it serves (`getIamPolicy` etc.) always return JSON bodies | not affected in practice | out of scope — recorded as adjacent finding |

Every `vmware_rest` `_write_sub_op` / ingested-write call site inherits the guard because `VmwareRestConnector` does not override the transport helpers.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — full tree, strict; 0 errors from this diff (1 pre-existing darwin-only artifact in untouched `net/icmp.py`: `socket.MSG_ERRQUEUE` is Linux-only; CI's Linux lane is authoritative)
- [x] Acceptance 1 — 204/empty-body on a non-idempotent verb returns `{}`: `test_post_json_204_no_content_returns_empty_payload[POST|DELETE]`, `test_post_json_200_empty_body_returns_empty_payload`, `test_request_json_204_no_content_returns_empty_payload` (symmetry)
- [x] Acceptance 2 — `vmware.composite.vm.power` success envelope on vendor 204: `test_vm_power_vendor_204_no_content_reports_ok_respx` (real `VmwareRestConnector` over respx, mocked 204 — the adapter guard, not a recording double, maps the ack)
- [x] Acceptance 3 — call-site audit: table above
- [x] Acceptance 4 — 200-with-JSON byte-identical: `test_post_json_200_with_json_body_unchanged_by_empty_guard` + full existing suites
- [x] Override parity: `test_post_json_204_no_content_returns_empty_payload` (vcf_automation, through the 401-dance override)
- [x] Scoped sweeps (foreground): `test_connectors_http_adapter.py` + `test_connectors_vcf_automation_auth.py` — 139 passed; `test_connectors_vmware_rest_composites_write.py` — 111 passed; dispatcher/403/auth/credread/write_gate/write_e2e/write_preview/github sub-issues — 224 passed; full `test_connectors_*` sweep — 4508 passed, 2 env-only failures (net-diag raw DNS/ICMP, `OSError: [Errno 49]` macOS sandbox, unrelated to this diff)
- [x] `docs/codebase/connectors-vmware-rest.md` — new "204 / empty-body write acks (#3082)" subsection

## Out of scope

- gcloud `_post_json_abs` (separate GCP-specific contract, always-JSON responses) — adjacent finding only.
- The `# code-quality-allow: file-size` marker at the top of `adapters/http.py` predates this change and keeps its original justification.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3082
