### PR TITLE
fix(connectors): vim task fault extraction falls back through the fault body (#3116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — vim task fault messages no longer swallowed (#3116)
+
+- A faulted vim `*_Task` (live-observed: `CreateVM_Task` on vCenter 8.0.3)
+  surfaced as `<no fault reported>` while the `TaskInfo` carried a
+  perfectly good localized message: the poll helper's fault extraction
+  required `error.localizedMessage` to be a plain string and discarded
+  every other piece of fault content. The extraction now falls back
+  `localizedMessage` → `fault.faultMessage[*].message` (joined) →
+  `fault._typeName`, so `<no fault reported>` remains only for a
+  `TaskInfo` that truly carries no fault content — and every vim-arm
+  composite (create / reconfigure / clone / disk.grow / snapshot /
+  migrate / maintenance) inherits the legible `rollback_reason` through
+  the shared `VimTaskResult.error_message`. Box tolerance for the #3106
+  class is pinned end-to-end by a composite-level regression fixture
+  (a fully boxed faulted `TaskInfo`'s message survives into `vm.create`'s
+  `rollback_reason`). (#3116 / #3119)
+
 ### Fixed — VI-JSON boxed response values un-boxed at every vim property consumer (#3106)
 
 - The response-side twin of #3103: `DynamicProperty.val` is an `Any`

--- a/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
@@ -28,11 +28,12 @@ Poll semantics
 * **success** -- ``TaskInfo.state == "success"``; the
   :class:`VimTaskResult` carries ``TaskInfo.result`` (e.g. the new VM
   MoRef a ``CloneVM_Task`` produced) so the caller can thread it forward.
-* **error** -- ``TaskInfo.state == "error"``; the result carries the
-  localized fault message (``TaskInfo.error.localizedMessage``). The poll
-  helper does **not** raise on a task fault -- it returns the outcome so
-  each caller maps it to its own status envelope (a disk-grow fault and a
-  clone fault surface differently).
+* **error** -- ``TaskInfo.state == "error"``; the result carries the best
+  available fault description (``TaskInfo.error.localizedMessage``, falling
+  back through ``fault.faultMessage[*].message`` to ``fault._typeName`` --
+  #3116). The poll helper does **not** raise on a task fault -- it returns
+  the outcome so each caller maps it to its own status envelope (a
+  disk-grow fault and a clone fault surface differently).
 * **timeout** -- the deadline elapsed before a terminal state; the result
   carries the last-observed progress. The task itself may still complete
   in the background -- the wall-clock bound mirrors the 600 s convention
@@ -112,9 +113,10 @@ class VimTaskResult:
         result: ``TaskInfo.result`` on success -- e.g. the new VM MoRef a
             ``CloneVM_Task`` produced. ``None`` on error / timeout, and on a
             success whose task produces no result (``ReconfigVM_Task``).
-        error_message: The localized fault message
-            (``TaskInfo.error.localizedMessage``) on error; ``None``
-            otherwise.
+        error_message: The best available fault description on error --
+            ``TaskInfo.error.localizedMessage``, falling back through the
+            joined ``fault.faultMessage[*].message`` texts to the fault's
+            ``_typeName`` (#3116); ``None`` otherwise.
         progress: Last-observed ``TaskInfo.progress`` (0-100) -- present on
             a timeout so the caller can report how far the background task
             got.
@@ -187,12 +189,47 @@ def _extract_task_info(retrieve_result: Any, task_moid: str) -> dict[str, Any] |
 
 
 def _fault_message(info: dict[str, Any]) -> str | None:
-    """Return the localized fault message from a faulted ``TaskInfo``."""
+    """Return the best fault description from a faulted ``TaskInfo`` (#3116).
+
+    ``TaskInfo.error`` is a ``LocalizedMethodFault`` -- ``localizedMessage``
+    plus the concrete ``fault`` DataObject -- and ``localizedMessage`` is
+    optional on the wire, so the extraction falls back through the fault
+    body rather than discarding it:
+
+    1. ``error.localizedMessage`` -- the server-localized text, when present;
+    2. ``fault.faultMessage[*].message`` joined -- each ``LocalizableMessage``
+       carries an optional per-message text;
+    3. ``fault._typeName`` -- the concrete fault class (``InvalidArgument``,
+       ...), always tagged on a live VI-JSON DataObject.
+
+    Returns ``None`` -- the callers' ``<no fault reported>`` path -- only
+    when the ``TaskInfo`` carries no usable fault content at all. Boxed
+    nested primitives (the #3106 live-8.0.3 shape) are already bare here:
+    :func:`_extract_task_info` funnels the whole ``TaskInfo`` through the
+    recursive :func:`unwrap_vim_value` before any field read.
+    """
     error = info.get("error")
     if not isinstance(error, dict):
         return None
     localized = error.get("localizedMessage")
-    return localized if isinstance(localized, str) else None
+    if isinstance(localized, str) and localized.strip():
+        return localized
+    fault = error.get("fault")
+    if not isinstance(fault, dict):
+        return None
+    fault_messages = fault.get("faultMessage")
+    if isinstance(fault_messages, list):
+        texts = [
+            message
+            for entry in fault_messages
+            if isinstance(entry, dict)
+            and isinstance(message := entry.get("message"), str)
+            and message.strip()
+        ]
+        if texts:
+            return "; ".join(texts)
+    type_name = fault.get("_typeName")
+    return type_name if isinstance(type_name, str) and type_name.strip() else None
 
 
 def _progress(info: dict[str, Any]) -> int | None:

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1339,6 +1339,63 @@ async def test_vm_create_pre9_task_fault_returns_rolled_back(gate: _GateRecorder
 
 
 @pytest.mark.asyncio
+async def test_vm_create_pre9_boxed_task_fault_message_survives_to_rollback_reason(
+    gate: _GateRecorder,
+) -> None:
+    """A live-8.0.3 boxed faulted ``TaskInfo`` keeps its message in ``rollback_reason`` (#3116).
+
+    RetrievePropertiesEx delivers ``TaskInfo`` through an ``anyType`` val and
+    live 8.0.3 boxes every nested primitive (``{"_typeName": "string",
+    "_value": ...}`` -- the #3106/#3109 class). The fault's
+    ``localizedMessage`` must survive the unwrap + extraction into the
+    composite's ``rollback_reason`` -- the pre-#3116 extractor degraded this
+    exact shape to ``<no fault reported>``.
+    """
+    boxed_fault_info = {
+        "_typeName": "TaskInfo",
+        "state": {"_typeName": "string", "_value": "error"},
+        "error": {
+            "_typeName": "LocalizedMethodFault",
+            "localizedMessage": {
+                "_typeName": "string",
+                "_value": "The input arguments had entities that did not belong "
+                "to the same datacenter.",
+            },
+            "fault": {"_typeName": "InvalidArgument"},
+        },
+    }
+    conn = _pre9_conn(
+        rest={
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/datastore/datastore-11": {"name": "datastore1"},
+        },
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-509"),
+            "Task": _retrieve_result("Task", "task-509", "info", boxed_fault_info),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "create"
+    assert (
+        "The input arguments had entities that did not belong to the same datacenter."
+        in out["rollback_reason"]
+    )
+    assert "<no fault reported>" not in out["rollback_reason"]
+
+
+@pytest.mark.asyncio
 async def test_vm_create_pre9_poll_timeout_returns_rolled_back(
     gate: _GateRecorder, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_connectors_vmware_rest_vim_task.py
+++ b/backend/tests/test_connectors_vmware_rest_vim_task.py
@@ -41,19 +41,24 @@ def _task_info_result(
     state: Any,
     result: Any = None,
     error_message: Any = None,
+    error: Any = None,
     progress: Any = None,
 ) -> dict[str, Any]:
     """Build a single-Task ``RetrievePropertiesEx`` result carrying one ``TaskInfo``.
 
     Fields are ``Any``-typed so tests can seed either the bare primitives
     or the boxed ``{"_typeName": ..., "_value": ...}`` forms live VI-JSON
-    puts in ``Any`` placeholders (#3106).
+    puts in ``Any`` placeholders (#3106). ``error_message`` shorthands a
+    fault that carries only ``localizedMessage``; ``error`` seeds the full
+    ``LocalizedMethodFault`` object for the fallback-chain tests (#3116).
     """
     info: dict[str, Any] = {"state": state}
     if result is not None:
         info["result"] = result
     if error_message is not None:
         info["error"] = {"localizedMessage": error_message}
+    if error is not None:
+        info["error"] = error
     if progress is not None:
         info["progress"] = progress
     return {
@@ -239,6 +244,167 @@ async def test_poll_surfaces_fault_from_boxed_error_state_and_message() -> None:
     assert outcome.state == TASK_STATE_ERROR
     assert outcome.error_message == "Boxed boom."
     assert outcome.result is None
+
+
+async def test_poll_fault_without_localized_message_joins_fault_message_texts() -> None:
+    """No ``localizedMessage``: the joined ``fault.faultMessage[*].message`` surfaces (#3116)."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state="error",
+                error={
+                    "_typeName": "LocalizedMethodFault",
+                    "fault": {
+                        "_typeName": "InvalidArgument",
+                        "faultMessage": [
+                            {
+                                "_typeName": "LocalizableMessage",
+                                "key": "com.vmware.wcp.arg.invalid",
+                                "message": "The argument is invalid.",
+                            },
+                            {
+                                "_typeName": "LocalizableMessage",
+                                "key": "com.vmware.wcp.arg.detail",
+                                "message": "Entity crosses datacenter boundary.",
+                            },
+                        ],
+                    },
+                },
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message == "The argument is invalid.; Entity crosses datacenter boundary."
+
+
+async def test_poll_fault_without_any_message_falls_back_to_fault_type_name() -> None:
+    """No ``localizedMessage`` and no message texts: ``fault._typeName`` surfaces (#3116)."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state="error",
+                error={
+                    "_typeName": "LocalizedMethodFault",
+                    "fault": {
+                        "_typeName": "InvalidArgument",
+                        "faultMessage": [
+                            {"_typeName": "LocalizableMessage", "key": "com.vmware.no.text"}
+                        ],
+                    },
+                },
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message == "InvalidArgument"
+
+
+async def test_poll_fault_with_boxed_nested_primitives_surfaces_fallback_chain() -> None:
+    """Fully boxed fault content (#3106 live-8.0.3 shape) still surfaces a message (#3116).
+
+    Every nested primitive rides a ``{"_typeName": ..., "_value": ...}``
+    box and the ``faultMessage`` array rides its ``ArrayOfLocalizableMessage``
+    box; the recursive unwrap at ``Task.info`` extraction plus the fallback
+    chain must compose to the joined message texts -- never
+    ``<no fault reported>``.
+    """
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state={"_typeName": "string", "_value": "error"},
+                error={
+                    "_typeName": "LocalizedMethodFault",
+                    "fault": {
+                        "_typeName": "InvalidArgument",
+                        "faultMessage": {
+                            "_typeName": "ArrayOfLocalizableMessage",
+                            "_value": [
+                                {
+                                    "_typeName": "LocalizableMessage",
+                                    "key": {
+                                        "_typeName": "string",
+                                        "_value": "com.vmware.arg.invalid",
+                                    },
+                                    "message": {
+                                        "_typeName": "string",
+                                        "_value": "The argument is invalid.",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                },
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message == "The argument is invalid."
+
+
+async def test_poll_fault_blank_localized_message_falls_through_to_fault_body() -> None:
+    """A whitespace-only ``localizedMessage`` is absent, not a fault description (#3116)."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1",
+                state="error",
+                error={
+                    "_typeName": "LocalizedMethodFault",
+                    "localizedMessage": "   ",
+                    "fault": {"_typeName": "TaskInProgress"},
+                },
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message == "TaskInProgress"
+
+
+async def test_poll_fault_with_no_usable_content_reports_none() -> None:
+    """A faulted TaskInfo with no fault content at all keeps ``error_message=None``."""
+    conn = _SeqTaskConnector(
+        [_task_info_result("task-1", state="error", error={"fault": "not-a-dict"})]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.error_message is None
 
 
 async def test_poll_times_out_when_never_terminal() -> None:

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -711,7 +711,13 @@ task, timeout_seconds=600, poll_interval=2)` re-reads `Task.info` (via
 `_post_vmomi_json` + the shared `build_task_info_retrieve_params` request
 builder generalized from `tasks.recent`) on a fixed cadence until the vim
 state is `success` / `error` or the wall-clock deadline elapses, returning
-a `VimTaskResult{task, state, result, error_message, progress}`. It does
+a `VimTaskResult{task, state, result, error_message, progress}`. On a
+fault, `error_message` carries the best available description via a
+fallback chain (#3116): `error.localizedMessage` (optional on the wire) →
+the joined `fault.faultMessage[*].message` texts → the concrete fault's
+`_typeName` (e.g. `InvalidArgument`) — so every vim-arm composite's
+`rollback_reason` degrades to `<no fault reported>` only when the
+`TaskInfo` truly carries no fault content. It does
 **not** raise on a task *fault* — the outcome is a legible value each
 caller maps to its own status envelope (a clone surfaces `result` as the
 new VM MoRef; disk-grow raises on a fault so the dispatcher wraps it


### PR DESCRIPTION
## Summary

- `vim_task.py::_fault_message` now falls back through the fault body instead of requiring a plain-str `error.localizedMessage`: `localizedMessage` → `fault.faultMessage[*].message` (joined with `; `) → `fault._typeName`. `error_message` degrades to `None` (the callers' `<no fault reported>` path) only when the `TaskInfo` truly carries no fault content — fixing the live 8.0.3 CreateVM_Task fault that surfaced as `<no fault reported>` while the platform fully described it.
- The fallback order is grounded in the vim25 VMODL contract: `LocalizedMethodFault.localizedMessage` is optional on the wire, `MethodFault.faultMessage` is an optional `LocalizableMessage[]` whose per-entry `message` is itself optional, and the concrete fault DataObject always carries its `_typeName` discriminator on live VI-JSON.
- Issue ask 1 (box-tolerant unwrap) was **verified rather than re-added**: `unwrap_vim_value` (#3109) is recursive and `_extract_task_info` funnels the whole `TaskInfo` through it before any field read, so boxed nested primitives (the #3106 class) are already bare inside `_fault_message`. The new tests pin that composition end-to-end so a future shallow-unwrap regression fails loudly.
- Every vim-arm composite (create / reconfigure / clone / disk.grow / snapshot / migrate / maintenance) inherits the improvement through `VimTaskResult.error_message`; `docs/codebase/connectors-vmware-rest.md` records the fallback chain.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 1574 files already formatted
- [x] `mypy src/` — clean except one pre-existing darwin-only artifact in untouched `net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; CI runs Linux)
- [x] `pytest tests/test_connectors_vmware_rest_vim_task.py tests/test_connectors_vmware_rest_composites_write.py` — 150 passed
- [x] Ask 1 (box tolerance): `test_poll_fault_with_boxed_nested_primitives_surfaces_fallback_chain` — fully boxed fault content (boxed `state`, `ArrayOfLocalizableMessage` box, boxed `key`/`message` strings) surfaces the joined message
- [x] Ask 2 (fallback chain): `test_poll_fault_without_localized_message_joins_fault_message_texts`, `test_poll_fault_without_any_message_falls_back_to_fault_type_name`, `test_poll_fault_blank_localized_message_falls_through_to_fault_body`, `test_poll_fault_with_no_usable_content_reports_none`
- [x] Ask 3 (regression fixture at composite level): `test_vm_create_pre9_boxed_task_fault_message_survives_to_rollback_reason` — a live-8.0.3-shaped boxed faulted `TaskInfo` keeps its localized message in `vm.create`'s `rollback_reason`, and `<no fault reported>` is asserted absent

## Out of scope

- Structured fault objects on `VimTaskResult` (e.g. surfacing `faultCause` chains) — the string contract is what all 8 composite call sites consume; nothing asked for more.
- The pre-existing darwin-only mypy artifact in `net/icmp.py` (noted above, untouched).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-24)

Addressed review findings from the iteration-1 degraded-mode review comment:

- **B1** `42125b77` — added the `### Fixed` bullet under `## [Unreleased]` for the fault-extraction fallback chain (#3116 / #3119), matching the sibling #3103/#3106/#3109 entry style.

<!-- auto-implement-issue: continue, iteration 1 -->
