### PR TITLE
fix(operations): bundle nested $ref components at ingest; structured invalid_op_schema at dispatch

### DIFF
--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -15,7 +15,8 @@ dispatcher's :func:`dispatch` body stay focused on control flow.
 
 Each builder owns one ``error_code`` from the contract documented in
 :mod:`meho_backplane.operations.dispatcher`'s module docstring:
-``unknown_op`` / ``invalid_params`` / ``no_connector`` /
+``unknown_op`` / ``invalid_params`` / ``invalid_op_schema`` /
+``no_connector`` /
 ``ambiguous_connector`` / ``handler_unreachable`` / ``denied`` /
 ``awaiting_approval`` / ``connector_unsupported`` /
 ``connector_http_403`` / ``connector_http_422`` /
@@ -59,6 +60,7 @@ __all__ = [
     "result_connector_vault_write_forbidden",
     "result_denied",
     "result_handler_unreachable",
+    "result_invalid_op_schema",
     "result_invalid_params",
     "result_no_connector",
     "result_no_target",
@@ -140,6 +142,47 @@ def result_invalid_params(
         extras={
             "error_code": "invalid_params",
             "validation_errors": validation_errors,
+        },
+    )
+
+
+def result_invalid_op_schema(
+    op_id: str,
+    missing_ref: str,
+    duration_ms: float,
+) -> OperationResult:
+    """The stored ``parameter_schema`` is self-broken -- a ``$ref`` resolves nowhere.
+
+    #3095. Raised-shape sibling of :func:`result_invalid_params` with the
+    blame inverted: ``invalid_params`` means the *caller's* params failed
+    a sound schema; ``invalid_op_schema`` means the *descriptor's* schema
+    could never validate any input (a nested ``$ref`` was stored without
+    its component -- pre-#3095 ingest, or a hand-registered typed op with
+    a dangling ref). Before #3095 this crashed dispatch with an unhandled
+    ``PointerToNowhere`` -> HTTP 500, indistinguishable from an outage.
+
+    ``extras`` carries ``missing_ref`` (the ``$ref`` spelling the spec
+    author would recognise) and ``remediation``: re-ingesting the
+    connector's spec rebuilds the descriptor with the component bundle,
+    which is the durable fix for rows written by older ingests.
+    """
+    return OperationResult(
+        status="error",
+        op_id=op_id,
+        error=(
+            f"invalid_op_schema: stored parameter_schema for {op_id!r} contains "
+            f"an unresolvable $ref ({missing_ref}); the op cannot validate any "
+            f"params until its descriptor is repaired"
+        ),
+        duration_ms=duration_ms,
+        extras={
+            "error_code": "invalid_op_schema",
+            "missing_ref": missing_ref,
+            "remediation": (
+                "re-ingest the connector's spec (ingestion bundles referenced "
+                "component schemas transitively since #3095); if the ref names "
+                "a component the vendor spec never defines, fix the spec"
+            ),
         },
     )
 

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -60,12 +60,44 @@ from meho_backplane.operations._lookup import (
     lookup_descriptor,
     parse_connector_id,
 )
-from meho_backplane.operations._validate import validate_params
+from meho_backplane.operations._validate import InvalidOpSchemaError, validate_params
 from meho_backplane.redaction import apply_connector_boundary_redaction
 
 __all__ = ["preview_dispatch"]
 
 _log = structlog.get_logger(__name__)
+
+
+def _invalid_op_schema_envelope(
+    *,
+    op_id: str,
+    connector_id: str,
+    source_kind: str,
+    missing_ref: str,
+) -> dict[str, Any]:
+    """Structured envelope for a self-broken stored ``parameter_schema`` (#3095).
+
+    Mirrors the dispatcher's ``result_invalid_op_schema`` shape: the
+    descriptor — not the caller's params — is at fault, and the missing
+    pointer rides in ``extras`` so the operator can repair the spec /
+    re-ingest.
+    """
+    return {
+        "status": "error",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": source_kind,
+        "error": (
+            f"invalid_op_schema: stored parameter_schema for {op_id!r} "
+            f"contains an unresolvable $ref ({missing_ref}); the op "
+            "cannot validate any params until its descriptor is repaired "
+            "(re-ingest the connector's spec)."
+        ),
+        "extras": {
+            "error_code": "invalid_op_schema",
+            "missing_ref": missing_ref,
+        },
+    }
 
 
 async def _resolve_previewable_descriptor(
@@ -86,6 +118,9 @@ async def _resolve_previewable_descriptor(
       ``composite`` op has no single literal HTTP request to preview.
     * ``invalid_params`` -- params failed the descriptor's
       ``parameter_schema`` (same validation ``dispatch`` runs).
+    * ``invalid_op_schema`` -- the stored ``parameter_schema`` itself
+      carries an unresolvable ``$ref`` (#3095); same structured envelope
+      ``dispatch`` returns for the same broken descriptor.
     """
     product, version, impl_id = parse_connector_id(connector_id)
 
@@ -141,25 +176,49 @@ async def _resolve_previewable_descriptor(
         }
 
     # --- Step 3: parameter_schema validation (mirrors dispatch) -----------
-    validation_errors = validate_params(descriptor.parameter_schema, params)
+    try:
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+    except InvalidOpSchemaError as exc:
+        return _invalid_op_schema_envelope(
+            op_id=op_id,
+            connector_id=connector_id,
+            source_kind=descriptor.source_kind,
+            missing_ref=exc.missing_ref,
+        )
     if validation_errors:
-        return {
-            "status": "error",
-            "op_id": op_id,
-            "connector_id": connector_id,
-            "source_kind": descriptor.source_kind,
-            "error": (
-                "invalid_params: params failed the operation's parameter_schema; "
-                "fix the params shape (see extras.validation_errors) before "
-                "previewing."
-            ),
-            "extras": {
-                "error_code": "invalid_params",
-                "validation_errors": validation_errors,
-            },
-        }
+        return _invalid_params_envelope(
+            op_id=op_id,
+            connector_id=connector_id,
+            source_kind=descriptor.source_kind,
+            validation_errors=validation_errors,
+        )
 
     return descriptor
+
+
+def _invalid_params_envelope(
+    *,
+    op_id: str,
+    connector_id: str,
+    source_kind: str,
+    validation_errors: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Structured envelope for params that failed the stored schema."""
+    return {
+        "status": "error",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": source_kind,
+        "error": (
+            "invalid_params: params failed the operation's parameter_schema; "
+            "fix the params shape (see extras.validation_errors) before "
+            "previewing."
+        ),
+        "extras": {
+            "error_code": "invalid_params",
+            "validation_errors": validation_errors,
+        },
+    }
 
 
 def _redact_request_body(

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import structlog
 from jsonschema import Draft202012Validator
+from referencing.exceptions import Unresolvable
 
 from meho_backplane.auth.operator import Operator, PrincipalKind
 from meho_backplane.auth.permissions import _more_restrictive, resolve_verdict
@@ -40,10 +41,35 @@ from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
 _log = structlog.get_logger(__name__)
 
 __all__ = [
+    "InvalidOpSchemaError",
     "compute_params_hash",
     "policy_gate",
     "validate_params",
 ]
+
+
+class InvalidOpSchemaError(Exception):
+    """The stored ``parameter_schema`` itself is broken — not the params.
+
+    Raised by :func:`validate_params` when jsonschema's reference
+    machinery cannot resolve a ``$ref`` inside the descriptor's stored
+    schema (``referencing.exceptions.Unresolvable`` —
+    ``PointerToNowhere`` / ``NoSuchAnchor``). The classic producer is a
+    descriptor ingested before #3095's component bundling: its body
+    schema carries ``$ref: "#/components/schemas/X"`` but ``X`` was
+    never materialized into the stored document, so *no* input could
+    ever validate. Callers map this to a structured
+    ``invalid_op_schema`` error (the descriptor is at fault; the
+    caller's params were never judged) instead of letting the
+    referencing error escape as an HTTP 500.
+
+    ``missing_ref`` carries the offending ``$ref`` in the spelling a
+    spec author would recognise (``#/...``).
+    """
+
+    def __init__(self, missing_ref: str) -> None:
+        self.missing_ref = missing_ref
+        super().__init__(f"stored parameter_schema contains an unresolvable $ref: {missing_ref}")
 
 
 def compute_params_hash(params: dict[str, Any]) -> str:
@@ -81,19 +107,33 @@ def validate_params(
     registered without a parameter_schema (or with ``{}``) accept any
     params; the dispatcher is permissive at the schema layer when the
     descriptor itself is.
+
+    Raises:
+        InvalidOpSchemaError: The stored schema carries a ``$ref`` the
+            validator cannot resolve within the schema document
+            (#3095). The fault is the descriptor's, not the caller's,
+            so it is a distinct typed exception rather than an entry in
+            the returned (caller-attributed) error list. Surfaces
+            lazily — jsonschema resolves refs while validating — which
+            is why the ``iter_errors`` loop sits inside the guard.
     """
     if not parameter_schema:
         return []
-    validator = Draft202012Validator(parameter_schema)
     out: list[dict[str, Any]] = []
-    for err in validator.iter_errors(params):
-        out.append(
-            {
-                "path": err.json_path,
-                "message": err.message,
-                "validator": err.validator,
-            }
-        )
+    try:
+        validator = Draft202012Validator(parameter_schema)
+        for err in validator.iter_errors(params):
+            out.append(
+                {
+                    "path": err.json_path,
+                    "message": err.message,
+                    "validator": err.validator,
+                }
+            )
+    except Unresolvable as exc:
+        pointer = str(exc.ref)
+        missing_ref = f"#{pointer}" if pointer.startswith("/") else pointer
+        raise InvalidOpSchemaError(missing_ref) from exc
     return out
 
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -72,6 +72,13 @@ Detail payloads land in ``extras``. Codes:
 
 * ``unknown_op`` -- the natural key didn't resolve a descriptor.
 * ``invalid_params`` -- params failed JSON Schema validation.
+* ``invalid_op_schema`` -- the **stored** ``parameter_schema`` itself is
+  broken: it carries a ``$ref`` the validator cannot resolve within the
+  stored schema document (a descriptor ingested before #3095's
+  component bundling, or a hand-registered op with a dangling ref). The
+  caller's params were never judged; ``extras`` carries ``missing_ref``
+  and a ``remediation`` naming re-ingest as the durable fix. Before
+  #3095 this escaped as an unhandled ``PointerToNowhere`` -> HTTP 500.
 * ``no_connector`` -- resolver couldn't pick a connector for the target.
   ``extras["exception_message"]`` carries the
   :exc:`~meho_backplane.connectors.NoMatchingConnector` text when the
@@ -282,6 +289,7 @@ from meho_backplane.operations._errors import (
     result_connector_vault_write_forbidden,
     result_denied,
     result_handler_unreachable,
+    result_invalid_op_schema,
     result_invalid_params,
     result_no_connector,
     result_target_required,
@@ -307,6 +315,7 @@ from meho_backplane.operations._preview import (
     describe_preview_provenance,
 )
 from meho_backplane.operations._validate import (
+    InvalidOpSchemaError,
     compute_params_hash,
     policy_gate,
     validate_params,
@@ -2115,7 +2124,13 @@ async def dispatch(
         return result_unknown_op(op_id, known_op_count, _elapsed_ms(started))
 
     # --- Step 3: parameter_schema validation ------------------------------
-    validation_errors = validate_params(descriptor.parameter_schema, params)
+    try:
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+    except InvalidOpSchemaError as exc:
+        # #3095: the stored schema itself is broken (dangling $ref) --
+        # the descriptor is at fault, not the caller. Structured error
+        # instead of letting PointerToNowhere escape as a 500.
+        return result_invalid_op_schema(op_id, exc.missing_ref, _elapsed_ms(started))
     if validation_errors:
         return result_invalid_params(op_id, validation_errors, _elapsed_ms(started))
 

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -65,6 +65,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.models import (
     AuditLog,
+    EndpointDescriptor,
     GatewayCommand,
     GatewayCommandStatus,
     PermissionVerdict,
@@ -77,6 +78,7 @@ from meho_backplane.gateway.queue import (
 )
 from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
 from meho_backplane.operations._validate import (
+    InvalidOpSchemaError,
     compute_params_hash,
     policy_gate,
     validate_params,
@@ -141,6 +143,7 @@ class MintRefusalCode(StrEnum):
 
     DESCRIPTOR_UNKNOWN = "descriptor_unknown"
     INVALID_PARAMS = "invalid_params"
+    INVALID_OP_SCHEMA = "invalid_op_schema"
     OP_NOT_SAFE = "op_not_safe"
     POLICY_DENIED = "policy_denied"
     NEEDS_APPROVAL = "needs_approval"
@@ -170,6 +173,55 @@ class MintResult:
 def _refused(code: MintRefusalCode, reason: str) -> MintResult:
     """Build a fail-closed refusal result (no rows written)."""
     return MintResult(refusal_code=code, refusal_reason=reason)
+
+
+def _refuse_unvalidatable_params(
+    *,
+    descriptor: EndpointDescriptor,
+    params: dict[str, Any],
+    op_id: str,
+    operator_sub: str,
+) -> MintResult | None:
+    """Mint ladder Step 3: refuse when params fail — or cannot be — validated.
+
+    ``None`` means the params validated cleanly and the ladder proceeds.
+    Two refusal shapes, distinguished because the fault differs:
+
+    * :attr:`MintRefusalCode.INVALID_PARAMS` — the caller's params
+      failed a sound stored schema.
+    * :attr:`MintRefusalCode.INVALID_OP_SCHEMA` (#3095) — the stored
+      schema itself carries a ``$ref`` that resolves nowhere, so *no*
+      params could ever validate; the descriptor is at fault and the
+      remediation (re-ingest the spec) rides in the refusal reason.
+    """
+    try:
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+    except InvalidOpSchemaError as exc:
+        structlog.get_logger(__name__).info(
+            "gateway_command_mint_refused",
+            reason=MintRefusalCode.INVALID_OP_SCHEMA.value,
+            op_id=op_id,
+            operator_sub=operator_sub,
+            missing_ref=exc.missing_ref,
+        )
+        return _refused(
+            MintRefusalCode.INVALID_OP_SCHEMA,
+            f"stored parameter_schema for op {op_id!r} contains an "
+            f"unresolvable $ref ({exc.missing_ref}); re-ingest the "
+            f"connector's spec to repair the descriptor",
+        )
+    if validation_errors:
+        structlog.get_logger(__name__).info(
+            "gateway_command_mint_refused",
+            reason=MintRefusalCode.INVALID_PARAMS.value,
+            op_id=op_id,
+            operator_sub=operator_sub,
+        )
+        return _refused(
+            MintRefusalCode.INVALID_PARAMS,
+            f"params failed schema validation for op {op_id!r}",
+        )
+    return None
 
 
 async def _write_gateway_audit_row(
@@ -213,6 +265,11 @@ async def _write_gateway_audit_row(
     await session.flush()
 
 
+# Pre-existing mint-ladder size debt (~180 lines before #3095, which
+# net-shrinks it by extracting Step 3 into _refuse_unvalidatable_params);
+# splitting the remaining lookup / safe-wall / policy-gate / audit /
+# enqueue phases is its own refactor task, out of scope for #3095.
+# code-quality-allow: function-size — pre-existing ladder debt, net-shrunk here
 async def mint_gateway_command(
     session: AsyncSession,
     *,
@@ -233,7 +290,9 @@ async def mint_gateway_command(
     for a ``safety_level == 'safe'`` op:
 
     1. ``lookup_descriptor`` — unknown op → :attr:`MintRefusalCode.DESCRIPTOR_UNKNOWN`.
-    2. ``validate_params`` — invalid params → :attr:`MintRefusalCode.INVALID_PARAMS`.
+    2. ``validate_params`` — invalid params → :attr:`MintRefusalCode.INVALID_PARAMS`;
+       a stored schema whose own ``$ref`` cannot resolve (#3095) →
+       :attr:`MintRefusalCode.INVALID_OP_SCHEMA`.
     3. **safe-only wall** — ``descriptor.safety_level != 'safe'`` →
        :attr:`MintRefusalCode.OP_NOT_SAFE`. Checked **before** the policy
        gate so a non-``safe`` op is refused without even consulting it (and
@@ -297,18 +356,11 @@ async def mint_gateway_command(
         )
 
     # --- Step 3: parameter_schema validation -----------------------------
-    validation_errors = validate_params(descriptor.parameter_schema, params)
-    if validation_errors:
-        structlog.get_logger(__name__).info(
-            "gateway_command_mint_refused",
-            reason=MintRefusalCode.INVALID_PARAMS.value,
-            op_id=op_id,
-            operator_sub=operator.sub,
-        )
-        return _refused(
-            MintRefusalCode.INVALID_PARAMS,
-            f"params failed schema validation for op {op_id!r}",
-        )
+    params_refusal = _refuse_unvalidatable_params(
+        descriptor=descriptor, params=params, op_id=op_id, operator_sub=operator.sub
+    )
+    if params_refusal is not None:
+        return params_refusal
 
     # --- Safe-only wall (v1 read-only guarantee) -------------------------
     # Bound to the real op-identity metadata read straight off the

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -33,10 +33,23 @@ Out of scope (no conversion performed in-process):
 * GraphQL SDL / WSDL / protobuf — separate parsers; v0.2.next.
 * Cross-document ``$ref`` (``$ref: "other.yaml#/..."``) — raises
   :exc:`UnsupportedSpecError`.
-* Deep ``$ref`` resolution — only top-level refs under each parameter
-  / body schema are inlined; nested ``$ref`` strings are preserved
-  verbatim for the dispatcher's jsonschema validator to resolve at
-  call time.
+
+Nested ``$ref`` handling (#3095): only the top-level ref under each
+parameter / body schema is inlined; nested ``$ref`` strings are
+preserved verbatim, and every ``#/components/schemas/*`` component they
+transitively reference is **bundled** into the stored
+``parameter_schema`` under its own ``components.schemas`` key. The
+dispatcher's jsonschema validator resolves the nested refs as plain
+JSON Pointers into the stored document itself — no registry, no spec
+re-read — so a stored descriptor validates params standalone. A nested
+ref to a component the spec never defines fails the ingest with
+:exc:`InvalidSchemaError` (same posture as a dangling top-level ref);
+before #3095 it was stored silently and crashed dispatch with an
+unhandled ``PointerToNowhere``. ``response_schema`` is deliberately
+**not** bundled: nothing validates against it at dispatch (its only
+consumer is the JSONFlux reducer, which never resolves refs), and
+bundling it would multiply storage for the large recursive response
+types the vCenter / NSX specs declare.
 
 Known limitation: when an operation declares two parameters with the
 same ``name`` in different ``in`` locations (e.g. a ``cluster`` path
@@ -78,6 +91,12 @@ from meho_backplane.operations.ingest.exceptions import (
     InvalidSpecError,
     UnsupportedSpecError,
     UpstreamNotSpecError,
+)
+from meho_backplane.operations.ingest.refs import (
+    collect_component_schema_closure as _collect_component_schema_closure,
+)
+from meho_backplane.operations.ingest.refs import (
+    find_unresolvable_local_refs as _find_unresolvable_local_refs,
 )
 from meho_backplane.operations.ingest.refs import (
     normalize_boolean_schema as _normalize_boolean_schema,
@@ -982,6 +1001,40 @@ def _assert_json_serializable(*, op_id: str, field: str, schema: object) -> None
         ) from exc
 
 
+def _assert_parameter_schema_standalone(
+    *,
+    op_id: str,
+    parameter_schema: dict[str, object],
+) -> None:
+    """Fail closed when the stored ``parameter_schema`` cannot self-resolve.
+
+    The ingest-time lint for #3095: every schema-position ``$ref`` in
+    the final stored document must resolve as a JSON Pointer into that
+    same document, because that is exactly — and only — what the
+    dispatcher's jsonschema validator can do at call time. A descriptor
+    that fails this check could never validate any input; every
+    dispatch would return ``invalid_op_schema``. The component-closure
+    bundling in :func:`_build_parameter_schema` makes real vendor specs
+    pass; what this catches is the residue (absolute ``#/$defs/...``
+    pointers into a component's own document, ``$anchor``-style plain
+    fragments, hand-mutated specs). Fail posture, not warn: like
+    :func:`_assert_json_serializable`, both the ``dry_run`` and the
+    effectful ingest legs funnel through this proto-build boundary, so
+    they refuse the dead-on-arrival descriptor identically at parse
+    time instead of shipping an op that fails on first use.
+    """
+    unresolvable = _find_unresolvable_local_refs(parameter_schema)
+    if unresolvable:
+        refs = ", ".join(repr(ref) for ref in unresolvable)
+        raise InvalidSchemaError(
+            f"{op_id}: parameter_schema contains $ref pointers that do not "
+            f"resolve within the stored schema document ({refs}); the "
+            f"descriptor could never validate params at dispatch. Define the "
+            f"referenced components in the spec, or rewrite the refs as "
+            f"#/components/schemas/* pointers the parser can bundle."
+        )
+
+
 def _build_proto(
     *,
     method: str,
@@ -1038,6 +1091,7 @@ def _build_proto(
     _assert_json_serializable(op_id=op_id, field="parameter_schema", schema=parameter_schema)
     if response_schema is not None:
         _assert_json_serializable(op_id=op_id, field="response_schema", schema=response_schema)
+    _assert_parameter_schema_standalone(op_id=op_id, parameter_schema=parameter_schema)
 
     return EndpointDescriptorProto(
         op_id=op_id,
@@ -1117,6 +1171,13 @@ def _build_parameter_schema(
     payload regardless of property name. Operations with no params
     at all get the empty-but-valid ``{"type": "object", "properties":
     {}}``.
+
+    Nested ``$ref`` strings inside the inlined schemas are preserved
+    verbatim, and the components they transitively reference are
+    bundled under the returned schema's ``components.schemas`` key
+    (#3095) — see :func:`~meho_backplane.operations.ingest.refs.collect_component_schema_closure`.
+    A nested ref to a component the spec never defines raises
+    :class:`InvalidSchemaError` naming the operation and the ref.
     """
     properties: dict[str, object] = {}
     required: list[str] = []
@@ -1159,7 +1220,36 @@ def _build_parameter_schema(
     schema: dict[str, object] = {"type": "object", "properties": properties}
     if required:
         schema["required"] = required
+    _attach_component_closure(
+        schema=schema, component_schemas=component_schemas, path=path, method=method
+    )
     return schema
+
+
+def _attach_component_closure(
+    *,
+    schema: dict[str, object],
+    component_schemas: dict[str, Any],
+    path: str,
+    method: str,
+) -> None:
+    """Bundle the components *schema*'s nested refs transitively reference.
+
+    #3095: nested ``$ref`` strings survive the shallow inline verbatim,
+    and the dispatcher validates against the stored schema standalone
+    (no registry). Attaching the closure under the document's own
+    ``components.schemas`` key lets ``#/components/schemas/<name>``
+    resolve as a plain JSON Pointer at call time. Schemas with no
+    nested component refs gain no key and persist byte-identically to
+    pre-#3095 ingests. A ref to a component the spec never defines
+    raises :class:`InvalidSchemaError` naming the operation.
+    """
+    try:
+        closure = _collect_component_schema_closure(schema, component_schemas)
+    except InvalidSchemaError as exc:
+        raise InvalidSchemaError(f"paths.{path}.{method.lower()}: {exc}") from exc
+    if closure:
+        schema["components"] = {"schemas": closure}
 
 
 def _populate_param_properties(

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -350,11 +350,21 @@ def find_unresolvable_local_refs(schema: Any) -> list[str]:
             segment = _unescape_pointer_segment(raw_segment)
             if isinstance(node, dict) and segment in node:
                 node = node[segment]
-            elif isinstance(node, list) and segment.isdigit() and int(segment) < len(node):
+                continue
+            # RFC 6901 array indices are ASCII digits only. ``str.isdigit``
+            # alone also accepts non-ASCII digit codepoints ("²") that
+            # ``int()`` then rejects with ValueError -- guard with
+            # ``isascii`` so a pathological ref is flagged, not crashed on.
+            if (
+                isinstance(node, list)
+                and segment.isascii()
+                and segment.isdigit()
+                and int(segment) < len(node)
+            ):
                 node = node[int(segment)]
-            else:
-                unresolvable.add(ref)
-                break
+                continue
+            unresolvable.add(ref)
+            break
     return sorted(unresolvable)
 
 

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -11,6 +11,7 @@ across specs.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 
 from meho_backplane.operations.ingest.exceptions import (
@@ -20,6 +21,9 @@ from meho_backplane.operations.ingest.exceptions import (
 
 __all__ = [
     "PREFERRED_MEDIA_TYPES",
+    "collect_component_schema_closure",
+    "find_unresolvable_local_refs",
+    "iter_schema_refs",
     "normalize_boolean_schema",
     "resolve_shallow_ref",
     "select_media_type_schema",
@@ -192,6 +196,166 @@ def _resolve_named_component(
     if name not in bucket:
         raise InvalidSchemaError(f"$ref points at missing component (got {ref!r})")
     return bucket[name]
+
+
+#: The one component bucket a ``$ref`` nested *inside* a JSON Schema can
+#: legally point at. Parameter / response / requestBody refs only occur at
+#: the OpenAPI-object level and are resolved before schema extraction.
+_SCHEMA_COMPONENT_REF_PREFIX = "#/components/schemas/"
+
+#: JSON Schema keywords whose values are **named maps of subschemas** —
+#: the child *keys* are arbitrary names (property names, definition
+#: names), and every child *value* is itself a schema. The ref walk must
+#: descend through the values without applying the data-key skip list to
+#: the names (a property literally named ``enum`` still carries a schema).
+_SCHEMA_MAP_KEYWORDS = frozenset(
+    {"properties", "patternProperties", "dependentSchemas", "$defs", "definitions"}
+)
+
+#: JSON Schema keywords whose values are **data payloads**, not
+#: subschemas. A ``$ref``-shaped object inside an ``example`` or ``enum``
+#: member is literal data the validator never resolves, so the ref walk
+#: must not collect it (a false positive here would fail an ingest over
+#: a ref the dispatcher would never dereference).
+_DATA_VALUE_KEYWORDS = frozenset({"enum", "const", "default", "example", "examples"})
+
+
+def iter_schema_refs(node: Any) -> Iterator[str]:
+    """Yield every ``$ref`` string in *node* that sits in a schema position.
+
+    Walks the schema the way a JSON Schema 2020-12 validator does:
+    generic keywords (``allOf`` / ``items`` / ``additionalProperties`` /
+    ...) recurse structurally, named-map keywords
+    (:data:`_SCHEMA_MAP_KEYWORDS`) recurse through their *values*, and
+    data-valued keywords (:data:`_DATA_VALUE_KEYWORDS`) plus vendor
+    ``x-*`` extensions are skipped entirely — refs inside them are
+    literal data the validator never dereferences. A bundled
+    ``components.schemas`` map (the shape
+    :func:`collect_component_schema_closure` produces) is walked as a
+    named map so lint passes over a stored descriptor cover the bundle.
+    """
+    if isinstance(node, list):
+        for item in node:
+            yield from iter_schema_refs(item)
+        return
+    if not isinstance(node, dict):
+        return
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        yield ref
+    for key, value in node.items():
+        if key == "$ref":
+            continue
+        if key in _SCHEMA_MAP_KEYWORDS and isinstance(value, dict):
+            for subschema in value.values():
+                yield from iter_schema_refs(subschema)
+            continue
+        if key == "components" and isinstance(value, dict):
+            schemas_bucket = value.get("schemas")
+            if isinstance(schemas_bucket, dict):
+                for subschema in schemas_bucket.values():
+                    yield from iter_schema_refs(subschema)
+            continue
+        if key in _DATA_VALUE_KEYWORDS or key.startswith("x-"):
+            continue
+        yield from iter_schema_refs(value)
+
+
+def _unescape_pointer_segment(segment: str) -> str:
+    """Apply RFC 6901 unescaping (``~1`` → ``/``, then ``~0`` → ``~``)."""
+    return segment.replace("~1", "/").replace("~0", "~")
+
+
+def collect_component_schema_closure(
+    schema: Any,
+    component_schemas: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the transitive ``#/components/schemas/*`` closure *schema* needs.
+
+    Walks every schema-position ``$ref`` in *schema* (via
+    :func:`iter_schema_refs`), resolves each
+    ``#/components/schemas/<name>`` against *component_schemas*, and
+    recurses into the referenced components until the set is closed.
+    Cycles (``A`` → ``B`` → ``A``, or self-referential components) are
+    handled by the seen-set — each component is bundled exactly once,
+    never expanded inline, so recursive vendor types terminate.
+
+    The returned dict is sorted by component name so the persisted
+    descriptor bytes are deterministic across ingests of the same spec.
+    Component values are the spec's schema objects verbatim (no copy) —
+    callers persist them via JSON serialization, never mutate them.
+
+    Refs of any other shape (``#/$defs/...``, anchors, ``#``) are left
+    for :func:`find_unresolvable_local_refs` to police against the final
+    stored document.
+
+    Raises:
+        InvalidSchemaError: A ref drills into a component subpath, or
+            names a component absent from *component_schemas* — same
+            posture as the top-level resolver
+            (:func:`resolve_shallow_ref`): a descriptor whose schema
+            references a missing component could never validate any
+            input, so the spec defect is surfaced at ingest time.
+    """
+    closure: dict[str, Any] = {}
+    pending = [
+        ref for ref in iter_schema_refs(schema) if ref.startswith(_SCHEMA_COMPONENT_REF_PREFIX)
+    ]
+    while pending:
+        ref = pending.pop()
+        segment = ref[len(_SCHEMA_COMPONENT_REF_PREFIX) :]
+        if "/" in segment:
+            raise InvalidSchemaError(
+                f"$ref drill-down into component subpaths is not supported (got {ref!r})"
+            )
+        name = _unescape_pointer_segment(segment)
+        if name in closure:
+            continue
+        if name not in component_schemas:
+            raise InvalidSchemaError(f"$ref points at missing component (got {ref!r})")
+        component = component_schemas[name]
+        closure[name] = component
+        pending.extend(
+            nested
+            for nested in iter_schema_refs(component)
+            if nested.startswith(_SCHEMA_COMPONENT_REF_PREFIX)
+        )
+    return dict(sorted(closure.items()))
+
+
+def find_unresolvable_local_refs(schema: Any) -> list[str]:
+    """Return every schema-position ``$ref`` in *schema* that does not resolve.
+
+    Resolution is what the dispatcher's jsonschema validator will do at
+    call time: each ``#/<json-pointer>`` fragment is walked against
+    *schema* itself (the stored document is the whole resolution
+    universe — no registry, no retrieval). ``#`` (whole-document
+    self-ref) resolves trivially; any non-fragment ref (cross-document)
+    and any ``#<anchor>`` plain-name fragment is reported as
+    unresolvable — the parser never stores either shape, so their
+    presence means the descriptor would fail at dispatch.
+
+    Returns a sorted, de-duplicated list; empty means the stored schema
+    validates standalone.
+    """
+    unresolvable: set[str] = set()
+    for ref in iter_schema_refs(schema):
+        if ref == "#":
+            continue
+        if not ref.startswith("#/"):
+            unresolvable.add(ref)
+            continue
+        node: Any = schema
+        for raw_segment in ref[2:].split("/"):
+            segment = _unescape_pointer_segment(raw_segment)
+            if isinstance(node, dict) and segment in node:
+                node = node[segment]
+            elif isinstance(node, list) and segment.isdigit() and int(segment) < len(node):
+                node = node[int(segment)]
+            else:
+                unresolvable.add(ref)
+                break
+    return sorted(unresolvable)
 
 
 def select_media_type_schema(

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -96,7 +96,10 @@ def _operator() -> Operator:
 
 
 def _descriptor(
-    *, safety_level: str = "safe", requires_approval: bool = False
+    *,
+    safety_level: str = "safe",
+    requires_approval: bool = False,
+    parameter_schema: dict[str, object] | None = None,
 ) -> EndpointDescriptor:
     return EndpointDescriptor(
         product="net",
@@ -106,7 +109,7 @@ def _descriptor(
         source_kind="typed",
         safety_level=safety_level,
         requires_approval=requires_approval,
-        parameter_schema={},
+        parameter_schema=parameter_schema if parameter_schema is not None else {},
         is_enabled=True,
     )
 
@@ -178,6 +181,45 @@ async def test_mint_refuses_non_safe_op(monkeypatch: pytest.MonkeyPatch, level: 
 
     assert not result.minted
     assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+
+
+async def test_mint_refuses_poisoned_parameter_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stored schema with a dangling $ref refuses the mint fail-closed (#3095).
+
+    Same defect class as the dispatcher's ``invalid_op_schema`` branch:
+    the descriptor — not the caller's params — is broken, so the refusal
+    carries a distinct code and never reaches the policy gate or a runner.
+    """
+    await _seed_tenant()
+    _patch_lookup(
+        monkeypatch,
+        _descriptor(
+            parameter_schema={
+                "type": "object",
+                "properties": {"host": {"$ref": "#/components/schemas/Ghost"}},
+            }
+        ),
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        await session.commit()
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.INVALID_OP_SCHEMA
+    assert result.refusal_reason is not None
+    assert "#/components/schemas/Ghost" in result.refusal_reason
     assert await _count(GatewayCommand) == 0
     assert await _count(ApprovalRequest) == 0
 

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -484,6 +484,62 @@ async def test_dispatch_returns_invalid_params_when_schema_violated(
     assert any(err["validator"] == "required" for err in validation)
 
 
+@pytest.mark.asyncio
+async def test_dispatch_returns_invalid_op_schema_for_poisoned_descriptor(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A stored schema with a dangling $ref -> structured ``invalid_op_schema``.
+
+    #3095 regression: the live descriptor for the content-library
+    update-session file op carried ``$ref:
+    "#/components/schemas/Content.Library.Item.TransferEndpoint"`` with
+    no such component in the stored document. Validation raised an
+    unhandled ``PointerToNowhere`` (``_WrappedReferencingError``) that
+    escaped ``/api/v1/operations/call`` as an HTTP 500. The dispatcher
+    must return the governed envelope instead — blaming the descriptor,
+    not the caller's params — with the missing pointer named.
+    """
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.poisoned",
+        handler=_module_handler_returning_dict,
+        summary="Op with a self-broken stored schema.",
+        description="Poisoned descriptor.",
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "body": {"$ref": "#/components/schemas/Content.Library.Item.TransferEndpoint"}
+            },
+        },
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator()
+    target = _FakeTarget(product="vault")
+
+    # The params must reach the $ref during validation for the
+    # referencing failure to surface (jsonschema resolves lazily).
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.poisoned",
+        target=target,
+        params={"body": {"uri": "https://x"}},
+    )
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_op_schema:")
+    assert result.extras["error_code"] == "invalid_op_schema"
+    assert (
+        result.extras["missing_ref"] == "#/components/schemas/Content.Library.Item.TransferEndpoint"
+    )
+    assert "re-ingest" in result.extras["remediation"]
+
+
 # ---------------------------------------------------------------------------
 # Typed dispatch + audit + broadcast
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -26,6 +26,7 @@ import httpx
 import pytest
 import respx
 import yaml
+from jsonschema import Draft202012Validator
 from pydantic import ValidationError
 
 from meho_backplane.operations.ingest import (
@@ -43,6 +44,10 @@ from meho_backplane.operations.ingest.openapi import (
     _MAX_REDIRECTS,
     _assert_fetchable_remote_url,
     _server_base_path,
+)
+from meho_backplane.operations.ingest.refs import (
+    find_unresolvable_local_refs,
+    iter_schema_refs,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
@@ -653,8 +658,11 @@ def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
     # $ref to #/components/schemas/Pet got inlined one level deep.
     assert body["type"] == "object"
     assert set(body["properties"].keys()) == {"id", "name", "tag"}
-    # Nested $ref to Tag is preserved verbatim.
+    # Nested $ref to Tag is preserved verbatim...
     assert body["properties"]["tag"] == {"$ref": "#/components/schemas/Tag"}
+    # ...and its target is bundled into the stored document (#3095) so
+    # the dispatcher's registry-free validator can resolve the pointer.
+    assert "Tag" in post.parameter_schema["components"]["schemas"]
     # Body required because requestBody.required == true.
     assert "body" in post.parameter_schema["required"]
 
@@ -2097,3 +2105,250 @@ def test_read_spec_info_version_non_https_scheme_raises_invalid_spec() -> None:
     """Non-https schemes raise ``InvalidSpecError`` from read_spec_info_version too."""
     with pytest.raises(InvalidSpecError, match="https"):
         read_spec_info_version("file:///tmp/nope.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Nested $ref bundling (#3095)
+# ---------------------------------------------------------------------------
+
+
+def _nested_refs_spec(*, transfer_endpoint_defined: bool = True) -> bytes:
+    """A spec whose body schema transitively refs components two hops deep.
+
+    Models the live #3095 shape: the update-session file op's body refs
+    ``AddSpec`` (inlined at parse), whose ``source_endpoint`` refs
+    ``TransferEndpoint`` (hop 1), whose ``uri`` refs ``Uri`` (hop 2) and
+    whose ``node`` refs the self-recursive ``Node``. With
+    *transfer_endpoint_defined* False the hop-1 component is absent —
+    the descriptor could never validate a body, which must fail ingest.
+    """
+    components: dict[str, object] = {
+        "AddSpec": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "source_endpoint": {"$ref": "#/components/schemas/TransferEndpoint"},
+            },
+            "required": ["name"],
+        },
+        "Uri": {"type": "string"},
+        "Node": {
+            "type": "object",
+            "properties": {"parent": {"$ref": "#/components/schemas/Node"}},
+        },
+    }
+    if transfer_endpoint_defined:
+        components["TransferEndpoint"] = {
+            "type": "object",
+            "properties": {
+                "uri": {"$ref": "#/components/schemas/Uri"},
+                "node": {"$ref": "#/components/schemas/Node"},
+            },
+            "required": ["uri"],
+        }
+    return yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "nested-refs", "version": "1.0.0"},
+            "paths": {
+                "/library/item/update-session/{sessionId}/file": {
+                    "post": {
+                        "parameters": [
+                            {
+                                "name": "sessionId",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/AddSpec"}
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                },
+                "/flat": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"name": {"type": "string"}},
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                },
+            },
+            "components": {"schemas": components},
+        }
+    ).encode()
+
+
+def test_parse_nested_refs_bundled_and_schema_validates_standalone() -> None:
+    """AC (#3095): a two-hop-deep ref chain yields a standalone-validating schema.
+
+    The stored ``parameter_schema`` must carry every transitively
+    referenced component under its own ``components.schemas`` key so the
+    dispatcher's registry-free ``Draft202012Validator`` resolves the
+    nested refs as same-document JSON Pointers — a conforming payload
+    validates, a violation reports its deep path, and no
+    ``PointerToNowhere`` escapes.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "nested_refs.yaml", _nested_refs_spec())
+        rows = parse_openapi(url)
+    op = _by_op_id(rows)["POST:/library/item/update-session/{sessionId}/file"]
+    schema = op.parameter_schema
+
+    bundle = schema["components"]["schemas"]
+    assert set(bundle.keys()) == {"Node", "TransferEndpoint", "Uri"}
+    # Nested refs are preserved verbatim — bundling adds targets, never
+    # rewrites pointers.
+    body = schema["properties"]["body"]
+    assert body["properties"]["source_endpoint"] == {
+        "$ref": "#/components/schemas/TransferEndpoint"
+    }
+
+    validator = Draft202012Validator(schema)
+    conforming = {
+        "sessionId": "s-1",
+        "body": {
+            "name": "disk.iso",
+            "source_endpoint": {"uri": "https://x", "node": {"parent": {}}},
+        },
+    }
+    assert list(validator.iter_errors(conforming)) == []
+    violations = [
+        (err.json_path, err.message)
+        for err in validator.iter_errors(
+            {"sessionId": "s-1", "body": {"name": "disk.iso", "source_endpoint": {"uri": 42}}}
+        )
+    ]
+    assert violations == [("$.body.source_endpoint.uri", "42 is not of type 'string'")]
+
+
+def test_parse_nested_ref_cycle_terminates_and_bundle_is_sorted() -> None:
+    """Mutually-recursive components bundle once each; keys are sorted.
+
+    ``Node`` refs itself — deep-inlining would never terminate, the
+    closure walk must. Sorted bundle keys keep re-ingests of the same
+    spec byte-deterministic.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "nested_refs.yaml", _nested_refs_spec())
+        rows = parse_openapi(url)
+    op = _by_op_id(rows)["POST:/library/item/update-session/{sessionId}/file"]
+    bundle = op.parameter_schema["components"]["schemas"]
+    assert list(bundle.keys()) == sorted(bundle.keys())
+    assert bundle["Node"]["properties"]["parent"] == {"$ref": "#/components/schemas/Node"}
+
+
+def test_parse_nested_ref_to_missing_component_fails_ingest() -> None:
+    """AC (#3095): a nested ref to an undefined component refuses the ingest.
+
+    Before #3095 the dangling ref was stored silently and every dispatch
+    of the op crashed with an unhandled ``PointerToNowhere`` → 500. The
+    ingest-time lint now fails the parse — same posture as a dangling
+    top-level ref — naming the operation and the missing component.
+    """
+    spec = _nested_refs_spec(transfer_endpoint_defined=False)
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "nested_refs_missing.yaml", spec)
+        with pytest.raises(InvalidSchemaError, match="missing component") as excinfo:
+            parse_openapi(url)
+    message = str(excinfo.value)
+    assert "TransferEndpoint" in message
+    assert "/library/item/update-session/{sessionId}/file" in message
+
+
+def test_parse_schema_without_nested_refs_gains_no_components_key() -> None:
+    """AC (#3095): descriptors with no nested refs persist byte-identically.
+
+    The bundle key is added only when a closure exists, so every
+    well-formed pre-#3095 descriptor re-ingests to the exact same
+    ``parameter_schema`` bytes.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "nested_refs.yaml", _nested_refs_spec())
+        rows = parse_openapi(url)
+    flat = _by_op_id(rows)["POST:/flat"]
+    assert flat.parameter_schema == {
+        "type": "object",
+        "properties": {
+            "body": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "x-meho-param-loc": "body",
+            }
+        },
+    }
+
+
+def test_parse_response_schema_is_deliberately_not_bundled() -> None:
+    """``response_schema`` keeps nested refs unbundled — nothing validates it.
+
+    Scope decision on #3095: the JSONFlux reducer (the response schema's
+    only dispatch-time consumer) never resolves refs, and bundling the
+    large recursive response types of the vCenter/NSX specs would
+    multiply per-op storage for no functional gain.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
+    page = _by_op_id(rows)["GET:/pets"].response_schema
+    assert page is not None
+    assert "components" not in page
+
+
+def test_iter_schema_refs_walks_schema_positions_only() -> None:
+    """Refs in data positions (enum/const/default/example[s], x-*) are not refs.
+
+    A ``$ref``-shaped object inside an example is literal payload data
+    the validator never dereferences — collecting it would fail ingests
+    over pointers that can never be resolved at dispatch. Named-map
+    keywords (``properties``) recurse through their values even when a
+    property is literally named ``enum``.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "real": {"$ref": "#/components/schemas/Real"},
+            "enum": {"$ref": "#/components/schemas/PropertyNamedEnum"},
+        },
+        "default": {"$ref": "#/components/schemas/NotARef"},
+        "examples": [{"$ref": "#/components/schemas/NotARef"}],
+        "x-vendor": {"$ref": "#/components/schemas/NotARef"},
+        "allOf": [{"$ref": "#/components/schemas/InAllOf"}],
+    }
+    assert sorted(iter_schema_refs(schema)) == [
+        "#/components/schemas/InAllOf",
+        "#/components/schemas/PropertyNamedEnum",
+        "#/components/schemas/Real",
+    ]
+
+
+def test_find_unresolvable_local_refs_reports_only_dangling_pointers() -> None:
+    """The lint resolves pointers against the stored document itself."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "ok": {"$ref": "#/components/schemas/Present"},
+            "bad": {"$ref": "#/components/schemas/Absent"},
+            "defs": {"$ref": "#/$defs/nowhere"},
+        },
+        "components": {"schemas": {"Present": {"type": "string"}}},
+    }
+    assert find_unresolvable_local_refs(schema) == [
+        "#/$defs/nowhere",
+        "#/components/schemas/Absent",
+    ]
+    assert find_unresolvable_local_refs({"$ref": "#"}) == []

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -2352,3 +2352,7 @@ def test_find_unresolvable_local_refs_reports_only_dangling_pointers() -> None:
         "#/components/schemas/Absent",
     ]
     assert find_unresolvable_local_refs({"$ref": "#"}) == []
+    # A non-ASCII "digit" index is flagged as unresolvable, never crashes
+    # (str.isdigit accepts "²" but int() rejects it).
+    assert find_unresolvable_local_refs({"$ref": "#/allOf/²", "allOf": [{}]}) == ["#/allOf/²"]
+    assert find_unresolvable_local_refs({"$ref": "#/allOf/0", "allOf": [{}]}) == []

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -717,6 +717,53 @@ async def test_preview_invalid_params_returns_structured_error(
 
 
 @pytest.mark.asyncio
+async def test_preview_invalid_op_schema_returns_structured_error(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A poisoned stored schema -> structured invalid_op_schema envelope (#3095).
+
+    The preview mirrors dispatch Step 3, so a descriptor whose stored
+    ``parameter_schema`` carries a dangling ``$ref`` must yield the same
+    governed ``invalid_op_schema`` envelope dispatch returns — never an
+    unhandled ``PointerToNowhere`` -> 500.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "body": {
+                    "$ref": "#/components/schemas/Ghost",
+                    "x-meho-param-loc": "body",
+                }
+            },
+        },
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params={"body": {"title": "hi"}},
+    )
+
+    assert envelope["status"] == "error"
+    assert envelope["error"].startswith("invalid_op_schema:")
+    assert envelope["extras"]["error_code"] == "invalid_op_schema"
+    assert envelope["extras"]["missing_ref"] == "#/components/schemas/Ghost"
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
 async def test_preview_unknown_op_returns_structured_error(
     stub_embedding_service: AsyncMock,
     session: AsyncSession,

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -93,6 +93,7 @@ preview_dispatch(operator, connector_id, op_id, target, params)
         ├─ lookup_descriptor → None ? → status=error error_code=unknown_op
         ├─ source_kind != 'ingested' ? → status=unavailable (not_ingested)
         ├─ validate_params → errors ? → status=error error_code=invalid_params
+        │       (InvalidOpSchemaError ? → status=error error_code=invalid_op_schema, #3095)
         ├─ resolve_connector_or_label → label ? → status=error (no_connector /
         │       ambiguous_connector)
         ├─ get_or_create_connector_instance(cls)   (cached singleton)
@@ -119,7 +120,7 @@ surfaces stay `OPERATOR`-gated at the route / tool layer.
 | `status` | meaning | extra fields |
 |---|---|---|
 | `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind` |
-| `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail |
+| `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `invalid_op_schema` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail (`invalid_op_schema` carries `extras.missing_ref`, #3095) |
 | `unavailable` | not an HTTP-ingested op | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
 
 Operator-input faults come back **inside** the envelope (not as

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1717,18 +1717,49 @@ parse_openapi
       ├─ _build_parameter_schema
       │  ├─ _resolve_shallow_ref      # $ref → #/components/schemas/X
       │  ├─ _build_param_property     # one property per path/query/header
-      │  └─ _build_body_property      # requestBody under "body" key
+      │  ├─ _build_body_property      # requestBody under "body" key
+      │  └─ collect_component_schema_closure  # bundle nested-ref targets (#3095)
       ├─ _extract_response_schema     # picks 200 > 201 > 202 > ... > 2XX
-      └─ _assert_json_serializable    # fail-closed: param/response schema must JSON-encode (#2272)
+      ├─ _assert_json_serializable    # fail-closed: param/response schema must JSON-encode (#2272)
+      └─ _assert_parameter_schema_standalone  # fail-closed: every stored $ref must self-resolve (#3095)
 ```
 
 `_resolve_shallow_ref` is the load-bearing helper. It inlines exactly
 one level of `$ref` into the parameter / response / body schema and
-preserves any nested `$ref` strings verbatim. The intent is that the
-parameter_schema is self-contained enough for the dispatcher's
-JSON-Schema validator to validate the immediate parameter shape;
-deeper schema dereferencing (chasing nested `$ref`s) is the
-dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
+preserves any nested `$ref` strings verbatim. Since #3095,
+`_build_parameter_schema` then bundles every component those nested
+refs transitively reference into the stored schema's own
+`components.schemas` key (`collect_component_schema_closure` in
+`refs.py` — cycle-safe seen-set walk, sorted keys for deterministic
+bytes, schemas with no nested refs gain no key and persist
+byte-identically). The dispatcher's registry-free
+`Draft202012Validator` resolves the nested refs as same-document JSON
+Pointers, so a stored descriptor validates params **standalone**. The
+pre-#3095 contract ("deeper dereferencing is the dispatcher's
+concern") was a broken promise — the dispatcher never had the
+components, so any op whose body schema carried a nested ref crashed
+validation with an unhandled `PointerToNowhere` → HTTP 500 (the
+observed content-library update-session file op). Two guards keep the
+defect class out:
+
+* ingest-time — a nested ref to a component the spec never defines
+  raises `InvalidSchemaError` during the closure walk, and
+  `_assert_parameter_schema_standalone` (same fail-closed posture and
+  proto-build placement as `_assert_json_serializable`) re-walks the
+  final stored document rejecting any `$ref` that does not resolve
+  within it (absolute `#/$defs/...` pointers, `$anchor` fragments,
+  cross-document residue). `response_schema` is deliberately **not**
+  bundled or linted: its only dispatch-time consumer is the JSONFlux
+  reducer, which never resolves refs, and bundling the large recursive
+  vCenter/NSX response types would multiply per-op storage for no
+  functional gain.
+* dispatch-time — `validate_params` (`operations/_validate.py`) maps
+  `referencing.exceptions.Unresolvable` to the typed
+  `InvalidOpSchemaError`, which the dispatcher / request preview /
+  gateway mint each convert to a structured `invalid_op_schema`
+  refusal (extras carry `missing_ref` + re-ingest remediation) —
+  covering rows persisted by pre-#3095 ingests until they are
+  re-ingested.
 
 The four supported component buckets are: `#/components/schemas/*`,
 `#/components/parameters/*` (vi-json.yaml's shared `moId`),


### PR DESCRIPTION
## Summary

- **Ingest arm** — `_build_parameter_schema` now bundles the transitive `#/components/schemas/*` closure of every nested `$ref` into the stored schema's own `components.schemas` key (`collect_component_schema_closure` in `ingest/refs.py`: schema-position-aware walk that skips data keywords (`enum`/`const`/`default`/`example[s]`/`x-*`), cycle-safe via seen-set, sorted keys for deterministic bytes). The dispatcher's registry-free `Draft202012Validator` then resolves nested refs as same-document JSON Pointers, so a stored descriptor validates params **standalone**. Design choices: bundling over deep-inlining (vendor types are recursive — inlining diverges), and over a registry-at-dispatch (new table + migration, out of proportion). Schemas with no nested refs gain no key and persist **byte-identically**.
- **Ingest lint (fail posture)** — a nested ref to a component the spec never defines now fails the parse (`InvalidSchemaError` naming op + ref, same posture as a dangling top-level ref), and `_assert_parameter_schema_standalone` re-lints the final stored document (both `dry_run` and effectful legs refuse identically — same placement pattern as `_assert_json_serializable`). `response_schema` is deliberately **not** bundled/linted: its only dispatch-time consumer is the JSONFlux reducer, which never resolves refs; bundling the recursive vCenter/NSX response types would multiply per-op storage for zero functional gain.
- **Dispatch arm** — `validate_params` maps `referencing.exceptions.Unresolvable` (the public base of the `_WrappedReferencingError`/`PointerToNowhere` that escaped as a 500) to the typed `InvalidOpSchemaError`; the dispatcher, the request preview, and the gateway mint each convert it to a structured `invalid_op_schema` error (`extras.missing_ref` + re-ingest remediation; gateway adds `MintRefusalCode.INVALID_OP_SCHEMA`) — blaming the descriptor, not the caller. This covers rows persisted by pre-fix ingests until they are re-ingested.
- **Docs** — `docs/codebase/spec-ingestion.md` (control flow + the now-corrected "deeper dereferencing is the dispatcher's concern" contract) and `docs/codebase/dispatch-request-preview.md` (flow + error-code table).

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` (strict, 782 files) — clean except pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` (Linux-only socket constant; file untouched; green in Linux CI)
- [x] `pytest` wide scoped sweep (ingest/dispatch/preview/gateway/register/reconcile/catalog/composite/jsonflux/operations suites) — **1957 passed** incl. all shelf-backed spec-reconcile lanes run against the real spec shelf
- [x] AC1 (dispatch structured error, poisoned descriptor): `test_dispatch_returns_invalid_op_schema_for_poisoned_descriptor` (+ preview and gateway variants) — envelope carries `error_code=invalid_op_schema`, `missing_ref` names the pointer
- [x] AC2 (transitive bundling, two-hop spec slice): `test_parse_nested_refs_bundled_and_schema_validates_standalone` — stored schema validates a conforming payload standalone and reports deep violation paths
- [x] AC3 (ingest lint): `test_parse_nested_ref_to_missing_component_fails_ingest` — fail posture, names op + missing component
- [x] AC4 (byte-identity): `test_parse_schema_without_nested_refs_gains_no_components_key`; plus full parses of the real `vcenter.yaml` + `vi-json.yaml` (the live case's own connector) pass under the new posture
- [x] code-quality gate (`--diff`) — exit 0

## Out of scope

- Repairing already-persisted poisoned descriptor rows — the structured dispatch error carries the re-ingest remediation; re-ingesting rebuilds them with the bundle.
- `response_schema` bundling (deliberate, see above; locked by `test_parse_response_schema_is_deliberately_not_bundled`).
- Pre-existing adjacent findings: `resolve_shallow_ref` (105 lines) and `mint_gateway_command` (~175 lines, net-shrunk here, `code-quality-allow` marker with reason) size debt; `_resolve_named_component` does not RFC-6901-unescape top-level component names (the new closure walk does).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3095
