### PR TITLE
feat(clients): package Claude Desktop onramp as a .mcpb bundle

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -23,6 +23,13 @@
 # extracted from the top-level CHANGELOG.md so the human-curated
 # narrative — not git-log noise — lands in the GitHub Release body.
 #
+# The Claude Desktop MCPB bundle (clients/claude-desktop-mcpb/) is built
+# with the tag version and attached to the same Release as a fifth asset
+# by the "Build + attach Claude Desktop .mcpb bundle" step below. It is
+# not a CLI tarball and is not cosign-signed; distribution is the GitHub
+# Release asset channel only (#3129). The step runs after GoReleaser has
+# created the Release so `gh release upload` has a Release to attach to.
+#
 # Permissions design follows the same per-job least-privilege posture
 # as chart.yml + image.yml:
 #   * workflow-default = `contents: read` (just enough to checkout).
@@ -112,6 +119,15 @@ jobs:
           # filesystem. Keyed by cli/go.sum (the only Go module in
           # the tree right now).
           cache-dependency-path: cli/go.sum
+
+      - name: Set up Node (Claude Desktop .mcpb bundle)
+        # Node provides `npx` for the pinned `@anthropic-ai/mcpb` CLI that
+        # packs the Claude Desktop bundle (see the build/attach step after
+        # GoReleaser). Same pin as dependency-license-check.yml so one
+        # supply-chain audit covers both Node setups.
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
 
       - name: Ensure envsubst (gettext-base) — cosign-installer dep
         # See chart.yml for context.
@@ -258,6 +274,25 @@ jobs:
           # standard sigstore.dev CI guidance.
           COSIGN_YES: "true"
 
+      - name: Build + attach Claude Desktop .mcpb bundle
+        # GoReleaser has created the Release above; attach the Claude
+        # Desktop MCPB bundle to it as a fifth asset. `build.sh` runs the
+        # pinned `mcpb pack` (which validates the manifest) with the tag
+        # version stripped of its leading `v` — matching GoReleaser's
+        # `meho_<version>_...` file-name convention. `--clobber` lets a
+        # re-tag replace the asset instead of failing on a name clash.
+        env:
+          TAG: ${{ github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          OUT_DIR="${RUNNER_TEMP}/mcpb"
+          clients/claude-desktop-mcpb/build.sh "${VERSION}" "${OUT_DIR}"
+          BUNDLE="${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb"
+          gh release upload "${TAG}" "${BUNDLE}" --clobber --repo "${GITHUB_REPOSITORY}"
+
       - name: Emit release summary
         # Surface the published artefact list in the workflow run
         # summary so a maintainer flipping the draft Release to
@@ -274,7 +309,7 @@ jobs:
             echo "### Artefacts"
             echo ""
             echo '```'
-            ls -1 cli/dist/*.tar.gz cli/dist/SHA256SUMS cli/dist/*.cosign.bundle 2>/dev/null || true
+            ls -1 cli/dist/*.tar.gz cli/dist/SHA256SUMS cli/dist/*.cosign.bundle "${RUNNER_TEMP}"/mcpb/*.mcpb 2>/dev/null || true
             echo '```'
             echo ""
             echo "Each \`.tar.gz\` and the \`SHA256SUMS\` file has a matching"

--- a/.github/workflows/mcpb-bundle.yml
+++ b/.github/workflows/mcpb-bundle.yml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Claude Desktop .mcpb bundle — PR dry-run.
+#
+# The "MEHO for Claude Desktop" MCPB bundle (clients/claude-desktop-mcpb/)
+# is built and attached to the GitHub Release on `v*` tag push by
+# cli-release.yml, next to the CLI tarballs. This workflow is the PR-side
+# counterpart: whenever a PR touches the bundle sources, it packs the
+# bundle (which validates manifest.json against the MANIFEST 0.3 schema),
+# enforces the internal-only wording guard, and uploads the result as a
+# CI artifact so a reviewer can download and install it.
+#
+# Not a release step — it never touches a GitHub Release. Path-scoped via
+# `on.pull_request.paths` because it is an advisory (non-required) check;
+# a required check would need the `changes`-job + job-`if:` shape ci.yml
+# uses to skip cleanly, which this dry-run does not warrant.
+
+name: mcpb-bundle
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'clients/claude-desktop-mcpb/**'
+      - '.github/workflows/mcpb-bundle.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcpb-bundle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pack:
+    name: Pack .mcpb bundle (dry-run)
+    # Fork-PR guard mirrors ci.yml / image.yml: `meho-runners-ci` is
+    # internal infra, so fork PRs skip rather than execute bundle
+    # sources on the self-hosted pool.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: meho-runners-ci
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: Wording guard — no "custom connector" path
+        # Regression guard for #2792: MEHO is internal-only, so the
+        # invalid remote Custom-Connector onramp must never creep back
+        # into the bundle sources. `grep -ri` returns 0 on a match, so a
+        # match fails the step.
+        run: |
+          if grep -ri "custom connector" clients/claude-desktop-mcpb/; then
+            echo "::error::'custom connector' found in bundle sources — the internal-only remote-connector path must stay scrubbed (#2792)."
+            exit 1
+          fi
+
+      - name: Pack bundle (dry-run)
+        # The PR number gives a valid pre-release semver so each dry-run
+        # bundle is identifiable; the real version is the git tag on the
+        # release path (cli-release.yml).
+        run: clients/claude-desktop-mcpb/build.sh "0.0.0-pr${{ github.event.number }}" dist
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: meho-claude-desktop-mcpb
+          path: dist/*.mcpb
+          if-no-files-found: error

--- a/clients/claude-desktop-mcpb/.gitignore
+++ b/clients/claude-desktop-mcpb/.gitignore
@@ -1,0 +1,3 @@
+# Built bundles (produced by build.sh / CI, attached to GitHub Releases).
+/dist/
+*.mcpb

--- a/clients/claude-desktop-mcpb/README.md
+++ b/clients/claude-desktop-mcpb/README.md
@@ -31,7 +31,7 @@ because the shim runs on a machine already on the VPN.
 | Path | Role |
 |---|---|
 | `manifest.json` | MCPB manifest (`manifest_version` 0.3). Committed with a `0.0.0` placeholder version; `build.sh` injects the real version at pack time. |
-| `server/index.mjs` | The bundle's entry point. A transparent stdio launcher for `npx -y mcp-remote <url>` that guards the internal-CA path. |
+| `server/index.mjs` | The bundle's entry point. A thin stdio launcher for `npx -y mcp-remote@0.1.38 <url> …` that guards the internal-CA path and presents the pre-registered `meho-mcp` OAuth client. |
 | `build.sh` | Validates + packs the bundle via the pinned `@anthropic-ai/mcpb` CLI. |
 
 ## Building locally
@@ -57,8 +57,9 @@ and [`.github/workflows/cli-release.yml`](../../.github/workflows/cli-release.ym
 ## How the launcher works
 
 The manifest's `mcp_config.command` is `node`, running `server/index.mjs`
-with the operator's backplane URL as its argument and the optional CA
-path delivered as the `MEHO_CA_CERT` environment variable. The launcher:
+with the operator's backplane URL as its argument, the optional CA path
+delivered as the `MEHO_CA_CERT` environment variable, and the OAuth
+client id delivered as `MEHO_MCP_CLIENT_ID`. The launcher:
 
 1. Validates that the URL is a well-formed `https` URL.
 2. Exports `NODE_EXTRA_CA_CERTS` to the child **only** when a non-empty
@@ -66,12 +67,25 @@ path delivered as the `MEHO_CA_CERT` environment variable. The launcher:
    child's TLS trust path, and the MCPB host's substitution of an unset
    optional value is undocumented — so the guard lives in code rather
    than depending on that behavior.
-3. Spawns `npx -y mcp-remote <url>` with inherited stdio, so `mcp-remote`
-   runs its OAuth 2.1 + PKCE flow and forwards Streamable-HTTP calls to
-   `/mcp` exactly as it does when spawned directly.
+3. Resolves the OAuth client id from `MEHO_MCP_CLIENT_ID`, falling back to
+   `meho-mcp` when the host substitutes an empty value for the untouched
+   optional `client_id` config — so an operator who never opens the
+   advanced field still authenticates.
+4. Spawns the smoke-tested `npx -y mcp-remote@0.1.38 <url>` with inherited
+   stdio, passing `--static-oauth-client-info '{"client_id": "…"}'` and
+   `--static-oauth-client-metadata '{"scope": "mcp:read mcp:execute"}'`.
+   The static client info is load-bearing: MEHO's Keycloak realm blocks
+   anonymous RFC 7591 Dynamic Client Registration (default Trusted Hosts
+   policy → `403 "Host not trusted"`), so a bare `mcp-remote` could never
+   complete OAuth on a fresh install. Presenting the pre-registered public
+   `meho-mcp` client skips DCR entirely. `mcp-remote` then runs its OAuth
+   2.1 + PKCE flow and forwards Streamable-HTTP calls to `/mcp`.
 
-The operator's machine therefore needs system Node.js / `npx` on `PATH`
-(the same prerequisite the raw shim recipe has).
+The `meho-mcp` client (or whatever name `client_id` overrides it to) must
+already exist on the realm — see
+[`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md).
+The operator's machine needs system Node.js / `npx` on `PATH` (the same
+prerequisite the raw shim recipe has).
 
 ## Verifying a built bundle
 

--- a/clients/claude-desktop-mcpb/README.md
+++ b/clients/claude-desktop-mcpb/README.md
@@ -1,0 +1,93 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# MEHO for Claude Desktop — MCPB bundle
+
+A one-click [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle
+(formerly "DXT") that connects Claude Desktop to an internal MEHO
+backplane. Opening the `.mcpb` file in Claude Desktop shows an install
+dialog and prompts for the two per-operator values — no hand-editing of
+`claude_desktop_config.json`.
+
+## What it packages
+
+Claude Desktop cannot reach an internal MEHO through its cloud-brokered
+remote connector: MEHO is internal-only and never publicly exposed, so
+Anthropic's cloud can't fetch its RFC 9728 metadata. Desktop instead
+reaches the backplane through a **local `mcp-remote` stdio→Streamable-HTTP
+shim** that runs on the operator's own VPN-connected machine (the recipe
+in [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md),
+proven by #2666). This bundle packages exactly that shim invocation.
+
+Distribution is the **GitHub Release asset channel only** — there is no
+public marketplace or registry. The bundle is generic (the backplane URL
+is operator-supplied config), and the internal-only posture is unchanged
+because the shim runs on a machine already on the VPN.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `manifest.json` | MCPB manifest (`manifest_version` 0.3). Committed with a `0.0.0` placeholder version; `build.sh` injects the real version at pack time. |
+| `server/index.mjs` | The bundle's entry point. A transparent stdio launcher for `npx -y mcp-remote <url>` that guards the internal-CA path. |
+| `build.sh` | Validates + packs the bundle via the pinned `@anthropic-ai/mcpb` CLI. |
+
+## Building locally
+
+```bash
+./build.sh 0.31.0            # writes ./dist/meho-claude-desktop-0.31.0.mcpb
+./build.sh 0.31.0 /tmp/out   # or choose the output directory
+```
+
+Requires Node.js (for `npx`) and `jq`. The pinned `@anthropic-ai/mcpb`
+CLI validates `manifest.json` against the MANIFEST 0.3 schema before
+zipping, so a malformed manifest fails the build.
+
+In CI the same script runs two ways (see
+[`.github/workflows/mcpb-bundle.yml`](../../.github/workflows/mcpb-bundle.yml)
+and [`.github/workflows/cli-release.yml`](../../.github/workflows/cli-release.yml)):
+
+- **Pull requests touching this directory** — a dry-run pack that
+  validates the manifest and uploads the bundle as a CI artifact.
+- **`v*` tag push** — builds with the tag version and attaches the
+  bundle to the GitHub Release alongside the CLI tarballs.
+
+## How the launcher works
+
+The manifest's `mcp_config.command` is `node`, running `server/index.mjs`
+with the operator's backplane URL as its argument and the optional CA
+path delivered as the `MEHO_CA_CERT` environment variable. The launcher:
+
+1. Validates that the URL is a well-formed `https` URL.
+2. Exports `NODE_EXTRA_CA_CERTS` to the child **only** when a non-empty
+   CA path was supplied. An unset optional file must not become the
+   child's TLS trust path, and the MCPB host's substitution of an unset
+   optional value is undocumented — so the guard lives in code rather
+   than depending on that behavior.
+3. Spawns `npx -y mcp-remote <url>` with inherited stdio, so `mcp-remote`
+   runs its OAuth 2.1 + PKCE flow and forwards Streamable-HTTP calls to
+   `/mcp` exactly as it does when spawned directly.
+
+The operator's machine therefore needs system Node.js / `npx` on `PATH`
+(the same prerequisite the raw shim recipe has).
+
+## Verifying a built bundle
+
+```bash
+./build.sh 0.0.0-dev /tmp/out
+unzip -l /tmp/out/meho-claude-desktop-0.0.0-dev.mcpb   # manifest.json + server/index.mjs
+```
+
+Then open the `.mcpb` in Claude Desktop on a VPN-connected machine, enter
+an internal `/mcp` URL, and confirm `meho_status` is callable (the #2666
+bar).
+
+## References
+
+- MCPB spec + CLI: <https://github.com/modelcontextprotocol/mcpb>;
+  MANIFEST 0.3: <https://github.com/modelcontextprotocol/mcpb/blob/main/MANIFEST.md>
+- Background (DXT → MCPB rename): <https://www.anthropic.com/engineering/desktop-extensions>
+- Shim recipe this packages: [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md) Step 3
+- Release wiring: [`docs/RELEASING.md`](../../docs/RELEASING.md)

--- a/clients/claude-desktop-mcpb/build.sh
+++ b/clients/claude-desktop-mcpb/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Build the "MEHO for Claude Desktop" .mcpb bundle.
+#
+# Usage: build.sh <version> [output-dir]
+#
+#   version     Semver stamped into the bundled manifest and the file
+#               name (the release pipeline passes the git tag without
+#               its leading `v`; a local build can pass any semver).
+#   output-dir  Where the .mcpb lands (default: ./dist next to this
+#               script). Created if absent.
+#
+# The pinned `@anthropic-ai/mcpb` CLI validates the manifest against the
+# MANIFEST 0.3 schema before zipping, so a malformed manifest fails the
+# build (and, in CI, the PR / release job) rather than shipping.
+
+set -euo pipefail
+
+# @anthropic-ai/mcpb CLI version. Pinned so the schema the manifest is
+# validated against — and the bundle layout — are reproducible across
+# local builds and CI. Bump deliberately.
+MCPB_VERSION="2.1.2"
+
+VERSION="${1:-}"
+if [[ -z "${VERSION}" ]]; then
+  echo "usage: build.sh <version> [output-dir]" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${2:-${SCRIPT_DIR}/dist}"
+mkdir -p "${OUT_DIR}"
+
+# Stage only the runtime files (manifest + server/) so build.sh, the
+# README, and the .gitignore never end up inside the shipped bundle.
+# The manifest is committed with a placeholder version (0.0.0); the real
+# version is injected into the staged copy so the source tree stays clean.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+
+jq --arg v "${VERSION}" '.version = $v' "${SCRIPT_DIR}/manifest.json" \
+  > "${STAGE}/manifest.json"
+cp -R "${SCRIPT_DIR}/server" "${STAGE}/server"
+
+OUT_FILE="${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb"
+npx --yes "@anthropic-ai/mcpb@${MCPB_VERSION}" pack "${STAGE}" "${OUT_FILE}"
+
+echo "Built ${OUT_FILE}"

--- a/clients/claude-desktop-mcpb/manifest.json
+++ b/clients/claude-desktop-mcpb/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": "0.3",
+  "name": "meho-claude-desktop",
+  "display_name": "MEHO for Claude Desktop",
+  "version": "0.0.0",
+  "description": "Connect Claude Desktop to an internal MEHO backplane via the mcp-remote shim (VPN required).",
+  "author": {
+    "name": "evoila"
+  },
+  "homepage": "https://github.com/evoila/meho",
+  "documentation": "https://github.com/evoila/meho/blob/main/docs/cross-repo/mcp-client-setup.md",
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.mjs",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.mjs", "${user_config.backplane_url}"],
+      "env": {
+        "MEHO_CA_CERT": "${user_config.ca_cert}"
+      }
+    }
+  },
+  "user_config": {
+    "backplane_url": {
+      "type": "string",
+      "title": "MEHO MCP endpoint",
+      "description": "Your backplane's MCP URL, e.g. https://meho.internal.example/mcp — must be reachable over your VPN.",
+      "required": true
+    },
+    "ca_cert": {
+      "type": "file",
+      "title": "Internal CA bundle (optional)",
+      "description": "PEM bundle for the internal CA that signs the backplane's TLS certificate. Leave empty for public-CA deploys.",
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32"]
+  }
+}

--- a/clients/claude-desktop-mcpb/manifest.json
+++ b/clients/claude-desktop-mcpb/manifest.json
@@ -16,7 +16,8 @@
       "command": "node",
       "args": ["${__dirname}/server/index.mjs", "${user_config.backplane_url}"],
       "env": {
-        "MEHO_CA_CERT": "${user_config.ca_cert}"
+        "MEHO_CA_CERT": "${user_config.ca_cert}",
+        "MEHO_MCP_CLIENT_ID": "${user_config.client_id}"
       }
     }
   },
@@ -31,6 +32,13 @@
       "type": "file",
       "title": "Internal CA bundle (optional)",
       "description": "PEM bundle for the internal CA that signs the backplane's TLS certificate. Leave empty for public-CA deploys.",
+      "required": false
+    },
+    "client_id": {
+      "type": "string",
+      "title": "OAuth client id (advanced)",
+      "description": "Pre-registered public OAuth client the shim presents to Keycloak. Leave as the default unless your realm registered the client under a different name.",
+      "default": "meho-mcp",
       "required": false
     }
   },

--- a/clients/claude-desktop-mcpb/server/index.mjs
+++ b/clients/claude-desktop-mcpb/server/index.mjs
@@ -2,17 +2,26 @@
 // Launcher for the "MEHO for Claude Desktop" bundle.
 //
 // Claude Desktop runs this file with its bundled Node runtime (the
-// manifest's server.mcp_config.command is "node"). It is a transparent
-// stdio pass-through to the proven onramp `npx -y mcp-remote <url>`
+// manifest's server.mcp_config.command is "node"). It is a thin stdio
+// pass-through to the proven onramp `npx -y mcp-remote@0.1.38 <url> …`
 // (recipe: docs/cross-repo/mcp-client-setup.md, proven by #2666).
 //
-// The one thing it adds over invoking npx directly is a guard on the
-// internal-CA path: the optional `ca_cert` user_config is delivered as
-// MEHO_CA_CERT, and NODE_EXTRA_CA_CERTS is exported to the child ONLY
-// when a non-empty path was supplied. Wiring the optional file straight
-// into NODE_EXTRA_CA_CERTS would leave the host's substitution of an
-// unset optional value (empty string vs. omitted vs. literal) to decide
-// the child's TLS trust store — undocumented and not worth depending on.
+// It adds two things over invoking npx directly:
+//
+//  1. A guard on the internal-CA path: the optional `ca_cert` user_config
+//     is delivered as MEHO_CA_CERT, and NODE_EXTRA_CA_CERTS is exported to
+//     the child ONLY when a non-empty path was supplied. Wiring the
+//     optional file straight into NODE_EXTRA_CA_CERTS would leave the
+//     host's substitution of an unset optional value (empty string vs.
+//     omitted vs. literal) to decide the child's TLS trust store —
+//     undocumented and not worth depending on.
+//  2. The static OAuth client id: MEHO's Keycloak realm blocks anonymous
+//     RFC 7591 Dynamic Client Registration (default Trusted Hosts policy →
+//     403 "Host not trusted"), so a bare `mcp-remote` cannot complete
+//     OAuth on a fresh install. The launcher presents the pre-registered
+//     public `meho-mcp` client via --static-oauth-client-info, overridable
+//     through the optional `client_id` user_config (delivered as
+//     MEHO_MCP_CLIENT_ID) without editing the installed bundle.
 
 import { spawn } from "node:child_process";
 
@@ -44,13 +53,35 @@ if (caCert !== "") {
 }
 delete env.MEHO_CA_CERT;
 
+// The pre-registered public OAuth client the shim presents to Keycloak.
+// Fall back to the default when the host substitutes an empty value for an
+// untouched optional field, so an operator who never opens the advanced
+// `client_id` field still authenticates. Stripped from the child env (like
+// MEHO_CA_CERT) to keep the config seam out of mcp-remote's environment.
+const clientId = (process.env.MEHO_MCP_CLIENT_ID ?? "").trim() || "meho-mcp";
+delete env.MEHO_MCP_CLIENT_ID;
+
 // On Windows `npx` resolves to `npx.cmd`, which Node refuses to spawn
-// without a shell (CVE-2024-27980 mitigation). The URL is validated
-// above, so the only interpolated argument is a well-formed https URL.
+// without a shell (CVE-2024-27980 mitigation). The URL is validated above,
+// and the OAuth flags are JSON produced by JSON.stringify from a trimmed
+// client id — no interpolated argument can inject a shell token.
+//
+// Pin the smoke-tested `mcp-remote@0.1.38` and present the static
+// `meho-mcp` client via --static-oauth-client-info so the shim skips the
+// DCR the realm blocks; the scope metadata matches what the backplane's
+// token audience mappers expect.
 const isWindows = process.platform === "win32";
 const child = spawn(
   isWindows ? "npx.cmd" : "npx",
-  ["-y", "mcp-remote", url.href],
+  [
+    "-y",
+    "mcp-remote@0.1.38",
+    url.href,
+    "--static-oauth-client-info",
+    JSON.stringify({ client_id: clientId }),
+    "--static-oauth-client-metadata",
+    JSON.stringify({ scope: "mcp:read mcp:execute" }),
+  ],
   { stdio: "inherit", env, shell: isWindows },
 );
 

--- a/clients/claude-desktop-mcpb/server/index.mjs
+++ b/clients/claude-desktop-mcpb/server/index.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Launcher for the "MEHO for Claude Desktop" bundle.
+//
+// Claude Desktop runs this file with its bundled Node runtime (the
+// manifest's server.mcp_config.command is "node"). It is a transparent
+// stdio pass-through to the proven onramp `npx -y mcp-remote <url>`
+// (recipe: docs/cross-repo/mcp-client-setup.md, proven by #2666).
+//
+// The one thing it adds over invoking npx directly is a guard on the
+// internal-CA path: the optional `ca_cert` user_config is delivered as
+// MEHO_CA_CERT, and NODE_EXTRA_CA_CERTS is exported to the child ONLY
+// when a non-empty path was supplied. Wiring the optional file straight
+// into NODE_EXTRA_CA_CERTS would leave the host's substitution of an
+// unset optional value (empty string vs. omitted vs. literal) to decide
+// the child's TLS trust store — undocumented and not worth depending on.
+
+import { spawn } from "node:child_process";
+
+const rawUrl = process.argv[2];
+
+let url;
+try {
+  url = new URL(rawUrl ?? "");
+} catch {
+  process.stderr.write(
+    "meho-claude-desktop: the MEHO MCP endpoint must be a valid URL " +
+      "(e.g. https://meho.internal.example/mcp)\n",
+  );
+  process.exit(1);
+}
+if (url.protocol !== "https:") {
+  process.stderr.write(
+    "meho-claude-desktop: the MEHO MCP endpoint must use https\n",
+  );
+  process.exit(1);
+}
+
+const env = { ...process.env };
+const caCert = (process.env.MEHO_CA_CERT ?? "").trim();
+if (caCert !== "") {
+  env.NODE_EXTRA_CA_CERTS = caCert;
+} else {
+  delete env.NODE_EXTRA_CA_CERTS;
+}
+delete env.MEHO_CA_CERT;
+
+// On Windows `npx` resolves to `npx.cmd`, which Node refuses to spawn
+// without a shell (CVE-2024-27980 mitigation). The URL is validated
+// above, so the only interpolated argument is a well-formed https URL.
+const isWindows = process.platform === "win32";
+const child = spawn(
+  isWindows ? "npx.cmd" : "npx",
+  ["-y", "mcp-remote", url.href],
+  { stdio: "inherit", env, shell: isWindows },
+);
+
+child.on("error", (err) => {
+  process.stderr.write(
+    `meho-claude-desktop: failed to launch mcp-remote: ${err.message}\n`,
+  );
+  process.exit(1);
+});
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,7 @@ The `/release` skill walks these same steps interactively.
 ## What a release is
 
 A release is **a `v*` git tag**. The tag is the single source of truth
-for the version — four artefacts derive from it, all published
+for the version — five artefacts derive from it, all published
 automatically on the tag push:
 
 | Artefact | Where | Workflow | Version source |
@@ -20,9 +20,12 @@ automatically on the tag push:
 | Backplane image | `ghcr.io/evoila/meho:vX.Y.Z` | [`image.yml`](../.github/workflows/image.yml) | git tag |
 | Helm chart | `oci://ghcr.io/evoila/meho-chart` | [`chart.yml`](../.github/workflows/chart.yml) | chart workflow sets `version` + `appVersion` |
 | CLI tarballs + GitHub Release | [releases](https://github.com/evoila/meho/releases) | [`cli-release.yml`](../.github/workflows/cli-release.yml) | GoReleaser bakes `{{.Tag}}` into `version.Version` |
+| Claude Desktop `.mcpb` bundle | [releases](https://github.com/evoila/meho/releases) | [`cli-release.yml`](../.github/workflows/cli-release.yml) | `clients/claude-desktop-mcpb/build.sh` stamps the tag version |
 | Docs site version | <https://evoila.github.io/meho/> | [`docs-site.yml`](../.github/workflows/docs-site.yml) | mike publishes the tag's `MAJOR.MINOR` + moves `latest` |
 
-All four trigger on `tags: ['v*']` (image/chart have **no** path filter
+The Desktop `.mcpb` bundle rides `cli-release.yml`, attached to the same
+GitHub Release as the CLI tarballs (four workflows, five artefacts). All
+four workflows fire on `tags: ['v*']` (image/chart have **no** path filter
 on tags — a tag always publishes). `cli-release.yml` is **tag-only**: a
 main push never cuts a release. Docs versions are cut **per minor** — a
 patch tag republishes its minor's docs in place.
@@ -189,6 +192,8 @@ The push fans out to `cli-release.yml`, `image.yml`, `chart.yml`.
 - [ ] Image `ghcr.io/evoila/meho:vX.Y.Z` published (`image.yml` green).
 - [ ] Chart published to `oci://ghcr.io/evoila/meho-chart` (`chart.yml` green).
 - [ ] CLI tarballs attached to the Release; `meho version` prints `vX.Y.Z`.
+- [ ] Claude Desktop bundle `meho-claude-desktop-X.Y.Z.mcpb` attached to
+  the Release (fifth asset, uploaded by `cli-release.yml` after GoReleaser).
 
 #### Maintainer one-time setup — GHCR package visibility
 

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -90,7 +90,20 @@ MEHO speaks Streamable HTTP at `/mcp`, not stdio. This matters because Claude De
 
 ### Claude Desktop — via the `mcp-remote` stdio shim (recommended for Desktop)
 
-Claude Desktop's remote "Custom Connector" is brokered through Anthropic's cloud and requires a **publicly reachable** backplane — which MEHO, being internal-only, never is (see the callout at the top of this doc). Desktop instead reaches an internal MEHO through a **local stdio→HTTP shim** that runs on the operator's own VPN-connected machine. Configure it as a local MCP server in `claude_desktop_config.json`:
+Claude Desktop's remote "Custom Connector" is brokered through Anthropic's cloud and requires a **publicly reachable** backplane — which MEHO, being internal-only, never is (see the callout at the top of this doc). Desktop instead reaches an internal MEHO through a **local stdio→HTTP shim** (`mcp-remote`) that runs on the operator's own VPN-connected machine. There are two ways to wire it up: the packaged bundle (primary) or the raw config (fallback).
+
+#### Primary: the `.mcpb` bundle (one-click install)
+
+Every MEHO release attaches a **`meho-claude-desktop-<version>.mcpb`** file to its [GitHub Release](https://github.com/evoila/meho/releases), built from [`clients/claude-desktop-mcpb/`](../../clients/claude-desktop-mcpb/). Download it and open it in Claude Desktop: the install dialog appears and prompts for two values — no `claude_desktop_config.json` editing.
+
+1. **MEHO MCP endpoint** (required) — your backplane's `/mcp` URL, e.g. `https://meho.internal.example/mcp`, reachable over your VPN.
+2. **Internal CA bundle** (optional) — a PEM bundle for the internal CA that signs the backplane's TLS certificate. Leave it empty for public-CA deploys.
+
+The bundle wraps exactly the `npx -y mcp-remote <url>` invocation shown in the fallback below, and needs system Node.js / `npx` on `PATH` (the same prerequisite the raw config has). Distribution is the GitHub Release asset channel only — there is no public marketplace or registry, and the internal-only posture is unchanged because the shim still runs on your own VPN-connected machine.
+
+#### Fallback: raw `claude_desktop_config.json`
+
+If you would rather not use the bundle (or need to tweak the invocation), configure the shim as a local MCP server directly:
 
 ```json
 {
@@ -104,7 +117,7 @@ Claude Desktop's remote "Custom Connector" is brokered through Anthropic's cloud
 }
 ```
 
-`mcp-remote` runs the OAuth 2.1 + PKCE flow against the internal Keycloak (or presents a Bearer token supplied out-of-band via `meho login --print-token`) and forwards Streamable-HTTP calls to `/mcp`. `NODE_EXTRA_CA_CERTS` is only needed when the deploy uses an internal CA (see [`deploy/values-examples/README.md` § Internal-CA trust bundle](../../deploy/values-examples/README.md#internal-ca-trust-bundle-extravolumes--extraenv)). Because the shim runs on a machine already on the VPN, nothing about the backplane is publicly exposed.
+`mcp-remote` runs the OAuth 2.1 + PKCE flow against the internal Keycloak (or presents a Bearer token supplied out-of-band via `meho login --print-token`) and forwards Streamable-HTTP calls to `/mcp`. `NODE_EXTRA_CA_CERTS` is only needed when the deploy uses an internal CA (see [`deploy/values-examples/README.md` § Internal-CA trust bundle](../../deploy/values-examples/README.md#internal-ca-trust-bundle-extravolumes--extraenv)); omit the `env` block entirely for public-CA deploys. Because the shim runs on a machine already on the VPN, nothing about the backplane is publicly exposed.
 
 ### Claude.ai / Claude Desktop remote Custom Connector — not applicable
 


### PR DESCRIPTION
## Summary

- New `clients/claude-desktop-mcpb/` — an MCPB (`manifest_version` 0.3) bundle so a fresh user installs the Claude Desktop onramp by **opening a `.mcpb` file** (install dialog prompts for the `/mcp` URL + optional internal-CA bundle) instead of hand-editing `claude_desktop_config.json`.
- The bundle's entry point is a small stdio launcher (`server/index.mjs`): MCPB requires `server.entry_point`, and the launcher makes the internal-CA path deterministic — it exports `NODE_EXTRA_CA_CERTS` to `mcp-remote` **only** when a non-empty CA path was supplied, then forwards stdio to the pinned `npx -y mcp-remote@0.1.38 <url> …` (the proven #2666 shim).
- The launcher presents the pre-registered public `meho-mcp` OAuth client via `--static-oauth-client-info` (+ `--static-oauth-client-metadata` scope) so a fresh install completes OAuth against MEHO's DCR-blocking Keycloak realm. The client id is overridable without editing the installed bundle via an optional `client_id` MCPB `user_config` (default `meho-mcp`), delivered as `MEHO_MCP_CLIENT_ID`.
- Release wiring: the tag build is a step in `cli-release.yml` **after** GoReleaser (so `gh release upload` has a Release to attach to — a standalone tag workflow would race GoReleaser's Release creation); a new `mcpb-bundle.yml` runs a dry-run pack + wording guard on PRs touching the bundle. The `@anthropic-ai/mcpb` CLI is pinned (`2.1.2`); distribution is the GitHub Release asset channel only, so the internal-only posture is unchanged.
- Docs: `RELEASING.md` gains the fifth artefact row + a post-tag verification line; `mcp-client-setup.md` Step 3 leads with the bundle and keeps the raw shim JSON as the fallback.

## Test plan

- [x] `clients/claude-desktop-mcpb/build.sh 0.31.0` — `mcpb pack` validates the manifest against the MANIFEST 0.3 schema and produces `meho-claude-desktop-0.31.0.mcpb` containing exactly `manifest.json` + `server/index.mjs`.
- [x] Pre-release version (`0.0.0-pr42`, the CI dry-run form) packs cleanly.
- [x] Launcher behaviour (stub-`npx`, 22 checks): missing / non-`https` / malformed URL → exit 1 with a clear message; empty or unset `MEHO_CA_CERT` → `NODE_EXTRA_CA_CERTS` unset in the child; a supplied path → `NODE_EXTRA_CA_CERTS` set to it; `MEHO_CA_CERT` scrubbed from the child env in every case.
- [x] Launcher OAuth args (stub-`npx`): argv carries pinned `mcp-remote@0.1.38` (no bare `mcp-remote`), `--static-oauth-client-info {"client_id":"meho-mcp"}` by default, `MEHO_MCP_CLIENT_ID` override yields `{"client_id":"custom-client"}`, an empty value falls back to `meho-mcp`, `--static-oauth-client-metadata {"scope":"mcp:read mcp:execute"}` present, exact argv order verified, and `MEHO_MCP_CLIENT_ID` scrubbed from the child env.
- [x] `shellcheck build.sh` — clean; `node --check server/index.mjs` — clean; `jq empty manifest.json` — valid.
- [x] `grep -ri "custom connector" clients/claude-desktop-mcpb/` — empty (acceptance #5, #2792 guard; also enforced in `mcpb-bundle.yml`).
- [x] pre-commit hygiene hooks (check-yaml / check-json / trailing-whitespace / EOF / mixed-line-ending / gitleaks) — all pass on the changed files.
- [x] `code-quality.py --diff` — exit 0.
- [ ] **Manual (acceptance #4, same bar as #2666):** open the `.mcpb` on a VPN-connected machine, enter an internal `/mcp` URL, confirm `meho_status` is callable. Requires Claude Desktop + a live backplane — to be recorded here by the operator.

## Out of scope

- Publishing to any public marketplace / registry / website (Release-asset channel only).
- Realm / Keycloak recipe changes; the Claude Code plugin (sibling task #3130); signing beyond what the release pipeline already does.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3129

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-26)

Addressed cross-PR consistency finding **B1** (same blocker fixed on sibling PR #3136): the bare, unpinned `npx -y mcp-remote <url>` cannot complete OAuth on a fresh install because MEHO's Keycloak realm blocks anonymous RFC 7591 Dynamic Client Registration (Trusted Hosts → `403 "Host not trusted"`).

New invocation contract (`server/index.mjs`):

```
npx -y mcp-remote@0.1.38 <url> \
  --static-oauth-client-info '{"client_id":"<id>"}' \
  --static-oauth-client-metadata '{"scope":"mcp:read mcp:execute"}'
```

- **`48770baf`** — pin `mcp-remote@0.1.38`; present the static `meho-mcp` client + scope metadata (JSON built with `JSON.stringify`, injection-safe); new optional `client_id` `user_config` (default `meho-mcp`) → `MEHO_MCP_CLIENT_ID`, resolved in the launcher with an empty-value fallback and scrubbed from the child env. URL/`https` + internal-CA guards unchanged. README `How the launcher works` + layout row updated. No positional callback port pinned (realm wildcard loopback redirect URIs cover mcp-remote's ephemeral `/oauth/callback`).

Re-validated: `mcpb pack` dry-run (manifest schema passes), `node --check`, `jq`, and the extended stubbed-`npx` suite (22/22).

The manual Claude Desktop install verification (test-plan item above) remains an open human-only item — not claimed here.

<!-- auto-implement-issue: continue, iteration 1 -->
