### PR TITLE
docs(consumer-onboarding): correct stale #316 preamble claims

### DIFF
--- a/docs/examples/consumer-onboarding/CLAUDE.md
+++ b/docs/examples/consumer-onboarding/CLAUDE.md
@@ -48,12 +48,14 @@ operational discipline (Vault canonical, naming rules, secret
 handling, CLI-wrapper fallback policy). This file (Layer 2) handles
 only the **"prefer MEHO" routing rules**.
 
-> **Current state (v0.2 staging).** The MCP `initialize` response's
-> `instructions` field is the carrier for the assembled Layer-1
-> preamble. Until [G7.1-T4 #316](https://github.com/evoila/meho/issues/316)
-> lands, that field is `None` and Layer-1 rules are not yet reaching
-> agents — only Layer 2 (this file) is live. Once T4 ships, sessions
-> reconnecting via MCP will receive both layers automatically.
+> **How Layer 1 reaches the session.** The MCP `initialize`
+> response's `instructions` field is the carrier for the assembled
+> Layer-1 preamble, filled by the assembler shipped in
+> [G7.1-T4 #316](https://github.com/evoila/meho/issues/316). A
+> session connecting via MCP receives the tenant-conventions preamble
+> in that field at connect time, so both layers reach the session
+> automatically. The preamble is assembled fresh on each `initialize`,
+> so a reconnect (new MCP session) picks up the current conventions.
 
 ## Preferred MEHO surfaces
 

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -329,8 +329,12 @@ you expect, walk these checks:
 
 1. **Does the tenant actually have conventions rows?** Run `meho
    conventions list`. An empty list means there is nothing to
-   assemble — publish rules with `meho conventions edit <slug>`
-   (requires `tenant_admin`). The assembler still returns a
+   assemble — publish a first rule with `meho conventions create
+   --slug <slug> --kind operational --title "<label>" --body
+   @<file>` (requires `tenant_admin`; `--kind operational` so the
+   rule is packed into the preamble — `edit` only updates an
+   existing rule and 404s against an absent slug). The assembler
+   still returns a
    non-empty preamble in this case (it always carries the static
    broadcast-discipline band), so "no tenant rules in the preamble"
    and "no preamble at all" are different symptoms.

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -35,15 +35,16 @@ teach their Claude session to prefer MEHO features by hand, and the
 result varies per operator. The starter template gives consumer
 repos a consistent, upgradeable surface.
 
-> **Current state (v0.2 staging).** Layer 1 is partially shipped —
-> the database schema, API, CLI verbs, and seed migration land via
-> [G7.1-T1..T3 + T5](https://github.com/evoila/meho/issues/229), but
-> the assembler that fills the MCP `initialize` `instructions` field
-> is [G7.1-T4 #316](https://github.com/evoila/meho/issues/316),
-> still open. Until T4 ships, the `instructions` field is `None`
-> and Layer 1 is not yet reaching agents at session start. Layer 2
-> (this template) is live independently — your local session reads
-> the file the moment it opens the repo, regardless of T4's state.
+> **How the two layers reach a session.** Layer 1 is fully shipped —
+> the database schema, API, CLI verbs, seed migration, and the
+> assembler that fills the MCP `initialize` `instructions` field all
+> land via [G7.1-T1..T5](https://github.com/evoila/meho/issues/229)
+> ([#316](https://github.com/evoila/meho/issues/316) shipped the
+> assembler). A session connecting via MCP receives the tenant-
+> conventions preamble in that field at session start. Layer 2 (this
+> template) reaches the session from the other side — your local
+> session reads the file the moment it opens the repo, whether or not
+> it also connects to MEHO over MCP.
 
 ## Step 1 — Install the template
 
@@ -317,17 +318,40 @@ The operator's MEHO role doesn't satisfy the verb's requirement
 Confirm via `meho status` (renders the operator's tenant + role)
 and request the role change through the realm admin if it's wrong.
 
-### MCP `initialize` returns no preamble
+### MCP `initialize` doesn't carry the tenant conventions you expect
 
-The MCP server's `initialize` response carries `instructions: None`
-until [G7.1-T4 #316](https://github.com/evoila/meho/issues/316)
-lands the session-preamble assembler. This is **expected** in v0.2
-staging — Layer 1 conventions are queryable via `meho conventions
-list / show` once
-[G7.1-T2/T3 #314/#315](https://github.com/evoila/meho/issues/229)
-ship, but the auto-load into the MCP session preamble is gated on
-T4. Layer 2 (this template) is unaffected — the local Claude
-session reads `CLAUDE.md` directly from disk, independent of MCP.
+The `initialize` response's `instructions` field carries the
+assembled Layer-1 preamble (the assembler shipped in
+[G7.1-T4 #316](https://github.com/evoila/meho/issues/316)), so a
+session connecting via MCP should receive the tenant-conventions
+preamble at connect time. If a session isn't seeing the conventions
+you expect, walk these checks:
+
+1. **Does the tenant actually have conventions rows?** Run `meho
+   conventions list`. An empty list means there is nothing to
+   assemble — publish rules with `meho conventions edit <slug>`
+   (requires `tenant_admin`). The assembler still returns a
+   non-empty preamble in this case (it always carries the static
+   broadcast-discipline band), so "no tenant rules in the preamble"
+   and "no preamble at all" are different symptoms.
+2. **Did the client actually re-initialize?** The preamble is a
+   snapshot taken from the `initialize` response; a client that
+   cached that response has no signal to refresh until it re-runs
+   `initialize`, and a transport reconnect on the same session is
+   not enough (same client-side caching class as `tools/list` — see
+   [`docs/codebase/mcp.md` § Known issues](https://github.com/evoila/meho/blob/main/docs/codebase/mcp.md#known-issues)).
+   Restart the MCP client (or open a new session) so it re-runs
+   `initialize`.
+3. **Does the token carry the right tenant claims?** The preamble is
+   assembled for the operator's tenant. Run `meho status` and
+   confirm it renders the tenant you expect; a token bound to the
+   wrong (or no) tenant assembles the preamble from the wrong
+   tenant's rows. Re-authenticate with `meho login "$MEHO_INSTANCE"`
+   if the tenant is wrong.
+
+Layer 2 (this template) is independent of all three — the local
+Claude session reads `CLAUDE.md` directly from disk, regardless of
+the MCP preamble.
 
 ### Broadcast meta-tools missing from `tools/list`
 

--- a/docs/examples/consumer-onboarding/README.md
+++ b/docs/examples/consumer-onboarding/README.md
@@ -30,9 +30,10 @@ local Claude session from different angles:
   `instructions` field for any agent connecting *through* MEHO.
   Bound to the **tenant**; binds every session no matter where it
   runs. Shipped by [G7.1-T1..T5](https://github.com/evoila/meho/issues/229)
-  (T4 #316 is the assembler that fills the `instructions` field;
-  until it lands, that field is `None` and Layer 1 is not yet
-  reaching agents).
+  (T4 [#316](https://github.com/evoila/meho/issues/316) shipped the
+  assembler that fills the `instructions` field, so a session
+  connecting via MCP receives the tenant-conventions preamble at
+  session start).
 * **Layer 2 — this template.** The in-repo `CLAUDE.md` the operator's
   local Claude session reads when it opens a cloned consumer repo.
   Bound to the **repo on the operator's machine**; teaches the


### PR DESCRIPTION
## Summary

- The `docs/examples/consumer-onboarding/` Layer-2 starter template told every new consumer that the MCP session-preamble assembler (G7.1-T4 #316) had **not** landed and that `initialize`'s `instructions` field was `None`. #316 closed 2026-05-25 and the assembler (`_session_instructions`, `backend/src/meho_backplane/mcp/server.py`) is live and wired into the `initialize` response — the stale claims suppressed exactly the Layer-1 reflex channel the backplane already provides.
- Rewrote the three "not landed" claims (`README.md`, the template `CLAUDE.md`, `ONBOARDING.md`) to state the live behavior: a session connecting via MCP receives the tenant-conventions preamble in the `instructions` field at connect time.
- Rewrote the `ONBOARDING.md` troubleshooting subsection from "an empty preamble is **expected**" into a real 3-step diagnostic path for a *missing* preamble: tenant conventions rows (`meho conventions list`), client re-`initialize` (client-side caching per `docs/codebase/mcp.md` § Known issues), and tenant claims on the token (`meho status`).

## Test plan

- [x] `grep -rn "field is \`None\`\|not yet reaching agents\|still open" docs/examples/consumer-onboarding/` — empty
- [x] `grep -rn "not yet reaching agents" docs/examples/consumer-onboarding/` — empty
- [x] `grep -rn "316" docs/examples/consumer-onboarding/` — only shipped-by attributions remain
- [x] Troubleshooting subsection describes live behavior + a checkable diagnostic sequence (each step names a command or doc)
- [x] No change outside `docs/examples/consumer-onboarding/` (`git diff --stat` — 3 files, all under that dir)
- [x] `.claude/hooks/code-quality.py --diff` — clean (exit 0)
- [x] No trailing whitespace / all files end with a newline (pre-commit hygiene hooks)

## Out of scope

- Migrating the template into the Claude Code plugin (sibling task under #3128).
- `docs/cross-repo/mcp-client-setup.md` and the docs site (#2663).

## Adjacent finding (not touched)

- `ONBOARDING.md` § "Broadcast meta-tools missing from `tools/list`" still says the broadcast meta-tools' MCP registration "is not yet wired", which contradicts the template `CLAUDE.md`'s own note that they shipped in #1092. Left untouched — outside this task's scope; worth a separate follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3135


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-26)

Addressed the iteration-1 review's single blocker:

- **B1** `ddd55027` — empty-tenant troubleshooting step 1 now publishes a first rule with `meho conventions create --slug <slug> --kind operational --title "<label>" --body @<file>` (requires `tenant_admin`). The prior `meho conventions edit <slug>` is update-only (PATCH `/{slug}`) and 404s `convention_not_found` against an absent slug — the exact empty-tenant state that branch addresses. `--kind operational` is named so the published rule reaches the preamble.

Deferred (adjacent findings; out of #3135 scope, unchanged):

- Pre-existing `ONBOARDING.md` L205/L227 also use `conventions edit` as a publish verb — same create-vs-edit imprecision, outside this task; worth a follow-up alignment pass.
- `ONBOARDING.md` § "Broadcast meta-tools missing from `tools/list`" contradicts the template `CLAUDE.md`'s #1092-shipped note — separate follow-up.

<!-- auto-implement-issue: continue, iteration 1 -->
