### PR TITLE
fix(ui): humanize broadcast drawer labels + format timestamp (#230)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer.html
@@ -59,19 +59,24 @@
     <section aria-label="Operation">
       <h3 class="text-sm font-semibold uppercase opacity-60">Operation</h3>
       <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-        <dt class="opacity-60">operator</dt>
+        <dt class="opacity-60">Operator</dt>
         <dd class="font-mono break-all">{{ row.operator_sub }}</dd>
-        <dt class="opacity-60">method</dt>
+        <dt class="opacity-60">Method</dt>
         <dd>
           <span class="badge badge-outline badge-xs">{{ row.method }}</span>
           <span class="font-mono text-xs break-all">{{ row.path }}</span>
         </dd>
-        <dt class="opacity-60">status</dt>
+        <dt class="opacity-60">Status</dt>
         <dd>{{ row.status_code }}</dd>
-        <dt class="opacity-60">occurred_at</dt>
-        <dd>{{ row.occurred_at.isoformat() }}</dd>
+        <dt class="opacity-60">Occurred</dt>
+        {# Console-standard timestamp: ``%Y-%m-%d %H:%M UTC`` for display,
+           full ISO retained in the ``<time datetime>`` for machines
+           (mirrors ``topology/_drawer.html``). #}
+        <dd>
+          <time datetime="{{ row.occurred_at.isoformat() }}">{{ row.occurred_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>
+        </dd>
         {% if row.duration_ms is not none %}
-          <dt class="opacity-60">duration_ms</dt>
+          <dt class="opacity-60">Duration (ms)</dt>
           <dd>{{ row.duration_ms }}</dd>
         {% endif %}
       </dl>
@@ -81,13 +86,13 @@
     <section aria-label="Identifiers">
       <h3 class="text-sm font-semibold uppercase opacity-60">Identifiers</h3>
       <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-        <dt class="opacity-60">audit_id</dt>
+        <dt class="opacity-60">Audit ID</dt>
         <dd class="font-mono break-all">{{ row.id }}</dd>
-        <dt class="opacity-60">request_id</dt>
+        <dt class="opacity-60">Request ID</dt>
         <dd class="font-mono break-all">
           {% if row.request_id %}{{ row.request_id }}{% else %}<span class="opacity-50">—</span>{% endif %}
         </dd>
-        <dt class="opacity-60">event_id</dt>
+        <dt class="opacity-60">Event ID</dt>
         <dd class="font-mono break-all">
           {% if event_id %}{{ event_id }}{% else %}<span class="opacity-50">—</span>{% endif %}
         </dd>

--- a/backend/tests/test_ui_broadcast_filters.py
+++ b/backend/tests/test_ui_broadcast_filters.py
@@ -536,6 +536,16 @@ def test_drawer_renders_full_detail_for_non_aggregate_op() -> None:
     # Drawer carries the Alpine click-outside dismiss island.
     assert 'id="event-drawer"' in body
     assert "click.outside" in body
+    # #230: detail rows use human-readable labels, not raw machine keys.
+    for label in ("Operator", "Method", "Status", "Occurred", "Audit ID", "Request ID", "Event ID"):
+        assert f">{label}</dt>" in body, f"missing humanized label {label!r}"
+    assert ">occurred_at</dt>" not in body
+    assert ">audit_id</dt>" not in body
+    # #230: occurred_at renders in the console-standard format (machine ISO
+    # in <time datetime>, `%Y-%m-%d %H:%M UTC` for display) — not a bare
+    # isoformat() dump.
+    assert "<time datetime=" in body
+    assert "UTC</time>" in body
 
 
 def test_drawer_strips_internal_payload_keys() -> None:


### PR DESCRIPTION
## Summary
- The broadcast event-detail drawer (`_event_drawer.html`) showed raw snake_case machine keys as detail-row labels (`operator`, `occurred_at`, `audit_id`, `request_id`, `event_id`, …) and rendered `occurred_at` as a bare `.isoformat()` string.
- Humanized every `<dt>` label (Operator / Method / Status / Occurred / Duration (ms) / Audit ID / Request ID / Event ID) and rendered `occurred_at` in the console-standard `%Y-%m-%d %H:%M UTC` display format with the full ISO in a `<time datetime>` attribute — mirroring `topology/_drawer.html`.
- Presentation only — open-on-click, the aggregate-only payload gate, identifiers shown, and the "Suppress this op" cross-link are unchanged.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_broadcast_filters.py` — 24 passed
- [x] **Human labels** — guard asserts each humanized `<dt>` label present and the raw `occurred_at`/`audit_id` keys absent
- [x] **Timestamp** — guard asserts `<time datetime=` + `UTC</time>` (formatted, not a bare isoformat dump)
- [x] **No regression** — drawer open/dismiss, aggregate gate, suppress cross-link covered by the 24 passing tests

## Out of scope
- The overrides *table* timestamp (`_overrides.html`, also raw ISO) — folded into sibling task evoila-bosnia/meho-internal#231 if low-risk.
- Sibling round-6 tasks #229 (filters, PR #3072) and #231 (overrides dialog) under initiative #228.

## Issue
Implements **evoila-bosnia/meho-internal#230** (subtask of initiative **evoila-bosnia/meho-internal#228**). Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#230