### PR TITLE
fix(connectors): installer.sddc.bringup.status reduces the ~260-row sddcSubTasks array (#3122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,26 @@ connector-related release-notes line.
   discovery time what this program learned from validator errors and
   inventory stack traces.
 
+### Fixed — `installer.sddc.bringup.status` reduces the ~260-row sub-task array (#3122)
+
+- Polling a live VCF 9.1 management-domain bring-up returned the whole vendor
+  `SddcTask` document inline on every 150 s poll — including the full
+  `sddcSubTasks[]` array (~260 rows, tens of KB) — with no JSONFlux handle and
+  no reduction, violating v0.1-spec §4. Root cause: the live `SddcTask` carries
+  **both** `sddcSubTasks[]` and a populated `milestones[]`, so the reducer's
+  #2113 multi-list detail-object exemption classified it as a dict-of-arrays
+  and passed it through unreduced — the `result_scalars` hint (#3084) never even
+  fired. New opt-in `result_digest` reducer hint (threaded like `result_scalars`
+  / `result_ordering` / `pagination_hint`): an op names its dominant collection,
+  so the reducer reduces it despite the sibling array, and writes a drivable
+  inline digest — per-`status` counts, the names of `IN_PROGRESS` sub-tasks, and
+  every `FAILED` / `COMPLETED_WITH_FAILURE` sub-task preserved **whole with its
+  `errors[]`** so the restart-from-failed flow (`installer.sddc.bringup.retry`)
+  never needs a drill-in. The full `sddcSubTasks` array stays behind the result
+  handle for `result_query`. Applied to the three `SddcTask` bring-up ops
+  (`start` / `retry` / `status`); the #2113 exemption is unchanged for every op
+  that does not register the hint.
+
 ### Added — governed bring-up retry: `installer.sddc.bringup.retry` (#3123)
 
 - A failed VCF management-domain bring-up was unrecoverable through the

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -144,6 +144,7 @@ def _instructions(
     output_shape: str,
     parameter_hints: dict[str, str],
     result_scalars: tuple[str, ...] | None = None,
+    result_digest: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     instructions: dict[str, Any] = {
         "when_to_use": when_to_use,
@@ -157,6 +158,13 @@ def _instructions(
         # summary so the submit → poll loop stays drivable through the
         # governed surface (the reducer's ``_preserved_scalars`` contract).
         instructions["result_scalars"] = {"keys": list(result_scalars)}
+    if result_digest is not None:
+        # #3122: the row-digest hint — names the collection to reduce (so a
+        # two-list SddcTask reduces sddcSubTasks[] instead of passing through
+        # the reducer's multi-list detail-object exemption) and drives the
+        # inline per-state counts / IN_PROGRESS names / FAILED-rows-with-errors
+        # digest (the reducer's ``_row_digest`` contract).
+        instructions["result_digest"] = dict(result_digest)
     return instructions
 
 
@@ -186,6 +194,27 @@ _SDDC_TASK_RESULT_SCALARS: tuple[str, ...] = (
     "vcfInstanceName",
     "creationTimestamp",
 )
+
+#: ``SddcTask`` row-digest hint (#3122). On a live management-domain bring-up
+#: ``sddcSubTasks[]`` runs to ~260 rows AND the vendor ``SddcTask`` carries a
+#: populated ``milestones[]`` — two list fields, so the reducer's #2113
+#: dict-of-arrays detail-object exemption would pass the whole document
+#: through UNREDUCED (tens of KB every 150 s poll). This hint names
+#: ``sddcSubTasks`` as THE collection to reduce (so it reduces despite the
+#: sibling ``milestones``) and drives the inline digest: per-``status`` counts,
+#: the ``name`` of every IN_PROGRESS sub-task, and every FAILED /
+#: COMPLETED_WITH_FAILURE sub-task preserved WHOLE (with its ``errors[]``) so
+#: the restart-from-failed flow (installer.sddc.bringup.retry) never needs a
+#: drill-in. The full ``sddcSubTasks`` array stays behind the result handle for
+#: ``result_query`` drill-in. Status field names match the vendored
+#: ``vcf-installer-9.1`` OpenAPI (``components.schemas.SddcSubTask.status``).
+_SDDC_TASK_RESULT_DIGEST: dict[str, Any] = {
+    "collection": "sddcSubTasks",
+    "status_field": "status",
+    "name_field": "name",
+    "active_states": ["IN_PROGRESS"],
+    "failed_states": ["FAILED", "COMPLETED_WITH_FAILURE"],
+}
 
 
 #: The shared ``spec`` parameter hint for the submit primitives — carrying the
@@ -344,11 +373,13 @@ _BRINGUP_START = InstallerTypedOp(
         output_shape=(
             "{id, name, status, vcfInstanceName, ...} (SddcTask). Keep the id "
             "and poll installer.sddc.bringup.status to terminal. When the "
-            "task's sub-task list reduces to a JSONFlux handle, id / status "
-            "stay top-level on the result."
+            "sub-task list reduces to a JSONFlux handle, id / status stay "
+            "top-level and a status_counts / in_progress / failed digest of "
+            "the sub-tasks rides inline (see installer.sddc.bringup.status)."
         ),
         parameter_hints={"spec": _SDDC_SPEC_HINT},
         result_scalars=_SDDC_TASK_RESULT_SCALARS,
+        result_digest=_SDDC_TASK_RESULT_DIGEST,
     ),
 )
 
@@ -408,8 +439,9 @@ _BRINGUP_RETRY = InstallerTypedOp(
         output_shape=(
             "{id, name, status, vcfInstanceName, ...} (SddcTask). The id is "
             "unchanged — keep polling installer.sddc.bringup.status with it "
-            "to terminal. When the task's sub-task list reduces to a JSONFlux "
-            "handle, id / status stay top-level on the result."
+            "to terminal. When the sub-task list reduces to a JSONFlux handle, "
+            "id / status stay top-level and a status_counts / in_progress / "
+            "failed digest of the sub-tasks rides inline."
         ),
         parameter_hints={
             "id": "The failed bring-up (SDDC) task id from the deploy.",
@@ -419,6 +451,7 @@ _BRINGUP_RETRY = InstallerTypedOp(
             ),
         },
         result_scalars=_SDDC_TASK_RESULT_SCALARS,
+        result_digest=_SDDC_TASK_RESULT_DIGEST,
     ),
 )
 
@@ -461,11 +494,17 @@ _BRINGUP_STATUS = InstallerTypedOp(
         output_shape=(
             "{id, name, status, vcfInstanceName, sddcSubTasks: [...], "
             "milestones: [...]}. Surface the top-level status and any failed "
-            "sub-task. When the task's sub-task list reduces to a JSONFlux "
-            "handle, id / status stay top-level on the result."
+            "sub-task. On a live bring-up the ~260-row sddcSubTasks reduces to "
+            "a JSONFlux handle; the inline summary then keeps id / status and "
+            "carries a sub-task digest — status_counts (per-state counts), "
+            "in_progress (names of IN_PROGRESS sub-tasks), and failed "
+            "(FAILED / COMPLETED_WITH_FAILURE sub-tasks WITH their errors[], so "
+            "no drill-in is needed to triage or retry). Drill into the full "
+            "sddcSubTasks via result_query on the handle."
         ),
         parameter_hints={"id": "The bring-up (SDDC) task id from the deploy."},
         result_scalars=_SDDC_TASK_RESULT_SCALARS,
+        result_digest=_SDDC_TASK_RESULT_DIGEST,
     ),
 )
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1679,6 +1679,35 @@ def _result_scalars_from_descriptor(descriptor: EndpointDescriptor) -> dict[str,
     return None
 
 
+def _result_digest_from_descriptor(descriptor: EndpointDescriptor) -> dict[str, Any] | None:
+    """Extract ``result_digest`` from a descriptor's ``llm_instructions``.
+
+    #3122. Connectors whose op returns a dict-of-arrays with one dominant
+    collection that must reduce even though a sibling array is present (the VCF
+    Installer's ``SddcTask``: ``sddcSubTasks[]`` beside a populated
+    ``milestones[]``) attach ``{"collection": ..., "status_field": ...,
+    "active_states": [...], "failed_states": [...]}`` under
+    ``llm_instructions.result_digest``; the reducer reads it via the
+    dispatcher-supplied context to (1) reduce the named array instead of hitting
+    the multi-list detail-object exemption and (2) write a per-state count /
+    active-names / failed-rows digest inline. Mirrors
+    :func:`_result_scalars_from_descriptor` exactly — a plain dict is returned
+    (not a validated model) so this layer stays free of a connectors-schema
+    import; the reducer validates it.
+
+    ``None`` outcomes (op didn't register the hint, ``llm_instructions`` is
+    ``None``, or the slot's value is not a dict) all flow to the reducer as
+    "no hint" — it detects the collection heuristically and writes no digest.
+    """
+    instructions = descriptor.llm_instructions
+    if not isinstance(instructions, dict):
+        return None
+    raw = instructions.get("result_digest")
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
 async def _reduce_or_error(
     *,
     op_id: str,
@@ -1763,6 +1792,16 @@ async def _reduce_or_error(
     result_scalars = _result_scalars_from_descriptor(descriptor)
     if result_scalars is not None:
         reducer_context["result_scalars"] = result_scalars
+    # #3122: forward the op's row-digest hint (when the connector author
+    # registered one via ``llm_instructions``) so the reducer reduces the
+    # named collection even in the presence of a sibling array and writes the
+    # per-state counts / in-progress names / failed-rows digest inline.
+    # ``None`` on ops without a hint -- the reducer detects the collection
+    # heuristically and writes no digest. Pulled here (vs. in the reducer) for
+    # the same decoupling reason as the three hints above.
+    result_digest = _result_digest_from_descriptor(descriptor)
+    if result_digest is not None:
+        reducer_context["result_digest"] = result_digest
     try:
         return await _DEFAULT_REDUCER.reduce(
             raw,

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -204,6 +204,23 @@ _SAMPLE_TAIL = "tail"
 #: submit → poll loop of #3084).
 _RESULT_SCALARS_CONTEXT_KEY = "result_scalars"
 
+#: ``context`` key carrying the op's row-digest hint (#3122). Extends the
+#: ``result_scalars`` pattern to the *collection* the reduction spills: the
+#: connector author registers ``llm_instructions["result_digest"] =
+#: {"collection": ..., "status_field": ..., "name_field": ..., "active_states":
+#: [...], "failed_states": [...]}`` on an op whose dict payload is a
+#: dict-of-arrays where ONE array is THE collection and the sibling arrays are
+#: companions (VCF Installer's ``SddcTask``: ``sddcSubTasks[]`` beside a
+#: populated ``milestones[]``). The hint does two jobs: (1) it names the
+#: collection to reduce, so :func:`_detect_collection` reduces it directly
+#: instead of hitting the #2113 multi-list detail-object exemption and passing
+#: the whole document through UNREDUCED; (2) it drives the inline digest
+#: :func:`_row_digest` writes onto the summary — per-``status_field`` counts,
+#: the ``name_field`` of every row in an ``active_states`` state, and every row
+#: in a ``failed_states`` state preserved WHOLE (with its nested ``errors[]``)
+#: so a failure never requires a drill-in (the #3084 drivability lesson).
+_RESULT_DIGEST_CONTEXT_KEY = "result_digest"
+
 #: Summary keys the reducer itself owns. A hinted scalar key colliding with
 #: one of these is skipped (with a warning) — the reduction bookkeeping is
 #: load-bearing for every consumer and must never be shadowed by a vendor
@@ -373,7 +390,11 @@ class JsonFluxReducer:
         """
         del schema  # schema is inferred from the registered table
 
-        envelope_key, rows = _detect_collection(payload)
+        # Resolve the digest hint once (#3122) so both the collection detection
+        # and the row-digest read the same validated spec — a single warning on
+        # a malformed hint, not one per consumer.
+        digest_spec = _resolve_digest_hint(context)
+        envelope_key, rows = _detect_collection(payload, digest_spec)
         if rows is None:
             # Not a set-shaped payload (scalar, dict-of-scalars, None) —
             # nothing to reduce.
@@ -385,7 +406,10 @@ class JsonFluxReducer:
         materialized = self._materialize(rows, context)
         spill_outcome = await self._spill(materialized, context)
         preserved_scalars = _preserved_scalars(payload, envelope_key, context)
-        return self._assemble(materialized, envelope_key, context, spill_outcome, preserved_scalars)
+        digest = _row_digest(rows, envelope_key, digest_spec)
+        return self._assemble(
+            materialized, envelope_key, context, spill_outcome, preserved_scalars, digest
+        )
 
     def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
         """True when *rows* exceeds the row OR byte threshold.
@@ -537,6 +561,7 @@ class JsonFluxReducer:
         context: dict[str, Any] | None,
         spill_outcome: _SpillOutcome,
         preserved_scalars: dict[str, Any] | None = None,
+        digest: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], ResultHandle]:
         """Build the inline summary + the :class:`ResultHandle`.
 
@@ -551,6 +576,12 @@ class JsonFluxReducer:
         never shadow ``row_count`` / ``total`` / ``sample_rows_returned``
         / ``sample_bytes`` / ``source_key`` even if the helper's reserved
         filter is bypassed.
+
+        ``digest`` (#3122) carries the reduced collection's inline digest
+        (:func:`_row_digest`): per-state ``status_counts`` plus, when the op
+        configured them, the ``in_progress`` row names and the whole
+        ``failed`` rows (errors included). It is merged after the scalars and
+        before the bookkeeping, so the reducer-owned keys still win.
 
         The inline sample is serialized **exactly once** (#134): it lives
         only on :attr:`ResultHandle.sample_rows` -- the audit hoist
@@ -591,9 +622,12 @@ class JsonFluxReducer:
         # serialized size the reducer bounded the preview to, so an agent
         # reading the summary knows a preview exists and where to find it
         # without re-measuring the handle. Hinted scalar siblings (#3084)
-        # seed the dict first; the reducer-owned bookkeeping keys are
-        # written after them and therefore always win.
+        # seed the dict first, then the collection digest (#3122); the
+        # reducer-owned bookkeeping keys are written after both and
+        # therefore always win.
         summary: dict[str, Any] = dict(preserved_scalars or {})
+        if digest:
+            summary.update(digest)
         summary.update(
             {
                 "row_count": total_rows,
@@ -619,13 +653,28 @@ class JsonFluxReducer:
         return get_settings().jsonflux_sample_byte_budget
 
 
-def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
+def _detect_collection(
+    payload: Any, digest_spec: _RowDigestSpec | None = None
+) -> tuple[str | None, list[Any] | None]:
     """Locate the primary set-shaped collection in *payload*.
 
     Returns ``(envelope_key, rows)`` where ``envelope_key`` is the dict
     key the list was found under (``None`` for a bare top-level list)
     and ``rows`` is the list itself, or ``(None, None)`` when *payload*
     carries no *paginable* list-shaped collection.
+
+    Author-named collection (#3122)
+    -------------------------------
+    When *digest_spec* names a ``collection`` (the op registered a
+    ``result_digest`` hint) and *payload* is a dict carrying that key as a
+    list, that list is THE collection — returned directly, ahead of every
+    heuristic below. This is what lets an op opt a dict-of-arrays payload
+    OUT of the multi-list detail-object exemption: the VCF Installer's
+    ``SddcTask`` carries ``sddcSubTasks[]`` (~260 rows on a live bring-up)
+    beside a populated ``milestones[]``, so without the hint the >1-real-list
+    rule below would exempt it and pass the whole document through UNREDUCED.
+    A named collection that is absent or not a list falls through to the
+    heuristics — the hint is additive, never a hard failure.
 
     Resolution order:
 
@@ -669,6 +718,12 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
     paginated collections while leaving the pod-info detail object (whose
     arrays are all real coordinate fields) at >1 and still exempt.
     """
+    if digest_spec is not None and isinstance(payload, dict):
+        named = payload.get(digest_spec.collection)
+        if isinstance(named, list):
+            return digest_spec.collection, named
+        # Named collection absent or not a list — fall through to the
+        # heuristics so the op still reduces on the shape it does emit.
     if isinstance(payload, list):
         return None, payload
     if not isinstance(payload, dict):
@@ -875,6 +930,151 @@ def _preserved_scalars(
             continue
         preserved[key] = value
     return preserved
+
+
+@dataclass(frozen=True, slots=True)
+class _RowDigestSpec:
+    """A validated ``result_digest`` hint (#3122).
+
+    Built once per reduce by :func:`_resolve_digest_hint` and shared by
+    :func:`_detect_collection` (which uses :attr:`collection` to reduce the
+    named array directly) and :func:`_row_digest` (which uses the rest to
+    build the inline digest). ``active_states`` / ``failed_states`` are
+    frozensets for O(1) membership; either may be empty (a counts-only
+    digest is valid).
+    """
+
+    collection: str
+    status_field: str
+    name_field: str
+    active_states: frozenset[str]
+    failed_states: frozenset[str]
+
+
+def _coerce_state_list(value: Any, context: dict[str, Any] | None, field: str) -> frozenset[str]:
+    """Coerce an ``active_states`` / ``failed_states`` hint value to a frozenset.
+
+    ``None`` (unset) → empty. A list of strings → that set. Anything else is a
+    malformed extra: logged once and treated as empty, so the digest degrades
+    to counts-only rather than raising or silently mis-bucketing — the
+    never-raise discipline the sibling hint paths follow.
+    """
+    if value is None:
+        return frozenset()
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return frozenset(value)
+    _log.warning(
+        "jsonflux_result_digest_invalid_states",
+        op_id=context.get("op_id") if context else None,
+        field=field,
+        received_type=type(value).__name__,
+    )
+    return frozenset()
+
+
+def _resolve_digest_hint(context: dict[str, Any] | None) -> _RowDigestSpec | None:
+    """Validate ``context['result_digest']`` into a :class:`_RowDigestSpec` or ``None``.
+
+    The connector author registers ``llm_instructions["result_digest"]`` on an
+    op whose dict payload is a dict-of-arrays with one dominant collection (the
+    VCF Installer's ``SddcTask``); the dispatcher forwards it verbatim under
+    :data:`_RESULT_DIGEST_CONTEXT_KEY`. ``collection`` and ``status_field`` are
+    load-bearing (they select the array to reduce and the per-row state field),
+    so a missing/non-string value for either disables the hint wholesale
+    (``None`` → the reducer falls back to auto-detection). The enrichment
+    extras degrade gracefully: ``name_field`` defaults to ``"name"`` and the
+    two state lists default to empty via :func:`_coerce_state_list`. Every
+    rejection logs once and never raises — matching the ``result_scalars`` /
+    ``result_ordering`` / ``pagination_hint`` never-raise discipline.
+    """
+    if not context:
+        return None
+    raw = context.get(_RESULT_DIGEST_CONTEXT_KEY)
+    if raw is None:
+        return None
+    op_id = context.get("op_id")
+    if not isinstance(raw, dict):
+        _log.warning(
+            "jsonflux_result_digest_invalid_shape",
+            op_id=op_id,
+            received_type=type(raw).__name__,
+        )
+        return None
+    collection = raw.get("collection")
+    if not isinstance(collection, str) or not collection:
+        _log.warning(
+            "jsonflux_result_digest_invalid_collection",
+            op_id=op_id,
+            received_type=type(collection).__name__,
+        )
+        return None
+    status_field = raw.get("status_field")
+    if not isinstance(status_field, str) or not status_field:
+        _log.warning(
+            "jsonflux_result_digest_invalid_status_field",
+            op_id=op_id,
+            received_type=type(status_field).__name__,
+        )
+        return None
+    name_raw = raw.get("name_field", "name")
+    name_field = name_raw if isinstance(name_raw, str) and name_raw else "name"
+    return _RowDigestSpec(
+        collection=collection,
+        status_field=status_field,
+        name_field=name_field,
+        active_states=_coerce_state_list(raw.get("active_states"), context, "active_states"),
+        failed_states=_coerce_state_list(raw.get("failed_states"), context, "failed_states"),
+    )
+
+
+def _row_digest(
+    rows: list[Any],
+    envelope_key: str | None,
+    digest_spec: _RowDigestSpec | None,
+) -> dict[str, Any]:
+    """Digest the reduced collection into poll-sufficient inline aggregates (#3122).
+
+    Runs only when *digest_spec* is set AND the collection that actually reduced
+    is the one it names (``digest_spec.collection == envelope_key``) — so if the
+    named array was absent and the reducer fell back to a different collection,
+    the digest is skipped rather than computed against the wrong rows.
+
+    Emits, over the FULL collection (not the bounded sample):
+
+    * ``status_counts`` — ``{status: count}`` for every row (a row whose
+      ``status_field`` is missing/non-string buckets under ``"UNKNOWN"``, so
+      ``sum(status_counts.values()) == total_rows``);
+    * ``in_progress`` (only when ``active_states`` is configured) — the
+      ``name_field`` of every row in an active state;
+    * ``failed`` (only when ``failed_states`` is configured) — every row in a
+      failed state, **whole** (nested ``errors[]`` included) so the
+      restart-from-failed flow never needs a drill-in.
+
+    The reduced full collection is still reachable via the result handle; this
+    digest is the drivable summary that rides inline alongside it.
+    """
+    if digest_spec is None or digest_spec.collection != envelope_key:
+        return {}
+    counts: dict[str, int] = {}
+    in_progress: list[Any] = []
+    failed: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        state = row.get(digest_spec.status_field)
+        bucket = state if isinstance(state, str) else "UNKNOWN"
+        counts[bucket] = counts.get(bucket, 0) + 1
+        if isinstance(state, str):
+            if state in digest_spec.active_states:
+                in_progress.append(row.get(digest_spec.name_field))
+            if state in digest_spec.failed_states:
+                failed.append(row)
+    digest: dict[str, Any] = {"status_counts": counts}
+    if digest_spec.active_states:
+        digest["in_progress"] = in_progress
+    if digest_spec.failed_states:
+        digest["failed"] = failed
+    return digest
 
 
 def _serialize(payload: Any) -> bytes:

--- a/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
+++ b/backend/tests/test_connectors_vcf_installer_jsonflux_scalars.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""#3084 regression tests — installer poll scalars survive JSONFlux reduction.
+"""#3084 / #3122 regression tests — installer poll reduction stays drivable.
 
 Proven live against a real VCF Installer 9.0.2 appliance: the first governed
 ``installer.sddc.spec.validate`` returned a JSONFlux-reduced ``result`` that
@@ -20,8 +20,21 @@ vendor-shaped payloads — the hint each test feeds the reducer is read off
 the op tuple, never re-typed, so a drift between registration and test is
 structurally impossible.
 
+#3122 extends this to the ``SddcTask`` bring-up poll. Live, the vendor
+``SddcTask`` carries BOTH ``sddcSubTasks[]`` (~260 rows) and a populated
+``milestones[]``: two list fields, so the reducer's #2113 multi-list
+detail-object exemption passed the whole document through UNREDUCED on every
+150 s poll — the ``result_scalars`` hint never even fired. The fix is the
+opt-in ``result_digest`` hint: it names ``sddcSubTasks`` as THE collection to
+reduce (overriding the exemption) and drives an inline digest — per-``status``
+counts, IN_PROGRESS names, and FAILED / COMPLETED_WITH_FAILURE sub-tasks kept
+WHOLE with their ``errors[]`` so the restart-from-failed flow never drills in.
+These tests read both hints off the op tuple (never re-typed), so a drift
+between registration and behavior is structurally impossible.
+
 Payload field names are pinned by the vendored ``vcf-installer-9.1`` OpenAPI
-(``components.schemas.Validation`` / ``components.schemas.SddcTask``).
+(``components.schemas.Validation`` / ``components.schemas.SddcTask`` /
+``components.schemas.SddcSubTask``).
 """
 
 from __future__ import annotations
@@ -57,6 +70,27 @@ def _registered_scalars_context(op_id: str) -> dict[str, Any]:
     return {"op_id": op_id, "result_scalars": hint}
 
 
+def _registered_reducer_context(op_id: str) -> dict[str, Any]:
+    """The FULL reducer context a dispatch of *op_id* carries, from live metadata.
+
+    Lifts both ``result_scalars`` (#3084) and ``result_digest`` (#3122) off the
+    registered op tuple — exactly the two dicts the dispatcher's
+    ``_result_scalars_from_descriptor`` / ``_result_digest_from_descriptor``
+    forward from the persisted descriptor at dispatch time. Reading them off the
+    tuple (never re-typing) keeps registration and test in lockstep.
+    """
+    instructions = _OPS_BY_ID[op_id].llm_instructions
+    assert instructions is not None, f"{op_id} must register llm_instructions"
+    context: dict[str, Any] = {"op_id": op_id}
+    scalars = instructions.get("result_scalars")
+    if isinstance(scalars, dict):
+        context["result_scalars"] = scalars
+    digest = instructions.get("result_digest")
+    if isinstance(digest, dict):
+        context["result_digest"] = digest
+    return context
+
+
 def _validation(check_count: int) -> dict[str, Any]:
     """A vendor ``Validation`` object with *check_count* checks."""
     return {
@@ -70,14 +104,47 @@ def _validation(check_count: int) -> dict[str, Any]:
     }
 
 
-def _sddc_task(subtask_count: int, *, with_milestones: bool) -> dict[str, Any]:
+def _sddc_task(
+    subtask_count: int,
+    *,
+    with_milestones: bool,
+    active: int = 0,
+    failed: int = 0,
+) -> dict[str, Any]:
     """A vendor ``SddcTask`` with *subtask_count* sub-tasks.
 
     ``with_milestones=False`` models the early bring-up shape (the 202
     from ``POST /v1/sddcs`` and the first polls) where ``milestones`` is
     not yet populated — the shape whose single real list field made the
-    pre-#3084 reduction swallow the task scalars.
+    pre-#3084 reduction swallow the task scalars. ``with_milestones=True``
+    is the live multi-hour poll shape: two populated list fields, the #3122
+    defect where the reducer's multi-list detail-object exemption passed the
+    whole document through UNREDUCED.
+
+    The first *active* sub-tasks are ``IN_PROGRESS``, the next *failed* are
+    ``FAILED`` with a nested ``errors[]``, and the remainder are
+    ``COMPLETED_WITH_SUCCESS`` — the mix the digest must summarize inline
+    (names for active, whole rows for failed).
     """
+    subtasks: list[dict[str, Any]] = []
+    for i in range(subtask_count):
+        if i < active:
+            subtasks.append({"name": f"subtask-{i}", "status": "IN_PROGRESS"})
+        elif i < active + failed:
+            subtasks.append(
+                {
+                    "name": f"subtask-{i}",
+                    "status": "FAILED",
+                    "errors": [
+                        {
+                            "errorCode": "INVENTORY_INTERNAL_SERVER_ERROR",
+                            "message": f"sub-task {i} boom",
+                        }
+                    ],
+                }
+            )
+        else:
+            subtasks.append({"name": f"subtask-{i}", "status": "COMPLETED_WITH_SUCCESS"})
     task: dict[str, Any] = {
         "id": "3f9e7d6c-5b4a-4938-8271-6a5b4c3d2e1f",
         "name": "sddc-bringup-lab01",
@@ -85,9 +152,7 @@ def _sddc_task(subtask_count: int, *, with_milestones: bool) -> dict[str, Any]:
         "vcfInstanceName": "lab01",
         "status": "IN_PROGRESS",
         "creationTimestamp": "2026-08-20T14:00:00.000Z",
-        "sddcSubTasks": [
-            {"name": f"subtask-{i}", "status": "PENDING"} for i in range(subtask_count)
-        ],
+        "sddcSubTasks": subtasks,
     }
     if with_milestones:
         task["milestones"] = [{"name": f"milestone-{i}", "status": "PENDING"} for i in range(4)]
@@ -119,6 +184,29 @@ def test_all_primitives_register_the_result_scalars_hint() -> None:
             "vcfInstanceName",
             "creationTimestamp",
         ], op_id
+
+
+def test_sddc_task_ops_register_the_result_digest_hint() -> None:
+    """#3122: every SddcTask op names sddcSubTasks + the active/failed states.
+
+    The digest hint is what overrides the multi-list detail-object exemption
+    (so a live two-list task reduces) and drives the inline digest. The
+    validation ops must NOT carry it — their single-list validationChecks
+    shape needs no override.
+    """
+    for op_id in _SDDC_TASK_OPS:
+        instructions = _OPS_BY_ID[op_id].llm_instructions
+        assert instructions is not None
+        digest = instructions.get("result_digest")
+        assert isinstance(digest, dict), f"{op_id} must register a result_digest hint (#3122)"
+        assert digest["collection"] == "sddcSubTasks", op_id
+        assert digest["status_field"] == "status", op_id
+        assert digest["active_states"] == ["IN_PROGRESS"], op_id
+        assert digest["failed_states"] == ["FAILED", "COMPLETED_WITH_FAILURE"], op_id
+    for op_id in _VALIDATION_OPS:
+        instructions = _OPS_BY_ID[op_id].llm_instructions
+        assert instructions is not None
+        assert "result_digest" not in instructions, f"{op_id} must not carry a digest hint"
 
 
 # ---------------------------------------------------------------------------
@@ -183,14 +271,15 @@ async def test_bringup_task_scalars_survive_single_list_reduction() -> None:
     The early bring-up shape — ``milestones`` not yet populated — has
     exactly one real list field, so ``_detect_collection`` reduces
     ``sddcSubTasks`` and (pre-#3084) swallowed the task scalars, including
-    the ``id`` the status poll needs. The registered hint pins them.
+    the ``id`` the status poll needs. The registered hints pin them, and
+    (#3122) the digest rides inline.
     """
     reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=4096)
-    payload = _sddc_task(60, with_milestones=False)
+    payload = _sddc_task(60, with_milestones=False, active=2, failed=1)
 
     for op_id in _SDDC_TASK_OPS:
         reduced, handle = await reducer.reduce(
-            dict(payload), None, _registered_scalars_context(op_id)
+            dict(payload), None, _registered_reducer_context(op_id)
         )
 
         assert handle is not None, f"{op_id}: 60 sub-tasks must materialize a handle"
@@ -201,27 +290,104 @@ async def test_bringup_task_scalars_survive_single_list_reduction() -> None:
         assert reduced["vcfInstanceName"] == "lab01", op_id
         assert reduced["source_key"] == "sddcSubTasks", op_id
         assert "sddcSubTasks" not in reduced, f"{op_id}: sub-tasks must stay reduced"
+        # #3122 digest rides inline: counts sum to the full set, active names
+        # are listed, failures carry their errors[].
+        assert reduced["status_counts"] == {
+            "IN_PROGRESS": 2,
+            "FAILED": 1,
+            "COMPLETED_WITH_SUCCESS": 57,
+        }, op_id
+        assert sum(reduced["status_counts"].values()) == 60, op_id
+        assert reduced["in_progress"] == ["subtask-0", "subtask-1"], op_id
+        assert [row["name"] for row in reduced["failed"]] == ["subtask-2"], op_id
+        assert reduced["failed"][0]["errors"][0]["errorCode"] == (
+            "INVENTORY_INTERNAL_SERVER_ERROR"
+        ), op_id
 
 
-async def test_bringup_task_with_milestones_is_a_detail_object_passthrough() -> None:
-    """A two-list ``SddcTask`` rides the #2113 detail-object exemption.
+async def test_bringup_task_with_milestones_reduces_and_digests_the_live_gap() -> None:
+    """#3122 root-cause fix: a two-list ``SddcTask`` now REDUCES, not passes through.
 
-    When both ``sddcSubTasks`` and ``milestones`` are populated the payload
-    is a dict-of-arrays detail object — more than one real list field — so
-    it passes through verbatim (scalars trivially intact, both arrays
-    retrievable, no handle). Pinned so a future detection change that
-    starts reducing one of the two arrays cannot silently drop the other
-    or the task scalars.
+    Live, the vendor ``SddcTask`` carries BOTH ``sddcSubTasks[]`` (~260 rows)
+    and a populated ``milestones[]`` — two real list fields, so the reducer's
+    #2113 multi-list detail-object exemption used to pass the whole document
+    through with ``handle=None`` (the defect this issue fixes: tens of KB every
+    poll, the ``result_scalars`` hint never firing). The ``result_digest``
+    hint names ``sddcSubTasks`` as THE collection, so it reduces despite the
+    sibling ``milestones``. The full array goes behind the handle; the inline
+    summary keeps the task scalars AND the sub-task digest — including every
+    failure WITH its ``errors[]`` so restart-from-failed needs no drill-in.
+    """
+    reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=4096)
+    # 260 sub-tasks: 3 in progress, 2 failed (with errors), 255 succeeded.
+    payload = _sddc_task(260, with_milestones=True, active=3, failed=2)
+
+    for op_id in _SDDC_TASK_OPS:
+        reduced, handle = await reducer.reduce(
+            dict(payload), None, _registered_reducer_context(op_id)
+        )
+
+        assert handle is not None, f"{op_id}: the two-list live task MUST reduce (#3122)"
+        assert handle.total_rows == 260, op_id
+        assert handle.fetch_more is not None, f"{op_id}: drill-in envelope must ship"
+        # Task scalars survive for the poll loop (#3084).
+        assert reduced["id"] == payload["id"], op_id
+        assert reduced["status"] == "IN_PROGRESS", op_id
+        assert reduced["creationTimestamp"] == "2026-08-20T14:00:00.000Z", op_id
+        # The reduced collection is sddcSubTasks; the full array is NOT inline.
+        assert reduced["source_key"] == "sddcSubTasks", op_id
+        assert "sddcSubTasks" not in reduced, op_id
+        # Digest: per-state counts over the whole set, active names, failures.
+        assert reduced["status_counts"] == {
+            "IN_PROGRESS": 3,
+            "FAILED": 2,
+            "COMPLETED_WITH_SUCCESS": 255,
+        }, op_id
+        assert reduced["in_progress"] == ["subtask-0", "subtask-1", "subtask-2"], op_id
+        assert [row["name"] for row in reduced["failed"]] == ["subtask-3", "subtask-4"], op_id
+        for failed_row in reduced["failed"]:
+            assert failed_row["status"] == "FAILED", op_id
+            assert failed_row["errors"][0]["message"], f"{op_id}: failure keeps its errors[]"
+
+
+async def test_two_list_task_without_digest_hint_stays_exempt() -> None:
+    """The #2113 exemption is intact for ops that don't register a digest hint.
+
+    The #3122 fix is strictly opt-in: it is the ``result_digest`` hint that
+    overrides the multi-list detail-object exemption, NOT a blanket detection
+    change. Fed a scalars-only context (no digest), the same two-list task
+    still passes through verbatim — proving the generic exemption other
+    connectors rely on (k8s.pod.info) is untouched.
     """
     reducer = JsonFluxReducer()
-    payload = _sddc_task(60, with_milestones=True)
+    payload = _sddc_task(60, with_milestones=True, active=3, failed=2)
 
     reduced, handle = await reducer.reduce(
         payload, None, _registered_scalars_context("installer.sddc.bringup.status")
     )
 
-    assert handle is None, "a two-list SddcTask is a detail object, not a collection"
+    assert handle is None, "without the digest hint a two-list task is still exempt"
     assert reduced is payload
-    assert reduced["id"] == payload["id"]
     assert len(reduced["sddcSubTasks"]) == 60
     assert len(reduced["milestones"]) == 4
+
+
+async def test_small_two_list_task_passes_through_even_with_digest_hint() -> None:
+    """The digest hint must not force a reduction the thresholds don't warrant.
+
+    An early poll with a handful of sub-tasks (under the 50-row threshold and
+    within the byte bound) passes through verbatim even though the digest hint
+    names ``sddcSubTasks`` — the hint changes WHICH collection reduces, never
+    WHETHER the thresholds are met. Both arrays and the task scalars stay
+    inline; no handle.
+    """
+    reducer = JsonFluxReducer()
+    payload = _sddc_task(5, with_milestones=True, active=1)
+
+    reduced, handle = await reducer.reduce(
+        payload, None, _registered_reducer_context("installer.sddc.bringup.status")
+    )
+
+    assert handle is None, "an under-threshold task must not materialize"
+    assert reduced is payload, "pass-through must return the exact vendor object"
+    assert "status_counts" not in reduced, "no digest when nothing reduced"

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -70,6 +70,8 @@ from meho_backplane.operations.jsonflux_reducer import (
     _fit_sample_to_budget,
     _preserved_scalars,
     _query_sample,
+    _resolve_digest_hint,
+    _row_digest,
     _sample_from_tail,
     _serialize,
 )
@@ -1406,6 +1408,185 @@ def test_detect_collection_reduces_paginated_collection_with_hateoas_metadata() 
         "``links`` metadata array"
     )
     assert rows == payload["resourceList"]
+
+
+# ---------------------------------------------------------------------------
+# #3122 — result_digest hint: explicit collection override + inline digest
+# ---------------------------------------------------------------------------
+
+
+def test_detect_collection_digest_hint_overrides_multi_list_exemption() -> None:
+    """A named collection reduces even when a sibling array would exempt it.
+
+    Two real list fields normally hit the #2113 detail-object exemption
+    (``(None, None)``). A ``result_digest`` hint naming one of them makes
+    ``_detect_collection`` return that array directly — the opt-in that lets
+    an SddcTask (``sddcSubTasks`` beside ``milestones``) reduce.
+    """
+    payload = {
+        "id": "task-1",
+        "sddcSubTasks": [{"name": f"s-{i}", "status": "PENDING"} for i in range(60)],
+        "milestones": [{"name": "m-0", "status": "PENDING"}],
+    }
+    # Without the hint: exempt (two real lists).
+    assert _detect_collection(payload) == (None, None)
+
+    spec = _resolve_digest_hint(
+        {"result_digest": {"collection": "sddcSubTasks", "status_field": "status"}}
+    )
+    envelope_key, rows = _detect_collection(payload, spec)
+
+    assert envelope_key == "sddcSubTasks"
+    assert rows == payload["sddcSubTasks"]
+
+
+def test_detect_collection_digest_hint_absent_collection_falls_through() -> None:
+    """A named collection that isn't present falls back to the heuristics.
+
+    The hint is additive: if the named array is absent (or not a list) the
+    reducer still reduces whatever single-list collection the payload does
+    carry, rather than failing to detect anything.
+    """
+    payload = {"pod": "p", "lines": ["a", "b", "c"]}
+    spec = _resolve_digest_hint(
+        {"result_digest": {"collection": "sddcSubTasks", "status_field": "status"}}
+    )
+
+    envelope_key, rows = _detect_collection(payload, spec)
+
+    assert envelope_key == "lines"
+    assert rows == ["a", "b", "c"]
+
+
+def test_row_digest_counts_active_and_failed_over_full_set() -> None:
+    """The digest counts every row, lists active names, keeps failures whole."""
+    rows = [
+        {"name": "a", "status": "IN_PROGRESS"},
+        {"name": "b", "status": "COMPLETED_WITH_SUCCESS"},
+        {"name": "c", "status": "FAILED", "errors": [{"message": "boom"}]},
+        {"name": "d", "status": "COMPLETED_WITH_FAILURE", "errors": [{"message": "bang"}]},
+        {"name": "e"},  # missing status -> UNKNOWN bucket
+    ]
+    spec = _resolve_digest_hint(
+        {
+            "result_digest": {
+                "collection": "subs",
+                "status_field": "status",
+                "name_field": "name",
+                "active_states": ["IN_PROGRESS"],
+                "failed_states": ["FAILED", "COMPLETED_WITH_FAILURE"],
+            }
+        }
+    )
+
+    digest = _row_digest(rows, "subs", spec)
+
+    assert digest["status_counts"] == {
+        "IN_PROGRESS": 1,
+        "COMPLETED_WITH_SUCCESS": 1,
+        "FAILED": 1,
+        "COMPLETED_WITH_FAILURE": 1,
+        "UNKNOWN": 1,
+    }
+    assert sum(digest["status_counts"].values()) == len(rows)
+    assert digest["in_progress"] == ["a"]
+    assert [row["name"] for row in digest["failed"]] == ["c", "d"]
+    assert digest["failed"][0]["errors"] == [{"message": "boom"}]
+
+
+def test_row_digest_skipped_when_reduced_collection_is_not_the_named_one() -> None:
+    """A digest is not computed against the wrong rows.
+
+    When the named collection was absent and a different array reduced, the
+    envelope key won't match the hint's collection, so no digest is emitted.
+    """
+    spec = _resolve_digest_hint({"result_digest": {"collection": "subs", "status_field": "status"}})
+    assert _row_digest([{"status": "X"}], "lines", spec) == {}
+    assert _row_digest([{"status": "X"}], "subs", None) == {}
+
+
+def test_resolve_digest_hint_rejects_missing_required_fields() -> None:
+    """Missing/invalid collection or status_field disables the hint wholesale."""
+    assert _resolve_digest_hint(None) is None
+    assert _resolve_digest_hint({}) is None
+    assert _resolve_digest_hint({"result_digest": "nope"}) is None
+    assert _resolve_digest_hint({"result_digest": {"status_field": "status"}}) is None
+    assert _resolve_digest_hint({"result_digest": {"collection": "subs"}}) is None
+    assert _resolve_digest_hint({"result_digest": {"collection": "", "status_field": "s"}}) is None
+
+
+def test_resolve_digest_hint_defaults_optional_fields() -> None:
+    """name_field defaults to 'name'; malformed state lists degrade to empty."""
+    spec = _resolve_digest_hint(
+        {
+            "result_digest": {
+                "collection": "subs",
+                "status_field": "status",
+                "active_states": "IN_PROGRESS",  # not a list -> empty
+            }
+        }
+    )
+    assert spec is not None
+    assert spec.name_field == "name"
+    assert spec.active_states == frozenset()
+    assert spec.failed_states == frozenset()
+
+
+async def test_reduce_digest_hint_reduces_two_list_payload_end_to_end() -> None:
+    """End-to-end: a two-list payload reduces the named array + emits the digest."""
+    reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=4096)
+    payload = {
+        "id": "task-1",
+        "status": "IN_PROGRESS",
+        "sddcSubTasks": [
+            {"name": f"s-{i}", "status": "IN_PROGRESS" if i < 2 else "COMPLETED_WITH_SUCCESS"}
+            for i in range(60)
+        ],
+        "milestones": [{"name": "m-0", "status": "PENDING"}],
+    }
+    context = {
+        "op_id": "x",
+        "result_scalars": {"keys": ["id", "status"]},
+        "result_digest": {
+            "collection": "sddcSubTasks",
+            "status_field": "status",
+            "name_field": "name",
+            "active_states": ["IN_PROGRESS"],
+            "failed_states": ["FAILED"],
+        },
+    }
+
+    reduced, handle = await reducer.reduce(payload, None, context)
+
+    assert handle is not None, "the named collection must reduce despite milestones"
+    assert handle.total_rows == 60
+    assert reduced["id"] == "task-1"
+    assert reduced["source_key"] == "sddcSubTasks"
+    assert "sddcSubTasks" not in reduced
+    assert reduced["status_counts"] == {"IN_PROGRESS": 2, "COMPLETED_WITH_SUCCESS": 58}
+    assert reduced["in_progress"] == ["s-0", "s-1"]
+    assert reduced["failed"] == []  # failed_states configured -> key present, empty
+
+
+async def test_reduce_digest_hint_malformed_falls_back_to_heuristics() -> None:
+    """A malformed digest hint never raises; detection falls back, no digest.
+
+    Matches the never-raise discipline of the sibling hints: a broken hint
+    degrades to the pre-#3122 behavior (heuristic detection) rather than
+    failing the read. A two-list payload then re-hits the exemption.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    payload = {
+        "id": "task-1",
+        "sddcSubTasks": [{"name": f"s-{i}", "status": "PENDING"} for i in range(60)],
+        "milestones": [{"name": "m-0", "status": "PENDING"}],
+    }
+    context = {"op_id": "x", "result_digest": {"status_field": "status"}}  # no collection
+
+    reduced, handle = await reducer.reduce(payload, None, context)
+
+    assert handle is None, "malformed hint -> heuristic detection -> two-list exemption"
+    assert reduced is payload
 
 
 def _large_application_pod(now: datetime) -> Any:


### PR DESCRIPTION
## Problem

Polling a live VCF 9.1 management-domain bring-up through governed dispatch (`call_operation` → `installer.sddc.bringup.status` on `installer-rest-9.1`) returned the whole vendor `SddcTask` document inline on every 150 s poll — the full `sddcSubTasks[]` array (~260 rows, tens of KB), with **no JSONFlux handle and no reduction**. Per v0.1-spec §4 / postulate 6, set-shaped responses past ~50 rows / 4 KB must return a handle + reduced view.

## Root-cause gap

The reducer *can* reduce this payload (the `test_connectors_vcf_installer_jsonflux_scalars` #3084 tests prove it), but the **live dispatch path never invoked reduction** for this op. In `jsonflux_reducer._detect_collection`, a live `SddcTask` carries **both** `sddcSubTasks[]` **and** a populated `milestones[]` — two *real* list fields — so it hit the #2113 dict-of-arrays **detail-object exemption** and returned `(None, None)`, passing the whole document through verbatim. The `result_scalars` hint (#3084) never even fired, because the payload was never reduced in the first place. The prior `test_bringup_task_with_milestones_is_a_detail_object_passthrough` test had actually *pinned* this buggy behavior (it fed a scalars-only context and asserted `handle is None`).

## Fix

A new opt-in **`result_digest`** reducer hint, threaded exactly like the existing `result_scalars` / `result_ordering` / `pagination_hint` hints (descriptor `llm_instructions` → `dispatcher._result_digest_from_descriptor` → reducer context). It does two jobs:

1. **Collection override** — names the dominant collection, so `_detect_collection` reduces it directly (overriding the multi-list exemption). The exemption is untouched for any op that does not register the hint (re-pinned by test).
2. **Inline digest** — `_row_digest` computes, over the **full** set: `status_counts` (per-state counts; `sum == total_rows`), `in_progress` (names of `IN_PROGRESS` sub-tasks when `active_states` configured), and `failed` (every `FAILED` / `COMPLETED_WITH_FAILURE` sub-task preserved **whole, with its `errors[]`**) when `failed_states` configured.

Failures ride inline so the restart-from-failed flow (`installer.sddc.bringup.retry`) never needs a drill-in — the #3084 drivability lesson generalized. The full `sddcSubTasks` array stays behind the result handle for `result_query`. Registered on the three `SddcTask` bring-up ops (`start` / `retry` / `status`) — symmetric with the shared `_SDDC_TASK_RESULT_SCALARS`.

The hint validation follows the never-raise discipline of the sibling hints: `collection` + `status_field` are load-bearing (a bad value disables the hint and logs once → falls back to heuristic detection); `name_field` / `active_states` / `failed_states` degrade gracefully. An under-threshold task still passes through verbatim (the hint changes *which* collection reduces, never *whether* the thresholds are met).

## Tests

- `test_operations_jsonflux_reducer.py`: collection-override vs the multi-list exemption, absent-collection fall-through, `_row_digest` counts/active/failed-with-errors over the full set, digest skipped when the reduced collection isn't the named one, malformed-hint rejection + graceful defaults, end-to-end reduce of a two-list payload, and malformed-hint → heuristic fallback (never raises).
- `test_connectors_vcf_installer_jsonflux_scalars.py`: digest-hint registration on the 3 SddcTask ops (and its absence on the validation ops); the live two-list gap now **reduces + digests** (260 sub-tasks, 3 in-progress, 2 failed with `errors[]`); the #2113 exemption re-pinned for the non-hinted (scalars-only) context; a small two-list task still passes through even with the digest hint.

`uv run pytest tests/test_connectors_vcf_installer_*.py tests/test_operations_jsonflux_reducer.py tests/test_operations_dispatcher.py tests/test_operations_reducer.py tests/test_vault_kv_list_jsonflux.py tests/test_connectors_k8s_dispatcher_shim.py tests/test_dispatcher_redaction_integration.py` → all green. `ruff check` + `ruff format` clean; `mypy` clean on the three touched source packages.

Closes #3122

🤖 Generated with [Claude Code](https://claude.com/claude-code)