### PR TITLE
feat(connectors): vm.create nested_hv — governed VHV enable via the vim substrate (#3093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — `vm.create` `nested_hv`: governed VHV enable via the vim substrate (#3093)
+
+- `vmware.composite.vm.create` grows an optional `nested_hv: boolean` param:
+  when true, the composite enables nested hardware-assisted virtualization
+  after create + NIC attach and **before any power-on** — a vim
+  `ReconfigVM_Task` with `VirtualMachineConfigSpec.nestedHVEnabled=true`
+  through the governed vmomi write seam (`_write_vmomi_sub_op` →
+  `_post_vmomi_json`, the `/sdk/vim25/{release}` mount that is
+  version-correct on vCenter 8.0.x **and** 9.x), task-polled to terminal.
+  The flag has no REST expression and raw VI-JSON dispatch 404s on 8.0.x
+  (#2466), so this is the only cross-version governed path — the flag a
+  nested-hypervisor build cannot skip. A failed leg (transport fault, task
+  fault, or poll timeout) follows the composite's existing rollback
+  contract; the `created` envelope echoes the applied `nested_hv` state
+  when the param was supplied, and a param-absent call stays byte-identical
+  to before. Reconcile lane pins the vim paths + `nestedHVEnabled` against
+  the pinned `vcenter-9.0/vi-json.yaml`.
+
 ### Added — governed content-library ISO import-from-URL + iso.image mount recipe (#3086)
 
 - Verified + documented the fully-governed path for pulling a bootable ISO

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -392,11 +392,12 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
     _CompositeSpec(
         op_id="vmware.composite.vm.create",
         handler=vm_create_composite,
-        summary="Create a VM with NIC attach + optional power-on; rollback on failure.",
+        summary="Create a VM with NIC attach, optional VHV enable + optional power-on.",
         description=(
             "Orchestrates folder lookup, POST:/vcenter/vm create, per-NIC "
             "adapter create via POST:/vcenter/vm/{vm}/hardware/ethernet, "
-            "and optional "
+            "an optional nested_hv vim ReconfigVM_Task (nestedHVEnabled, "
+            "task-polled, applied before any power-on), and optional "
             "POST:/vcenter/vm/{vm}/power start. Partial-failure rollback: "
             "if any step after the create succeeds fails, the half-"
             "created VM is removed via DELETE:/vcenter/vm/{vm} so the "

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -294,6 +294,29 @@ _PROP_CONFIG_HARDWARE_DEVICE = "config.hardware.device"
 # ``vm.clone`` convention.
 _DISK_GROW_TASK_TIMEOUT_SECONDS = 600.0
 
+# vm.create's optional VHV leg (#3093) rides the same two vim paths.
+# ``VirtualMachineConfigSpec.nestedHVEnabled`` has no REST expression (the
+# pinned ``vcenter.yaml`` serves no ``hardware_virtualization`` / ``nestedHV``
+# spelling anywhere, pinned by the #3087 recipe lanes) and *raw* VI-JSON
+# dispatch mounts on ``/api`` — a 9.x-fleet accommodation that 404s on
+# vCenter 8.0.x (#2466) — so the composites' vim substrate
+# (:func:`_write_vmomi_sub_op` → ``_post_vmomi_json`` on the documented
+# ``/sdk/vim25/{release}`` base) is the only cross-version governed path to
+# the flag. ``RetrievePropertiesEx`` is the shared Task-poll read.
+_VIM_SUB_OPS_VM_CREATE: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIG_VM_TASK,
+)
+
+# Default wall-clock bound for the VHV ReconfigVM_Task poll — the 600s
+# convention; module-global so tests can zero it.
+_VM_CREATE_VHV_TASK_TIMEOUT_SECONDS = 600.0
+
+# The one-field ``VirtualMachineConfigSpec`` the VHV reconfigure sends. The
+# ``"spec"`` key is the vim request type's genuine required parameter (the
+# legacy-envelope sweep #2973 does not apply to vim bodies).
+_NESTED_HV_RECONFIG_BODY: Final[dict[str, Any]] = {"spec": {"nestedHVEnabled": True}}
+
 # vim (VI-JSON) op_ids for the folder-template clone write path (#2894).
 # Same ``METHOD:/path`` shape the ingest parser emits from ``vi-json.yaml``
 # (moId rides the path as ``{moId}``); kept out of the ``_SUB_OPS_*``
@@ -960,6 +983,65 @@ async def _rollback_created_vm(
         return
 
 
+async def _enable_nested_hv(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_id: str,
+) -> tuple[OperationResult | None, str | None]:
+    """Enable VHV on a freshly-created (powered-off) VM via ``ReconfigVM_Task``.
+
+    The #3093 leg of :func:`vm_create_composite`: issues the one-field
+    ``nestedHVEnabled`` reconfigure through the governed vmomi write seam
+    (:func:`_write_vmomi_sub_op` — version-correct on vCenter 8.0.x *and*
+    9.x, unlike raw VI-JSON dispatch) and drives the returned ``*_Task``
+    MoRef to a terminal state via :func:`poll_vim_task`.
+
+    Returns ``(gate, failure_reason)``:
+
+    * ``(gate, None)`` — the #2254 seam parked/denied the write; the caller
+      returns the :class:`OperationResult` verbatim (no reconfigure fired).
+    * ``(None, None)`` — VHV applied (task reached ``success``).
+    * ``(None, reason)`` — the leg failed (transport fault, task fault, or
+      poll timeout); the caller folds *reason* into vm.create's existing
+      rollback contract. A timeout counts as failure: the composite can
+      only report ``created`` when every requested step verifiably landed.
+    """
+    try:
+        gate, task_payload = await _write_vmomi_sub_op(
+            connector,
+            target,
+            operator,
+            op_id=_OP_RECONFIG_VM_TASK,
+            vmomi_path=f"/VirtualMachine/{vm_id}/ReconfigVM_Task",
+            body=_NESTED_HV_RECONFIG_BODY,
+            params={"vm": vm_id, "nested_hv": True},
+        )
+        if gate is not None:
+            return gate, None
+        outcome = await poll_vim_task(
+            connector,
+            target,
+            operator,
+            task=_unwrap_value(task_payload),
+            timeout_seconds=_VM_CREATE_VHV_TASK_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        return None, f"nested_hv reconfigure failed: {exc}"
+    if outcome.state == TASK_STATE_ERROR:
+        return None, (
+            f"nested_hv ReconfigVM_Task on vm {vm_id!r} faulted: "
+            f"{outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return None, (
+            f"nested_hv ReconfigVM_Task {outcome.task} did not reach a terminal "
+            f"state within {int(_VM_CREATE_VHV_TASK_TIMEOUT_SECONDS)}s"
+        )
+    return None, None
+
+
 async def vm_create_composite(
     *,
     operator: Operator,
@@ -967,10 +1049,14 @@ async def vm_create_composite(
     params: dict[str, Any],
     connector: VmwareRestConnector,
 ) -> dict[str, Any] | OperationResult:
-    """Create a VM with NIC attach + optional power-on; rollback on failure.
+    """Create a VM with NIC attach, optional VHV enable + optional power-on.
 
     Op-id: ``vmware.composite.vm.create``. See module docstring for the
     sub-op chain, the direct-session governance seam, and rollback semantics.
+    The optional ``nested_hv`` leg (#3093) runs after NIC attach and strictly
+    **before** any power-on — a powered-on reconfigure of
+    ``nestedHVEnabled`` is invalid — and follows the same rollback contract
+    as the other post-create steps.
     """
     folder_name = params["folder_name"]
     name = params["name"]
@@ -978,6 +1064,7 @@ async def vm_create_composite(
     cpu_count = int(params.get("cpu_count", 1))
     memory_mib = int(params.get("memory_mib", 1024))
     nics: list[dict[str, Any]] = list(params.get("nics") or [])
+    nested_hv = bool(params.get("nested_hv", False))
     power_on = bool(params.get("power_on_after_create", False))
 
     steps: list[str] = []
@@ -1042,6 +1129,19 @@ async def vm_create_composite(
     if nics:
         steps.append("nic_attach")
 
+    if nested_hv:
+        gate, vhv_failure = await _enable_nested_hv(
+            connector=connector, target=target, operator=operator, vm_id=vm_id
+        )
+        if gate is not None:
+            return gate
+        if vhv_failure is not None:
+            await _rollback_created_vm(
+                connector=connector, target=target, operator=operator, vm_id=vm_id
+            )
+            return _rolled_back(steps=steps, failed_step="nested_hv", reason=vhv_failure)
+        steps.append("nested_hv")
+
     if power_on:
         try:
             gate, _ = await _write_sub_op(
@@ -1060,13 +1160,18 @@ async def vm_create_composite(
             return gate
         steps.append("power_on")
 
-    return {
+    created: dict[str, Any] = {
         "status": "created",
         "vm_id": vm_id,
         "steps_succeeded": steps,
         "failed_step": None,
         "rollback_reason": None,
     }
+    if "nested_hv" in params:
+        # Applied state, echoed only when the operator asked for the leg —
+        # a param-absent call keeps today's envelope byte-identical (#3093).
+        created["nested_hv"] = nested_hv
+    return created
 
 
 # ===========================================================================

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -23,7 +23,7 @@ helpers, never the mutating sub-ops.
 ``host.detach_from_vds``  ``{host, dvs, fallback_network, resolved,
                           total_resolved}``
 ``cluster.patch``         ``{cluster, resolved, total_resolved}``
-``vm.create``             echo: name, guest_os, sizing, networks, power-on
+``vm.create``             echo: name, guest_os, sizing, networks, VHV, power-on
 ``vm.clone``              echo: source_vm, target_name, library_item
 ``vm.clone_from_template`` echo: source_template, new_vm_name, folder,
                           resource_pool, datastore, host, power_on,
@@ -310,6 +310,7 @@ async def _vm_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "cpu_count": int(ctx.params.get("cpu_count", 1)),
         "memory_mib": int(ctx.params.get("memory_mib", 1024)),
         "networks": networks,
+        "nested_hv": bool(ctx.params.get("nested_hv", False)),
         "power_on_after_create": bool(ctx.params.get("power_on_after_create", False)),
     }
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -670,13 +670,28 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "NICs."
             ),
         },
+        "nested_hv": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, the handler enables nested hardware-assisted "
+                "virtualization (VHV) after NIC attach and before any "
+                "power-on: a vim ``ReconfigVM_Task`` with "
+                "``VirtualMachineConfigSpec.nestedHVEnabled=true`` through "
+                "the governed vmomi write seam (version-correct on vCenter "
+                "8.0.x and 9.x — the flag has no REST expression), polled "
+                "to a terminal state. A failed leg follows the composite's "
+                "rollback contract."
+            ),
+        },
         "power_on_after_create": {
             "type": "boolean",
             "default": False,
             "description": (
                 "When true, the handler issues "
                 "``POST:/vcenter/vm/{vm}/power?action=start`` after "
-                "NIC attach. Default false leaves the VM powered-off."
+                "NIC attach (and after the optional ``nested_hv`` "
+                "reconfigure). Default false leaves the VM powered-off."
             ),
         },
     },
@@ -1212,7 +1227,7 @@ VM_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
             "items": {"type": "string"},
             "description": (
                 "Per-step success ledger: ``folder_lookup``, "
-                "``create``, ``nic_attach``, ``power_on``."
+                "``create``, ``nic_attach``, ``nested_hv``, ``power_on``."
             ),
         },
         "failed_step": {
@@ -1226,6 +1241,15 @@ VM_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
             "description": (
                 "Human-readable explanation of the rollback trigger; "
                 "``null`` when ``status='created'``."
+            ),
+        },
+        "nested_hv": {
+            "type": "boolean",
+            "description": (
+                "Applied VHV state (#3093). Present only when the request "
+                "carried the ``nested_hv`` param — a param-absent call "
+                "keeps the pre-#3093 envelope byte-identical. ``true`` "
+                "iff the ``ReconfigVM_Task`` leg completed."
             ),
         },
     },

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -721,3 +721,77 @@ def test_2970_vim_paths_exist_in_the_pinned_spec(manifest_name: str) -> None:
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
             f"{manifest_name} vim sub-op targets a path the spec does not serve"
         )
+
+
+# ---------------------------------------------------------------------------
+# vm.create VHV leg VI-JSON sub-op reconciliation (#3093)
+# ---------------------------------------------------------------------------
+#
+# vm.create's optional ``nested_hv`` leg is vi-json, not vcenter REST:
+# ``VirtualMachineConfigSpec.nestedHVEnabled`` has no REST expression (the
+# #3087 recipe lanes pin that gap) and raw VI-JSON dispatch mounts on
+# ``/api`` — a 9.x-fleet shape that 404s on vCenter 8.0.x (#2466) — so the
+# leg rides the same governed vmomi substrate as disk-grow:
+# ``POST:/VirtualMachine/{moId}/ReconfigVM_Task`` (the flag write) plus the
+# shared Task-poll read ``RetrievePropertiesEx``. Declared in
+# ``_write._VIM_SUB_OPS_VM_CREATE`` (deliberately NOT in the ``_SUB_OPS_*``
+# namespace, so the vcenter.yaml sweep above skips it).
+
+
+def test_vm_create_vhv_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
+    """Pin the vm.create VHV vi-json manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_VM_CREATE) == {
+        "POST:/VirtualMachine/{moId}/ReconfigVM_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+
+
+def test_vm_create_vhv_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The VHV-leg vi-json op_ids are byte-for-byte what the parser emits.
+
+    Same proof shape as the #2893-#2895 round-trips above: the ``{moId}``
+    path template survives the parser, so ``enforce_subop_policy``'s op_id /
+    a grant's op_pattern resolve against the ingested rows once the operator
+    ingests ``vi-json.yaml``.
+    """
+    required = set(_write._VIM_SUB_OPS_VM_CREATE)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_vm_create_vhv_paths_and_flag_exist_in_the_pinned_spec() -> None:
+    """The VHV vim paths are real POST paths and ``nestedHVEnabled`` is served.
+
+    The definitive #3093 grounding: the leg targets paths the pinned
+    ``vi-json.yaml`` actually serves, and the one field its body sets —
+    ``VirtualMachineConfigSpec.nestedHVEnabled`` — exists in the pinned
+    schema corpus (the schema-level pin lives in the #3087 recipe reconcile
+    lane; this is the cheap text-level guard alongside the path check).
+    Skips when the spec-shelf is not configured (the canary's convention),
+    so CI is the operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_VM_CREATE:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "vm.create VHV vi-json sub-op targets a path the spec does not serve"
+        )
+    assert "nestedHVEnabled:" in spec_text, (
+        "``nestedHVEnabled`` is absent from the pinned vi-json.yaml — the "
+        "vm.create VHV reconfigure body sets a field the spec does not serve"
+    )

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -474,6 +474,295 @@ async def test_vm_create_gated_create_returns_awaiting_approval_no_write(
     assert [c["method"] for c in conn.calls] == ["GET"]
 
 
+class _UnifiedRecordingConnector(_RecordingConnector):
+    """Recording connector that logs vmomi POSTs into the shared ``calls`` list.
+
+    ``_RecordingConnector`` keeps REST and vmomi calls in two separate
+    lists, which loses their *relative* order. The vm.create VHV tests
+    need the cross-seam ordering proof (reconfigure + task poll strictly
+    before the power-on POST), so this subclass additionally appends a
+    ``POST-VMOMI`` marker into ``calls`` before delegating.
+    """
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.calls.append(
+            {
+                "method": "POST-VMOMI",
+                "path": path,
+                "query": None,
+                "body": json,
+                "timeout": httpx.USE_CLIENT_DEFAULT,
+            }
+        )
+        return await super()._post_vmomi_json(target, path, operator=operator, json=json)
+
+
+_VMOMI_TASK_INFO_READ_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+
+@pytest.mark.asyncio
+async def test_vm_create_nested_hv_reconfigures_before_power_on(gate: _GateRecorder) -> None:
+    """nested_hv=true: ReconfigVM_Task + task poll run after NIC attach, before power-on."""
+    conn = _UnifiedRecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+            "/api/vcenter/vm/vm-99/hardware/ethernet": {"value": "nic-1"},
+            "/api/vcenter/vm/vm-99/power?action=start": {},
+        },
+        vmomi={"/VirtualMachine/vm-99/ReconfigVM_Task": _task_moref("task-501")},
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "esx-nested-01",
+            "guest_os": "VMKERNEL_8",
+            "nics": [{"network": "net-3"}],
+            "nested_hv": True,
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    # The ordering criterion: the vim reconfigure + its Task.info poll land
+    # strictly between the NIC attach and the power-on POST.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/folder"),
+        ("POST", "/api/vcenter/vm"),
+        ("POST", "/api/vcenter/vm/vm-99/hardware/ethernet"),
+        ("POST-VMOMI", "/VirtualMachine/vm-99/ReconfigVM_Task"),
+        ("POST-VMOMI", _VMOMI_TASK_INFO_READ_PATH),
+        ("POST", "/api/vcenter/vm/vm-99/power?action=start"),
+    ]
+    # The reconfigure body is the one-field VirtualMachineConfigSpec.
+    assert conn.vmomi_calls[0] == (
+        "/VirtualMachine/vm-99/ReconfigVM_Task",
+        {"spec": {"nestedHVEnabled": True}},
+    )
+
+    # Governance: the vim write is gated under its canonical vi-json op_id,
+    # with params naming the entity, between the NIC and power writes.
+    assert gate.gated_op_ids == [
+        "POST:/vcenter/vm",
+        "POST:/vcenter/vm/{vm}/hardware/ethernet",
+        "POST:/VirtualMachine/{moId}/ReconfigVM_Task",
+        "POST:/vcenter/vm/{vm}/power?action=start",
+    ]
+    assert gate.calls[2]["params"] == {"vm": "vm-99", "nested_hv": True}
+
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create", "nic_attach", "nested_hv", "power_on"],
+        "failed_step": None,
+        "rollback_reason": None,
+        "nested_hv": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_create_nested_hv_transport_fault_rolls_back(gate: _GateRecorder) -> None:
+    """A transport fault on the VHV reconfigure rolls back via DELETE."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-1", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-77"},
+            "/api/vcenter/vm/vm-77": {},  # DELETE rollback
+        },
+        vmomi={
+            "/VirtualMachine/vm-77/ReconfigVM_Task": _http_error(
+                500, "https://vc/sdk/vim25/8.0.3.0/VirtualMachine/vm-77/ReconfigVM_Task"
+            )
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "esx-nested-02",
+            "guest_os": "VMKERNEL_8",
+            "nested_hv": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert ("DELETE", "/api/vcenter/vm/vm-77") in [(c["method"], c["path"]) for c in conn.calls]
+    assert out["status"] == "rolled_back"
+    assert out["vm_id"] is None
+    assert out["failed_step"] == "nested_hv"
+    assert "nested_hv reconfigure failed" in out["rollback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_nested_hv_task_fault_rolls_back(gate: _GateRecorder) -> None:
+    """A faulted ReconfigVM_Task rolls back; the vim fault message is surfaced."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-1", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-77"},
+            "/api/vcenter/vm/vm-77": {},  # DELETE rollback
+        },
+        vmomi={
+            "/VirtualMachine/vm-77/ReconfigVM_Task": _task_moref("task-9"),
+            "Task": _task_info_result("task-9", "error", "VHV not supported on this host"),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "esx-nested-03",
+            "guest_os": "VMKERNEL_8",
+            "nested_hv": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert ("DELETE", "/api/vcenter/vm/vm-77") in [(c["method"], c["path"]) for c in conn.calls]
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "nested_hv"
+    assert "VHV not supported on this host" in out["rollback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_nested_hv_poll_timeout_rolls_back(
+    gate: _GateRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A VHV task-poll timeout counts as leg failure: rollback, not 'created'."""
+    monkeypatch.setattr(_write, "_VM_CREATE_VHV_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-1", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-77"},
+            "/api/vcenter/vm/vm-77": {},  # DELETE rollback
+        },
+        vmomi={
+            "/VirtualMachine/vm-77/ReconfigVM_Task": _task_moref("task-9"),
+            "Task": _task_info_result("task-9", "running"),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "esx-nested-04",
+            "guest_os": "VMKERNEL_8",
+            "nested_hv": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert ("DELETE", "/api/vcenter/vm/vm-77") in [(c["method"], c["path"]) for c in conn.calls]
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "nested_hv"
+    assert "did not reach a terminal state" in out["rollback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_gated_nested_hv_returns_awaiting_no_power_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gated VHV reconfigure short-circuits: no vmomi write, no power-on."""
+    vim_op = "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={vim_op: _awaiting(vim_op)}))
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-1", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-77"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "esx-nested-05",
+            "guest_os": "VMKERNEL_8",
+            "nested_hv": True,
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == vim_op
+    assert conn.vmomi_calls == []
+    # The power-on never fired: the folder GET and create POST are the only calls.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/folder"),
+        ("POST", "/api/vcenter/vm"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_without_nested_hv_param_is_byte_identical(gate: _GateRecorder) -> None:
+    """Param absent: no vim call, no vim gate, and the envelope carries no new key."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+            "/api/vcenter/vm/vm-99/power?action=start": {},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.vmomi_calls == []
+    assert "POST:/VirtualMachine/{moId}/ReconfigVM_Task" not in gate.gated_op_ids
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create", "power_on"],
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_create_nested_hv_false_skips_leg_and_echoes_false(
+    gate: _GateRecorder,
+) -> None:
+    """An explicit nested_hv=false skips the vim leg and echoes the applied state."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-02",
+            "guest_os": "UBUNTU_64",
+            "nested_hv": False,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.vmomi_calls == []
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create"],
+        "failed_step": None,
+        "rollback_reason": None,
+        "nested_hv": False,
+    }
+
+
 # ===========================================================================
 # vm.clone
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -384,6 +384,7 @@ async def test_vm_create_preview_echoes_creation_spec() -> None:
                 "cpu_count": 4,
                 "memory_mib": 8192,
                 "nics": [{"network": "net-1"}, {"network": "net-2"}],
+                "nested_hv": True,
                 "power_on_after_create": True,
             }
         )
@@ -395,6 +396,7 @@ async def test_vm_create_preview_echoes_creation_spec() -> None:
         "cpu_count": 4,
         "memory_mib": 8192,
         "networks": ["net-1", "net-2"],
+        "nested_hv": True,
         "power_on_after_create": True,
     }
 
@@ -407,6 +409,7 @@ async def test_vm_create_preview_mirrors_handler_defaults() -> None:
     assert preview["cpu_count"] == 1
     assert preview["memory_mib"] == 1024
     assert preview["networks"] == []
+    assert preview["nested_hv"] is False
     assert preview["power_on_after_create"] is False
 
 
@@ -925,6 +928,7 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
             "cpu_count": 1,
             "memory_mib": 1024,
             "networks": [],
+            "nested_hv": False,
             "power_on_after_create": False,
         },
         "preview_populated": True,

--- a/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
+++ b/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
@@ -23,14 +23,15 @@ addressable as a datastore path (`[datastore1] iso/esxi-9.iso`).
 
 | # | Step | Op (governed id) | Kind |
 |---|------|------------------|------|
-| 1 | Base VM | `vmware.composite.vm.create` | composite |
-| 2 | Expose VHV to the guest | `POST:/VirtualMachine/{moId}/ReconfigVM_Task` | raw ingested (VI-JSON) |
+| 1 | Base VM **+ VHV** | `vmware.composite.vm.create` (`nested_hv: true`, #3093) | composite |
+| 2 | VHV, 9.x-only alternative | `POST:/VirtualMachine/{moId}/ReconfigVM_Task` | raw ingested (VI-JSON) |
 | 3 | Data disks (× N) | `POST:/vcenter/vm/{vm}/hardware/disk` | raw ingested |
 | 4 | Resize later (optional) | `PATCH:/vcenter/vm/{vm}/hardware/cpu` (or `vmware.composite.vm.resize`) | raw ingested / composite |
 | 5 | Installer media | `POST:/vcenter/vm/{vm}/hardware/cdrom` | raw ingested |
 | 6 | Power on | `vmware.composite.vm.power` (`{"vm": …, "verb": "on"}`) | composite |
 
-Steps 2–5 target the powered-off VM step 1 created; power on last. All
+Steps 3–5 target the powered-off VM step 1 created; power on last. Step
+2 exists only for a VM created *without* `nested_hv` on a 9.x fleet. All
 raw bodies are the **flat `/api` `*Spec` shape** — never the legacy
 `/rest`-style `{"spec": {...}}` envelope (#2973/#3071 class; the one
 `"spec"` key in step 2 is the vim request type's genuine required
@@ -46,6 +47,7 @@ parameter, not an envelope).
   "cpu_count": 8,
   "memory_mib": 16384,
   "nics": [{"network": "<portgroup-moid>", "backing_type": "DISTRIBUTED_PORTGROUP"}],
+  "nested_hv": true,
   "power_on_after_create": false
 }
 ```
@@ -55,6 +57,15 @@ parameter, not an envelope).
   spec: prose-only enum). `VMKERNEL_8` / `VMKERNEL_9` are documented
   values in the pinned 9.0 spec, so an ESXi guest is a legitimate,
   spec-grounded identifier (gap 5 on typo behaviour, gap 4 on casing).
+- `nested_hv: true` (#3093) enables nested hardware-assisted
+  virtualization as part of the create: after NIC attach and **before any
+  power-on**, the composite issues the vim `ReconfigVM_Task`
+  (`VirtualMachineConfigSpec.nestedHVEnabled=true`) through its governed
+  vmomi substrate — the `/sdk/vim25/{release}` mount that is
+  version-correct on vCenter 8.0.x **and** 9.x, unlike the raw step 2 —
+  and polls the task to terminal. A failed VHV leg rolls the VM back like
+  any other post-create step; the `created` envelope echoes the applied
+  `nested_hv` state.
 - The composite resolves the folder by display name, attaches NICs, and
   rolls back (`DELETE:/vcenter/vm/{vm}`) on partial failure.
 - The composite does **not** expose the CreateSpec's `disks`, `cdroms`,
@@ -64,11 +75,7 @@ parameter, not an envelope).
   call), drop to the raw `POST:/vcenter/vm` — its pinned CreateSpec
   carries all of them inline, keyed `guest_os` (required, snake_case).
 
-### 2. VHV — VI-JSON `ReconfigVM_Task` (the step REST cannot express)
-
-```json
-{"moId": "<vm-id>", "body": {"spec": {"nestedHVEnabled": true}}}
-```
+### 2. VHV — raw VI-JSON `ReconfigVM_Task` (9.x-only alternative)
 
 Nested hardware-assisted virtualization (VHV — required for the nested
 ESXi to run 64-bit guests) has **no field on the vSphere Automation REST
@@ -76,11 +83,23 @@ surface**: the pinned `vcenter.yaml` serves no `hardware_virtualization`
 or `nestedHV` spelling anywhere, and `Cpu.UpdateSpec` is exactly
 `{count, cores_per_socket, hot_add_enabled, hot_remove_enabled}` (gap 1
 — issue #3087's `PATCH …/hardware/cpu` premise does not hold on the
-pinned spec). The governed path is the VI-JSON reconfigure:
+pinned spec).
+
+**The primary governed path is step 1's `vm.create(nested_hv=true)`
+(#3093)** — the composite's vim substrate mounts `ReconfigVM_Task` on the
+documented release-versioned base, so it works on vCenter 8.0.x *and*
+9.x, and the leg is task-polled with the composite's rollback contract.
+Use this raw form only when the VM already exists without VHV (e.g. a
+pre-#3093 create) **and** the target is a 9.x fleet:
+
+```json
+{"moId": "<vm-id>", "body": {"spec": {"nestedHVEnabled": true}}}
+```
+
 `VirtualMachineConfigSpec.nestedHVEnabled` is served by the pinned
 `vi-json.yaml`, both specs are ingested for this connector (G3.1-T2/T3),
-and the same op_id is already governance-registered as a composite
-sub-op (`vm.disk.grow` gates on it).
+and the same op_id is governance-registered as a composite sub-op
+(`vm.create`'s VHV leg and `vm.disk.grow` both gate on it).
 
 - Issue against the **powered-off** VM; the 200 body is a Task MoRef
   (`{"type": "Task", "value": "task-…"}`) — confirm completion via the
@@ -91,8 +110,8 @@ sub-op (`vm.disk.grow` gates on it).
   (`/sdk/vim25/{release}`) is applied only by the typed
   `_post_vmomi_json` helper inside composites, so this raw step is
   **9.x-fleet-only**: on vCenter 8.0.x the `/api`-mounted vmomi form
-  404s. The nested-substrate goal is VCF 9.x-first, so this is a
-  documented constraint, not a blocker.
+  404s — on an 8.0.x outer vCenter, `vm.create(nested_hv=true)` is the
+  only governed route.
 
 ### 3. Data disks — raw disk add, one call per disk
 
@@ -148,21 +167,27 @@ inspectable powered-off VM; the operator retries or deletes. The one
 genuinely composite-shaped step (base VM create with rollback) already
 exists. A `vm.nested_prepare` wrapper would add agent-surface weight
 without changing governance: each raw op above is individually
-policy-gated, approval-routed, and audited.
+policy-gated, approval-routed, and audited. #3093 follows the same
+logic from the other side: the VHV flag folded into the *existing*
+`vm.create` composite as a param (where the before-power-on ordering
+and rollback contract already live) instead of growing a new op.
 
 ## Gap list (each pinned by a test)
 
 1. **VHV is not expressible on the REST surface.** No
    `hardware_virtualization` / `nestedHV` anywhere in the pinned
    `vcenter.yaml` (neither `Cpu.UpdateSpec` nor `Vm.CreateSpec.cpu`).
-   Governed path = VI-JSON `ReconfigVM_Task` (step 2). When a re-pinned
+   Governed path = `vm.create(nested_hv=true)` (#3093, the composite's
+   vim substrate); raw VI-JSON `ReconfigVM_Task` (step 2) is the
+   9.x-only alternative for an already-created VM. When a re-pinned
    spec grows the REST field, the gap lane fails → move the recipe to
    the REST field.
 2. **Raw VI-JSON dispatch mounts on `/api`, not `/sdk/vim25/{release}`.**
    Works on the 9.x fleet (observed accommodation, #2466); 404s on
    vCenter 8.0.x. Only typed composite helpers do release-versioned
-   VI-JSON mounting. Follow-up candidate if 8.x nested targets ever
-   matter.
+   VI-JSON mounting — which is why #3093 routes the recipe's VHV flag
+   through `vm.create` rather than the raw op. Follow-up candidate if
+   8.x nested targets ever need the *raw* vim surface beyond this flag.
 3. **Thin provisioning is not expressible on the disk add.**
    `VmdkCreateSpec` = `{name, capacity, storage_policy}`; provisioning
    follows the datastore default / storage policy.
@@ -192,10 +217,12 @@ policy-gated, approval-routed, and audited.
 | Recipe REST ops served by pinned spec; flat bodies; VHV/thin gaps; `guest_os` casing + prose enum; ISO backing; `nestedHVEnabled` served | `backend/tests/test_connectors_vmware_rest_nested_esxi_spec_reconcile.py` |
 | Wire shape of every raw call (path/verb/mount/body), 204 handling, `/api` vmomi mount caveat, schema validation of the examples, `VMKERNEL_*` pass-through | `backend/tests/test_connectors_vmware_rest_nested_esxi_recipe.py` |
 | cdrom composite manifest (update/remove/disconnect only) | `test_cdrom_composite_covers_update_remove_disconnect_only` (reconcile module) |
+| `vm.create(nested_hv=true)` leg: reconfigure-before-power-on ordering, body shape, gating, rollback on leg failure, param-absent byte-identity | `test_vm_create_nested_hv_*` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; vim manifest + pinned-spec lane in `..._composites_l2_ingest_reconcile.py` (#3093) |
 
 ## References
 
-- #3087 (this recipe), #3086 (sibling: ISO import + mount)
+- #3087 (this recipe), #3086 (sibling: ISO import + mount), #3093
+  (`vm.create` `nested_hv` — the composite VHV leg)
 - #2973 / #3071 — the `/rest`-vs-`/api` body-envelope class the raw
   bodies were checked against; #2466 — VI-JSON mount bases; #3082 —
   204-no-body writes

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -584,7 +584,7 @@ enum) are:
 
 | Composite | Status values |
 | --- | --- |
-| `vm.create` | `created`, `rolled_back` |
+| `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical) |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
 | `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item`, `resolve_error` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error`, and a faulted content-library `find` during name resolution → `resolve_error` (#3071), both with a structured message carrying the vCenter status — so a placement/mapping/resolution error is a structured status, never a raw vendor fault) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
@@ -674,7 +674,13 @@ capacity field, spec-verified), so the capacity change is only reachable
 through vim `VirtualMachine.ReconfigVM_Task`. This is the connector's first
 *mutating* VI-JSON call, and it establishes two reusable seams that Tasks D
 (`vm.clone_from_template`, `CloneVM_Task`, #2894) and E (`cluster.drs_rule.create`,
-`ReconfigureComputeResource_Task`, #2895) ride.
+`ReconfigureComputeResource_Task`, #2895) ride. `vm.create`'s optional
+`nested_hv` leg (#3093) rides the same two seams:
+`VirtualMachineConfigSpec.nestedHVEnabled` has no REST expression (pinned by
+the #3087 recipe lanes) and *raw* VI-JSON dispatch mounts on `/api` — a
+9.x-fleet accommodation that 404s on vCenter 8.0.x (#2466) — so the
+substrate's `/sdk/vim25/{release}` mount is the only cross-version governed
+path to the flag.
 
 **1. Governed mutating vmomi sub-op — `_write_vmomi_sub_op` (in `_write.py`).**
 A mutating vmomi POST is a *write* sub-op, not a transport detail, so it
@@ -1080,7 +1086,7 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `vm.resize` | `{vm, name, power_state, current, requested}` sizing from->to | live read (`GET:/vcenter/vm/{vm}`) |
 | `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
 | `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
-| `vm.create` | creation-spec echo (name, guest_os, sizing, networks, power-on) | param echo, no I/O |
+| `vm.create` | creation-spec echo (name, guest_os, sizing, networks, nested_hv, power-on) | param echo, no I/O |
 | `vm.clone` | clone-coordinates echo | param echo, no I/O |
 | `vm.deploy_from_library` | deploy-coordinates echo (item ref, placement, network mappings, provisioning, `ovf_property_keys` — **ids only**, never values #1503, power-on) | param echo, no I/O |
 | `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |


### PR DESCRIPTION
## Summary

- `vmware.composite.vm.create` grows an optional `nested_hv: boolean` param: when true, after create + NIC attach and **before any power-on**, the composite enables nested hardware-assisted virtualization via vim `ReconfigVM_Task` (`{"spec": {"nestedHVEnabled": true}}`) through the existing governed vmomi write seam (`_write_vmomi_sub_op` → `_post_vmomi_json`, the `/sdk/vim25/{release}` mount that works on vCenter **8.0.x and 9.x** — REST cannot express the flag, pinned by the #3087 recipe lanes, and raw VI-JSON dispatch 404s on 8.0.x, #2466).
- The returned `*_Task` MoRef is polled to terminal via the shared `poll_vim_task` (600 s module-global `_VM_CREATE_VHV_TASK_TIMEOUT_SECONDS`, zeroable in tests). Any leg failure — transport fault, task fault, or poll timeout — follows vm.create's **existing rollback contract** (`DELETE:/vcenter/vm/{vm}` + `rolled_back` envelope with `failed_step="nested_hv"`); a parked/denied gate returns the `OperationResult` verbatim with no power-on.
- The `created` envelope echoes the applied `nested_hv` state **only when the param was supplied** — a param-absent call is byte-identical to today (proven by an exact-envelope regression test).
- Vim sub-ops declared in `_VIM_SUB_OPS_VM_CREATE` with the standard reconcile lane (manifest pin, ingest round-trip, pinned `vi-json.yaml` path + `nestedHVEnabled` field existence); schema, park-time preview, register description, connector doc, and the nested-ESXi recipe doc updated (VHV step is now `vm.create(nested_hv=true)`; the raw VI-JSON form is kept as the 9.x-only alternative for already-created VMs).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — 1 pre-existing platform-only error in `connectors/net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; file untouched, error identical on origin/main on darwin; CI runs Linux where it is green)
- [x] Composites + recipe suites (spec-shelf wired, pinned-spec lanes ran for real): `pytest tests/test_connectors_vmware_rest_composites_write.py tests/..._l2_ingest_reconcile.py tests/..._write_preview.py tests/..._write_register.py tests/..._write_e2e.py tests/..._write_gate.py tests/..._write_body_reconcile.py tests/test_connectors_vmware_rest_nested_esxi_recipe.py tests/test_connectors_vmware_rest_nested_esxi_spec_reconcile.py` — **304 passed**
- [x] Adjacent suites (`test_runbooks_schemas.py`, `test_operations_composite_register.py`, `test_db_endpoint_descriptor.py`, `..._recursive_e2e.py`) — 59 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `cd cli && make snapshot-openapi && make generate` — regenerated, **no drift** (composite parameter schemas live in `endpoint_descriptor` rows, not the FastAPI document), so the committed snapshot/client stay unchanged and the CI freshness gate compares like-for-like
- [x] Acceptance: VHV reconfigure through the substrate seam, task-polled, before power-on — `test_vm_create_nested_hv_reconfigures_before_power_on` (cross-seam call-order pin)
- [x] Acceptance: VHV-leg failure follows the rollback contract — transport-fault / task-fault / poll-timeout / gated tests
- [x] Acceptance: param absent = byte-identical — `test_vm_create_without_nested_hv_param_is_byte_identical` (exact envelope + no vim gate/call)

## Out of scope

- Live-appliance verify of the leg against a real 8.0.x vCenter (the recipe doc's standing deferred follow-up; wire shapes are pinned against the pinned `vi-json.yaml`).
- Version-correct mounting for *raw* VI-JSON dispatch (#2466 class) — this PR routes the recipe's one 8.0.x-blocked flag through the composite instead.
- Rebased onto `origin/main` after #3089 merged and reconciled the recipe doc it introduced.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3093
