### PR TITLE
feat(connectors): vm.create placement passthrough — resource_pool/datastore/host pins (#3096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — `vm.create` placement passthrough: resource_pool / datastore / host pins (#3096)
+
+- `vmware.composite.vm.create` accepts optional `resource_pool`, `datastore`
+  and `host` moid params and threads the supplied ones into the CreateSpec
+  `placement` alongside the resolved folder moid. Folder-only placement
+  cannot pin a multi-host cluster with host-local datastores — the pinned
+  spec marks `resource_pool` as currently required when neither host nor
+  cluster is given, so an underspecified create either fails at the vendor
+  or lands wherever vCenter defaults it — and the composite is the only
+  governed path for a nested-hypervisor-ready VM (its #3093 `nested_hv` leg
+  rides the vim substrate REST cannot express). Absent params keep the
+  create body and the `created` envelope byte-identical (exact-body and
+  exact-envelope regressions pin both), the approval preview echoes the
+  pins, and the pinned `Vcenter.VM.PlacementSpec` field set is reconciled
+  in the nested-ESXi spec lane.
+
 ### Added — `vm.create` `nested_hv`: governed VHV enable via the vim substrate (#3093)
 
 - `vmware.composite.vm.create` grows an optional `nested_hv: boolean` param:

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1056,7 +1056,11 @@ async def vm_create_composite(
     The optional ``nested_hv`` leg (#3093) runs after NIC attach and strictly
     **before** any power-on — a powered-on reconfigure of
     ``nestedHVEnabled`` is invalid — and follows the same rollback contract
-    as the other post-create steps.
+    as the other post-create steps. Optional placement pins (#3096:
+    ``resource_pool`` / ``datastore`` / ``host`` moids) thread into the
+    CreateSpec ``placement`` alongside the resolved folder moid; absent
+    pins leave vCenter's placement defaulting untouched and keep the
+    create body byte-identical to a pre-#3096 call.
     """
     folder_name = params["folder_name"]
     name = params["name"]
@@ -1064,6 +1068,9 @@ async def vm_create_composite(
     cpu_count = int(params.get("cpu_count", 1))
     memory_mib = int(params.get("memory_mib", 1024))
     nics: list[dict[str, Any]] = list(params.get("nics") or [])
+    placement_pins: dict[str, Any] = {
+        key: params[key] for key in ("resource_pool", "datastore", "host") if key in params
+    }
     nested_hv = bool(params.get("nested_hv", False))
     power_on = bool(params.get("power_on_after_create", False))
 
@@ -1079,7 +1086,7 @@ async def vm_create_composite(
     create_spec = {
         "name": name,
         "guest_OS": guest_os,
-        "placement": {"folder": folder_moid},
+        "placement": {"folder": folder_moid, **placement_pins},
         "cpu": {"count": cpu_count},
         "memory": {"size_MiB": memory_mib},
     }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -23,7 +23,9 @@ helpers, never the mutating sub-ops.
 ``host.detach_from_vds``  ``{host, dvs, fallback_network, resolved,
                           total_resolved}``
 ``cluster.patch``         ``{cluster, resolved, total_resolved}``
-``vm.create``             echo: name, guest_os, sizing, networks, VHV, power-on
+``vm.create``             echo: name, guest_os, sizing, placement pins
+                          (folder_name, resource_pool, datastore, host),
+                          networks, VHV, power-on
 ``vm.clone``              echo: source_vm, target_name, library_item
 ``vm.clone_from_template`` echo: source_template, new_vm_name, folder,
                           resource_pool, datastore, host, power_on,
@@ -307,6 +309,9 @@ async def _vm_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "name": name,
         "guest_os": guest_os,
         "folder_name": ctx.params.get("folder_name"),
+        "resource_pool": ctx.params.get("resource_pool"),
+        "datastore": ctx.params.get("datastore"),
+        "host": ctx.params.get("host"),
         "cpu_count": int(ctx.params.get("cpu_count", 1)),
         "memory_mib": int(ctx.params.get("memory_mib", 1024)),
         "networks": networks,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -597,7 +597,9 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
 #:
 #: Orchestrates folder lookup -> ``POST:/vcenter/vm`` -> per-NIC attach
 #: -> optional power-on. Partial-failure rollback removes the half-
-#: created VM via ``DELETE:/vcenter/vm/{vm}``.
+#: created VM via ``DELETE:/vcenter/vm/{vm}``. Optional placement pins
+#: (``resource_pool`` / ``datastore`` / ``host`` moids, #3096) thread
+#: into the CreateSpec ``placement`` alongside the resolved folder moid.
 VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -608,6 +610,40 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "Display name of the target VM folder. Resolved via "
                 "``GET:/vcenter/folder?filter.names=...`` to the moid "
                 "passed to ``POST:/vcenter/vm``."
+            ),
+        },
+        "resource_pool": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional ResourcePool moid pin (#3096). Threaded into "
+                "the CreateSpec ``placement`` alongside the resolved "
+                "folder moid. The pinned spec marks ``resource_pool`` as "
+                "currently required when neither host nor cluster is "
+                "given, so multi-host clusters should pin it; absent, "
+                "vCenter's placement defaulting applies."
+            ),
+        },
+        "datastore": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional Datastore moid pin (#3096) for the VM home and "
+                "disk storage. Threaded into the CreateSpec "
+                "``placement``; absent, vCenter's placement defaulting "
+                "applies — on hosts with host-local datastores the "
+                "default may land the VM on the wrong store."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional HostSystem moid pin (#3096). Threaded into the "
+                "CreateSpec ``placement``; per the pinned spec a "
+                "``resource_pool`` given alongside it must belong to "
+                "that host. Absent, vCenter's placement defaulting "
+                "applies."
             ),
         },
         "name": {

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -397,6 +397,121 @@ async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
 
 
 @pytest.mark.asyncio
+async def test_vm_create_placement_pins_thread_into_the_create_body(gate: _GateRecorder) -> None:
+    """resource_pool / datastore / host moids ride the CreateSpec placement (#3096).
+
+    Exact-body assertion: the three pins land inside ``placement`` alongside
+    the resolved folder moid, and the ``created`` envelope grows no new key
+    (placement is vendor-facing input, not applied state to echo).
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "host": "host-14",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.calls[1]["body"] == {
+        "name": "web-01",
+        "guest_OS": "UBUNTU_64",
+        "placement": {
+            "folder": "folder-7",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "host": "host-14",
+        },
+        "cpu": {"count": 1},
+        "memory": {"size_MiB": 1024},
+    }
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create"],
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_create_partial_placement_pin_adds_only_the_supplied_key(
+    gate: _GateRecorder,
+) -> None:
+    """A lone datastore pin adds exactly that key -- no None-filled siblings."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+        }
+    )
+    await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.calls[1]["body"]["placement"] == {
+        "folder": "folder-7",
+        "datastore": "datastore-11",
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_create_without_placement_pins_create_body_is_byte_identical(
+    gate: _GateRecorder,
+) -> None:
+    """Pins absent: the create body is exactly the pre-#3096 shape (folder only)."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "cpu_count": 2,
+            "memory_mib": 4096,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.calls[1]["body"] == {
+        "name": "web-01",
+        "guest_OS": "UBUNTU_64",
+        "placement": {"folder": "folder-7"},
+        "cpu": {"count": 2},
+        "memory": {"size_MiB": 4096},
+    }
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create"],
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_vm_create_nic_failure_rolls_back_via_delete(gate: _GateRecorder) -> None:
     """A NIC-attach transport error triggers DELETE rollback; status=rolled_back."""
     conn = _RecordingConnector(

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -381,6 +381,9 @@ async def test_vm_create_preview_echoes_creation_spec() -> None:
                 "folder_name": "prod",
                 "name": "vm-new",
                 "guest_os": "UBUNTU_64",
+                "resource_pool": "resgroup-8",
+                "datastore": "datastore-11",
+                "host": "host-14",
                 "cpu_count": 4,
                 "memory_mib": 8192,
                 "nics": [{"network": "net-1"}, {"network": "net-2"}],
@@ -393,6 +396,9 @@ async def test_vm_create_preview_echoes_creation_spec() -> None:
         "name": "vm-new",
         "guest_os": "UBUNTU_64",
         "folder_name": "prod",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-11",
+        "host": "host-14",
         "cpu_count": 4,
         "memory_mib": 8192,
         "networks": ["net-1", "net-2"],
@@ -411,6 +417,10 @@ async def test_vm_create_preview_mirrors_handler_defaults() -> None:
     assert preview["networks"] == []
     assert preview["nested_hv"] is False
     assert preview["power_on_after_create"] is False
+    # No placement pin supplied -> the echo names the vCenter-defaulting gap.
+    assert preview["resource_pool"] is None
+    assert preview["datastore"] is None
+    assert preview["host"] is None
 
 
 async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
@@ -925,6 +935,9 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
             "name": "vm-new",
             "guest_os": "UBUNTU_64",
             "folder_name": "prod",
+            "resource_pool": None,
+            "datastore": None,
+            "host": None,
             "cpu_count": 1,
             "memory_mib": 1024,
             "networks": [],

--- a/backend/tests/test_connectors_vmware_rest_nested_esxi_spec_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_nested_esxi_spec_reconcile.py
@@ -292,6 +292,31 @@ def test_vm_create_spec_guest_os_is_a_snake_case_free_string_with_esxi_values() 
     assert {"disks", "cdroms", "cpu", "memory", "nics", "boot", "boot_devices"} <= set(props)
 
 
+def test_vm_placement_spec_serves_the_composite_placement_pins() -> None:
+    """``Vcenter.VM.PlacementSpec`` serves the pins ``vm.create`` threads (#3096).
+
+    The composite threads optional ``resource_pool`` / ``datastore`` /
+    ``host`` moids into the CreateSpec ``placement`` alongside the resolved
+    folder moid — the recipe's way to pin a multi-host cluster with
+    host-local datastores. Exact pin: the pinned PlacementSpec is
+    ``{cluster, datastore, folder, host, resource_pool}`` with no
+    schema-level required set (``resource_pool`` is required only by prose,
+    when neither host nor cluster is given). ``cluster`` is served but
+    deliberately not exposed by the composite; a re-pin that grows or
+    hard-requires a placement field fails here, forcing a deliberate
+    schema review.
+    """
+    schema = _component_schema(_vcenter_spec_text(), "Vcenter.VM.PlacementSpec")
+    assert set(schema.get("properties", {})) == {
+        "cluster",
+        "datastore",
+        "folder",
+        "host",
+        "resource_pool",
+    }
+    assert not schema.get("required")
+
+
 # ---------------------------------------------------------------------------
 # vi-json.yaml lanes — the VHV escape hatch
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
+++ b/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
@@ -68,6 +68,16 @@ parameter, not an envelope).
   `nested_hv` state.
 - The composite resolves the folder by display name, attaches NICs, and
   rolls back (`DELETE:/vcenter/vm/{vm}`) on partial failure.
+- **Placement is first-class on the composite (#3096):** optional
+  `resource_pool`, `datastore`, `host` (moids) thread into the CreateSpec
+  `placement` alongside the resolved folder moid — the way to pin a
+  multi-host cluster with host-local datastores. Folder-only placement
+  leaves the pick to vCenter's defaulting, and the pinned spec marks
+  `resource_pool` as currently required when neither host nor cluster is
+  given, so an underspecified create can fail outright on such
+  inventories. Absent pins keep the create body byte-identical to a
+  pre-#3096 call. (`cluster` is served by the pinned PlacementSpec but
+  not exposed — pin the cluster via its root resource pool.)
 - The composite does **not** expose the CreateSpec's `disks`, `cdroms`,
   `boot`, `boot_devices`, or `hardware_version` — vCenter creates a
   single guest-specific blank boot disk by default. When the shape needs
@@ -218,11 +228,13 @@ and rollback contract already live) instead of growing a new op.
 | Wire shape of every raw call (path/verb/mount/body), 204 handling, `/api` vmomi mount caveat, schema validation of the examples, `VMKERNEL_*` pass-through | `backend/tests/test_connectors_vmware_rest_nested_esxi_recipe.py` |
 | cdrom composite manifest (update/remove/disconnect only) | `test_cdrom_composite_covers_update_remove_disconnect_only` (reconcile module) |
 | `vm.create(nested_hv=true)` leg: reconfigure-before-power-on ordering, body shape, gating, rollback on leg failure, param-absent byte-identity | `test_vm_create_nested_hv_*` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; vim manifest + pinned-spec lane in `..._composites_l2_ingest_reconcile.py` (#3093) |
+| `vm.create` placement pins (`resource_pool` / `datastore` / `host`) thread into the create body; pin-absent body byte-identity; pinned `VM.PlacementSpec` field set | `test_vm_create_placement_pins_thread_into_the_create_body` / `test_vm_create_without_placement_pins_create_body_is_byte_identical` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; `test_vm_placement_spec_serves_the_composite_placement_pins` (reconcile module) (#3096) |
 
 ## References
 
 - #3087 (this recipe), #3086 (sibling: ISO import + mount), #3093
-  (`vm.create` `nested_hv` — the composite VHV leg)
+  (`vm.create` `nested_hv` — the composite VHV leg), #3096 (`vm.create`
+  placement pins)
 - #2973 / #3071 — the `/rest`-vs-`/api` body-envelope class the raw
   bodies were checked against; #2466 — VI-JSON mount bases; #3082 —
   204-no-body writes

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -584,7 +584,7 @@ enum) are:
 
 | Composite | Status values |
 | --- | --- |
-| `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical) |
+| `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical. Optional placement pins — `resource_pool` / `datastore` / `host` moids, #3096 — thread into the CreateSpec `placement` alongside the resolved folder moid; absent pins keep the create body byte-identical and never echo into the envelope) |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
 | `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item`, `resolve_error` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error`, and a faulted content-library `find` during name resolution → `resolve_error` (#3071), both with a structured message carrying the vCenter status — so a placement/mapping/resolution error is a structured status, never a raw vendor fault) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
@@ -1086,7 +1086,7 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `vm.resize` | `{vm, name, power_state, current, requested}` sizing from->to | live read (`GET:/vcenter/vm/{vm}`) |
 | `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
 | `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
-| `vm.create` | creation-spec echo (name, guest_os, sizing, networks, nested_hv, power-on) | param echo, no I/O |
+| `vm.create` | creation-spec echo (name, guest_os, placement pins — folder_name, resource_pool, datastore, host (#3096) — sizing, networks, nested_hv, power-on) | param echo, no I/O |
 | `vm.clone` | clone-coordinates echo | param echo, no I/O |
 | `vm.deploy_from_library` | deploy-coordinates echo (item ref, placement, network mappings, provisioning, `ovf_property_keys` — **ids only**, never values #1503, power-on) | param echo, no I/O |
 | `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |


### PR DESCRIPTION
## Summary

- `vmware.composite.vm.create` accepts optional `resource_pool` / `datastore` / `host` (moid strings) and threads the supplied ones into the CreateSpec `placement` alongside the existing resolved `folder` moid. Folder-only placement cannot pin a multi-host cluster with host-local datastores — the pinned `Vcenter.VM.PlacementSpec` marks `resource_pool` as *currently required* when neither host nor cluster is given — and the composite is the only governed path for a nested-hypervisor-ready VM (#3093's `nested_hv` leg rides the vim substrate REST cannot express).
- Only supplied keys are added (no None-filling), so a pin-absent call keeps the create body **and** the `created` envelope byte-identical to before — pinned by exact-body + exact-envelope regressions, the #3094 pattern. Placement is vendor-facing input, not applied state, so nothing new echoes into the envelope.
- The approval preview echoes the pins (value-or-None, the `deploy_from_library` convention), and a new shelf-gated reconcile lane exact-pins the pinned `Vcenter.VM.PlacementSpec` field set (`{cluster, datastore, folder, host, resource_pool}`, no schema-level required) — `cluster` is served but deliberately unexposed; a cluster pin rides its root resource pool.
- Docs: nested-ESXi recipe (placement now first-class on step 1, claim-table row, refs), `connectors-vmware-rest.md` status + preview rows, CHANGELOG `[Unreleased]` bullet.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check src/ tests/` — 1571 files already formatted
- [x] `mypy src/` — clean except the pre-existing Linux-only `net/icmp.py` `MSG_ERRQUEUE` artifact (file untouched, green in CI)
- [x] `pytest tests/ -k vmware_rest` with the spec shelf wired — 573 passed, 2 skipped
- [x] `pytest tests/test_connectors_registry_v2.py tests/test_db_endpoint_descriptor.py` — 50 passed
- [x] AC1 — all three fields pass through; `test_vm_create_placement_pins_thread_into_the_create_body` asserts the **exact** built create body (plus a partial-pin test proving no None-filled siblings)
- [x] AC2 — param-absent byte-identical; `test_vm_create_without_placement_pins_create_body_is_byte_identical` exact-asserts body + envelope
- [x] AC3 — schema (`VM_CREATE_PARAMETER_SCHEMA`), preview (`_vm_create_preview` + module table), CLI OpenAPI snapshot (regenerated via `make snapshot-openapi`: **zero drift** — composite parameter schemas ride `endpoint_descriptor`, not the FastAPI document, so the committed snapshot is already current), recipe doc updated
- [x] New reconcile lane runs non-vacuously against the local shelf (`test_vm_placement_spec_serves_the_composite_placement_pins` PASSED, not skipped)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (warnings are pre-existing file-size debt in the composites package)

## Out of scope

- `cluster` placement pin (served by the pinned spec, no consumer yet — the exact-pin lane forces a deliberate review if a re-pin changes the field set)
- Name→moid resolution for the new pins (the issue specifies moid strings, matching `deploy_from_library`)
- The recorded `guest_OS`/`size_MiB` field-casing gap (recipe gap 4) — unchanged, pending live-appliance verify

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3096
