### PR TITLE
feat(connectors): installer air-gapped depot lifecycle — depot settings, trusted certificates, bundle downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,33 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — air-gapped depot lifecycle ops on the installer connector (#3121)
+
+- A governed air-gapped VCF 9.1 bring-up had to leave the governed path at
+  exactly the step that gates everything else: configuring the release
+  depot, trusting its TLS certificate, and explicitly pre-downloading the
+  release bundles all had no connector ops (performed out-of-band during
+  the live bring-up program, documented on the issue). Six new typed
+  primitives close the gap (group `installer-depot`):
+  `installer.system.depot.get`/`.set` (settings read is password-scrubbed
+  at every depth; the PUT runs the vendor connection check synchronously
+  and maps rejections to a structured `depot_error` — the common
+  `VMWARE_DEPOT_CONNECT_FAILURE` TLS-trust case carries its remediation
+  inline), `installer.system.trusted-certificates.list`/`.add` (the
+  depot-trust fix; preview echoes a SHA-256 fingerprint, never the PEM),
+  and `installer.bundles.list`/`.download` (the mandatory explicit GA
+  pre-download — one approval per batch, per-bundle vendor rejections
+  collected as `partial`, not fatal). Writes are `caution` +
+  `requires_approval` with secret-free park-time previews. The submit
+  primitives' `spec` hint and the new group's `when_to_use` now carry the
+  live-proven 9.1 SddcSpec field rules (three unique `vspClusterSpec`
+  FQDNs each resolving outside the services pool — omitting `fleetFqdn`
+  passes validation but fails bring-up at "Save VCF Management
+  Components"; ≤20-char core passwords; the derived `vcf-identity` FQDN;
+  `esaConfig` for all-flash/nested), so the next operator reads at
+  discovery time what this program learned from validator errors and
+  inventory stack traces.
+
 ### Added — governed bring-up retry: `installer.sddc.bringup.retry` (#3123)
 
 - A failed VCF management-domain bring-up was unrecoverable through the

--- a/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/bringup.py
@@ -61,6 +61,7 @@ secrets (e.g. the GOSC composites). It is *not* redacted.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -72,6 +73,9 @@ from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.vcf_installer.typed_writes import (
     INSTALLER_BRINGUP_RETRY_OP_ID,
     INSTALLER_BRINGUP_START_OP_ID,
+    INSTALLER_BUNDLES_DOWNLOAD_OP_ID,
+    INSTALLER_DEPOT_SET_OP_ID,
+    INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID,
 )
 from meho_backplane.operations._preview import PreviewContext, register_preview_builder
 from meho_backplane.operations.composite import enforce_subop_policy
@@ -554,6 +558,73 @@ async def _sddc_bringup_retry_preview(ctx: PreviewContext) -> dict[str, Any] | N
     return preview
 
 
+async def _depot_set_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Park-time preview for ``installer.system.depot.set`` (#3121).
+
+    Echoes depot identity only — hostname / port / mode and which account
+    kind carries credentials (plus its username) — never a ``password``
+    value or key.
+    """
+    settings = ctx.params.get("settings")
+    if not isinstance(settings, dict):
+        return None
+    config = settings.get("depotConfiguration")
+    config = config if isinstance(config, dict) else {}
+    preview: dict[str, Any] = {
+        "operation": "Configure Installer release depot",
+        "is_offline_depot": config.get("isOfflineDepot"),
+        "hostname": config.get("hostname"),
+        "port": config.get("port"),
+    }
+    for account_key in ("offlineAccount", "vmwareAccount"):
+        account = settings.get(account_key)
+        if isinstance(account, dict):
+            preview["account"] = account_key
+            preview["account_username"] = account.get("username")
+            break
+    return preview
+
+
+async def _trusted_certificate_add_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Park-time preview for ``installer.system.trusted-certificates.add`` (#3121).
+
+    Certificates are public material, but a preview should be reviewable at a
+    glance — echo the usage type and a SHA-256 fingerprint of the PEM, not
+    the PEM body.
+    """
+    certificate = ctx.params.get("certificate")
+    if not isinstance(certificate, str) or not certificate:
+        return None
+    fingerprint = hashlib.sha256(certificate.encode()).hexdigest()
+    return {
+        "operation": "Trust outbound TLS certificate on Installer",
+        "certificate_usage_type": ctx.params.get("certificate_usage_type")
+        or "TRUSTED_FOR_OUTBOUND",
+        "certificate_sha256": fingerprint,
+        "certificate_length": len(certificate),
+    }
+
+
+async def _bundles_download_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Park-time preview for ``installer.bundles.download`` (#3121).
+
+    One approval covers the batch — the approver sees how many and which
+    bundle ids will download (ids truncated past 20 to keep the preview
+    reviewable).
+    """
+    bundle_ids = ctx.params.get("bundle_ids")
+    if not isinstance(bundle_ids, list) or not bundle_ids:
+        return None
+    preview: dict[str, Any] = {
+        "operation": "Download release bundles on Installer",
+        "bundle_count": len(bundle_ids),
+        "bundle_ids": bundle_ids[:20],
+    }
+    if len(bundle_ids) > 20:
+        preview["bundle_ids_truncated"] = len(bundle_ids) - 20
+    return preview
+
+
 # Side-effect: register the park-time preview builders at import time (#1608),
 # mirroring how ``connectors/vmware_rest/composites/_write_preview`` wires its
 # builders. This module is imported by the package ``__init__`` (which pulls in
@@ -566,3 +637,8 @@ async def _sddc_bringup_retry_preview(ctx: PreviewContext) -> dict[str, Any] | N
 register_preview_builder(INSTALLER_BRINGUP_OP_ID, _sddc_bringup_preview)
 register_preview_builder(INSTALLER_BRINGUP_START_OP_ID, _sddc_bringup_preview)
 register_preview_builder(INSTALLER_BRINGUP_RETRY_OP_ID, _sddc_bringup_retry_preview)
+# The #3121 depot-lifecycle writes park too; their previews live here as well
+# (this module is the connector's single preview home).
+register_preview_builder(INSTALLER_DEPOT_SET_OP_ID, _depot_set_preview)
+register_preview_builder(INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID, _trusted_certificate_add_preview)
+register_preview_builder(INSTALLER_BUNDLES_DOWNLOAD_OP_ID, _bundles_download_preview)

--- a/backend/src/meho_backplane/connectors/vcf_installer/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/connector.py
@@ -436,6 +436,66 @@ class InstallerConnector(HttpConnector):
 
         return await installer_sddc_bringup_status_impl(self, operator, target, params)
 
+    async def system_depot_get(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.system.depot.get`` shim — depot settings read (scrubbed)."""
+        from meho_backplane.connectors.vcf_installer.typed_reads import (
+            installer_depot_settings_get_impl,
+        )
+
+        return await installer_depot_settings_get_impl(self, operator, target, params)
+
+    async def system_depot_set(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.system.depot.set`` shim — depot configure write."""
+        from meho_backplane.connectors.vcf_installer.typed_writes import (
+            installer_depot_settings_set_impl,
+        )
+
+        return await installer_depot_settings_set_impl(self, operator, target, params)
+
+    async def system_trusted_certificates_list(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.system.trusted-certificates.list`` shim — trust store read."""
+        from meho_backplane.connectors.vcf_installer.typed_reads import (
+            installer_trusted_certificates_list_impl,
+        )
+
+        return await installer_trusted_certificates_list_impl(self, operator, target, params)
+
+    async def system_trusted_certificate_add(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.system.trusted-certificates.add`` shim — trust store write."""
+        from meho_backplane.connectors.vcf_installer.typed_writes import (
+            installer_trusted_certificate_add_impl,
+        )
+
+        return await installer_trusted_certificate_add_impl(self, operator, target, params)
+
+    async def bundles_list(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.bundles.list`` shim — bundle inventory read."""
+        from meho_backplane.connectors.vcf_installer.typed_reads import (
+            installer_bundles_list_impl,
+        )
+
+        return await installer_bundles_list_impl(self, operator, target, params)
+
+    async def bundles_download(
+        self, operator: Operator, target: InstallerTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``installer.bundles.download`` shim — batch bundle-download write."""
+        from meho_backplane.connectors.vcf_installer.typed_writes import (
+            installer_bundles_download_impl,
+        )
+
+        return await installer_bundles_download_impl(self, operator, target, params)
+
     async def aclose(self) -> None:
         """Clear cached session tokens + credentials, then tear down the httpx pool."""
         async with self._session_lock:

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -19,6 +19,15 @@ a fresh boot with zero catalog ingest:
 * ``installer.sddc.bringup.status`` — poll one bring-up task
   (``GET /v1/sddcs/{id}``; ``safe``).
 
+Plus the **air-gapped depot lifecycle** family (#3121, group
+``installer-depot``): ``installer.system.depot.get`` / ``.set`` (read /
+configure the release depot, PUT running the vendor connection check
+synchronously), ``installer.system.trusted-certificates.list`` / ``.add``
+(outbound trust store — the depot TLS-trust fix), and
+``installer.bundles.list`` / ``.download`` (bundle inventory + the mandatory
+explicit GA pre-download). Reads are ``safe``; the three writes are
+``caution`` + ``requires_approval``.
+
 The vendor bring-up API is natively asynchronous — every submit returns its
 tracking object in seconds and progress rides the status polls — so each
 primitive is a short call and the standard park → approve → resume machinery
@@ -44,7 +53,10 @@ import structlog
 from meho_backplane.connectors.vcf_installer.typed_writes import (
     INSTALLER_BRINGUP_RETRY_OP_ID,
     INSTALLER_BRINGUP_START_OP_ID,
+    INSTALLER_BUNDLES_DOWNLOAD_OP_ID,
+    INSTALLER_DEPOT_SET_OP_ID,
     INSTALLER_SPEC_VALIDATE_OP_ID,
+    INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID,
 )
 
 if TYPE_CHECKING:
@@ -60,6 +72,7 @@ __all__ = [
 _log = structlog.get_logger(__name__)
 
 _GROUP_BRINGUP = "installer-bringup"
+_GROUP_DEPOT = "installer-depot"
 
 
 @dataclass(frozen=True)
@@ -101,6 +114,26 @@ INSTALLER_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "approval-gated) resumes the task from its failed sub-task. The "
         "one-shot governed validate-then-deploy unit is "
         "installer.composite.sddc.bringup."
+    ),
+    _GROUP_DEPOT: (
+        "Use to make an air-gapped/offline Installer ready to deploy — the "
+        "mandatory pre-bring-up depot lifecycle, in order: "
+        "installer.system.depot.get reads the current depot settings and "
+        "connection status; installer.system.depot.set (approval-gated) "
+        "configures the release depot and runs the vendor connection check "
+        "synchronously — on a VMWARE_DEPOT_CONNECT_FAILURE for an HTTPS "
+        "depot, first import the depot's TLS certificate via "
+        "installer.system.trusted-certificates.add (approval-gated; "
+        "installer.system.trusted-certificates.list reads the trust store) "
+        "and retry; after a successful connect the catalog ingests and "
+        "installer.bundles.list populates within about a minute; then "
+        "installer.bundles.download (approval-gated, one batch) explicitly "
+        "downloads the release bundles BEFORE validating a spec — a freshly "
+        "connected installer pins components to the newest catalog versions "
+        "and hard-fails Versions-and-Bundles when those binaries are absent "
+        "from the depot, so the explicit GA download is a required step, not "
+        "an optimization. Poll installer.bundles.list downloadStatus until "
+        "the set is SUCCESSFUL."
     ),
 }
 
@@ -155,6 +188,31 @@ _SDDC_TASK_RESULT_SCALARS: tuple[str, ...] = (
 )
 
 
+#: The shared ``spec`` parameter hint for the submit primitives — carrying the
+#: 9.1 SddcSpec shape rules that are undocumented upstream and were each paid
+#: for with a live bring-up iteration (#3121 follow-up; c3-class program,
+#: 2026-08-25). Field names pinned by the vendored ``vcf-installer-9.1``
+#: OpenAPI; the FLEET_LCM consequence observed live in the SDDC Manager
+#: inventory translation.
+_SDDC_SPEC_HINT = (
+    "The full SddcSpec object, POSTed verbatim. 9.1 shape rules proven live: "
+    "(1) vspClusterSpec needs THREE unique FQDNs — platformFqdn, "
+    "instanceFqdn AND fleetFqdn — each resolving (A+PTR) to its OWN address "
+    "OUTSIDE vspClusterSpec.ipv4Pool; omitting fleetFqdn PASSES validation "
+    "but fails bring-up later at 'Save VCF Management Components' "
+    "(FLEET_LCM fqdn=null -> INVENTORY_INTERNAL_SERVER_ERROR 500), while "
+    "reusing vcfOperationsFleetManagementSpec.hostname as fleetFqdn crashes "
+    "the Network Configuration validation with IllegalStateException "
+    "'Duplicate key'. (2) The five core passwords (sddcManagerSpec "
+    "root/ssh/localUser, vcenterSpec rootVcenter/adminUserSso) are limited "
+    "to 20 characters. (3) vidbSpec's FQDN defaults to "
+    "vcf-identity.<dnsSpec.subdomain> — pre-create that DNS record or set "
+    "it explicitly. (4) All-flash/nested labs pass the vSAN check via "
+    "datastoreSpec.vsanSpec.esaConfig.enabled=false. (5) The ipv4Pool "
+    "ipRange needs >=12 free addresses for a small deployment."
+)
+
+
 def _sddc_spec_parameter_schema(posted_to: str) -> dict[str, Any]:
     """The shared ``{"spec": <SddcSpec>}`` parameter schema of the two submits."""
     return {
@@ -206,7 +264,7 @@ _SPEC_VALIDATE = InstallerTypedOp(
             "a JSONFlux handle, id / executionStatus / resultStatus stay "
             "top-level on the result."
         ),
-        parameter_hints={"spec": "The full SddcSpec object, POSTed verbatim."},
+        parameter_hints={"spec": _SDDC_SPEC_HINT},
         result_scalars=_VALIDATION_RESULT_SCALARS,
     ),
 )
@@ -289,7 +347,7 @@ _BRINGUP_START = InstallerTypedOp(
             "task's sub-task list reduces to a JSONFlux handle, id / status "
             "stay top-level on the result."
         ),
-        parameter_hints={"spec": "The full SddcSpec object, POSTed verbatim."},
+        parameter_hints={"spec": _SDDC_SPEC_HINT},
         result_scalars=_SDDC_TASK_RESULT_SCALARS,
     ),
 )
@@ -355,7 +413,10 @@ _BRINGUP_RETRY = InstallerTypedOp(
         ),
         parameter_hints={
             "id": "The failed bring-up (SDDC) task id from the deploy.",
-            "spec": "Optional corrected SddcSpec (edit-and-retry); usually omitted.",
+            "spec": (
+                "Optional corrected SddcSpec (edit-and-retry); usually omitted. "
+                "Same 9.1 shape rules as installer.sddc.spec.validate's spec hint."
+            ),
         },
         result_scalars=_SDDC_TASK_RESULT_SCALARS,
     ),
@@ -409,15 +470,286 @@ _BRINGUP_STATUS = InstallerTypedOp(
 )
 
 
+_EMPTY_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_DEPOT_GET = InstallerTypedOp(
+    op_id="installer.system.depot.get",
+    handler_attr="system_depot_get",
+    summary="Read the Installer's release-depot settings and connection status.",
+    description=(
+        "Reads GET /v1/system/settings/depot — the DepotSettings object "
+        "(vmwareAccount / offlineAccount / depotConfiguration with "
+        "isOfflineDepot, hostname, port). Every password key is scrubbed at "
+        "every depth before the result crosses the governed surface; the "
+        "account status/message fields (e.g. DEPOT_CONNECTION_SUCCESSFUL) "
+        "survive, so this is the read that tells you whether a depot is "
+        "connected. safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("read-only", "vcf", "installer", "depot", "system"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to check whether (and which) release depot the Installer "
+            "is connected to before configuring one or triggering downloads."
+        ),
+        output_shape=(
+            "{vmwareAccount?, offlineAccount?, depotConfiguration: "
+            "{isOfflineDepot, hostname, port, url}}. Account status carries "
+            "the connection verdict (e.g. DEPOT_CONNECTION_SUCCESSFUL); "
+            "password keys are scrubbed and never present."
+        ),
+        parameter_hints={},
+    ),
+)
+
+_DEPOT_SET = InstallerTypedOp(
+    op_id=INSTALLER_DEPOT_SET_OP_ID,
+    handler_attr="system_depot_set",
+    summary="Configure the Installer's release depot (vendor connection check inline).",
+    description=(
+        "Submits the DepotSettings object to PUT /v1/system/settings/depot. "
+        "The appliance runs its depot connection check synchronously, so the "
+        "result is the verdict: status='ok' with the scrubbed settings echo "
+        "on success, or the structured status='depot_error' (http_status + "
+        "vendor error_code + message) on rejection — the common "
+        "VMWARE_DEPOT_CONNECT_FAILURE TLS-trust case carries its remediation "
+        "inline (import the depot certificate via "
+        "installer.system.trusted-certificates.add first). caution + "
+        "requires_approval — appliance-scoped configuration that gates what "
+        "any later bring-up may install; the approval preview echoes "
+        "hostname/port/mode and username only, never a password."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "settings": {
+                "type": "object",
+                "description": (
+                    "The vendor DepotSettings object, PUT verbatim: "
+                    "depotConfiguration {isOfflineDepot, hostname, port} plus "
+                    "offlineAccount {username, password} for offline depots "
+                    "(or vmwareAccount for the online Broadcom depot)."
+                ),
+                "additionalProperties": True,
+            },
+        },
+        "required": ["settings"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("vcf", "installer", "depot", "system", "write"),
+    safety_level="caution",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to point the Installer at a release depot (offline/air-gapped "
+            "or the online Broadcom depot). Parks for approval. On depot_error "
+            "with VMWARE_DEPOT_CONNECT_FAILURE, follow the inline remediation."
+        ),
+        output_shape=(
+            "{status: 'ok', settings: {...scrubbed echo...}} or {status: "
+            "'depot_error', http_status, error_code, message, remediation?}."
+        ),
+        parameter_hints={
+            "settings": (
+                "DepotSettings verbatim. Offline example shape: "
+                "{offlineAccount: {username, password}, depotConfiguration: "
+                "{isOfflineDepot: true, hostname, port}}."
+            ),
+        },
+    ),
+)
+
+_TRUSTED_CERTIFICATES_LIST = InstallerTypedOp(
+    op_id="installer.system.trusted-certificates.list",
+    handler_attr="system_trusted_certificates_list",
+    summary="List the Installer's outbound trusted certificates.",
+    description=(
+        "Reads GET /v1/sddc-manager/trusted-certificates — the appliance "
+        "outbound trust store (public certificate material). The read half "
+        "of the depot TLS-trust flow. safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("read-only", "vcf", "installer", "certificates", "system"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to see which outbound TLS certificates the Installer "
+            "already trusts (e.g. before/after adding a depot certificate)."
+        ),
+        output_shape="Vendor page of trusted certificates (public material).",
+        parameter_hints={},
+    ),
+)
+
+_TRUSTED_CERTIFICATE_ADD = InstallerTypedOp(
+    op_id=INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID,
+    handler_attr="system_trusted_certificate_add",
+    summary="Trust an outbound TLS certificate on the Installer (depot TLS trust).",
+    description=(
+        "POSTs {certificate, certificateUsageType} to "
+        "/v1/sddc-manager/trusted-certificates. The fix for "
+        "VMWARE_DEPOT_CONNECT_FAILURE against an HTTPS depot with a "
+        "self-signed/private-CA certificate: import the depot's certificate "
+        "(usage TRUSTED_FOR_OUTBOUND, the default), then re-run "
+        "installer.system.depot.set. Certificates are public material — the "
+        "PEM rides the params verbatim and the preview echoes a fingerprint. "
+        "caution + requires_approval."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "certificate": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The PEM-encoded certificate to trust.",
+            },
+            "certificate_usage_type": {
+                "type": "string",
+                "description": (
+                    "Vendor certificateUsageType; defaults to "
+                    "TRUSTED_FOR_OUTBOUND (the depot-trust case)."
+                ),
+            },
+        },
+        "required": ["certificate"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("vcf", "installer", "certificates", "system", "write"),
+    safety_level="caution",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call when installer.system.depot.set returns depot_error with "
+            "VMWARE_DEPOT_CONNECT_FAILURE for an HTTPS depot: trust the "
+            "depot's certificate, then retry depot.set."
+        ),
+        output_shape="{status: 'ok', result: <vendor echo>}.",
+        parameter_hints={
+            "certificate": "PEM string of the depot/CA certificate.",
+            "certificate_usage_type": "Omit for TRUSTED_FOR_OUTBOUND.",
+        },
+    ),
+)
+
+_BUNDLES_LIST = InstallerTypedOp(
+    op_id="installer.bundles.list",
+    handler_attr="bundles_list",
+    summary="List the Installer's bundle inventory (download states).",
+    description=(
+        "Reads GET /v1/bundles — the PageOfBundle inventory the catalog "
+        "ingest populates after a successful depot connect (typically within "
+        "about a minute; empty before any connect). Each element carries "
+        "id / version / downloadStatus / components — the poll target after "
+        "installer.bundles.download. safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("read-only", "vcf", "installer", "bundles", "depot"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call after a depot connect to enumerate available bundles and "
+            "their download states, and to poll downloads to SUCCESSFUL "
+            "after installer.bundles.download."
+        ),
+        output_shape=(
+            "{elements: [{id, version, downloadStatus, components, ...}], "
+            "pageMetadata}. A 9.1 release depot advertises ~180 bundles — "
+            "filter by downloadStatus/version instead of dumping elements."
+        ),
+        parameter_hints={},
+    ),
+)
+
+_BUNDLES_DOWNLOAD = InstallerTypedOp(
+    op_id=INSTALLER_BUNDLES_DOWNLOAD_OP_ID,
+    handler_attr="bundles_download",
+    summary="Trigger release-bundle downloads on the Installer (one approved batch).",
+    description=(
+        "PATCHes {bundleDownloadSpec: {downloadNow: true}} to "
+        "/v1/bundles/{id} for every id in bundle_ids — the mandatory "
+        "pre-download step of an air-gapped bring-up: a freshly connected "
+        "installer pins components to the newest catalog versions and "
+        "hard-fails the Versions-and-Bundles validation when those binaries "
+        "are absent, so the release bundles must be explicitly downloaded "
+        "BEFORE spec validation. Per-bundle vendor rejections are collected "
+        "(status 'partial'), not fatal; re-triggering an in-flight bundle is "
+        "harmless. Poll installer.bundles.list to SUCCESSFUL afterwards. "
+        "caution + requires_approval — one approval covers the batch; the "
+        "preview echoes the bundle count and ids."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "bundle_ids": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "minItems": 1,
+                "description": "Bundle ids (from installer.bundles.list) to download.",
+            },
+        },
+        "required": ["bundle_ids"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_DEPOT,
+    tags=("vcf", "installer", "bundles", "depot", "write"),
+    safety_level="caution",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call after the bundle inventory populates to download the "
+            "release (GA) bundles before validating an SddcSpec. One "
+            "approval covers the whole batch."
+        ),
+        output_shape=(
+            "{status: 'ok'|'partial', accepted, failed, results: [{id, "
+            "status: 'accepted'|'failed', task_id?, error_code?, "
+            "message?}]}. Then poll installer.bundles.list."
+        ),
+        parameter_hints={
+            "bundle_ids": (
+                "Ids from installer.bundles.list (e.g. every bundle of the target release)."
+            ),
+        },
+    ),
+)
+
+
 #: The typed ops :class:`InstallerConnector` registers at lifespan startup,
 #: in submit → poll order per primitive pair (the bring-up trio adds the
-#: failed-task retry between its submit and its poll).
+#: failed-task retry between its submit and its poll; the depot family runs
+#: in its air-gapped lifecycle order: settings read/write → trust store
+#: read/write → bundle inventory read/download).
 INSTALLER_TYPED_OPS: tuple[InstallerTypedOp, ...] = (
     _SPEC_VALIDATE,
     _VALIDATION_STATUS,
     _BRINGUP_START,
     _BRINGUP_RETRY,
     _BRINGUP_STATUS,
+    _DEPOT_GET,
+    _DEPOT_SET,
+    _TRUSTED_CERTIFICATES_LIST,
+    _TRUSTED_CERTIFICATE_ADD,
+    _BUNDLES_LIST,
+    _BUNDLES_DOWNLOAD,
 )
 
 

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_reads.py
@@ -3,14 +3,17 @@
 
 """Typed (bound-method) read implementations for :class:`InstallerConnector`.
 
-The two bring-up *poll* primitives — the bring-up task status and the spec
-validation status — are registered as typed ops (``source_kind="typed"``) so
-they dispatch on a fresh boot with zero catalog state. Each function here is
-the body a thin bound-method shim on
-:class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
+The bring-up *poll* primitives — the bring-up task status and the spec
+validation status — plus the air-gapped depot-lifecycle *reads* (#3121:
+depot settings, trusted certificates, bundle inventory) are registered as
+typed ops (``source_kind="typed"``) so they dispatch on a fresh boot with
+zero catalog state. Each function here is the body a thin bound-method shim
+on :class:`~meho_backplane.connectors.vcf_installer.connector.InstallerConnector`
 delegates to; the metadata + registrar live in
-:mod:`meho_backplane.connectors.vcf_installer.typed_ops`, and the submit twins
-(``spec.validate`` / ``bringup.start``) live in :mod:`.typed_writes`.
+:mod:`meho_backplane.connectors.vcf_installer.typed_ops`, and the write twins
+(``spec.validate`` / ``bringup.start`` / ``bringup.retry`` / ``depot.set`` /
+``trusted-certificates.add`` / ``bundles.download``) live in
+:mod:`.typed_writes`.
 
 Each read is issued directly on the connector's own authenticated token
 session via :meth:`HttpConnector._get_json`. A raw ``401`` (the Installer's
@@ -20,11 +23,16 @@ the connector's public :meth:`InstallerConnector.invalidate_session` hook and
 re-dispatches once — so the handlers do not wrap the call in the internal
 ``_get_json_with_session_retry`` helper (that helper serves the
 fingerprint/probe path, which the dispatcher does not drive).
+
+**Secret hygiene:** the vendor ``DepotSettings`` object carries account
+``password`` fields. :func:`installer_depot_settings_get_impl` scrubs every
+``password`` key from the response before returning — whatever the appliance
+echoes, no depot credential ever crosses the governed surface on a read.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -32,8 +40,12 @@ if TYPE_CHECKING:
     from meho_backplane.connectors.vcf_installer.session import InstallerTargetLike
 
 __all__ = [
+    "installer_bundles_list_impl",
+    "installer_depot_settings_get_impl",
     "installer_sddc_bringup_status_impl",
     "installer_sddc_validation_status_impl",
+    "installer_trusted_certificates_list_impl",
+    "scrub_password_keys",
 ]
 
 #: The bring-up status vendor path (``{id}`` substituted at call time). A module
@@ -43,6 +55,32 @@ _SDDC_STATUS_PATH = "/v1/sddcs/{id}"
 
 #: The spec-validation status vendor path (``{id}`` substituted at call time).
 _VALIDATION_STATUS_PATH = "/v1/sddcs/validations/{id}"
+
+#: Depot settings (``DepotSettings``: vmwareAccount / offlineAccount /
+#: depotConfiguration) — the read half of #3121's depot pair.
+_DEPOT_SETTINGS_PATH = "/v1/system/settings/depot"
+
+#: Appliance outbound trust store (``TrustedCertificate`` page) — the read
+#: half of #3121's trusted-certificates pair.
+_TRUSTED_CERTIFICATES_PATH = "/v1/sddc-manager/trusted-certificates"
+
+#: Bundle inventory (``PageOfBundle``; populated only after a depot connect +
+#: catalog ingest) — the read half of #3121's bundle pair.
+_BUNDLES_PATH = "/v1/bundles"
+
+
+def scrub_password_keys(value: Any) -> Any:
+    """Recursively drop every ``password`` key from *value* (dicts/lists).
+
+    The vendor ``DepotSettings`` echo nests credentials under
+    ``vmwareAccount`` / ``offlineAccount``; scrubbing by key at every depth is
+    redaction that cannot rot when the vendor moves the field.
+    """
+    if isinstance(value, dict):
+        return {k: scrub_password_keys(v) for k, v in value.items() if k != "password"}
+    if isinstance(value, list):
+        return [scrub_password_keys(v) for v in value]
+    return value
 
 
 async def installer_sddc_bringup_status_impl(
@@ -83,3 +121,55 @@ async def installer_sddc_validation_status_impl(
     return await connector._get_json(
         target, _VALIDATION_STATUS_PATH.replace("{id}", validation_id), operator=operator
     )
+
+
+async def installer_depot_settings_get_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.system.depot.get`` — read depot settings via
+    ``GET /v1/system/settings/depot``.
+
+    Returns the vendor ``DepotSettings`` (``vmwareAccount`` /
+    ``offlineAccount`` / ``depotConfiguration``) with every ``password`` key
+    scrubbed at every depth — the account *status*/*message* fields (e.g.
+    ``DEPOT_CONNECTION_SUCCESSFUL``) survive, credentials never do.
+    """
+    payload = await connector._get_json(target, _DEPOT_SETTINGS_PATH, operator=operator)
+    return cast("dict[str, Any]", scrub_password_keys(payload))
+
+
+async def installer_trusted_certificates_list_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.system.trusted-certificates.list`` — read the appliance
+    outbound trust store via ``GET /v1/sddc-manager/trusted-certificates``.
+
+    Returns the vendor page of trusted certificates (public material — no
+    scrubbing needed).
+    """
+    return await connector._get_json(target, _TRUSTED_CERTIFICATES_PATH, operator=operator)
+
+
+async def installer_bundles_list_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.bundles.list`` — read the bundle inventory via
+    ``GET /v1/bundles``.
+
+    Returns the vendor ``PageOfBundle`` (``elements[]`` with per-bundle
+    ``id`` / ``version`` / ``downloadStatus`` / ``components``). The
+    inventory is empty until a depot connect has ingested a catalog; after a
+    connect it typically populates within ~a minute. The set is release-sized
+    (a 9.1 depot advertises ~180 bundles), so callers drill via the
+    ``downloadStatus`` / ``version`` fields rather than dumping elements.
+    """
+    return await connector._get_json(target, _BUNDLES_PATH, operator=operator)

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_writes.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_writes.py
@@ -32,6 +32,17 @@ deploy-automation add-on, not this connector.
   Same posture as the start — ``dangerous`` + ``requires_approval=True``,
   with its own park-time preview (task id + optional spec identity) in
   :mod:`.bringup`.
+* The **air-gapped depot lifecycle writes** (#3121) — the three steps that
+  used to force a governed bring-up out-of-band:
+  ``installer.system.depot.set`` (``PUT /v1/system/settings/depot``;
+  synchronous connection check, vendor rejection mapped to a structured
+  ``depot_error`` with inline remediation for the TLS-trust case),
+  ``installer.system.trusted-certificates.add``
+  (``POST /v1/sddc-manager/trusted-certificates``), and
+  ``installer.bundles.download`` (``PATCH /v1/bundles/{id}`` per id in one
+  approved batch, per-bundle failures collected not fatal). All three are
+  ``caution`` + ``requires_approval=True`` — appliance-scoped configuration,
+  not estate mutation, but each gates what a bring-up may install.
 
 Each write is issued directly on the connector's own authenticated token
 session via :meth:`HttpConnector._post_json`. A raw ``401`` (the Installer's
@@ -49,6 +60,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final
 
+import httpx
+
+from meho_backplane.connectors.vcf_installer.typed_reads import scrub_password_keys
+
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.vcf_installer.connector import InstallerConnector
@@ -57,11 +72,17 @@ if TYPE_CHECKING:
 __all__ = [
     "INSTALLER_BRINGUP_RETRY_OP_ID",
     "INSTALLER_BRINGUP_START_OP_ID",
+    "INSTALLER_BUNDLES_DOWNLOAD_OP_ID",
+    "INSTALLER_DEPOT_SET_OP_ID",
     "INSTALLER_SPEC_VALIDATE_OP_ID",
+    "INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID",
     "TYPED_WRITE_DECLARED_OP_IDS",
+    "installer_bundles_download_impl",
+    "installer_depot_settings_set_impl",
     "installer_sddc_bringup_retry_impl",
     "installer_sddc_bringup_start_impl",
     "installer_sddc_spec_validate_impl",
+    "installer_trusted_certificate_add_impl",
 ]
 
 #: ``installer.sddc.spec.validate`` — submit an ``SddcSpec`` validation dry-run.
@@ -70,6 +91,12 @@ INSTALLER_SPEC_VALIDATE_OP_ID: Final[str] = "installer.sddc.spec.validate"
 INSTALLER_BRINGUP_START_OP_ID: Final[str] = "installer.sddc.bringup.start"
 #: ``installer.sddc.bringup.retry`` — resume a failed bring-up from its failed sub-task.
 INSTALLER_BRINGUP_RETRY_OP_ID: Final[str] = "installer.sddc.bringup.retry"
+#: ``installer.system.depot.set`` — configure the release depot (#3121).
+INSTALLER_DEPOT_SET_OP_ID: Final[str] = "installer.system.depot.set"
+#: ``installer.system.trusted-certificates.add`` — trust an outbound TLS cert (#3121).
+INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID: Final[str] = "installer.system.trusted-certificates.add"
+#: ``installer.bundles.download`` — trigger GA bundle downloads (#3121).
+INSTALLER_BUNDLES_DOWNLOAD_OP_ID: Final[str] = "installer.bundles.download"
 
 # --- Hand-coded wire paths — the spec-reconcile lane's introspection source
 # (module constants introspected by value, the #2944 pattern). ---
@@ -79,6 +106,12 @@ _SPEC_VALIDATE_PATH = "/v1/sddcs/validations"
 _BRINGUP_START_PATH = "/v1/sddcs"
 #: ``PATCH`` — retry a failed bring-up (the vendor ``retrySddc`` operation).
 _BRINGUP_RETRY_PATH = "/v1/sddcs/{id}"
+#: ``PUT`` — configure the release depot (the vendor ``updateDepotSettings``).
+_DEPOT_SET_PATH = "/v1/system/settings/depot"
+#: ``POST`` — add an outbound trusted certificate (``addTrustedCertificate``).
+_TRUSTED_CERTIFICATE_ADD_PATH = "/v1/sddc-manager/trusted-certificates"
+#: ``PATCH`` — trigger one bundle download (``startBundleDownloadByID``).
+_BUNDLE_DOWNLOAD_PATH = "/v1/bundles/{id}"
 
 #: The exact ``METHOD:/path`` set these write primitives hand-code. The
 #: reconcile lane (:mod:`tests.test_connectors_vcf_installer_spec_reconcile`)
@@ -89,6 +122,9 @@ TYPED_WRITE_DECLARED_OP_IDS: frozenset[str] = frozenset(
         f"POST:{_SPEC_VALIDATE_PATH}",
         f"POST:{_BRINGUP_START_PATH}",
         f"PATCH:{_BRINGUP_RETRY_PATH}",
+        f"PUT:{_DEPOT_SET_PATH}",
+        f"POST:{_TRUSTED_CERTIFICATE_ADD_PATH}",
+        f"PATCH:{_BUNDLE_DOWNLOAD_PATH}",
     }
 )
 
@@ -158,3 +194,152 @@ async def installer_sddc_bringup_retry_impl(
         verb="PATCH",
         json=params.get("spec"),
     )
+
+
+def _vendor_error_body(exc: httpx.HTTPStatusError) -> dict[str, Any]:
+    """The vendor error envelope of *exc*'s response, or ``{}`` when unparseable."""
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
+#: Remediation surfaced on the depot TLS-trust failure — the common first-run
+#: outcome for HTTPS offline depots (#3121: cert import fixes the settings
+#: check; note the 9.1 bundle *downloader* has been observed TLS-handshaking
+#: against plain-HTTP depots, so plain HTTP + the LCM ``httpsEnabled``
+#: property off remains the reliable combination for HTTP-only depots).
+_DEPOT_CONNECT_REMEDIATION = (
+    "The depot's TLS certificate is not trusted by the appliance. Import it "
+    "first via installer.system.trusted-certificates.add "
+    "(certificateUsageType TRUSTED_FOR_OUTBOUND), then re-run depot.set."
+)
+
+
+async def installer_depot_settings_set_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.system.depot.set`` — ``PUT /v1/system/settings/depot``.
+
+    Submits ``params["settings"]`` (the vendor ``DepotSettings`` object —
+    ``depotConfiguration`` {isOfflineDepot, hostname, port} plus
+    ``offlineAccount`` / ``vmwareAccount`` credentials) verbatim. The
+    appliance runs its depot connection check synchronously, so the answer is
+    the verdict: ``{"status": "ok", "settings": <scrubbed echo>}`` on
+    ``DEPOT_CONNECTION_SUCCESSFUL``, or the structured
+    ``{"status": "depot_error", http_status, error_code, message[, remediation]}``
+    when the vendor rejects the settings (#1627/#1649/#1804 pattern) — the
+    common ``VMWARE_DEPOT_CONNECT_FAILURE`` TLS-trust case carries its
+    remediation inline. A raw ``401`` still propagates to the dispatcher's
+    #2067 session-recovery arm.
+    """
+    try:
+        payload = await connector._post_json(
+            target, _DEPOT_SET_PATH, operator=operator, verb="PUT", json=params["settings"]
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise
+        body = _vendor_error_body(exc)
+        result: dict[str, Any] = {
+            "status": "depot_error",
+            "http_status": exc.response.status_code,
+            "error_code": body.get("errorCode"),
+            "message": body.get("message"),
+        }
+        if body.get("errorCode") == "VMWARE_DEPOT_CONNECT_FAILURE":
+            result["remediation"] = _DEPOT_CONNECT_REMEDIATION
+        return result
+    return {"status": "ok", "settings": scrub_password_keys(payload)}
+
+
+async def installer_trusted_certificate_add_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.system.trusted-certificates.add`` —
+    ``POST /v1/sddc-manager/trusted-certificates``.
+
+    Adds ``params["certificate"]`` (PEM) to the appliance outbound trust
+    store with ``certificateUsageType`` from
+    ``params["certificate_usage_type"]`` (default ``TRUSTED_FOR_OUTBOUND`` —
+    the depot-trust case). Certificates are public material; the PEM rides
+    the params verbatim and the preview echoes only a fingerprint.
+    """
+    body = {
+        "certificate": params["certificate"],
+        "certificateUsageType": params.get("certificate_usage_type", "TRUSTED_FOR_OUTBOUND"),
+    }
+    payload = await connector._post_json(
+        target, _TRUSTED_CERTIFICATE_ADD_PATH, operator=operator, json=body
+    )
+    return {"status": "ok", "result": payload}
+
+
+async def installer_bundles_download_impl(
+    connector: InstallerConnector,
+    operator: Operator,
+    target: InstallerTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``installer.bundles.download`` — ``PATCH /v1/bundles/{id}`` per bundle.
+
+    Triggers ``{"bundleDownloadSpec": {"downloadNow": true}}`` for every id in
+    ``params["bundle_ids"]`` (one approved batch — the mandatory pre-download
+    step of an air-gapped bring-up, #3121). Per-bundle vendor rejections are
+    collected, not fatal: each element of ``results`` is
+    ``{"id", "status": "accepted"|"failed", ...}`` and the envelope reports
+    ``accepted`` / ``failed`` counts with ``status`` ``"ok"`` or
+    ``"partial"``. Re-triggering an in-flight/downloaded bundle is harmless —
+    the vendor either no-ops or rejects that bundle individually. A raw
+    ``401`` propagates (session recovery); the dispatcher's single re-dispatch
+    re-PATCHes the already-accepted ids, which is safe for the same reason.
+    Poll ``installer.bundles.list`` for ``downloadStatus`` afterwards.
+    """
+    results: list[dict[str, Any]] = []
+    accepted = failed = 0
+    for bundle_id in params["bundle_ids"]:
+        try:
+            task = await connector._post_json(
+                target,
+                _BUNDLE_DOWNLOAD_PATH.replace("{id}", str(bundle_id)),
+                operator=operator,
+                verb="PATCH",
+                json={"bundleDownloadSpec": {"downloadNow": True}},
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                raise
+            body = _vendor_error_body(exc)
+            failed += 1
+            results.append(
+                {
+                    "id": bundle_id,
+                    "status": "failed",
+                    "http_status": exc.response.status_code,
+                    "error_code": body.get("errorCode"),
+                    "message": body.get("message"),
+                }
+            )
+            continue
+        accepted += 1
+        results.append(
+            {
+                "id": bundle_id,
+                "status": "accepted",
+                "task_id": task.get("id"),
+                "task_name": task.get("name"),
+            }
+        )
+    return {
+        "status": "ok" if failed == 0 else "partial",
+        "accepted": accepted,
+        "failed": failed,
+        "results": results,
+    }

--- a/backend/tests/test_connectors_vcf_installer_bringup.py
+++ b/backend/tests/test_connectors_vcf_installer_bringup.py
@@ -475,6 +475,67 @@ async def test_bringup_retry_preview_returns_none_without_id() -> None:
     assert await _bringup._sddc_bringup_retry_preview(ctx) is None  # type: ignore[arg-type]
 
 
+@pytest.mark.asyncio
+async def test_depot_set_preview_echoes_identity_never_secrets() -> None:
+    ctx = SimpleNamespace(
+        params={
+            "settings": {
+                "offlineAccount": {"username": "depot-svc", "password": "SECRET-depot"},
+                "depotConfiguration": {
+                    "isOfflineDepot": True,
+                    "hostname": "depot.test.invalid",
+                    "port": 80,
+                },
+            }
+        }
+    )
+    preview = await _bringup._depot_set_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview == {
+        "operation": "Configure Installer release depot",
+        "is_offline_depot": True,
+        "hostname": "depot.test.invalid",
+        "port": 80,
+        "account": "offlineAccount",
+        "account_username": "depot-svc",
+    }
+    dumped = json.dumps(preview)
+    assert "SECRET" not in dumped
+    assert "password" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_depot_set_preview_returns_none_without_settings() -> None:
+    ctx = SimpleNamespace(params={})
+    assert await _bringup._depot_set_preview(ctx) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_trusted_certificate_add_preview_echoes_fingerprint_not_pem() -> None:
+    import hashlib
+
+    pem = "-----BEGIN CERTIFICATE-----\nMIIBdummy\n-----END CERTIFICATE-----\n"
+    ctx = SimpleNamespace(params={"certificate": pem})
+    preview = await _bringup._trusted_certificate_add_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview is not None
+    assert preview["certificate_usage_type"] == "TRUSTED_FOR_OUTBOUND"
+    assert preview["certificate_sha256"] == hashlib.sha256(pem.encode()).hexdigest()
+    assert "BEGIN CERTIFICATE" not in json.dumps(preview)
+
+
+@pytest.mark.asyncio
+async def test_bundles_download_preview_truncates_past_twenty_ids() -> None:
+    ids = [f"bundle-{i}" for i in range(25)]
+    ctx = SimpleNamespace(params={"bundle_ids": ids})
+    preview = await _bringup._bundles_download_preview(ctx)  # type: ignore[arg-type]
+
+    assert preview is not None
+    assert preview["bundle_count"] == 25
+    assert len(preview["bundle_ids"]) == 20
+    assert preview["bundle_ids_truncated"] == 5
+
+
 # --------------------------------------------------------------- guards / plumbing
 
 

--- a/backend/tests/test_connectors_vcf_installer_ops_register.py
+++ b/backend/tests/test_connectors_vcf_installer_ops_register.py
@@ -47,6 +47,12 @@ _EXPECTED_POSTURE: dict[str, tuple[str, bool]] = {
     "installer.sddc.bringup.start": ("dangerous", True),
     "installer.sddc.bringup.retry": ("dangerous", True),
     "installer.sddc.bringup.status": ("safe", False),
+    "installer.system.depot.get": ("safe", False),
+    "installer.system.depot.set": ("caution", True),
+    "installer.system.trusted-certificates.list": ("safe", False),
+    "installer.system.trusted-certificates.add": ("caution", True),
+    "installer.bundles.list": ("safe", False),
+    "installer.bundles.download": ("caution", True),
 }
 
 
@@ -88,9 +94,7 @@ async def _fetch_installer_rows() -> dict[str, EndpointDescriptor]:
         rows = (
             (
                 await fresh.execute(
-                    select(EndpointDescriptor).where(
-                        EndpointDescriptor.op_id.like("installer.sddc.%")
-                    )
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.like("installer.%"))
                 )
             )
             .scalars()
@@ -143,21 +147,33 @@ async def test_rows_resolve_their_bound_method_handlers(
 async def test_rows_persist_the_result_scalars_reduction_hint(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Every persisted row carries the #3084 ``result_scalars`` hint with ``id``.
+    """Every submit/poll row carries the #3084 ``result_scalars`` hint with ``id``.
 
     The dispatcher lifts ``llm_instructions["result_scalars"]`` off the
     *persisted* descriptor row (``_result_scalars_from_descriptor``), so the
     hint must survive the DB round-trip — otherwise a reduce of the vendor
     ``Validation`` / ``SddcTask`` swallows the poll ``id`` again and the
-    submit → poll loop breaks exactly as observed live.
+    submit → poll loop breaks exactly as observed live. The #3121 depot
+    family declares no hint (its envelopes are small or handled by the
+    generic reduction path), so the round-trip contract is asserted exactly
+    for the ops that declare one — and only those.
     """
     await register_installer_typed_operations(embedding_service=stub_embedding_service)
     rows = await _fetch_installer_rows()
+    hinted = 0
     for op in INSTALLER_TYPED_OPS:
         row = rows[op.op_id]
         assert isinstance(row.llm_instructions, dict), op.op_id
-        hint = row.llm_instructions.get("result_scalars")
-        assert isinstance(hint, dict), f"{op.op_id} must persist a result_scalars hint"
         assert op.llm_instructions is not None
-        assert hint == op.llm_instructions["result_scalars"], op.op_id
+        declared = op.llm_instructions.get("result_scalars")
+        hint = row.llm_instructions.get("result_scalars")
+        if declared is None:
+            assert hint is None, f"{op.op_id} persisted an undeclared result_scalars hint"
+            continue
+        hinted += 1
+        assert isinstance(hint, dict), f"{op.op_id} must persist a result_scalars hint"
+        assert hint == declared, op.op_id
         assert "id" in hint["keys"], f"{op.op_id}: the poll id must be a preserved scalar"
+    # The five submit/poll primitives all declare the hint — the loop must
+    # never go vacuous.
+    assert hinted == 5

--- a/backend/tests/test_connectors_vcf_installer_primitives.py
+++ b/backend/tests/test_connectors_vcf_installer_primitives.py
@@ -396,3 +396,221 @@ def test_bringup_retry_registers_its_own_preview_builder() -> None:
     assert (
         _PREVIEW_BUILDERS.get(INSTALLER_BRINGUP_RETRY_OP_ID) is _bringup._sddc_bringup_retry_preview
     )
+
+
+# --------------------------------------------------------------- depot family (#3121)
+
+_DEPOT_PATH = "/v1/system/settings/depot"
+_CERTS_PATH = "/v1/sddc-manager/trusted-certificates"
+_BUNDLES_PATH = "/v1/bundles"
+
+
+def _depot_settings() -> dict[str, object]:
+    return {
+        "offlineAccount": {"username": "depot-svc", "password": "SECRET-depot"},
+        "depotConfiguration": {
+            "isOfflineDepot": True,
+            "hostname": "depot.test.invalid",
+            "port": 80,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_depot_get_scrubs_every_password_key() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.get(_DEPOT_PATH).respond(
+            200,
+            json={
+                "offlineAccount": {
+                    "username": "depot-svc",
+                    "password": "SECRET-depot",
+                    "status": "DEPOT_CONNECTION_SUCCESSFUL",
+                },
+                "depotConfiguration": {"isOfflineDepot": True, "hostname": "depot.test.invalid"},
+            },
+        )
+        result = await connector.system_depot_get(_make_operator(), _TARGET, {})
+
+    assert result["offlineAccount"]["status"] == "DEPOT_CONNECTION_SUCCESSFUL"
+    assert "password" not in result["offlineAccount"]
+    assert "SECRET" not in json.dumps(result)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_depot_set_puts_settings_and_returns_scrubbed_ok() -> None:
+    connector = _make_connector()
+    settings = _depot_settings()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        put_route = mock.put(_DEPOT_PATH).respond(
+            202,
+            json={
+                "offlineAccount": {
+                    "username": "depot-svc",
+                    "password": "SECRET-depot",
+                    "status": "DEPOT_CONNECTION_SUCCESSFUL",
+                },
+                "depotConfiguration": settings["depotConfiguration"],
+            },
+        )
+        result = await connector.system_depot_set(_make_operator(), _TARGET, {"settings": settings})
+
+    # The DepotSettings body reaches the wire verbatim (credentials included) …
+    assert json.loads(put_route.calls[0].request.content) == settings
+    # … but the governed echo is scrubbed.
+    assert result["status"] == "ok"
+    assert result["settings"]["offlineAccount"]["status"] == "DEPOT_CONNECTION_SUCCESSFUL"
+    assert "SECRET" not in json.dumps(result)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_depot_set_maps_vendor_rejection_to_depot_error() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.put(_DEPOT_PATH).respond(
+            500,
+            json={
+                "errorCode": "VMWARE_DEPOT_CONNECT_FAILURE",
+                "message": "Secure protocol communication error",
+            },
+        )
+        result = await connector.system_depot_set(
+            _make_operator(), _TARGET, {"settings": _depot_settings()}
+        )
+
+    assert result["status"] == "depot_error"
+    assert result["http_status"] == 500
+    assert result["error_code"] == "VMWARE_DEPOT_CONNECT_FAILURE"
+    assert "trusted-certificates.add" in result["remediation"]
+    # A vendor rejection is not an auth failure: no re-login.
+    assert token_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_depot_set_propagates_401_for_session_recovery() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.put(_DEPOT_PATH).respond(401, json={"message": "token expired"})
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector.system_depot_set(
+                _make_operator(), _TARGET, {"settings": _depot_settings()}
+            )
+
+    # The raw 401 must reach the dispatcher's #2067 recovery arm, never map
+    # to depot_error.
+    assert exc_info.value.response.status_code == 401
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_trusted_certificates_list_reads_store() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.get(_CERTS_PATH).respond(200, json={"elements": []})
+        result = await connector.system_trusted_certificates_list(_make_operator(), _TARGET, {})
+
+    assert result == {"elements": []}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_trusted_certificate_add_defaults_usage_type() -> None:
+    connector = _make_connector()
+    pem = "-----BEGIN CERTIFICATE-----\nMIIBdummy\n-----END CERTIFICATE-----\n"
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        add_route = mock.post(_CERTS_PATH).respond(200, json={})
+        result = await connector.system_trusted_certificate_add(
+            _make_operator(), _TARGET, {"certificate": pem}
+        )
+
+    assert json.loads(add_route.calls[0].request.content) == {
+        "certificate": pem,
+        "certificateUsageType": "TRUSTED_FOR_OUTBOUND",
+    }
+    assert result["status"] == "ok"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bundles_list_reads_inventory() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.get(_BUNDLES_PATH).respond(
+            200, json={"elements": [{"id": "bundle-1", "downloadStatus": "PENDING"}]}
+        )
+        result = await connector.bundles_list(_make_operator(), _TARGET, {})
+
+    assert result["elements"][0]["id"] == "bundle-1"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bundles_download_collects_partial_failures() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        ok_route = mock.patch(f"{_BUNDLES_PATH}/bundle-1").respond(
+            202, json={"id": "task-1", "name": "Download BUNDLE - X"}
+        )
+        mock.patch(f"{_BUNDLES_PATH}/bundle-2").respond(
+            400, json={"errorCode": "BUNDLE_ALREADY_DOWNLOADED", "message": "already local"}
+        )
+        result = await connector.bundles_download(
+            _make_operator(), _TARGET, {"bundle_ids": ["bundle-1", "bundle-2"]}
+        )
+
+    assert json.loads(ok_route.calls[0].request.content) == {
+        "bundleDownloadSpec": {"downloadNow": True}
+    }
+    assert result["status"] == "partial"
+    assert result["accepted"] == 1
+    assert result["failed"] == 1
+    assert result["results"][0] == {
+        "id": "bundle-1",
+        "status": "accepted",
+        "task_id": "task-1",
+        "task_name": "Download BUNDLE - X",
+    }
+    assert result["results"][1]["error_code"] == "BUNDLE_ALREADY_DOWNLOADED"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bundles_download_propagates_401_for_session_recovery() -> None:
+    connector = _make_connector()
+    async with respx.mock(base_url="https://installer-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(201, json={"accessToken": "tok-abc"})
+        mock.patch(f"{_BUNDLES_PATH}/bundle-1").respond(401, json={"message": "token expired"})
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector.bundles_download(
+                _make_operator(), _TARGET, {"bundle_ids": ["bundle-1"]}
+            )
+
+    assert exc_info.value.response.status_code == 401
+    await connector.aclose()
+
+
+def test_depot_family_registers_preview_builders() -> None:
+    """Each #3121 write parks — each registers its own preview builder."""
+    from meho_backplane.connectors.vcf_installer import typed_writes as _tw
+
+    assert _PREVIEW_BUILDERS.get(_tw.INSTALLER_DEPOT_SET_OP_ID) is _bringup._depot_set_preview
+    assert (
+        _PREVIEW_BUILDERS.get(_tw.INSTALLER_TRUSTED_CERTIFICATE_ADD_OP_ID)
+        is _bringup._trusted_certificate_add_preview
+    )
+    assert (
+        _PREVIEW_BUILDERS.get(_tw.INSTALLER_BUNDLES_DOWNLOAD_OP_ID)
+        is _bringup._bundles_download_preview
+    )

--- a/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_installer_spec_reconcile.py
@@ -77,7 +77,13 @@ def test_typed_read_path_constants_are_all_discovered() -> None:
     constant — or a new one that skips the suffix convention — can't silently
     shrink the reconciled set to a vacuous pass.
     """
-    assert sorted(_typed_read_paths()) == ["_SDDC_STATUS_PATH", "_VALIDATION_STATUS_PATH"]
+    assert sorted(_typed_read_paths()) == [
+        "_BUNDLES_PATH",
+        "_DEPOT_SETTINGS_PATH",
+        "_SDDC_STATUS_PATH",
+        "_TRUSTED_CERTIFICATES_PATH",
+        "_VALIDATION_STATUS_PATH",
+    ]
 
 
 def test_typed_write_declared_op_ids_are_pinned() -> None:
@@ -92,6 +98,9 @@ def test_typed_write_declared_op_ids_are_pinned() -> None:
                 "POST:/v1/sddcs/validations",
                 "POST:/v1/sddcs",
                 "PATCH:/v1/sddcs/{id}",
+                "PUT:/v1/system/settings/depot",
+                "POST:/v1/sddc-manager/trusted-certificates",
+                "PATCH:/v1/bundles/{id}",
             }
         )
         == _typed_writes.TYPED_WRITE_DECLARED_OP_IDS

--- a/docs/codebase/connectors-vcf-installer.md
+++ b/docs/codebase/connectors-vcf-installer.md
@@ -99,6 +99,31 @@ machinery exist here.
 | `installer.sddc.bringup.start` | `POST /v1/sddcs` → `SddcTask` | `dangerous` + `requires_approval` |
 | `installer.sddc.bringup.retry` | `PATCH /v1/sddcs/{id}` (`retrySddc`) → `SddcTask` | `dangerous` + `requires_approval` |
 | `installer.sddc.bringup.status` | `GET /v1/sddcs/{id}` → `SddcTask` | `safe` |
+| `installer.system.depot.get` | `GET /v1/system/settings/depot` → `DepotSettings` (passwords scrubbed) | `safe` |
+| `installer.system.depot.set` | `PUT /v1/system/settings/depot` (sync connection check) | `caution` + `requires_approval` |
+| `installer.system.trusted-certificates.list` | `GET /v1/sddc-manager/trusted-certificates` | `safe` |
+| `installer.system.trusted-certificates.add` | `POST /v1/sddc-manager/trusted-certificates` | `caution` + `requires_approval` |
+| `installer.bundles.list` | `GET /v1/bundles` → `PageOfBundle` | `safe` |
+| `installer.bundles.download` | `PATCH /v1/bundles/{id}` per id (one approved batch) | `caution` + `requires_approval` |
+
+The bottom six rows are the **air-gapped depot lifecycle** (#3121, group
+`installer-depot`) — the steps that used to force a governed bring-up
+out-of-band: configure the depot (`depot.set` maps the vendor rejection to a
+structured `depot_error`, with inline remediation for the common
+`VMWARE_DEPOT_CONNECT_FAILURE` TLS-trust case → `trusted-certificates.add`,
+then retry), then explicitly download the release bundles
+(`bundles.download`, one approval per batch; per-bundle failures collected as
+`status="partial"`, not fatal) **before** validating a spec — a freshly
+connected installer pins components to the newest catalog versions and
+hard-fails Versions-and-Bundles when those binaries are absent. `depot.get`
+scrubs every `password` key at every depth before the settings echo crosses
+the governed surface; `depot.set`'s park-time preview echoes
+hostname/port/mode + account username only, `trusted-certificates.add`'s a
+SHA-256 fingerprint, `bundles.download`'s the id batch (truncated past 20).
+The group's `when_to_use` and the `spec` parameter hint on the submit
+primitives carry the 9.1 field rules proven live (three unique
+`vspClusterSpec` FQDNs outside the pool, ≤20-char core passwords, the
+derived `vcf-identity` FQDN, `esaConfig` for all-flash/nested).
 
 `spec.validate` submits the caller's `SddcSpec` verbatim as a non-mutating
 dry-run; `validation.status` polls the returned id to a terminal


### PR DESCRIPTION
## Summary

Implements #3121 (+ its addendum): the three steps that forced the live governed VCF 9.1 bring-up out-of-band now have governed ops — configuring the release depot, trusting its TLS certificate, and explicitly pre-downloading the release bundles. New group `installer-depot`, six typed primitives:

| op | wire | posture |
|---|---|---|
| `installer.system.depot.get` | `GET /v1/system/settings/depot` | safe (passwords scrubbed at every depth) |
| `installer.system.depot.set` | `PUT /v1/system/settings/depot` | caution + approval |
| `installer.system.trusted-certificates.list` | `GET /v1/sddc-manager/trusted-certificates` | safe |
| `installer.system.trusted-certificates.add` | `POST /v1/sddc-manager/trusted-certificates` | caution + approval |
| `installer.bundles.list` | `GET /v1/bundles` | safe |
| `installer.bundles.download` | `PATCH /v1/bundles/{id}` per id | caution + approval (one batch) |

## Design points

- **`depot.set` is the verdict**: the appliance runs its connection check synchronously, so vendor rejection maps to a structured `depot_error` (http_status + errorCode + message) per the #1627/#1649/#1804 pattern — the common `VMWARE_DEPOT_CONNECT_FAILURE` TLS-trust case carries its remediation inline (→ `trusted-certificates.add`, retry). Raw `401`s still propagate to the #2067 session-recovery arm (pinned by test).
- **`bundles.download` batches**: one approval covers the id set; per-bundle vendor rejections are collected (`status="partial"`), not fatal; re-triggering in-flight bundles is harmless, which also makes the dispatcher's 401 re-dispatch safe mid-batch.
- **Secret hygiene**: `depot.get`/`depot.set` echoes are scrubbed recursively by key; park-time previews echo depot identity + account username / cert SHA-256 fingerprint / bundle-id batch (truncated past 20) — never a password or PEM body. All preview builders live in `bringup.py` (the connector's single preview home) with no-secret pins in tests.
- **Institutional knowledge shipped**: the `spec` parameter hint on validate/start(/retry) and the new group's `when_to_use` document the 9.1 SddcSpec rules this program paid for live — the three-unique-`vspClusterSpec`-FQDNs rule (omitting `fleetFqdn` passes validation but 500s bring-up at 'Save VCF Management Components'), the ≤20-char core passwords, the derived `vcf-identity` FQDN, `esaConfig` for nested/all-flash — plus the mandatory explicit GA pre-download and its catalog-pinning rationale.
- **Reconcile lane**: all six wire paths verified against the vendored `vcf-installer-9.1` OpenAPI (`updateDepotSettings`, `addTrustedCertificate`, `getBundles`, `startBundleDownloadByID`); read-constant and write-set pins extended.

## Tests

85 passed locally across the installer modules (scrub behavior, verbatim PUT body vs scrubbed echo, depot_error mapping, 401 propagation on both writes, batch partial-failure collection, preview registration + content no-secret pins, posture map, reconcile pins); ruff + format + mypy clean.

Closes #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)