### PR TITLE
fix(connectors): vm.create rides the vim substrate on pre-9.0 vCenter — bare REST create is vendor-defective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `vm.create` rides the vim substrate on pre-9.0 vCenter (#3099)
+
+- `vmware.composite.vm.create` now creates through vim `Folder.CreateVM_Task`
+  (task-polled via the governed vmomi write seam) when the live
+  `about.version` major is < 9: bare REST `POST /api/vcenter/vm` is
+  vendor-defective on vCenter 8.0.x — an opaque
+  `500 UNABLE_TO_ALLOCATE_RESOURCE {messages:[]}` for every spec shape and
+  placement, proven by live controlled probes, while the identical vim
+  create succeeds. On that arm the NICs (vmxnet3; DVPG backing resolved to
+  `switchUuid` + `portgroupKey`, standard portgroup to `deviceName`) and the
+  #3093 `nested_hv` flag fold into the one `VirtualMachineConfigSpec`
+  (collapsing the separate reconfigure), the datastore display name becomes
+  the `files.vmPathName` VM home, and `resource_pool` / `datastore` are
+  required — missing pins, an unmapped `guest_os` enum (curated
+  spec-grounded guestId table, e.g. `VMKERNEL_8` → `vmkernel8Guest`), or an
+  `OPAQUE_NETWORK` NIC fail closed with structured `rolled_back` envelopes
+  before any write. 9.0+ and unresolved versions keep the REST create
+  byte-identical (exact-body and exact-envelope regressions pin it), the
+  response envelope and rollback contract are unchanged, and reconcile
+  lanes pin the new vim path + both sides of the guestId map against the
+  pinned `vcenter-9.0` specs.
+
 ### Added — `vm.create` placement passthrough: resource_pool / datastore / host pins (#3096)
 
 - `vmware.composite.vm.create` accepts optional `resource_pool`, `datastore`

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -398,11 +398,17 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
             "adapter create via POST:/vcenter/vm/{vm}/hardware/ethernet, "
             "an optional nested_hv vim ReconfigVM_Task (nestedHVEnabled, "
             "task-polled, applied before any power-on), and optional "
-            "POST:/vcenter/vm/{vm}/power start. Partial-failure rollback: "
-            "if any step after the create succeeds fails, the half-"
-            "created VM is removed via DELETE:/vcenter/vm/{vm} so the "
-            "caller knows the VM did not persist. Equivalent of 'govc "
-            "vm.create' for operator-facing dispatch."
+            "POST:/vcenter/vm/{vm}/power start. On pre-9.0 vCenter (live "
+            "about.version major < 9) the create instead rides vim "
+            "Folder.CreateVM_Task through the governed vmomi substrate, "
+            "task-polled, with NICs and nested_hv folded into the one "
+            "ConfigSpec — the bare REST create is vendor-defective on "
+            "8.0.x; resource_pool and datastore are required there. "
+            "Partial-failure rollback: if any step after the create "
+            "succeeds fails, the half-created VM is removed via "
+            "DELETE:/vcenter/vm/{vm} so the caller knows the VM did not "
+            "persist. Equivalent of 'govc vm.create' for operator-facing "
+            "dispatch."
         ),
         parameter_schema=VM_CREATE_PARAMETER_SCHEMA,
         response_schema=VM_CREATE_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -233,6 +233,14 @@ _NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
 # ``Vcenter.Vm.Hardware.Ethernet.BackingSpec.type`` value for a standard
 # portgroup -- the default backing the NIC create / repoint specs target.
 _NIC_BACKING_STANDARD_PORTGROUP = "STANDARD_PORTGROUP"
+# ``Ethernet.BackingSpec.type`` value for a distributed portgroup — on the
+# pre-9.0 vim create arm (#3099) this backing maps to
+# ``VirtualEthernetCardDistributedVirtualPortBackingInfo``.
+_NIC_BACKING_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
+# REST Datastore.Info read — the pre-9.0 vim create arm (#3099) resolves the
+# datastore display name off this to build the vim
+# ``files.vmPathName = "[<name>] <vm>"`` home path.
+_OP_GET_DATASTORE = "GET:/vcenter/datastore/{datastore}"
 # REST Disk.Info read — the disk-grow park-time preview reads label +
 # current capacity (bytes) off this; the disk id is the vim device key.
 _OP_GET_VM_DISK = "GET:/vcenter/vm/{vm}/hardware/disk/{disk}"
@@ -294,7 +302,7 @@ _PROP_CONFIG_HARDWARE_DEVICE = "config.hardware.device"
 # ``vm.clone`` convention.
 _DISK_GROW_TASK_TIMEOUT_SECONDS = 600.0
 
-# vm.create's optional VHV leg (#3093) rides the same two vim paths.
+# vm.create's optional VHV leg (#3093) rides the vim substrate:
 # ``VirtualMachineConfigSpec.nestedHVEnabled`` has no REST expression (the
 # pinned ``vcenter.yaml`` serves no ``hardware_virtualization`` / ``nestedHV``
 # spelling anywhere, pinned by the #3087 recipe lanes) and *raw* VI-JSON
@@ -303,14 +311,86 @@ _DISK_GROW_TASK_TIMEOUT_SECONDS = 600.0
 # (:func:`_write_vmomi_sub_op` → ``_post_vmomi_json`` on the documented
 # ``/sdk/vim25/{release}`` base) is the only cross-version governed path to
 # the flag. ``RetrievePropertiesEx`` is the shared Task-poll read.
+#
+# ``Folder.CreateVM_Task`` (#3099) is the create itself on pre-9.0 targets:
+# bare REST ``POST /api/vcenter/vm`` is vendor-defective on vCenter 8.0.x —
+# an opaque ``500 UNABLE_TO_ALLOCATE_RESOURCE {messages:[]}`` for every
+# spec shape and placement (proven by live controlled probes), while the
+# identical create through the vim surface succeeds. When the live
+# ``about.version`` major is < 9 the whole create rides this task-polled
+# vim path, with NICs and the VHV flag folded into the one
+# ``VirtualMachineConfigSpec`` (collapsing the #3093 second call on that
+# arm); 9.0+ and unresolved versions keep the REST create byte-identical.
+_OP_CREATE_VM_TASK = "POST:/Folder/{moId}/CreateVM_Task"
 _VIM_SUB_OPS_VM_CREATE: tuple[str, ...] = (
     _OP_RETRIEVE_PROPERTIES,
     _OP_RECONFIG_VM_TASK,
+    _OP_CREATE_VM_TASK,
 )
 
 # Default wall-clock bound for the VHV ReconfigVM_Task poll — the 600s
 # convention; module-global so tests can zero it.
 _VM_CREATE_VHV_TASK_TIMEOUT_SECONDS = 600.0
+
+# Default wall-clock bound for the pre-9.0 CreateVM_Task poll (#3099) —
+# same 600s convention; module-global so tests can zero it.
+_VM_CREATE_TASK_TIMEOUT_SECONDS = 600.0
+
+#: REST ``Vcenter.Vm.GuestOS`` enum → vim ``VirtualMachineGuestOsIdentifier``
+#: for the pre-9.0 CreateVM_Task arm (#3099). Spec-grounded on both sides:
+#: every key is an enum value of the pinned ``vcenter.yaml``'s
+#: ``Vcenter.Vm.GuestOS`` and every value an enum value of the pinned
+#: ``vi-json.yaml``'s ``VirtualMachineGuestOsIdentifier_enum`` with the same
+#: per-value description label (e.g. ``VMKERNEL_8`` / ``vmkernel8Guest`` are
+#: both documented "VMware ESX 8"); the reconcile lane asserts both sides.
+#: Deliberately curated, not exhaustive: the ``VMKERNEL_*`` family (the
+#: nested-ESXi recipe, #3087) plus the common Linux / Windows / catch-all
+#: identifiers. An unmapped enum fails closed with a structured
+#: ``rolled_back`` before any sub-call — never a silent guess.
+_VIM_GUEST_ID_BY_REST_GUEST_OS: Final[dict[str, str]] = {
+    "VMKERNEL": "vmkernelGuest",
+    "VMKERNEL_5": "vmkernel5Guest",
+    "VMKERNEL_6": "vmkernel6Guest",
+    "VMKERNEL_65": "vmkernel65Guest",
+    "VMKERNEL_7": "vmkernel7Guest",
+    "VMKERNEL_8": "vmkernel8Guest",
+    "VMKERNEL_9": "vmkernel9Guest",
+    "OTHER": "otherGuest",
+    "OTHER_64": "otherGuest64",
+    "OTHER_LINUX": "otherLinuxGuest",
+    "OTHER_LINUX_64": "otherLinux64Guest",
+    "UBUNTU": "ubuntuGuest",
+    "UBUNTU_64": "ubuntu64Guest",
+    "DEBIAN_12": "debian12Guest",
+    "DEBIAN_12_64": "debian12_64Guest",
+    "RHEL_8_64": "rhel8_64Guest",
+    "RHEL_9_64": "rhel9_64Guest",
+    "CENTOS_8_64": "centos8_64Guest",
+    "CENTOS_9_64": "centos9_64Guest",
+    "VMWARE_PHOTON_64": "vmwarePhoton64Guest",
+    "WINDOWS_SERVER_2019": "windows2019srv_64Guest",
+    "WINDOWS_SERVER_2021": "windows2019srvNext_64Guest",
+    "WINDOWS_11_64": "windows11_64Guest",
+}
+
+# vim NIC shape for the pre-9.0 create arm (#3099). The ConfigSpec's
+# ``deviceChange`` entries are ``VirtualDeviceConfigSpec`` (declared type ==
+# runtime type, no ``_typeName``), but the ``device`` is declared as the base
+# ``VirtualDevice`` and the ``backing`` as the base
+# ``VirtualDeviceBackingInfo``, so both subtypes carry the ``_typeName``
+# discriminator for the vim25-JSON binding to deserialise them — the
+# ``ClusterConfigSpecEx`` precedent (#2895, spec-verified). The DVPG backing's
+# ``port`` is a ``DistributedVirtualSwitchPortConnection`` (declared ==
+# runtime, no tag) whose ``switchUuid`` / ``portgroupKey`` are resolved from
+# the portgroup moid via the un-gated vmomi property reads below — the same
+# ``key`` + ``config.distributedVirtualSwitch`` → ``uuid`` walk govc performs.
+_VIRTUAL_VMXNET3_TYPE = "VirtualVmxnet3"
+_DV_PORT_BACKING_TYPE = "VirtualEthernetCardDistributedVirtualPortBackingInfo"
+_STANDARD_NETWORK_BACKING_TYPE = "VirtualEthernetCardNetworkBackingInfo"
+_DVPG_MO_TYPE = "DistributedVirtualPortgroup"
+_PROP_DVPG_KEY = "key"
+_PROP_DVPG_DVS = "config.distributedVirtualSwitch"
+_PROP_DVS_UUID = "uuid"
 
 # The one-field ``VirtualMachineConfigSpec`` the VHV reconfigure sends. The
 # ``"spec"`` key is the vim request type's genuine required parameter (the
@@ -622,6 +702,11 @@ _SUB_OPS_VM_CREATE: tuple[str, ...] = (
     _OP_DELETE_VM,
     _OP_CREATE_VM_NIC,
     _power_vm_op_id("start"),
+    # #3099 pre-9.0 vim-arm resolution reads (both REST, vcenter.yaml-served):
+    # the datastore display name for ``files.vmPathName`` and the network
+    # display name for a standard-portgroup NIC backing.
+    _OP_GET_DATASTORE,
+    _OP_LIST_NETWORK,
 )
 _SUB_OPS_VM_CLONE: tuple[str, ...] = (
     _OP_GET_VM,
@@ -1042,6 +1127,436 @@ async def _enable_nested_hv(
     return None, None
 
 
+def _vim_create_required(about_version: str | None) -> bool:
+    """``True`` when the live ``about.version`` major is a resolvable pre-9.0.
+
+    The #3099 arm gate, mirroring :func:`_deploy_eula_field_name`'s
+    version-conditional pattern (#3075): a resolvable pre-9.0 major routes
+    the create through vim ``Folder.CreateVM_Task`` (bare REST
+    ``POST /api/vcenter/vm`` is vendor-defective on vCenter 8.0.x — an
+    opaque ``500 UNABLE_TO_ALLOCATE_RESOURCE`` for every spec shape and
+    placement, proven live, while the identical vim create succeeds);
+    9.0+ — and an unresolved version — keep the REST create byte-identical.
+    """
+    major = about_version.split(".", 1)[0].strip() if about_version else ""
+    return major.isdigit() and int(major) < 9
+
+
+async def _resolve_datastore_name(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    datastore_moid: str,
+) -> tuple[str | None, str | None]:
+    """Resolve a datastore moid to its display name via ``GET:/vcenter/datastore/{datastore}``.
+
+    Returns ``(name, None)`` on success or ``(None, reason)`` when the
+    ``Datastore.Info`` payload carries no usable name — the caller folds the
+    reason into a ``rolled_back`` envelope. A transport fault propagates
+    (the dispatcher wraps it as ``connector_error``), mirroring
+    :func:`_resolve_folder_moid`.
+    """
+    info = _unwrap_value(
+        await _read_sub_op(
+            connector, target, operator, _OP_GET_DATASTORE, {"datastore": datastore_moid}
+        )
+    )
+    name = info.get("name") if isinstance(info, dict) else None
+    if not isinstance(name, str) or not name:
+        return None, f"datastore {datastore_moid!r} info returned no display name"
+    return name, None
+
+
+def _build_dvpg_retrieve_params(portgroup_moid: str) -> dict[str, Any]:
+    """Build the one-object DVPG property read for the vim NIC backing (#3099).
+
+    A single ``RetrievePropertiesEx`` reading ``key`` +
+    ``config.distributedVirtualSwitch`` off the ``DistributedVirtualPortgroup``
+    — the two properties the ``DistributedVirtualSwitchPortConnection``
+    needs (the DVS moid is then resolved to its ``uuid`` in a second read).
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [{"type": _DVPG_MO_TYPE, "pathSet": [_PROP_DVPG_KEY, _PROP_DVPG_DVS]}],
+                "objectSet": [{"obj": {"type": _DVPG_MO_TYPE, "value": portgroup_moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+async def _resolve_vim_nic_backing(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    nic: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build one NIC's vim backing for the pre-9.0 create arm (#3099).
+
+    Returns ``(backing, None)`` or ``(None, reason)``:
+
+    * ``DISTRIBUTED_PORTGROUP`` → ``VirtualEthernetCardDistributedVirtualPortBackingInfo``
+      with the port connection's ``switchUuid`` + ``portgroupKey`` resolved
+      through two un-gated vmomi property reads (DVPG ``key`` +
+      ``config.distributedVirtualSwitch``, then the owning switch's
+      ``uuid`` — the walk govc performs for the same backing).
+    * ``STANDARD_PORTGROUP`` (the schema default) →
+      ``VirtualEthernetCardNetworkBackingInfo`` keyed by the network's
+      display name, resolved via the ``GET:/vcenter/network`` listing.
+    * anything else (``OPAQUE_NETWORK``) fails closed — it has no
+      implemented vim expression on this arm.
+    """
+    network = nic.get("network")
+    if not isinstance(network, str) or not network:
+        return None, "nic entry carries no ``network`` moid"
+    backing_type = nic.get("backing_type", _NIC_BACKING_STANDARD_PORTGROUP)
+    if backing_type == _NIC_BACKING_DISTRIBUTED_PORTGROUP:
+        portgroup_read = await connector._post_vmomi_json(
+            target,
+            _VMOMI_RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=_build_dvpg_retrieve_params(network),
+        )
+        portgroup_key = _extract_single_prop(portgroup_read, _PROP_DVPG_KEY)
+        switch_ref = _extract_single_prop(portgroup_read, _PROP_DVPG_DVS)
+        switch_moid = switch_ref.get("value") if isinstance(switch_ref, dict) else None
+        switch_type = switch_ref.get("type") if isinstance(switch_ref, dict) else None
+        if (
+            not isinstance(portgroup_key, str)
+            or not isinstance(switch_moid, str)
+            or not isinstance(switch_type, str)
+        ):
+            return None, (
+                f"distributed portgroup {network!r} did not resolve to a "
+                "portgroup key + owning switch"
+            )
+        uuid_read = await connector._post_vmomi_json(
+            target,
+            _VMOMI_RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=_build_single_prop_retrieve_params(switch_type, switch_moid, _PROP_DVS_UUID),
+        )
+        switch_uuid = _extract_single_prop(uuid_read, _PROP_DVS_UUID)
+        if not isinstance(switch_uuid, str) or not switch_uuid:
+            return None, f"switch {switch_moid!r} owning portgroup {network!r} has no uuid"
+        return {
+            _VMOMI_TYPE_NAME_KEY: _DV_PORT_BACKING_TYPE,
+            "port": {"switchUuid": switch_uuid, "portgroupKey": portgroup_key},
+        }, None
+    if backing_type == _NIC_BACKING_STANDARD_PORTGROUP:
+        listing = _unwrap_value(
+            await _read_sub_op(
+                connector, target, operator, _OP_LIST_NETWORK, {"filter.networks": [network]}
+            )
+        )
+        first = listing[0] if isinstance(listing, list) and listing else None
+        network_name = first.get("name") if isinstance(first, dict) else None
+        if not isinstance(network_name, str) or not network_name:
+            return None, f"network {network!r} did not resolve to a display name"
+        return {
+            _VMOMI_TYPE_NAME_KEY: _STANDARD_NETWORK_BACKING_TYPE,
+            "deviceName": network_name,
+        }, None
+    return None, (
+        f"nic backing_type {backing_type!r} has no vim expression on the pre-9.0 "
+        "CreateVM_Task arm; use DISTRIBUTED_PORTGROUP or STANDARD_PORTGROUP"
+    )
+
+
+def _build_vim_create_request(
+    *,
+    name: str,
+    guest_id: str,
+    cpu_count: int,
+    memory_mib: int,
+    datastore_name: str,
+    nic_backings: list[dict[str, Any]],
+    nested_hv: bool,
+    pool_moid: str,
+    host_moid: str | None,
+) -> dict[str, Any]:
+    """Assemble the ``Folder.CreateVM_Task`` request body (#3099).
+
+    ``CreateVMRequestType`` (spec-verified against the pinned
+    ``vi-json.yaml``): ``{config: VirtualMachineConfigSpec, pool:
+    ResourcePool-MoRef, host?: HostSystem-MoRef}``. The ConfigSpec carries
+    the same logical inputs the REST CreateSpec did — ``name`` /
+    ``guestId`` / ``numCPUs`` / ``memoryMB`` — plus the vim-only shape:
+    ``files.vmPathName`` (the VM home, ``"[<datastore-name>] <name>"``),
+    the NIC ``deviceChange`` adds (vmxnet3, negative temp keys — the new-
+    device convention), and ``nestedHVEnabled`` folded inline when the
+    operator asked for the #3093 leg.
+    """
+    config: dict[str, Any] = {
+        "name": name,
+        "guestId": guest_id,
+        "numCPUs": cpu_count,
+        "memoryMB": memory_mib,
+        "files": {"vmPathName": f"[{datastore_name}] {name}"},
+    }
+    if nested_hv:
+        config["nestedHVEnabled"] = True
+    if nic_backings:
+        config["deviceChange"] = [
+            {
+                "operation": "add",
+                "device": {
+                    _VMOMI_TYPE_NAME_KEY: _VIRTUAL_VMXNET3_TYPE,
+                    "key": -(index + 1),
+                    "backing": backing,
+                },
+            }
+            for index, backing in enumerate(nic_backings)
+        ]
+    body: dict[str, Any] = {"config": config, "pool": _moref(_RESOURCE_POOL_MO_TYPE, pool_moid)}
+    if host_moid is not None:
+        body["host"] = _moref(_HOST_SYSTEM_MO_TYPE, host_moid)
+    return body
+
+
+async def _issue_vim_create(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    folder_moid: str,
+    body: dict[str, Any],
+    gate_params: dict[str, Any],
+    name: str,
+) -> tuple[OperationResult | None, str | None, str | None]:
+    """Gate + issue ``CreateVM_Task`` and poll it to terminal (#3099).
+
+    Returns ``(gate, vm_id, failure_reason)``:
+
+    * ``(gate, None, None)`` — the #2254 seam parked/denied the write.
+    * ``(None, vm_id, None)`` — the task succeeded; ``vm_id`` is the new
+      VirtualMachine moid from ``TaskInfo.result``.
+    * ``(None, None, reason)`` — transport fault, task fault, poll timeout,
+      or an unreadable task result; the caller folds *reason* into the
+      ``rolled_back`` envelope (nothing was verifiably created, so there is
+      nothing to delete — a timed-out create may still land in the
+      background, which the reason spells out).
+    """
+    try:
+        gate, task_payload = await _write_vmomi_sub_op(
+            connector,
+            target,
+            operator,
+            op_id=_OP_CREATE_VM_TASK,
+            vmomi_path=f"/Folder/{folder_moid}/CreateVM_Task",
+            body=body,
+            params=gate_params,
+        )
+        if gate is not None:
+            return gate, None, None
+        outcome = await poll_vim_task(
+            connector,
+            target,
+            operator,
+            task=_unwrap_value(task_payload),
+            timeout_seconds=_VM_CREATE_TASK_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        return None, None, f"create via CreateVM_Task failed: {exc}"
+    if outcome.state == TASK_STATE_ERROR:
+        return (
+            None,
+            None,
+            (
+                f"CreateVM_Task creating {name!r} faulted: "
+                f"{outcome.error_message or '<no fault reported>'}"
+            ),
+        )
+    if outcome.timed_out:
+        return (
+            None,
+            None,
+            (
+                f"CreateVM_Task {outcome.task} did not reach a terminal state within "
+                f"{int(_VM_CREATE_TASK_TIMEOUT_SECONDS)}s; the create may still complete "
+                "in the background — poll the task or list the folder before retrying"
+            ),
+        )
+    vm_id = _extract_task_vm_moid(outcome.result)
+    if vm_id is None:
+        return None, None, "CreateVM_Task succeeded but its result carried no VirtualMachine moid"
+    return None, vm_id, None
+
+
+async def _power_on_created_vm(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_id: str,
+) -> tuple[OperationResult | None, str | None]:
+    """Issue the gated power-on leg of ``vm.create``; ``(gate, failure_reason)``.
+
+    Shared by the REST and vim create arms (#3099) — the power endpoint is
+    not part of the 8.0.x create defect, so both arms finish through the
+    same REST sub-op. A parked/denied gate rides back for the caller to
+    return verbatim; a transport fault becomes the failure reason the
+    caller folds into the rollback contract.
+    """
+    try:
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _power_vm_op_id("start"), {"vm": vm_id}
+        )
+    except httpx.HTTPError as exc:
+        return None, f"power_on failed: {exc}"
+    return gate, None
+
+
+async def _vm_create_via_vim(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """The pre-9.0 arm of :func:`vm_create_composite` (#3099): vim ``CreateVM_Task``.
+
+    Same logical inputs, same response envelope, same rollback contract as
+    the REST arm — only the create transport differs. NICs and the optional
+    ``nested_hv`` flag fold into the one ``VirtualMachineConfigSpec`` (the
+    create is atomic vCenter-side, so there are no per-NIC / per-flag
+    partial-failure legs), and the task is polled to terminal through the
+    shared #2893 substrate. Fail-closed validations run before any
+    sub-call: an unmapped ``guest_os`` enum, missing ``resource_pool`` /
+    ``datastore`` pins (vim needs an explicit pool and VM home — vCenter-
+    side placement defaulting exists only on the REST create), and an
+    unsupported NIC backing each return a structured ``rolled_back``.
+    """
+    folder_name = params["folder_name"]
+    name = params["name"]
+    guest_os = params["guest_os"]
+    cpu_count = int(params.get("cpu_count", 1))
+    memory_mib = int(params.get("memory_mib", 1024))
+    nics: list[dict[str, Any]] = list(params.get("nics") or [])
+    nested_hv = bool(params.get("nested_hv", False))
+    power_on = bool(params.get("power_on_after_create", False))
+    pool_moid = params.get("resource_pool")
+    datastore_moid = params.get("datastore")
+    host_moid = params.get("host")
+
+    guest_id = _VIM_GUEST_ID_BY_REST_GUEST_OS.get(guest_os)
+    if guest_id is None:
+        return _rolled_back(
+            steps=[],
+            failed_step="guest_id_mapping",
+            reason=(
+                f"guest_os {guest_os!r} has no vim guestId mapping for the pre-9.0 "
+                "CreateVM_Task arm; supported identifiers: "
+                + ", ".join(sorted(_VIM_GUEST_ID_BY_REST_GUEST_OS))
+            ),
+        )
+    if not isinstance(pool_moid, str) or not isinstance(datastore_moid, str):
+        return _rolled_back(
+            steps=[],
+            failed_step="placement_params",
+            reason=(
+                "resource_pool and datastore moids are required on a pre-9.0 target: "
+                "vim CreateVM_Task needs an explicit pool and a datastore for the VM "
+                "home (files.vmPathName) — vCenter-side placement defaulting exists "
+                "only on the REST create"
+            ),
+        )
+
+    steps: list[str] = []
+    folder_moid, folder_err = await _resolve_folder_moid(
+        connector=connector, target=target, operator=operator, folder_name=folder_name
+    )
+    if folder_moid is None:
+        return _rolled_back(steps=steps, failed_step="folder_lookup", reason=folder_err or "")
+    steps.append("folder_lookup")
+
+    datastore_name, datastore_err = await _resolve_datastore_name(
+        connector=connector, target=target, operator=operator, datastore_moid=datastore_moid
+    )
+    if datastore_name is None:
+        return _rolled_back(steps=steps, failed_step="datastore_lookup", reason=datastore_err or "")
+
+    nic_backings: list[dict[str, Any]] = []
+    for nic in nics:
+        backing, nic_err = await _resolve_vim_nic_backing(connector, target, operator, nic=nic)
+        if backing is None:
+            return _rolled_back(steps=steps, failed_step="network_lookup", reason=nic_err or "")
+        nic_backings.append(backing)
+
+    create_body = _build_vim_create_request(
+        name=name,
+        guest_id=guest_id,
+        cpu_count=cpu_count,
+        memory_mib=memory_mib,
+        datastore_name=datastore_name,
+        nic_backings=nic_backings,
+        nested_hv=nested_hv,
+        pool_moid=pool_moid,
+        host_moid=host_moid if isinstance(host_moid, str) else None,
+    )
+    # Identity-only gate params: the durable ApprovalRequest names the
+    # blast radius (what gets created, where) without the assembled vim
+    # body — mirroring the clone-from-template gate discipline.
+    gate_params = {
+        "name": name,
+        "folder_name": folder_name,
+        "folder": folder_moid,
+        "guest_os": guest_os,
+        "resource_pool": pool_moid,
+        "datastore": datastore_moid,
+        "host": host_moid,
+        "cpu_count": cpu_count,
+        "memory_mib": memory_mib,
+        "nics": [nic.get("network") for nic in nics],
+        "nested_hv": nested_hv,
+    }
+    gate, vm_id, create_failure = await _issue_vim_create(
+        connector=connector,
+        target=target,
+        operator=operator,
+        folder_moid=folder_moid,
+        body=create_body,
+        gate_params=gate_params,
+        name=name,
+    )
+    if gate is not None:
+        return gate
+    if create_failure is not None or vm_id is None:
+        return _rolled_back(steps=steps, failed_step="create", reason=create_failure or "")
+    steps.append("create")
+    if nics:
+        steps.append("nic_attach")
+    if nested_hv:
+        steps.append("nested_hv")
+
+    if power_on:
+        gate, power_failure = await _power_on_created_vm(
+            connector=connector, target=target, operator=operator, vm_id=vm_id
+        )
+        if gate is not None:
+            return gate
+        if power_failure is not None:
+            await _rollback_created_vm(
+                connector=connector, target=target, operator=operator, vm_id=vm_id
+            )
+            return _rolled_back(steps=steps, failed_step="power_on", reason=power_failure)
+        steps.append("power_on")
+
+    created: dict[str, Any] = {
+        "status": "created",
+        "vm_id": vm_id,
+        "steps_succeeded": steps,
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+    if "nested_hv" in params:
+        created["nested_hv"] = nested_hv
+    return created
+
+
 async def vm_create_composite(
     *,
     operator: Operator,
@@ -1061,7 +1576,20 @@ async def vm_create_composite(
     CreateSpec ``placement`` alongside the resolved folder moid; absent
     pins leave vCenter's placement defaulting untouched and keep the
     create body byte-identical to a pre-#3096 call.
+
+    Version-conditional create transport (#3099): when the live
+    ``about.version`` major is < 9 the whole create rides vim
+    ``Folder.CreateVM_Task`` (:func:`_vm_create_via_vim`) — bare REST
+    ``POST /api/vcenter/vm`` is vendor-defective on vCenter 8.0.x — with
+    NICs and ``nested_hv`` folded into the one ConfigSpec. 9.0+ and
+    unresolved versions keep the REST path below byte-identical.
     """
+    about_version = await connector._about_version(target, operator)
+    if _vim_create_required(about_version):
+        return await _vm_create_via_vim(
+            operator=operator, target=target, params=params, connector=connector
+        )
+
     folder_name = params["folder_name"]
     name = params["name"]
     guest_os = params["guest_os"]
@@ -1150,21 +1678,16 @@ async def vm_create_composite(
         steps.append("nested_hv")
 
     if power_on:
-        try:
-            gate, _ = await _write_sub_op(
-                connector, target, operator, _power_vm_op_id("start"), {"vm": vm_id}
-            )
-        except httpx.HTTPError as exc:
+        gate, power_failure = await _power_on_created_vm(
+            connector=connector, target=target, operator=operator, vm_id=vm_id
+        )
+        if gate is not None:
+            return gate
+        if power_failure is not None:
             await _rollback_created_vm(
                 connector=connector, target=target, operator=operator, vm_id=vm_id
             )
-            return _rolled_back(
-                steps=steps,
-                failed_step="power_on",
-                reason=f"power_on failed: {exc}",
-            )
-        if gate is not None:
-            return gate
+            return _rolled_back(steps=steps, failed_step="power_on", reason=power_failure)
         steps.append("power_on")
 
     created: dict[str, Any] = {
@@ -2990,13 +3513,14 @@ def _extract_config_template(retrieve_result: Any, vm_moid: str) -> bool | None:
     return None
 
 
-def _extract_cloned_vm_moid(task_result: Any) -> str | None:
-    """Pull the new VM moid out of a SUCCEEDED CloneVM_Task ``result`` MoRef.
+def _extract_task_vm_moid(task_result: Any) -> str | None:
+    """Pull the new VM moid out of a SUCCEEDED ``*_Task`` ``result`` MoRef.
 
-    ``TaskInfo.result`` for ``CloneVM_Task`` is the new VirtualMachine
-    ``ManagedObjectReference`` (``{"type": "VirtualMachine", "value":
-    "vm-99"}``); a bare moid string is tolerated. ``None`` when the shape is
-    neither -- the clone still succeeded, the moid is just unreadable.
+    ``TaskInfo.result`` for ``CloneVM_Task`` (#2894) and ``CreateVM_Task``
+    (#3099) is the new VirtualMachine ``ManagedObjectReference``
+    (``{"type": "VirtualMachine", "value": "vm-99"}``); a bare moid string
+    is tolerated. ``None`` when the shape is neither -- the task still
+    succeeded, the moid is just unreadable.
     """
     if isinstance(task_result, dict):
         value = task_result.get("value")
@@ -3296,7 +3820,7 @@ async def vm_clone_from_template_composite(
         source_template=source_template,
         source_template_id=template_moid,
         new_vm_name=new_vm_name,
-        new_vm_id=_extract_cloned_vm_moid(outcome.result),
+        new_vm_id=_extract_task_vm_moid(outcome.result),
         folder=folder_moid,
         task=outcome.task,
         customization_spec_name=customization_spec_name,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -600,6 +600,11 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
 #: created VM via ``DELETE:/vcenter/vm/{vm}``. Optional placement pins
 #: (``resource_pool`` / ``datastore`` / ``host`` moids, #3096) thread
 #: into the CreateSpec ``placement`` alongside the resolved folder moid.
+#: On pre-9.0 vCenter (live ``about.version`` major < 9, #3099) the
+#: create rides vim ``Folder.CreateVM_Task`` instead — the bare REST
+#: create is vendor-defective on 8.0.x — with NICs and ``nested_hv``
+#: folded into the one ConfigSpec; ``resource_pool`` and ``datastore``
+#: are required on that arm.
 VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -621,7 +626,9 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "folder moid. The pinned spec marks ``resource_pool`` as "
                 "currently required when neither host nor cluster is "
                 "given, so multi-host clusters should pin it; absent, "
-                "vCenter's placement defaulting applies."
+                "vCenter's placement defaulting applies. On a pre-9.0 "
+                "target it is REQUIRED (#3099): vim CreateVM_Task takes "
+                "an explicit pool and has no placement defaulting."
             ),
         },
         "datastore": {
@@ -632,7 +639,10 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "disk storage. Threaded into the CreateSpec "
                 "``placement``; absent, vCenter's placement defaulting "
                 "applies — on hosts with host-local datastores the "
-                "default may land the VM on the wrong store."
+                "default may land the VM on the wrong store. On a "
+                "pre-9.0 target it is REQUIRED (#3099): the vim arm "
+                "resolves its display name into the "
+                "``files.vmPathName`` VM home."
             ),
         },
         "host": {
@@ -656,7 +666,11 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
             "minLength": 1,
             "description": (
                 "Guest-OS identifier (e.g. ``UBUNTU_64``). Drives the "
-                "ConfigSpec.guestOS field on ``POST:/vcenter/vm``."
+                "ConfigSpec.guestOS field on ``POST:/vcenter/vm``. On a "
+                "pre-9.0 target (#3099) it is mapped to the vim guestId "
+                "(``VMKERNEL_8`` -> ``vmkernel8Guest``); an identifier "
+                "outside the curated mapping fails closed with a "
+                "structured ``rolled_back`` before any write."
             ),
         },
         "cpu_count": {
@@ -703,7 +717,11 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "``POST:/vcenter/vm/{vm}/hardware/ethernet`` adapter "
                 "create (the network rides the ``backing`` spec) after "
                 "the VM is created. Empty list creates the VM with no "
-                "NICs."
+                "NICs. On a pre-9.0 target (#3099) NICs fold into the "
+                "CreateVM_Task ConfigSpec as vmxnet3 ``deviceChange`` "
+                "adds (distributed or standard portgroup backing; "
+                "``OPAQUE_NETWORK`` has no vim expression there and "
+                "fails closed)."
             ),
         },
         "nested_hv": {
@@ -1269,7 +1287,11 @@ VM_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
         "failed_step": {
             "type": ["string", "null"],
             "description": (
-                "Name of the first failing step on rollback; ``null`` when ``status='created'``."
+                "Name of the first failing step on rollback; ``null`` "
+                "when ``status='created'``. The pre-9.0 vim arm (#3099) "
+                "adds fail-closed resolution steps: "
+                "``guest_id_mapping``, ``placement_params``, "
+                "``datastore_lookup``, ``network_lookup``."
             ),
         },
         "rollback_reason": {

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -724,7 +724,7 @@ def test_2970_vim_paths_exist_in_the_pinned_spec(manifest_name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# vm.create VHV leg VI-JSON sub-op reconciliation (#3093)
+# vm.create VI-JSON sub-op reconciliation (#3093 VHV leg + #3099 create arm)
 # ---------------------------------------------------------------------------
 #
 # vm.create's optional ``nested_hv`` leg is vi-json, not vcenter REST:
@@ -733,21 +733,26 @@ def test_2970_vim_paths_exist_in_the_pinned_spec(manifest_name: str) -> None:
 # ``/api`` — a 9.x-fleet shape that 404s on vCenter 8.0.x (#2466) — so the
 # leg rides the same governed vmomi substrate as disk-grow:
 # ``POST:/VirtualMachine/{moId}/ReconfigVM_Task`` (the flag write) plus the
-# shared Task-poll read ``RetrievePropertiesEx``. Declared in
-# ``_write._VIM_SUB_OPS_VM_CREATE`` (deliberately NOT in the ``_SUB_OPS_*``
-# namespace, so the vcenter.yaml sweep above skips it).
+# shared Task-poll read ``RetrievePropertiesEx``. The #3099 pre-9.0 create
+# arm adds ``POST:/Folder/{moId}/CreateVM_Task`` — on vCenter 8.0.x the
+# bare REST ``POST /api/vcenter/vm`` is vendor-defective, so the whole
+# create rides the vim path there (NICs + nested_hv folded into the one
+# ConfigSpec). Declared in ``_write._VIM_SUB_OPS_VM_CREATE`` (deliberately
+# NOT in the ``_SUB_OPS_*`` namespace, so the vcenter.yaml sweep above
+# skips it).
 
 
-def test_vm_create_vhv_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
-    """Pin the vm.create VHV vi-json manifest so a drift can't shrink the reconcile."""
+def test_vm_create_vi_json_sub_op_manifest_is_the_expected_triple() -> None:
+    """Pin the vm.create vi-json manifest so a drift can't shrink the reconcile."""
     assert set(_write._VIM_SUB_OPS_VM_CREATE) == {
         "POST:/VirtualMachine/{moId}/ReconfigVM_Task",
         "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/Folder/{moId}/CreateVM_Task",
     }
 
 
-def test_vm_create_vhv_vi_json_sub_ops_round_trip_through_ingest() -> None:
-    """The VHV-leg vi-json op_ids are byte-for-byte what the parser emits.
+def test_vm_create_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The vm.create vi-json op_ids are byte-for-byte what the parser emits.
 
     Same proof shape as the #2893-#2895 round-trips above: the ``{moId}``
     path template survives the parser, so ``enforce_subop_policy``'s op_id /
@@ -770,16 +775,17 @@ def test_vm_create_vhv_vi_json_sub_ops_round_trip_through_ingest() -> None:
     assert required <= ingested_op_ids
 
 
-def test_vm_create_vhv_paths_and_flag_exist_in_the_pinned_spec() -> None:
-    """The VHV vim paths are real POST paths and ``nestedHVEnabled`` is served.
+def test_vm_create_vim_paths_and_flag_exist_in_the_pinned_spec() -> None:
+    """The vm.create vim paths are real POST paths and ``nestedHVEnabled`` is served.
 
-    The definitive #3093 grounding: the leg targets paths the pinned
-    ``vi-json.yaml`` actually serves, and the one field its body sets —
-    ``VirtualMachineConfigSpec.nestedHVEnabled`` — exists in the pinned
-    schema corpus (the schema-level pin lives in the #3087 recipe reconcile
-    lane; this is the cheap text-level guard alongside the path check).
-    Skips when the spec-shelf is not configured (the canary's convention),
-    so CI is the operator-visible signal.
+    The definitive #3093 + #3099 grounding: the VHV leg and the pre-9.0
+    create arm target paths the pinned ``vi-json.yaml`` actually serves
+    (``ReconfigVM_Task``, ``CreateVM_Task``, the Task-poll read), and the
+    one flag the bodies set — ``VirtualMachineConfigSpec.nestedHVEnabled``
+    — exists in the pinned schema corpus (the schema-level pin lives in
+    the #3087 recipe reconcile lane; this is the cheap text-level guard
+    alongside the path check). Skips when the spec-shelf is not configured
+    (the canary's convention), so CI is the operator-visible signal.
     """
     spec_path = resolve_vi_json_yaml()
     if spec_path is None:
@@ -789,9 +795,43 @@ def test_vm_create_vhv_paths_and_flag_exist_in_the_pinned_spec() -> None:
         _, _, path = op_id.partition(":")
         assert _vi_json_path_item_has_post(spec_text, path), (
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
-            "vm.create VHV vi-json sub-op targets a path the spec does not serve"
+            "vm.create vi-json sub-op targets a path the spec does not serve"
         )
     assert "nestedHVEnabled:" in spec_text, (
         "``nestedHVEnabled`` is absent from the pinned vi-json.yaml — the "
         "vm.create VHV reconfigure body sets a field the spec does not serve"
     )
+
+
+def test_vm_create_guest_id_map_is_grounded_in_both_pinned_specs() -> None:
+    """Every #3099 guestId mapping row exists in both pinned spec enums.
+
+    The pre-9.0 create arm maps the composite's REST-style ``guest_os``
+    enum to the vim ``guestId`` the ``CreateVM_Task`` ConfigSpec takes.
+    Both sides of every curated pair must be real enum values: the key in
+    the pinned ``vcenter.yaml``'s ``Vcenter.Vm.GuestOS`` enum, the value
+    in the pinned ``vi-json.yaml``'s
+    ``VirtualMachineGuestOsIdentifier_enum``. Text-level pins (the
+    ``nestedHVEnabled`` guard's convention): the YAML enum entries are
+    unambiguous single-line items, so a substring with the trailing
+    newline is an exact-value match. Skips when the spec-shelf is not
+    configured, so CI is the operator-visible signal.
+    """
+    vcenter_path = resolve_vcenter_yaml()
+    vi_json_path = resolve_vi_json_yaml()
+    if vcenter_path is None or vi_json_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    vcenter_text = vcenter_path.read_text(encoding="utf-8")
+    vi_json_text = vi_json_path.read_text(encoding="utf-8")
+    assert _write._VIM_GUEST_ID_BY_REST_GUEST_OS, "guestId map is empty — wiring broke"
+    for rest_enum, vim_guest_id in _write._VIM_GUEST_ID_BY_REST_GUEST_OS.items():
+        assert f"- {rest_enum}\n" in vcenter_text, (
+            f"{rest_enum!r} is not a Vm.GuestOS enum value in the pinned "
+            "vcenter.yaml — the #3099 guestId map keys an identifier the REST "
+            "surface does not serve"
+        )
+        assert f"- '{vim_guest_id}'\n" in vi_json_text, (
+            f"{vim_guest_id!r} is not a VirtualMachineGuestOsIdentifier enum "
+            "value in the pinned vi-json.yaml — the #3099 guestId map targets "
+            "a vim identifier the spec does not serve"
+        )

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -312,11 +312,19 @@ def _retrieve_result(obj_type: str, moid: str, prop: str, val: Any) -> dict[str,
     }
 
 
-def _task_info_result(task_moid: str, state: str, error: str | None = None) -> dict[str, Any]:
-    """A ``Task.info`` RetrievePropertiesEx result in the requested state."""
+def _task_info_result(
+    task_moid: str, state: str, error: str | None = None, *, result: Any = None
+) -> dict[str, Any]:
+    """A ``Task.info`` RetrievePropertiesEx result in the requested state.
+
+    ``result`` seeds ``TaskInfo.result`` — the new-entity MoRef a
+    ``CreateVM_Task`` / ``CloneVM_Task`` success carries.
+    """
     info: dict[str, Any] = {"state": state}
     if error is not None:
         info["error"] = {"localizedMessage": error}
+    if result is not None:
+        info["result"] = result
     return _retrieve_result("Task", task_moid, "info", info)
 
 
@@ -876,6 +884,510 @@ async def test_vm_create_nested_hv_false_skips_leg_and_echoes_false(
         "rollback_reason": None,
         "nested_hv": False,
     }
+
+
+# ===========================================================================
+# vm.create — pre-9.0 vim CreateVM_Task arm (#3099)
+# ===========================================================================
+#
+# On vCenter 8.0.x the bare REST ``POST /api/vcenter/vm`` is vendor-
+# defective (opaque 500 UNABLE_TO_ALLOCATE_RESOURCE for every spec shape /
+# placement, proven live), so a resolvable pre-9.0 ``about.version`` major
+# routes the whole create through vim ``Folder.CreateVM_Task`` with NICs +
+# nested_hv folded into the one ConfigSpec. 9.0+/unresolved stay on the
+# REST arm byte-identical (the tests above run with about_version=None).
+
+_DVPG_BACKING_PROPS: dict[str, Any] = {
+    "objects": [
+        {
+            "obj": {"type": "DistributedVirtualPortgroup", "value": "dvportgroup-1015"},
+            "propSet": [
+                {"name": "key", "val": "dvportgroup-1015"},
+                {
+                    "name": "config.distributedVirtualSwitch",
+                    "val": {"type": "VmwareDistributedVirtualSwitch", "value": "dvs-21"},
+                },
+            ],
+        }
+    ]
+}
+
+_DVS_UUID = "50 1e ab cd 12 34 56 78-90 ab cd ef 12 34 56 78"
+
+
+def _pre9_conn(
+    rest: dict[str, Any] | None = None, vmomi: dict[str, Any] | None = None
+) -> _UnifiedRecordingConnector:
+    """A recording connector reporting a live vCenter 8.0.3 about.version."""
+    return _UnifiedRecordingConnector(rest or {}, about_version="8.0.3.00500", vmomi=vmomi or {})
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
+    """Pre-9.0: one CreateVM_Task carries placement, NIC, and nestedHVEnabled.
+
+    The full-shape proof: the REST create is never attempted, the DVPG
+    backing is resolved through the two vmomi property reads (portgroup
+    key + owning switch, then switch uuid — the govc walk), the ConfigSpec
+    folds the #3093 flag inline (no separate ReconfigVM_Task), and the
+    envelope is byte-identical to the REST arm's.
+    """
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "nested-lab"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+            "/api/vcenter/vm/vm-88/power?action=start": {},
+        },
+        vmomi={
+            "DistributedVirtualPortgroup": _DVPG_BACKING_PROPS,
+            "VmwareDistributedVirtualSwitch": _retrieve_result(
+                "VmwareDistributedVirtualSwitch", "dvs-21", "uuid", _DVS_UUID
+            ),
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-501"),
+            "Task": _task_info_result(
+                "task-501", "success", result={"type": "VirtualMachine", "value": "vm-88"}
+            ),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "nested-lab",
+            "name": "esx-nested-01",
+            "guest_os": "VMKERNEL_8",
+            "cpu_count": 8,
+            "memory_mib": 16384,
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "host": "host-14",
+            "nics": [{"network": "dvportgroup-1015", "backing_type": "DISTRIBUTED_PORTGROUP"}],
+            "nested_hv": True,
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    # The REST create never fired; the vim create + poll ride between the
+    # resolution reads and the (still-REST) power-on.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/folder"),
+        ("GET", "/api/vcenter/datastore/datastore-11"),
+        ("POST-VMOMI", _VMOMI_TASK_INFO_READ_PATH),  # DVPG key + owning switch
+        ("POST-VMOMI", _VMOMI_TASK_INFO_READ_PATH),  # switch uuid
+        ("POST-VMOMI", "/Folder/folder-7/CreateVM_Task"),
+        ("POST-VMOMI", _VMOMI_TASK_INFO_READ_PATH),  # task poll
+        ("POST", "/api/vcenter/vm/vm-88/power?action=start"),
+    ]
+    create_body = conn.vmomi_calls[2][1]
+    assert create_body == {
+        "config": {
+            "name": "esx-nested-01",
+            "guestId": "vmkernel8Guest",
+            "numCPUs": 8,
+            "memoryMB": 16384,
+            "files": {"vmPathName": "[datastore1] esx-nested-01"},
+            "nestedHVEnabled": True,
+            "deviceChange": [
+                {
+                    "operation": "add",
+                    "device": {
+                        "_typeName": "VirtualVmxnet3",
+                        "key": -1,
+                        "backing": {
+                            "_typeName": ("VirtualEthernetCardDistributedVirtualPortBackingInfo"),
+                            "port": {
+                                "switchUuid": _DVS_UUID,
+                                "portgroupKey": "dvportgroup-1015",
+                            },
+                        },
+                    },
+                }
+            ],
+        },
+        "pool": {"type": "ResourcePool", "value": "resgroup-8"},
+        "host": {"type": "HostSystem", "value": "host-14"},
+    }
+
+    # Governance: exactly the vim create + the power-on were gated — no
+    # separate ReconfigVM_Task (the #3093 leg folded into the ConfigSpec)
+    # and no REST create gate.
+    assert gate.gated_op_ids == [
+        "POST:/Folder/{moId}/CreateVM_Task",
+        "POST:/vcenter/vm/{vm}/power?action=start",
+    ]
+    assert gate.calls[0]["params"] == {
+        "name": "esx-nested-01",
+        "folder_name": "nested-lab",
+        "folder": "folder-7",
+        "guest_os": "VMKERNEL_8",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-11",
+        "host": "host-14",
+        "cpu_count": 8,
+        "memory_mib": 16384,
+        "nics": ["dvportgroup-1015"],
+        "nested_hv": True,
+    }
+
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-88",
+        "steps_succeeded": ["folder_lookup", "create", "nic_attach", "nested_hv", "power_on"],
+        "failed_step": None,
+        "rollback_reason": None,
+        "nested_hv": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("about_version", [None, "9.0.0.24755230"])
+async def test_vm_create_v9_and_unresolved_keep_rest_create_byte_identical(
+    gate: _GateRecorder, about_version: str | None
+) -> None:
+    """9.0+ and unresolved about.version: the REST arm is byte-identical (#3099).
+
+    The exact-envelope regression in the #3094/#3097 discipline: same
+    create body, same sub-op chain, same envelope — and zero vim traffic.
+    """
+    conn = _UnifiedRecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+        },
+        about_version=about_version,
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "cpu_count": 2,
+            "memory_mib": 4096,
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.vmomi_calls == []
+    assert conn.calls[1]["body"] == {
+        "name": "web-01",
+        "guest_OS": "UBUNTU_64",
+        "placement": {
+            "folder": "folder-7",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        "cpu": {"count": 2},
+        "memory": {"size_MiB": 4096},
+    }
+    assert gate.gated_op_ids == ["POST:/vcenter/vm"]
+    assert out == {
+        "status": "created",
+        "vm_id": "vm-99",
+        "steps_succeeded": ["folder_lookup", "create"],
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_unknown_guest_enum_fails_closed(gate: _GateRecorder) -> None:
+    """An unmapped guest_os enum refuses before any sub-call — never a guess."""
+    conn = _pre9_conn()
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "VMKERNEL8",  # typo: not a mapped enum
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "guest_id_mapping"
+    assert "'VMKERNEL8'" in out["rollback_reason"]
+    assert "VMKERNEL_8" in out["rollback_reason"]  # the supported list is named
+    assert conn.calls == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_requires_resource_pool_and_datastore(
+    gate: _GateRecorder,
+) -> None:
+    """Missing placement pins fail closed: vim create has no placement defaulting."""
+    conn = _pre9_conn()
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"folder_name": "Prod", "name": "web-01", "guest_os": "UBUNTU_64"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "placement_params"
+    assert "resource_pool and datastore" in out["rollback_reason"]
+    assert conn.calls == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_standard_portgroup_nic_uses_network_backing(
+    gate: _GateRecorder,
+) -> None:
+    """The default STANDARD_PORTGROUP backing maps to the deviceName vim backing."""
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+            "/api/vcenter/network": [
+                {"network": "network-33", "name": "VM Network", "type": "STANDARD_PORTGROUP"}
+            ],
+        },
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-502"),
+            "Task": _task_info_result(
+                "task-502", "success", result={"type": "VirtualMachine", "value": "vm-90"}
+            ),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "nics": [{"network": "network-33"}],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    # The network listing resolved the display name (bare param on /api, #2298).
+    network_reads = [c for c in conn.calls if c["path"] == "/api/vcenter/network"]
+    assert len(network_reads) == 1
+    assert network_reads[0]["query"] == {"networks": ["network-33"]}
+    create_body = conn.vmomi_calls[0][1]
+    assert create_body["config"]["deviceChange"] == [
+        {
+            "operation": "add",
+            "device": {
+                "_typeName": "VirtualVmxnet3",
+                "key": -1,
+                "backing": {
+                    "_typeName": "VirtualEthernetCardNetworkBackingInfo",
+                    "deviceName": "VM Network",
+                },
+            },
+        }
+    ]
+    assert out["status"] == "created"
+    assert out["steps_succeeded"] == ["folder_lookup", "create", "nic_attach"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_opaque_network_nic_fails_closed(gate: _GateRecorder) -> None:
+    """OPAQUE_NETWORK has no vim expression on this arm: structured refusal, no write."""
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "nics": [{"network": "net-77", "backing_type": "OPAQUE_NETWORK"}],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "network_lookup"
+    assert "OPAQUE_NETWORK" in out["rollback_reason"]
+    assert gate.calls == []  # the CreateVM_Task write was never gated / issued
+    assert conn.vmomi_calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_datastore_without_name_fails_closed(
+    gate: _GateRecorder,
+) -> None:
+    """A datastore info payload without a name refuses before the vim write."""
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "datastore_lookup"
+    assert "datastore-11" in out["rollback_reason"]
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_task_fault_returns_rolled_back(gate: _GateRecorder) -> None:
+    """A faulted CreateVM_Task surfaces the vim fault; nothing exists to delete."""
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+        },
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-503"),
+            "Task": _task_info_result("task-503", "error", "Insufficient capacity"),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "create"
+    assert "Insufficient capacity" in out["rollback_reason"]
+    # The create never landed, so no DELETE rollback fires.
+    assert "DELETE" not in [c["method"] for c in conn.calls]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_poll_timeout_returns_rolled_back(
+    gate: _GateRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A create task-poll timeout names the task; the VM may still land later."""
+    monkeypatch.setattr(_write, "_VM_CREATE_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+        },
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-504"),
+            "Task": _task_info_result("task-504", "running"),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "create"
+    assert "task-504" in out["rollback_reason"]
+    assert "may still complete" in out["rollback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_gate_short_circuits_before_create_vm_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gated vim create returns awaiting_approval verbatim; no vmomi write fires."""
+    vim_op = "POST:/Folder/{moId}/CreateVM_Task"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={vim_op: _awaiting(vim_op)}))
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+        }
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == vim_op
+    assert conn.vmomi_calls == []
+    # Only the two resolution reads hit the session; no power-on either.
+    assert [c["method"] for c in conn.calls] == ["GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_pre9_power_on_failure_rolls_back_via_delete(
+    gate: _GateRecorder,
+) -> None:
+    """The vim arm keeps the REST rollback contract: power-on fault -> DELETE."""
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+            "/api/vcenter/vm/vm-90/power?action=start": _http_error(
+                500, "https://vc/api/vcenter/vm/vm-90/power?action=start"
+            ),
+            "/api/vcenter/vm/vm-90": {},  # DELETE rollback
+        },
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-505"),
+            "Task": _task_info_result(
+                "task-505", "success", result={"type": "VirtualMachine", "value": "vm-90"}
+            ),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "power_on_after_create": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert ("DELETE", "/api/vcenter/vm/vm-90") in [(c["method"], c["path"]) for c in conn.calls]
+    assert out["status"] == "rolled_back"
+    assert out["vm_id"] is None
+    assert out["failed_step"] == "power_on"
+    assert "power_on failed" in out["rollback_reason"]
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -127,6 +127,11 @@ class _RecordingConnector:
         self._vmomi = vmomi or {}
         self.writes: list[dict[str, Any]] = []
 
+    async def _about_version(self, target: Any, operator: Operator) -> str | None:
+        """Unresolved ``about.version`` keeps ``vm.create`` on its REST arm (#3099)."""
+        del target, operator
+        return None
+
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         return f"/api{path}"
 

--- a/backend/tests/test_connectors_vmware_rest_nested_esxi_recipe.py
+++ b/backend/tests/test_connectors_vmware_rest_nested_esxi_recipe.py
@@ -480,12 +480,18 @@ class _RecordingSession:
 
     The full recording connector lives in
     ``tests/test_connectors_vmware_rest_composites_write.py``; this subset
-    carries only the three methods ``vm_create_composite`` touches.
+    carries only the methods ``vm_create_composite`` touches. The
+    ``_about_version`` read serves ``None`` (unresolved), which keeps the
+    composite on the REST create arm this module pins (#3099).
     """
 
     def __init__(self, responses: dict[str, Any]) -> None:
         self._responses = responses
         self.calls: list[dict[str, Any]] = []
+
+    async def _about_version(self, target: Any, operator: Operator) -> str | None:
+        del target, operator
+        return None
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         return f"/api{path}"

--- a/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
+++ b/docs/codebase/connectors-vmware-rest-nested-esxi-recipe.md
@@ -52,11 +52,29 @@ parameter, not an envelope).
 }
 ```
 
-- `guest_os` passes through **verbatim** — no machine enum constrains it
-  anywhere on the path (composite schema: any non-empty string; pinned
-  spec: prose-only enum). `VMKERNEL_8` / `VMKERNEL_9` are documented
-  values in the pinned 9.0 spec, so an ESXi guest is a legitimate,
-  spec-grounded identifier (gap 5 on typo behaviour, gap 4 on casing).
+- **The 8.0.x arm is first-class (#3099).** On a live pre-9.0
+  `about.version` major the composite creates through vim
+  `Folder.CreateVM_Task` (task-polled, same governed vmomi substrate as
+  the VHV leg) instead of REST `POST:/vcenter/vm` — the bare REST create
+  is vendor-defective on vCenter 8.0.x (opaque
+  `500 UNABLE_TO_ALLOCATE_RESOURCE` for every spec shape and placement,
+  proven live; the identical vim create succeeds). On that arm the NICs
+  (vmxnet3; DVPG backing resolved to `switchUuid` + `portgroupKey`,
+  standard portgroup to `deviceName`) and `nested_hv` fold into the one
+  `VirtualMachineConfigSpec`, `resource_pool` **and** `datastore` are
+  required (fail-closed `placement_params` — vim has no placement
+  defaulting; the datastore name becomes the `files.vmPathName` VM home),
+  and `guest_os` maps through a curated spec-grounded guestId table
+  (`VMKERNEL_8` → `vmkernel8Guest`; an unmapped enum is a fail-closed
+  `guest_id_mapping` refusal — the pre-9.0 arm closes gap 5's silent-typo
+  hole). 9.0+ and unresolved versions keep the REST arm below
+  byte-identical.
+- `guest_os` passes through **verbatim on the REST arm** — no machine
+  enum constrains it there (composite schema: any non-empty string;
+  pinned spec: prose-only enum). `VMKERNEL_8` / `VMKERNEL_9` are
+  documented values in the pinned 9.0 spec, so an ESXi guest is a
+  legitimate, spec-grounded identifier (gap 5 on typo behaviour, gap 4
+  on casing).
 - `nested_hv: true` (#3093) enables nested hardware-assisted
   virtualization as part of the create: after NIC attach and **before any
   power-on**, the composite issues the vim `ReconfigVM_Task`
@@ -210,9 +228,11 @@ and rollback contract already live) instead of growing a new op.
    9.x wire accepts is exactly what the deferred live-appliance verify
    must answer before touching five composite bodies. Until then the
    recipe's step 1 carries this as its one named risk.
-5. **No machine-readable guest-OS enum.** The identifier is a free
-   string end to end; a typo (`VMKERNEL8`) parks nothing at dispatch and
-   surfaces as a vCenter 400.
+5. **No machine-readable guest-OS enum on the REST arm.** The identifier
+   is a free string there; a typo (`VMKERNEL8`) parks nothing at dispatch
+   and surfaces as a vCenter 400. The pre-9.0 vim arm (#3099) closes this
+   for its targets: the curated guestId map refuses an unmapped enum with
+   a structured `guest_id_mapping` rollback before any write.
 6. **`vm.device.cdrom` has no ADD leg** — by design; the raw op is the
    governed ADD (step 5).
 7. **Boot-order / firmware / hardware-version knobs** are not exposed by
@@ -229,12 +249,14 @@ and rollback contract already live) instead of growing a new op.
 | cdrom composite manifest (update/remove/disconnect only) | `test_cdrom_composite_covers_update_remove_disconnect_only` (reconcile module) |
 | `vm.create(nested_hv=true)` leg: reconfigure-before-power-on ordering, body shape, gating, rollback on leg failure, param-absent byte-identity | `test_vm_create_nested_hv_*` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; vim manifest + pinned-spec lane in `..._composites_l2_ingest_reconcile.py` (#3093) |
 | `vm.create` placement pins (`resource_pool` / `datastore` / `host`) thread into the create body; pin-absent body byte-identity; pinned `VM.PlacementSpec` field set | `test_vm_create_placement_pins_thread_into_the_create_body` / `test_vm_create_without_placement_pins_create_body_is_byte_identical` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; `test_vm_placement_spec_serves_the_composite_placement_pins` (reconcile module) (#3096) |
+| `vm.create` pre-9.0 arm: CreateVM_Task body shape (placement, NIC backings, inline nestedHVEnabled), no REST create attempted, fail-closed guest/placement/backing refusals, task fault/timeout, gate short-circuit, rollback contract; 9.0+/unresolved REST byte-identity | `test_vm_create_pre9_*` + `test_vm_create_v9_and_unresolved_keep_rest_create_byte_identical` in `backend/tests/test_connectors_vmware_rest_composites_write.py`; vim manifest triple + guestId-map spec grounding in `..._composites_l2_ingest_reconcile.py` (#3099) |
 
 ## References
 
 - #3087 (this recipe), #3086 (sibling: ISO import + mount), #3093
   (`vm.create` `nested_hv` — the composite VHV leg), #3096 (`vm.create`
-  placement pins)
+  placement pins), #3099 (`vm.create` pre-9.0 vim `CreateVM_Task` arm —
+  the 8.0.x REST create is vendor-defective)
 - #2973 / #3071 — the `/rest`-vs-`/api` body-envelope class the raw
   bodies were checked against; #2466 — VI-JSON mount bases; #3082 —
   204-no-body writes

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -584,7 +584,7 @@ enum) are:
 
 | Composite | Status values |
 | --- | --- |
-| `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical. Optional placement pins — `resource_pool` / `datastore` / `host` moids, #3096 — thread into the CreateSpec `placement` alongside the resolved folder moid; absent pins keep the create body byte-identical and never echo into the envelope) |
+| `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical. Optional placement pins — `resource_pool` / `datastore` / `host` moids, #3096 — thread into the CreateSpec `placement` alongside the resolved folder moid; absent pins keep the create body byte-identical and never echo into the envelope. **Version-conditional create transport (#3099):** on a live pre-9.0 `about.version` major the whole create rides vim `Folder.CreateVM_Task` through the governed vmomi seam, task-polled — bare REST `POST /api/vcenter/vm` is vendor-defective on vCenter 8.0.x (opaque `500 UNABLE_TO_ALLOCATE_RESOURCE` for every spec shape/placement, proven live) — with NICs (vmxnet3; DVPG backing resolved via portgroup-key + switch-uuid vmomi reads, standard-portgroup backing via the network display name) and `nested_hv` folded into the one ConfigSpec; `resource_pool`/`datastore` are required there (`placement_params` fail-closed), the `guest_os` enum maps through a curated spec-grounded guestId table (`guest_id_mapping` fail-closed), and 9.0+/unresolved keep the REST path byte-identical) |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
 | `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item`, `resolve_error` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error`, and a faulted content-library `find` during name resolution → `resolve_error` (#3071), both with a structured message carrying the vCenter status — so a placement/mapping/resolution error is a structured status, never a raw vendor fault) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
@@ -680,7 +680,10 @@ through vim `VirtualMachine.ReconfigVM_Task`. This is the connector's first
 the #3087 recipe lanes) and *raw* VI-JSON dispatch mounts on `/api` — a
 9.x-fleet accommodation that 404s on vCenter 8.0.x (#2466) — so the
 substrate's `/sdk/vim25/{release}` mount is the only cross-version governed
-path to the flag.
+path to the flag. `vm.create`'s pre-9.0 create arm (#3099) rides them too:
+`Folder.CreateVM_Task` replaces the vendor-defective 8.0.x REST create,
+gated under its canonical vi-json op_id and polled through
+`poll_vim_task` like the sibling vim writes.
 
 **1. Governed mutating vmomi sub-op — `_write_vmomi_sub_op` (in `_write.py`).**
 A mutating vmomi POST is a *write* sub-op, not a transport detail, so it


### PR DESCRIPTION
## Summary

- `vmware.composite.vm.create` now creates through vim `Folder.CreateVM_Task` (task-polled via the #2893 governed vmomi substrate: `_write_vmomi_sub_op` → `_post_vmomi_json` + `poll_vim_task`) when the live `about.version` major is < 9 — bare REST `POST /api/vcenter/vm` is vendor-defective on vCenter 8.0.x (opaque `500 UNABLE_TO_ALLOCATE_RESOURCE {messages:[]}` for every spec shape and placement, proven by live controlled probes; the identical SOAP create succeeds).
- On the pre-9.0 arm the ConfigSpec folds everything into one atomic create: `name`, `guestId` (curated spec-grounded map, `VMKERNEL_8` → `vmkernel8Guest`, unknown enums fail closed), `numCPUs` / `memoryMB`, `files.vmPathName` `"[<ds-name>] <name>"` (datastore name resolved via the existing `GET:/vcenter/datastore/{datastore}` read), NIC `deviceChange` adds (vmxnet3; DVPG backing resolved to `switchUuid` + `portgroupKey` through two un-gated vmomi property reads — the govc walk; standard portgroup to `deviceName` via the network listing), `nestedHVEnabled` inline (collapsing #3093's separate `ReconfigVM_Task` on this arm), and `pool` / `host` MoRefs from the #3097 placement params (`resource_pool` + `datastore` required there, fail-closed).
- The ≥9.0 / unresolved-version REST arm stays byte-identical (exact-body + exact-envelope regressions in the #3094/#3097 discipline), the response envelope and DELETE-rollback contract are unchanged (`vm_id` from the task-result MoRef), and the vim write gates under its canonical `POST:/Folder/{moId}/CreateVM_Task` op_id through the same #2254 seam.
- Reconcile lanes updated: the `_VIM_SUB_OPS_VM_CREATE` manifest pin grows to the triple (round-trip + pinned-spec path checks ride the tuple), and a new lane grounds every guestId-map row in **both** pinned specs (`Vcenter.Vm.GuestOS` in `vcenter.yaml`, `VirtualMachineGuestOsIdentifier_enum` in `vi-json.yaml`).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean except the pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` false positive (present on origin/main; Linux CI green)
- [x] `MEHO_CONSUMER_DOCS_ROOT=<shelf> pytest tests/test_connectors_vmware_rest_*.py tests/test_operations_composite*.py` — 596 passed, shelf-backed reconcile lanes ran for real (incl. the new guestId-map lane and the CreateVM_Task path pin against the pinned `vcenter-9.0` specs)
- [x] AC1 — pre-9.0 create rides CreateVM_Task with placement pins, NICs, inline `nestedHVEnabled`; REST create never attempted: `test_vm_create_pre9_rides_create_vm_task` (exact wire-body + call-sequence + gate-op assertions)
- [x] AC2 — 9.0+/unresolved byte-identical: `test_vm_create_v9_and_unresolved_keep_rest_create_byte_identical` (parametrized `None` / `9.0.0`, zero vim traffic) plus all pre-existing vm.create tests unchanged and green
- [x] AC3 — guestId table spec-grounded, unknown enum fails closed: `test_vm_create_pre9_unknown_guest_enum_fails_closed` + `test_vm_create_guest_id_map_is_grounded_in_both_pinned_specs`
- [x] AC4 — reconcile-lane pins + docs: vim manifest triple pin, recipe doc 8.0.x-arm section, connectors doc, CHANGELOG
- [x] Full unit lane (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`) — green

## Out of scope

- Live-appliance verify of the vim create against a real 8.0.x vCenter (the recipe doc's standing deferred follow-up; the wire shapes are pinned against the vendor specs).
- `OPAQUE_NETWORK` NIC backing on the pre-9.0 arm — fails closed with a structured refusal (no vim expression implemented; NSX opaque networks are not a current 8.0.x lab shape).
- CLI OpenAPI snapshot — unchanged (composite descriptor text does not feed the REST API schema; verified).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3099
