### PR TITLE
fix(connectors): unwrap VI-JSON boxed primitive property values ({_typeName,_value}) at every vim consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,31 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Fixed — VI-JSON bodies carry `_typeName` discriminators throughout the vim substrate (#3103)
+### Fixed — VI-JSON boxed response values un-boxed at every vim property consumer (#3106)
+
+- The response-side twin of #3103: `DynamicProperty.val` is an `Any`
+  placeholder, and live vCenter 8.0.3 VI-JSON **boxes** what lands in one —
+  primitives arrive as `{"_typeName": "string", "_value":
+  "dvportgroup-1766"}` (live-observed) and arrays as
+  `{"_typeName": "ArrayOfX", "_value": [...]}` (every `PrimitiveX` /
+  `ArrayOfX` / enum-box component of the pinned `vi-json.yaml` keys its
+  payload `_value`), while MoRefs / DataObjects arrive as plain annotated
+  dicts. The substrate's extractors read `val` bare, so every
+  primitive-typed vim property read failed its type guard against real
+  8.0.x — observed live as `vm.create`'s DVPG lookup failing
+  `network_lookup` on a 200 that carried both properties. A tolerant
+  recursive un-boxer (`unwrap_vim_value` in `vim_body.py`, beside the
+  request-side #3103 helpers) now runs at **every** vim property consumer:
+  the write-composite extractors (single-prop, device list,
+  `config.template`, DRS rules), the read-composite props flattener, the
+  `Task.info` poll (a boxed `info.state` / fault message / progress still
+  reaches terminal states), and all five typed reads (incl. `tasks.recent`'s
+  boxed `recentTask` MoRef array). Plain (un-boxed) values pass through
+  unchanged — tolerant both ways, so 9.x / vcsim shapes keep working —
+  DataObject `_typeName` tags survive (the disk-grow `VirtualDisk` pick
+  still keys on them), and un-boxing is response-side only (payloads that
+  round-trip into request bodies keep their wire shape). Live-shaped
+  fixtures updated to the boxed forms byte-shaped from the #3106 evidence.
 
 - Every vim (VI-JSON) request body the vmware-rest connector sends now tags
   every DataObject with its `_typeName` discriminator, per the pinned

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -128,7 +128,10 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 from .schemas import DATASTORE_USAGE_MAX_VM_NAMES
 
@@ -340,7 +343,7 @@ def _extract_object_props(retrieve_result: Any) -> dict[str, Any]:
         for entry in obj.get("propSet", []) or []:
             name = entry.get("name") if isinstance(entry, dict) else None
             if isinstance(name, str):
-                props[name] = entry.get("val")
+                props[name] = unwrap_vim_value(entry.get("val"))
     return props
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -99,6 +99,7 @@ from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest.vim_body import (
     VIM_TYPE_NAME_KEY,
     retrieve_properties_body,
+    unwrap_vim_value,
     vim_moref,
 )
 from meho_backplane.connectors.vmware_rest.vim_task import TASK_STATE_ERROR, poll_vim_task
@@ -2277,7 +2278,11 @@ def _build_single_prop_retrieve_params(mo_type: str, moid: str, prop: str) -> di
 
 
 def _extract_single_prop(retrieve_result: Any, prop: str) -> Any:
-    """Pull one property's ``val`` off a single-object RetrievePropertiesEx result."""
+    """Pull one property's ``val`` off a single-object RetrievePropertiesEx result.
+
+    ``val`` is an ``Any`` placeholder, so live VI-JSON boxes primitives and
+    arrays in it -- :func:`unwrap_vim_value` strips the boxes (#3106).
+    """
     payload = _unwrap_value(retrieve_result)
     objects = payload.get("objects", []) if isinstance(payload, dict) else payload
     if not isinstance(objects, list):
@@ -2287,7 +2292,7 @@ def _extract_single_prop(retrieve_result: Any, prop: str) -> Any:
             continue
         for entry in obj.get("propSet", []) or []:
             if isinstance(entry, dict) and entry.get("name") == prop:
-                return entry.get("val")
+                return unwrap_vim_value(entry.get("val"))
     return None
 
 
@@ -3254,7 +3259,12 @@ def _build_vm_devices_retrieve_params(vm_moid: str) -> dict[str, Any]:
 
 
 def _extract_vm_devices(retrieve_result: Any) -> list[Any]:
-    """Pull the ``config.hardware.device`` list off a RetrievePropertiesEx result."""
+    """Pull the ``config.hardware.device`` list off a RetrievePropertiesEx result.
+
+    Live VI-JSON boxes the array-valued ``val`` as ``ArrayOfVirtualDevice``
+    (``{"_typeName": ..., "_value": [...]}``) -- unwrap before the list
+    check, tolerating the bare-list shape too (#3106).
+    """
     payload = _unwrap_value(retrieve_result)
     objects = payload.get("objects", []) if isinstance(payload, dict) else payload
     if not isinstance(objects, list):
@@ -3264,7 +3274,7 @@ def _extract_vm_devices(retrieve_result: Any) -> list[Any]:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and prop.get("name") == _PROP_CONFIG_HARDWARE_DEVICE:
-                val = prop.get("val")
+                val = unwrap_vim_value(prop.get("val"))
                 return val if isinstance(val, list) else []
     return []
 
@@ -3536,7 +3546,7 @@ def _extract_config_template(retrieve_result: Any, vm_moid: str) -> bool | None:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and prop.get("name") == _PROP_CONFIG_TEMPLATE:
-                val = prop.get("val")
+                val = unwrap_vim_value(prop.get("val"))
                 return val if isinstance(val, bool) else None
     return None
 
@@ -3907,7 +3917,8 @@ def _extract_cluster_rule_names(retrieve_result: Any) -> set[str]:
         for prop in obj.get("propSet", []) or []:
             if not isinstance(prop, dict) or prop.get("name") != _PROP_CONFIGURATION_EX_RULE:
                 continue
-            for rule in prop.get("val") or []:
+            rules = unwrap_vim_value(prop.get("val"))
+            for rule in rules if isinstance(rules, list) else []:
                 if isinstance(rule, dict) and isinstance(rule.get("name"), str):
                     names.add(rule["name"])
     return names

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -61,7 +61,10 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -185,7 +188,7 @@ def _extract_host_props(retrieve_result: Any) -> dict[str, Any]:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and isinstance(prop.get("name"), str):
-                prop_by_name[prop["name"]] = prop.get("val")
+                prop_by_name[prop["name"]] = unwrap_vim_value(prop.get("val"))
     return prop_by_name
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
@@ -36,7 +36,10 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -145,7 +148,7 @@ def _extract_host_network_props(retrieve_result: Any) -> tuple[list[Any], list[A
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and isinstance(prop.get("name"), str):
-                prop_by_name[prop["name"]] = prop.get("val")
+                prop_by_name[prop["name"]] = unwrap_vim_value(prop.get("val"))
     pnics = prop_by_name.get(_HOST_NET_PROP_PNIC)
     proxy_switches = prop_by_name.get(_HOST_NET_PROP_PROXYSWITCH)
     return (

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
@@ -41,7 +41,10 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -122,7 +125,7 @@ def _extract_object_content(retrieve_result: Any) -> tuple[dict[str, Any], list[
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and isinstance(prop.get("name"), str):
-                props[prop["name"]] = prop.get("val")
+                props[prop["name"]] = unwrap_vim_value(prop.get("val"))
         for miss in obj.get("missingSet", []) or []:
             if isinstance(miss, dict) and isinstance(miss.get("path"), str):
                 missing.append(miss["path"])

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
@@ -37,7 +37,10 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -117,7 +120,7 @@ def _extract_recent_task_moids(retrieve_result: Any) -> list[str]:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and prop.get("name") == _PROP_RECENT_TASK:
-                raw = prop.get("val")
+                raw = unwrap_vim_value(prop.get("val"))
                 if isinstance(raw, list):
                     return [m for m in (_moref_value(r) for r in raw) if m is not None]
     return []
@@ -163,7 +166,7 @@ def _parse_task_info_results(retrieve_result: Any) -> dict[str, Any]:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and prop.get("name") == _PROP_INFO:
-                info_by_moid[moid] = prop.get("val")
+                info_by_moid[moid] = unwrap_vim_value(prop.get("val"))
     return info_by_moid
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
@@ -49,7 +49,10 @@ import structlog
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
-from meho_backplane.connectors.vmware_rest.vim_body import retrieve_properties_body
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
@@ -132,7 +135,7 @@ def _extract_vm_props(retrieve_result: Any) -> dict[str, Any]:
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and isinstance(prop.get("name"), str):
-                prop_by_name[prop["name"]] = prop.get("val")
+                prop_by_name[prop["name"]] = unwrap_vim_value(prop.get("val"))
     return prop_by_name
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/vim_body.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/vim_body.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Shared ``_typeName``-annotated vim (VI-JSON) request-body pieces (#3103).
+"""Shared vim (VI-JSON) wire-format helpers: request bodies (#3103) + response unwrap (#3106).
 
 VI-JSON's wire format requires the ``_typeName`` discriminator on every
 DataObject in a request body: the pinned ``vi-json.yaml`` derives all
@@ -19,13 +19,29 @@ that premise -- the 8.0.x deserialiser demands the tag even where the
 declared type equals the runtime type. 9.x accepts annotated bodies (it
 is the spec'd format), so annotation is unconditional -- no version gate.
 
-This module carries the two shapes shared across the substrate: the
-annotated :func:`vim_moref` and the annotated single-filter
+This module carries the two request shapes shared across the substrate:
+the annotated :func:`vim_moref` and the annotated single-filter
 ``RetrievePropertiesEx`` body (:func:`retrieve_properties_body` -- the
 ``PropertyFilterSpec`` / ``PropertySpec`` / ``ObjectSpec`` trio plus
 ``RetrieveOptions``). Everything else stays an explicit per-builder
 annotation at its call site (spec-groundable and reviewable); there is
 deliberately no recursive type-inference magic here.
+
+It also carries the **response-side twin** (#3106):
+:func:`unwrap_vim_value`, the tolerant un-boxer every vim property
+consumer funnels ``DynamicProperty.val`` (and ``TaskInfo``) reads
+through. ``DynamicProperty.val`` is ``Any``-typed in the pinned
+``vi-json.yaml``, and VI-JSON **boxes** values in ``Any`` placeholders:
+a primitive arrives as ``{"_typeName": "string", "_value":
+"dvportgroup-1766"}`` (live-observed on vCenter 8.0.3, #3106) and an
+array as ``{"_typeName": "ArrayOfString", "_value": [...]}`` (every
+``PrimitiveX`` / ``ArrayOfX`` component in the spec keys its payload
+``_value``), while MoRefs / DataObjects arrive as plain
+``_typeName``-annotated dicts -- no box. The pre-#3106 extractors read
+``val`` as the bare value, so every primitive-typed property read
+failed its type guard against live 8.0.x (proven: ``vm.create``'s DVPG
+``key`` lookup returned 200 with the data present yet failed
+``network_lookup``).
 """
 
 from __future__ import annotations
@@ -38,13 +54,25 @@ if TYPE_CHECKING:
 __all__ = [
     "MOREF_TYPE_NAME",
     "VIM_TYPE_NAME_KEY",
+    "VIM_VALUE_KEY",
     "retrieve_properties_body",
+    "unwrap_vim_value",
     "vim_moref",
 ]
 
 #: The VI-JSON polymorphic-type discriminator key (``Any._typeName`` in
 #: the pinned ``vi-json.yaml``; required on every DataObject).
 VIM_TYPE_NAME_KEY: Final[str] = "_typeName"
+
+#: The VI-JSON boxed-value payload key. Every ``PrimitiveX`` /
+#: ``ArrayOfX`` component in the pinned ``vi-json.yaml`` -- the boxes
+#: VI-JSON puts around primitives and arrays in ``Any`` placeholders
+#: such as ``DynamicProperty.val`` -- names ``_value`` in ``required``.
+VIM_VALUE_KEY: Final[str] = "_value"
+
+#: ``_typeName`` prefix of the boxed-array components (``ArrayOfString``,
+#: ``ArrayOfManagedObjectReference``, ``ArrayOfVirtualDevice``, ...).
+_ARRAY_OF_PREFIX: Final[str] = "ArrayOf"
 
 #: ``_typeName`` of a vim managed-object reference.
 MOREF_TYPE_NAME: Final[str] = "ManagedObjectReference"
@@ -104,3 +132,48 @@ def retrieve_properties_body(
         ],
         "options": {VIM_TYPE_NAME_KEY: _RETRIEVE_OPTIONS_TYPE},
     }
+
+
+def unwrap_vim_value(value: Any) -> Any:
+    """Recursively un-box VI-JSON ``Any``-placeholder values; plain values pass through.
+
+    VI-JSON boxes what lands in an ``Any`` placeholder (``DynamicProperty.val``,
+    ``TaskInfo.result``, ``ArrayOfAnyType`` elements):
+
+    * a primitive as ``{"_typeName": "string", "_value": "dvportgroup-1766"}``
+      (live-observed 8.0.3 shape, #3106; the ``PrimitiveBoolean`` / ``PrimitiveInt``
+      / ... components of the pinned ``vi-json.yaml``),
+    * an array as ``{"_typeName": "ArrayOfString", "_value": [...]}`` (every
+      ``ArrayOfX`` component keys its payload ``_value`` too),
+
+    while MoRefs and DataObjects arrive as plain ``_typeName``-annotated dicts.
+    This helper strips the boxes and **only** the boxes -- ``_typeName`` tags on
+    DataObjects survive (consumers key on them, e.g. the disk-grow
+    ``VirtualDisk`` guard), and already-bare values return unchanged, so it is
+    tolerant both ways (9.x / vcsim payloads that arrive un-boxed keep working).
+    The walk recurses through nested containers so boxes in nested ``Any``
+    positions (a ``TaskInfo.result`` primitive, ``ArrayOfAnyType`` elements)
+    normalise in the same pass.
+
+    A SOAP-flavoured boxed array that keys its payload by element type instead
+    (``{"_typeName": "ArrayOfString", "string": [...]}`` -- the shape #3106's
+    report cites) is tolerated as well: any ``ArrayOf*``-tagged dict whose
+    single payload key holds a list unwraps to that list.
+
+    Apply this at **response consumption** only -- never on a payload that
+    round-trips into a request body (e.g. the resolved ``CustomizationSpec``
+    a clone embeds), where a stripped box would corrupt an ``Any``-typed
+    request field.
+    """
+    if isinstance(value, dict):
+        if VIM_VALUE_KEY in value:
+            return unwrap_vim_value(value[VIM_VALUE_KEY])
+        type_name = value.get(VIM_TYPE_NAME_KEY)
+        if isinstance(type_name, str) and type_name.startswith(_ARRAY_OF_PREFIX):
+            payload = [v for k, v in value.items() if k != VIM_TYPE_NAME_KEY]
+            if len(payload) == 1 and isinstance(payload[0], list):
+                return unwrap_vim_value(payload[0])
+        return {key: unwrap_vim_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [unwrap_vim_value(item) for item in value]
+    return value

--- a/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
@@ -59,6 +59,7 @@ from meho_backplane.connectors.vmware_rest.typed_ops import _unwrap_value
 from meho_backplane.connectors.vmware_rest.typed_ops_tasks_recent import (
     build_task_info_retrieve_params,
 )
+from meho_backplane.connectors.vmware_rest.vim_body import unwrap_vim_value
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -161,6 +162,12 @@ def _extract_task_info(retrieve_result: Any, task_moid: str) -> dict[str, Any] |
     back to the first object's ``info`` (single-object query). Returns
     ``None`` when the property is absent -- the caller treats that as "not
     terminal yet", never an exception.
+
+    The ``val`` sits in an ``Any`` placeholder, so it funnels through
+    :func:`unwrap_vim_value` (#3106): a boxed ``info.state`` /
+    ``error.localizedMessage`` / ``progress`` / ``result`` primitive
+    normalises to its bare value here, which is what makes the downstream
+    terminal-state, fault-message, and progress reads box-tolerant.
     """
     payload = _unwrap_value(retrieve_result)
     objects = payload.get("objects", []) if isinstance(payload, dict) else payload
@@ -174,7 +181,7 @@ def _extract_task_info(retrieve_result: Any, task_moid: str) -> dict[str, Any] |
             continue
         for prop in obj.get("propSet", []) or []:
             if isinstance(prop, dict) and prop.get("name") == _PROP_INFO:
-                val = prop.get("val")
+                val = unwrap_vim_value(prop.get("val"))
                 return val if isinstance(val, dict) else None
     return None
 

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -275,13 +275,23 @@ async def test_cluster_drs_recommendations_reads_summary_then_vim_drs_config() -
 
 @pytest.mark.asyncio
 async def test_cluster_drs_recommendations_history_flag_widens_read_and_surfaces_recs() -> None:
-    """``include_recommendations_history=True`` reads ``drsRecommendation`` too."""
+    """``include_recommendations_history=True`` reads ``drsRecommendation`` too.
+
+    The array-valued ``drsRecommendation`` arrives **boxed** on live
+    VI-JSON (#3106); the composite surfaces the un-boxed rows.
+    """
     recs = [{"key": "1", "rating": 5, "migrationList": []}]
     conn = _RecordingConnector(
         {
             "/api/vcenter/cluster/domain-c123": {"name": "Cluster-A"},
             _RETRIEVE_PROPERTIES_PATH: _retrieve_result(
-                {"configurationEx.drsConfig": {"enabled": True}, "drsRecommendation": recs}
+                {
+                    "configurationEx.drsConfig": {"enabled": True},
+                    "drsRecommendation": {
+                        "_typeName": "ArrayOfClusterDrsRecommendation",
+                        "_value": recs,
+                    },
+                }
             ),
         }
     )

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -917,19 +917,40 @@ async def test_vm_create_nested_hv_false_skips_leg_and_echoes_false(
 # nested_hv folded into the one ConfigSpec. 9.0+/unresolved stay on the
 # REST arm byte-identical (the tests above run with about_version=None).
 
+# Byte-shaped from the live vCenter 8.0.3 evidence on #3106: the
+# primitive-typed ``key`` arrives **boxed** (``{"_typeName": "string",
+# "_value": ...}`` -- ``DynamicProperty.val`` is an ``Any`` placeholder)
+# while the MoRef arrives as a plain ``_typeName``-annotated dict. The
+# pre-#3106 extractor read the box as the value and failed the DVPG
+# ``network_lookup`` despite a 200 carrying both properties.
 _DVPG_BACKING_PROPS: dict[str, Any] = {
+    "_typeName": "RetrieveResult",
     "objects": [
         {
-            "obj": {"type": "DistributedVirtualPortgroup", "value": "dvportgroup-1015"},
+            "_typeName": "ObjectContent",
+            "obj": {
+                "_typeName": "ManagedObjectReference",
+                "type": "DistributedVirtualPortgroup",
+                "value": "dvportgroup-1015",
+            },
             "propSet": [
-                {"name": "key", "val": "dvportgroup-1015"},
                 {
+                    "_typeName": "DynamicProperty",
+                    "name": "key",
+                    "val": {"_typeName": "string", "_value": "dvportgroup-1015"},
+                },
+                {
+                    "_typeName": "DynamicProperty",
                     "name": "config.distributedVirtualSwitch",
-                    "val": {"type": "VmwareDistributedVirtualSwitch", "value": "dvs-21"},
+                    "val": {
+                        "_typeName": "ManagedObjectReference",
+                        "type": "VmwareDistributedVirtualSwitch",
+                        "value": "dvs-21",
+                    },
                 },
             ],
         }
-    ]
+    ],
 }
 
 _DVS_UUID = "50 1e ab cd 12 34 56 78-90 ab cd ef 12 34 56 78"
@@ -960,8 +981,13 @@ async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
         },
         vmomi={
             "DistributedVirtualPortgroup": _DVPG_BACKING_PROPS,
+            # The switch ``uuid`` is a primitive read too -- boxed on live
+            # 8.0.3 (#3106).
             "VmwareDistributedVirtualSwitch": _retrieve_result(
-                "VmwareDistributedVirtualSwitch", "dvs-21", "uuid", _DVS_UUID
+                "VmwareDistributedVirtualSwitch",
+                "dvs-21",
+                "uuid",
+                {"_typeName": "string", "_value": _DVS_UUID},
             ),
             "/Folder/folder-7/CreateVM_Task": _task_moref("task-501"),
             "Task": _task_info_result(
@@ -2136,22 +2162,31 @@ async def test_vm_snapshot_revert_not_found(gate: _GateRecorder) -> None:
 
 
 def _drs_recommendation_vmomi(vm_moid: str, destination: str) -> dict[str, Any]:
-    """Canned ``ClusterComputeResource.drsRecommendation`` property read."""
+    """Canned ``ClusterComputeResource.drsRecommendation`` property read.
+
+    Array-valued ``Any`` placeholder -- live VI-JSON boxes it as
+    ``ArrayOfClusterDrsRecommendation`` with the rows under ``_value``
+    (#3106).
+    """
     return _retrieve_result(
         "ClusterComputeResource",
         "cluster-7",
         "drsRecommendation",
-        [
-            {
-                "key": "1",
-                "migrationList": [
-                    {
-                        "vm": {"type": "VirtualMachine", "value": vm_moid},
-                        "destination": {"type": "HostSystem", "value": destination},
-                    }
-                ],
-            }
-        ],
+        {
+            "_typeName": "ArrayOfClusterDrsRecommendation",
+            "_value": [
+                {
+                    "_typeName": "ClusterDrsRecommendation",
+                    "key": "1",
+                    "migrationList": [
+                        {
+                            "vm": {"type": "VirtualMachine", "value": vm_moid},
+                            "destination": {"type": "HostSystem", "value": destination},
+                        }
+                    ],
+                }
+            ],
+        },
     )
 
 
@@ -2938,11 +2973,13 @@ class _DiskGrowConnector:
             return {"type": "Task", "value": self.reconfig_task}
         spec_type = json["specSet"][0]["propSet"][0]["type"]
         if spec_type == "VirtualMachine":
+            # Live VI-JSON boxes the array-valued ``val`` (#3106).
+            boxed_devices = {"_typeName": "ArrayOfVirtualDevice", "_value": self.devices}
             return {
                 "objects": [
                     {
                         "obj": {"type": "VirtualMachine", "value": "vm-1"},
-                        "propSet": [{"name": "config.hardware.device", "val": self.devices}],
+                        "propSet": [{"name": "config.hardware.device", "val": boxed_devices}],
                     }
                 ]
             }
@@ -3178,7 +3215,13 @@ async def test_vm_disk_grow_reconfig_body_reaches_the_wire_respx(
         "objects": [
             {
                 "obj": {"type": "VirtualMachine", "value": "vm-1"},
-                "propSet": [{"name": "config.hardware.device", "val": [device]}],
+                "propSet": [
+                    {
+                        "name": "config.hardware.device",
+                        # Boxed array -- the live 8.0.3 ``Any``-placeholder shape (#3106).
+                        "val": {"_typeName": "ArrayOfVirtualDevice", "_value": [device]},
+                    }
+                ],
             }
         ]
     }
@@ -3317,11 +3360,13 @@ class _CloneFromTemplateConnector:
         spec_type = json["specSet"][0]["propSet"][0]["type"]
         if spec_type == "VirtualMachine":
             moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+            # Live VI-JSON boxes the primitive ``config.template`` (#3106).
+            boxed_template = {"_typeName": "boolean", "_value": self.is_template}
             return {
                 "objects": [
                     {
                         "obj": {"type": "VirtualMachine", "value": moid},
-                        "propSet": [{"name": "config.template", "val": self.is_template}],
+                        "propSet": [{"name": "config.template", "val": boxed_template}],
                     }
                 ]
             }
@@ -3779,11 +3824,13 @@ class _DrsRuleConnector:
             return {"type": "Task", "value": self.reconfig_task}
         spec_type = json["specSet"][0]["propSet"][0]["type"]
         if spec_type == "ClusterComputeResource":
+            # Live VI-JSON boxes the array-valued rules read (#3106).
+            boxed_rules = {"_typeName": "ArrayOfClusterRuleInfo", "_value": self.existing_rules}
             return {
                 "objects": [
                     {
                         "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
-                        "propSet": [{"name": "configurationEx.rule", "val": self.existing_rules}],
+                        "propSet": [{"name": "configurationEx.rule", "val": boxed_rules}],
                     }
                 ]
             }

--- a/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
@@ -137,14 +137,24 @@ class _FakeConnector:
 
 
 def _retrieve_result(moid: str, pnics: list[Any], proxy_switches: list[Any]) -> dict[str, Any]:
-    """Build a RetrievePropertiesEx ``RetrieveResult`` for one host."""
+    """Build a RetrievePropertiesEx ``RetrieveResult`` for one host.
+
+    The array-valued ``Any`` placeholders arrive **boxed** (``ArrayOfX``
+    with the rows under ``_value``) on live VI-JSON (#3106).
+    """
     return {
         "objects": [
             {
                 "obj": {"type": "HostSystem", "value": moid},
                 "propSet": [
-                    {"name": "config.network.pnic", "val": pnics},
-                    {"name": "config.network.proxySwitch", "val": proxy_switches},
+                    {
+                        "name": "config.network.pnic",
+                        "val": {"_typeName": "ArrayOfPhysicalNic", "_value": pnics},
+                    },
+                    {
+                        "name": "config.network.proxySwitch",
+                        "val": {"_typeName": "ArrayOfHostProxySwitch", "_value": proxy_switches},
+                    },
                 ],
             }
         ]

--- a/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
@@ -139,7 +139,13 @@ def _retrieve_result(moid: str, quick_stats: Any, hardware: Any, in_maint: Any) 
     """Build a RetrievePropertiesEx ``RetrieveResult`` for one host.
 
     ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
+    The primitive ``runtime.inMaintenanceMode`` bool arrives **boxed**
+    (``{"_typeName": "boolean", "_value": ...}``) on live 8.0.x (#3106);
+    non-bool sentinels (``None`` -- prop absent / unreadable) stay bare.
     """
+    boxed_maint = (
+        {"_typeName": "boolean", "_value": in_maint} if isinstance(in_maint, bool) else in_maint
+    )
     return {
         "_typeName": "RetrieveResult",
         "objects": [
@@ -153,7 +159,7 @@ def _retrieve_result(moid: str, quick_stats: Any, hardware: Any, in_maint: Any) 
                 "propSet": [
                     {"name": "summary.quickStats", "val": quick_stats},
                     {"name": "summary.hardware", "val": hardware},
-                    {"name": "runtime.inMaintenanceMode", "val": in_maint},
+                    {"name": "runtime.inMaintenanceMode", "val": boxed_maint},
                 ],
             }
         ],

--- a/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
@@ -135,11 +135,15 @@ def test_build_params_is_single_object_no_traversal() -> None:
 
 @pytest.mark.asyncio
 async def test_object_collect_reads_datastore_properties() -> None:
+    """Boxed primitive vals (#3106): live VI-JSON boxes ``Any``-placeholder longs."""
     conn = _FakeConnector(
         props_result=_object_content(
             "Datastore",
             "datastore-5",
-            {"summary.freeSpace": 1073741824, "summary.capacity": 5368709120},
+            {
+                "summary.freeSpace": {"_typeName": "long", "_value": 1073741824},
+                "summary.capacity": {"_typeName": "long", "_value": 5368709120},
+            },
             [],
         )
     )

--- a/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
@@ -89,7 +89,9 @@ class _FakeConnector:
 
 
 def _recent_task_result(moids: list[str]) -> dict[str, Any]:
-    # ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance).
+    # ``_typeName``-tagged like a live VI-JSON response (#3103 tolerance);
+    # the array-valued ``Any`` placeholder arrives **boxed** as
+    # ``ArrayOfManagedObjectReference`` on live 8.0.x (#3106).
     return {
         "_typeName": "RetrieveResult",
         "objects": [
@@ -103,10 +105,13 @@ def _recent_task_result(moids: list[str]) -> dict[str, Any]:
                 "propSet": [
                     {
                         "name": "recentTask",
-                        "val": [
-                            {"_typeName": "ManagedObjectReference", "type": "Task", "value": m}
-                            for m in moids
-                        ],
+                        "val": {
+                            "_typeName": "ArrayOfManagedObjectReference",
+                            "_value": [
+                                {"_typeName": "ManagedObjectReference", "type": "Task", "value": m}
+                                for m in moids
+                            ],
+                        },
                     }
                 ],
             }

--- a/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
@@ -139,21 +139,29 @@ def _vm_retrieve_result(moid: str, props: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# Live-shaped (#3106): ``DynamicProperty.val`` is an ``Any`` placeholder,
+# so primitives / enums arrive **boxed** (``{"_typeName": ..., "_value":
+# ...}``) and arrays boxed as ``ArrayOfX`` -- the sibling by-name tests
+# keep bare vals to pin the tolerant both-ways contract.
 _POWERED_ON_NO_IP = {
-    "name": "hung-appliance",
-    "runtime.powerState": "poweredOn",
-    "guestHeartbeatStatus": "red",
-    "guest.toolsStatus": "toolsOk",
-    "guest.toolsRunningStatus": "guestToolsRunning",
+    "name": {"_typeName": "string", "_value": "hung-appliance"},
+    "runtime.powerState": {"_typeName": "VirtualMachinePowerState", "_value": "poweredOn"},
+    "guestHeartbeatStatus": {"_typeName": "ManagedEntityStatus", "_value": "red"},
+    "guest.toolsStatus": {"_typeName": "VirtualMachineToolsStatus", "_value": "toolsOk"},
+    "guest.toolsRunningStatus": {"_typeName": "string", "_value": "guestToolsRunning"},
     # guest.ipAddress + guest.hostName deliberately absent -> the hung tell.
-    "storage.perDatastoreUsage": [
-        {
-            "datastore": {"type": "Datastore", "value": "datastore-9"},
-            "committed": 42949672960,
-            "uncommitted": 10737418240,
-            "unshared": 42949672960,
-        }
-    ],
+    "storage.perDatastoreUsage": {
+        "_typeName": "ArrayOfVirtualMachineUsageOnDatastore",
+        "_value": [
+            {
+                "_typeName": "VirtualMachineUsageOnDatastore",
+                "datastore": {"type": "Datastore", "value": "datastore-9"},
+                "committed": 42949672960,
+                "uncommitted": 10737418240,
+                "unshared": 42949672960,
+            }
+        ],
+    },
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_vim_body.py
+++ b/backend/tests/test_connectors_vmware_rest_vim_body.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the VI-JSON response un-boxer ``unwrap_vim_value`` (#3106).
+
+VI-JSON boxes what lands in an ``Any`` placeholder (``DynamicProperty.val``,
+``TaskInfo.result``): a primitive arrives as ``{"_typeName": "string",
+"_value": "dvportgroup-1766"}`` (live-observed on vCenter 8.0.3) and an
+array as ``{"_typeName": "ArrayOfString", "_value": [...]}`` -- every
+``PrimitiveX`` / ``ArrayOfX`` component of the pinned ``vi-json.yaml`` keys
+its payload ``_value`` -- while MoRefs / DataObjects arrive as plain
+``_typeName``-annotated dicts. These tests pin the un-boxer's contract:
+
+* primitive boxes (string / int / bool) unwrap to the bare value;
+* ``ArrayOf*`` boxes unwrap to the bare list -- both the spec'd
+  ``_value``-keyed form and the SOAP-flavoured element-keyed variant;
+* plain values, MoRefs, and annotated DataObjects pass through unchanged
+  (tolerant both ways -- un-boxed 9.x / vcsim payloads keep working);
+* the walk recurses so boxes in nested ``Any`` positions normalise too.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.vmware_rest.vim_body import unwrap_vim_value
+
+# ---------------------------------------------------------------------------
+# Primitive boxes (the live 8.0.3 evidence shapes, #3106)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("boxed", "expected"),
+    [
+        # The byte-shaped live evidence from #3106: vm.create's DVPG key read.
+        ({"_typeName": "string", "_value": "dvportgroup-1766"}, "dvportgroup-1766"),
+        ({"_typeName": "int", "_value": 42}, 42),
+        ({"_typeName": "long", "_value": 17179869184}, 17179869184),
+        ({"_typeName": "boolean", "_value": True}, True),
+        ({"_typeName": "boolean", "_value": False}, False),
+    ],
+)
+def test_primitive_boxes_unwrap_to_bare_values(boxed: dict[str, Any], expected: Any) -> None:
+    assert unwrap_vim_value(boxed) == expected
+
+
+def test_boxed_none_value_unwraps_to_none() -> None:
+    assert unwrap_vim_value({"_typeName": "boolean", "_value": None}) is None
+
+
+# ---------------------------------------------------------------------------
+# ArrayOf* boxes
+# ---------------------------------------------------------------------------
+
+
+def test_array_box_value_keyed_unwraps_to_list() -> None:
+    """The pinned-spec shape: every ``ArrayOfX`` keys its payload ``_value``."""
+    assert unwrap_vim_value({"_typeName": "ArrayOfString", "_value": ["a", "b"]}) == ["a", "b"]
+
+
+def test_array_box_element_keyed_variant_unwraps_to_list() -> None:
+    """The SOAP-flavoured element-keyed variant the #3106 report cites is tolerated."""
+    assert unwrap_vim_value({"_typeName": "ArrayOfString", "string": ["a", "b"]}) == ["a", "b"]
+
+
+def test_array_box_of_dataobjects_unwraps_and_keeps_element_tags() -> None:
+    """``ArrayOfVirtualDevice`` unwraps to the device list; element ``_typeName`` survives.
+
+    The disk-grow handler keys the ``VirtualDisk`` pick on the element's
+    ``_typeName`` tag, so the un-boxer must strip only the box.
+    """
+    disk = {"_typeName": "VirtualDisk", "key": 2000, "capacityInBytes": 10737418240}
+    boxed = {"_typeName": "ArrayOfVirtualDevice", "_value": [disk]}
+    assert unwrap_vim_value(boxed) == [disk]
+
+
+def test_array_box_of_morefs_unwraps_to_plain_moref_list() -> None:
+    """``TaskManager.recentTask`` arrives as a boxed MoRef array on live 8.0.x."""
+    morefs = [
+        {"_typeName": "ManagedObjectReference", "type": "Task", "value": "task-1"},
+        {"_typeName": "ManagedObjectReference", "type": "Task", "value": "task-2"},
+    ]
+    assert unwrap_vim_value({"_typeName": "ArrayOfManagedObjectReference", "_value": morefs}) == (
+        morefs
+    )
+
+
+def test_array_of_anytype_elements_unbox_individually() -> None:
+    """``ArrayOfAnyType`` elements are ``Any`` themselves -- nested boxes normalise."""
+    boxed = {
+        "_typeName": "ArrayOfAnyType",
+        "_value": ["bare", {"_typeName": "string", "_value": "boxed"}],
+    }
+    assert unwrap_vim_value(boxed) == ["bare", "boxed"]
+
+
+# ---------------------------------------------------------------------------
+# Plain values pass through (tolerant both ways)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plain",
+    [
+        "dvportgroup-1766",
+        42,
+        True,
+        None,
+        ["a", "b"],
+        {},
+        {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-9"},
+        {"type": "VirtualMachine", "value": "vm-9"},  # un-annotated MoRef (vcsim)
+    ],
+)
+def test_plain_values_pass_through_unchanged(plain: Any) -> None:
+    assert unwrap_vim_value(plain) == plain
+
+
+def test_annotated_dataobject_keeps_its_type_tag_and_fields() -> None:
+    """A DataObject is not a box -- ``_typeName`` and every field survive."""
+    snapshot_info = {
+        "_typeName": "VirtualMachineSnapshotInfo",
+        "rootSnapshotList": [
+            {
+                "_typeName": "VirtualMachineSnapshotTree",
+                "name": "pre-upgrade",
+                "snapshot": {
+                    "_typeName": "ManagedObjectReference",
+                    "type": "VirtualMachineSnapshot",
+                    "value": "snapshot-5",
+                },
+                "childSnapshotList": [],
+            }
+        ],
+    }
+    assert unwrap_vim_value(snapshot_info) == snapshot_info
+
+
+# ---------------------------------------------------------------------------
+# Recursion through nested Any positions
+# ---------------------------------------------------------------------------
+
+
+def test_nested_boxes_inside_a_dataobject_normalise_in_one_pass() -> None:
+    """A ``TaskInfo`` with boxed ``state`` / ``progress`` and a plain MoRef result."""
+    moref = {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-88"}
+    info = {
+        "_typeName": "TaskInfo",
+        "state": {"_typeName": "string", "_value": "success"},
+        "progress": {"_typeName": "int", "_value": 100},
+        "result": moref,
+    }
+    assert unwrap_vim_value(info) == {
+        "_typeName": "TaskInfo",
+        "state": "success",
+        "progress": 100,
+        "result": moref,
+    }

--- a/backend/tests/test_connectors_vmware_rest_vim_task.py
+++ b/backend/tests/test_connectors_vmware_rest_vim_task.py
@@ -38,12 +38,17 @@ _RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrieveProper
 def _task_info_result(
     task_moid: str,
     *,
-    state: str,
+    state: Any,
     result: Any = None,
-    error_message: str | None = None,
-    progress: int | None = None,
+    error_message: Any = None,
+    progress: Any = None,
 ) -> dict[str, Any]:
-    """Build a single-Task ``RetrievePropertiesEx`` result carrying one ``TaskInfo``."""
+    """Build a single-Task ``RetrievePropertiesEx`` result carrying one ``TaskInfo``.
+
+    Fields are ``Any``-typed so tests can seed either the bare primitives
+    or the boxed ``{"_typeName": ..., "_value": ...}`` forms live VI-JSON
+    puts in ``Any`` placeholders (#3106).
+    """
     info: dict[str, Any] = {"state": state}
     if result is not None:
         info["result"] = result
@@ -167,6 +172,72 @@ async def test_poll_returns_error_with_localized_message() -> None:
     assert outcome.state == TASK_STATE_ERROR
     assert outcome.succeeded is False
     assert outcome.error_message == "The disk cannot be shrunk."
+    assert outcome.result is None
+
+
+async def test_poll_reaches_terminal_states_on_boxed_task_info_fields() -> None:
+    """Boxed ``TaskInfo`` primitives (#3106) unbox: wrapped ``info.state`` terminates the poll.
+
+    VI-JSON boxes primitives in ``Any`` placeholders (live 8.0.3, #3106);
+    the tolerant unwrap must normalise a boxed ``state`` / ``progress`` /
+    ``result`` so the poll recognises terminal states instead of spinning
+    to timeout, while an un-boxed MoRef ``result`` passes through intact.
+    """
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state={"_typeName": "string", "_value": "running"},
+                progress={"_typeName": "int", "_value": 40},
+            ),
+            _task_info_result(
+                "task-1",
+                state={"_typeName": "string", "_value": "success"},
+                result={
+                    "_typeName": "ManagedObjectReference",
+                    "type": "VirtualMachine",
+                    "value": "vm-9",
+                },
+            ),
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_SUCCESS
+    assert outcome.succeeded is True
+    assert outcome.result == {
+        "_typeName": "ManagedObjectReference",
+        "type": "VirtualMachine",
+        "value": "vm-9",
+    }
+    assert len(conn.calls) == 2
+
+
+async def test_poll_surfaces_fault_from_boxed_error_state_and_message() -> None:
+    """A boxed ``error`` state + boxed ``localizedMessage`` surface the fault (#3106)."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state={"_typeName": "string", "_value": "error"},
+                error_message={"_typeName": "string", "_value": "Boxed boom."},
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message == "Boxed boom."
     assert outcome.result is None
 
 

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -740,13 +740,44 @@ the shape every property read and task poll sends); every other body keeps
 an **explicit per-builder annotation** at its call site (spec-groundable
 and reviewable — deliberately no recursive type-inference magic). Server
 responses have always carried `_typeName` tags and the extraction helpers
-read fields by name, so response parsing is unchanged; the unit-test canned
+read fields by name; the unit-test canned
 payloads mirror the tagged live shapes to pin that tolerance. The
 annotation *vocabulary* is grounded by a reconcile lane in
 `tests/test_connectors_vmware_rest_composites_write_body_reconcile.py`:
 every `_typeName` literal the substrate emits must name a component schema
 in the pinned `vi-json.yaml` (shelf-gated), and the exact annotated
 single-prop retrieve body is pinned byte-for-byte in an always-on lane.
+
+**4. Boxed response values un-boxed at every vim property consumer
+(#3106).** The response-side twin of #3103: `DynamicProperty.val` (what
+every `RetrievePropertiesEx` propSet entry carries) is an **`Any`
+placeholder**, and VI-JSON *boxes* what lands in one — a primitive
+arrives as `{"_typeName": "string", "_value": "dvportgroup-1766"}`
+(live-observed on vCenter 8.0.3; the `PrimitiveBoolean` / `PrimitiveInt`
+/ enum-box components of the pinned `vi-json.yaml`, every one keying its
+payload `_value`) and an array as `{"_typeName": "ArrayOfString",
+"_value": [...]}` (`ArrayOfVirtualDevice`,
+`ArrayOfManagedObjectReference`, ... — same `_value` key), while MoRefs
+and DataObjects arrive as plain `_typeName`-annotated dicts, no box. The
+pre-#3106 extractors read `val` as the bare value, so every
+primitive-typed property read failed its type guard against live 8.0.x —
+observed as `vm.create`'s DVPG lookup failing `network_lookup` on a 200
+that carried both properties (the boxed `key` next to the plain MoRef).
+Mechanically: `vim_body.py` carries `unwrap_vim_value()`, a tolerant
+recursive un-boxer (strips `_value` boxes and `ArrayOf*` wrappers —
+including the SOAP-flavoured element-keyed variant — passes plain values
+through unchanged, keeps DataObject `_typeName` tags, and normalises
+nested `Any` positions like `TaskInfo.result` in the same pass), and
+**every** propSet consumer funnels `val` through it: the `_write.py`
+extractors (single-prop, `config.hardware.device`, `config.template`,
+`configurationEx.rule`), `_read.py`'s `_extract_object_props`,
+`vim_task.py`'s `Task.info` extraction (a boxed `info.state` /
+`error.localizedMessage` / `progress` still reaches terminal states), and
+the typed reads (`host.usage`, `vm.info`, `host.network_uplinks`,
+`object.collect`, `tasks.recent` — whose `recentTask` is a boxed MoRef
+array on live 8.0.x). Un-boxing happens at **response consumption only**
+— never on payloads that round-trip into request bodies (the resolved
+`CustomizationSpec` a clone embeds must keep its wire shape).
 
 **`vm.disk.grow` flow** (the proving op): read the VM's
 `config.hardware.device` (a *read* `RetrievePropertiesEx`, un-gated) to


### PR DESCRIPTION
## Summary

- **Response-side twin of #3103/#3105.** `DynamicProperty.val` is an `Any` placeholder, and live vCenter 8.0.3 VI-JSON **boxes** what lands in one: primitives arrive as `{"_typeName": "string", "_value": "dvportgroup-1766"}` (live evidence on #3106) and arrays as `{"_typeName": "ArrayOfX", "_value": [...]}` — spec-grounded against the pinned `vi-json.yaml`, whose every `PrimitiveX` / `ArrayOfX` / enum-box component names `_value` in `required` — while MoRefs / DataObjects arrive as plain annotated dicts. The substrate's extractors read `val` bare, so every primitive-typed vim property read failed its type guard on real 8.0.x (observed live: `vm.create`'s DVPG lookup failing `network_lookup` on a 200 carrying both properties).
- **Fix:** `unwrap_vim_value()` in `vim_body.py` (beside the request-side #3103 helpers) — a tolerant recursive un-boxer (strips `_value` boxes + `ArrayOf*` wrappers incl. the SOAP-flavoured element-keyed variant the issue cites; plain values pass through; DataObject `_typeName` tags survive; nested `Any` positions like `TaskInfo.result` normalise in one pass) — applied at **every** vim property consumer: `_write.py` extractors (single-prop / `config.hardware.device` / `config.template` / `configurationEx.rule`), `_read.py`'s `_extract_object_props`, `vim_task.py`'s `Task.info` extraction, and the five typed reads (`host.usage`, `vm.info`, `host.network_uplinks`, `object.collect`, `tasks.recent`).
- **Deliberately not touched:** the raw transport (`_post_vmomi_json` stays pure) and method-return payloads that round-trip into request bodies (the resolved `CustomizationSpec` a clone embeds must keep its wire shape — un-boxing there would corrupt `Any`-typed request fields).
- Docs: `connectors-vmware-rest.md` vim-substrate section gains point 4 (response-side boxing); CHANGELOG bullet under `[Unreleased]`.

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] `mypy src/` (strict, full tree) — clean except pre-existing platform-only `net/icmp.py` `MSG_ERRQUEUE` error (Linux-only socket attr; present on pristine main, CI green)
- [x] AC1 — wrapped primitives (string/int/bool/long/enum) + `ArrayOf*` unwrap across every consumer; live-shaped fixtures moved to the WRAPPED forms: new `test_connectors_vmware_rest_vim_body.py` (17 cases) + boxed fixtures in write/read/typed-op test files — 199 + 174 targeted tests pass
- [x] AC2 — `vm.create` DVPG regression: `_DVPG_BACKING_PROPS` is now byte-shaped from the issue evidence (boxed `key` next to plain annotated MoRef); `test_vm_create_pre9_rides_create_vm_task` proves the resolved `portgroupKey`/`switchUuid` land in the `CreateVM_Task` body
- [x] AC3 — task-poll on boxed `info.state` reaches terminal states: `test_poll_reaches_terminal_states_on_boxed_task_info_fields` + `test_poll_surfaces_fault_from_boxed_error_state_and_message`
- [x] AC4 — plain values still accepted: untouched plain-fixture tests (vim_task plain states, snapshot trees, migrate/rules empty lists, vm.info by-name reads) all pass + parametrized pass-through cases
- [x] Reconcile lanes (shelf-resolved locally): write-body / read / L2-ingest / nested-esxi — 59 passed
- [x] Full CI-equivalent unit sweep (`-n 3 --dist loadscope`, ignoring integration/migrations) — 12,608 passed; only pre-existing local-env failures (macOS ICMP/DNS, helm chart), all reproduced on pristine main
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope

- Pre-existing size warnings in `typed_ops_vm_info.py` / `poll_vim_task` (code-quality WARNs, not introduced here).
- Live-appliance verification of the enum-box shape for propSet paths like `runtime.powerState` (spec-grounded here; the deep unwrap is tolerant either way).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3106
