### PR TITLE
fix(connectors): preserve installer poll scalars through JSONFlux reduction (#3084)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — installer poll scalars survive JSONFlux reduction (#3084 / #3085)
+
+- The vcf-installer submit/poll primitives lost their poll identity under
+  JSONFlux reduction: an over-threshold `validationChecks[]` /
+  `sddcSubTasks[]` replaced the **whole** vendor `Validation` / `SddcTask`
+  with the reduction bookkeeping, swallowing the top-level `id` /
+  `executionStatus` / `resultStatus` (proven live against a VCF Installer
+  9.0.2 appliance — the validation `id` had to be recovered out-of-band, so
+  the submit → poll loop was undrivable through MEHO alone). A new opt-in
+  `result_scalars` reduction hint (registered under `llm_instructions`,
+  threaded dispatcher → reducer like `pagination_hint` / `result_ordering`)
+  keeps the listed scalar siblings top-level on the reduced result; all four
+  installer primitives register it, check/sub-task rows keep the full handle
+  + drill-in contract, and ops without the hint are byte-identical to
+  before. Docs: `docs/architecture/jsonflux.md` § *Preserved scalar
+  siblings*.
+
 ### Added — VCF Installer 9.1 governed submit/poll bring-up primitives (Initiative #2907, task #3078)
 
 - Four typed primitives decompose the Installer bring-up surface into short

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -99,13 +99,53 @@ INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
 
 
 def _instructions(
-    *, when_to_use: str, output_shape: str, parameter_hints: dict[str, str]
+    *,
+    when_to_use: str,
+    output_shape: str,
+    parameter_hints: dict[str, str],
+    result_scalars: tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
-    return {
+    instructions: dict[str, Any] = {
         "when_to_use": when_to_use,
         "output_shape": output_shape,
         "parameter_hints": parameter_hints,
     }
+    if result_scalars is not None:
+        # #3084: the JSONFlux reduction hint — when the vendor object's
+        # set-shaped field (validationChecks[] / sddcSubTasks[]) rides the
+        # reduction, the listed scalar siblings survive on the inline
+        # summary so the submit → poll loop stays drivable through the
+        # governed surface (the reducer's ``_preserved_scalars`` contract).
+        instructions["result_scalars"] = {"keys": list(result_scalars)}
+    return instructions
+
+
+#: ``Validation`` scalars that must survive a ``validationChecks[]``
+#: reduction (#3084): ``id`` is the poll key for
+#: ``installer.sddc.validation.status``; ``executionStatus`` /
+#: ``resultStatus`` carry the lifecycle + verdict; ``description`` names the
+#: run. Field names pinned by the vendored ``vcf-installer-9.1`` OpenAPI
+#: (``components.schemas.Validation``).
+_VALIDATION_RESULT_SCALARS: tuple[str, ...] = (
+    "id",
+    "description",
+    "executionStatus",
+    "resultStatus",
+)
+
+#: ``SddcTask`` scalars that must survive an ``sddcSubTasks[]`` /
+#: ``milestones[]`` reduction (#3084): ``id`` is the poll key for
+#: ``installer.sddc.bringup.status``; ``status`` carries the lifecycle
+#: state; the rest identify the bring-up. Field names pinned by the
+#: vendored ``vcf-installer-9.1`` OpenAPI (``components.schemas.SddcTask``).
+_SDDC_TASK_RESULT_SCALARS: tuple[str, ...] = (
+    "id",
+    "name",
+    "status",
+    "deploymentType",
+    "vcfInstanceName",
+    "creationTimestamp",
+)
 
 
 def _sddc_spec_parameter_schema(posted_to: str) -> dict[str, Any]:
@@ -155,9 +195,12 @@ _SPEC_VALIDATE = InstallerTypedOp(
         output_shape=(
             "{id, executionStatus, resultStatus, validationChecks: [...]}. "
             "Keep the id and poll installer.sddc.validation.status until "
-            "executionStatus is terminal."
+            "executionStatus is terminal. When validationChecks reduces to "
+            "a JSONFlux handle, id / executionStatus / resultStatus stay "
+            "top-level on the result."
         ),
         parameter_hints={"spec": "The full SddcSpec object, POSTed verbatim."},
+        result_scalars=_VALIDATION_RESULT_SCALARS,
     ),
 )
 
@@ -198,9 +241,12 @@ _VALIDATION_STATUS = InstallerTypedOp(
         output_shape=(
             "{id, executionStatus, resultStatus, validationChecks: [...]}. "
             "Terminal when executionStatus leaves IN_PROGRESS; surface any "
-            "FAILED check."
+            "FAILED check. When validationChecks reduces to a JSONFlux "
+            "handle, id / executionStatus / resultStatus stay top-level on "
+            "the result."
         ),
         parameter_hints={"id": "The validation id from installer.sddc.spec.validate."},
+        result_scalars=_VALIDATION_RESULT_SCALARS,
     ),
 )
 
@@ -232,9 +278,12 @@ _BRINGUP_START = InstallerTypedOp(
         ),
         output_shape=(
             "{id, name, status, vcfInstanceName, ...} (SddcTask). Keep the id "
-            "and poll installer.sddc.bringup.status to terminal."
+            "and poll installer.sddc.bringup.status to terminal. When the "
+            "task's sub-task list reduces to a JSONFlux handle, id / status "
+            "stay top-level on the result."
         ),
         parameter_hints={"spec": "The full SddcSpec object, POSTed verbatim."},
+        result_scalars=_SDDC_TASK_RESULT_SCALARS,
     ),
 )
 
@@ -277,9 +326,11 @@ _BRINGUP_STATUS = InstallerTypedOp(
         output_shape=(
             "{id, name, status, vcfInstanceName, sddcSubTasks: [...], "
             "milestones: [...]}. Surface the top-level status and any failed "
-            "sub-task."
+            "sub-task. When the task's sub-task list reduces to a JSONFlux "
+            "handle, id / status stay top-level on the result."
         ),
         parameter_hints={"id": "The bring-up (SDDC) task id from the deploy."},
+        result_scalars=_SDDC_TASK_RESULT_SCALARS,
     ),
 )
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1642,6 +1642,34 @@ def _result_ordering_from_descriptor(descriptor: EndpointDescriptor) -> dict[str
     return None
 
 
+def _result_scalars_from_descriptor(descriptor: EndpointDescriptor) -> dict[str, Any] | None:
+    """Extract ``result_scalars`` from a descriptor's ``llm_instructions``.
+
+    #3084. Connectors whose op returns a dict carrying poll-relevant scalars
+    next to the collection that reduces (the VCF Installer's ``Validation``:
+    ``id`` / ``executionStatus`` / ``resultStatus`` beside
+    ``validationChecks[]``) attach ``{"keys": [...]}`` under
+    ``llm_instructions.result_scalars``; the reducer reads it via the
+    dispatcher-supplied context and copies the listed scalar values into the
+    inline summary so the reduction never swallows the id the caller must
+    feed to the next call. Mirrors :func:`_result_ordering_from_descriptor`
+    exactly -- a plain dict is returned (not a validated model) so this
+    layer stays free of a connectors-schema import; the reducer interprets
+    it.
+
+    ``None`` outcomes (op didn't register the hint, ``llm_instructions`` is
+    ``None``, or the slot's value is not a dict) all flow to the reducer as
+    "no hint" -- the summary keeps its reduction-bookkeeping-only shape.
+    """
+    instructions = descriptor.llm_instructions
+    if not isinstance(instructions, dict):
+        return None
+    raw = instructions.get("result_scalars")
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
 async def _reduce_or_error(
     *,
     op_id: str,
@@ -1716,6 +1744,16 @@ async def _reduce_or_error(
     result_ordering = _result_ordering_from_descriptor(descriptor)
     if result_ordering is not None:
         reducer_context["result_ordering"] = result_ordering
+    # #3084: forward the op's preserved-scalar hint (when the connector
+    # author registered one via ``llm_instructions``) so the reducer copies
+    # the listed scalar siblings (a validation/task id, execution status)
+    # into the inline summary instead of swallowing them with the rest of
+    # the dict envelope. ``None`` on ops without a hint -- the summary
+    # keeps its bookkeeping-only shape. Pulled here (vs. in the reducer)
+    # for the same decoupling reason as the two hints above.
+    result_scalars = _result_scalars_from_descriptor(descriptor)
+    if result_scalars is not None:
+        reducer_context["result_scalars"] = result_scalars
     try:
         return await _DEFAULT_REDUCER.reduce(
             raw,

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -192,6 +192,33 @@ _ORDERING_CONTEXT_KEY = "result_ordering"
 #: end is "more recent".
 _SAMPLE_TAIL = "tail"
 
+#: ``context`` key carrying the op's preserved-scalar hint (#3084). Mirrors
+#: the ``result_ordering`` threading: the connector author registers
+#: ``llm_instructions["result_scalars"] = {"keys": [...]}`` on an op whose
+#: dict payload carries poll-relevant scalars *next to* the reduced
+#: collection (VCF Installer's ``Validation``: ``id`` / ``executionStatus``
+#: / ``resultStatus`` beside ``validationChecks[]``); the dispatcher
+#: forwards the dict verbatim and :meth:`JsonFluxReducer._assemble` copies
+#: the listed keys' scalar values into the inline summary so the reduction
+#: never swallows the identity the caller needs for the next call (the
+#: submit → poll loop of #3084).
+_RESULT_SCALARS_CONTEXT_KEY = "result_scalars"
+
+#: Summary keys the reducer itself owns. A hinted scalar key colliding with
+#: one of these is skipped (with a warning) — the reduction bookkeeping is
+#: load-bearing for every consumer and must never be shadowed by a vendor
+#: field that happens to share a name.
+_RESERVED_SUMMARY_KEYS = frozenset(
+    {"row_count", "total", "sample_rows_returned", "sample_bytes", "source_key"}
+)
+
+#: JSON scalar types a ``result_scalars`` hint may preserve. ``bool`` is an
+#: ``int`` subclass, so listing ``int`` covers it; ``None`` is allowed
+#: separately. Anything else (nested dict, list) is skipped with a warning —
+#: the hint is named *scalars* because copying an unbounded vendor object
+#: into the inline summary would defeat the reduction it rides on.
+_SCALAR_VALUE_TYPES = (str, int, float)
+
 #: Positional row-ordinal column the tail-sample query assigns via
 #: ``row_number() OVER ()``. DuckDB does not guarantee the order of a bare
 #: ``SELECT``; numbering the registered (Arrow-backed, insertion-ordered)
@@ -357,7 +384,8 @@ class JsonFluxReducer:
 
         materialized = self._materialize(rows, context)
         spill_outcome = await self._spill(materialized, context)
-        return self._assemble(materialized, envelope_key, context, spill_outcome)
+        preserved_scalars = _preserved_scalars(payload, envelope_key, context)
+        return self._assemble(materialized, envelope_key, context, spill_outcome, preserved_scalars)
 
     def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
         """True when *rows* exceeds the row OR byte threshold.
@@ -508,6 +536,7 @@ class JsonFluxReducer:
         envelope_key: str | None,
         context: dict[str, Any] | None,
         spill_outcome: _SpillOutcome,
+        preserved_scalars: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], ResultHandle]:
         """Build the inline summary + the :class:`ResultHandle`.
 
@@ -515,6 +544,13 @@ class JsonFluxReducer:
         persisted -- the handle's drill-in branch flips to
         ``available=True`` pointing at ``result_query`` -- or the skip
         reason the unavailable branch surfaces verbatim (#1629).
+
+        ``preserved_scalars`` (#3084) carries the payload's hinted scalar
+        siblings (:func:`_preserved_scalars`); they seed the summary
+        *before* the reduction bookkeeping is written, so a hinted key can
+        never shadow ``row_count`` / ``total`` / ``sample_rows_returned``
+        / ``sample_bytes`` / ``source_key`` even if the helper's reserved
+        filter is bypassed.
 
         The inline sample is serialized **exactly once** (#134): it lives
         only on :attr:`ResultHandle.sample_rows` -- the audit hoist
@@ -554,13 +590,18 @@ class JsonFluxReducer:
         # ``handle.sample_rows`` (#134). ``sample_bytes`` records the
         # serialized size the reducer bounded the preview to, so an agent
         # reading the summary knows a preview exists and where to find it
-        # without re-measuring the handle.
-        summary: dict[str, Any] = {
-            "row_count": total_rows,
-            "total": total_rows,
-            "sample_rows_returned": len(sample_rows),
-            "sample_bytes": len(_serialize(sample_rows)) if sample_rows else 0,
-        }
+        # without re-measuring the handle. Hinted scalar siblings (#3084)
+        # seed the dict first; the reducer-owned bookkeeping keys are
+        # written after them and therefore always win.
+        summary: dict[str, Any] = dict(preserved_scalars or {})
+        summary.update(
+            {
+                "row_count": total_rows,
+                "total": total_rows,
+                "sample_rows_returned": len(sample_rows),
+                "sample_bytes": len(_serialize(sample_rows)) if sample_rows else 0,
+            }
+        )
         if envelope_key is not None:
             summary["source_key"] = envelope_key
         return summary, handle
@@ -755,6 +796,85 @@ def _sample_from_tail(context: dict[str, Any] | None) -> bool:
         )
         return False
     return raw.get("sample") == _SAMPLE_TAIL
+
+
+def _preserved_scalars(
+    payload: Any,
+    envelope_key: str | None,
+    context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Scalar siblings of the reduced collection the op asked to keep (#3084).
+
+    The connector author registers ``llm_instructions["result_scalars"] =
+    {"keys": [...]}`` on an op whose dict payload carries poll-relevant
+    scalars next to the collection that reduces — the VCF Installer's
+    ``Validation`` (``id`` / ``executionStatus`` / ``resultStatus`` beside
+    ``validationChecks[]``) and ``SddcTask`` (``id`` / ``status`` beside
+    ``sddcSubTasks[]``). Without the hint the reduction replaced the whole
+    payload with the bookkeeping summary, swallowing the validation ``id``
+    the caller must feed to the status poll — the submit → poll loop could
+    not be driven through the governed surface alone.
+
+    Per listed key, the value is copied when it exists on the dict payload
+    and is a JSON scalar (:data:`_SCALAR_VALUE_TYPES` or ``None``). Skipped
+    (never raised, matching the sibling hint paths' never-raise
+    discipline):
+
+    * a malformed hint (non-dict, or ``keys`` not a list of strings) —
+      logged once, whole hint ignored;
+    * a non-dict payload (a bare top-level list has no scalar siblings);
+    * the collection key itself (already represented as ``source_key``);
+    * a key absent from the payload (a poll-shape variance, not an error);
+    * a reserved reducer bookkeeping key (:data:`_RESERVED_SUMMARY_KEYS`)
+      — logged, the reduction contract must never be shadowed;
+    * a non-scalar value (nested dict / list) — logged, copying an
+      unbounded vendor object inline would defeat the reduction.
+    """
+    if not context:
+        return {}
+    raw = context.get(_RESULT_SCALARS_CONTEXT_KEY)
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        _log.warning(
+            "jsonflux_result_scalars_invalid_shape",
+            op_id=context.get("op_id"),
+            received_type=type(raw).__name__,
+        )
+        return {}
+    keys = raw.get("keys")
+    if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+        _log.warning(
+            "jsonflux_result_scalars_invalid_keys",
+            op_id=context.get("op_id"),
+            received_type=type(keys).__name__,
+        )
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+
+    preserved: dict[str, Any] = {}
+    for key in keys:
+        if key == envelope_key or key not in payload:
+            continue
+        if key in _RESERVED_SUMMARY_KEYS:
+            _log.warning(
+                "jsonflux_result_scalars_reserved_key_skipped",
+                op_id=context.get("op_id"),
+                key=key,
+            )
+            continue
+        value = payload[key]
+        if value is not None and not isinstance(value, _SCALAR_VALUE_TYPES):
+            _log.warning(
+                "jsonflux_result_scalars_non_scalar_skipped",
+                op_id=context.get("op_id"),
+                key=key,
+                received_type=type(value).__name__,
+            )
+            continue
+        preserved[key] = value
+    return preserved
 
 
 def _serialize(payload: Any) -> bytes:

--- a/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
+++ b/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""#3084 regression tests — installer poll scalars survive JSONFlux reduction.
+
+Proven live against a real VCF Installer 9.0.2 appliance: the first governed
+``installer.sddc.spec.validate`` returned a JSONFlux-reduced ``result`` that
+carried *only* the reduction bookkeeping (``row_count`` / ``total`` /
+``sample_rows_returned`` / ``sample_bytes`` / ``source_key``) — the vendor
+``Validation``'s top-level ``id`` / ``executionStatus`` / ``resultStatus``
+were swallowed by the reduction, so the validation ``id`` needed to drive
+``installer.sddc.validation.status`` had to be recovered out-of-band and the
+submit → poll loop was undrivable through MEHO alone.
+
+The fix is the opt-in ``result_scalars`` reduction hint (registered under
+``llm_instructions``, threaded dispatcher → reducer like ``result_ordering``
+/ ``pagination_hint``). These tests close the loop between the *registered*
+hint metadata (:data:`INSTALLER_TYPED_OPS`) and the reducer behavior against
+vendor-shaped payloads — the hint each test feeds the reducer is read off
+the op tuple, never re-typed, so a drift between registration and test is
+structurally impossible.
+
+Payload field names are pinned by the vendored ``vcf-installer-9.1`` OpenAPI
+(``components.schemas.Validation`` / ``components.schemas.SddcTask``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.vcf_installer.typed_ops import INSTALLER_TYPED_OPS
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+
+_OPS_BY_ID = {op.op_id: op for op in INSTALLER_TYPED_OPS}
+
+#: The vendor object each op returns, keyed by op_id — the two submit/poll
+#: pairs share their response shape, so the expected scalar keys pair up.
+_VALIDATION_OPS = ("installer.sddc.spec.validate", "installer.sddc.validation.status")
+_SDDC_TASK_OPS = ("installer.sddc.bringup.start", "installer.sddc.bringup.status")
+
+
+def _registered_scalars_context(op_id: str) -> dict[str, Any]:
+    """The reducer context a dispatch of *op_id* carries, from live metadata.
+
+    Reads ``llm_instructions["result_scalars"]`` off the registered op tuple
+    — exactly the dict ``dispatcher._result_scalars_from_descriptor`` lifts
+    from the persisted descriptor row at dispatch time.
+    """
+    instructions = _OPS_BY_ID[op_id].llm_instructions
+    assert instructions is not None, f"{op_id} must register llm_instructions"
+    hint = instructions.get("result_scalars")
+    assert isinstance(hint, dict), f"{op_id} must register a result_scalars hint (#3084)"
+    return {"op_id": op_id, "result_scalars": hint}
+
+
+def _validation(check_count: int) -> dict[str, Any]:
+    """A vendor ``Validation`` object with *check_count* checks."""
+    return {
+        "id": "6d1c8a4e-42d7-4f1b-9c58-0f8a2b3c4d5e",
+        "description": "SDDC specification validation",
+        "executionStatus": "IN_PROGRESS",
+        "resultStatus": "UNKNOWN",
+        "validationChecks": [
+            {"description": f"check-{i}", "resultStatus": "SUCCEEDED"} for i in range(check_count)
+        ],
+    }
+
+
+def _sddc_task(subtask_count: int, *, with_milestones: bool) -> dict[str, Any]:
+    """A vendor ``SddcTask`` with *subtask_count* sub-tasks.
+
+    ``with_milestones=False`` models the early bring-up shape (the 202
+    from ``POST /v1/sddcs`` and the first polls) where ``milestones`` is
+    not yet populated — the shape whose single real list field made the
+    pre-#3084 reduction swallow the task scalars.
+    """
+    task: dict[str, Any] = {
+        "id": "3f9e7d6c-5b4a-4938-8271-6a5b4c3d2e1f",
+        "name": "sddc-bringup-lab01",
+        "deploymentType": "INITIAL",
+        "vcfInstanceName": "lab01",
+        "status": "IN_PROGRESS",
+        "creationTimestamp": "2026-08-20T14:00:00.000Z",
+        "sddcSubTasks": [
+            {"name": f"subtask-{i}", "status": "PENDING"} for i in range(subtask_count)
+        ],
+    }
+    if with_milestones:
+        task["milestones"] = [{"name": f"milestone-{i}", "status": "PENDING"} for i in range(4)]
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Registration metadata — every primitive carries the right hint
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_primitives_register_the_result_scalars_hint() -> None:
+    """The hint is registered per response shape, poll key first.
+
+    ``id`` must be listed for every op — it is the poll key the live
+    defect swallowed — and the lifecycle/verdict scalars must match the
+    vendor object the op returns.
+    """
+    for op_id in _VALIDATION_OPS:
+        keys = _registered_scalars_context(op_id)["result_scalars"]["keys"]
+        assert keys == ["id", "description", "executionStatus", "resultStatus"], op_id
+    for op_id in _SDDC_TASK_OPS:
+        keys = _registered_scalars_context(op_id)["result_scalars"]["keys"]
+        assert keys == [
+            "id",
+            "name",
+            "status",
+            "deploymentType",
+            "vcfInstanceName",
+            "creationTimestamp",
+        ], op_id
+
+
+# ---------------------------------------------------------------------------
+# Validation — spec.validate / validation.status
+# ---------------------------------------------------------------------------
+
+
+async def test_validate_scalars_survive_when_checks_exceed_threshold() -> None:
+    """AC 1+2: over-threshold ``validationChecks`` reduce; the poll keys stay.
+
+    The exact live-defect shape: 60 checks clear the 50-row threshold, the
+    checks materialize into a handle with drill-in, and — with the
+    registered hint — ``id`` / ``executionStatus`` / ``resultStatus`` /
+    ``description`` are top-level result fields the caller can poll with.
+    """
+    reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=4096)
+    payload = _validation(60)
+
+    for op_id in _VALIDATION_OPS:
+        reduced, handle = await reducer.reduce(
+            dict(payload), None, _registered_scalars_context(op_id)
+        )
+
+        assert handle is not None, f"{op_id}: 60 checks must materialize a handle"
+        assert handle.total_rows == 60
+        assert handle.fetch_more is not None, f"{op_id}: drill-in envelope must ship"
+        assert reduced["id"] == payload["id"], f"{op_id}: the poll id must survive"
+        assert reduced["executionStatus"] == "IN_PROGRESS", op_id
+        assert reduced["resultStatus"] == "UNKNOWN", op_id
+        assert reduced["description"] == payload["description"], op_id
+        assert reduced["row_count"] == 60, op_id
+        assert reduced["source_key"] == "validationChecks", op_id
+        assert "validationChecks" not in reduced, f"{op_id}: checks must stay reduced"
+
+
+async def test_validate_small_check_set_passes_through_verbatim() -> None:
+    """AC 4 (the "exactly when" bound): under threshold nothing changes.
+
+    A 14-check validation (the live appliance's count) is under the 50-row
+    threshold and within the byte bound, so the whole ``Validation``
+    passes through verbatim — scalars trivially present, no handle. The
+    hint must not force a reduction that the thresholds don't."""
+    reducer = JsonFluxReducer()
+    payload = _validation(14)
+
+    reduced, handle = await reducer.reduce(
+        payload, None, _registered_scalars_context("installer.sddc.spec.validate")
+    )
+
+    assert handle is None, "an under-threshold validation must not materialize"
+    assert reduced is payload, "pass-through must return the exact vendor object"
+
+
+# ---------------------------------------------------------------------------
+# SddcTask — bringup.start / bringup.status
+# ---------------------------------------------------------------------------
+
+
+async def test_bringup_task_scalars_survive_single_list_reduction() -> None:
+    """AC 3: ``SddcTask.id`` / ``status`` survive an ``sddcSubTasks`` reduction.
+
+    The early bring-up shape — ``milestones`` not yet populated — has
+    exactly one real list field, so ``_detect_collection`` reduces
+    ``sddcSubTasks`` and (pre-#3084) swallowed the task scalars, including
+    the ``id`` the status poll needs. The registered hint pins them.
+    """
+    reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=4096)
+    payload = _sddc_task(60, with_milestones=False)
+
+    for op_id in _SDDC_TASK_OPS:
+        reduced, handle = await reducer.reduce(
+            dict(payload), None, _registered_scalars_context(op_id)
+        )
+
+        assert handle is not None, f"{op_id}: 60 sub-tasks must materialize a handle"
+        assert handle.total_rows == 60
+        assert reduced["id"] == payload["id"], f"{op_id}: the poll id must survive"
+        assert reduced["status"] == "IN_PROGRESS", op_id
+        assert reduced["name"] == payload["name"], op_id
+        assert reduced["vcfInstanceName"] == "lab01", op_id
+        assert reduced["source_key"] == "sddcSubTasks", op_id
+        assert "sddcSubTasks" not in reduced, f"{op_id}: sub-tasks must stay reduced"
+
+
+async def test_bringup_task_with_milestones_is_a_detail_object_passthrough() -> None:
+    """A two-list ``SddcTask`` rides the #2113 detail-object exemption.
+
+    When both ``sddcSubTasks`` and ``milestones`` are populated the payload
+    is a dict-of-arrays detail object — more than one real list field — so
+    it passes through verbatim (scalars trivially intact, both arrays
+    retrievable, no handle). Pinned so a future detection change that
+    starts reducing one of the two arrays cannot silently drop the other
+    or the task scalars.
+    """
+    reducer = JsonFluxReducer()
+    payload = _sddc_task(60, with_milestones=True)
+
+    reduced, handle = await reducer.reduce(
+        payload, None, _registered_scalars_context("installer.sddc.bringup.status")
+    )
+
+    assert handle is None, "a two-list SddcTask is a detail object, not a collection"
+    assert reduced is payload
+    assert reduced["id"] == payload["id"]
+    assert len(reduced["sddcSubTasks"]) == 60
+    assert len(reduced["milestones"]) == 4

--- a/backend/tests/test_connectors_vcf_installer_ops_register.py
+++ b/backend/tests/test_connectors_vcf_installer_ops_register.py
@@ -136,3 +136,27 @@ async def test_rows_resolve_their_bound_method_handlers(
     for op in INSTALLER_TYPED_OPS:
         row = rows[op.op_id]
         assert row.handler_ref and op.handler_attr in row.handler_ref, row.handler_ref
+
+
+@pytest.mark.asyncio
+async def test_rows_persist_the_result_scalars_reduction_hint(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Every persisted row carries the #3084 ``result_scalars`` hint with ``id``.
+
+    The dispatcher lifts ``llm_instructions["result_scalars"]`` off the
+    *persisted* descriptor row (``_result_scalars_from_descriptor``), so the
+    hint must survive the DB round-trip — otherwise a reduce of the vendor
+    ``Validation`` / ``SddcTask`` swallows the poll ``id`` again and the
+    submit → poll loop breaks exactly as observed live.
+    """
+    await register_installer_typed_operations(embedding_service=stub_embedding_service)
+    rows = await _fetch_installer_rows()
+    for op in INSTALLER_TYPED_OPS:
+        row = rows[op.op_id]
+        assert isinstance(row.llm_instructions, dict), op.op_id
+        hint = row.llm_instructions.get("result_scalars")
+        assert isinstance(hint, dict), f"{op.op_id} must persist a result_scalars hint"
+        assert op.llm_instructions is not None
+        assert hint == op.llm_instructions["result_scalars"], op.op_id
+        assert "id" in hint["keys"], f"{op.op_id}: the poll id must be a preserved scalar"

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -68,6 +68,7 @@ from meho_backplane.operations.jsonflux_reducer import (
     JsonFluxReducer,
     _detect_collection,
     _fit_sample_to_budget,
+    _preserved_scalars,
     _query_sample,
     _sample_from_tail,
     _serialize,
@@ -475,6 +476,166 @@ async def test_reduce_leaves_string_shaped_payload_untouched() -> None:
 
     assert handle is None, "string-shaped exec output must not materialize a handle"
     assert reduced is payload, "pass-through must return the exact input payload object"
+
+
+# ---------------------------------------------------------------------------
+# Preserved scalar siblings — the ``result_scalars`` hint (#3084)
+# ---------------------------------------------------------------------------
+
+
+def _validation_payload(check_count: int) -> dict[str, Any]:
+    """A VCF Installer ``Validation``-shaped payload (#3084's live shape).
+
+    Field names pinned by the vendored ``vcf-installer-9.1`` OpenAPI
+    (``components.schemas.Validation``): four scalar siblings next to the
+    set-shaped ``validationChecks[]`` the reducer materializes.
+    """
+    return {
+        "id": "b2f5c0de-9a11-4c37-8f7e-3d2f6c1a9e55",
+        "description": "SDDC specification validation",
+        "executionStatus": "COMPLETED",
+        "resultStatus": "SUCCEEDED",
+        "validationChecks": [
+            {"description": f"check-{i}", "resultStatus": "SUCCEEDED"} for i in range(check_count)
+        ],
+    }
+
+
+_VALIDATION_SCALARS_CONTEXT: dict[str, Any] = {
+    "op_id": "installer.sddc.spec.validate",
+    "result_scalars": {"keys": ["id", "description", "executionStatus", "resultStatus"]},
+}
+
+
+async def test_reduce_preserves_hinted_scalars_alongside_reduction() -> None:
+    """Hinted scalar siblings survive on the summary; the checks still reduce.
+
+    #3084 acceptance: the live defect was a governed ``spec.validate``
+    whose ``result`` carried *only* the reduction bookkeeping — the
+    validation ``id`` needed to drive ``installer.sddc.validation.status``
+    was swallowed, so the submit → poll loop was undrivable through MEHO
+    alone. With the hint, the poll-relevant scalars ride the summary while
+    the set-shaped ``validationChecks`` keeps the full reduction + handle
+    drill-in contract.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    payload = _validation_payload(60)
+
+    reduced, handle = await reducer.reduce(payload, None, dict(_VALIDATION_SCALARS_CONTEXT))
+
+    # The reduction itself is unchanged: handle minted, checks not inline.
+    assert handle is not None, "60 checks are over the 50-row threshold; expected a handle"
+    assert handle.total_rows == 60
+    assert "validationChecks" not in reduced
+
+    # The hinted scalars are top-level on the summary.
+    assert reduced["id"] == payload["id"]
+    assert reduced["description"] == payload["description"]
+    assert reduced["executionStatus"] == "COMPLETED"
+    assert reduced["resultStatus"] == "SUCCEEDED"
+
+    # The reducer-owned bookkeeping is intact next to them.
+    assert reduced["row_count"] == 60
+    assert reduced["total"] == 60
+    assert reduced["source_key"] == "validationChecks"
+    assert reduced["sample_rows_returned"] == len(handle.sample_rows or ())
+
+
+async def test_reduce_without_scalar_hint_keeps_bookkeeping_only_summary() -> None:
+    """No hint → the summary shape is exactly the pre-#3084 bookkeeping.
+
+    Backwards-compat guard: scalar preservation is opt-in per op. An op
+    that never declared ``result_scalars`` must not suddenly grow vendor
+    fields on its reduced summary.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    payload = _validation_payload(60)
+
+    reduced, handle = await reducer.reduce(payload, None, {"op_id": "installer.sddc.spec.validate"})
+
+    assert handle is not None
+    assert set(reduced) == {
+        "row_count",
+        "total",
+        "sample_rows_returned",
+        "sample_bytes",
+        "source_key",
+    }
+
+
+async def test_reduce_scalar_hint_skips_reserved_non_scalar_and_absent_keys() -> None:
+    """Reserved / non-scalar / absent / collection keys never reach the summary.
+
+    * ``total`` collides with reducer bookkeeping — the reduction contract
+      wins (the vendor value is dropped with a warning).
+    * ``additionalProperties`` is a nested object — copying it inline would
+      defeat the reduction the hint rides on.
+    * ``missing`` is absent from the payload — a poll-shape variance, not
+      an error.
+    * ``validationChecks`` is the collection itself — already represented
+      as ``source_key``.
+    * a ``None``-valued scalar is preserved as ``None`` (shape stability).
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    payload = _validation_payload(60)
+    payload["total"] = "vendor-total"
+    payload["additionalProperties"] = {"nested": "object"}
+    payload["resultStatus"] = None
+    context = {
+        "op_id": "installer.sddc.spec.validate",
+        "result_scalars": {
+            "keys": [
+                "id",
+                "resultStatus",
+                "total",
+                "additionalProperties",
+                "missing",
+                "validationChecks",
+            ]
+        },
+    }
+
+    reduced, handle = await reducer.reduce(payload, None, context)
+
+    assert handle is not None
+    assert reduced["id"] == payload["id"]
+    assert reduced["resultStatus"] is None
+    assert reduced["total"] == 60, "reducer bookkeeping must win over a colliding vendor field"
+    assert "additionalProperties" not in reduced
+    assert "missing" not in reduced
+    assert "validationChecks" not in reduced
+
+
+async def test_reduce_scalar_hint_malformed_is_ignored() -> None:
+    """A malformed hint never raises and never leaks keys — bookkeeping only.
+
+    Matches the never-raise discipline of the sibling ``pagination_hint`` /
+    ``result_ordering`` paths: a connector author shipping a broken hint
+    must not break the operator's read at runtime.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    bookkeeping_keys = {"row_count", "total", "sample_rows_returned", "sample_bytes", "source_key"}
+
+    for bad_hint in (
+        "id,executionStatus",  # non-dict hint
+        {"keys": "id"},  # keys not a list
+        {"keys": ["id", 42]},  # keys not all strings
+        {},  # no keys slot at all
+    ):
+        payload = _validation_payload(60)
+        context: dict[str, Any] = {"op_id": "x", "result_scalars": bad_hint}
+        reduced, handle = await reducer.reduce(payload, None, context)
+        assert handle is not None
+        assert set(reduced) == bookkeeping_keys, f"hint {bad_hint!r} must be ignored wholesale"
+
+
+def test_preserved_scalars_noop_on_bare_list_payload_and_absent_hint() -> None:
+    """A bare-list payload has no scalar siblings; no hint means no scalars."""
+    hint_context = {"result_scalars": {"keys": ["id"]}}
+
+    assert _preserved_scalars([{"id": "row"}] * 3, None, hint_context) == {}
+    assert _preserved_scalars({"id": "x", "rows": []}, "rows", None) == {}
+    assert _preserved_scalars({"id": "x", "rows": []}, "rows", {}) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1617,3 +1778,90 @@ async def test_reducing_dispatch_honours_result_ordering_tail_hint(
         "line-198",
         "line-199",
     ], "the dispatched tail-ordered op must surface the most-recent lines inline"
+
+
+async def _validation_shaped_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Module-level handler returning a 60-check ``Validation``-shaped object.
+
+    Mirrors ``installer.sddc.spec.validate``'s vendor response: four scalar
+    siblings next to the set-shaped ``validationChecks[]``, over the 50-row
+    materialization threshold so the dispatch path reduces it.
+    """
+    del target, params
+    return _validation_payload(60)
+
+
+@pytest.fixture
+async def _registered_scalar_hinted_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Register a typed op carrying ``llm_instructions.result_scalars``.
+
+    Exercises the dispatcher → reducer scalar wiring end to end: the
+    descriptor's ``llm_instructions`` slot is what
+    ``_result_scalars_from_descriptor`` lifts into the reducer context.
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="installer.validate.like",
+        handler=_validation_shaped_handler,
+        summary="Submit a validation.",
+        description="Submit a validation.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        llm_instructions={
+            "result_scalars": {"keys": ["id", "description", "executionStatus", "resultStatus"]}
+        },
+        embedding_service=stub_embedding_service,
+    )
+    yield
+
+
+async def test_reducing_dispatch_preserves_registered_result_scalars(
+    _registered_scalar_hinted_op: None,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A scalar-hinted op dispatched end-to-end keeps its poll keys top-level.
+
+    #3084. The descriptor's ``llm_instructions["result_scalars"]`` is
+    lifted by ``dispatcher._result_scalars_from_descriptor`` into
+    ``reducer_context["result_scalars"]``; ``JsonFluxReducer`` then copies
+    the listed scalar siblings onto the inline summary. This proves the
+    whole wire — the exact live defect was a governed ``spec.validate``
+    returning a summary without the validation ``id``, so the submit →
+    poll loop could not be driven through the governed surface alone.
+    """
+    set_default_reducer(JsonFluxReducer(sample_size=5))
+    try:
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id="vault-1.x",
+            op_id="installer.validate.like",
+            target=_FakeTarget(),
+            params={},
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result.status == "ok", (
+        f"expected ok; got status={result.status!r} error={result.error!r}"
+    )
+    assert result.handle is not None, "a 60-check response must materialize a handle"
+    assert result.handle.total_rows == 60
+
+    assert isinstance(result.result, dict)
+    expected = _validation_payload(60)
+    assert result.result["id"] == expected["id"]
+    assert result.result["description"] == expected["description"]
+    assert result.result["executionStatus"] == "COMPLETED"
+    assert result.result["resultStatus"] == "SUCCEEDED"
+    # The reduction contract is intact next to the preserved scalars.
+    assert result.result["row_count"] == 60
+    assert result.result["source_key"] == "validationChecks"
+    assert "validationChecks" not in result.result

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -476,6 +476,60 @@ non-dict value is logged once (actionable for the connector author) and
 treated as "no tail ordering" rather than raised, matching the
 never-raise discipline the pagination-hint path follows.
 
+### Preserved scalar siblings — `result_scalars` (#3084)
+
+The reduced summary replaces the **whole** payload. For a bare list that
+is lossless, but many vendor objects carry poll-relevant scalars *next
+to* the collection that reduces — the VCF Installer's `Validation` is
+`{id, description, executionStatus, resultStatus, validationChecks: […]}`,
+and its `SddcTask` is `{id, name, status, …, sddcSubTasks: […]}`. Before
+#3084 an over-threshold `validationChecks` reduction swallowed the
+top-level scalars, so a governed `installer.sddc.spec.validate` returned
+a summary without the validation `id` — the submit → poll loop could not
+be driven through the governed surface alone (observed live against a
+VCF Installer 9.0.2 appliance).
+
+Connectors whose op returns such a shape declare a `result_scalars`
+hint under `llm_instructions`:
+
+```python
+register_typed_operation(
+    op_id="installer.sddc.spec.validate",
+    ...,
+    llm_instructions={
+        "result_scalars": {
+            "keys": ["id", "description", "executionStatus", "resultStatus"],
+        },
+        # ...other llm_instructions slots...
+    },
+)
+```
+
+`dispatcher._result_scalars_from_descriptor(descriptor)` lifts the raw
+dict from `descriptor.llm_instructions["result_scalars"]` and threads it
+through `reducer_context["result_scalars"]` — the exact sibling of the
+`pagination_hint` / `result_ordering` paths. The reducer's
+`_preserved_scalars` copies each listed key's value from the dict payload
+onto the inline summary *before* the reduction bookkeeping is written, so
+the reduced result reads
+`{id, executionStatus, …, row_count, total, sample_rows_returned,
+sample_bytes, source_key}` — identity first, bookkeeping after. The
+collection itself still reduces with the full handle + drill-in contract.
+
+Skips (never raises, matching the sibling hints' discipline): a malformed
+hint (non-dict, or `keys` not a list of strings) is logged and ignored
+wholesale; a non-dict payload has no scalar siblings; the collection key
+itself is skipped (already represented as `source_key`); a key absent
+from the payload is skipped silently; a reserved bookkeeping key
+(`row_count` / `total` / `sample_rows_returned` / `sample_bytes` /
+`source_key`) is skipped with a warning — the reduction contract can
+never be shadowed by a vendor field; and a non-scalar value (nested
+dict / list) is skipped with a warning — copying an unbounded vendor
+object inline would defeat the reduction the hint rides on. `None`
+values are preserved (shape stability across poll states). The hint is
+purely additive: an op without it keeps the bookkeeping-only summary,
+byte-identical to the pre-#3084 shape.
+
 For the wire shape of `fetch_more` on a serialized `ResultHandle`,
 see [`operations-substrate.md` § `ResultHandle` shape](operations-substrate.md#resulthandle-shape-future-facing).
 

--- a/docs/codebase/connectors-vcf-installer.md
+++ b/docs/codebase/connectors-vcf-installer.md
@@ -112,6 +112,24 @@ echo (registered for both op_ids in `bringup.py`) — never a password.
 POSTs too, since a `401` is rejected at auth before the server processes the
 request).
 
+**Poll scalars survive JSONFlux reduction
+([#3084](https://github.com/evoila/meho/issues/3084)).** All four
+primitives register the `result_scalars` reduction hint (see
+`docs/architecture/jsonflux.md` § *Preserved scalar siblings*): when an
+over-threshold `validationChecks[]` / `sddcSubTasks[]` rides the JSONFlux
+reduction, the vendor object's top-level scalars stay on the reduced
+result — `Validation`'s `id` / `description` / `executionStatus` /
+`resultStatus`, `SddcTask`'s `id` / `name` / `status` / `deploymentType` /
+`vcfInstanceName` / `creationTimestamp` — so the submit → poll loop is
+drivable from the governed response alone (the pre-#3084 reduction
+replaced the whole object with reduction bookkeeping and swallowed the
+poll `id`, observed live against a VCF Installer 9.0.2 appliance). The
+check/sub-task rows keep the full handle + drill-in contract; an
+under-threshold response passes through verbatim as before. An `SddcTask`
+carrying **both** `sddcSubTasks[]` and `milestones[]` is a dict-of-arrays
+detail object (#2113) and passes through whole. Regression-pinned by
+`backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py`.
+
 **When to use which surface.** The primitives are the deploy-automation
 add-on's durable-workflow surface: validate first (no approval), surface the
 verdict to a human, then request approval for a bare submit whose

--- a/docs/codebase/result-spill.md
+++ b/docs/codebase/result-spill.md
@@ -12,8 +12,10 @@ provenance, reduction thresholds, sample ordering); this doc covers the
 When `JsonFluxReducer.reduce()` materializes a set-shaped payload above
 threshold (>50 rows or >4 KB by default), the caller gets back:
 
-- an inline summary `{row_count, total, sample, source_key?}` (the
-  `sample` is bounded at 5 rows by default), and
+- an inline summary `{row_count, total, sample_rows_returned,
+  sample_bytes, source_key?}` (the bounded preview itself lives once on
+  `handle.sample_rows`, #134; ops registering a `result_scalars` hint
+  additionally keep the listed payload scalars top-level, #3084), and
 - a `ResultHandle` on `OperationResult.handle` carrying `summary_md`,
   `schema_`, `total_rows`, `sample_rows`, and the self-documenting
   `fetch_more` envelope.


### PR DESCRIPTION
## Summary
- **Bug (proven live, VCF Installer 9.0.2):** `installer.sddc.spec.validate` / `installer.sddc.validation.status` return the vendor `Validation`; its set-shaped `validationChecks` correctly rides the JSONFlux reduction — but the reduction **replaced the whole result** with the bookkeeping summary (`{row_count, total, sample_rows_returned, sample_bytes, source_key}`), swallowing the top-level `id` / `executionStatus` / `resultStatus` / `description`. The caller never got the validation `id` needed to poll, so the submit→poll loop was undrivable through MEHO alone.
- **Fix:** a new opt-in `result_scalars` reduction hint — registered under `llm_instructions`, threaded dispatcher → reducer exactly like the existing `pagination_hint` / `result_ordering` hints (`_result_scalars_from_descriptor` → `reducer_context["result_scalars"]` → `_preserved_scalars`). The reducer copies the listed keys' **scalar** values onto the inline summary *before* the reduction bookkeeping is written, so a hinted vendor field can never shadow the reducer-owned keys. Malformed hints / non-scalar values / reserved keys / absent keys / the collection key are skipped (logged where actionable), never raised — matching the sibling hints' discipline. Ops without the hint keep the byte-identical pre-existing summary shape.
- **Registrations:** all four installer primitives carry the hint — `Validation` ops preserve `id`/`description`/`executionStatus`/`resultStatus`; `SddcTask` ops preserve `id`/`name`/`status`/`deploymentType`/`vcfInstanceName`/`creationTimestamp` (field names pinned by the vendored `vcf-installer-9.1` OpenAPI).
- **Bringup audit (per AC):** two `SddcTask` detection shapes pinned — `milestones` absent (single real list → reduces; scalars now survive via the hint) and both lists present (dict-of-arrays detail object, #2113 → passes through whole, scalars trivially intact).

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (1566 files)
- [x] `mypy src/` — clean on all touched files; the only tree error is the pre-existing darwin-only `socket.MSG_ERRQUEUE` in `net/icmp.py` (Linux-only constant; present on origin/main; CI runs Linux)
- [x] `pytest` scoped — 48 passed (new + touched files); 108 passed / 1 skipped (entangled installer + dispatcher suites); 783 passed / 9 skipped on the broad `jsonflux|reducer|dispatch|vcf_installer|result_handle|result_query` slice
- [x] Spec-reconcile lane green with the real shelf wired (`MEHO_CONSUMER_DOCS_ROOT`)
- [x] `code-quality.py --diff` — 0 blockers
- [x] AC1: governed `spec.validate` result carries `id` + `executionStatus`/`resultStatus` top-level while checks stay reduced with drill-in — `test_validate_scalars_survive_when_checks_exceed_threshold`, `test_reducing_dispatch_preserves_registered_result_scalars` (full descriptor→context wire)
- [x] AC2: `validation.status` likewise — same tests iterate both Validation ops with the hint read off `INSTALLER_TYPED_OPS` (registration and assertion cannot drift)
- [x] AC3: `bringup.start`/`bringup.status` audited; `SddcTask.id`/`status` pinned top-level — `test_bringup_task_scalars_survive_single_list_reduction`, `test_bringup_task_with_milestones_is_a_detail_object_passthrough`
- [x] AC4: scalars present exactly when rows exceed the threshold — over-threshold preserved + under-threshold verbatim passthrough pinned (`test_validate_small_check_set_passes_through_verbatim`); no-hint summary shape pinned byte-identical (`test_reduce_without_scalar_hint_keeps_bookkeeping_only_summary`)

## Docs
- `docs/architecture/jsonflux.md` — new *Preserved scalar siblings — `result_scalars` (#3084)* section (sibling of the `result_ordering` section)
- `docs/codebase/connectors-vcf-installer.md` — reduced-envelope scalar contract for the four primitives
- `docs/codebase/result-spill.md` — corrected the stale summary-shape bullet (pre-#134 `sample` key) while touching it

## Out of scope
- `installer.composite.sddc.bringup` returns curated envelopes with no top-level list — unaffected, not hinted.
- A fleet-wide *default* scalar-preservation (no hint) was considered and rejected here: it would change the reduced-envelope shape of every dict-envelope op (vCenter `value`, NSX `results` + cursors, SDDC `elements`) in one PR. The opt-in hint is additive; a follow-up could audit-and-flip the default if wanted.
- Pre-existing `docs/codebase/result-spill.md` triage-section wording still says "sample" in two historical-diagnosis spots (quoting the old envelope verbatim) — left as-is, they describe the pre-#134 observation.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3084
