### PR TITLE
fix(ui): structure broadcast overrides "New rule" dialog (#231)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/broadcast/_overrides.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_overrides.html
@@ -101,30 +101,30 @@
           class="space-y-3 py-2"
           aria-labelledby="broadcast-override-create-title"
         >
-          <label class="form-control">
-            <span class="label-text">Op id pattern</span>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Op id pattern</span>
             <input
               type="text"
               name="op_id_pattern"
               maxlength="128"
               required
               value="{{ op_id_prefill }}"
-              class="input input-bordered input-sm font-mono"
+              class="input input-bordered input-sm font-mono w-full"
               placeholder="vault.kv.* or k8s.configmap.info"
               aria-describedby="broadcast-override-pattern-hint"
             />
-            <span id="broadcast-override-pattern-hint" class="text-xs opacity-60 mt-1">
+            <span id="broadcast-override-pattern-hint" class="text-xs opacity-60">
               Glob only &mdash; <code>*</code> and literals; no regex
               (<code>[ ] ( ) { } \ + ? | ^ $</code> are rejected).
             </span>
           </label>
 
           <div class="grid gap-3 md:grid-cols-2">
-            <label class="form-control">
-              <span class="label-text">Scope</span>
+            <label class="flex flex-col gap-1">
+              <span class="text-sm font-medium">Scope</span>
               <select
                 name="scope_field"
-                class="select select-bordered select-sm"
+                class="select select-bordered select-sm w-full"
                 data-action="scope-select"
               >
                 <option value="">Op-wide (no scope)</option>
@@ -135,33 +135,33 @@
             </label>
 
             <label
-              class="form-control"
+              class="flex flex-col gap-1"
               data-scope-value-row
               style="display: none;"
             >
-              <span class="label-text">Scope value</span>
+              <span class="text-sm font-medium">Scope value</span>
               <input
                 type="text"
                 name="scope_value"
                 maxlength="128"
-                class="input input-bordered input-sm"
+                class="input input-bordered input-sm w-full"
                 placeholder="e.g. kube-system"
               />
             </label>
           </div>
 
-          <label class="form-control">
-            <span class="label-text">Detail level</span>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Detail level</span>
             <select
               name="detail"
-              class="select select-bordered select-sm"
+              class="select select-bordered select-sm w-full"
               required
             >
               {% for option in detail_options %}
                 <option value="{{ option }}">{{ option }}</option>
               {% endfor %}
             </select>
-            <span class="text-xs opacity-60 mt-1">
+            <span class="text-xs opacity-60">
               <code>aggregate</code> suppresses the op's detail on the feed;
               <code>full</code> pins it to full detail (re-exposing a
               normally-sensitive op).

--- a/backend/tests/test_ui_broadcast_overrides.py
+++ b/backend/tests/test_ui_broadcast_overrides.py
@@ -283,6 +283,14 @@ def test_overrides_tab_tenant_admin_gated() -> None:
     assert "vault.kv.read" in admin_resp.text
     assert 'aria-label="Broadcast suppression rules"' in admin_resp.text
     assert "Overrides require tenant_admin" not in admin_resp.text
+    # #231: the "New rule" create dialog is migrated off dead daisyUI-v4
+    # classes (removed in v5 — zero compiled rules — which collapsed the
+    # label-over-input column), and the scope-value toggle hooks survive.
+    assert "form-control" not in admin_resp.text
+    assert "label-text" not in admin_resp.text
+    assert 'id="broadcast-override-create-form"' in admin_resp.text
+    assert 'data-action="scope-select"' in admin_resp.text
+    assert "data-scope-value-row" in admin_resp.text
 
     # Clear the cached JWKS so the operator client's distinct keypair is
     # re-fetched -- the two clients mint under the same kid, and a stale


### PR DESCRIPTION
## Summary
- The "New rule" create dialog on the Broadcast **Overrides** tab (`_overrides.html`) used daisyUI v4 `form-control` + `label-text` on all four fields (Op id pattern, Scope, Scope value, Detail level), both removed in v5 (zero compiled rules), so the label-over-input column collapsed and the form read cramped.
- Migrated every field to `flex flex-col gap-1` label wrappers, `text-sm font-medium` labels, helper text as `text-xs opacity-60` blocks below, and `w-full` controls. The Scope / Scope-value pair keeps its `grid md:grid-cols-2` layout.
- Presentation only — the create POST, CSRF double-submit, and the scope-value visibility toggle (keys off the untouched `data-action="scope-select"` / `data-scope-value-row` hooks) are unchanged. Clears the **last** dead daisyUI class on the broadcast surface (round 6, #228).

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_broadcast_overrides.py` — 6 passed
- [x] **Aligned dialog** — all 4 fields stack label-over-input via `flex flex-col gap-1`; scope grid preserved
- [x] **No dead classes** — render-guard asserts `form-control`/`label-text` absent from the tenant-admin overrides fragment
- [x] **No functional regression** — create POST, CSRF, and the scope-value toggle (guard asserts `data-action="scope-select"` / `data-scope-value-row` present) covered by the 6 passing tests

## Out of scope
- The overrides *table* timestamp (`_overrides.html`, still raw ISO) — separate follow-up if desired; not part of the "New rule dialog" scope.
- Sibling round-6 tasks #229 (filters, PR #3072) and #230 (drawer, PR #3107) under initiative #228.

## Issue
Implements **evoila-bosnia/meho-internal#231** (subtask of initiative **evoila-bosnia/meho-internal#228**). Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#231