### PR TITLE
fix(operations): repair path for pre-#3095 descriptor rows — needs_reingest detect-and-flag (#3102)

### DIFF
--- a/backend/alembic/versions/0076_flag_unresolvable_descriptor_schemas.py
+++ b/backend/alembic/versions/0076_flag_unresolvable_descriptor_schemas.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flag ingested descriptors whose stored ``parameter_schema`` cannot self-resolve (#3102).
+
+Revision ID: 0076
+Revises: 0075
+Create Date: 2026-08-24
+
+#3095 made the OpenAPI parser bundle every ``#/components/schemas/*``
+component a stored ``parameter_schema``'s nested ``$ref``\\s transitively
+reference, and added the fail-closed ``_assert_parameter_schema_standalone``
+lint — so every row written by the fixed parser validates params standalone
+at dispatch. Both guards are **ingest-time**: rows persisted by earlier
+ingests keep their dangling-ref schemas and stay undispatchable, failing
+every call with the structured ``invalid_op_schema`` error (the live-hit:
+the governed content-library file-PULL op on a pre-fix vCenter ingest,
+claude-rdc-hetzner-dc's c3gov1 build, 2026-08-24).
+
+The original spec document is **not** recoverable server-side — the DB
+stores no spec bytes (``spec_provenance`` records only ``uri`` +
+``sha256``; probe-derived and URL ingests live on the network / the
+appliance) — so a re-bundling data migration is impossible. What this
+migration does instead is the one-time **detect-and-flag** pass:
+
+* DDL — add ``endpoint_descriptor.needs_reingest`` (boolean, NOT NULL,
+  default false).
+* DML — for every ``source_kind = 'ingested'`` row (any tenant scope,
+  same blanket-scope rationale as ``0075``: a broken stored schema is
+  broken regardless of scope), walk the stored ``parameter_schema`` the
+  way the dispatcher's registry-free ``Draft202012Validator`` resolves
+  it, and set ``needs_reingest = true`` when any schema-position
+  ``$ref`` fails to resolve as a JSON Pointer within the stored
+  document itself.
+
+The remedy the flag names is a **same-spec re-ingest**: the ingest
+upsert (``operations/ingest/_upsert.py``) overwrites
+``parameter_schema`` in place on both existing-row branches while
+leaving ``is_enabled`` / ``group_id`` / operator curation untouched,
+and clears ``needs_reingest`` — the freshly parsed schema passed the
+standalone lint by construction. Typed / composite rows are excluded:
+their schemas are hand-authored in code, the re-ingest remedy does not
+apply, and a dangling ref there is a code bug the spec-reconcile CI
+lanes own.
+
+``response_schema`` is deliberately not scanned — it is neither bundled
+nor linted by #3095 (its only dispatch-time consumer is the JSONFlux
+reducer, which never resolves refs), so a dangling ref there is inert.
+
+Frozen-logic discipline
+-----------------------
+
+The ref-walk below is a point-in-time port of
+``meho_backplane.operations.ingest.refs.iter_schema_refs`` /
+``find_unresolvable_local_refs`` — deliberately **copied, not
+imported**, per the data-migration self-containment rule
+(``docs/codebase/migrations.md``: a migration is a frozen snapshot; app
+code evolves). The paired test
+(``tests/migrations/test_migration_0076_flag_unresolvable_descriptor_schemas.py``)
+carries a drift guard that cross-checks this copy against the live
+``refs`` functions over a fixture corpus, the same lock-step discipline
+``0070`` uses for its frozen state vocabulary.
+
+Additive-only forward, real back
+--------------------------------
+
+``upgrade()`` is one ``add_column`` plus UPDATEs — additive, clears
+``scripts/ci/check_migration_compat.py``, and an older image simply
+never reads the new column (the ``helm rollback`` forward-compat
+contract holds). The UPDATE is naturally idempotent (re-running flags
+the same rows). ``downgrade()`` drops the column — a real reversal,
+same shape as ``0062``.
+"""
+
+import json
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0076"
+down_revision: str | None = "0075"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# --- Frozen ref-walk (port of operations/ingest/refs.py @ 0076) ----------
+
+#: JSON Schema keywords whose values are **named maps of subschemas** —
+#: child keys are arbitrary names, every child value is a schema.
+_SCHEMA_MAP_KEYWORDS = frozenset(
+    {"properties", "patternProperties", "dependentSchemas", "$defs", "definitions"}
+)
+
+#: JSON Schema keywords whose values are **data payloads**, not
+#: subschemas. A ``$ref``-shaped object inside them is literal data the
+#: validator never resolves — collecting it would false-flag a healthy
+#: row.
+_DATA_VALUE_KEYWORDS = frozenset({"enum", "const", "default", "example", "examples"})
+
+
+def _iter_schema_refs(node: Any) -> Iterator[str]:
+    """Yield every ``$ref`` string in *node* that sits in a schema position.
+
+    Frozen copy of ``refs.iter_schema_refs``: generic keywords recurse
+    structurally, named-map keywords recurse through their values, a
+    bundled ``components.schemas`` map is walked as a named map, and
+    data-valued keywords plus vendor ``x-*`` extensions are skipped.
+    """
+    if isinstance(node, list):
+        for item in node:
+            yield from _iter_schema_refs(item)
+        return
+    if not isinstance(node, dict):
+        return
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        yield ref
+    for key, value in node.items():
+        if key == "$ref":
+            continue
+        if key in _SCHEMA_MAP_KEYWORDS and isinstance(value, dict):
+            for subschema in value.values():
+                yield from _iter_schema_refs(subschema)
+            continue
+        if key == "components" and isinstance(value, dict):
+            schemas_bucket = value.get("schemas")
+            if isinstance(schemas_bucket, dict):
+                for subschema in schemas_bucket.values():
+                    yield from _iter_schema_refs(subschema)
+            continue
+        if key in _DATA_VALUE_KEYWORDS or key.startswith("x-"):
+            continue
+        yield from _iter_schema_refs(value)
+
+
+def _unescape_pointer_segment(segment: str) -> str:
+    """Apply RFC 6901 unescaping (``~1`` → ``/``, then ``~0`` → ``~``)."""
+    return segment.replace("~1", "/").replace("~0", "~")
+
+
+def _has_unresolvable_local_refs(schema: Any) -> bool:
+    """Return whether any schema-position ``$ref`` fails to self-resolve.
+
+    Frozen copy of ``refs.find_unresolvable_local_refs`` reduced to a
+    boolean: each ``#/<json-pointer>`` fragment is walked against
+    *schema* itself — exactly what the dispatcher's registry-free
+    jsonschema validator does at call time. ``#`` resolves trivially;
+    any non-fragment (cross-document) ref and any ``#<anchor>``
+    plain-name fragment counts as unresolvable.
+    """
+    for ref in _iter_schema_refs(schema):
+        if ref == "#":
+            continue
+        if not ref.startswith("#/"):
+            return True
+        node: Any = schema
+        for raw_segment in ref[2:].split("/"):
+            segment = _unescape_pointer_segment(raw_segment)
+            if isinstance(node, dict) and segment in node:
+                node = node[segment]
+                continue
+            if (
+                isinstance(node, list)
+                and segment.isascii()
+                and segment.isdigit()
+                and int(segment) < len(node)
+            ):
+                node = node[int(segment)]
+                continue
+            return True
+    return False
+
+
+def _coerce_json(raw: object) -> Any:
+    """Normalise a ``parameter_schema`` column value to a Python object.
+
+    Belt-and-suspenders: the typed ``sa.JSON()`` column on the reflected
+    table already deserialises on both dialects, but a value that
+    arrives as a raw JSON string (driver / dialect drift) is decoded
+    here rather than silently skipped. Undecodable content returns
+    ``None`` — the row is left unflagged, matching the walk's posture of
+    never false-flagging what it cannot read.
+    """
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except ValueError:
+            return None
+    return raw
+
+
+def _descriptor_table() -> sa.TableClause:
+    """Reflect the four ``endpoint_descriptor`` columns this migration touches."""
+    return sa.table(
+        "endpoint_descriptor",
+        sa.column("id", sa.Uuid()),
+        sa.column("source_kind", sa.Text()),
+        sa.column("parameter_schema", sa.JSON()),
+        sa.column("needs_reingest", sa.Boolean()),
+    )
+
+
+def upgrade() -> None:
+    """Add ``needs_reingest`` and flag ingested rows whose schema can't self-resolve."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.add_column(
+        "endpoint_descriptor",
+        sa.Column(
+            "needs_reingest",
+            sa.Boolean(),
+            nullable=False,
+            # Same dialect-branched boolean-literal shape as 0005's
+            # ``requires_approval`` — constant literals, never
+            # interpolated ``text()``.
+            server_default=sa.text("false") if is_postgres else sa.text("0"),
+        ),
+    )
+
+    descriptor = _descriptor_table()
+    rows = bind.execute(
+        sa.select(descriptor.c.id, descriptor.c.parameter_schema).where(
+            descriptor.c.source_kind == "ingested"
+        )
+    ).all()
+
+    flagged_ids = [
+        row_id
+        for row_id, raw_schema in rows
+        if (schema := _coerce_json(raw_schema)) is not None and _has_unresolvable_local_refs(schema)
+    ]
+    if not flagged_ids:
+        return
+
+    # The typed ``sa.Uuid()`` column carries the dialect-correct bind
+    # processing (``.hex`` CHAR(32) on SQLite, native uuid on PG), so the
+    # read-back ids round-trip without the manual ``_uuid_param`` dance
+    # raw ``sa.text`` migrations need (docs/codebase/migrations.md).
+    bind.execute(
+        sa.update(descriptor)
+        .where(descriptor.c.id == sa.bindparam("row_id"))
+        .values(needs_reingest=True),
+        [{"row_id": row_id} for row_id in flagged_ids],
+    )
+
+
+def downgrade() -> None:
+    """Drop ``needs_reingest`` — a real reversal; the flag is derived state."""
+    op.drop_column("endpoint_descriptor", "needs_reingest")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1536,6 +1536,23 @@ class EndpointDescriptor(Base):
         nullable=False,
         default=True,
     )
+    # #3102: the stored ``parameter_schema`` failed the standalone-
+    # resolution check (a schema-position ``$ref`` does not resolve as a
+    # JSON Pointer within the stored document), so dispatch returns
+    # ``invalid_op_schema`` for every call until the descriptor is
+    # repaired. Set by migration ``0076``'s one-time detect pass over
+    # rows ingested before #3095's component bundling; cleared by the
+    # ingest upsert (``operations/ingest/_upsert.py``) whenever a fresh
+    # parse rewrites ``parameter_schema`` — the parser's
+    # ``_assert_parameter_schema_standalone`` lint guarantees every
+    # newly written schema self-resolves. The remedy is a same-spec
+    # re-ingest, which repairs in place (``is_enabled`` / ``group_id`` /
+    # operator curation are untouched by the upsert's update branches).
+    needs_reingest: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        default=False,
+    )
     # Nullable on both dialects — T1 ships the column shape only;
     # T4 populates it before the descriptor is dispatchable for
     # retrieval. Round-trips as list[float] via _PORTABLE_VECTOR_384

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -346,6 +346,29 @@ async def count_ops_in_scope(session: AsyncSession, scope: ConnectorScope) -> in
     return int(await session.scalar(stmt) or 0)
 
 
+async def count_needs_reingest_in_scope(session: AsyncSession, scope: ConnectorScope) -> int:
+    """Count *scope*'s descriptor rows flagged ``needs_reingest`` (#3102).
+
+    Same full-universe predicate as :func:`count_ops_in_scope` (group or
+    not) plus the flag filter, so an undispatchable op whose ``group_id``
+    is null — or whose group is unrendered — still surfaces on the
+    review payload's ``needs_reingest_op_count``. ``> 0`` tells the
+    operator the stored schemas predate an ingest-parser fix and a
+    same-spec re-ingest repairs them in place.
+    """
+    stmt = select(func.count(EndpointDescriptor.id)).where(
+        EndpointDescriptor.product == scope.product,
+        EndpointDescriptor.version == scope.version,
+        EndpointDescriptor.impl_id == scope.impl_id,
+        EndpointDescriptor.needs_reingest.is_(True),
+    )
+    if scope.tenant_id is None:
+        stmt = stmt.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(EndpointDescriptor.tenant_id == scope.tenant_id)
+    return int(await session.scalar(stmt) or 0)
+
+
 # ---------------------------------------------------------------------------
 # Audit emission
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/operations/ingest/_upsert.py
+++ b/backend/src/meho_backplane/operations/ingest/_upsert.py
@@ -231,6 +231,15 @@ def _apply_skip_reembed(existing: EndpointDescriptor, ctx: UpsertContext) -> Non
     Leave ``summary`` / ``description`` / ``tags`` alone (the hash
     match proved they're equal) so the ORM identity map stays
     consistent; only refresh the proto-derived non-embedding fields.
+
+    ``needs_reingest`` is cleared on both existing-row branches (#3102):
+    the freshly parsed ``parameter_schema`` just replaced the stored one
+    and passed the parser's ``_assert_parameter_schema_standalone`` lint
+    by construction, so a same-spec re-ingest is the repair path for a
+    row migration ``0076`` flagged. The skip-re-embed branch matters
+    here — a byte-identical spec re-ingested through the *fixed* parser
+    lands on this branch (unchanged embedding text) yet still carries
+    the newly bundled schema.
     """
     existing.method = ctx.proto.method
     existing.path = ctx.proto.path
@@ -238,6 +247,7 @@ def _apply_skip_reembed(existing: EndpointDescriptor, ctx: UpsertContext) -> Non
     existing.response_schema = ctx.proto.response_schema
     existing.safety_level = ctx.proto.safety_level
     existing.requires_approval = ctx.proto.requires_approval
+    existing.needs_reingest = False
     existing.updated_at = ctx.now
 
 
@@ -246,7 +256,12 @@ def _apply_reembed_update(
     ctx: UpsertContext,
     embedding: list[float],
 ) -> None:
-    """Re-embed path: existing row, embedding text changed."""
+    """Re-embed path: existing row, embedding text changed.
+
+    Clears ``needs_reingest`` for the same reason as
+    :func:`_apply_skip_reembed` — the incoming schema self-resolves by
+    construction (#3102).
+    """
     existing.method = ctx.proto.method
     existing.path = ctx.proto.path
     existing.summary = ctx.proto.summary
@@ -256,6 +271,7 @@ def _apply_reembed_update(
     existing.response_schema = ctx.proto.response_schema
     existing.safety_level = ctx.proto.safety_level
     existing.requires_approval = ctx.proto.requires_approval
+    existing.needs_reingest = False
     existing.embedding = embedding
     existing.updated_at = ctx.now
 
@@ -286,6 +302,7 @@ def _build_new_descriptor(
         safety_level=ctx.proto.safety_level,
         requires_approval=ctx.proto.requires_approval,
         is_enabled=False,
+        needs_reingest=False,
         embedding=embedding,
         custom_description=None,
         custom_notes=None,

--- a/backend/src/meho_backplane/operations/ingest/payload.py
+++ b/backend/src/meho_backplane/operations/ingest/payload.py
@@ -93,6 +93,12 @@ class ConnectorReviewOp(BaseModel):
     requires_approval: bool
     is_enabled: bool
     tags: list[str]
+    # #3102: the stored ``parameter_schema`` cannot self-resolve (a
+    # pre-#3095 ingest left a dangling ``$ref``), so dispatch refuses
+    # every call with ``invalid_op_schema`` until the connector's spec
+    # is re-ingested. Additive with a default so existing construction
+    # call sites keep working; the service sets it from the row.
+    needs_reingest: bool = False
 
 
 class ConnectorReviewGroup(BaseModel):
@@ -173,3 +179,12 @@ class ConnectorReviewPayload(BaseModel):
     # Additive with a default so existing construction call sites keep
     # working; the service always sets it from the persisted rows.
     provenance: list[ConnectorReviewProvenance] = []
+    # #3102: how many descriptor rows in this connector's scope carry
+    # ``needs_reingest`` — counted over the same full descriptor
+    # universe as ``total_op_count + ungrouped_op_count`` (group or
+    # not), so a flagged op outside any rendered group still surfaces.
+    # ``> 0`` means the stored schemas predate an ingest-parser fix and
+    # a same-spec re-ingest repairs them in place (enablement, groups,
+    # and operator curation are preserved by the upsert). Additive with
+    # a default so existing construction call sites keep working.
+    needs_reingest_op_count: int = 0

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -96,6 +96,7 @@ from meho_backplane.operations.ingest._internals import (
     audit_profile_stamp,
     bulk_enable_read_ops,
     cascade_is_enabled,
+    count_needs_reingest_in_scope,
     count_ops_in_scope,
     enable_time_auto_shim_warnings,
     load_group,
@@ -508,6 +509,7 @@ class ReviewService:
                         requires_approval=op.requires_approval,
                         is_enabled=op.is_enabled,
                         tags=list(op.tags),
+                        needs_reingest=op.needs_reingest,
                     )
                     for op in ops_by_group[group.id]
                 ],
@@ -525,6 +527,11 @@ class ReviewService:
         # ``ungrouped_op_count`` is the reconciling remainder:
         # ``total_op_count + ungrouped_op_count == listing.operation_count``.
         all_op_count = await count_ops_in_scope(session, scope)
+        # #3102: full-universe count of rows whose stored schema cannot
+        # self-resolve — the operator's "how much of this connector needs
+        # a same-spec re-ingest" signal, including ungrouped ops the
+        # rendered groups never show.
+        needs_reingest_op_count = await count_needs_reingest_in_scope(session, scope)
         # #2291: durable per-spec provenance for this connector scope,
         # ordered by ``uri``. Empty for connectors ingested before the
         # provenance table landed — the surfaces render that gap rather
@@ -545,6 +552,7 @@ class ReviewService:
             groups=rendered_groups,
             total_op_count=grouped_op_count,
             ungrouped_op_count=max(all_op_count - grouped_op_count, 0),
+            needs_reingest_op_count=needs_reingest_op_count,
             kind=kind,
             dispatchable=dispatchable,
             provenance=[

--- a/backend/tests/migrations/test_migration_0076_flag_unresolvable_descriptor_schemas.py
+++ b/backend/tests/migrations/test_migration_0076_flag_unresolvable_descriptor_schemas.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0076_flag_unresolvable_descriptor_schemas``.
+
+Task #3102. The migration adds ``endpoint_descriptor.needs_reingest``
+and runs the one-time detect pass over ``source_kind = 'ingested'``
+rows, flagging those whose stored ``parameter_schema`` carries a
+schema-position ``$ref`` that does not resolve as a JSON Pointer within
+the stored document — the pre-#3095 dangling-ref shape that fails every
+dispatch with ``invalid_op_schema``.
+
+Pinned properties:
+
+* A pre-fix-shaped ingested row (nested component ref, no bundle) IS
+  flagged; a post-#3095 bundled row, a ref-free row, and a row whose
+  only ``$ref``-shaped object sits in a data-value position (``enum``)
+  are NOT (:func:`test_detect_pass_flags_exactly_the_broken_rows`).
+* Tenant-scoped rows are in scope — the live-hit rows are consumer
+  tenant ingests (:func:`test_tenant_scoped_dangling_row_flagged`).
+* ``source_kind = 'typed'`` rows are exempt: the re-ingest remedy does
+  not apply to hand-coded schemas
+  (:func:`test_typed_row_with_dangling_ref_not_flagged`).
+* ``downgrade()`` really drops the column
+  (:func:`test_downgrade_drops_column`).
+* The migration's **frozen** ref-walk agrees with the live
+  ``operations.ingest.refs`` functions over a corpus — the same
+  lock-step drift-guard discipline ``0070`` uses for its frozen state
+  vocabulary (:func:`test_frozen_walk_matches_live_refs_module`).
+
+Revision pin: every test drives the forward pass with
+``command.upgrade(cfg, "0076")`` (this migration's own revision, NOT
+``head``). Sync-test constraint identical to the sibling migration
+tests: ``alembic.command`` drives env.py's async cookbook via
+``asyncio.run``, so the test functions stay sync.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.operations.ingest.refs import find_unresolvable_local_refs
+from meho_backplane.settings import get_settings
+
+#: This migration's own revision -- the forward-pass target (NOT ``head``).
+_THIS_REVISION: Final[str] = "0076"
+#: The immediately preceding head this migration revises.
+_DOWN_REVISION: Final[str] = "0075"
+
+#: Stable seed timestamp -- keeps the raw-SQL seeds deterministic.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+#: The pre-#3095 stored shape: a nested component ref with no bundle.
+_DANGLING_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "body": {
+            "type": "object",
+            "properties": {
+                "file_spec": {"$ref": "#/components/schemas/TransferEndpoint"},
+            },
+            "x-meho-param-loc": "body",
+        },
+    },
+    "required": ["body"],
+}
+
+#: The post-#3095 shape for the same op: identical plus the bundled closure.
+_BUNDLED_SCHEMA: Final[dict[str, Any]] = {
+    **_DANGLING_SCHEMA,
+    "components": {
+        "schemas": {
+            "TransferEndpoint": {
+                "type": "object",
+                "properties": {"uri": {"type": "string"}},
+            },
+        },
+    },
+}
+
+#: No refs at all -- the common healthy row.
+_REF_FREE_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {"name": {"type": "string", "x-meho-param-loc": "query"}},
+}
+
+#: A ``$ref``-shaped object in a data-value position: literal data the
+#: validator never dereferences. Flagging it would false-positive a
+#: healthy row -- the walk must skip ``enum`` members.
+_REF_IN_ENUM_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "x-meho-param-loc": "query",
+            "enum": [{"$ref": "#/components/schemas/NotASchemaRef"}, "plain"],
+        },
+    },
+}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as the sibling migration tests: sync fixture
+    (``alembic.command`` calls ``asyncio.run`` internally), per-test
+    SQLite file under ``tmp_path``, settings + engine caches reset on
+    both sides so the alembic env reads *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0076.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    parameter_schema: dict[str, Any],
+    tenant_id: UUID | None = None,
+    op_id: str = "POST:/api/library/upload-file",
+    source_kind: str = "ingested",
+) -> UUID:
+    """Insert one ``endpoint_descriptor`` row at the migration base.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration runs against; ``parameter_schema`` is serialised the way
+    the portable JSON column stores it on SQLite. UUID binds use
+    ``.hex`` per ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, parameter_schema, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, 'vmware', '9.0', 'vmware-rest-probe', :op_id,
+                        :source_kind, :parameter_schema, :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "op_id": op_id,
+                    "source_kind": source_kind,
+                    "parameter_schema": json.dumps(parameter_schema),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _needs_reingest(sync_url: str, row_id: UUID) -> bool:
+    """Read one row's ``needs_reingest`` back as a bool (SQLite stores 0/1)."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            value = conn.execute(
+                text("SELECT needs_reingest FROM endpoint_descriptor WHERE id = :id"),
+                {"id": row_id.hex},
+            ).scalar_one()
+            return bool(value)
+    finally:
+        sync_eng.dispose()
+
+
+def _column_names(sync_url: str) -> set[str]:
+    """Return the live column names of ``endpoint_descriptor``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        return {col["name"] for col in sa_inspect(sync_eng).get_columns("endpoint_descriptor")}
+    finally:
+        sync_eng.dispose()
+
+
+def test_detect_pass_flags_exactly_the_broken_rows(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Only the dangling-ref ingested row is flagged; healthy shapes stay false.
+
+    The three negative shapes each pin a distinct false-positive class:
+    a post-#3095 bundled document (the ref resolves into the bundle), a
+    ref-free schema, and a ``$ref``-shaped object inside ``enum`` (data,
+    not a schema position).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    dangling = _insert_descriptor_row(
+        sync_url, parameter_schema=_DANGLING_SCHEMA, op_id="POST:/a"
+    )
+    bundled = _insert_descriptor_row(sync_url, parameter_schema=_BUNDLED_SCHEMA, op_id="POST:/b")
+    ref_free = _insert_descriptor_row(sync_url, parameter_schema=_REF_FREE_SCHEMA, op_id="GET:/c")
+    ref_in_enum = _insert_descriptor_row(
+        sync_url, parameter_schema=_REF_IN_ENUM_SCHEMA, op_id="GET:/d"
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _needs_reingest(sync_url, dangling) is True, (
+        "the pre-#3095 dangling-ref row must be flagged"
+    )
+    assert _needs_reingest(sync_url, bundled) is False, (
+        "a bundled document self-resolves and must stay unflagged"
+    )
+    assert _needs_reingest(sync_url, ref_free) is False
+    assert _needs_reingest(sync_url, ref_in_enum) is False, (
+        "a $ref-shaped enum member is data the validator never resolves"
+    )
+
+
+def test_tenant_scoped_dangling_row_flagged(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The pass spans every tenant scope -- the live-hit rows are tenant ingests."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    tenant_row = _insert_descriptor_row(
+        sync_url,
+        parameter_schema=_DANGLING_SCHEMA,
+        tenant_id=uuid4(),
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _needs_reingest(sync_url, tenant_row) is True
+
+
+def test_typed_row_with_dangling_ref_not_flagged(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``source_kind='typed'`` is exempt -- re-ingest is not the remedy there.
+
+    A dangling ref in a hand-coded schema is a code bug the
+    spec-reconcile CI lanes own; flagging it ``needs_reingest`` would
+    name a remedy that cannot repair it.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    typed_row = _insert_descriptor_row(
+        sync_url,
+        parameter_schema=_DANGLING_SCHEMA,
+        op_id="vault.kv.read",
+        source_kind="typed",
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _needs_reingest(sync_url, typed_row) is False
+
+
+def test_downgrade_drops_column(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The downgrade is a real reversal: the column is gone at 0075."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _THIS_REVISION)
+    assert "needs_reingest" in _column_names(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert "needs_reingest" not in _column_names(sync_url)
+
+
+def _load_migration_0076() -> Any:
+    """Load migration ``0076`` as a module via its file path.
+
+    Alembic version files are digit-prefixed and not importable as
+    normal dotted modules; loading by file path with
+    :mod:`importlib.util` is the robust way to reach the migration's
+    frozen ref-walk (same shape as ``test_migration_0059``).
+    """
+    path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "alembic"
+        / "versions"
+        / "0076_flag_unresolvable_descriptor_schemas.py"
+    )
+    spec = importlib.util.spec_from_file_location("_migration_0076", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pytest.param(_DANGLING_SCHEMA, id="dangling-component-ref"),
+        pytest.param(_BUNDLED_SCHEMA, id="bundled-closure"),
+        pytest.param(_REF_FREE_SCHEMA, id="ref-free"),
+        pytest.param(_REF_IN_ENUM_SCHEMA, id="ref-in-enum-data-position"),
+        pytest.param({"$ref": "#/$defs/Missing"}, id="absolute-defs-pointer-dangling"),
+        pytest.param(
+            {"$defs": {"X": {"type": "string"}}, "$ref": "#/$defs/X"},
+            id="absolute-defs-pointer-resolving",
+        ),
+        pytest.param({"$ref": "#anchor-fragment"}, id="plain-name-anchor"),
+        pytest.param({"$ref": "https://other.doc/schema.json#/a"}, id="cross-document"),
+        pytest.param({"$ref": "#"}, id="whole-document-self-ref"),
+        pytest.param(
+            {"allOf": [{"type": "object"}], "$ref": "#/allOf/0"},
+            id="array-index-pointer",
+        ),
+        pytest.param(
+            {
+                "properties": {"a~b/c": {"type": "string"}},
+                "$ref": "#/properties/a~0b~1c",
+            },
+            id="rfc6901-escaped-segments",
+        ),
+        pytest.param(
+            {"x-vendor": {"$ref": "#/components/schemas/SkippedExtension"}},
+            id="ref-under-x-extension",
+        ),
+        pytest.param(
+            {
+                "components": {
+                    "schemas": {"A": {"$ref": "#/components/schemas/MissingSibling"}}
+                },
+            },
+            id="dangling-ref-inside-bundle",
+        ),
+    ],
+)
+def test_frozen_walk_matches_live_refs_module(schema: dict[str, Any]) -> None:
+    """Drift guard: the migration's frozen walk == the live ``refs`` walk.
+
+    The migration deliberately carries a **copy** of
+    ``find_unresolvable_local_refs`` (data-migration self-containment,
+    ``docs/codebase/migrations.md``). This corpus pins the copy to the
+    live module's verdicts at authoring time -- if a future ``refs.py``
+    behaviour change makes the two disagree, this fails and forces a
+    deliberate decision (new migration vs. corpus update), instead of
+    silent divergence.
+    """
+    migration = _load_migration_0076()
+    assert migration._has_unresolvable_local_refs(schema) == bool(
+        find_unresolvable_local_refs(schema)
+    )

--- a/backend/tests/migrations/test_migration_0076_flag_unresolvable_descriptor_schemas.py
+++ b/backend/tests/migrations/test_migration_0076_flag_unresolvable_descriptor_schemas.py
@@ -224,9 +224,7 @@ def test_detect_pass_flags_exactly_the_broken_rows(
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _DOWN_REVISION)
 
-    dangling = _insert_descriptor_row(
-        sync_url, parameter_schema=_DANGLING_SCHEMA, op_id="POST:/a"
-    )
+    dangling = _insert_descriptor_row(sync_url, parameter_schema=_DANGLING_SCHEMA, op_id="POST:/a")
     bundled = _insert_descriptor_row(sync_url, parameter_schema=_BUNDLED_SCHEMA, op_id="POST:/b")
     ref_free = _insert_descriptor_row(sync_url, parameter_schema=_REF_FREE_SCHEMA, op_id="GET:/c")
     ref_in_enum = _insert_descriptor_row(
@@ -354,9 +352,7 @@ def _load_migration_0076() -> Any:
         ),
         pytest.param(
             {
-                "components": {
-                    "schemas": {"A": {"$ref": "#/components/schemas/MissingSibling"}}
-                },
+                "components": {"schemas": {"A": {"$ref": "#/components/schemas/MissingSibling"}}},
             },
             id="dangling-ref-inside-bundle",
         ),

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -60,7 +60,7 @@ from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
 from meho_backplane.operations import (
     PassThroughReducer,
     dispatch,
@@ -68,7 +68,9 @@ from meho_backplane.operations import (
     register_typed_operation,
     reset_dispatcher_caches,
 )
+from meho_backplane.operations._validate import validate_params
 from meho_backplane.operations.dispatcher import _handler_requires_target
+from meho_backplane.operations.ingest import parse_openapi, register_ingested_operations
 from meho_backplane.settings import get_settings
 
 # ---------------------------------------------------------------------------
@@ -2784,3 +2786,171 @@ def test_compute_params_hash_handles_non_json_natives() -> None:
     h = compute_params_hash({"id": uuid.UUID("00000000-0000-0000-0000-000000000001")})
     assert isinstance(h, str)
     assert len(h) == 64
+
+
+# ---------------------------------------------------------------------------
+# #3102 -- a pre-#3095 stored row is repaired end-to-end by same-spec re-ingest
+# ---------------------------------------------------------------------------
+
+#: Minimal spec whose request body carries a nested component ref -- the
+#: exact defect class of the live content-library file-PULL op: the top
+#: -level ``UploadSpec`` ref is shallow-inlined at parse time, and the
+#: nested ``TransferEndpoint`` ref survives verbatim inside it.
+_REPAIR_SPEC_YAML = """\
+openapi: 3.0.0
+info:
+  title: Repair fixture
+  version: "1.0"
+paths:
+  /api/library/upload-file:
+    post:
+      summary: Upload a file
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UploadSpec'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    UploadSpec:
+      type: object
+      properties:
+        file_spec:
+          $ref: '#/components/schemas/TransferEndpoint'
+    TransferEndpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+"""
+
+
+@pytest.mark.asyncio
+async def test_reingest_repairs_pre_fix_row_through_dispatch_validation(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#3102 end-to-end: flagged pre-fix row -> ``invalid_op_schema``; re-ingest -> repaired.
+
+    The full deploy-then-heal loop the issue demands:
+
+    1. A stored descriptor shaped like a pre-#3095 ingest (nested
+       ``$ref``, no ``components`` bundle) and flagged by migration
+       0076 refuses dispatch with the structured ``invalid_op_schema``.
+    2. A same-spec re-ingest through the fixed parser
+       (``parse_openapi`` bundles the closure) upserts the row in
+       place: bundled schema, ``needs_reingest`` cleared,
+       ``is_enabled`` untouched.
+    3. Dispatch validation now accepts the same params -- the op no
+       longer fails as ``invalid_op_schema`` (it proceeds to connector
+       resolution), and ``validate_params`` returns zero errors against
+       the repaired stored schema.
+    """
+    op_id = "POST:/api/library/upload-file"
+    pre_fix_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "body": {
+                "type": "object",
+                "properties": {
+                    "file_spec": {"$ref": "#/components/schemas/TransferEndpoint"},
+                },
+                "x-meho-param-loc": "body",
+            },
+        },
+        "required": ["body"],
+    }
+    row_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            EndpointDescriptor(
+                id=row_id,
+                tenant_id=None,
+                product="library",
+                version="1.0",
+                impl_id="library-rest",
+                op_id=op_id,
+                source_kind="ingested",
+                method="POST",
+                path="/api/library/upload-file",
+                handler_ref=None,
+                summary="Upload a file",
+                description=None,
+                group_id=None,
+                tags=["repair.yaml", "spec:repair.yaml"],
+                parameter_schema=pre_fix_schema,
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="caution",
+                requires_approval=False,
+                is_enabled=True,
+                needs_reingest=True,
+                embedding=[0.5] * 384,
+                custom_description=None,
+                custom_notes=None,
+            )
+        )
+        await session.commit()
+
+    operator = _make_operator()
+    target = _FakeTarget(product="library")
+    params = {"body": {"file_spec": {"uri": "https://datastore.example/iso"}}}
+
+    # --- 1. Pre-repair: the stored schema cannot validate any input. ---
+    broken = await dispatch(
+        operator=operator,
+        connector_id="library-rest-1.0",
+        op_id=op_id,
+        target=target,
+        params=params,
+    )
+    assert broken.status == "error"
+    assert broken.extras["error_code"] == "invalid_op_schema"
+    assert broken.extras["missing_ref"] == "#/components/schemas/TransferEndpoint"
+
+    # --- 2. Repair: re-ingest the same spec through the fixed parser. ---
+    protos = parse_openapi(
+        "file:///repair.yaml",
+        spec_source="repair.yaml",
+        content=_REPAIR_SPEC_YAML,
+    )
+    assert [proto.op_id for proto in protos] == [op_id]
+    await register_ingested_operations(
+        product="library",
+        version="1.0",
+        impl_id="library-rest",
+        spec_source="repair.yaml",
+        operations=protos,
+        embedding_service=stub_embedding_service,
+    )
+
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(select(EndpointDescriptor).where(EndpointDescriptor.id == row_id))
+        ).scalar_one()
+    assert row.needs_reingest is False, "the upsert must clear the 0076 flag"
+    assert row.is_enabled is True, "repair must not reset the operator's enable decision"
+    bundled = row.parameter_schema.get("components")
+    assert isinstance(bundled, dict)
+    assert "TransferEndpoint" in bundled.get("schemas", {})
+    # The repaired stored document validates the same params standalone --
+    # exactly what the dispatcher's registry-free validator does.
+    assert validate_params(row.parameter_schema, params) == []
+
+    # --- 3. Post-repair dispatch clears schema validation. ---
+    repaired = await dispatch(
+        operator=operator,
+        connector_id="library-rest-1.0",
+        op_id=op_id,
+        target=target,
+        params=params,
+    )
+    assert (repaired.extras or {}).get("error_code") != "invalid_op_schema", (
+        "the repaired descriptor must pass dispatch-time schema validation; "
+        f"got {repaired.error!r}"
+    )

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -2951,6 +2951,5 @@ async def test_reingest_repairs_pre_fix_row_through_dispatch_validation(
         params=params,
     )
     assert (repaired.extras or {}).get("error_code") != "invalid_op_schema", (
-        "the repaired descriptor must pass dispatch-time schema validation; "
-        f"got {repaired.error!r}"
+        f"the repaired descriptor must pass dispatch-time schema validation; got {repaired.error!r}"
     )

--- a/backend/tests/test_operations_ingest_review.py
+++ b/backend/tests/test_operations_ingest_review.py
@@ -308,6 +308,62 @@ async def test_get_review_payload_returns_groups_with_counts() -> None:
         for op in group.ops:
             assert op.is_enabled is False
             assert op.safety_level == "safe"
+            assert op.needs_reingest is False
+    assert payload.needs_reingest_op_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_review_payload_surfaces_needs_reingest_flag_and_count() -> None:
+    """#3102: the per-op flag renders, and the rollup counts ungrouped rows too.
+
+    Migration 0076 flags descriptor rows whose stored ``parameter_schema``
+    cannot self-resolve. The review payload is the operator's enumeration
+    surface: each rendered op carries ``needs_reingest``, and
+    ``needs_reingest_op_count`` counts the **full** descriptor universe
+    (like ``total_op_count + ungrouped_op_count``) so a flagged op whose
+    ``group_id`` is null still shows up in the rollup.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_id, group_count=1, ops_per_group=2)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        flagged = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "GET:/api/v1/group-0/0",
+                    EndpointDescriptor.tenant_id == tenant_id,
+                )
+            )
+        ).scalar_one()
+        flagged.needs_reingest = True
+        # A flagged row outside any group -- invisible to the rendered
+        # groups, but the rollup must still count it.
+        session.add(
+            EndpointDescriptor(
+                tenant_id=tenant_id,
+                product="vmware",
+                version="9.0",
+                impl_id="vmware-rest",
+                op_id="POST:/api/v1/ungrouped/upload",
+                source_kind="ingested",
+                method="POST",
+                path="/api/v1/ungrouped/upload",
+                group_id=None,
+                summary="Ungrouped flagged op",
+                is_enabled=True,
+                needs_reingest=True,
+            )
+        )
+        await session.commit()
+    service = ReviewService(_make_operator(tenant_id=tenant_id))
+
+    payload = await service.get_review_payload("vmware-rest-9.0", tenant_id)
+
+    ops_by_id = {op.op_id: op for group in payload.groups for op in group.ops}
+    assert ops_by_id["GET:/api/v1/group-0/0"].needs_reingest is True
+    assert ops_by_id["GET:/api/v1/group-0/1"].needs_reingest is False
+    assert payload.needs_reingest_op_count == 2
+    assert payload.ungrouped_op_count == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -65,7 +65,7 @@ from meho_backplane.connectors.registry import (
     register_connector_v2,
 )
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations._lookup import connector_exists, parse_connector_id
 from meho_backplane.operations.ingest import (
     EndpointDescriptorProto,
@@ -1519,3 +1519,210 @@ async def test_aligned_ingest_reuses_handrolled_class_no_shim(
         impl_id="vrli-rest",
     )
     assert exists is True
+
+
+# ---------------------------------------------------------------------------
+# #3102 -- same-spec re-ingest repairs a pre-#3095 row in place
+# ---------------------------------------------------------------------------
+
+#: The stored shape a pre-#3095 ingest left behind: a nested ``$ref``
+#: with no ``components`` bundle, so the dispatcher's registry-free
+#: validator can never resolve it (every call -> ``invalid_op_schema``).
+_PRE_FIX_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "body": {
+            "type": "object",
+            "properties": {
+                "file_spec": {"$ref": "#/components/schemas/TransferEndpoint"},
+            },
+            "x-meho-param-loc": "body",
+        },
+    },
+    "required": ["body"],
+}
+
+#: What the fixed parser produces for the same operation: identical
+#: shallow shape plus the transitively bundled component closure.
+_BUNDLED_SCHEMA: dict[str, Any] = {
+    **_PRE_FIX_SCHEMA,
+    "components": {
+        "schemas": {
+            "TransferEndpoint": {
+                "type": "object",
+                "properties": {"uri": {"type": "string"}},
+            },
+        },
+    },
+}
+
+
+async def _seed_pre_fix_row(
+    *,
+    op_id: str = "POST:/pets/upload",
+    summary: str = "Upload a file",
+    description: str = "Push bytes to the library item.",
+    custom_description: str | None = None,
+    custom_notes: str | None = None,
+    llm_instructions: dict[str, Any] | None = None,
+    with_group: bool = False,
+) -> tuple[uuid.UUID, uuid.UUID | None]:
+    """Persist one enabled, flagged, pre-#3095-shaped ingested row.
+
+    Mirrors the post-migration-0076 state of a live catalog: the row was
+    ingested (and operator-enabled) before #3095's bundling, then the
+    0076 detect pass flagged it ``needs_reingest``. Returns
+    ``(row_id, group_id)``.
+    """
+    group_id: uuid.UUID | None = None
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if with_group:
+            group_id = uuid.uuid4()
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=None,
+                    product="petstore",
+                    version="1.0",
+                    impl_id="petstore-rest",
+                    group_key="library",
+                    name="Library",
+                    when_to_use="Library item content transfer.",
+                    review_status="enabled",
+                )
+            )
+        row_id = uuid.uuid4()
+        session.add(
+            EndpointDescriptor(
+                id=row_id,
+                tenant_id=None,
+                product="petstore",
+                version="1.0",
+                impl_id="petstore-rest",
+                op_id=op_id,
+                source_kind="ingested",
+                method=op_id.split(":", 1)[0],
+                path=op_id.split(":", 1)[1],
+                handler_ref=None,
+                summary=summary,
+                description=description,
+                group_id=group_id,
+                tags=["pets", "spec:petstore.yaml"],
+                parameter_schema=_PRE_FIX_SCHEMA,
+                response_schema=None,
+                llm_instructions=llm_instructions,
+                safety_level="caution",
+                requires_approval=False,
+                is_enabled=True,
+                needs_reingest=True,
+                embedding=[0.5] * 384,
+                custom_description=custom_description,
+                custom_notes=custom_notes,
+            )
+        )
+        await session.commit()
+    return row_id, group_id
+
+
+def _bundled_proto(op_id: str = "POST:/pets/upload") -> EndpointDescriptorProto:
+    """The fixed parser's output for the seeded op -- bundled, self-resolving."""
+    return EndpointDescriptorProto(
+        op_id=op_id,
+        method=op_id.split(":", 1)[0],
+        path=op_id.split(":", 1)[1],
+        summary="Upload a file",
+        description="Push bytes to the library item.",
+        tags=["pets"],
+        parameter_schema=_BUNDLED_SCHEMA,
+        response_schema=None,
+        safety_level="caution",
+        requires_approval=False,
+    )
+
+
+async def _reload_row(row_id: uuid.UUID) -> EndpointDescriptor:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        return (
+            await fresh.execute(select(EndpointDescriptor).where(EndpointDescriptor.id == row_id))
+        ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_reingest_repairs_flagged_row_on_skip_reembed_branch(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A byte-identical same-spec re-ingest repairs a flagged row in place.
+
+    #3102 regression, the operationally critical branch: re-ingesting
+    the *unchanged* spec through the *fixed* parser hash-matches the
+    embedding text and lands on the skip-re-embed branch -- which must
+    still replace the stored ``parameter_schema`` with the bundled
+    document and clear ``needs_reingest``, while leaving the operator's
+    review state (``is_enabled``, ``group_id``) untouched. This is what
+    makes "re-ingest the connector's spec" a repair, not a reset.
+    """
+    row_id, group_id = await _seed_pre_fix_row(with_group=True)
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[_bundled_proto()],
+        embedding_service=stub_embedding_service,
+    )
+
+    assert result.inserted_count == 0
+    assert result.updated_count == 0
+    assert result.skipped_count == 1
+    # Skip branch: the unchanged embedding text is never re-encoded.
+    assert stub_embedding_service.encode_one.call_count == 0
+
+    row = await _reload_row(row_id)
+    assert row.parameter_schema == _BUNDLED_SCHEMA
+    assert row.needs_reingest is False
+    assert row.is_enabled is True, "repair must not reset the operator's enable decision"
+    assert row.group_id == group_id, "repair must not detach the op from its group"
+    assert "spec:petstore.yaml" in row.tags
+
+
+@pytest.mark.asyncio
+async def test_reingest_repairs_curated_row_on_reembed_branch(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The re-embed branch also repairs + clears the flag, keeping curation.
+
+    A row the operator curated (``custom_description`` feeds the
+    embedding text) hash-mismatches and takes the re-embed branch; the
+    repair semantics must be identical -- schema replaced, flag cleared
+    -- and the curation fields the upsert never writes
+    (``custom_description`` / ``custom_notes`` / ``llm_instructions``)
+    must survive verbatim.
+    """
+    row_id, _ = await _seed_pre_fix_row(
+        custom_description="Curated: governed ISO/OVA import step 3.",
+        custom_notes="Falls back to govc library.import -pull.",
+        llm_instructions={"when_to_call": "during governed content-library PULL"},
+    )
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[_bundled_proto()],
+        embedding_service=stub_embedding_service,
+    )
+
+    assert result.updated_count == 1
+    assert result.skipped_count == 0
+
+    row = await _reload_row(row_id)
+    assert row.parameter_schema == _BUNDLED_SCHEMA
+    assert row.needs_reingest is False
+    assert row.is_enabled is True
+    assert row.custom_description == "Curated: governed ISO/OVA import step 3."
+    assert row.custom_notes == "Falls back to govc library.import -pull."
+    assert row.llm_instructions == {"when_to_call": "during governed content-library PULL"}

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -23569,6 +23569,11 @@
             },
             "type": "array",
             "title": "Tags"
+          },
+          "needs_reingest": {
+            "type": "boolean",
+            "title": "Needs Reingest",
+            "default": false
           }
         },
         "type": "object",
@@ -23648,6 +23653,11 @@
             "type": "array",
             "title": "Provenance",
             "default": []
+          },
+          "needs_reingest_op_count": {
+            "type": "integer",
+            "title": "Needs Reingest Op Count",
+            "default": 0
           }
         },
         "type": "object",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3026,6 +3026,7 @@ type ConnectorReviewOp struct {
 	CustomDescription *string  `json:"custom_description"`
 	Description       *string  `json:"description"`
 	IsEnabled         bool     `json:"is_enabled"`
+	NeedsReingest     *bool    `json:"needs_reingest,omitempty"`
 	OpId              string   `json:"op_id"`
 	RequiresApproval  bool     `json:"requires_approval"`
 	SafetyLevel       string   `json:"safety_level"`
@@ -3062,17 +3063,18 @@ type ConnectorReviewOp struct {
 // (the Goal flags secret-handling sensitivity). See
 // :data:`~meho_backplane.operations.ingest.api_schemas.ConnectorAuthoringKind`.
 type ConnectorReviewPayload struct {
-	ConnectorId      string                       `json:"connector_id"`
-	Dispatchable     *bool                        `json:"dispatchable,omitempty"`
-	Groups           []ConnectorReviewGroup       `json:"groups"`
-	ImplId           string                       `json:"impl_id"`
-	Kind             *ConnectorReviewPayloadKind  `json:"kind,omitempty"`
-	Product          string                       `json:"product"`
-	Provenance       *[]ConnectorReviewProvenance `json:"provenance,omitempty"`
-	TenantId         *openapi_types.UUID          `json:"tenant_id"`
-	TotalOpCount     int                          `json:"total_op_count"`
-	UngroupedOpCount *int                         `json:"ungrouped_op_count,omitempty"`
-	Version          string                       `json:"version"`
+	ConnectorId          string                       `json:"connector_id"`
+	Dispatchable         *bool                        `json:"dispatchable,omitempty"`
+	Groups               []ConnectorReviewGroup       `json:"groups"`
+	ImplId               string                       `json:"impl_id"`
+	Kind                 *ConnectorReviewPayloadKind  `json:"kind,omitempty"`
+	NeedsReingestOpCount *int                         `json:"needs_reingest_op_count,omitempty"`
+	Product              string                       `json:"product"`
+	Provenance           *[]ConnectorReviewProvenance `json:"provenance,omitempty"`
+	TenantId             *openapi_types.UUID          `json:"tenant_id"`
+	TotalOpCount         int                          `json:"total_op_count"`
+	UngroupedOpCount     *int                         `json:"ungrouped_op_count,omitempty"`
+	Version              string                       `json:"version"`
 }
 
 // ConnectorReviewPayloadKind defines model for ConnectorReviewPayload.Kind.

--- a/cli/internal/cmd/connector/review.go
+++ b/cli/internal/cmd/connector/review.go
@@ -136,6 +136,15 @@ func printReviewTable(w io.Writer, r *api.ConnectorReviewPayload) {
 		len(r.Groups), r.TotalOpCount,
 	)
 	printProvenance(w, r.Provenance)
+	// #3102: rows flagged by the needs_reingest detect pass fail every
+	// dispatch with invalid_op_schema until the spec is re-ingested.
+	// Surface the count loudly here; the per-op flags ride the --json
+	// render (ConnectorReviewOp.needs_reingest) for enumeration.
+	if r.NeedsReingestOpCount != nil && *r.NeedsReingestOpCount > 0 {
+		fmt.Fprintf(w, "\nWARNING: %d op(s) need re-ingest — their stored parameter schemas predate an ingest-parser fix and fail dispatch with invalid_op_schema. Re-ingest the connector's spec to repair in place (enablement, groups, and curation are preserved).\n",
+			*r.NeedsReingestOpCount,
+		)
+	}
 	if len(r.Groups) == 0 {
 		fmt.Fprintln(w, "(no groups; the connector has no operations or the grouping pass produced no buckets)")
 		return

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1761,6 +1761,46 @@ defect class out:
   covering rows persisted by pre-#3095 ingests until they are
   re-ingested.
 
+### Repairing pre-#3095 rows (#3102)
+
+Both #3095 guards are ingest-time, so rows persisted by earlier ingests
+keep their dangling-ref schemas after a deploy — the ops stay
+undispatchable (live-hit: the governed content-library file-PULL on the
+consumer's pre-fix vCenter ingest). A re-bundling migration is
+impossible: the DB stores no spec document (`spec_provenance` records
+only `uri` + `sha256`; probe-derived and URL-sourced specs live on the
+network/appliance), so the component definitions the bundle needs are
+not recoverable server-side. The shipped repair path is
+**detect-and-flag + same-spec re-ingest**:
+
+* **Detect** — migration `0076` adds
+  `endpoint_descriptor.needs_reingest` (boolean, default false) and
+  runs a one-time pass over every `source_kind='ingested'` row (any
+  tenant scope), flagging those whose stored `parameter_schema` fails
+  the same self-resolution walk `find_unresolvable_local_refs` models
+  (the migration carries a frozen copy of the walk per the
+  data-migration self-containment rule; a drift-guard test pins the
+  copy against the live `refs` functions). `response_schema` is not
+  scanned — it is neither bundled nor linted (see above), and its refs
+  are inert at dispatch.
+* **Surface** — the review payload carries the flag per op
+  (`ConnectorReviewOp.needs_reingest`) plus a full-universe rollup
+  (`ConnectorReviewPayload.needs_reingest_op_count`, counted like
+  `total_op_count + ungrouped_op_count` so ungrouped ops are included).
+  Dispatch keeps returning the structured `invalid_op_schema` error
+  whose `extras.remediation` names the re-ingest remedy.
+* **Repair** — re-ingesting the *same* spec under the *same* connector
+  triple heals rows in place: the upsert's two existing-row branches
+  (`_upsert.py`) overwrite `parameter_schema` with the freshly bundled
+  document (the skip-re-embed branch included — a byte-identical spec
+  hits it, and it still refreshes the schema) and clear
+  `needs_reingest`, while leaving `is_enabled`, `group_id`, and the
+  operator's `custom_*` / `llm_instructions` untouched. No re-review is
+  needed; grouping is a zero-LLM-call no-op when every op is already
+  assigned. There is deliberately **no** separate "repair" verb — the
+  existing `meho connector ingest` / `POST /api/v1/connectors/ingest` /
+  `meho_connector_ingest` surfaces are the repair path.
+
 The four supported component buckets are: `#/components/schemas/*`,
 `#/components/parameters/*` (vi-json.yaml's shared `moId`),
 `#/components/responses/*` (the GitHub REST spec's 1.9k shared


### PR DESCRIPTION
## Summary
- **Why**: the #3095 fix (transitive `$ref` bundling + `_assert_parameter_schema_standalone` lint) applies only at ingest time — `endpoint_descriptor` rows persisted before it keep their dangling-ref `parameter_schema` and fail every dispatch with `invalid_op_schema` after deploy (live-hit: the governed content-library file-PULL on `vmware-rest-probe-9.0.0.0` / `rdc-vcenter`, claude-rdc-hetzner-dc#2668).
- **Repair posture — detect-and-flag, not migrate-and-rebundle**: a re-bundling data migration is genuinely impossible. The DB retains no spec document: `spec_provenance` stores only `uri` + `sha256`, the packaged `ingest/specs/*` resources cover only the minimal catalog on-ramp rows, and the live-hit connector's spec was probe-fetched off the appliance. Without the original `components.schemas`, there is nothing to re-bundle from.
- **Detect** — migration `0076` adds `endpoint_descriptor.needs_reingest` (boolean, NOT NULL default false; additive-only upgrade, real `drop_column` downgrade) and runs a one-time pass over `source_kind='ingested'` rows in every tenant scope, flagging rows whose stored schema fails the exact self-resolution walk the dispatcher's registry-free validator performs. The walk is a frozen copy of `refs.iter_schema_refs`/`find_unresolvable_local_refs` per the data-migration self-containment rule (`docs/codebase/migrations.md`); a parametrized drift-guard test pins the copy against the live module (same discipline as `0070`'s frozen vocabulary). Typed/composite rows are exempt (re-ingest is not their remedy); `response_schema` is not scanned (never bundled/linted — inert at dispatch).
- **Repair** — a same-spec re-ingest is the repair, and now provably so: both existing-row upsert branches rewrite `parameter_schema` with the freshly bundled document **and clear the flag**, while preserving `is_enabled`, `group_id`, and operator curation (`custom_*`, `llm_instructions`). The skip-re-embed branch matters — a byte-identical spec re-ingested through the fixed parser lands there and still refreshes the schema. No new "repair" verb: the existing `meho connector ingest` / REST / MCP surfaces are the path (documented in `docs/codebase/spec-ingestion.md` → "Repairing pre-#3095 rows").
- **Surface** — `ConnectorReviewOp.needs_reingest` (per-op) + `ConnectorReviewPayload.needs_reingest_op_count` (full descriptor universe, ungrouped rows included); `meho connector review` prints a WARNING line when the count is non-zero (per-op enumeration rides `--json`). CLI OpenAPI snapshot + generated client regenerated. Dispatch is unchanged — the structured `invalid_op_schema` error already names the re-ingest remediation.

## Test plan
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict, full tree) — clean except one **pre-existing, untouched** darwin-only false positive (`net/icmp.py` `MSG_ERRQUEUE`; Linux CI green)
- [x] `pytest tests/migrations/test_migration_0076_*.py` — 17 passed: dangling-ref row flagged; bundled / ref-free / ref-in-`enum` rows stay false (false-positive guards); tenant-scoped row flagged; typed row exempt; downgrade drops the column; 13-case frozen-walk↔live-`refs` drift corpus
- [x] `pytest tests/migrations/test_migration_compat.py tests/migrations/test_alembic_uuid_param_consistency.py tests/migrations/test_alembic_probe.py` — 111 passed; `scripts/ci/check_migration_compat.py` exit 0
- [x] `pytest tests/migrations/test_migration_rollback.py` — 5 passed on real pgvector testcontainers (0076 up/down round-trips on PostgreSQL)
- [x] **End-to-end acceptance** (`test_reingest_repairs_pre_fix_row_through_dispatch_validation`): pre-fix-shaped enabled stored row → dispatch returns `invalid_op_schema` naming the missing ref → same-spec re-ingest through the real `parse_openapi` → row carries the bundle, flag cleared, `is_enabled` untouched → `validate_params` returns zero errors and dispatch proceeds past schema validation
- [x] Upsert repair semantics (`test_operations_register_ingested.py`): skip-re-embed branch repairs without re-embedding (encode call count 0) and preserves enable + group; re-embed branch preserves `custom_description`/`custom_notes`/`llm_instructions`
- [x] Review payload (`test_operations_ingest_review.py`): per-op flag renders; rollup counts an ungrouped flagged row
- [x] Full blast-radius sweep: dispatcher (50), register-ingested + review (96), REST/MCP/UI payload consumers + provenance + safety-changes (206), llm-groups/delete/catalog/typed-register (156 + 1 skipped) — all green
- [x] CLI: `make snapshot-openapi && make generate` committed; `go build ./...`, `go vet`, `gofmt -l` clean; `go test ./...` all packages ok
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope / adjacent findings
- `IngestionPipelineService._run_grouping_phase` resolves the LLM client factory **eagerly** (pipeline.py:1107) even when re-grouping would be a zero-call no-op — on a keyless deploy a repair re-ingest 503s *after* the register phase has already healed the rows. Confusing but not blocking (rows are repaired; the live-hit deploy is keyed). Worth a follow-up ticket.
- Dispatch-time self-marking (setting the flag when `validate_params` raises) was considered and rejected: a DB write on the read/validation path for no operator gain — the migration covers the stock, the upsert covers the flow.
- `code-quality.py --diff` reports 10 pre-existing warnings in touched legacy files (e.g. `service.py::_transition_connector` at 82 lines) — untouched debt, not introduced here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3102
