### PR TITLE
fix(connectors): annotate every VI-JSON request body with _typeName discriminators (#3103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — VI-JSON bodies carry `_typeName` discriminators throughout the vim substrate (#3103)
+
+- Every vim (VI-JSON) request body the vmware-rest connector sends now tags
+  every DataObject with its `_typeName` discriminator, per the pinned
+  `vi-json.yaml` wire format (`Any.required` names `_typeName`). A live
+  vCenter 8.0.3 rejects un-annotated bodies outright — a controlled
+  differential against `RetrievePropertiesEx` returned `500 InvalidArgument`
+  (`Invalid MoRef field: pathSet`) bare and `200 RetrieveResult` annotated —
+  so every vim-riding composite and typed read 500'd against real 8.0.x.
+  Covered end to end: the shared `RetrievePropertiesEx` trio +
+  `RetrieveOptions` (all property reads, task polls, config pre-reads, via
+  the new `vim_body.py` helpers), MoRefs everywhere (`ManagedObjectReference`
+  tags on placement pins, DRS-rule VM lists, the vSAN health cluster ref),
+  `ReconfigVM_Task` specs (`nested_hv`, disk grow), the pre-9.0
+  `CreateVM_Task` ConfigSpec (files, NIC deviceChange, DVPG port
+  connection), `CloneVM_Task` (clone + relocate specs), `ReconfigureDvs_Task`
+  (DVS config + host member specs) and the DRS `ClusterRuleSpec` entries.
+  Annotation is unconditional — 9.x accepts the spec'd format, so no version
+  gate. Response parsing is unchanged (tags were always present in
+  responses); unit fixtures now mirror the tagged live shapes to pin
+  tolerance, exact annotated bodies are pinned byte-for-byte, and a
+  reconcile lane grounds every emitted `_typeName` against the pinned
+  `vi-json.yaml` component schemas.
+
 ### Fixed — `vm.create` rides the vim substrate on pre-9.0 vCenter (#3099)
 
 - `vmware.composite.vm.create` now creates through vim `Folder.CreateVM_Task`

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -128,6 +128,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 from .schemas import DATASTORE_USAGE_MAX_VM_NAMES
 
@@ -315,19 +316,10 @@ def _build_cluster_props_retrieve_body(cluster_moid: str, path_set: list[str]) -
     One ``PropertyFilterSpec`` scoped directly to the cluster's MoRef;
     the singleton ``propertyCollector`` moId rides the path, so the body
     is only the method args -- the same shape the write composites'
-    config reads send.
+    config reads send, ``_typeName``-annotated via the shared trio
+    helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "pathSet": path_set}],
-                "objectSet": [
-                    {"obj": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid}}
-                ],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_CLUSTER_COMPUTE_RESOURCE_MO_TYPE, [cluster_moid], path_set)
 
 
 def _extract_object_props(retrieve_result: Any) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -96,6 +96,11 @@ import httpx
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    VIM_TYPE_NAME_KEY,
+    retrieve_properties_body,
+    vim_moref,
+)
 from meho_backplane.connectors.vmware_rest.vim_task import TASK_STATE_ERROR, poll_vim_task
 from meho_backplane.operations.composite import DispatchChild, enforce_subop_policy
 
@@ -292,8 +297,10 @@ _VIM_SUB_OPS_VM_DISK_GROW: tuple[str, ...] = (
 # VI-JSON polymorphic-type discriminator (``Any._typeName`` in
 # vi-json.yaml) + the VirtualDisk data-object type name. A device read
 # from ``config.hardware.device`` carries ``_typeName`` so the handler can
-# pick the VirtualDisk out of the mixed device list.
-_VMOMI_TYPE_NAME_KEY = "_typeName"
+# pick the VirtualDisk out of the mixed device list. Request-side, every
+# DataObject in a vim body carries the tag too (#3103; see
+# :mod:`..vim_body` for the live-differential grounding).
+_VMOMI_TYPE_NAME_KEY = VIM_TYPE_NAME_KEY
 _VIRTUAL_DISK_TYPE = "VirtualDisk"
 _VIRTUAL_MACHINE_MO_TYPE = "VirtualMachine"
 _PROP_CONFIG_HARDWARE_DEVICE = "config.hardware.device"
@@ -373,20 +380,40 @@ _VIM_GUEST_ID_BY_REST_GUEST_OS: Final[dict[str, str]] = {
     "WINDOWS_11_64": "windows11_64Guest",
 }
 
-# vim NIC shape for the pre-9.0 create arm (#3099). The ConfigSpec's
-# ``deviceChange`` entries are ``VirtualDeviceConfigSpec`` (declared type ==
-# runtime type, no ``_typeName``), but the ``device`` is declared as the base
-# ``VirtualDevice`` and the ``backing`` as the base
-# ``VirtualDeviceBackingInfo``, so both subtypes carry the ``_typeName``
-# discriminator for the vim25-JSON binding to deserialise them — the
-# ``ClusterConfigSpecEx`` precedent (#2895, spec-verified). The DVPG backing's
-# ``port`` is a ``DistributedVirtualSwitchPortConnection`` (declared ==
-# runtime, no tag) whose ``switchUuid`` / ``portgroupKey`` are resolved from
-# the portgroup moid via the un-gated vmomi property reads below — the same
-# ``key`` + ``config.distributedVirtualSwitch`` → ``uuid`` walk govc performs.
+# vim NIC shape for the pre-9.0 create arm (#3099). The ``device`` is
+# declared as the base ``VirtualDevice`` and the ``backing`` as the base
+# ``VirtualDeviceBackingInfo``, so both carry their concrete-subtype
+# ``_typeName`` for the vim25-JSON binding to pick the subtype — and since
+# #3103 every enclosing DataObject (the ``VirtualDeviceConfigSpec`` entry,
+# the ConfigSpec, its ``files``) carries its own tag as well: the live
+# 8.0.3 differential disproved the earlier "declared type == runtime type
+# needs no ``_typeName``" premise. The DVPG backing's ``port`` is a
+# ``DistributedVirtualSwitchPortConnection`` whose ``switchUuid`` /
+# ``portgroupKey`` are resolved from the portgroup moid via the un-gated
+# vmomi property reads below — the same ``key`` +
+# ``config.distributedVirtualSwitch`` → ``uuid`` walk govc performs.
 _VIRTUAL_VMXNET3_TYPE = "VirtualVmxnet3"
 _DV_PORT_BACKING_TYPE = "VirtualEthernetCardDistributedVirtualPortBackingInfo"
 _STANDARD_NETWORK_BACKING_TYPE = "VirtualEthernetCardNetworkBackingInfo"
+_DV_PORT_CONNECTION_TYPE = "DistributedVirtualSwitchPortConnection"
+
+# vim data-object ``_typeName`` discriminators for the request-body specs
+# the write composites assemble by hand (#3103, all spec-verified against
+# the pinned ``vi-json.yaml``): the ConfigSpec rides ``ReconfigVMRequestType
+# .spec`` / ``CreateVMRequestType.config``, ``files`` is its
+# ``VirtualMachineFileInfo``, ``deviceChange`` entries are
+# ``VirtualDeviceConfigSpec``, the clone body is ``CloneVMRequestType.spec``
+# (``VirtualMachineCloneSpec``) with a ``VirtualMachineRelocateSpec``
+# ``location``, and the DVS detach spec is ``ReconfigureDvsRequestType.spec``
+# (``DVSConfigSpec``) with ``DistributedVirtualSwitchHostMemberConfigSpec``
+# member entries.
+_VM_CONFIG_SPEC_TYPE = "VirtualMachineConfigSpec"
+_VM_FILE_INFO_TYPE = "VirtualMachineFileInfo"
+_VIRTUAL_DEVICE_CONFIG_SPEC_TYPE = "VirtualDeviceConfigSpec"
+_VM_CLONE_SPEC_TYPE = "VirtualMachineCloneSpec"
+_VM_RELOCATE_SPEC_TYPE = "VirtualMachineRelocateSpec"
+_DVS_CONFIG_SPEC_TYPE = "DVSConfigSpec"
+_DVS_HOST_MEMBER_CONFIG_SPEC_TYPE = "DistributedVirtualSwitchHostMemberConfigSpec"
 _DVPG_MO_TYPE = "DistributedVirtualPortgroup"
 _PROP_DVPG_KEY = "key"
 _PROP_DVPG_DVS = "config.distributedVirtualSwitch"
@@ -394,8 +421,11 @@ _PROP_DVS_UUID = "uuid"
 
 # The one-field ``VirtualMachineConfigSpec`` the VHV reconfigure sends. The
 # ``"spec"`` key is the vim request type's genuine required parameter (the
-# legacy-envelope sweep #2973 does not apply to vim bodies).
-_NESTED_HV_RECONFIG_BODY: Final[dict[str, Any]] = {"spec": {"nestedHVEnabled": True}}
+# legacy-envelope sweep #2973 does not apply to vim bodies); the spec value
+# is a DataObject, so it carries its ``_typeName`` (#3103).
+_NESTED_HV_RECONFIG_BODY: Final[dict[str, Any]] = {
+    "spec": {VIM_TYPE_NAME_KEY: _VM_CONFIG_SPEC_TYPE, "nestedHVEnabled": True}
+}
 
 # vim (VI-JSON) op_ids for the folder-template clone write path (#2894).
 # Same ``METHOD:/path`` shape the ingest parser emits from ``vi-json.yaml``
@@ -423,7 +453,8 @@ _VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE: tuple[str, ...] = (
 )
 
 # vim ManagedObjectReference type discriminators for the clone placement
-# MoRefs. A vim MoRef serialises as ``{"type": <T>, "value": <moid>}`` — the
+# MoRefs. A request-side vim MoRef serialises as ``{"_typeName":
+# "ManagedObjectReference", "type": <T>, "value": <moid>}`` (#3103) — the
 # handler wraps the operator-supplied placement moids into these.
 _FOLDER_MO_TYPE = "Folder"
 _RESOURCE_POOL_MO_TYPE = "ResourcePool"
@@ -471,11 +502,13 @@ _OP_CREATE_FOLDER = "POST:/Folder/{moId}/CreateFolder"
 # reconfigure must tag the spec ``ClusterConfigSpecEx`` for the vim25-JSON
 # binding to deserialise the subtype; likewise ``ClusterRuleSpec.info`` is
 # declared as the base ``ClusterRuleInfo``, so the affinity / anti-affinity
-# subtype is tagged. The ``ClusterRuleSpec`` array item and the
-# ``VirtualMachine`` MoRefs need no ``_typeName`` (declared type == runtime
-# type), mirroring the disk-grow ``VirtualDeviceConfigSpec`` precedent
-# (spec-verified against the pinned ``vi-json.yaml``).
+# subtype is tagged. Since #3103 the ``ClusterRuleSpec`` array items and
+# the ``VirtualMachine`` MoRefs are tagged too — the live 8.0.3
+# differential disproved the earlier "declared type == runtime type needs
+# no ``_typeName``" premise (spec-verified against the pinned
+# ``vi-json.yaml``, whose ``Any.required`` names ``_typeName``).
 _CLUSTER_CONFIG_SPEC_EX_TYPE = "ClusterConfigSpecEx"
+_CLUSTER_RULE_SPEC_TYPE = "ClusterRuleSpec"
 _CLUSTER_AFFINITY_RULE_TYPE = "ClusterAffinityRuleSpec"
 _CLUSTER_ANTI_AFFINITY_RULE_TYPE = "ClusterAntiAffinityRuleSpec"
 _CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
@@ -1175,16 +1208,11 @@ def _build_dvpg_retrieve_params(portgroup_moid: str) -> dict[str, Any]:
     ``config.distributedVirtualSwitch`` off the ``DistributedVirtualPortgroup``
     — the two properties the ``DistributedVirtualSwitchPortConnection``
     needs (the DVS moid is then resolved to its ``uuid`` in a second read).
+    ``_typeName``-annotated via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": _DVPG_MO_TYPE, "pathSet": [_PROP_DVPG_KEY, _PROP_DVPG_DVS]}],
-                "objectSet": [{"obj": {"type": _DVPG_MO_TYPE, "value": portgroup_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(
+        _DVPG_MO_TYPE, [portgroup_moid], [_PROP_DVPG_KEY, _PROP_DVPG_DVS]
+    )
 
 
 async def _resolve_vim_nic_backing(
@@ -1244,7 +1272,11 @@ async def _resolve_vim_nic_backing(
             return None, f"switch {switch_moid!r} owning portgroup {network!r} has no uuid"
         return {
             _VMOMI_TYPE_NAME_KEY: _DV_PORT_BACKING_TYPE,
-            "port": {"switchUuid": switch_uuid, "portgroupKey": portgroup_key},
+            "port": {
+                _VMOMI_TYPE_NAME_KEY: _DV_PORT_CONNECTION_TYPE,
+                "switchUuid": switch_uuid,
+                "portgroupKey": portgroup_key,
+            },
         }, None
     if backing_type == _NIC_BACKING_STANDARD_PORTGROUP:
         listing = _unwrap_value(
@@ -1288,20 +1320,26 @@ def _build_vim_create_request(
     ``files.vmPathName`` (the VM home, ``"[<datastore-name>] <name>"``),
     the NIC ``deviceChange`` adds (vmxnet3, negative temp keys — the new-
     device convention), and ``nestedHVEnabled`` folded inline when the
-    operator asked for the #3093 leg.
+    operator asked for the #3093 leg. Every DataObject in the body carries
+    its ``_typeName`` discriminator (#3103).
     """
     config: dict[str, Any] = {
+        _VMOMI_TYPE_NAME_KEY: _VM_CONFIG_SPEC_TYPE,
         "name": name,
         "guestId": guest_id,
         "numCPUs": cpu_count,
         "memoryMB": memory_mib,
-        "files": {"vmPathName": f"[{datastore_name}] {name}"},
+        "files": {
+            _VMOMI_TYPE_NAME_KEY: _VM_FILE_INFO_TYPE,
+            "vmPathName": f"[{datastore_name}] {name}",
+        },
     }
     if nested_hv:
         config["nestedHVEnabled"] = True
     if nic_backings:
         config["deviceChange"] = [
             {
+                _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DEVICE_CONFIG_SPEC_TYPE,
                 "operation": "add",
                 "device": {
                     _VMOMI_TYPE_NAME_KEY: _VIRTUAL_VMXNET3_TYPE,
@@ -2232,17 +2270,10 @@ def _build_single_prop_retrieve_params(mo_type: str, moid: str, prop: str) -> di
     A single ``PropertyFilterSpec`` scoped directly to the managed object;
     the singleton ``propertyCollector`` moId rides the path, so the body is
     only the method args (the shape the typed reads + the disk-grow /
-    clone-template config reads send).
+    clone-template config reads send), ``_typeName``-annotated via the
+    shared trio helper — the live-verified 200 shape (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": mo_type, "pathSet": [prop]}],
-                "objectSet": [{"obj": {"type": mo_type, "value": moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(mo_type, [moid], [prop])
 
 
 def _extract_single_prop(retrieve_result: Any, prop: str) -> Any:
@@ -2976,9 +3007,11 @@ async def host_detach_from_vds_composite(
         vmomi_path=f"/{_DVS_MO_TYPE}/{dvs_moid}/ReconfigureDvs_Task",
         body={
             "spec": {
+                _VMOMI_TYPE_NAME_KEY: _DVS_CONFIG_SPEC_TYPE,
                 "configVersion": config_version,
                 "host": [
                     {
+                        _VMOMI_TYPE_NAME_KEY: _DVS_HOST_MEMBER_CONFIG_SPEC_TYPE,
                         "operation": "remove",
                         "host": _moref(_HOST_SYSTEM_MO_TYPE, host_moid),
                     }
@@ -3212,19 +3245,12 @@ def _build_vm_devices_retrieve_params(vm_moid: str) -> dict[str, Any]:
     its VI-JSON ``_typeName`` discriminator so the disk-grow handler can
     pick the ``VirtualDisk`` out. The singleton ``propertyCollector`` moId
     rides the path, so the body is only the method args (the shape the
-    typed reads send).
+    typed reads send), ``_typeName``-annotated via the shared trio helper
+    (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [
-                    {"type": _VIRTUAL_MACHINE_MO_TYPE, "pathSet": [_PROP_CONFIG_HARDWARE_DEVICE]}
-                ],
-                "objectSet": [{"obj": {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": vm_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(
+        _VIRTUAL_MACHINE_MO_TYPE, [vm_moid], [_PROP_CONFIG_HARDWARE_DEVICE]
+    )
 
 
 def _extract_vm_devices(retrieve_result: Any) -> list[Any]:
@@ -3390,11 +3416,20 @@ async def vm_disk_grow_composite(
             ),
         }
 
+    # The edited device is the server-read ``VirtualDisk`` echoed back
+    # ("fully specified" per the spec), so it already carries its own
+    # ``_typeName`` from the response; the enclosing ConfigSpec and
+    # ``VirtualDeviceConfigSpec`` entry are tagged here (#3103).
     reconfig_spec = {
         "spec": {
+            _VMOMI_TYPE_NAME_KEY: _VM_CONFIG_SPEC_TYPE,
             "deviceChange": [
-                {"operation": "edit", "device": {**device, "capacityInBytes": requested}}
-            ]
+                {
+                    _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DEVICE_CONFIG_SPEC_TYPE,
+                    "operation": "edit",
+                    "device": {**device, "capacityInBytes": requested},
+                }
+            ],
         }
     }
     gate, task_payload = await _write_vmomi_sub_op(
@@ -3465,8 +3500,8 @@ async def vm_disk_grow_composite(
 
 
 def _moref(mo_type: str, moid: str) -> dict[str, str]:
-    """A vim ``ManagedObjectReference`` JSON object (``{type, value}``)."""
-    return {"type": mo_type, "value": moid}
+    """An annotated vim ``ManagedObjectReference`` (shared helper, #3103)."""
+    return vim_moref(mo_type, moid)
 
 
 def _build_config_template_retrieve_params(vm_moid: str) -> dict[str, Any]:
@@ -3476,17 +3511,10 @@ def _build_config_template_retrieve_params(vm_moid: str) -> dict[str, Any]:
     ``config.template`` -- the boolean that distinguishes a marked-as-template
     VM from a regular one. The singleton ``propertyCollector`` moId rides the
     path, so the body is only the method args (the shape the typed reads +
-    the disk-grow config read send).
+    the disk-grow config read send), ``_typeName``-annotated via the shared
+    trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": _VIRTUAL_MACHINE_MO_TYPE, "pathSet": [_PROP_CONFIG_TEMPLATE]}],
-                "objectSet": [{"obj": {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": vm_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_VIRTUAL_MACHINE_MO_TYPE, [vm_moid], [_PROP_CONFIG_TEMPLATE])
 
 
 def _extract_config_template(retrieve_result: Any, vm_moid: str) -> bool | None:
@@ -3619,15 +3647,23 @@ def _build_clone_body(
     (``pool`` + ``datastore`` MoRefs, optional ``host`` pin), ``template:
     false`` (clone to a VM, never a template) and ``powerOn``. ``customization``
     (an inline ``CustomizationSpec``) is added only when a GOSC spec was
-    requested.
+    requested -- it is the server-resolved ``GetCustomizationSpec`` object
+    echoed back, so it round-trips its own ``_typeName`` tags; the
+    hand-assembled DataObjects here carry theirs explicitly (#3103).
     """
     location: dict[str, Any] = {
+        _VMOMI_TYPE_NAME_KEY: _VM_RELOCATE_SPEC_TYPE,
         "pool": _moref(_RESOURCE_POOL_MO_TYPE, pool_moid),
         "datastore": _moref(_DATASTORE_MO_TYPE, datastore_moid),
     }
     if host_moid is not None:
         location["host"] = _moref(_HOST_SYSTEM_MO_TYPE, host_moid)
-    clone_spec: dict[str, Any] = {"location": location, "template": False, "powerOn": power_on}
+    clone_spec: dict[str, Any] = {
+        _VMOMI_TYPE_NAME_KEY: _VM_CLONE_SPEC_TYPE,
+        "location": location,
+        "template": False,
+        "powerOn": power_on,
+    }
     if customization is not None:
         clone_spec["customization"] = customization
     return {"folder": _moref(_FOLDER_MO_TYPE, folder_moid), "name": new_vm_name, "spec": clone_spec}
@@ -3850,24 +3886,12 @@ def _build_cluster_rules_retrieve_params(cluster_moid: str) -> dict[str, Any]:
     name-collision check reads this before any write so a duplicate rule
     name returns a structured status instead of a raw vim ``DuplicateName``
     fault. The singleton ``propertyCollector`` moId rides the path, so the
-    body is only the method args (the shape the typed reads send).
+    body is only the method args (the shape the typed reads send),
+    ``_typeName``-annotated via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [
-                    {
-                        "type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE,
-                        "pathSet": [_PROP_CONFIGURATION_EX_RULE],
-                    }
-                ],
-                "objectSet": [
-                    {"obj": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid}}
-                ],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(
+        _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, [cluster_moid], [_PROP_CONFIGURATION_EX_RULE]
+    )
 
 
 def _extract_cluster_rule_names(retrieve_result: Any) -> set[str]:
@@ -4035,15 +4059,13 @@ async def cluster_drs_rule_create_composite(
             _VMOMI_TYPE_NAME_KEY: _CLUSTER_CONFIG_SPEC_EX_TYPE,
             "rulesSpec": [
                 {
+                    _VMOMI_TYPE_NAME_KEY: _CLUSTER_RULE_SPEC_TYPE,
                     "operation": "add",
                     "info": {
                         _VMOMI_TYPE_NAME_KEY: rule_info_type,
                         "name": rule_name,
                         "enabled": enabled,
-                        "vm": [
-                            {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": row["vm"]}
-                            for row in resolved
-                        ],
+                        "vm": [vim_moref(_VIRTUAL_MACHINE_MO_TYPE, row["vm"]) for row in resolved],
                     },
                 }
             ],

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -61,6 +61,7 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -155,22 +156,10 @@ def build_host_usage_retrieve_params(host_moid: str) -> dict[str, Any]:
     property paths. The singleton ``propertyCollector`` moId is carried
     in the URL (:data:`_RETRIEVE_PROPERTIES_PATH`), so the body is just
     the method arguments ``specSet`` + ``options`` -- the VI-JSON
-    ``RetrievePropertiesExRequestType`` shape.
+    ``RetrievePropertiesExRequestType`` shape, ``_typeName``-annotated
+    via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [
-                    {
-                        "type": _HOST_SYSTEM_MO_TYPE,
-                        "pathSet": list(_HOST_USAGE_PATH_SET),
-                    }
-                ],
-                "objectSet": [{"obj": {"type": _HOST_SYSTEM_MO_TYPE, "value": host_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], _HOST_USAGE_PATH_SET)
 
 
 def _extract_host_props(retrieve_result: Any) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
@@ -36,6 +36,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -162,22 +163,9 @@ def build_host_network_uplinks_retrieve_params(host_moid: str) -> dict[str, Any]
     request path (:data:`_RETRIEVE_PROPERTIES_PATH`), so the body is just
     the ``specSet`` + ``options`` method arguments -- the VI-JSON
     ``RetrievePropertiesExRequestType`` shape ``vmware.host.usage``
-    sends.
+    sends, ``_typeName``-annotated via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [
-                    {
-                        "type": _HOST_SYSTEM_MO_TYPE,
-                        "pathSet": list(_HOST_NET_PATH_SET),
-                    }
-                ],
-                "objectSet": [{"obj": {"type": _HOST_SYSTEM_MO_TYPE, "value": host_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], _HOST_NET_PATH_SET)
 
 
 async def _read_host_uplink_row(

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_vsan_health.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_vsan_health.py
@@ -36,6 +36,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import vim_moref
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -107,12 +108,13 @@ def build_vsan_query_health_params(cluster_moid: str) -> dict[str, Any]:
     The ``vsan-cluster-health-system`` singleton moId rides the request
     path (:data:`_VSAN_QUERY_HEALTH_PATH`); the body carries the method's
     ``cluster`` argument -- the target cluster's MoRef (a
-    ``ClusterComputeResource``). Every other parameter of the method
+    ``ClusterComputeResource``), ``_typeName``-annotated per the vim wire
+    format (#3103). Every other parameter of the method
     (``includeObjUuids`` / ``fields`` / …) is optional and left to the
     health service's defaults so the read returns the full summary.
     """
     return {
-        "cluster": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid},
+        "cluster": vim_moref(_CLUSTER_COMPUTE_RESOURCE_MO_TYPE, cluster_moid),
     }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
@@ -41,6 +41,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -91,17 +92,10 @@ def build_object_collect_retrieve_params(
     ``TraversalSpec`` -- the read cannot leave the named object. The
     singleton ``propertyCollector`` moId rides the request path
     (:data:`_RETRIEVE_PROPERTIES_PATH`), so the body is just the
-    ``specSet`` + ``options`` method arguments.
+    ``specSet`` + ``options`` method arguments, ``_typeName``-annotated
+    via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": mo_type, "pathSet": list(properties)}],
-                "objectSet": [{"obj": {"type": mo_type, "value": moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(mo_type, [moid], properties)
 
 
 def _extract_object_content(retrieve_result: Any) -> tuple[dict[str, Any], list[str]]:

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
@@ -37,6 +37,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -71,18 +72,13 @@ TASKS_RECENT_GROUP_KEY = "vmware-tasks-recent"
 
 
 def build_recent_tasks_retrieve_params() -> dict[str, Any]:
-    """Build the ``RetrievePropertiesEx`` body reading ``TaskManager.recentTask``."""
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": _TASK_MANAGER_MO_TYPE, "pathSet": [_PROP_RECENT_TASK]}],
-                "objectSet": [
-                    {"obj": {"type": _TASK_MANAGER_MO_TYPE, "value": _TASK_MANAGER_MOID}}
-                ],
-            }
-        ],
-        "options": {},
-    }
+    """Build the ``RetrievePropertiesEx`` body reading ``TaskManager.recentTask``.
+
+    ``_typeName``-annotated via the shared trio helper (#3103).
+    """
+    return retrieve_properties_body(
+        _TASK_MANAGER_MO_TYPE, [_TASK_MANAGER_MOID], [_PROP_RECENT_TASK]
+    )
 
 
 def build_task_info_retrieve_params(task_moids: list[str]) -> dict[str, Any]:
@@ -90,19 +86,12 @@ def build_task_info_retrieve_params(task_moids: list[str]) -> dict[str, Any]:
 
     One ``PropertyFilterSpec`` with a ``propSet`` for the ``Task.info``
     property and one ``objectSet`` entry per task moid -- a single round
-    trip for every task, no traversal.
+    trip for every task, no traversal. ``_typeName``-annotated via the
+    shared trio helper (#3103) -- this is the task-poll read shape every
+    ``*_Task`` write drives to terminal through
+    :func:`~meho_backplane.connectors.vmware_rest.vim_task.poll_vim_task`.
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [{"type": _TASK_MO_TYPE, "pathSet": [_PROP_INFO]}],
-                "objectSet": [
-                    {"obj": {"type": _TASK_MO_TYPE, "value": moid}} for moid in task_moids
-                ],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_TASK_MO_TYPE, task_moids, [_PROP_INFO])
 
 
 def _moref_value(ref: Any) -> str | None:

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
@@ -49,6 +49,7 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -103,22 +104,10 @@ def build_vm_info_retrieve_params(vm_moid: str) -> dict[str, Any]:
     runtime / storage property paths. The singleton ``propertyCollector``
     moId rides the path (:data:`_RETRIEVE_PROPERTIES_PATH`), so the body
     is just the ``specSet`` + ``options`` method arguments -- the VI-JSON
-    ``RetrievePropertiesExRequestType`` shape ``vmware.host.usage`` sends.
+    ``RetrievePropertiesExRequestType`` shape ``vmware.host.usage`` sends,
+    ``_typeName``-annotated via the shared trio helper (#3103).
     """
-    return {
-        "specSet": [
-            {
-                "propSet": [
-                    {
-                        "type": _VIRTUAL_MACHINE_MO_TYPE,
-                        "pathSet": list(_VM_INFO_PATH_SET),
-                    }
-                ],
-                "objectSet": [{"obj": {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": vm_moid}}],
-            }
-        ],
-        "options": {},
-    }
+    return retrieve_properties_body(_VIRTUAL_MACHINE_MO_TYPE, [vm_moid], _VM_INFO_PATH_SET)
 
 
 def _extract_vm_props(retrieve_result: Any) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/vmware_rest/vim_body.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/vim_body.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared ``_typeName``-annotated vim (VI-JSON) request-body pieces (#3103).
+
+VI-JSON's wire format requires the ``_typeName`` discriminator on every
+DataObject in a request body: the pinned ``vi-json.yaml`` derives all
+data objects from ``Any``, whose ``required`` list names ``_typeName``,
+and a live vCenter 8.0.3 **rejects** un-annotated bodies outright -- a
+controlled differential against
+``POST /sdk/vim25/8.0.3.0/PropertyCollector/propertyCollector/RetrievePropertiesEx``
+returned ``500 InvalidArgument`` (vim fault message ``Invalid MoRef
+field: pathSet``) for the bare body and ``200 RetrieveResult`` for the
+same body with ``PropertyFilterSpec`` / ``PropertySpec`` / ``ObjectSpec``
+/ ``ManagedObjectReference`` / ``RetrieveOptions`` annotations (#3103).
+The pre-#3103 substrate annotated only base-typed *polymorphic* fields
+(device backings, ``ClusterConfigSpecEx``); the differential disproved
+that premise -- the 8.0.x deserialiser demands the tag even where the
+declared type equals the runtime type. 9.x accepts annotated bodies (it
+is the spec'd format), so annotation is unconditional -- no version gate.
+
+This module carries the two shapes shared across the substrate: the
+annotated :func:`vim_moref` and the annotated single-filter
+``RetrievePropertiesEx`` body (:func:`retrieve_properties_body` -- the
+``PropertyFilterSpec`` / ``PropertySpec`` / ``ObjectSpec`` trio plus
+``RetrieveOptions``). Everything else stays an explicit per-builder
+annotation at its call site (spec-groundable and reviewable); there is
+deliberately no recursive type-inference magic here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "MOREF_TYPE_NAME",
+    "VIM_TYPE_NAME_KEY",
+    "retrieve_properties_body",
+    "vim_moref",
+]
+
+#: The VI-JSON polymorphic-type discriminator key (``Any._typeName`` in
+#: the pinned ``vi-json.yaml``; required on every DataObject).
+VIM_TYPE_NAME_KEY: Final[str] = "_typeName"
+
+#: ``_typeName`` of a vim managed-object reference.
+MOREF_TYPE_NAME: Final[str] = "ManagedObjectReference"
+
+# ``_typeName`` values of the RetrievePropertiesEx body trio + options
+# (spec-verified against the pinned ``vi-json.yaml``:
+# ``RetrievePropertiesExRequestType.specSet`` items are
+# ``PropertyFilterSpec``; its ``propSet`` / ``objectSet`` items are
+# ``PropertySpec`` / ``ObjectSpec``; ``options`` is ``RetrieveOptions``).
+_PROPERTY_FILTER_SPEC_TYPE: Final[str] = "PropertyFilterSpec"
+_PROPERTY_SPEC_TYPE: Final[str] = "PropertySpec"
+_OBJECT_SPEC_TYPE: Final[str] = "ObjectSpec"
+_RETRIEVE_OPTIONS_TYPE: Final[str] = "RetrieveOptions"
+
+
+def vim_moref(mo_type: str, moid: str) -> dict[str, str]:
+    """An annotated vim ``ManagedObjectReference`` JSON object.
+
+    ``{"_typeName": "ManagedObjectReference", "type": <T>, "value":
+    <moid>}`` -- the request-body form every MoRef-typed field takes on
+    the VI-JSON wire (#3103; response-side MoRefs carry the same tag).
+    """
+    return {VIM_TYPE_NAME_KEY: MOREF_TYPE_NAME, "type": mo_type, "value": moid}
+
+
+def retrieve_properties_body(
+    mo_type: str, moids: Sequence[str], path_set: Sequence[str]
+) -> dict[str, Any]:
+    """An annotated single-filter ``RetrievePropertiesEx`` request body.
+
+    One ``PropertyFilterSpec`` scoped directly to the ``(mo_type, moid)``
+    object(s) -- one ``ObjectSpec`` per moid, no ``TraversalSpec``, one
+    ``PropertySpec`` naming *path_set* -- the shape every property read
+    in the substrate sends (typed reads, config pre-reads, task polls).
+    The singleton ``propertyCollector`` moId rides the request path, so
+    the body is only the ``RetrievePropertiesExRequestType`` method args
+    ``specSet`` + ``options``, with every DataObject carrying its
+    ``_typeName`` discriminator -- the live-verified 200 shape from the
+    #3103 differential.
+    """
+    return {
+        "specSet": [
+            {
+                VIM_TYPE_NAME_KEY: _PROPERTY_FILTER_SPEC_TYPE,
+                "propSet": [
+                    {
+                        VIM_TYPE_NAME_KEY: _PROPERTY_SPEC_TYPE,
+                        "type": mo_type,
+                        "pathSet": list(path_set),
+                    }
+                ],
+                "objectSet": [
+                    {VIM_TYPE_NAME_KEY: _OBJECT_SPEC_TYPE, "obj": vim_moref(mo_type, moid)}
+                    for moid in moids
+                ],
+            }
+        ],
+        "options": {VIM_TYPE_NAME_KEY: _RETRIEVE_OPTIONS_TYPE},
+    }

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -248,16 +248,27 @@ async def test_cluster_drs_recommendations_reads_summary_then_vim_drs_config() -
     assert body == {
         "specSet": [
             {
+                "_typeName": "PropertyFilterSpec",
                 "propSet": [
                     {
+                        "_typeName": "PropertySpec",
                         "type": "ClusterComputeResource",
                         "pathSet": ["configurationEx.drsConfig"],
                     }
                 ],
-                "objectSet": [{"obj": {"type": "ClusterComputeResource", "value": "domain-c123"}}],
+                "objectSet": [
+                    {
+                        "_typeName": "ObjectSpec",
+                        "obj": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": "ClusterComputeResource",
+                            "value": "domain-c123",
+                        },
+                    }
+                ],
             }
         ],
-        "options": {},
+        "options": {"_typeName": "RetrieveOptions"},
     }
     assert out == {"cluster": cluster_payload, "drs": drs_config}
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -296,19 +296,29 @@ def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
 
 
 def _task_moref(value: str) -> dict[str, str]:
-    """A vim Task ``ManagedObjectReference`` as a ``*_Task`` method returns it."""
-    return {"type": "Task", "value": value}
+    """A vim Task ``ManagedObjectReference`` as a ``*_Task`` method returns it.
+
+    Live VI-JSON responses tag every DataObject with ``_typeName`` — the
+    canned payloads mirror that so the tests double as the #3103
+    response-tolerance proof.
+    """
+    return {"_typeName": "ManagedObjectReference", "type": "Task", "value": value}
 
 
 def _retrieve_result(obj_type: str, moid: str, prop: str, val: Any) -> dict[str, Any]:
-    """A single-object ``RetrievePropertiesEx`` result carrying one property."""
+    """A single-object ``RetrievePropertiesEx`` result carrying one property.
+
+    ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
+    """
     return {
+        "_typeName": "RetrieveResult",
         "objects": [
             {
-                "obj": {"type": obj_type, "value": moid},
-                "propSet": [{"name": prop, "val": val}],
+                "_typeName": "ObjectContent",
+                "obj": {"_typeName": "ManagedObjectReference", "type": obj_type, "value": moid},
+                "propSet": [{"_typeName": "DynamicProperty", "name": prop, "val": val}],
             }
-        ]
+        ],
     }
 
 
@@ -318,11 +328,12 @@ def _task_info_result(
     """A ``Task.info`` RetrievePropertiesEx result in the requested state.
 
     ``result`` seeds ``TaskInfo.result`` — the new-entity MoRef a
-    ``CreateVM_Task`` / ``CloneVM_Task`` success carries.
+    ``CreateVM_Task`` / ``CloneVM_Task`` success carries. ``_typeName``-tagged
+    like a live VI-JSON response (#3103 tolerance).
     """
-    info: dict[str, Any] = {"state": state}
+    info: dict[str, Any] = {"_typeName": "TaskInfo", "state": state}
     if error is not None:
-        info["error"] = {"localizedMessage": error}
+        info["error"] = {"_typeName": "LocalizedMethodFault", "localizedMessage": error}
     if result is not None:
         info["result"] = result
     return _retrieve_result("Task", task_moid, "info", info)
@@ -331,9 +342,17 @@ def _task_info_result(
 def _snapshot_tree_node(
     moid: str, name: str, children: list[dict[str, Any]] | None = None
 ) -> dict[str, Any]:
-    """A ``VirtualMachineSnapshotTree`` node as the ``snapshot`` property returns it."""
+    """A ``VirtualMachineSnapshotTree`` node as the ``snapshot`` property returns it.
+
+    ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
+    """
     return {
-        "snapshot": {"type": "VirtualMachineSnapshot", "value": moid},
+        "_typeName": "VirtualMachineSnapshotTree",
+        "snapshot": {
+            "_typeName": "ManagedObjectReference",
+            "type": "VirtualMachineSnapshot",
+            "value": moid,
+        },
         "name": name,
         "childSnapshotList": children or [],
     }
@@ -661,10 +680,11 @@ async def test_vm_create_nested_hv_reconfigures_before_power_on(gate: _GateRecor
         ("POST-VMOMI", _VMOMI_TASK_INFO_READ_PATH),
         ("POST", "/api/vcenter/vm/vm-99/power?action=start"),
     ]
-    # The reconfigure body is the one-field VirtualMachineConfigSpec.
+    # The reconfigure body is the one-field VirtualMachineConfigSpec,
+    # ``_typeName``-annotated per the vim wire format (#3103).
     assert conn.vmomi_calls[0] == (
         "/VirtualMachine/vm-99/ReconfigVM_Task",
-        {"spec": {"nestedHVEnabled": True}},
+        {"spec": {"_typeName": "VirtualMachineConfigSpec", "nestedHVEnabled": True}},
     )
 
     # Governance: the vim write is gated under its canonical vi-json op_id,
@@ -982,14 +1002,19 @@ async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
     create_body = conn.vmomi_calls[2][1]
     assert create_body == {
         "config": {
+            "_typeName": "VirtualMachineConfigSpec",
             "name": "esx-nested-01",
             "guestId": "vmkernel8Guest",
             "numCPUs": 8,
             "memoryMB": 16384,
-            "files": {"vmPathName": "[datastore1] esx-nested-01"},
+            "files": {
+                "_typeName": "VirtualMachineFileInfo",
+                "vmPathName": "[datastore1] esx-nested-01",
+            },
             "nestedHVEnabled": True,
             "deviceChange": [
                 {
+                    "_typeName": "VirtualDeviceConfigSpec",
                     "operation": "add",
                     "device": {
                         "_typeName": "VirtualVmxnet3",
@@ -997,6 +1022,7 @@ async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
                         "backing": {
                             "_typeName": ("VirtualEthernetCardDistributedVirtualPortBackingInfo"),
                             "port": {
+                                "_typeName": "DistributedVirtualSwitchPortConnection",
                                 "switchUuid": _DVS_UUID,
                                 "portgroupKey": "dvportgroup-1015",
                             },
@@ -1005,8 +1031,12 @@ async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
                 }
             ],
         },
-        "pool": {"type": "ResourcePool", "value": "resgroup-8"},
-        "host": {"type": "HostSystem", "value": "host-14"},
+        "pool": {
+            "_typeName": "ManagedObjectReference",
+            "type": "ResourcePool",
+            "value": "resgroup-8",
+        },
+        "host": {"_typeName": "ManagedObjectReference", "type": "HostSystem", "value": "host-14"},
     }
 
     # Governance: exactly the vim create + the power-on were gated — no
@@ -1176,6 +1206,7 @@ async def test_vm_create_pre9_standard_portgroup_nic_uses_network_backing(
     create_body = conn.vmomi_calls[0][1]
     assert create_body["config"]["deviceChange"] == [
         {
+            "_typeName": "VirtualDeviceConfigSpec",
             "operation": "add",
             "device": {
                 "_typeName": "VirtualVmxnet3",
@@ -2647,11 +2678,17 @@ async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
             "/DistributedVirtualSwitch/dvs-1/ReconfigureDvs_Task",
             {
                 "spec": {
+                    "_typeName": "DVSConfigSpec",
                     "configVersion": "42",
                     "host": [
                         {
+                            "_typeName": "DistributedVirtualSwitchHostMemberConfigSpec",
                             "operation": "remove",
-                            "host": {"type": "HostSystem", "value": "host-9"},
+                            "host": {
+                                "_typeName": "ManagedObjectReference",
+                                "type": "HostSystem",
+                                "value": "host-9",
+                            },
                         }
                     ],
                 }
@@ -3368,16 +3405,31 @@ async def test_vm_clone_from_template_happy_path_clones_and_polls(gate: _GateRec
     }
 
     # The CloneVM_Task body: folder MoRef + name + CloneSpec (template:false,
-    # powerOn, relocate placement pool+datastore, no host pin, no customization).
+    # powerOn, relocate placement pool+datastore, no host pin, no
+    # customization), every DataObject ``_typeName``-annotated (#3103).
     assert len(conn.clone_bodies) == 1
     body = conn.clone_bodies[0]
-    assert body["folder"] == {"type": "Folder", "value": "group-v10"}
+    assert body["folder"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "Folder",
+        "value": "group-v10",
+    }
     assert body["name"] == "web-01"
     spec = body["spec"]
+    assert spec["_typeName"] == "VirtualMachineCloneSpec"
     assert spec["template"] is False
     assert spec["powerOn"] is True
-    assert spec["location"]["pool"] == {"type": "ResourcePool", "value": "resgroup-8"}
-    assert spec["location"]["datastore"] == {"type": "Datastore", "value": "datastore-15"}
+    assert spec["location"]["_typeName"] == "VirtualMachineRelocateSpec"
+    assert spec["location"]["pool"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "ResourcePool",
+        "value": "resgroup-8",
+    }
+    assert spec["location"]["datastore"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "Datastore",
+        "value": "datastore-15",
+    }
     assert "host" not in spec["location"]
     assert "customization" not in spec
 
@@ -3394,7 +3446,11 @@ async def test_vm_clone_from_template_host_pin_included_when_given(gate: _GateRe
     assert isinstance(out, dict)
     assert out["status"] == "cloned"
     body = conn.clone_bodies[0]
-    assert body["spec"]["location"]["host"] == {"type": "HostSystem", "value": "host-19"}
+    assert body["spec"]["location"]["host"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "HostSystem",
+        "value": "host-19",
+    }
     assert gate.calls[0]["params"]["host"] == "host-19"
 
 
@@ -3639,12 +3695,22 @@ async def test_vm_clone_from_template_clone_body_reaches_the_wire_respx(
         assert out["new_vm_id"] == "vm-99"
         assert clone.called
         body = json.loads(clone.calls[0].request.content)
-        assert body["folder"] == {"type": "Folder", "value": "group-v10"}
+        assert body["folder"] == {
+            "_typeName": "ManagedObjectReference",
+            "type": "Folder",
+            "value": "group-v10",
+        }
         assert body["name"] == "web-01"
+        assert body["spec"]["_typeName"] == "VirtualMachineCloneSpec"
         assert body["spec"]["template"] is False
         assert body["spec"]["powerOn"] is True
-        assert body["spec"]["location"]["pool"] == {"type": "ResourcePool", "value": "resgroup-8"}
+        assert body["spec"]["location"]["pool"] == {
+            "_typeName": "ManagedObjectReference",
+            "type": "ResourcePool",
+            "value": "resgroup-8",
+        }
         assert body["spec"]["location"]["datastore"] == {
+            "_typeName": "ManagedObjectReference",
             "type": "Datastore",
             "value": "datastore-15",
         }
@@ -3784,14 +3850,15 @@ async def test_drs_rule_create_happy_path_adds_anti_affinity_and_polls(gate: _Ga
     assert body["spec"]["_typeName"] == "ClusterConfigSpecEx"
     rules_spec = body["spec"]["rulesSpec"]
     assert len(rules_spec) == 1
+    assert rules_spec[0]["_typeName"] == "ClusterRuleSpec"
     assert rules_spec[0]["operation"] == "add"
     info = rules_spec[0]["info"]
     assert info["_typeName"] == "ClusterAntiAffinityRuleSpec"
     assert info["name"] == "keep-apart"
     assert info["enabled"] is True
     assert info["vm"] == [
-        {"type": "VirtualMachine", "value": "vm-1"},
-        {"type": "VirtualMachine", "value": "vm-2"},
+        {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-1"},
+        {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-2"},
     ]
 
 
@@ -3990,12 +4057,13 @@ async def test_drs_rule_create_reconfig_body_reaches_the_wire_respx(
         assert body["modify"] is True
         assert body["spec"]["_typeName"] == "ClusterConfigSpecEx"
         assert len(body["spec"]["rulesSpec"]) == 1
+        assert body["spec"]["rulesSpec"][0]["_typeName"] == "ClusterRuleSpec"
         assert body["spec"]["rulesSpec"][0]["operation"] == "add"
         info = body["spec"]["rulesSpec"][0]["info"]
         assert info["_typeName"] == "ClusterAntiAffinityRuleSpec"
         assert info["vm"] == [
-            {"type": "VirtualMachine", "value": "vm-1"},
-            {"type": "VirtualMachine", "value": "vm-2"},
+            {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-1"},
+            {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-2"},
         ]
     finally:
         await connector.aclose()

--- a/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
@@ -172,3 +172,153 @@ def test_flattened_2973_bodies_are_served_flat_by_the_pinned_spec() -> None:
             f"{op_id}: still a single-`spec` wrapper in the pinned spec -- the flat-body "
             "contract this task relies on does not hold for it."
         )
+
+
+# ---------------------------------------------------------------------------
+# vim (VI-JSON) ``_typeName`` annotation reconcile (#3103)
+# ---------------------------------------------------------------------------
+#
+# VI-JSON request bodies must tag every DataObject with its ``_typeName``
+# discriminator: the pinned ``vi-json.yaml`` derives all data objects from
+# ``Any`` (whose ``required`` list names ``_typeName``), and a live vCenter
+# 8.0.3 rejects un-annotated bodies (``500 InvalidArgument`` — the #3103
+# controlled differential; the annotated body returns ``200``). The
+# byte-for-byte body pins live in the always-on unit lanes
+# (``test_connectors_vmware_rest_composites_write.py`` and the typed-op
+# tests); this lane grounds the annotation *vocabulary*: every ``_typeName``
+# literal the substrate can emit must name a real component schema in the
+# pinned ``vi-json.yaml``.
+
+from meho_backplane.connectors.vmware_rest.vim_body import (  # noqa: E402
+    MOREF_TYPE_NAME,
+    retrieve_properties_body,
+)
+
+#: Every ``_typeName`` value the vim substrate emits, sourced from the
+#: emitting constants themselves (a rename/typo there fails this lane's
+#: spec grounding immediately). New hand-assembled vim bodies add their
+#: type names here; the unit-test byte pins force that addition.
+_EMITTED_VIM_TYPE_NAMES: set[str] = {
+    MOREF_TYPE_NAME,
+    _write._VIRTUAL_DISK_TYPE,
+    _write._VIRTUAL_VMXNET3_TYPE,
+    _write._DV_PORT_BACKING_TYPE,
+    _write._STANDARD_NETWORK_BACKING_TYPE,
+    _write._DV_PORT_CONNECTION_TYPE,
+    _write._VM_CONFIG_SPEC_TYPE,
+    _write._VM_FILE_INFO_TYPE,
+    _write._VIRTUAL_DEVICE_CONFIG_SPEC_TYPE,
+    _write._VM_CLONE_SPEC_TYPE,
+    _write._VM_RELOCATE_SPEC_TYPE,
+    _write._DVS_CONFIG_SPEC_TYPE,
+    _write._DVS_HOST_MEMBER_CONFIG_SPEC_TYPE,
+    _write._CLUSTER_CONFIG_SPEC_EX_TYPE,
+    _write._CLUSTER_RULE_SPEC_TYPE,
+    _write._CLUSTER_AFFINITY_RULE_TYPE,
+    _write._CLUSTER_ANTI_AFFINITY_RULE_TYPE,
+}
+
+
+def _collect_type_names(node: object) -> set[str]:
+    """Collect every ``_typeName`` value in a *built* body (test-side walk)."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        tag = node.get("_typeName")
+        if isinstance(tag, str):
+            found.add(tag)
+        for value in node.values():
+            found |= _collect_type_names(value)
+    elif isinstance(node, list):
+        for item in node:
+            found |= _collect_type_names(item)
+    return found
+
+
+def test_single_prop_retrieve_body_is_the_live_verified_annotated_shape() -> None:
+    """Pin the exact annotated single-prop retrieve body (always runs, no shelf).
+
+    Byte-for-byte (modulo values) the body the #3103 live differential
+    proved: un-annotated → ``500 InvalidArgument`` (``Invalid MoRef field:
+    pathSet``), annotated → ``200 RetrieveResult`` on vCenter 8.0.3.
+    """
+    body = _write._build_single_prop_retrieve_params("VirtualMachine", "vm-42", "snapshot")
+    assert body == {
+        "specSet": [
+            {
+                "_typeName": "PropertyFilterSpec",
+                "propSet": [
+                    {
+                        "_typeName": "PropertySpec",
+                        "type": "VirtualMachine",
+                        "pathSet": ["snapshot"],
+                    }
+                ],
+                "objectSet": [
+                    {
+                        "_typeName": "ObjectSpec",
+                        "obj": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": "VirtualMachine",
+                            "value": "vm-42",
+                        },
+                    }
+                ],
+            }
+        ],
+        "options": {"_typeName": "RetrieveOptions"},
+    }
+
+
+def test_trio_helper_annotates_every_data_object_and_nothing_else() -> None:
+    """The shared retrieve trio emits exactly the five annotation names."""
+    body = retrieve_properties_body("HostSystem", ["host-1", "host-2"], ["summary.quickStats"])
+    assert _collect_type_names(body) == {
+        "PropertyFilterSpec",
+        "PropertySpec",
+        "ObjectSpec",
+        "ManagedObjectReference",
+        "RetrieveOptions",
+    }
+    # One annotated ObjectSpec per moid — multi-object reads (the task
+    # poll shape) stay fully annotated too.
+    object_set = body["specSet"][0]["objectSet"]
+    assert [o["obj"]["value"] for o in object_set] == ["host-1", "host-2"]
+
+
+def _vi_json_component_schema_exists(spec_text: str, name: str) -> bool:
+    """Whether *name* is a component schema key in the pinned ``vi-json.yaml``.
+
+    Line-scans rather than parsing the ~10 MB YAML (the
+    ``_vi_json_path_item_has_post`` precedent in the l2 ingest reconcile):
+    component schemas are keyed at 4-space indent (``    VirtualDisk:``),
+    and the CamelCase vim type names collide with no other 4-indent key
+    family in the document.
+    """
+    return f"\n    {name}:\n" in spec_text
+
+
+def test_every_emitted_vim_type_name_is_a_pinned_vi_json_schema() -> None:
+    """Each ``_typeName`` the substrate emits names a schema in the pinned spec.
+
+    The #3103 grounding lane: the annotation vocabulary — the retrieve trio
+    + options, the MoRef tag, and every hand-assembled write-spec tag —
+    must exist as component schemas in the pinned ``vi-json.yaml``. A
+    fictional or misspelled discriminator fails here before it ever
+    reaches a live vCenter. Skips uniformly without the spec shelf.
+    """
+    spec_path = require_shelf_spec("vcenter-9.0", "vi-json.yaml")
+    spec_text = spec_path.read_text(encoding="utf-8")
+    trio_names = _collect_type_names(
+        retrieve_properties_body("VirtualMachine", ["vm-1"], ["snapshot"])
+    )
+    missing = [
+        name
+        for name in sorted(_EMITTED_VIM_TYPE_NAMES | trio_names)
+        if not _vi_json_component_schema_exists(spec_text, name)
+    ]
+    assert not missing, (
+        f"_typeName value(s) {missing} are not component schemas in the pinned "
+        "vi-json.yaml — a fictional/misspelled vim discriminator would be "
+        "rejected (or mis-deserialised) by a live vCenter. "
+        "Protocol: docs/decisions/spec-reconcile-guards-standard.md."
+    )

--- a/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
@@ -157,15 +157,33 @@ def _retrieve_result(moid: str, pnics: list[Any], proxy_switches: list[Any]) -> 
 
 
 def test_build_retrieve_params_shape_is_single_host_property_filter() -> None:
+    """Pins the exact ``_typeName``-annotated body (#3103, live-verified shape)."""
     body = build_host_network_uplinks_retrieve_params("host-42")
-    assert set(body) == {"specSet", "options"}
-    assert body["options"] == {}
-    (spec,) = body["specSet"]
-    (prop_spec,) = spec["propSet"]
-    assert prop_spec["type"] == "HostSystem"
-    assert prop_spec["pathSet"] == ["config.network.pnic", "config.network.proxySwitch"]
-    (obj_spec,) = spec["objectSet"]
-    assert obj_spec["obj"] == {"type": "HostSystem", "value": "host-42"}
+    assert body == {
+        "specSet": [
+            {
+                "_typeName": "PropertyFilterSpec",
+                "propSet": [
+                    {
+                        "_typeName": "PropertySpec",
+                        "type": "HostSystem",
+                        "pathSet": ["config.network.pnic", "config.network.proxySwitch"],
+                    }
+                ],
+                "objectSet": [
+                    {
+                        "_typeName": "ObjectSpec",
+                        "obj": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": "HostSystem",
+                            "value": "host-42",
+                        },
+                    }
+                ],
+            }
+        ],
+        "options": {"_typeName": "RetrieveOptions"},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -226,7 +244,11 @@ async def test_lists_then_reads_props_per_host_mounted() -> None:
         "config.network.pnic",
         "config.network.proxySwitch",
     ]
-    assert spec["objectSet"][0]["obj"] == {"type": "HostSystem", "value": "host-1"}
+    assert spec["objectSet"][0]["obj"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "HostSystem",
+        "value": "host-1",
+    }
 
     hosts = out["hosts"]
     assert len(hosts) == 2

--- a/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
@@ -136,18 +136,27 @@ class _FakeConnector:
 
 
 def _retrieve_result(moid: str, quick_stats: Any, hardware: Any, in_maint: Any) -> dict[str, Any]:
-    """Build a RetrievePropertiesEx ``RetrieveResult`` for one host."""
+    """Build a RetrievePropertiesEx ``RetrieveResult`` for one host.
+
+    ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
+    """
     return {
+        "_typeName": "RetrieveResult",
         "objects": [
             {
-                "obj": {"type": "HostSystem", "value": moid},
+                "_typeName": "ObjectContent",
+                "obj": {
+                    "_typeName": "ManagedObjectReference",
+                    "type": "HostSystem",
+                    "value": moid,
+                },
                 "propSet": [
                     {"name": "summary.quickStats", "val": quick_stats},
                     {"name": "summary.hardware", "val": hardware},
                     {"name": "runtime.inMaintenanceMode", "val": in_maint},
                 ],
             }
-        ]
+        ],
     }
 
 
@@ -168,19 +177,37 @@ _HW_FULL = {
 
 
 def test_build_retrieve_params_shape_is_single_host_property_filter() -> None:
+    """Pins the exact ``_typeName``-annotated body (#3103, live-verified shape)."""
     body = build_host_usage_retrieve_params("host-42")
-    assert set(body) == {"specSet", "options"}
-    assert body["options"] == {}
-    (spec,) = body["specSet"]
-    (prop_spec,) = spec["propSet"]
-    assert prop_spec["type"] == "HostSystem"
-    assert prop_spec["pathSet"] == [
-        "summary.quickStats",
-        "summary.hardware",
-        "runtime.inMaintenanceMode",
-    ]
-    (obj_spec,) = spec["objectSet"]
-    assert obj_spec["obj"] == {"type": "HostSystem", "value": "host-42"}
+    assert body == {
+        "specSet": [
+            {
+                "_typeName": "PropertyFilterSpec",
+                "propSet": [
+                    {
+                        "_typeName": "PropertySpec",
+                        "type": "HostSystem",
+                        "pathSet": [
+                            "summary.quickStats",
+                            "summary.hardware",
+                            "runtime.inMaintenanceMode",
+                        ],
+                    }
+                ],
+                "objectSet": [
+                    {
+                        "_typeName": "ObjectSpec",
+                        "obj": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": "HostSystem",
+                            "value": "host-42",
+                        },
+                    }
+                ],
+            }
+        ],
+        "options": {"_typeName": "RetrieveOptions"},
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_typed_host_vsan_health.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_vsan_health.py
@@ -123,8 +123,15 @@ def _vsan_summary(overall: str, groups: list[Any]) -> dict[str, Any]:
 
 
 def test_build_query_params_scopes_to_cluster_moref() -> None:
+    """Pins the exact ``_typeName``-annotated MoRef body (#3103)."""
     body = build_vsan_query_health_params("domain-c123")
-    assert body == {"cluster": {"type": "ClusterComputeResource", "value": "domain-c123"}}
+    assert body == {
+        "cluster": {
+            "_typeName": "ManagedObjectReference",
+            "type": "ClusterComputeResource",
+            "value": "domain-c123",
+        }
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +177,13 @@ async def test_queries_health_summary_for_cluster_mounted() -> None:
     assert len(conn.post_calls) == 1
     path, body = conn.post_calls[0]
     assert path == _VSAN_PATH
-    assert body == {"cluster": {"type": "ClusterComputeResource", "value": "domain-c123"}}
+    assert body == {
+        "cluster": {
+            "_typeName": "ManagedObjectReference",
+            "type": "ClusterComputeResource",
+            "value": "domain-c123",
+        }
+    }
 
     assert out["cluster"] == "domain-c123"
     assert out["overall_health"] == "green"

--- a/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
@@ -110,9 +110,20 @@ def test_build_params_is_single_object_no_traversal() -> None:
     )
     (spec,) = body["specSet"]
     (prop_spec,) = spec["propSet"]
-    assert prop_spec == {"type": "Datastore", "pathSet": ["summary.freeSpace", "summary.capacity"]}
+    assert prop_spec == {
+        "_typeName": "PropertySpec",
+        "type": "Datastore",
+        "pathSet": ["summary.freeSpace", "summary.capacity"],
+    }
     (obj_spec,) = spec["objectSet"]
-    assert obj_spec == {"obj": {"type": "Datastore", "value": "datastore-5"}}
+    assert obj_spec == {
+        "_typeName": "ObjectSpec",
+        "obj": {
+            "_typeName": "ManagedObjectReference",
+            "type": "Datastore",
+            "value": "datastore-5",
+        },
+    }
     # No traversal spec / selectSet anywhere -> cannot walk the inventory.
     assert "selectSet" not in obj_spec
 

--- a/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
@@ -89,18 +89,28 @@ class _FakeConnector:
 
 
 def _recent_task_result(moids: list[str]) -> dict[str, Any]:
+    # ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
     return {
+        "_typeName": "RetrieveResult",
         "objects": [
             {
-                "obj": {"type": "TaskManager", "value": "TaskManager"},
+                "_typeName": "ObjectContent",
+                "obj": {
+                    "_typeName": "ManagedObjectReference",
+                    "type": "TaskManager",
+                    "value": "TaskManager",
+                },
                 "propSet": [
                     {
                         "name": "recentTask",
-                        "val": [{"type": "Task", "value": m} for m in moids],
+                        "val": [
+                            {"_typeName": "ManagedObjectReference", "type": "Task", "value": m}
+                            for m in moids
+                        ],
                     }
                 ],
             }
-        ]
+        ],
     }
 
 
@@ -146,8 +156,12 @@ def test_build_task_info_params_one_objectset_entry_per_task() -> None:
     body = build_task_info_retrieve_params(["task-1", "task-2"])
     (spec,) = body["specSet"]
     (prop_spec,) = spec["propSet"]
-    assert prop_spec == {"type": "Task", "pathSet": ["info"]}
+    assert prop_spec == {"_typeName": "PropertySpec", "type": "Task", "pathSet": ["info"]}
     assert [o["obj"]["value"] for o in spec["objectSet"]] == ["task-1", "task-2"]
+    # The task-poll read is annotated end to end (#3103).
+    assert all(o["_typeName"] == "ObjectSpec" for o in spec["objectSet"])
+    assert all(o["obj"]["_typeName"] == "ManagedObjectReference" for o in spec["objectSet"])
+    assert body["options"] == {"_typeName": "RetrieveOptions"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
@@ -173,7 +173,11 @@ def test_build_retrieve_params_is_single_vm_property_filter() -> None:
     assert "guestHeartbeatStatus" in prop_spec["pathSet"]
     assert "storage.perDatastoreUsage" in prop_spec["pathSet"]
     (obj_spec,) = spec["objectSet"]
-    assert obj_spec["obj"] == {"type": "VirtualMachine", "value": "vm-42"}
+    assert obj_spec["obj"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "VirtualMachine",
+        "value": "vm-42",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -720,6 +720,34 @@ new VM MoRef; disk-grow raises on a fault so the dispatcher wraps it
 *does* propagate — it is a load-bearing failure, not "still running". The
 600 s bound mirrors the `vm.clone` `GET:/cis/tasks/{task}` convention.
 
+**3. `_typeName` annotations on every vim request body (#3103).** VI-JSON's
+wire format requires the `_typeName` discriminator on **every DataObject**
+in a request body — the pinned `vi-json.yaml` derives all data objects from
+`Any`, whose `required` list names `_typeName`, and a live vCenter 8.0.3
+**rejects** un-annotated bodies outright: a controlled differential against
+`POST /sdk/vim25/8.0.3.0/PropertyCollector/propertyCollector/RetrievePropertiesEx`
+returned `500 InvalidArgument` (vim fault `Invalid MoRef field: pathSet`)
+for the bare body and `200 RetrieveResult` for the same body annotated. The
+pre-#3103 substrate tagged only base-typed polymorphic fields (device
+backings, `ClusterConfigSpecEx`); the differential disproved that premise —
+the 8.0.x deserialiser demands the tag even where declared type == runtime
+type. 9.x accepts annotated bodies (it is the spec'd format), so annotation
+is **unconditional** — no version gate. Mechanically: the shared
+`vim_body.py` module carries `vim_moref()` (the annotated MoRef) and
+`retrieve_properties_body()` (the annotated
+`PropertyFilterSpec`/`PropertySpec`/`ObjectSpec` trio + `RetrieveOptions` —
+the shape every property read and task poll sends); every other body keeps
+an **explicit per-builder annotation** at its call site (spec-groundable
+and reviewable — deliberately no recursive type-inference magic). Server
+responses have always carried `_typeName` tags and the extraction helpers
+read fields by name, so response parsing is unchanged; the unit-test canned
+payloads mirror the tagged live shapes to pin that tolerance. The
+annotation *vocabulary* is grounded by a reconcile lane in
+`tests/test_connectors_vmware_rest_composites_write_body_reconcile.py`:
+every `_typeName` literal the substrate emits must name a component schema
+in the pinned `vi-json.yaml` (shelf-gated), and the exact annotated
+single-prop retrieve body is pinned byte-for-byte in an always-on lane.
+
 **`vm.disk.grow` flow** (the proving op): read the VM's
 `config.hardware.device` (a *read* `RetrievePropertiesEx`, un-gated) to
 find the full `VirtualDisk` device (the `VirtualDeviceConfigSpec` requires


### PR DESCRIPTION
## Summary
- Every vim (VI-JSON) request body now carries the `_typeName` discriminator on every DataObject, per the pinned `vi-json.yaml` wire format (`Any.required` names `_typeName`). Live differential evidence (#3103): vCenter 8.0.3 returns `500 InvalidArgument` ("Invalid MoRef field: pathSet") for the un-annotated single-prop retrieve body and `200 RetrieveResult` for the identical body annotated — so every vim-substrate composite and typed read 500'd against real 8.0.x.
- New `vim_body.py` carries the two shared shapes — `vim_moref()` and the annotated `retrieve_properties_body()` trio (`PropertyFilterSpec`/`PropertySpec`/`ObjectSpec` + `RetrieveOptions`) — which all twelve property-read builders and the task-poll read delegate to. Every other body keeps an explicit per-builder annotation (no recursive type inference): `ReconfigVM_Task` specs (nested-HV #3093, disk grow), `CreateVM_Task` ConfigSpec (#3101: `VirtualMachineFileInfo`, `VirtualDeviceConfigSpec` NIC adds, `DistributedVirtualSwitchPortConnection`, pool/host MoRefs), `CloneVM_Task` (clone + relocate specs, placement MoRefs), `ReconfigureDvs_Task` (`DVSConfigSpec` + host member spec), DRS `ClusterRuleSpec` + VM MoRefs, and the vSAN health cluster MoRef.
- Unconditional — 9.x accepts annotated bodies (it is the spec'd format); no version gate. All envelope contracts are byte-identical otherwise.
- Response parsing unchanged (live responses always carried the tags); unit fixtures now mirror the tagged live shapes to pin tolerance. Docs: `connectors-vmware-rest.md` vim section documents the requirement; CHANGELOG bullet added.

## Test plan
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] `mypy src/` (strict, 783 files) — clean except one pre-existing darwin-only artifact in untouched `net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; Linux CI is the gate of record and main is green on identical code)
- [x] Full vmware_rest battery incl. reconcile lanes with the spec shelf wired (`MEHO_CONSUMER_DOCS_ROOT`): 589 passed, 2 skipped (docker-gated vcsim integration)
- [x] Exact annotated bodies pinned byte-for-byte: single-prop retrieve (matches the live-verified 200 shape from #3103), nested-HV `ReconfigVM_Task`, `CreateVM_Task` ConfigSpec incl. NIC deviceChange + MoRefs, task-poll reads, snapshot-revert pre-read, disk grow, DVS detach, clone-from-template, DRS rule (unit + respx wire-level lanes)
- [x] New reconcile lane: every emitted `_typeName` literal names a component schema in the pinned `vi-json.yaml` (shelf-gated); always-on lanes pin the trio shape and the exact single-prop retrieve body
- [x] `test_operations_ingest_openapi.py` — 137 passed (parser untouched, belt-and-suspenders)

## Out of scope (adjacent findings, pre-existing)
- `performance_summary_composite` sends `{"entity": <str>, "interval_seconds": <int>}` where the spec'd `QueryAvailablePerfMetricRequestType.entity` is a MoRef and `QueryPerfRequestType` requires `querySpec: PerfQuerySpec[]` — a wire-shape defect in a different family (wrong arg shapes, not missing tags); needs entity-type resolution design.
- `event_tail_composite` posts `QueryEvents` with no body while `QueryEventsRequestType.filter` (an `EventFilterSpec`) is required.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3103
