### PR TITLE
feat(connectors): verify+document governed ISO path — library import-from-URL + iso.image mount (#3086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — governed content-library ISO import-from-URL + iso.image mount recipe (#3086)
+
+- Verified + documented the fully-governed path for pulling a bootable ISO
+  from an HTTP depot into a vCenter content library and mounting it on a VM,
+  entirely on **raw ingested** `vmware-rest` ops (no composite): item create →
+  update session → `PULL` file add (`source_endpoint.uri`) → complete → poll,
+  then `POST:/vcenter/iso/image?action=mount` / `?action=unmount`. The generic
+  dispatcher is envelope-clean for every step (the caller's `body` param rides
+  the wire verbatim — no `/rest`-style `{"spec": …}` wrapper, cf. #2973/#3071),
+  bare-string acks wrap as `{"value": …}` and 204 acks return `{}`. New
+  always-on respx full-dispatch pins + a shelf-gated reconcile lane ground the
+  recipe's op list, body shapes, and required fields against the pinned
+  `vcenter-9.0/vcenter.yaml`. Recipe + explicit gap statement (PUSH upload
+  cannot ride the generic dispatcher; caller owns the poll loop):
+  `docs/codebase/vmware-rest-governed-iso-path.md`.
+
 ### Fixed — installer poll scalars survive JSONFlux reduction (#3084 / #3085)
 
 - The vcf-installer submit/poll primitives lost their poll identity under

--- a/backend/tests/_governed_iso_recipe.py
+++ b/backend/tests/_governed_iso_recipe.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Canonical op table for the governed content-library ISO path (#3086).
+
+Single source of truth for the raw ingested vcenter ops the governed
+ISO recipe (``docs/codebase/vmware-rest-governed-iso-path.md``) names:
+the content-library **import-from-URL** flow (create item → create
+update session → add a ``PULL`` file sourced from an HTTP endpoint →
+complete → poll) and the **iso.image mount/unmount** pair. Two test
+lanes consume this table so the recipe's op list can never fork:
+
+* ``test_connectors_vmware_rest_governed_iso_dispatch.py`` — always-on
+  respx full-dispatch tests seeding these descriptors and asserting the
+  literal wire request (flat ``/api`` body, no ``/rest``-style
+  ``{"spec": ...}`` envelope — the #2973/#3071 bug class) and the
+  result envelope (scalar → ``{"value": ...}``, 204 → ``{}``).
+* ``test_connectors_vmware_rest_governed_iso_reconcile.py`` —
+  shelf-gated reconcile lane grounding every op_id and request-body
+  shape against the pinned ``vcenter-9.0/vcenter.yaml`` (the #2980
+  harness contract).
+
+``parameter_schema`` mirrors the shape the G0.7 ingest parser emits for
+each op (a single ``body`` container param tagged
+``x-meho-param-loc: "body"``, path vars tagged ``"path"``, query params
+tagged ``"query"``) — deliberately *minimal* (only the fields the
+recipe exercises) so the unit lane stays spec-shelf-free; the reconcile
+lane is what grounds the full shapes against the pinned spec.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["RECIPE_OPS", "RecipeOp"]
+
+
+@dataclass(frozen=True)
+class RecipeOp:
+    """One raw ingested op the governed ISO recipe names."""
+
+    op_id: str
+    stage: str
+    safety_level: str
+    #: Seed shape for the unit-lane descriptor row (parser-emitted form).
+    parameter_schema: dict[str, Any] = field(default_factory=dict)
+    #: Reconcile contract: body property names the pinned spec must serve
+    #: at the TOP level of the requestBody (flat ``/api`` shape). ``None``
+    #: for bodyless ops; exact-match when ``body_props_exact`` is True,
+    #: subset otherwise (the *Model bodies carry server-populated fields
+    #: the recipe never sends).
+    body_props: frozenset[str] | None = None
+    body_props_exact: bool = False
+    #: Reconcile contract: body properties the pinned spec marks required.
+    body_required: frozenset[str] | None = None
+
+
+def _schema(
+    *,
+    body: dict[str, Any] | None = None,
+    body_required: list[str] | None = None,
+    path_vars: list[str] | None = None,
+    query: list[str] | None = None,
+    required: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a parser-shaped parameter_schema for a descriptor seed."""
+    props: dict[str, Any] = {}
+    if body is not None:
+        body_schema: dict[str, Any] = {
+            "type": "object",
+            "x-meho-param-loc": "body",
+            "properties": body,
+        }
+        if body_required:
+            body_schema["required"] = body_required
+        props["body"] = body_schema
+    for name in path_vars or []:
+        props[name] = {"type": "string", "x-meho-param-loc": "path"}
+    for name in query or []:
+        props[name] = {"type": "string", "x-meho-param-loc": "query"}
+    schema: dict[str, Any] = {"type": "object", "properties": props}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+_STR = {"type": "string"}
+
+#: The recipe's ops, keyed by op_id, in recipe order. op_id strings are
+#: byte-for-byte the ``METHOD:/path`` values the ingest parser emits from
+#: the pinned ``vcenter.yaml`` (action-discriminated endpoints keep the
+#: ``?action=<verb>`` suffix in the path key itself; the required-query
+#: marker form ``?library_id`` likewise rides the path key).
+RECIPE_OPS: dict[str, RecipeOp] = {
+    op.op_id: op
+    for op in (
+        RecipeOp(
+            op_id="GET:/content/library",
+            stage="discover: list library ids",
+            safety_level="safe",
+            parameter_schema=_schema(),
+        ),
+        RecipeOp(
+            op_id="GET:/content/library/item?library_id",
+            stage="discover: list item ids in a library",
+            safety_level="safe",
+            parameter_schema=_schema(query=["library_id"], required=["library_id"]),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item",
+            stage="import 1: create the library item",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={"library_id": _STR, "name": _STR, "type": _STR, "description": _STR},
+                required=["body"],
+            ),
+            body_props=frozenset({"library_id", "name", "type", "description"}),
+            body_required=frozenset(),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item/update-session",
+            stage="import 2: create the update session",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={"library_item_id": _STR},
+                required=["body"],
+            ),
+            body_props=frozenset({"library_item_id"}),
+            body_required=frozenset(),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item/update-session/{updateSessionId}/file",
+            stage="import 3: add the PULL file (HTTP source)",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={
+                    "name": _STR,
+                    "source_type": _STR,
+                    "source_endpoint": {
+                        "type": "object",
+                        "properties": {"uri": _STR},
+                    },
+                },
+                body_required=["name", "source_type"],
+                path_vars=["updateSessionId"],
+                required=["updateSessionId", "body"],
+            ),
+            body_props=frozenset({"name", "source_type", "source_endpoint"}),
+            body_required=frozenset({"name", "source_type"}),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item/update-session/{updateSessionId}?action=complete",
+            stage="import 4: complete the session",
+            safety_level="caution",
+            parameter_schema=_schema(path_vars=["updateSessionId"], required=["updateSessionId"]),
+        ),
+        RecipeOp(
+            op_id="GET:/content/library/item/update-session/{updateSessionId}",
+            stage="import 5: poll session state to DONE / ERROR",
+            safety_level="safe",
+            parameter_schema=_schema(path_vars=["updateSessionId"], required=["updateSessionId"]),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item/update-session/{updateSessionId}?action=cancel",
+            stage="failure path: cancel the session",
+            safety_level="caution",
+            parameter_schema=_schema(path_vars=["updateSessionId"], required=["updateSessionId"]),
+        ),
+        RecipeOp(
+            op_id="POST:/content/library/item/update-session/{updateSessionId}?action=keep-alive",
+            stage="long pull: keep the session alive",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={"client_progress": {"type": "integer"}},
+                path_vars=["updateSessionId"],
+                required=["updateSessionId"],
+            ),
+            body_props=frozenset({"client_progress"}),
+            body_required=frozenset(),
+        ),
+        RecipeOp(
+            op_id="POST:/vcenter/iso/image?action=mount",
+            stage="mount: attach the ISO item to a VM CD-ROM",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={"library_item": _STR, "vm": _STR},
+                body_required=["library_item", "vm"],
+                required=["body"],
+            ),
+            body_props=frozenset({"library_item", "vm"}),
+            body_props_exact=True,
+            body_required=frozenset({"library_item", "vm"}),
+        ),
+        RecipeOp(
+            op_id="POST:/vcenter/iso/image?action=unmount",
+            stage="unmount: detach the ISO-backed CD-ROM from a VM",
+            safety_level="caution",
+            parameter_schema=_schema(
+                body={"vm": _STR, "cdrom": _STR},
+                body_required=["vm", "cdrom"],
+                required=["body"],
+            ),
+            body_props=frozenset({"vm", "cdrom"}),
+            body_props_exact=True,
+            body_required=frozenset({"vm", "cdrom"}),
+        ),
+    )
+}

--- a/backend/tests/test_connectors_vmware_rest_governed_iso_dispatch.py
+++ b/backend/tests/test_connectors_vmware_rest_governed_iso_dispatch.py
@@ -1,0 +1,513 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Full-dispatch wire + envelope pins for the governed content-library ISO path (#3086).
+
+The recipe (``docs/codebase/vmware-rest-governed-iso-path.md``) rides
+**raw ingested ops** — no composite — so the load-bearing questions are
+all generic-dispatch questions, each pinned here through the real
+``dispatch()`` chain (policy gate → connector resolution → session mint
+→ ``dispatch_ingested`` → audit + broadcast) against a respx-mocked
+vCenter, mirroring ``test_connectors_vmware_rest_credread.py``:
+
+* **Flat ``/api`` bodies, never the ``/rest`` envelope** (the #2973 /
+  #3071 bug class). ``_unwrap_body`` sends the caller's ``body`` param
+  verbatim as the JSON request body; the byte-for-byte wire assertions
+  here fail the moment anything re-wraps it in ``{"spec": ...}``.
+* **``?action=`` discriminators ride the descriptor path key** — the
+  ingest parser keeps vCenter's ``?action=<verb>`` suffix in the path,
+  and httpx carries it onto the wire under the ``/api`` mount prefix.
+* **Response envelopes survive dispatch**: a bare-JSON-string ack (item
+  id / session id / cdrom id) wraps to ``{"value": ...}`` per
+  ``wrap_ok_result``; a ``204 No Content`` ack returns ``{}`` (#3082);
+  dict / list payloads pass through (small sets — no JSONFlux handle).
+* **Governance engages**: the ingested writes land ``caution`` +
+  ``requires_approval=False`` (auto-execute for a human operator, one
+  audit + broadcast per dispatch), and an operator who tightens
+  ``requires_approval`` on the mount op parks the dispatch in the
+  approval queue *before* any vendor call fires.
+
+Descriptor seeds come from ``tests/_governed_iso_recipe.py`` — the
+same table the shelf-gated reconcile lane grounds against the pinned
+``vcenter-9.0/vcenter.yaml``, so the ops pinned here are the ops the
+pinned spec actually serves.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._governed_iso_recipe import RECIPE_OPS
+from ._vault_fakes import install_fake_client
+
+_PRODUCT = "vmware"
+_VERSION = "9.0"
+_IMPL_ID = "vmware-rest"
+_CONNECTOR_ID = "vmware-rest-9.0"
+
+#: RFC 6761 ``.test.``/``.invalid`` host — guarantees no real egress.
+_VCENTER_HOST = "vcenter-iso-recipe.test.invalid"
+_VCENTER_BASE_URL = f"https://{_VCENTER_HOST}"
+_SESSION_TOKEN = "iso-recipe-session-token"
+
+_TENANT_ID = UUID("00000000-0000-0000-0000-00000000b1b1")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Fresh dispatcher caches + a clean vmware-rest registration per test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=VmwareRestConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture(autouse=True)
+def _fake_vault(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canned service-account creds via the in-process Vault fake.
+
+    The resolver builds ``VmwareRestConnector()`` with the *default*
+    session loader, so the real operator-context Vault read path runs
+    against the fake — no injected stub loader.
+    """
+    install_fake_client(
+        monkeypatch,
+        secret={"username": "svc-iso-recipe", "password": "iso-recipe-pass"},
+    )
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor rows."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+class _IsoRecipeTarget:
+    """Resolver-shaped + vmware-loader-shaped target for the mocked vCenter."""
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = "vcenter-iso-recipe"
+        self.host = _VCENTER_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-iso/vcenter-iso-recipe"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-iso-recipe",
+        name="ISO Recipe Operator",
+        email=None,
+        raw_jwt="op.iso.jwt",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_recipe_descriptor(
+    session: AsyncSession,
+    op_id: str,
+    embedding: list[float],
+    *,
+    requires_approval: bool = False,
+) -> None:
+    """Insert one enabled ingested descriptor row from the recipe table."""
+    op = RECIPE_OPS[op_id]
+    method, _, path = op_id.partition(":")
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=op_id,
+        source_kind="ingested",
+        method=method,
+        path=path,
+        handler_ref=None,
+        summary=op.stage,
+        description=op.stage,
+        tags=["content-library-iso"],
+        parameter_schema=op.parameter_schema,
+        response_schema=None,
+        llm_instructions=None,
+        safety_level=op.safety_level,
+        requires_approval=requires_approval,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+def _mock_session_routes(mock: respx.MockRouter) -> None:
+    mock.post("/api/session").respond(200, json=_SESSION_TOKEN)
+    mock.delete("/api/session").respond(204)
+
+
+@pytest.mark.asyncio
+async def test_iso_mount_sends_flat_body_and_wraps_scalar_ack(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Mount rides ``?action=mount`` with the flat two-field body; string ack wraps.
+
+    The wire body must be byte-for-byte the caller's ``body`` param —
+    ``{"library_item", "vm"}`` at the TOP level, no ``{"spec": ...}``
+    envelope (#2973/#3071 class) — and the bare-JSON-string CD-ROM id
+    vCenter acks with must survive dispatch as ``{"value": <id>}``.
+    """
+    op_id = "POST:/vcenter/iso/image?action=mount"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+    body = {"library_item": "item-11", "vm": "vm-77"}
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        mount_route = mock.post("/api/vcenter/iso/image", params={"action": "mount"}).respond(
+            200, json="16002"
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"body": body},
+        )
+
+    assert result.status == "ok", result.error
+    assert mount_route.call_count == 1
+    wire_request = mount_route.calls.last.request
+    assert wire_request.url.params["action"] == "mount"
+    assert json.loads(wire_request.content) == body  # flat — no {"spec": ...} envelope
+    # Bare-string ack survives dispatch under the documented scalar envelope.
+    assert result.result == {"value": "16002"}
+    assert result.handle is None
+    # The governed path engaged: exactly one audit/broadcast for the dispatch.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_iso_mount_parks_in_approval_queue_when_tightened(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """``requires_approval=True`` parks the mount BEFORE any vendor call.
+
+    Ingest defaults the recipe's writes to ``requires_approval=False``
+    (auto-execute for human operators); an operator who tightens the
+    mount op in ingest review gets the approval-queue park — and the
+    park must fire ahead of the vCenter round-trip.
+    """
+    op_id = "POST:/vcenter/iso/image?action=mount"
+    await _seed_recipe_descriptor(
+        session,
+        op_id,
+        stub_embedding_service.encode_one.return_value,
+        requires_approval=True,
+    )
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        mount_route = mock.post("/api/vcenter/iso/image", params={"action": "mount"}).respond(
+            200, json="16002"
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"body": {"library_item": "item-11", "vm": "vm-77"}},
+        )
+
+    assert result.status == "awaiting_approval"
+    assert mount_route.call_count == 0  # parked before the connector fired
+
+
+@pytest.mark.asyncio
+async def test_iso_unmount_sends_flat_body_and_204_ack_is_empty_dict(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Unmount rides ``?action=unmount`` with ``{vm, cdrom}``; 204 acks as ``{}`` (#3082)."""
+    op_id = "POST:/vcenter/iso/image?action=unmount"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+    body = {"vm": "vm-77", "cdrom": "16002"}
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        unmount_route = mock.post("/api/vcenter/iso/image", params={"action": "unmount"}).respond(
+            204
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"body": body},
+        )
+
+    assert result.status == "ok", result.error
+    assert json.loads(unmount_route.calls.last.request.content) == body
+    assert result.result == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("op_id", "wire_path", "body", "vendor_ack"),
+    [
+        (
+            "POST:/content/library/item",
+            "/api/content/library/item",
+            {"library_id": "lib-1", "name": "esxi-installer", "type": "iso"},
+            "item-11",
+        ),
+        (
+            "POST:/content/library/item/update-session",
+            "/api/content/library/item/update-session",
+            {"library_item_id": "item-11"},
+            "us-42",
+        ),
+    ],
+)
+async def test_create_ops_send_flat_model_bodies_and_wrap_string_ids(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    wire_path: str,
+    body: dict[str, Any],
+    vendor_ack: str,
+) -> None:
+    """Item / update-session create send the *Model flat; string ids wrap.
+
+    Both creates take their model at the TOP level of the ``/api`` body
+    (the legacy ``/rest`` mount wrapped these in ``create_spec`` — the
+    envelope class this lane bans from the wire) and ack with a bare
+    JSON string id that must survive as ``{"value": <id>}``.
+    """
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        create_route = mock.post(wire_path).respond(201, json=vendor_ack)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"body": body},
+        )
+
+    assert result.status == "ok", result.error
+    assert json.loads(create_route.calls.last.request.content) == body
+    assert result.result == {"value": vendor_ack}
+
+
+@pytest.mark.asyncio
+async def test_file_add_substitutes_session_path_and_sends_pull_source_verbatim(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The PULL file-add: ``{updateSessionId}`` → URL; nested AddSpec rides flat.
+
+    ``source_type="PULL"`` + ``source_endpoint.uri`` is the governed
+    import-from-URL core — vCenter itself fetches the ISO from the HTTP
+    depot, so no file bytes ever transit MEHO. The nested
+    ``source_endpoint`` object must reach the wire verbatim inside the
+    flat AddSpec body.
+    """
+    op_id = "POST:/content/library/item/update-session/{updateSessionId}/file"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+    body = {
+        "name": "esxi.iso",
+        "source_type": "PULL",
+        "source_endpoint": {"uri": "http://depot.lab.invalid/isos/esxi.iso"},
+    }
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        file_route = mock.post("/api/content/library/item/update-session/us-42/file").respond(
+            200,
+            json={"name": "esxi.iso", "source_type": "PULL", "status": "WAITING_FOR_TRANSFER"},
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"updateSessionId": "us-42", "body": body},
+        )
+
+    assert result.status == "ok", result.error
+    assert file_route.call_count == 1
+    assert json.loads(file_route.calls.last.request.content) == body
+    assert isinstance(result.result, dict)
+    assert result.result["status"] == "WAITING_FOR_TRANSFER"
+
+
+@pytest.mark.asyncio
+async def test_session_complete_sends_no_body_and_204_ack_is_empty_dict(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """``?action=complete`` is a bodyless verb: empty wire body, 204 → ``{}``."""
+    op_id = "POST:/content/library/item/update-session/{updateSessionId}?action=complete"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        complete_route = mock.post(
+            "/api/content/library/item/update-session/us-42",
+            params={"action": "complete"},
+        ).respond(204)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"updateSessionId": "us-42"},
+        )
+
+    assert result.status == "ok", result.error
+    wire_request = complete_route.calls.last.request
+    assert wire_request.url.params["action"] == "complete"
+    assert wire_request.content == b""  # no body param declared → nothing on the wire
+    assert result.result == {}
+
+
+@pytest.mark.asyncio
+async def test_session_poll_returns_state_object_passthrough(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The poll GET substitutes the session id and passes the state object through."""
+    op_id = "GET:/content/library/item/update-session/{updateSessionId}"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+    state = {"id": "us-42", "state": "DONE", "client_progress": 100}
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        poll_route = mock.get("/api/content/library/item/update-session/us-42").respond(
+            200, json=state
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"updateSessionId": "us-42"},
+        )
+
+    assert result.status == "ok", result.error
+    assert poll_route.call_count == 1
+    assert result.result == state
+
+
+@pytest.mark.asyncio
+async def test_item_list_merges_query_param_into_marker_path(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The ``?library_id`` marker path merges the query param to a single value.
+
+    The parser keys this op ``GET:/content/library/item?library_id``
+    (required-query marker in the path). httpx merges the query bucket
+    into the marker, so the wire carries exactly one
+    ``library_id=<value>`` pair — pinned here because a doubled or
+    empty param would 400 at vCenter.
+    """
+    op_id = "GET:/content/library/item?library_id"
+    await _seed_recipe_descriptor(session, op_id, stub_embedding_service.encode_one.return_value)
+
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        _mock_session_routes(mock)
+        list_route = mock.get("/api/content/library/item", params={"library_id": "lib-1"}).respond(
+            200, json=["item-11"]
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_IsoRecipeTarget(),
+            params={"library_id": "lib-1"},
+        )
+
+    assert result.status == "ok", result.error
+    wire_url = list_route.calls.last.request.url
+    assert wire_url.params.get_list("library_id") == ["lib-1"]
+    assert result.result == ["item-11"]

--- a/backend/tests/test_connectors_vmware_rest_governed_iso_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_governed_iso_reconcile.py
@@ -29,6 +29,7 @@ everywhere (including public CI, where the shelf is absent).
 
 from __future__ import annotations
 
+from meho_backplane.operations.ingest import parse_openapi
 from tests._governed_iso_recipe import RECIPE_OPS
 from tests._spec_shelf import (
     assert_op_ids_served,
@@ -128,8 +129,6 @@ def test_recipe_required_body_fields_match_the_pinned_spec() -> None:
     raw parsed body schema (``required`` is not part of
     :func:`openapi_request_body_props`' property-name map).
     """
-    from meho_backplane.operations.ingest import parse_openapi
-
     spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
     rows = parse_openapi(
         f"file://{spec_path}",

--- a/backend/tests/test_connectors_vmware_rest_governed_iso_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_governed_iso_reconcile.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-spec reconcile lane for the governed content-library ISO recipe (#3086).
+
+The recipe (``docs/codebase/vmware-rest-governed-iso-path.md``) names
+raw ingested ops; this lane grounds that op list against the pinned
+``vcenter-9.0/vcenter.yaml`` per the spec-reconcile standard
+(``docs/decisions/spec-reconcile-guards-standard.md``):
+
+* every recipe op_id is **served** by the pinned spec, byte-for-byte
+  the string an operator's ingest would emit (path lane), and
+* every bodied write op's ``requestBody`` is the **flat ``/api``
+  shape** — its top-level properties are the model/spec's own fields,
+  never the legacy ``/rest``-style single-``spec`` wrapper (body lane,
+  the #2973/#3071 envelope class the generic dispatcher forwards
+  verbatim from the caller's ``body`` param).
+
+Division of labour (mirrors
+``test_connectors_vmware_rest_composites_write_body_reconcile.py``):
+this lane grounds the contract against the pinned vendor spec and
+skips uniformly where the spec shelf is unprovisioned (the #2980
+harness contract); the **connector-side** proof — that the generic
+dispatch path puts those flat bodies on the wire — is the byte-for-byte
+respx assertion set in
+``test_connectors_vmware_rest_governed_iso_dispatch.py``, which runs
+everywhere (including public CI, where the shelf is absent).
+"""
+
+from __future__ import annotations
+
+from tests._governed_iso_recipe import RECIPE_OPS
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_request_body_props,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_LABEL = "vcenter-9.0/vcenter.yaml"
+
+
+def test_recipe_table_is_internally_consistent() -> None:
+    """Always-on wiring guard: the table is non-empty and well-formed.
+
+    A vacuously empty table would let both lanes go green while
+    guarding nothing; a malformed op_id (no ``METHOD:`` prefix, or a
+    body contract on a bodyless op) would ground the reconcile lane on
+    the wrong strings.
+    """
+    assert RECIPE_OPS, "recipe op table is empty — the wiring broke"
+    for op_id, op in RECIPE_OPS.items():
+        assert op.op_id == op_id
+        method, sep, path = op_id.partition(":")
+        assert sep and path.startswith("/"), f"malformed op_id {op_id!r}"
+        assert method in {"GET", "POST"}, f"unexpected recipe verb on {op_id!r}"
+        expected_safety = "safe" if method == "GET" else "caution"
+        assert op.safety_level == expected_safety, (
+            f"{op_id}: recipe table says {op.safety_level!r} but the ingest "
+            f"heuristic assigns {expected_safety!r} for {method}"
+        )
+        declares_body = "body" in (op.parameter_schema.get("properties") or {})
+        assert declares_body == (op.body_props is not None), (
+            f"{op_id}: body contract and seeded body param must agree"
+        )
+
+
+def test_every_recipe_op_is_served_by_the_pinned_spec() -> None:
+    """Path lane: each recipe op_id exists in the pinned vcenter.yaml.
+
+    Skips uniformly without the spec shelf; where the shelf is wired a
+    red run is the guard surfacing a real finding (renamed endpoint,
+    wrong-API-version path), never harness noise.
+    """
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(RECIPE_OPS.keys(), served, spec_label=_SPEC_LABEL)
+
+
+def test_recipe_write_bodies_are_flat_api_shapes() -> None:
+    """Body lane: every bodied recipe write is served flat, never ``{"spec": ...}``.
+
+    Checks two strengths per the table's contract:
+
+    * ``body_props_exact`` ops (the iso.image pair) must match the
+      pinned body properties **exactly** — a new required field there
+      is a recipe-breaking change this lane must surface.
+    * model-shaped bodies (item create / update-session create / file
+      add) must serve at least the fields the recipe sends, with the
+      spec-declared required set unchanged.
+    """
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    body_props = openapi_request_body_props(spec_path)
+    checked = 0
+    for op_id, op in RECIPE_OPS.items():
+        if op.body_props is None:
+            continue
+        served_props = body_props.get(op_id)
+        assert served_props is not None, (
+            f"{op_id}: the pinned {_SPEC_LABEL} serves no JSON request body for it — "
+            "the recipe's body contract has no grounding (path moved or body dropped)."
+        )
+        assert served_props != {"spec"}, (
+            f"{op_id}: single-`spec` request-body wrapper in the pinned spec — the "
+            "/api surface takes the model at the top level (#2973). "
+            "Protocol: docs/decisions/spec-reconcile-guards-standard.md."
+        )
+        if op.body_props_exact:
+            assert served_props == set(op.body_props), (
+                f"{op_id}: pinned body properties {sorted(served_props)} != the "
+                f"recipe's {sorted(op.body_props)} — update the recipe doc + table."
+            )
+        else:
+            assert set(op.body_props) <= served_props, (
+                f"{op_id}: recipe sends {sorted(set(op.body_props) - served_props)} "
+                f"which the pinned spec does not declare."
+            )
+        checked += 1
+    assert checked, "no recipe request bodies were checked — table or parser wiring broke"
+
+
+def test_recipe_required_body_fields_match_the_pinned_spec() -> None:
+    """The spec's required-field sets for the recipe's bodied writes are pinned.
+
+    A vendor bump that adds a required field to the mount body (or to
+    the file-add AddSpec) silently breaks every recipe consumer; this
+    lane turns that into a red diff against the pinned spec. Uses the
+    raw parsed body schema (``required`` is not part of
+    :func:`openapi_request_body_props`' property-name map).
+    """
+    from meho_backplane.operations.ingest import parse_openapi
+
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    rows = parse_openapi(
+        f"file://{spec_path}",
+        spec_source=f"spec:{spec_path.name}",
+        content=spec_path.read_text(encoding="utf-8"),
+    )
+    body_required_by_op = {}
+    for row in rows:
+        schema = row.parameter_schema if isinstance(row.parameter_schema, dict) else {}
+        body = (schema.get("properties") or {}).get("body")
+        if isinstance(body, dict):
+            body_required_by_op[row.op_id] = set(body.get("required") or [])
+    checked = 0
+    for op_id, op in RECIPE_OPS.items():
+        if op.body_required is None:
+            continue
+        assert op_id in body_required_by_op, f"{op_id}: no parsed body schema"
+        assert body_required_by_op[op_id] == set(op.body_required), (
+            f"{op_id}: pinned required body fields "
+            f"{sorted(body_required_by_op[op_id])} != recipe's "
+            f"{sorted(op.body_required)} — a required-field drift breaks callers."
+        )
+        checked += 1
+    assert checked, "no required-field sets were checked — table or parser wiring broke"

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1329,6 +1329,9 @@ they never park.
 
 ## References
 
+- Governed content-library ISO import-from-URL + `iso.image`
+  mount/unmount recipe (raw ingested ops, no composite):
+  [vmware-rest-governed-iso-path.md](vmware-rest-governed-iso-path.md) (#3086).
 - Parent Initiative: [#227 G3.1 vmware-rest-9.0](https://github.com/evoila/meho/issues/227)
 - Parent Task: [#498 G3.1-T1 VmwareRestConnector](https://github.com/evoila/meho/issues/498)
 - Composite-helper Task: [#504 G3.1-T4 register_composite_operation()](https://github.com/evoila/meho/issues/504)

--- a/docs/codebase/vmware-rest-governed-iso-path.md
+++ b/docs/codebase/vmware-rest-governed-iso-path.md
@@ -1,0 +1,174 @@
+# Governed ISO path: content-library import-from-URL + iso.image mount (vmware-rest)
+
+## Overview
+
+The governed way to get a bootable ISO from an HTTP depot into a
+vCenter content library and mounted on a VM — entirely on **raw
+ingested ops** of the `vmware-rest` connector (`vmware-rest-9.0`),
+dispatched through the ordinary
+`call_operation(connector_id, operation_id, target, params)` path with
+policy, audit, broadcast, and (when tightened) approvals applied per
+call. No composite exists and none is needed: every step is a single
+`call_operation`, the multi-step choreography is four writes plus one
+poll read, and each response is small and self-describing (#3086).
+
+First consumer: the governed nested-ESXi substrate build — the ESX
+installer ISO sits on an HTTP depot and must reach a VM's CD-ROM
+without out-of-band `scp`/`govc`.
+
+Verification basis (no live vCenter): the pinned
+`vcenter-9.0/vcenter.yaml` on the spec shelf (parsed with the real
+ingest parser), the generic dispatcher's request construction
+(`operations/_branches.py`), and respx full-dispatch unit tests with
+mocked vendor responses. Live-appliance verification is deferred (see
+Known gaps).
+
+## The recipe
+
+All op_ids below are byte-for-byte the strings the G0.7 ingest of
+`vcenter.yaml` emits (and therefore what `search_operations` /
+`call_operation` resolve). Prerequisite: the vcenter spec is ingested
+and the carrying groups are enabled — these are ingested rows, so they
+do not exist on a fresh boot the way the hand-coded composites do.
+
+Import-from-URL (server-side **PULL** — vCenter fetches the file
+itself; no file bytes transit MEHO):
+
+| # | Step | op_id | Params (shape) | Result envelope |
+|---|------|-------|----------------|-----------------|
+| 0a | List library ids | `GET:/content/library` | — | `list[str]` |
+| 0b | List item ids in a library | `GET:/content/library/item?library_id` | `{library_id}` | `list[str]` |
+| 1 | Create the item | `POST:/content/library/item` | `{body: {library_id, name, type: "iso", description?}}` | `{"value": "<item-id>"}` |
+| 2 | Create the update session | `POST:/content/library/item/update-session` | `{body: {library_item_id}}` | `{"value": "<session-id>"}` |
+| 3 | Add the PULL file | `POST:/content/library/item/update-session/{updateSessionId}/file` | `{updateSessionId, body: {name, source_type: "PULL", source_endpoint: {uri: "http://depot/…"}}}` | file-info object (`status: WAITING_FOR_TRANSFER → …`) |
+| 4 | Complete the session | `POST:/content/library/item/update-session/{updateSessionId}?action=complete` | `{updateSessionId}` (bodyless) | `{}` (204) |
+| 5 | Poll to terminal state | `GET:/content/library/item/update-session/{updateSessionId}` | `{updateSessionId}` | session object — `state: ACTIVE \| DONE \| ERROR \| CANCELED`, `client_progress`, `error_message` |
+
+Failure/liveness companions (same family, same dispatch shape):
+`?action=cancel` (abort), `?action=fail` (body
+`{client_error_message}`), `?action=keep-alive` (optional body
+`{client_progress}` — call it during a long pull; sessions carry an
+`expiration_time`), and
+`GET:/content/library/item/update-session/{updateSessionId}/file` for
+per-file transfer status.
+
+Mount / unmount (Iso.Image API — creates/removes a VM CD-ROM device
+backed by the library item's ISO):
+
+| # | Step | op_id | Params (shape) | Result envelope |
+|---|------|-------|----------------|-----------------|
+| 6 | Mount | `POST:/vcenter/iso/image?action=mount` | `{body: {library_item, vm}}` (both required) | `{"value": "<cdrom-id>"}` |
+| 7 | Unmount | `POST:/vcenter/iso/image?action=unmount` | `{body: {vm, cdrom}}` (both required) | `{}` (204) |
+
+The `cdrom` argument of unmount is the string mount returned. `type:
+"iso"` on step 1 selects the ISO type-adapter plugin so the item
+publishes as a mountable ISO.
+
+The canonical machine-readable form of this table is
+`backend/tests/_governed_iso_recipe.py` — both test lanes consume it,
+so the doc, the wire pins, and the spec grounding cannot fork
+silently.
+
+## Control flow — why the raw ingested path just works
+
+The #3071/#2973 `/rest`-vs-`/api` body-envelope bug class lives in
+**hand-coded composite** body construction. The generic ingested path
+is envelope-clean by construction, which is why this recipe needs no
+connector code:
+
+- **Body**: the ingest parser folds each op's `requestBody` into a
+  single container param named `body`
+  (`x-meho-param-loc: "body"`); at dispatch,
+  `_unwrap_body` (`operations/_branches.py`) sends that param's
+  **value** as the JSON body — top-level, verbatim, no wrapper. The
+  pinned spec declares every body in this recipe as the flat `/api`
+  shape (ItemModel / UpdateSessionModel / AddSpec / mount + unmount
+  field pairs at the top level), so caller-supplied `body` ==
+  wire body.
+- **`?action=` discriminators**: vCenter's OpenAPI keys these
+  endpoints with the `?action=<verb>` suffix *in the path key itself*;
+  the parser passes it through into `op_id` and `path`, and httpx
+  carries it onto the wire. The same applies to the required-query
+  marker form `GET:/content/library/item?library_id` — the query
+  bucket merges into the marker, yielding exactly one
+  `library_id=<value>` pair.
+- **Mount prefix**: `VmwareRestConnector.mount_op_path` prefixes the
+  spec-relative path with `/api` (modern) or `/rest` (legacy fallback)
+  per the established session (`connectors/vmware_rest/_mount.py`).
+  Note the legacy `/rest` mount would *not* accept these flat bodies —
+  the recipe assumes the modern `/api` mount, which every supported
+  target (vSphere 8.5+/9.0) serves.
+- **Response envelopes**: create/mount ack with a **bare JSON string**
+  (item id / session id / cdrom id); `wrap_ok_result`
+  (`operations/_errors.py`) wraps scalars as `{"value": …}` so
+  `OperationResult.result` stays dict/list-shaped. The bodyless acks
+  (`?action=complete`, unmount) return `204 No Content` →
+  `{}` (#3082). Dict/list payloads (session state, id lists) pass
+  through; they are far below the JSONFlux thresholds, so no result
+  handle is produced.
+
+## Governance metadata
+
+As ingested from the pinned spec (method-based heuristic in
+`operations/ingest/openapi.py`):
+
+- Every write in the recipe: `safety_level="caution"`,
+  `requires_approval=False` — a human/service operator auto-executes
+  (with the synchronous audit row + broadcast per dispatch); agent
+  principals resolve through the per-(principal, op, target) grant
+  model, with `requires_approval` as a needs-approval floor.
+- The reads: `safety_level="safe"`.
+- An operator can tighten any of these per op in ingest review;
+  `requires_approval=True` parks the dispatch in the approval queue
+  *before* any vendor call fires (pinned in the dispatch lane).
+- Mount/unmount are VM writes (they add/remove a CD-ROM device);
+  vCenter additionally enforces its own privilege set
+  (`ContentLibrary.DownloadSession` / VM device privileges) on the
+  service account.
+
+## Known gaps
+
+- **PUSH upload cannot ride the generic dispatcher.** An update
+  session with `source_type: "PUSH"` expects the client to stream file
+  bytes to the returned `upload_endpoint` via raw HTTP PUT — there is
+  no ingested-op transport for raw byte streams. The governed answer
+  is PULL (this recipe); a push-style import would need a typed op.
+  Symmetrically: the PULL source URL must be reachable **from the
+  vCenter appliance** (schemes `http`, `https`, `file`, `ds`), not
+  from MEHO.
+- **No task-shaped completion.** `?action=complete` acks immediately;
+  the transfer itself is asynchronous. The caller owns the poll loop
+  (step 5) until `state` reaches `DONE`/`ERROR` — there is no
+  `vmw-task` variant in this API family to lean on.
+- **Session expiry.** Update sessions expire (`expiration_time`); a
+  slow depot pull may need `?action=keep-alive` calls. The recipe
+  keeps that on the caller.
+- **Ingested-op prerequisite.** Unlike the write composites (which
+  work on a fresh boot), these rows exist only after the operator
+  ingests `vcenter.yaml` and enables the groups carrying
+  `Content.Library.Item*` and `Vcenter.Iso.Image`.
+- **Live-appliance verification deferred.** Everything here is
+  grounded on the pinned spec + dispatch-path unit tests with mocked
+  vendor responses; the first live run (real depot, real vCenter)
+  should confirm transfer-state transitions and the mount's returned
+  cdrom id round-trip. (Generic-dispatcher adjacent finding, not a
+  recipe blocker: ingested **non-idempotent** ops drop query-located
+  params — `dispatch_ingested` does not forward `request.query` to
+  `_post_json`. No op in this recipe carries one; every POST
+  discriminator here is embedded in the path key.)
+
+## References
+
+- Tests: `backend/tests/test_connectors_vmware_rest_governed_iso_dispatch.py`
+  (always-on wire + envelope pins),
+  `backend/tests/test_connectors_vmware_rest_governed_iso_reconcile.py`
+  (shelf-gated path + body-shape + required-field grounding),
+  `backend/tests/_governed_iso_recipe.py` (canonical op table).
+- Precedents: #2973 / #3071 (`/rest`-vs-`/api` envelope class),
+  #3082/#3083 (204/empty-body acks), #3084/#3085 (scalar preservation),
+  `docs/decisions/spec-reconcile-guards-standard.md` (#2979/#2980).
+- Related connector doc: `docs/codebase/connectors-vmware-rest.md`
+  (composites, mounts, session handling); the `vm.device.cdrom`
+  composite covers datastore-path ISO pinning — a *different* flow
+  from the library-backed Iso.Image mount documented here.
+- Issue: evoila/meho#3086 (nested-substrate prerequisite).

--- a/docs/codebase/vmware-rest-governed-iso-path.md
+++ b/docs/codebase/vmware-rest-governed-iso-path.md
@@ -38,7 +38,7 @@ itself; no file bytes transit MEHO):
 |---|------|-------|----------------|-----------------|
 | 0a | List library ids | `GET:/content/library` | — | `list[str]` |
 | 0b | List item ids in a library | `GET:/content/library/item?library_id` | `{library_id}` | `list[str]` |
-| 1 | Create the item | `POST:/content/library/item` | `{body: {library_id, name, type: "iso", description?}}` | `{"value": "<item-id>"}` |
+| 1 | Create the item | `POST:/content/library/item` | `{body: {library_id, name, type?, description?}}` | `{"value": "<item-id>"}` |
 | 2 | Create the update session | `POST:/content/library/item/update-session` | `{body: {library_item_id}}` | `{"value": "<session-id>"}` |
 | 3 | Add the PULL file | `POST:/content/library/item/update-session/{updateSessionId}/file` | `{updateSessionId, body: {name, source_type: "PULL", source_endpoint: {uri: "http://depot/…"}}}` | file-info object (`status: WAITING_FOR_TRANSFER → …`) |
 | 4 | Complete the session | `POST:/content/library/item/update-session/{updateSessionId}?action=complete` | `{updateSessionId}` (bodyless) | `{}` (204) |
@@ -60,9 +60,13 @@ backed by the library item's ISO):
 | 6 | Mount | `POST:/vcenter/iso/image?action=mount` | `{body: {library_item, vm}}` (both required) | `{"value": "<cdrom-id>"}` |
 | 7 | Unmount | `POST:/vcenter/iso/image?action=unmount` | `{body: {vm, cdrom}}` (both required) | `{}` (204) |
 
-The `cdrom` argument of unmount is the string mount returned. `type:
-"iso"` on step 1 selects the ISO type-adapter plugin so the item
-publishes as a mountable ISO.
+The `cdrom` argument of unmount is the string mount returned. On step
+1, `ItemModel.type` is an **open, optional** type-adapter identifier
+per the pinned spec (the spec enumerates no values); `"iso"` is the
+*conventional* value for ISO items but is **not spec-pinned** — its
+live acceptance rides the deferred live-appliance verification (see
+Known gaps). Mount itself keys on the item carrying an ISO file, per
+the Iso.Image API description.
 
 The canonical machine-readable form of this table is
 `backend/tests/_governed_iso_recipe.py` — both test lanes consume it,
@@ -150,8 +154,10 @@ As ingested from the pinned spec (method-based heuristic in
 - **Live-appliance verification deferred.** Everything here is
   grounded on the pinned spec + dispatch-path unit tests with mocked
   vendor responses; the first live run (real depot, real vCenter)
-  should confirm transfer-state transitions and the mount's returned
-  cdrom id round-trip. (Generic-dispatcher adjacent finding, not a
+  should confirm transfer-state transitions, the mount's returned
+  cdrom id round-trip, and the conventional `type: "iso"` item-type
+  literal (the pinned spec leaves `ItemModel.type` open, so the
+  literal is convention, not spec-verified). (Generic-dispatcher adjacent finding, not a
   recipe blocker: ingested **non-idempotent** ops drop query-located
   params — `dispatch_ingested` does not forward `request.query` to
   `_post_json`. No op in this recipe carries one; every POST


### PR DESCRIPTION
## Summary

- **Verifies the fully-governed ISO path on raw ingested ops — no composite needed.** Content-library import-from-URL (item create → update session → `PULL` file add with `source_endpoint.uri` → `?action=complete` → poll) plus `POST:/vcenter/iso/image?action=mount` / `?action=unmount`, all in the pinned `vcenter-9.0/vcenter.yaml` and all dispatchable through the generic path as-is.
- **The #2973/#3071 `/rest`-vs-`/api` body-envelope class cannot reach these ops.** The generic dispatcher (`_unwrap_body`) sends the caller's `body` param verbatim — top-level, no `{"spec": …}` wrapper — and the pinned spec declares every recipe body flat. Byte-for-byte respx wire assertions pin that; the `?action=` discriminators ride the descriptor path key (verified through `mount_op_path` + httpx), and the `?library_id` marker path merges its query param to a single value.
- **Response shapes survive dispatch**: bare-JSON-string acks (item id / session id / cdrom id) wrap as `{"value": …}` per `wrap_ok_result`; the 204 acks (`complete`, `unmount`) return `{}` (#3082); dict/list payloads pass through under the JSONFlux thresholds.
- **Governance metadata confirmed**: recipe writes ingest as `caution` + `requires_approval=False` (human operators auto-execute with one audit+broadcast per dispatch; agents resolve through the grant model); a tightened `requires_approval=True` parks in the approval queue *before* any vendor call — pinned by test.
- **Deliverables**: recipe note `docs/codebase/vmware-rest-governed-iso-path.md` (staged op table + control flow + governance + explicit gaps), always-on dispatch lane, shelf-gated reconcile lane (op_ids served + flat body shapes + required-field sets), one canonical op table (`backend/tests/_governed_iso_recipe.py`) feeding both lanes so doc/tests cannot fork.

## Gaps stated (in the doc's Known gaps)

- `source_type: "PUSH"` (client streams bytes to `upload_endpoint`) cannot ride the generic dispatcher — PULL is the governed answer; the depot URL must be reachable from the vCenter appliance, not from MEHO.
- `?action=complete` acks immediately; the caller owns the poll loop to `DONE`/`ERROR` (no `vmw-task` variant in this family). Sessions expire; `?action=keep-alive` covers long pulls.
- These are ingested rows — they require the vcenter spec ingest + group enable (unlike the fresh-boot composites).
- Live-appliance verification deferred (this task is pinned-spec + mocked-dispatch verification by design).

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean (1569 files)
- [x] `mypy src/` — clean except the documented pre-existing macOS-only `socket.MSG_ERRQUEUE` in untouched `net/icmp.py` (absent on Linux CI; same note as #3043)
- [x] New lanes **without** the spec shelf (public-CI path): 10 passed, 3 skipped
- [x] New lanes **with** the shelf armed: 13 passed — the reconcile lane grounded op_ids, flat bodies, and required-field sets against the real pinned `vcenter.yaml`
- [x] Scoped sweep `-k "vmware_rest or spec_shelf"` with shelf armed: **556 passed, 2 skipped**
- [x] `code-quality.py --diff` — pass

## Out of scope (adjacent findings)

- Generic-dispatcher latent gap: `dispatch_ingested` does not forward query-located params on non-idempotent verbs (`_post_json` has no `params=` seam). No recipe op carries one (every POST discriminator here is embedded in the path key); noted in the doc's Known gaps for a follow-up decision.
- `Client-Token` idempotency header (optional, header-located) — supported by the generic path, not exercised by the recipe.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3086
