### PR TITLE
feat(connectors): installer.sddc.bringup.retry — governed failed-bring-up resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — governed bring-up retry: `installer.sddc.bringup.retry` (#3123)
+
+- A failed VCF management-domain bring-up was unrecoverable through the
+  governed path: the vendor's only recovery — resume from the failed
+  sub-task via `PATCH /v1/sddcs/{id}` (`retrySddc`) — had no connector op,
+  forcing the operator out-of-band at the most sensitive moment of the
+  bring-up lifecycle (hit live at 262/263 sub-tasks green on a transient
+  first-boot `INVENTORY_INTERNAL_SERVER_ERROR`). The new
+  `installer.sddc.bringup.retry` typed primitive resumes the task under
+  the same posture as the start (`dangerous` + `requires_approval`): the
+  spec body is optional (omit to retry the stored `SddcSpec` as-is — the
+  common transient-failure case; pass a corrected spec for the vendor's
+  edit-and-retry flow), the park-time preview leads with the failed task
+  id (plus the secret-hygienic identity/network blast-radius when a spec
+  rides along), and the returned `SddcTask` keeps its id, so
+  `installer.sddc.bringup.status` polling continues unchanged. The
+  spec-reconcile lane pins the new `PATCH:/v1/sddcs/{id}` against the
+  vendored 9.1 OpenAPI.
+
 ### Fixed — vm.create folder lookup is datacenter-aware and fail-loud on ambiguity (#3115)
 
 - `vmware.composite.vm.create` resolved `folder_name` via an **unscoped**

--- a/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/__init__.py
@@ -44,6 +44,7 @@ from meho_backplane.connectors.vcf_installer.typed_ops import (
     register_installer_typed_operations,
 )
 from meho_backplane.connectors.vcf_installer.typed_writes import (
+    INSTALLER_BRINGUP_RETRY_OP_ID,
     INSTALLER_BRINGUP_START_OP_ID,
     INSTALLER_SPEC_VALIDATE_OP_ID,
 )
@@ -83,6 +84,7 @@ register_typed_op_registrar(register_installer_composite_operations)
 
 __all__ = [
     "INSTALLER_BRINGUP_OP_ID",
+    "INSTALLER_BRINGUP_RETRY_OP_ID",
     "INSTALLER_BRINGUP_START_OP_ID",
     "INSTALLER_CONNECTOR_ID",
     "INSTALLER_EXECUTION_PROFILE",

--- a/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
@@ -69,7 +69,10 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.schemas import OperationResult
-from meho_backplane.connectors.vcf_installer.typed_writes import INSTALLER_BRINGUP_START_OP_ID
+from meho_backplane.connectors.vcf_installer.typed_writes import (
+    INSTALLER_BRINGUP_RETRY_OP_ID,
+    INSTALLER_BRINGUP_START_OP_ID,
+)
 from meho_backplane.operations._preview import PreviewContext, register_preview_builder
 from meho_backplane.operations.composite import enforce_subop_policy
 
@@ -520,6 +523,37 @@ async def register_installer_composite_operations(
     )
 
 
+async def _sddc_bringup_retry_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Park-time approval preview for ``installer.sddc.bringup.retry`` (#3123).
+
+    The retry's normal params carry only the failed task's ``id`` — the preview
+    names the operation and echoes that id so the approver knows exactly which
+    bring-up resumes. For the edit-and-retry flow (an ``SddcSpec`` in params)
+    the composite's secret-hygienic identity/network blast-radius is appended —
+    via :func:`_blast_radius`, which never reads a secret field. Returns
+    ``None`` if the id is missing so the dispatcher falls back to its
+    identifier-only default.
+    """
+    task_id = ctx.params.get("id")
+    if not isinstance(task_id, str) or not task_id:
+        return None
+    preview: dict[str, Any] = {
+        "operation": "VCF bring-up retry (resume a failed installation task)",
+        "sddc_task_id": task_id,
+    }
+    spec = ctx.params.get("spec")
+    if isinstance(spec, dict):
+        br = _blast_radius(spec)
+        preview["edit_and_retry"] = True
+        preview["sddc_id"] = br["sddc_id"]
+        preview["vcf_instance_name"] = br["vcf_instance_name"]
+        preview["vcenter_hostname"] = br["vcenter_hostname"]
+        preview["sddc_manager_hostname"] = br["sddc_manager_hostname"]
+        preview["host_count"] = br["host_count"]
+        preview["management_networks"] = br["networks"]
+    return preview
+
+
 # Side-effect: register the park-time preview builders at import time (#1608),
 # mirroring how ``connectors/vmware_rest/composites/_write_preview`` wires its
 # builders. This module is imported by the package ``__init__`` (which pulls in
@@ -527,5 +561,8 @@ async def register_installer_composite_operations(
 # before any dispatch can park. The ``installer.sddc.bringup.start`` primitive
 # (#3078) parks the same ``{"spec": <SddcSpec>}`` params shape the composite
 # does, so it shares the composite's secret-hygienic identity/network preview.
+# The ``installer.sddc.bringup.retry`` primitive (#3123) parks ``{"id", "spec"?}``
+# and gets its own task-id-first preview.
 register_preview_builder(INSTALLER_BRINGUP_OP_ID, _sddc_bringup_preview)
 register_preview_builder(INSTALLER_BRINGUP_START_OP_ID, _sddc_bringup_preview)
+register_preview_builder(INSTALLER_BRINGUP_RETRY_OP_ID, _sddc_bringup_retry_preview)

--- a/backend/src/meho_backplane/connectors/vcf_installer/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/connector.py
@@ -416,6 +416,16 @@ class InstallerConnector(HttpConnector):
 
         return await installer_sddc_bringup_start_impl(self, operator, target, params)
 
+    async def sddc_bringup_retry(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.sddc.bringup.retry`` shim — failed bring-up resume."""
+        from meho_backplane.connectors.vcf_installer.typed_writes import (
+            installer_sddc_bringup_retry_impl,
+        )
+
+        return await installer_sddc_bringup_retry_impl(self, operator, target, params)
+
     async def sddc_bringup_status(
         self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
     ) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -3,15 +3,18 @@
 
 """Typed-op metadata + registrar for :class:`InstallerConnector`.
 
-The Installer's governed bring-up surface ships as four submit/poll typed
-primitives (``source_kind="typed"``, #3078) so they dispatch on a fresh boot
-with zero catalog ingest:
+The Installer's governed bring-up surface ships as five submit/poll typed
+primitives (``source_kind="typed"``, #3078; retry #3123) so they dispatch on
+a fresh boot with zero catalog ingest:
 
 * ``installer.sddc.spec.validate`` — submit an ``SddcSpec`` validation
   dry-run (``POST /v1/sddcs/validations``; ``caution``).
 * ``installer.sddc.validation.status`` — poll one validation
   (``GET /v1/sddcs/validations/{id}``; ``safe``).
 * ``installer.sddc.bringup.start`` — start the bring-up (``POST /v1/sddcs``;
+  ``dangerous`` + ``requires_approval``).
+* ``installer.sddc.bringup.retry`` — resume a failed bring-up from its
+  failed sub-task (``PATCH /v1/sddcs/{id}``, the vendor ``retrySddc``;
   ``dangerous`` + ``requires_approval``).
 * ``installer.sddc.bringup.status`` — poll one bring-up task
   (``GET /v1/sddcs/{id}``; ``safe``).
@@ -39,6 +42,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import structlog
 
 from meho_backplane.connectors.vcf_installer.typed_writes import (
+    INSTALLER_BRINGUP_RETRY_OP_ID,
     INSTALLER_BRINGUP_START_OP_ID,
     INSTALLER_SPEC_VALIDATE_OP_ID,
 )
@@ -92,8 +96,11 @@ INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "its verdict; installer.sddc.bringup.start (dangerous, approval-gated) "
         "starts the bring-up and installer.sddc.bringup.status polls the task's "
         "lifecycle state (IN_PROGRESS / COMPLETED_WITH_SUCCESS / "
-        "COMPLETED_WITH_FAILURE) and per-stage sub-tasks. The one-shot governed "
-        "validate-then-deploy unit is installer.composite.sddc.bringup."
+        "COMPLETED_WITH_FAILURE) and per-stage sub-tasks; on "
+        "COMPLETED_WITH_FAILURE, installer.sddc.bringup.retry (dangerous, "
+        "approval-gated) resumes the task from its failed sub-task. The "
+        "one-shot governed validate-then-deploy unit is "
+        "installer.composite.sddc.bringup."
     ),
 }
 
@@ -287,6 +294,73 @@ _BRINGUP_START = InstallerTypedOp(
     ),
 )
 
+_BRINGUP_RETRY = InstallerTypedOp(
+    op_id=INSTALLER_BRINGUP_RETRY_OP_ID,
+    handler_attr="sddc_bringup_retry",
+    summary="Retry a failed VCF management-domain bring-up from its failed sub-task.",
+    description=(
+        "Resumes a COMPLETED_WITH_FAILURE bring-up via PATCH /v1/sddcs/{id} — "
+        "the vendor retrySddc operation — and returns the same SddcTask the "
+        "moment the retry is accepted. The task re-runs from its failed "
+        "sub-task, not from scratch; poll installer.sddc.bringup.status with "
+        "the same id to a terminal state. The spec body is optional: omit it "
+        "to retry the stored SddcSpec as-is (the common transient-failure "
+        "case), or pass a corrected spec for the vendor's edit-and-retry "
+        "flow. dangerous + requires_approval — the dispatch parks first and "
+        "the approver sees the task id (plus, for edit-and-retry, the SDDC "
+        "identity/network preview), never passwords. Triage the failure via "
+        "installer.sddc.bringup.status (failed sub-tasks carry errors[]) "
+        "before retrying."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "The bring-up (SDDC) task id whose status is COMPLETED_WITH_FAILURE."
+                ),
+            },
+            "spec": {
+                "type": "object",
+                "description": (
+                    "Optional corrected SddcSpec for the vendor edit-and-retry "
+                    "flow; omitted, the appliance retries the stored spec "
+                    "as-is."
+                ),
+                "additionalProperties": True,
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_BRINGUP,
+    tags=("vcf", "installer", "bringup", "retry", "dangerous"),
+    safety_level="dangerous",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a failed bring-up task id to resume the deployment "
+            "from its failed sub-task. Parks for human approval before "
+            "anything runs. Read installer.sddc.bringup.status first to see "
+            "which sub-task failed and why."
+        ),
+        output_shape=(
+            "{id, name, status, vcfInstanceName, ...} (SddcTask). The id is "
+            "unchanged — keep polling installer.sddc.bringup.status with it "
+            "to terminal. When the task's sub-task list reduces to a JSONFlux "
+            "handle, id / status stay top-level on the result."
+        ),
+        parameter_hints={
+            "id": "The failed bring-up (SDDC) task id from the deploy.",
+            "spec": "Optional corrected SddcSpec (edit-and-retry); usually omitted.",
+        },
+        result_scalars=_SDDC_TASK_RESULT_SCALARS,
+    ),
+)
+
 _BRINGUP_STATUS = InstallerTypedOp(
     op_id="installer.sddc.bringup.status",
     handler_attr="sddc_bringup_status",
@@ -336,11 +410,13 @@ _BRINGUP_STATUS = InstallerTypedOp(
 
 
 #: The typed ops :class:`InstallerConnector` registers at lifespan startup,
-#: in submit → poll order per primitive pair.
+#: in submit → poll order per primitive pair (the bring-up trio adds the
+#: failed-task retry between its submit and its poll).
 INSTALLER_TYPED_OPS: tuple[InstallerTypedOp, ...] = (
     _SPEC_VALIDATE,
     _VALIDATION_STATUS,
     _BRINGUP_START,
+    _BRINGUP_RETRY,
     _BRINGUP_STATUS,
 )
 

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_writes.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_writes.py
@@ -3,9 +3,9 @@
 
 """Typed (bound-method) write implementations for :class:`InstallerConnector`.
 
-The two governed bring-up *submit* primitives (#3078). The vendor bring-up
-API is natively asynchronous — each POST returns its tracking object in
-seconds and progress is polled via the short status GETs in
+The governed bring-up *submit* primitives (#3078, retry #3123). The vendor
+bring-up API is natively asynchronous — each POST/PATCH returns its tracking
+object in seconds and progress is polled via the short status GETs in
 :mod:`.typed_reads` — so every call here is short, the standard
 park → approve → resume machinery governs the write as-is, and no
 long-blocking loop or async dispatch machinery exists in this module. The
@@ -24,15 +24,23 @@ deploy-automation add-on, not this connector.
   parks the call for approval *before* this handler runs, and the park-time
   preview (registered in :mod:`.bringup`, shared with the composite) echoes
   SDDC identity + network blast-radius only, never a password.
+* ``installer.sddc.bringup.retry`` — ``PATCH /v1/sddcs/{id}`` (the vendor
+  ``retrySddc`` operation), resuming a ``COMPLETED_WITH_FAILURE`` bring-up
+  from its failed sub-task and returning the same ``SddcTask`` to poll. The
+  ``SddcSpec`` body is optional: omitted, the appliance retries the stored
+  spec as-is; provided, it is the vendor's documented edit-and-retry flow.
+  Same posture as the start — ``dangerous`` + ``requires_approval=True``,
+  with its own park-time preview (task id + optional spec identity) in
+  :mod:`.bringup`.
 
 Each write is issued directly on the connector's own authenticated token
 session via :meth:`HttpConnector._post_json`. A raw ``401`` (the Installer's
 expired-token signal) propagates as :class:`httpx.HTTPStatusError` to the
 dispatcher's #2067 recovery arm, which evicts the cached session token via
 the connector's public :meth:`InstallerConnector.invalidate_session` hook and
-re-dispatches once. That retry is safe even for these non-idempotent POSTs:
-a ``401`` means the request was rejected at auth *before* the server
-processed it, so the first attempt had no effect — the same argument
+re-dispatches once. That retry is safe even for these non-idempotent
+POSTs/PATCHes: a ``401`` means the request was rejected at auth *before* the
+server processed it, so the first attempt had no effect — the same argument
 :meth:`InstallerConnector._post_json_with_session_retry` documents for the
 composite's internal sub-calls.
 """
@@ -47,9 +55,11 @@ if TYPE_CHECKING:
     from meho_backplane.connectors.vcf_installer.session import InstallerTargetLike
 
 __all__ = [
+    "INSTALLER_BRINGUP_RETRY_OP_ID",
     "INSTALLER_BRINGUP_START_OP_ID",
     "INSTALLER_SPEC_VALIDATE_OP_ID",
     "TYPED_WRITE_DECLARED_OP_IDS",
+    "installer_sddc_bringup_retry_impl",
     "installer_sddc_bringup_start_impl",
     "installer_sddc_spec_validate_impl",
 ]
@@ -58,6 +68,8 @@ __all__ = [
 INSTALLER_SPEC_VALIDATE_OP_ID: Final[str] = "installer.sddc.spec.validate"
 #: ``installer.sddc.bringup.start`` — start the management-domain bring-up.
 INSTALLER_BRINGUP_START_OP_ID: Final[str] = "installer.sddc.bringup.start"
+#: ``installer.sddc.bringup.retry`` — resume a failed bring-up from its failed sub-task.
+INSTALLER_BRINGUP_RETRY_OP_ID: Final[str] = "installer.sddc.bringup.retry"
 
 # --- Hand-coded wire paths — the spec-reconcile lane's introspection source
 # (module constants introspected by value, the #2944 pattern). ---
@@ -65,6 +77,8 @@ INSTALLER_BRINGUP_START_OP_ID: Final[str] = "installer.sddc.bringup.start"
 _SPEC_VALIDATE_PATH = "/v1/sddcs/validations"
 #: ``POST`` — start the bring-up (the estate mutation).
 _BRINGUP_START_PATH = "/v1/sddcs"
+#: ``PATCH`` — retry a failed bring-up (the vendor ``retrySddc`` operation).
+_BRINGUP_RETRY_PATH = "/v1/sddcs/{id}"
 
 #: The exact ``METHOD:/path`` set these write primitives hand-code. The
 #: reconcile lane (:mod:`tests.test_connectors_vcf_installer_spec_reconcile`)
@@ -74,6 +88,7 @@ TYPED_WRITE_DECLARED_OP_IDS: frozenset[str] = frozenset(
     {
         f"POST:{_SPEC_VALIDATE_PATH}",
         f"POST:{_BRINGUP_START_PATH}",
+        f"PATCH:{_BRINGUP_RETRY_PATH}",
     }
 )
 
@@ -115,4 +130,31 @@ async def installer_sddc_bringup_start_impl(
     """
     return await connector._post_json(
         target, _BRINGUP_START_PATH, operator=operator, json=params["spec"]
+    )
+
+
+async def installer_sddc_bringup_retry_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.sddc.bringup.retry`` — ``PATCH /v1/sddcs/{id}`` (``retrySddc``).
+
+    Resumes a ``COMPLETED_WITH_FAILURE`` bring-up from its failed sub-task and
+    returns the vendor ``SddcTask`` the moment the retry is accepted; poll
+    ``installer.sddc.bringup.status`` with the same ``id`` to a terminal state.
+    ``params["spec"]`` is optional: omitted, no request body is sent and the
+    appliance retries the stored spec as-is (the common transient-failure
+    case); provided, the ``SddcSpec`` rides the PATCH verbatim — the vendor's
+    documented edit-and-retry flow. The op is registered ``dangerous`` +
+    ``requires_approval=True``, so the dispatcher has already parked and an
+    approver has already resumed this call by the time the handler runs.
+    """
+    return await connector._post_json(
+        target,
+        _BRINGUP_RETRY_PATH.replace("{id}", params["id"]),
+        operator=operator,
+        verb="PATCH",
+        json=params.get("spec"),
     )

--- a/backend/tests/test_connectors_vcf_installer_bringup.py
+++ b/backend/tests/test_connectors_vcf_installer_bringup.py
@@ -438,6 +438,43 @@ async def test_bringup_preview_returns_none_without_spec() -> None:
     assert await _bringup._sddc_bringup_preview(ctx) is None  # type: ignore[arg-type]
 
 
+@pytest.mark.asyncio
+async def test_bringup_retry_preview_echoes_the_task_id() -> None:
+    """The plain retry parks with only the failed task id — the preview names
+    the operation and that id, nothing else (#3123)."""
+    ctx = SimpleNamespace(params={"id": "sddc-task-1"})
+    preview = await _bringup._sddc_bringup_retry_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview == {
+        "operation": "VCF bring-up retry (resume a failed installation task)",
+        "sddc_task_id": "sddc-task-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_preview_edit_and_retry_echoes_identity_never_secrets() -> None:
+    """Edit-and-retry appends the composite's blast-radius identity — and
+    inherits its no-password property."""
+    ctx = SimpleNamespace(params={"id": "sddc-task-1", "spec": _spec_with_secrets()})
+    preview = await _bringup._sddc_bringup_retry_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview is not None
+    assert preview["edit_and_retry"] is True
+    assert preview["sddc_task_id"] == "sddc-task-1"
+    assert preview["sddc_id"] == "mgmt-domain"
+    assert preview["vcenter_hostname"] == "vc01.evba.lab"
+    dumped = json.dumps(preview)
+    assert "SECRET" not in dumped
+    for secret_key in ("rootVcenterPassword", "credentials", "sshPassword"):
+        assert secret_key not in dumped
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_preview_returns_none_without_id() -> None:
+    ctx = SimpleNamespace(params={})
+    assert await _bringup._sddc_bringup_retry_preview(ctx) is None  # type: ignore[arg-type]
+
+
 # --------------------------------------------------------------- guards / plumbing
 
 

--- a/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
+++ b/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
@@ -36,7 +36,11 @@ _OPS_BY_ID = {op.op_id: op for op in INSTALLER_TYPED_OPS}
 #: The vendor object each op returns, keyed by op_id — the two submit/poll
 #: pairs share their response shape, so the expected scalar keys pair up.
 _VALIDATION_OPS = ("installer.sddc.spec.validate", "installer.sddc.validation.status")
-_SDDC_TASK_OPS = ("installer.sddc.bringup.start", "installer.sddc.bringup.status")
+_SDDC_TASK_OPS = (
+    "installer.sddc.bringup.start",
+    "installer.sddc.bringup.retry",
+    "installer.sddc.bringup.status",
+)
 
 
 def _registered_scalars_context(op_id: str) -> dict[str, Any]:
@@ -95,7 +99,7 @@ def _sddc_task(subtask_count: int, *, with_milestones: bool) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def test_all_four_primitives_register_the_result_scalars_hint() -> None:
+def test_all_primitives_register_the_result_scalars_hint() -> None:
     """The hint is registered per response shape, poll key first.
 
     ``id`` must be listed for every op — it is the poll key the live

--- a/backend/tests/test_connectors_vcf_installer_ops_register.py
+++ b/backend/tests/test_connectors_vcf_installer_ops_register.py
@@ -45,6 +45,7 @@ _EXPECTED_POSTURE: dict[str, tuple[str, bool]] = {
     "installer.sddc.spec.validate": ("caution", False),
     "installer.sddc.validation.status": ("safe", False),
     "installer.sddc.bringup.start": ("dangerous", True),
+    "installer.sddc.bringup.retry": ("dangerous", True),
     "installer.sddc.bringup.status": ("safe", False),
 }
 

--- a/backend/tests/test_connectors_vcf_installer_primitives.py
+++ b/backend/tests/test_connectors_vcf_installer_primitives.py
@@ -36,6 +36,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.schemas import AuthModel
 from meho_backplane.connectors.vcf_installer import (
+    INSTALLER_BRINGUP_RETRY_OP_ID,
     INSTALLER_BRINGUP_START_OP_ID,
     InstallerConnector,
     InstallerTargetLike,
@@ -291,3 +292,107 @@ def test_bringup_start_shares_the_composite_preview_builder() -> None:
     so it registers the composite's secret-hygienic identity/network preview
     (whose no-password property is pinned by the bring-up test module)."""
     assert _PREVIEW_BUILDERS.get(INSTALLER_BRINGUP_START_OP_ID) is _bringup._sddc_bringup_preview
+
+
+# --------------------------------------------------------------- bringup.retry
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_patches_the_task_with_no_body() -> None:
+    """The common transient-failure retry: PATCH the task id, no request body —
+    the appliance resumes the stored spec from the failed sub-task."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        retry_route = mock.patch(f"{_SDDCS_PATH}/sddc-task-1").respond(
+            202, json={"id": "sddc-task-1", "status": "IN_PROGRESS"}
+        )
+        result = await connector.sddc_bringup_retry(
+            _make_operator(), _TARGET, {"id": "sddc-task-1"}
+        )
+
+    assert result == {"id": "sddc-task-1", "status": "IN_PROGRESS"}
+    assert retry_route.call_count == 1
+    request = retry_route.calls[0].request
+    assert request.method == "PATCH"
+    assert request.content == b""
+    assert request.headers.get("authorization") == "Bearer tok-abc"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_patches_a_corrected_spec_when_provided() -> None:
+    """Edit-and-retry: an SddcSpec in params rides the PATCH verbatim."""
+    connector = _make_connector()
+    spec = _sddc_spec()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        retry_route = mock.patch(f"{_SDDCS_PATH}/sddc-task-1").respond(
+            202, json={"id": "sddc-task-1", "status": "IN_PROGRESS"}
+        )
+        result = await connector.sddc_bringup_retry(
+            _make_operator(), _TARGET, {"id": "sddc-task-1", "spec": spec}
+        )
+
+    assert result["id"] == "sddc-task-1"
+    assert json.loads(retry_route.calls[0].request.content) == spec
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_propagates_vendor_400_unretried() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        retry_route = mock.patch(f"{_SDDCS_PATH}/sddc-task-1").respond(
+            400, json={"errorCode": "SDDC_NOT_RETRIABLE", "message": "not in a failed state"}
+        )
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector.sddc_bringup_retry(_make_operator(), _TARGET, {"id": "sddc-task-1"})
+
+    assert exc_info.value.response.status_code == 400
+    # A 400 is not an auth failure: no re-login, no second submit.
+    assert token_route.call_count == 1
+    assert retry_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bringup_retry_recovers_after_session_invalidation() -> None:
+    """A 401 on the retry is rejected at auth before the server processes it,
+    so the dispatcher's evict → re-dispatch-once recovery cannot double-apply
+    the write; the re-issued PATCH carries the fresh token."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH)
+        token_route.side_effect = [
+            respx.MockResponse(201, json={"accessToken": "tok-1"}),
+            respx.MockResponse(201, json={"accessToken": "tok-2"}),
+        ]
+        retry_route = mock.patch(f"{_SDDCS_PATH}/sddc-task-1")
+        retry_route.side_effect = [
+            respx.MockResponse(401, json={"message": "token expired"}),
+            respx.MockResponse(202, json={"id": "sddc-task-1", "status": "IN_PROGRESS"}),
+        ]
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector.sddc_bringup_retry(_make_operator(), _TARGET, {"id": "sddc-task-1"})
+        assert exc_info.value.response.status_code == 401
+
+        await connector.invalidate_session(_TARGET)
+        result = await connector.sddc_bringup_retry(
+            _make_operator(), _TARGET, {"id": "sddc-task-1"}
+        )
+
+    assert result["id"] == "sddc-task-1"
+    assert token_route.call_count == 2
+    assert retry_route.calls[1].request.headers.get("authorization") == "Bearer tok-2"
+    await connector.aclose()
+
+
+def test_bringup_retry_registers_its_own_preview_builder() -> None:
+    """The retry parks ``{"id", "spec"?}`` — not the composite's spec shape —
+    so it registers its own task-id-first preview builder."""
+    assert (
+        _PREVIEW_BUILDERS.get(INSTALLER_BRINGUP_RETRY_OP_ID) is _bringup._sddc_bringup_retry_preview
+    )

--- a/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
@@ -91,6 +91,7 @@ def test_typed_write_declared_op_ids_are_pinned() -> None:
             {
                 "POST:/v1/sddcs/validations",
                 "POST:/v1/sddcs",
+                "PATCH:/v1/sddcs/{id}",
             }
         )
         == _typed_writes.TYPED_WRITE_DECLARED_OP_IDS

--- a/docs/codebase/connectors-vcf-installer.md
+++ b/docs/codebase/connectors-vcf-installer.md
@@ -21,7 +21,8 @@ governed bring-up **write** `installer.composite.sddc.bringup` — a `dangerous`
 `requires_approval` composite (validate → deploy) — because the
 highest-blast-radius write in the product must carry the preview + sub-op-policy
 machinery a raw op cannot. [#3078](https://github.com/evoila/meho/issues/3078)
-then decomposed the surface into four **submit/poll typed primitives** (the
+then decomposed the surface into **submit/poll typed primitives** — five since
+the [#3123](https://github.com/evoila/meho/issues/3123) failed-task retry — (the
 vendor bring-up API is natively asynchronous, so every governed call is short
 and the standard park → approve → resume machinery works as-is): the durable
 multi-hour orchestration loop belongs to the deploy-automation add-on, which
@@ -82,9 +83,9 @@ authenticated request covers reachability and auth-challenge.
 
 ## Operations
 
-### The four submit/poll primitives (typed, [#3078](https://github.com/evoila/meho/issues/3078))
+### The five submit/poll primitives (typed, [#3078](https://github.com/evoila/meho/issues/3078), retry [#3123](https://github.com/evoila/meho/issues/3123))
 
-All four are typed ops (`source_kind="typed"`), dispatchable on a fresh boot
+All five are typed ops (`source_kind="typed"`), dispatchable on a fresh boot
 with zero catalog ingest; read bodies live in `typed_reads.py`, submit bodies
 in `typed_writes.py`, a bound-method shim on the connector exposes each. Every
 call is short — the submits return their tracking object in seconds and the
@@ -96,6 +97,7 @@ machinery exist here.
 | `installer.sddc.spec.validate` | `POST /v1/sddcs/validations` → `Validation` | `caution` (writes to the installer, mutates no estate) |
 | `installer.sddc.validation.status` | `GET /v1/sddcs/validations/{id}` → `Validation` | `safe` |
 | `installer.sddc.bringup.start` | `POST /v1/sddcs` → `SddcTask` | `dangerous` + `requires_approval` |
+| `installer.sddc.bringup.retry` | `PATCH /v1/sddcs/{id}` (`retrySddc`) → `SddcTask` | `dangerous` + `requires_approval` |
 | `installer.sddc.bringup.status` | `GET /v1/sddcs/{id}` → `SddcTask` | `safe` |
 
 `spec.validate` submits the caller's `SddcSpec` verbatim as a non-mutating
@@ -105,15 +107,20 @@ dry-run; `validation.status` polls the returned id to a terminal
 mutation: the dispatcher parks it for approval before the handler runs, and its
 park-time preview is the composite's `_blast_radius`-backed identity/network
 echo (registered for both op_ids in `bringup.py`) — never a password.
-`bringup.status` polls the `SddcTask` (`IN_PROGRESS` /
+`bringup.retry` (#3123) resumes a `COMPLETED_WITH_FAILURE` task from its failed
+sub-task under the same posture: the `SddcSpec` body is optional (omitted, the
+appliance retries the stored spec as-is — the common transient-failure case;
+provided, it is the vendor's edit-and-retry flow), and its own park-time
+preview leads with the failed task id, appending the blast-radius identity only
+when a spec rides along. `bringup.status` polls the `SddcTask` (`IN_PROGRESS` /
 `COMPLETED_WITH_SUCCESS` / `COMPLETED_WITH_FAILURE`, plus `sddcSubTasks[]` /
-`milestones[]`). Session-expiry recovery for all four rides the dispatcher's
+`milestones[]`). Session-expiry recovery for all five rides the dispatcher's
 #2067 arm (raw `401` → `invalidate_session` → re-dispatch once — safe for the
-POSTs too, since a `401` is rejected at auth before the server processes the
-request).
+POSTs/PATCH too, since a `401` is rejected at auth before the server processes
+the request).
 
 **Poll scalars survive JSONFlux reduction
-([#3084](https://github.com/evoila/meho/issues/3084)).** All four
+([#3084](https://github.com/evoila/meho/issues/3084)).** All five
 primitives register the `result_scalars` reduction hint (see
 `docs/architecture/jsonflux.md` § *Preserved scalar siblings*): when an
 over-threshold `validationChecks[]` / `sddcSubTasks[]` rides the JSONFlux
@@ -213,8 +220,10 @@ shelf is unconfigured). Standard:
 - The composite **kicks off** the bring-up and returns the `SddcTask` id; it does
   not block on the multi-hour deployment. Terminal state (`COMPLETED_WITH_SUCCESS`
   / `ROLLBACK_SUCCESS` / `COMPLETED_WITH_FAILURE`) is reached by polling
-  `installer.sddc.bringup.status`. Durable orchestration of that wait (retry, resume) is
-  the deploy-automation add-on's DBOS workflow, not this connector.
+  `installer.sddc.bringup.status`. A `COMPLETED_WITH_FAILURE` resumes via the
+  `installer.sddc.bringup.retry` primitive (#3123); *durable* orchestration of
+  the wait-and-retry loop is the deploy-automation add-on's DBOS workflow, not
+  this connector.
 - `WARNING`-result validations proceed to deploy (VCF treats them as non-fatal);
   the return always echoes `validation_result_status` (and the leaf WARNING
   checks when present), but the approver saw the preview *before* validation ran.


### PR DESCRIPTION
## Summary

Implements #3123: a `COMPLETED_WITH_FAILURE` bring-up was unrecoverable through the governed path — the vendor's only recovery (resume from the failed sub-task via `PATCH /v1/sddcs/{id}`, `retrySddc`) had no connector op, forcing the operator out-of-band at the most sensitive moment of the bring-up lifecycle (hit live at 262/263 sub-tasks green on a transient first-boot `INVENTORY_INTERNAL_SERVER_ERROR` — see the issue).

## What

- **`installer.sddc.bringup.retry` typed primitive** (`typed_writes.py` + `typed_ops.py` + connector shim): `PATCH /v1/sddcs/{id}` under the same posture as `bringup.start` — `dangerous` + `requires_approval`. The `SddcSpec` body is optional: omitted, no body is sent and the appliance retries the stored spec as-is (the common transient-failure case); provided, it rides the PATCH verbatim (the vendor's documented edit-and-retry flow). The returned `SddcTask` keeps its id, so `installer.sddc.bringup.status` polling continues unchanged.
- **Own park-time preview** (`bringup.py`): leads with the failed task id; for edit-and-retry appends the composite's `_blast_radius` identity/network echo — redaction by construction, never a password.
- **Spec-reconcile lane**: `PATCH:/v1/sddcs/{id}` added to `TYPED_WRITE_DECLARED_OP_IDS` and the pinned set — asserted against the vendored `vcf-installer-9.1` OpenAPI (which serves it as `retrySddc`).
- **JSONFlux**: registers the `_SDDC_TASK_RESULT_SCALARS` reduction hint like its siblings (#3084 contract).
- Docs (`docs/codebase/connectors-vcf-installer.md`) + CHANGELOG.

## Tests

- Primitives: PATCH with no body / with corrected spec, vendor-400 unretried, 401 → `invalidate_session` → re-dispatch recovery, preview-builder registration.
- Bring-up module: retry preview content — task-id-only shape, edit-and-retry identity echo with the no-secrets pin, None-without-id fallback.
- Register/posture, JSONFlux scalar-hint, and reconcile-pin updates.
- `72 passed` across the installer test modules locally; ruff + mypy clean.

Closes #3123

🤖 Generated with [Claude Code](https://claude.com/claude-code)