### PR TITLE
feat(audit): reflex-adoption KPIs from audit_log (read-before-act, announce coverage, write-back)

### DIFF
--- a/backend/src/meho_backplane/api/v1/audit_reflex.py
+++ b/backend/src/meho_backplane/api/v1/audit_reflex.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /api/v1/audit/reflex`` -- reflex-adoption KPIs over ``audit_log``.
+
+Task #3134 (Initiative #3128). Exposes the four reflex-adoption metrics
+computed by :func:`meho_backplane.reflex.compute_reflex_report` over a
+time window, per tenant, split by surface (``agent`` / ``cli_rest``).
+Follows the #444 usage-telemetry route shape exactly. Operator
+workflow:
+
+* ``GET /api/v1/audit/reflex`` — operator's own tenant, default 7-day
+  window ending now.
+* ``GET /api/v1/audit/reflex?since=30d`` / ``?since=2026-08-01`` —
+  widen the window (relative ``<N>d`` / ``<N>h`` or ISO-8601 date).
+* ``GET /api/v1/audit/reflex?until=1d`` — cap the window's upper bound
+  (same grammar; default is now).
+* ``GET /api/v1/audit/reflex?tenant_filter=<uuid>`` — cross-tenant view,
+  gated behind the ``platform_admin`` capability (#1638).
+
+The route backs ``meho audit reflex``.
+
+Audit + broadcast contract
+--------------------------
+
+Reading ``audit_log`` is privacy-sensitive (decision #3,
+``docs/decisions/locked-decisions.md``): a free-text broadcast of
+"operator X read reflex KPIs for tenant Y" leaks the investigation
+target. The route binds the same two audit overrides the G8 audit-query
+and #444 usage surfaces use:
+
+* ``audit_op_id = "meho.audit.reflex"`` — the canonical op_id every
+  audit row this route writes carries.
+* ``audit_op_class = "audit_query"`` — flips the broadcast event into
+  aggregate-only mode (``{op_class, result_status, row_count}``).
+
+``audit_since`` / ``audit_until`` enrich the row's ``payload`` for
+forensic queries (aggregation parameters, not raw queries, so no
+redaction needed). ``audit_row_count`` is bound after
+:func:`compute_reflex_report` returns to the number of write-class
+operations scored — the aggregate cardinality the broadcast subscriber
+cares about.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import authorize_tenant_scope, require_role
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.reflex.adoption import (
+    DEFAULT_SINCE,
+    ReflexReport,
+    SinceValueError,
+    compute_reflex_report,
+    parse_since,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/audit", tags=["audit"])
+
+#: Module-level :class:`Depends` closure for the route's RBAC gate.
+#: Built once at import time to satisfy ruff's B008 rule, matching the
+#: pattern :mod:`~meho_backplane.api.v1.retrieve_usage` established.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+
+def _bind_request_audit_context(
+    *,
+    since: str,
+    until: str | None,
+    tenant_filter: UUID | None,
+    operator_tenant_id: UUID,
+) -> None:
+    """Bind the audit overrides + enrichment fields for this request.
+
+    Called **before** :func:`compute_reflex_report` runs so a handler
+    exception still produces an audit row with partial payload. Mirrors
+    :func:`meho_backplane.api.v1.retrieve_usage._bind_request_audit_context`.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="meho.audit.reflex",
+        audit_op_class="audit_query",
+        audit_since=since,
+        audit_until=until if until is not None else "now",
+        audit_tenant_scope=(
+            "other" if tenant_filter is not None and tenant_filter != operator_tenant_id else "self"
+        ),
+    )
+
+
+@router.get("/reflex", response_model=ReflexReport)
+async def reflex_endpoint(
+    since: str = Query(default=DEFAULT_SINCE, max_length=32),
+    until: str | None = Query(default=None, max_length=32),
+    tenant_filter: UUID | None = Query(default=None),
+    operator: Operator = _require_operator,
+) -> ReflexReport:
+    """Return reflex-adoption KPIs for *operator* over the requested window.
+
+    Tenant scoping: callers are scoped to ``operator.tenant_id``; a
+    ``tenant_filter`` naming a different tenant returns 403
+    ``cross_tenant_requires_platform_admin`` unless the caller holds the
+    ``platform_admin`` capability (#1638). *since* / *until* accept
+    ``<N>d`` / ``<N>h`` (relative) or an ISO-8601 date; malformed → 400.
+    *until* defaults to now. An empty window is a structured zero report
+    (both surfaces present, ``None`` ratios), not 404.
+    """
+    target_tenant = authorize_tenant_scope(operator, tenant_filter)
+
+    now = datetime.now(UTC)
+    try:
+        since_dt = parse_since(since, now=now)
+        until_dt = parse_since(until, now=now) if until is not None else now
+    except SinceValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    _bind_request_audit_context(
+        since=since,
+        until=until,
+        tenant_filter=tenant_filter,
+        operator_tenant_id=operator.tenant_id,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        report = await compute_reflex_report(
+            session=session,
+            since=since_dt,
+            until=until_dt,
+            tenant_id=target_tenant,
+        )
+
+    # The broadcast event's ``row_count`` reflects the aggregate the
+    # subscriber cares about: the number of write-class operations
+    # scored across surfaces, not the raw rows paged through.
+    row_count = sum(surface.announce_coverage_write_ops for surface in report.surfaces)
+    structlog.contextvars.bind_contextvars(audit_row_count=row_count)
+    return report

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -70,6 +70,7 @@ from meho_backplane.api.v1.agents import router as api_v1_agents_router
 from meho_backplane.api.v1.approvals import router as api_v1_approvals_router
 from meho_backplane.api.v1.ask_docs import router as api_v1_ask_docs_router
 from meho_backplane.api.v1.audit import router as api_v1_audit_router
+from meho_backplane.api.v1.audit_reflex import router as api_v1_audit_reflex_router
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
 from meho_backplane.api.v1.broadcast_overrides import (
     router as api_v1_broadcast_overrides_router,
@@ -929,6 +930,15 @@ app.include_router(api_v1_memory_router)
 # row this surface writes carries the canonical `meho.audit.query`
 # identity and broadcasts as aggregate-only per decision #3.
 app.include_router(api_v1_audit_router)
+# #3134 (Initiative #3128) -- reflex-adoption KPIs at
+# `GET /api/v1/audit/reflex`. Read-only `audit_log` + announce-store
+# aggregation reusing the #444 usage-telemetry seam: read-before-act,
+# announce coverage, write-back rate, each split by surface (agent vs
+# CLI/REST). Operator role minimum; the `tenant_filter` cross-tenant
+# param is gated behind platform_admin. Binds the same `audit_op_id`
+# (`meho.audit.reflex`) / `audit_op_class` (`audit_query`) overrides the
+# audit-query surface uses so the row broadcasts aggregate-only.
+app.include_router(api_v1_audit_reflex_router)
 # G6.3-T4 (#381) -- tenant-admin CRUD verbs for BroadcastOverride
 # rules (list / create / delete). Wraps the substrate ORM model T1
 # (#378) ships and the resolver-cache invalidation hook T2 (#379)

--- a/backend/src/meho_backplane/reflex/__init__.py
+++ b/backend/src/meho_backplane/reflex/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reflex-adoption KPIs computed over the append-only ``audit_log``.
+
+The reflex work (tool descriptions, plugin hooks, dispatch advisory)
+aims at behavioural change; this package measures whether that change
+is happening, directly from the audited record MEHO already keeps. See
+:mod:`meho_backplane.reflex.adoption` for the metric definitions.
+"""
+
+from meho_backplane.reflex.adoption import (
+    ReflexReport,
+    SurfaceMetrics,
+    compute_reflex_report,
+)
+
+__all__ = [
+    "ReflexReport",
+    "SurfaceMetrics",
+    "compute_reflex_report",
+]

--- a/backend/src/meho_backplane/reflex/adoption.py
+++ b/backend/src/meho_backplane/reflex/adoption.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reflex-adoption KPIs aggregated from ``audit_log`` + the announce store.
+
+Task #3134 (Initiative #3128). The reflex work — tool-group
+descriptions, plugin hooks, dispatch advisory — is behavioural: its
+whole point is to change what an agent does *first* in a session. This
+module makes that falsifiable by reading the synchronous, append-only,
+session-tagged ``audit_log`` (and the #2544 :class:`AgentAnnouncement`
+store) and reporting four v1 metrics over a time window, per tenant,
+split by surface. It reuses the #444 usage-telemetry seam (a
+``compute_*`` service behind a REST route + CLI verb, aggregating
+``audit_log`` in Python for cross-dialect portability) rather than a
+parallel metrics pipeline — the canonical record is the same one the
+G8 audit-trail surface queries, so the numbers can be re-derived at any
+time from the same source.
+
+Row shapes this module reads
+----------------------------
+
+Every audited operation lands in ``audit_log`` with a ``path``, a
+``method``, a ``status_code``, an ``occurred_at``, a ``tenant_id``, and
+a nullable ``agent_session_id`` (the MCP/agent-run session correlation
+key, migration ``0014``). Two row shapes matter here:
+
+* **MCP meta-tool envelope rows** — one per ``tools/call`` invocation,
+  written by :func:`meho_backplane.mcp.audit.write_mcp_audit_row` with
+  ``method="MCP"`` and ``path = f"{MCP_TOOL_PATH_PREFIX}{tool_name}"``.
+  The reflex meta-tools ``call_operation`` / ``broadcast_recent`` /
+  ``add_to_knowledge`` / ``add_to_memory`` are counted from these rows,
+  the same path-prefix filter #444 uses for the retrieval search tools.
+* **Dispatch rows** — one per connector operation, written by
+  :func:`meho_backplane.operations._audit.write_audit_row` with
+  ``method="DISPATCH"`` and ``path = descriptor.op_id`` (e.g.
+  ``vsphere.vm.create``, ``GET:/api/v2.0/systeminfo``). A row's
+  write-vs-read class is :func:`meho_backplane.broadcast.events.classify_op`
+  applied to ``path``; the mutating classes are :data:`WRITE_OP_CLASSES`.
+
+Only successful rows (``status_code == 200``) are counted, mirroring
+#444: a 4xx/5xx attempt did not dispatch and is not "acting".
+
+Surface split
+-------------
+
+Each metric is reported for two surfaces, partitioned by the presence
+of ``agent_session_id`` on the row:
+
+* ``agent`` — rows **with** ``agent_session_id`` (MCP/agent-run
+  traffic, where client-side reflex levers such as plugin hooks apply).
+* ``cli_rest`` — rows **without** ``agent_session_id`` (CLI/REST
+  traffic, which can only ever receive server-side levers).
+
+The split is the comparison the reflex work needs: read-before-act and
+write-back are structurally computable only on the ``agent`` surface
+(the meta-tool envelope rows always carry a session), so the
+``cli_rest`` surface reports them as ``None`` — that absence *is* the
+signal that a surface has no client-side reflex lever. Announce
+coverage splits meaningfully across both, since dispatch rows occur on
+either surface.
+
+Metric definitions (v1)
+-----------------------
+
+Let a *session* be a distinct non-null ``agent_session_id``.
+
+1. **read-before-act** (``read_before_act_pct``) — of the sessions with
+   at least one ``call_operation``, the fraction whose **first**
+   ``call_operation`` is strictly preceded, in the same session, by a
+   ``broadcast_recent``. Denominator: sessions with ≥1
+   ``call_operation``. ``None`` when that denominator is 0 (the
+   ``cli_rest`` surface, and any window with no agent operations).
+
+2. **announce-coverage** (``announce_coverage_pct``) — of the
+   write-class dispatch rows (:data:`WRITE_OP_CLASSES` via
+   :func:`classify_op`), the fraction executed with an announce claim
+   earlier in the same session: an :class:`AgentAnnouncement` whose
+   ``run_id`` equals the row's ``agent_session_id`` and whose
+   ``created_at`` is ``<=`` the row's ``occurred_at``. (The "active
+   claim" reading — a TTL-bounded window — is subsumed by "an announce
+   earlier in the same session" for the boolean, so v1 correlates on
+   session identity and leaves TTL as a future refinement.) A
+   ``cli_rest`` write op has no session to correlate, so it is never
+   covered. Denominator: write-class dispatch rows. ``None`` when 0.
+
+3. **write-back rate** (``write_back_per_100_call_ops``) — the count of
+   ``add_to_knowledge`` + ``add_to_memory`` calls per 100
+   ``call_operation`` calls. ``None`` when there are 0
+   ``call_operation`` calls on the surface.
+
+4. **surface split** — every metric above, reported once per surface
+   (``agent`` / ``cli_rest``).
+
+Tenant boundary
+---------------
+
+The router gate resolves the effective tenant (own tenant, or a
+``platform_admin``-supplied filter) and passes it here; this helper
+never inspects the :class:`Operator`. A non-null ``tenant_id`` scopes
+every query — ``audit_log`` rows *and* :class:`AgentAnnouncement` rows
+— so cross-tenant rows cannot leak into another tenant's numbers.
+
+References
+----------
+
+* Parent Initiative #3128; Task #3134.
+* #444 — the ``audit_log`` aggregation + REST + CLI precedent reused here.
+* #2544 — the structured announce-claim store (:class:`AgentAnnouncement`).
+* Delineation from evoila-bosnia/meho-internal#200: taint metrics
+  measure meho-vs-local-fallback *adoption*; these reflex KPIs measure
+  *in-session discipline*. Related, not merged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any, Final, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.db.models import AgentAnnouncement, AuditLog
+
+# Re-exported from the #444 seam so the reflex ``--since`` grammar is
+# identical to ``meho retrieval usage`` by construction, not by a
+# duplicated parser that could drift.
+from meho_backplane.retrieval.usage import (
+    MCP_TOOL_PATH_PREFIX,
+    SinceValueError,
+    parse_since,
+)
+
+__all__ = [
+    "ADD_TOOLS",
+    "BROADCAST_RECENT_TOOL",
+    "CALL_OPERATION_TOOL",
+    "DEFAULT_SINCE",
+    "DISPATCH_METHOD",
+    "MCP_TOOL_PATH_PREFIX",
+    "SUCCESS_STATUS",
+    "WRITE_OP_CLASSES",
+    "ReflexReport",
+    "SinceValueError",
+    "SurfaceMetrics",
+    "compute_reflex_report",
+    "parse_since",
+]
+
+#: The reflex meta-tools, keyed by the audited MCP tool name. Counted
+#: from the envelope rows written with
+#: ``path = f"{MCP_TOOL_PATH_PREFIX}{tool_name}"``.
+CALL_OPERATION_TOOL: Final[str] = "call_operation"
+BROADCAST_RECENT_TOOL: Final[str] = "broadcast_recent"
+
+#: The write-back meta-tools (knowledge + memory add). Their combined
+#: successful-call count is the write-back numerator.
+ADD_TOOLS: Final[tuple[str, ...]] = ("add_to_knowledge", "add_to_memory")
+
+#: ``method`` value on dispatcher-written rows (one per connector
+#: operation). ``path`` on these rows is the descriptor's ``op_id``.
+DISPATCH_METHOD: Final[str] = "DISPATCH"
+
+#: The :func:`classify_op` classes that count as a *write* (a mutating
+#: operation) for announce coverage. The three mutating classes the
+#: classifier emits; read / audit_query / approval / checks / other are
+#: excluded.
+WRITE_OP_CLASSES: Final[frozenset[str]] = frozenset(
+    {"write", "credential_write", "credential_mint"},
+)
+
+#: Only successful rows count (mirrors #444): a 4xx/5xx attempt did not
+#: dispatch, so it is not an act, a read, or a write-back.
+SUCCESS_STATUS: Final[int] = 200
+
+#: Default ``--since`` window. Reflex discipline is a recent-behaviour
+#: signal, so the default is a short week rather than #444's 30-day
+#: retire-threshold window.
+DEFAULT_SINCE: Final[str] = "7d"
+
+#: The two surfaces the report is split by.
+_SURFACES: Final[tuple[Literal["agent", "cli_rest"], ...]] = ("agent", "cli_rest")
+
+
+class SurfaceMetrics(BaseModel):
+    """The four reflex metrics for one surface (``agent`` / ``cli_rest``).
+
+    Each ratio is reported as a rounded percentage/rate together with
+    the raw numerator and denominator, so a consumer can re-derive the
+    ratio and a zero-denominator surface reads as ``None`` (N/A) rather
+    than a misleading ``0.0``. Frozen so report instances can be passed
+    around without accidental mutation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    surface: Literal["agent", "cli_rest"]
+
+    #: read-before-act.
+    read_before_act_pct: float | None
+    read_before_act_sessions: int
+    read_before_act_read_first: int
+
+    #: announce-coverage.
+    announce_coverage_pct: float | None
+    announce_coverage_write_ops: int
+    announce_coverage_announced: int
+
+    #: write-back rate (per 100 ``call_operation``).
+    write_back_per_100_call_ops: float | None
+    write_back_add_calls: int
+    write_back_call_operations: int
+
+
+class ReflexReport(BaseModel):
+    """Top-level shape returned by :func:`compute_reflex_report` + the route.
+
+    ``surfaces`` is always ordered ``[agent, cli_rest]`` so table
+    renderers and ``--json`` consumers see a stable shape even for an
+    empty window (both surfaces present with zero-valued / ``None``
+    metrics). ``tenant_id`` is the scope the report was computed for
+    (the operator's own tenant, or a ``platform_admin`` filter).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    since: datetime
+    until: datetime
+    tenant_id: UUID | None
+    surfaces: list[SurfaceMetrics]
+
+
+def _tool_path(tool_name: str) -> str:
+    """Return the audited MCP envelope path for *tool_name*."""
+    return f"{MCP_TOOL_PATH_PREFIX}{tool_name}"
+
+
+def _is_agent_surface(agent_session_id: UUID | None) -> Literal["agent", "cli_rest"]:
+    """Map a row's ``agent_session_id`` onto its surface label."""
+    return "agent" if agent_session_id is not None else "cli_rest"
+
+
+async def _fetch_meta_tool_rows(
+    session: AsyncSession,
+    *,
+    since: datetime,
+    until: datetime,
+    tenant_id: UUID | None,
+) -> list[Any]:
+    """Pull successful reflex meta-tool envelope rows in the window.
+
+    Returns ``(occurred_at, agent_session_id, path)`` for the four
+    reflex meta-tools, ordered by ``(agent_session_id, occurred_at)`` so
+    the per-session read-before-act walk sees each session's timeline in
+    order.
+    """
+    paths = [
+        _tool_path(CALL_OPERATION_TOOL),
+        _tool_path(BROADCAST_RECENT_TOOL),
+        *(_tool_path(tool) for tool in ADD_TOOLS),
+    ]
+    stmt = (
+        select(
+            AuditLog.occurred_at,
+            AuditLog.agent_session_id,
+            AuditLog.path,
+        )
+        .where(AuditLog.occurred_at >= since)
+        .where(AuditLog.occurred_at <= until)
+        .where(AuditLog.path.in_(paths))
+        .where(AuditLog.status_code == SUCCESS_STATUS)
+        .order_by(AuditLog.agent_session_id, AuditLog.occurred_at)
+    )
+    if tenant_id is not None:
+        stmt = stmt.where(AuditLog.tenant_id == tenant_id)
+    return list((await session.execute(stmt)).all())
+
+
+async def _fetch_dispatch_rows(
+    session: AsyncSession,
+    *,
+    since: datetime,
+    until: datetime,
+    tenant_id: UUID | None,
+) -> list[Any]:
+    """Pull successful dispatcher rows in the window (write-class filtered later).
+
+    Returns ``(occurred_at, agent_session_id, path)``. ``path`` is the
+    descriptor ``op_id``; the write-class filter is applied in Python via
+    :func:`classify_op` because the classifier is match-order-significant
+    Python, not expressible in portable SQL.
+    """
+    stmt = (
+        select(
+            AuditLog.occurred_at,
+            AuditLog.agent_session_id,
+            AuditLog.path,
+        )
+        .where(AuditLog.occurred_at >= since)
+        .where(AuditLog.occurred_at <= until)
+        .where(AuditLog.method == DISPATCH_METHOD)
+        .where(AuditLog.status_code == SUCCESS_STATUS)
+    )
+    if tenant_id is not None:
+        stmt = stmt.where(AuditLog.tenant_id == tenant_id)
+    return list((await session.execute(stmt)).all())
+
+
+async def _fetch_announce_first_seen(
+    session: AsyncSession,
+    *,
+    until: datetime,
+    tenant_id: UUID | None,
+) -> dict[UUID, datetime]:
+    """Return ``run_id -> earliest created_at`` for announce claims.
+
+    An op is announce-covered iff its session has an announcement whose
+    ``created_at`` is at or before the op — so the earliest announcement
+    per session (``run_id``) is the only fact the coverage check needs.
+    No lower time bound: an announcement made before the report window
+    can still cover an in-window op. Rows without a ``run_id`` cannot be
+    session-correlated and are skipped.
+    """
+    stmt = select(
+        AgentAnnouncement.run_id,
+        AgentAnnouncement.created_at,
+    ).where(AgentAnnouncement.created_at <= until)
+    if tenant_id is not None:
+        stmt = stmt.where(AgentAnnouncement.tenant_id == tenant_id)
+
+    first_seen: dict[UUID, datetime] = {}
+    for run_id, created_at in (await session.execute(stmt)).all():
+        if run_id is None:
+            continue
+        current = first_seen.get(run_id)
+        if current is None or created_at < current:
+            first_seen[run_id] = created_at
+    return first_seen
+
+
+def _read_before_act(
+    meta_rows: Iterable[Any],
+    surface: str,
+) -> tuple[int, int]:
+    """Return ``(read_first_sessions, sessions_with_call_op)`` for *surface*.
+
+    A session (distinct ``agent_session_id``) counts once it has ≥1
+    ``call_operation``; it is "read-first" when a ``broadcast_recent``
+    strictly precedes the session's first ``call_operation``.
+    """
+    call_path = _tool_path(CALL_OPERATION_TOOL)
+    recent_path = _tool_path(BROADCAST_RECENT_TOOL)
+    first_call: dict[UUID, datetime] = {}
+    first_recent: dict[UUID, datetime] = {}
+    for row in meta_rows:
+        sid = row.agent_session_id
+        if sid is None or _is_agent_surface(sid) != surface:
+            continue
+        if row.path == call_path:
+            current = first_call.get(sid)
+            if current is None or row.occurred_at < current:
+                first_call[sid] = row.occurred_at
+        elif row.path == recent_path:
+            current = first_recent.get(sid)
+            if current is None or row.occurred_at < current:
+                first_recent[sid] = row.occurred_at
+
+    sessions = len(first_call)
+    read_first = sum(
+        1
+        for sid, call_ts in first_call.items()
+        if sid in first_recent and first_recent[sid] < call_ts
+    )
+    return read_first, sessions
+
+
+def _announce_coverage(
+    dispatch_rows: Iterable[Any],
+    announce_first_seen: dict[UUID, datetime],
+    surface: str,
+) -> tuple[int, int]:
+    """Return ``(announced_write_ops, write_ops)`` for *surface*.
+
+    A write-class dispatch row is covered when its session has an
+    announcement first seen at or before the op. ``cli_rest`` rows carry
+    no session and so are never covered.
+    """
+    write_ops = 0
+    announced = 0
+    for row in dispatch_rows:
+        if _is_agent_surface(row.agent_session_id) != surface:
+            continue
+        if classify_op(row.path) not in WRITE_OP_CLASSES:
+            continue
+        write_ops += 1
+        sid = row.agent_session_id
+        if sid is not None:
+            seen = announce_first_seen.get(sid)
+            if seen is not None and seen <= row.occurred_at:
+                announced += 1
+    return announced, write_ops
+
+
+def _write_back(
+    meta_rows: Iterable[Any],
+    surface: str,
+) -> tuple[int, int]:
+    """Return ``(add_calls, call_operations)`` for *surface*."""
+    call_path = _tool_path(CALL_OPERATION_TOOL)
+    add_paths = {_tool_path(tool) for tool in ADD_TOOLS}
+    call_ops = 0
+    add_calls = 0
+    for row in meta_rows:
+        if _is_agent_surface(row.agent_session_id) != surface:
+            continue
+        if row.path == call_path:
+            call_ops += 1
+        elif row.path in add_paths:
+            add_calls += 1
+    return add_calls, call_ops
+
+
+def _pct(numerator: int, denominator: int) -> float | None:
+    """Return ``numerator/denominator`` as a 0-100 percentage, or ``None``.
+
+    ``None`` when *denominator* is 0 (N/A), so a zero-activity surface is
+    never mis-rendered as ``0.0``.
+    """
+    if denominator == 0:
+        return None
+    return round((numerator / denominator) * 100.0, 2)
+
+
+def _surface_metrics(
+    surface: Literal["agent", "cli_rest"],
+    *,
+    meta_rows: list[Any],
+    dispatch_rows: list[Any],
+    announce_first_seen: dict[UUID, datetime],
+) -> SurfaceMetrics:
+    """Compute all four metrics for one surface."""
+    read_first, rba_sessions = _read_before_act(meta_rows, surface)
+    announced, write_ops = _announce_coverage(dispatch_rows, announce_first_seen, surface)
+    add_calls, call_ops = _write_back(meta_rows, surface)
+    return SurfaceMetrics(
+        surface=surface,
+        read_before_act_pct=_pct(read_first, rba_sessions),
+        read_before_act_sessions=rba_sessions,
+        read_before_act_read_first=read_first,
+        announce_coverage_pct=_pct(announced, write_ops),
+        announce_coverage_write_ops=write_ops,
+        announce_coverage_announced=announced,
+        write_back_per_100_call_ops=_pct(add_calls, call_ops),
+        write_back_add_calls=add_calls,
+        write_back_call_operations=call_ops,
+    )
+
+
+async def compute_reflex_report(
+    *,
+    session: AsyncSession,
+    since: datetime,
+    until: datetime,
+    tenant_id: UUID | None,
+) -> ReflexReport:
+    """Aggregate ``audit_log`` + announce rows into a reflex-adoption report.
+
+    Three tenant-scoped fetches (meta-tool envelope rows, dispatcher
+    rows, per-session earliest announce), then per-surface Python
+    correlation. Read-only: the helper neither commits nor closes the
+    caller-owned *session*. An empty window yields both surfaces present
+    with zero counts and ``None`` ratios.
+    """
+    meta_rows = await _fetch_meta_tool_rows(
+        session,
+        since=since,
+        until=until,
+        tenant_id=tenant_id,
+    )
+    dispatch_rows = await _fetch_dispatch_rows(
+        session,
+        since=since,
+        until=until,
+        tenant_id=tenant_id,
+    )
+    announce_first_seen = await _fetch_announce_first_seen(
+        session,
+        until=until,
+        tenant_id=tenant_id,
+    )
+
+    surfaces = [
+        _surface_metrics(
+            surface,
+            meta_rows=meta_rows,
+            dispatch_rows=dispatch_rows,
+            announce_first_seen=announce_first_seen,
+        )
+        for surface in _SURFACES
+    ]
+    return ReflexReport(
+        since=since,
+        until=until,
+        tenant_id=tenant_id,
+        surfaces=surfaces,
+    )

--- a/backend/tests/test_reflex_adoption.py
+++ b/backend/tests/test_reflex_adoption.py
@@ -1,0 +1,538 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the #3134 reflex-adoption KPI surface.
+
+Coverage matrix (issue #3134 acceptance criteria):
+
+* **Service-level aggregation** (``compute_reflex_report``) — every
+  metric proven against a seeded ``audit_log`` fixture whose known
+  session sequences produce hand-computable expected values:
+  read-before-act (read-first / no-broadcast_recent / broadcast-after),
+  announce-coverage (covered / uncovered / announce-after-op),
+  write-back rate, and the surface split (CLI rows with no
+  ``agent_session_id``).
+* **Tenant boundary** — a second tenant's rows never leak into the
+  first tenant's numbers.
+* **HTTP route** — RBAC (operator 200, read_only 403, operator +
+  ``tenant_filter`` 403, ``platform_admin`` + ``tenant_filter`` 200),
+  malformed ``since`` → 400, and a populated end-to-end read-back.
+
+Service tests seed ``audit_log`` / ``agent_announcement`` directly via
+:class:`AsyncSession` so the aggregation logic is unit-testable without
+a live request. Route tests reuse the ``test_retrieval_usage`` app +
+JWT-helper pattern.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.api.v1.audit_reflex import router as reflex_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AgentAnnouncement, AuditLog, Tenant
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.reflex.adoption import (
+    ADD_TOOLS,
+    BROADCAST_RECENT_TOOL,
+    CALL_OPERATION_TOOL,
+    DISPATCH_METHOD,
+    MCP_TOOL_PATH_PREFIX,
+    ReflexReport,
+    compute_reflex_report,
+)
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS cache fixtures (mirrors test_retrieval_usage.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads, around every test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+# ---------------------------------------------------------------------------
+# Timeline + tenants
+# ---------------------------------------------------------------------------
+
+_T0 = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+_SINCE = _T0 - timedelta(hours=1)
+_UNTIL = _T0 + timedelta(hours=1)
+
+_TENANT_A = UUID("00000000-0000-0000-0000-00000000a0a0")
+_TENANT_B = UUID("00000000-0000-0000-0000-00000000b0b0")
+
+_CALL_PATH = f"{MCP_TOOL_PATH_PREFIX}{CALL_OPERATION_TOOL}"
+_RECENT_PATH = f"{MCP_TOOL_PATH_PREFIX}{BROADCAST_RECENT_TOOL}"
+_ADD_KB_PATH = f"{MCP_TOOL_PATH_PREFIX}{ADD_TOOLS[0]}"
+_ADD_MEM_PATH = f"{MCP_TOOL_PATH_PREFIX}{ADD_TOOLS[1]}"
+
+_WRITE_OP = "vsphere.vm.create"  # classify_op -> "write"
+_WRITE_OP_2 = "vsphere.vm.delete"  # classify_op -> "write"
+_READ_OP = "vsphere.vm.list"  # classify_op -> "read"
+
+
+def _at(seconds: int) -> datetime:
+    """A timestamp *seconds* after the fixture base ``_T0``."""
+    return _T0 + timedelta(seconds=seconds)
+
+
+async def _seed_tenant(tenant_id: UUID) -> None:
+    """Insert the FK-parent :class:`Tenant` row (announce store requires it)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Tenant(id=tenant_id, slug=f"t-{tenant_id.hex}", name=f"Tenant {tenant_id.hex[-6:]}"),
+        )
+        await session.commit()
+
+
+async def _seed_audit(
+    *,
+    tenant_id: UUID | None,
+    path: str,
+    occurred_at: datetime,
+    method: str = "MCP",
+    status_code: int = 200,
+    agent_session_id: UUID | None = None,
+) -> None:
+    """Insert one ``audit_log`` row directly."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AuditLog(
+                id=uuid.uuid4(),
+                occurred_at=occurred_at,
+                operator_sub="op-1",
+                tenant_id=tenant_id,
+                agent_session_id=agent_session_id,
+                method=method,
+                path=path,
+                status_code=status_code,
+                request_id=None,
+                duration_ms=Decimal("1.00"),
+                payload={},
+            ),
+        )
+        await session.commit()
+
+
+async def _seed_dispatch(
+    *,
+    tenant_id: UUID | None,
+    op_id: str,
+    occurred_at: datetime,
+    agent_session_id: UUID | None = None,
+    status_code: int = 200,
+) -> None:
+    """Insert one dispatcher (``method='DISPATCH'``) row with ``path=op_id``."""
+    await _seed_audit(
+        tenant_id=tenant_id,
+        path=op_id,
+        occurred_at=occurred_at,
+        method=DISPATCH_METHOD,
+        status_code=status_code,
+        agent_session_id=agent_session_id,
+    )
+
+
+async def _seed_announce(
+    *,
+    tenant_id: UUID,
+    run_id: UUID | None,
+    created_at: datetime,
+) -> None:
+    """Insert one :class:`AgentAnnouncement` claim (``run_id`` = session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AgentAnnouncement(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                principal_sub="op-1",
+                activity="announced work",
+                phase="start",
+                targets=[],
+                run_id=run_id,
+                created_at=created_at,
+            ),
+        )
+        await session.commit()
+
+
+async def _report(tenant_id: UUID | None) -> ReflexReport:
+    """Compute the report over the full fixture window for *tenant_id*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return await compute_reflex_report(
+            session=session,
+            since=_SINCE,
+            until=_UNTIL,
+            tenant_id=tenant_id,
+        )
+
+
+def _surface(report: ReflexReport, name: str) -> object:
+    """Return the :class:`SurfaceMetrics` for *name* (``agent`` / ``cli_rest``)."""
+    return next(s for s in report.surfaces if s.surface == name)
+
+
+# ---------------------------------------------------------------------------
+# Shape / empty baselines
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_window_returns_both_surfaces_with_none_ratios() -> None:
+    """Empty audit_log → both surfaces present, zero counts, ``None`` ratios."""
+    report = await _report(_TENANT_A)
+    assert isinstance(report, ReflexReport)
+    assert [s.surface for s in report.surfaces] == ["agent", "cli_rest"]
+    for surface in report.surfaces:
+        assert surface.read_before_act_pct is None
+        assert surface.read_before_act_sessions == 0
+        assert surface.announce_coverage_pct is None
+        assert surface.write_back_per_100_call_ops is None
+
+
+# ---------------------------------------------------------------------------
+# read-before-act
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_before_act_scores_first_call_vs_broadcast_recent() -> None:
+    """Four sessions → 2 read-first / 4 = 50%.
+
+    * ``s1`` broadcast_recent before first call → read-first.
+    * ``s2`` two broadcast_recents, earliest before first call → read-first.
+    * ``s3`` a call with no broadcast_recent at all → not read-first.
+    * ``s4`` a call then a broadcast_recent (after) → not read-first.
+    """
+    await _seed_tenant(_TENANT_A)
+    s1, s2, s3, s4 = (uuid.uuid4() for _ in range(4))
+    # s1: recent then call
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_RECENT_PATH, occurred_at=_at(10), agent_session_id=s1
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(20), agent_session_id=s1
+    )
+    # s2: two recents (earliest before the call), then call
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_RECENT_PATH, occurred_at=_at(100), agent_session_id=s2
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_RECENT_PATH, occurred_at=_at(110), agent_session_id=s2
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(120), agent_session_id=s2
+    )
+    # s3: call only (no broadcast_recent)
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(30), agent_session_id=s3
+    )
+    # s4: call then recent (recent after → does not count)
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(40), agent_session_id=s4
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_RECENT_PATH, occurred_at=_at(50), agent_session_id=s4
+    )
+
+    agent = _surface(await _report(_TENANT_A), "agent")
+    assert agent.read_before_act_sessions == 4
+    assert agent.read_before_act_read_first == 2
+    assert agent.read_before_act_pct == 50.0
+
+
+# ---------------------------------------------------------------------------
+# announce-coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_announce_coverage_counts_earlier_same_session_claim() -> None:
+    """Two write ops, one with an earlier same-session announce → 50%."""
+    await _seed_tenant(_TENANT_A)
+    a1, a2 = uuid.uuid4(), uuid.uuid4()
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_WRITE_OP, occurred_at=_at(200), agent_session_id=a1
+    )
+    await _seed_announce(tenant_id=_TENANT_A, run_id=a1, created_at=_at(150))
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_WRITE_OP_2, occurred_at=_at(210), agent_session_id=a2
+    )
+    # A read op in a1 must not count toward the write denominator.
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_READ_OP, occurred_at=_at(220), agent_session_id=a1
+    )
+
+    agent = _surface(await _report(_TENANT_A), "agent")
+    assert agent.announce_coverage_write_ops == 2
+    assert agent.announce_coverage_announced == 1
+    assert agent.announce_coverage_pct == 50.0
+
+
+@pytest.mark.asyncio
+async def test_announce_coverage_ignores_claim_created_after_op() -> None:
+    """An announce created *after* the write op does not cover it → 0%."""
+    await _seed_tenant(_TENANT_A)
+    a1 = uuid.uuid4()
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_WRITE_OP, occurred_at=_at(200), agent_session_id=a1
+    )
+    await _seed_announce(tenant_id=_TENANT_A, run_id=a1, created_at=_at(300))
+
+    agent = _surface(await _report(_TENANT_A), "agent")
+    assert agent.announce_coverage_write_ops == 1
+    assert agent.announce_coverage_announced == 0
+    assert agent.announce_coverage_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# write-back rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_back_rate_is_adds_per_100_call_ops() -> None:
+    """1 add over 2 call_operations → 50 per 100."""
+    await _seed_tenant(_TENANT_A)
+    sid = uuid.uuid4()
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(10), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(20), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_ADD_KB_PATH, occurred_at=_at(30), agent_session_id=sid
+    )
+
+    agent = _surface(await _report(_TENANT_A), "agent")
+    assert agent.write_back_call_operations == 2
+    assert agent.write_back_add_calls == 1
+    assert agent.write_back_per_100_call_ops == 50.0
+
+
+@pytest.mark.asyncio
+async def test_write_back_counts_both_add_tools() -> None:
+    """``add_to_knowledge`` + ``add_to_memory`` both feed the numerator."""
+    await _seed_tenant(_TENANT_A)
+    sid = uuid.uuid4()
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(10), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_ADD_KB_PATH, occurred_at=_at(20), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_ADD_MEM_PATH, occurred_at=_at(30), agent_session_id=sid
+    )
+
+    agent = _surface(await _report(_TENANT_A), "agent")
+    assert agent.write_back_add_calls == 2
+    assert agent.write_back_per_100_call_ops == 200.0
+
+
+# ---------------------------------------------------------------------------
+# surface split — CLI/REST rows (no agent_session_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cli_rows_split_out_and_meta_metrics_are_na() -> None:
+    """CLI rows (no ``agent_session_id``) land in ``cli_rest``.
+
+    * The MCP-meta-tool metrics (read-before-act, write-back) have no
+      session on ``cli_rest`` → ``None`` (N/A).
+    * A CLI write dispatch counts toward announce-coverage but can never
+      be covered (no session to correlate a claim) → 0%.
+    * The agent surface keeps its own numbers, unaffected by the split.
+    """
+    await _seed_tenant(_TENANT_A)
+    sid = uuid.uuid4()
+    # Agent-surface activity (read-first + write-back).
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_RECENT_PATH, occurred_at=_at(10), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(20), agent_session_id=sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_ADD_KB_PATH, occurred_at=_at(30), agent_session_id=sid
+    )
+    # CLI/REST activity (no agent_session_id): a write dispatch + a read dispatch.
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_WRITE_OP, occurred_at=_at(500), agent_session_id=None
+    )
+    await _seed_dispatch(
+        tenant_id=_TENANT_A, op_id=_READ_OP, occurred_at=_at(510), agent_session_id=None
+    )
+
+    report = await _report(_TENANT_A)
+    cli = _surface(report, "cli_rest")
+    assert cli.read_before_act_sessions == 0
+    assert cli.read_before_act_pct is None
+    assert cli.write_back_call_operations == 0
+    assert cli.write_back_per_100_call_ops is None
+    assert cli.announce_coverage_write_ops == 1
+    assert cli.announce_coverage_announced == 0
+    assert cli.announce_coverage_pct == 0.0
+
+    agent = _surface(report, "agent")
+    assert agent.read_before_act_pct == 100.0
+    assert agent.write_back_per_100_call_ops == 100.0
+    assert agent.announce_coverage_write_ops == 0
+    assert agent.announce_coverage_pct is None
+
+
+# ---------------------------------------------------------------------------
+# tenant boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_prevents_cross_tenant_leakage() -> None:
+    """Tenant B's read-first session never lifts tenant A's numbers."""
+    await _seed_tenant(_TENANT_A)
+    await _seed_tenant(_TENANT_B)
+    # Tenant A: one session that is NOT read-first (call only).
+    a_sid = uuid.uuid4()
+    await _seed_audit(
+        tenant_id=_TENANT_A, path=_CALL_PATH, occurred_at=_at(20), agent_session_id=a_sid
+    )
+    # Tenant B: one read-first session.
+    b_sid = uuid.uuid4()
+    await _seed_audit(
+        tenant_id=_TENANT_B, path=_RECENT_PATH, occurred_at=_at(10), agent_session_id=b_sid
+    )
+    await _seed_audit(
+        tenant_id=_TENANT_B, path=_CALL_PATH, occurred_at=_at(20), agent_session_id=b_sid
+    )
+
+    agent_a = _surface(await _report(_TENANT_A), "agent")
+    assert agent_a.read_before_act_sessions == 1
+    assert agent_a.read_before_act_read_first == 0
+    assert agent_a.read_before_act_pct == 0.0
+
+    agent_b = _surface(await _report(_TENANT_B), "agent")
+    assert agent_b.read_before_act_read_first == 1
+    assert agent_b.read_before_act_pct == 100.0
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """A :class:`FastAPI` with the reflex route + production middleware stack."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(reflex_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def test_route_read_only_returns_403(client: TestClient) -> None:
+    """``read_only`` is below the operator floor → 403."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-ro", tenant_role=TenantRole.READ_ONLY.value)
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, _public_jwks(key))
+        resp = client.get("/api/v1/audit/reflex", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+def test_route_operator_with_tenant_filter_returns_403(client: TestClient) -> None:
+    """``operator`` + a foreign ``tenant_filter`` → 403 (cross-tenant gate)."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-x", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/reflex?tenant_filter={_TENANT_B}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "cross_tenant_requires_platform_admin"}
+
+
+def test_route_platform_admin_with_tenant_filter_returns_200(client: TestClient) -> None:
+    """``platform_admin`` + ``tenant_filter`` → 200 scoped to the filter."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key,
+        sub="op-admin",
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        platform_admin=True,
+    )
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/reflex?tenant_filter={_TENANT_B}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["tenant_id"] == str(_TENANT_B)
+
+
+def test_route_malformed_since_returns_400(client: TestClient) -> None:
+    """``since=whenever`` is unparseable → 400 carrying the parser detail."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-1", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/audit/reflex?since=whenever",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+    assert "whenever" in resp.json()["detail"]
+
+
+def test_route_default_returns_200_zero_report(client: TestClient) -> None:
+    """Default request with no audit_log rows → 200, both surfaces, None ratios."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-1", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, _public_jwks(key))
+        resp = client.get("/api/v1/audit/reflex", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [s["surface"] for s in body["surfaces"]] == ["agent", "cli_rest"]
+    assert body["surfaces"][0]["read_before_act_pct"] is None

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6143,6 +6143,83 @@
         }
       }
     },
+    "/api/v1/audit/reflex": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "Reflex Endpoint",
+        "description": "Return reflex-adoption KPIs for *operator* over the requested window.\n\nTenant scoping: callers are scoped to ``operator.tenant_id``; a\n``tenant_filter`` naming a different tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` capability (#1638). *since* / *until* accept\n``<N>d`` / ``<N>h`` (relative) or an ISO-8601 date; malformed \u2192 400.\n*until* defaults to now. An empty window is a structured zero report\n(both surfaces present, ``None`` ratios), not 404.",
+        "operationId": "reflex_endpoint_api_v1_audit_reflex_get",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 32,
+              "default": "7d",
+              "title": "Since"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 32,
+              "nullable": true,
+              "title": "Until"
+            }
+          },
+          {
+            "name": "tenant_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true,
+              "title": "Tenant Filter"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReflexReport"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/broadcast/overrides": {
       "get": {
         "tags": [
@@ -27283,6 +27360,42 @@
         "title": "ReassignRunResponse",
         "description": "Returned by ``meho_runbook_reassign`` -- the new ownership coordinates."
       },
+      "ReflexReport": {
+        "properties": {
+          "since": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Since"
+          },
+          "until": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Until"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Tenant Id"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceMetrics"
+            },
+            "type": "array",
+            "title": "Surfaces"
+          }
+        },
+        "type": "object",
+        "required": [
+          "since",
+          "until",
+          "tenant_id",
+          "surfaces"
+        ],
+        "title": "ReflexReport",
+        "description": "Top-level shape returned by :func:`compute_reflex_report` + the route.\n\n``surfaces`` is always ordered ``[agent, cli_rest]`` so table\nrenderers and ``--json`` consumers see a stable shape even for an\nempty window (both surfaces present with zero-valued / ``None``\nmetrics). ``tenant_id`` is the scope the report was computed for\n(the operator's own tenant, or a ``platform_admin`` filter)."
+      },
       "RefreshResult": {
         "properties": {
           "target_id": {
@@ -29601,6 +29714,72 @@
         ],
         "title": "SurfaceChecklist",
         "description": "Per-surface checklist: the five criteria + the surface verdict."
+      },
+      "SurfaceMetrics": {
+        "properties": {
+          "surface": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "cli_rest"
+            ],
+            "title": "Surface"
+          },
+          "read_before_act_pct": {
+            "type": "number",
+            "nullable": true,
+            "title": "Read Before Act Pct"
+          },
+          "read_before_act_sessions": {
+            "type": "integer",
+            "title": "Read Before Act Sessions"
+          },
+          "read_before_act_read_first": {
+            "type": "integer",
+            "title": "Read Before Act Read First"
+          },
+          "announce_coverage_pct": {
+            "type": "number",
+            "nullable": true,
+            "title": "Announce Coverage Pct"
+          },
+          "announce_coverage_write_ops": {
+            "type": "integer",
+            "title": "Announce Coverage Write Ops"
+          },
+          "announce_coverage_announced": {
+            "type": "integer",
+            "title": "Announce Coverage Announced"
+          },
+          "write_back_per_100_call_ops": {
+            "type": "number",
+            "nullable": true,
+            "title": "Write Back Per 100 Call Ops"
+          },
+          "write_back_add_calls": {
+            "type": "integer",
+            "title": "Write Back Add Calls"
+          },
+          "write_back_call_operations": {
+            "type": "integer",
+            "title": "Write Back Call Operations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "surface",
+          "read_before_act_pct",
+          "read_before_act_sessions",
+          "read_before_act_read_first",
+          "announce_coverage_pct",
+          "announce_coverage_write_ops",
+          "announce_coverage_announced",
+          "write_back_per_100_call_ops",
+          "write_back_add_calls",
+          "write_back_call_operations"
+        ],
+        "title": "SurfaceMetrics",
+        "description": "The four reflex metrics for one surface (``agent`` / ``cli_rest``).\n\nEach ratio is reported as a rounded percentage/rate together with\nthe raw numerator and denominator, so a consumer can re-derive the\nratio and a zero-denominator surface reads as ``None`` (N/A) rather\nthan a misleading ``0.0``. Frozen so report instances can be passed\naround without accidental mutation."
       },
       "SurfaceResult": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -477,6 +477,12 @@ const (
 	SurfaceChecklistVerdictREVIEWMANUALLY SurfaceChecklistVerdict = "REVIEW MANUALLY"
 )
 
+// Defines values for SurfaceMetricsSurface.
+const (
+	SurfaceMetricsSurfaceAgent   SurfaceMetricsSurface = "agent"
+	SurfaceMetricsSurfaceCliRest SurfaceMetricsSurface = "cli_rest"
+)
+
 // Defines values for SurfaceResultBaselineVerdict.
 const (
 	SurfaceResultBaselineVerdictGreen  SurfaceResultBaselineVerdict = "green"
@@ -5579,6 +5585,20 @@ type ReassignRunResponse struct {
 	RunId        openapi_types.UUID `json:"run_id"`
 }
 
+// ReflexReport Top-level shape returned by :func:`compute_reflex_report` + the route.
+//
+// “surfaces“ is always ordered “[agent, cli_rest]“ so table
+// renderers and “--json“ consumers see a stable shape even for an
+// empty window (both surfaces present with zero-valued / “None“
+// metrics). “tenant_id“ is the scope the report was computed for
+// (the operator's own tenant, or a “platform_admin“ filter).
+type ReflexReport struct {
+	Since    time.Time           `json:"since"`
+	Surfaces []SurfaceMetrics    `json:"surfaces"`
+	TenantId *openapi_types.UUID `json:"tenant_id"`
+	Until    time.Time           `json:"until"`
+}
+
 // RefreshResult Per-target reconcile outcome returned by :func:`refresh_target_topology`.
 //
 // Counts are disjoint per object class: a node is counted in exactly
@@ -7134,6 +7154,29 @@ type SurfaceChecklistSurface string
 // SurfaceChecklistVerdict defines model for SurfaceChecklist.Verdict.
 type SurfaceChecklistVerdict string
 
+// SurfaceMetrics The four reflex metrics for one surface (“agent“ / “cli_rest“).
+//
+// Each ratio is reported as a rounded percentage/rate together with
+// the raw numerator and denominator, so a consumer can re-derive the
+// ratio and a zero-denominator surface reads as “None“ (N/A) rather
+// than a misleading “0.0“. Frozen so report instances can be passed
+// around without accidental mutation.
+type SurfaceMetrics struct {
+	AnnounceCoverageAnnounced int                   `json:"announce_coverage_announced"`
+	AnnounceCoveragePct       *float32              `json:"announce_coverage_pct"`
+	AnnounceCoverageWriteOps  int                   `json:"announce_coverage_write_ops"`
+	ReadBeforeActPct          *float32              `json:"read_before_act_pct"`
+	ReadBeforeActReadFirst    int                   `json:"read_before_act_read_first"`
+	ReadBeforeActSessions     int                   `json:"read_before_act_sessions"`
+	Surface                   SurfaceMetricsSurface `json:"surface"`
+	WriteBackAddCalls         int                   `json:"write_back_add_calls"`
+	WriteBackCallOperations   int                   `json:"write_back_call_operations"`
+	WriteBackPer100CallOps    *float32              `json:"write_back_per_100_call_ops"`
+}
+
+// SurfaceMetricsSurface defines model for SurfaceMetrics.Surface.
+type SurfaceMetricsSurface string
+
 // SurfaceResult Per-surface aggregate: corpus-wide metrics + verdict + per-query rows.
 //
 // The verdict band is computed from the macro-mean metrics against
@@ -8276,6 +8319,14 @@ type MyRecentApiV1AuditMyRecentGetParams struct {
 // QueryApiV1AuditQueryPostParams defines parameters for QueryApiV1AuditQueryPost.
 type QueryApiV1AuditQueryPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ReflexEndpointApiV1AuditReflexGetParams defines parameters for ReflexEndpointApiV1AuditReflexGet.
+type ReflexEndpointApiV1AuditReflexGetParams struct {
+	Since         *string             `form:"since,omitempty" json:"since,omitempty"`
+	Until         *string             `form:"until,omitempty" json:"until,omitempty"`
+	TenantFilter  *openapi_types.UUID `form:"tenant_filter,omitempty" json:"tenant_filter,omitempty"`
+	Authorization *string             `json:"authorization,omitempty"`
 }
 
 // ReplayApiV1AuditSessionsSessionIdReplayGetParams defines parameters for ReplayApiV1AuditSessionsSessionIdReplayGet.
@@ -11254,6 +11305,9 @@ type ClientInterface interface {
 
 	QueryApiV1AuditQueryPost(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ReflexEndpointApiV1AuditReflexGet request
+	ReflexEndpointApiV1AuditReflexGet(ctx context.Context, params *ReflexEndpointApiV1AuditReflexGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ReplayApiV1AuditSessionsSessionIdReplayGet request
 	ReplayApiV1AuditSessionsSessionIdReplayGet(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13037,6 +13091,18 @@ func (c *Client) QueryApiV1AuditQueryPostWithBody(ctx context.Context, params *Q
 
 func (c *Client) QueryApiV1AuditQueryPost(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewQueryApiV1AuditQueryPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ReflexEndpointApiV1AuditReflexGet(ctx context.Context, params *ReflexEndpointApiV1AuditReflexGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReflexEndpointApiV1AuditReflexGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -20718,6 +20784,102 @@ func NewQueryApiV1AuditQueryPostRequestWithBody(server string, params *QueryApiV
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewReflexEndpointApiV1AuditReflexGetRequest generates requests for ReflexEndpointApiV1AuditReflexGet
+func NewReflexEndpointApiV1AuditReflexGetRequest(server string, params *ReflexEndpointApiV1AuditReflexGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/audit/reflex")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Until != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "until", runtime.ParamLocationQuery, *params.Until); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TenantFilter != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "tenant_filter", runtime.ParamLocationQuery, *params.TenantFilter); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -38992,6 +39154,9 @@ type ClientWithResponsesInterface interface {
 
 	QueryApiV1AuditQueryPostWithResponse(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryApiV1AuditQueryPostResponse, error)
 
+	// ReflexEndpointApiV1AuditReflexGetWithResponse request
+	ReflexEndpointApiV1AuditReflexGetWithResponse(ctx context.Context, params *ReflexEndpointApiV1AuditReflexGetParams, reqEditors ...RequestEditorFn) (*ReflexEndpointApiV1AuditReflexGetResponse, error)
+
 	// ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse request
 	ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*ReplayApiV1AuditSessionsSessionIdReplayGetResponse, error)
 
@@ -40960,6 +41125,29 @@ func (r QueryApiV1AuditQueryPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r QueryApiV1AuditQueryPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ReflexEndpointApiV1AuditReflexGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ReflexReport
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ReflexEndpointApiV1AuditReflexGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReflexEndpointApiV1AuditReflexGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -48556,6 +48744,15 @@ func (c *ClientWithResponses) QueryApiV1AuditQueryPostWithResponse(ctx context.C
 	return ParseQueryApiV1AuditQueryPostResponse(rsp)
 }
 
+// ReflexEndpointApiV1AuditReflexGetWithResponse request returning *ReflexEndpointApiV1AuditReflexGetResponse
+func (c *ClientWithResponses) ReflexEndpointApiV1AuditReflexGetWithResponse(ctx context.Context, params *ReflexEndpointApiV1AuditReflexGetParams, reqEditors ...RequestEditorFn) (*ReflexEndpointApiV1AuditReflexGetResponse, error) {
+	rsp, err := c.ReflexEndpointApiV1AuditReflexGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReflexEndpointApiV1AuditReflexGetResponse(rsp)
+}
+
 // ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse request returning *ReplayApiV1AuditSessionsSessionIdReplayGetResponse
 func (c *ClientWithResponses) ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*ReplayApiV1AuditSessionsSessionIdReplayGetResponse, error) {
 	rsp, err := c.ReplayApiV1AuditSessionsSessionIdReplayGet(ctx, sessionId, params, reqEditors...)
@@ -53686,6 +53883,39 @@ func ParseQueryApiV1AuditQueryPostResponse(rsp *http.Response) (*QueryApiV1Audit
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AuditQueryResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseReflexEndpointApiV1AuditReflexGetResponse parses an HTTP response from a ReflexEndpointApiV1AuditReflexGetWithResponse call
+func ParseReflexEndpointApiV1AuditReflexGetResponse(rsp *http.Response) (*ReflexEndpointApiV1AuditReflexGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReflexEndpointApiV1AuditReflexGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ReflexReport
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -73,7 +73,7 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "audit",
-		Short: "Query the MEHO audit log (query / recent / show / who-touched / my-recent / replay)",
+		Short: "Query the MEHO audit log (query / recent / show / who-touched / my-recent / replay / reflex)",
 		Long: "Query the WORM-grade audit log written by the backplane on " +
 			"every authenticated request. Wraps the G8.1-T2 REST surface " +
 			"(/api/v1/audit/*). All verbs are tenant-scoped via the operator's " +
@@ -86,6 +86,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newWhoTouchedCmd())
 	cmd.AddCommand(newMyRecentCmd())
 	cmd.AddCommand(newReplayCmd())
+	cmd.AddCommand(newReflexCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/audit/reflex.go
+++ b/cli/internal/cmd/audit/reflex.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newReflexCmd returns the `meho audit reflex` command (#3134). The
+// verb wraps GET /api/v1/audit/reflex so operators can read the
+// reflex-adoption KPIs the backplane computes over `audit_log` +
+// the announce store: read-before-act, announce coverage, and
+// write-back rate, each split by surface (agent vs CLI/REST).
+//
+// CLI shape:
+//
+//	meho audit reflex \
+//	  [--since 7d]                        # default 7d; accepts 30d, 24h, 2026-08-01
+//	  [--until 1d]                        # window upper bound; default now
+//	  [--tenant <uuid>]                   # platform_admin only; backplane returns 403 otherwise
+//	  [--json]                            # raw ReflexReport JSON; default is a text table
+//	  [--backplane https://...]           # backplane URL override
+//
+// Exit codes mirror `meho audit query`.
+func newReflexCmd() *cobra.Command {
+	var (
+		since             string
+		until             string
+		tenant            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "reflex",
+		Short: "Read reflex-adoption KPIs (read-before-act / announce coverage / write-back)",
+		Long: "reflex calls GET /api/v1/audit/reflex and renders the " +
+			"reflex-adoption KPIs the backplane aggregates from the " +
+			"audit log and the announce store, split by surface (agent " +
+			"vs CLI/REST):\n\n" +
+			"  - read-before-act: %% of agent sessions whose first " +
+			"call_operation is preceded by a broadcast_recent.\n" +
+			"  - announce coverage: %% of write-class operations executed " +
+			"with an earlier same-session announce claim.\n" +
+			"  - write-back rate: add_to_knowledge + add_to_memory calls " +
+			"per 100 call_operation calls.\n\n" +
+			"--since / --until accept the same relative shorthand (`7d` / " +
+			"`24h`) and absolute ISO-8601 date forms the audit surface " +
+			"supports; --until defaults to now. Ratios read `n/a` when " +
+			"their denominator is zero (e.g. the CLI/REST surface has no " +
+			"agent session, so the client-side reflex metrics are N/A " +
+			"there). --tenant scopes a platform_admin query to a specific " +
+			"tenant; other tokens get a 403. --json emits the raw " +
+			"ReflexReport envelope.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runReflex(cmd, reflexOptions{
+				Since:             since,
+				Until:             until,
+				Tenant:            tenant,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "7d",
+		"window start; accepts relative (`7d`, `24h`) or ISO-8601 date (`2026-08-01`)")
+	cmd.Flags().StringVar(&until, "until", "",
+		"window end; same grammar as --since; defaults to now when omitted")
+	cmd.Flags().StringVar(&tenant, "tenant", "",
+		"tenant UUID filter (platform_admin only; other tokens get a 403)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw ReflexReport on stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+
+	return cmd
+}
+
+type reflexOptions struct {
+	Since             string
+	Until             string
+	Tenant            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// runReflex orchestrates the request: resolve backplane URL, GET the
+// endpoint, render the response.
+func runReflex(cmd *cobra.Command, opts reflexOptions) error {
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, report, err := getReflex(cmd.Context(), client, opts)
+	if err != nil {
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
+		return werr
+	}
+	if report == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against ReflexReport"),
+			opts.JSONOut,
+		)
+	}
+	printReflexReport(cmd.OutOrStdout(), report)
+	return nil
+}
+
+// buildReflexParams maps the CLI flags onto the generated query-param
+// shape. The query-param fields are pointer-typed so nil means "don't
+// emit on the wire"; the backend then applies its own defaults
+// (since=7d, until=now). --since is always sent (it carries a CLI
+// default). A malformed --tenant is left unset so the backend's own
+// tenant default renders, mirroring `meho retrieval usage`.
+func buildReflexParams(opts reflexOptions) *api.ReflexEndpointApiV1AuditReflexGetParams {
+	params := &api.ReflexEndpointApiV1AuditReflexGetParams{}
+	since := opts.Since
+	params.Since = &since
+	if opts.Until != "" {
+		until := opts.Until
+		params.Until = &until
+	}
+	if opts.Tenant != "" {
+		var tenantUUID openapi_types.UUID
+		if err := tenantUUID.UnmarshalText([]byte(opts.Tenant)); err == nil {
+			params.TenantFilter = &tenantUUID
+		}
+	}
+	return params
+}
+
+// getReflex drives the typed-client endpoint with the same one-shot
+// 401-retry shape the sibling audit verbs use.
+func getReflex(
+	ctx context.Context,
+	client *api.AuthedClient,
+	opts reflexOptions,
+) ([]byte, *api.ReflexReport, error) {
+	params := buildReflexParams(opts)
+	resp, err := client.ReflexEndpointApiV1AuditReflexGetWithResponse(ctx, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.ReflexEndpointApiV1AuditReflexGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.Body, resp.JSON200, nil
+}
+
+// printReflexReport renders the ReflexReport as a human-readable table.
+// Each surface gets one block with the three metrics and their raw
+// numerator/denominator. A nil ratio (zero denominator) renders `n/a`.
+func printReflexReport(w io.Writer, r *api.ReflexReport) {
+	tenant := "(operator's tenant)"
+	if r.TenantId != nil {
+		tenant = r.TenantId.String()
+	}
+	fmt.Fprintf(w, "Reflex adoption — tenant: %s\n", tenant)
+	fmt.Fprintf(w, "window: %s → %s\n",
+		r.Since.Format("2006-01-02T15:04:05Z07:00"),
+		r.Until.Format("2006-01-02T15:04:05Z07:00"),
+	)
+	for i := range r.Surfaces {
+		s := r.Surfaces[i]
+		fmt.Fprintf(w, "\n[%s]\n", s.Surface)
+		fmt.Fprintf(w, "  read-before-act:  %s  (%d/%d sessions read-first)\n",
+			pctOrNA(s.ReadBeforeActPct), s.ReadBeforeActReadFirst, s.ReadBeforeActSessions)
+		fmt.Fprintf(w, "  announce-coverage:%s  (%d/%d write ops announced)\n",
+			pctOrNA(s.AnnounceCoveragePct), s.AnnounceCoverageAnnounced, s.AnnounceCoverageWriteOps)
+		fmt.Fprintf(w, "  write-back rate:  %s  (%d adds / %d call_operation)\n",
+			rateOrNA(s.WriteBackPer100CallOps), s.WriteBackAddCalls, s.WriteBackCallOperations)
+	}
+}
+
+// pctOrNA renders a nullable percentage as `NN.NN%` or `n/a` (nil).
+func pctOrNA(v *float32) string {
+	if v == nil {
+		return "   n/a"
+	}
+	return fmt.Sprintf("%6.2f%%", *v)
+}
+
+// rateOrNA renders a nullable per-100 rate as `NN.NN` or `n/a` (nil).
+func rateOrNA(v *float32) string {
+	if v == nil {
+		return "   n/a"
+	}
+	return fmt.Sprintf("%6.2f", *v)
+}

--- a/cli/internal/cmd/audit/reflex_test.go
+++ b/cli/internal/cmd/audit/reflex_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+func f32(v float32) *float32 { return &v }
+
+// TestBuildReflexParamsAlwaysSendsSinceOmitsRest — --since carries a
+// CLI default so it is always emitted; --until / --tenant stay nil when
+// unset so the backend applies its own defaults.
+func TestBuildReflexParamsAlwaysSendsSinceOmitsRest(t *testing.T) {
+	p := buildReflexParams(reflexOptions{Since: "7d"})
+	if p.Since == nil || *p.Since != "7d" {
+		t.Errorf("Since: got %v; want 7d", p.Since)
+	}
+	if p.Until != nil {
+		t.Errorf("Until should be nil; got %v", *p.Until)
+	}
+	if p.TenantFilter != nil {
+		t.Errorf("TenantFilter should be nil; got %v", *p.TenantFilter)
+	}
+}
+
+// TestBuildReflexParamsEmitsUntilAndTenant — a set --until / --tenant
+// pair lands on the params struct.
+func TestBuildReflexParamsEmitsUntilAndTenant(t *testing.T) {
+	tid := "00000000-0000-0000-0000-0000000000ff"
+	p := buildReflexParams(reflexOptions{Since: "30d", Until: "1d", Tenant: tid})
+	if p.Until == nil || *p.Until != "1d" {
+		t.Errorf("Until: got %v; want 1d", p.Until)
+	}
+	if p.TenantFilter == nil || p.TenantFilter.String() != tid {
+		t.Errorf("TenantFilter: got %v; want %s", p.TenantFilter, tid)
+	}
+}
+
+// TestRunReflexRendersSurfaceTable — round-trip: the verb sends --since
+// on the wire and renders both surfaces, with the CLI/REST client-side
+// metrics reading `n/a`.
+func TestRunReflexRendersSurfaceTable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/reflex", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s; want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("since"); got != "30d" {
+			t.Errorf("since: got %q; want 30d", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ReflexReport{
+			Since: mustTS(t, "2026-08-01T00:00:00Z"),
+			Until: mustTS(t, "2026-08-20T00:00:00Z"),
+			Surfaces: []api.SurfaceMetrics{
+				{
+					Surface:                   api.SurfaceMetricsSurfaceAgent,
+					ReadBeforeActPct:          f32(50.0),
+					ReadBeforeActReadFirst:    1,
+					ReadBeforeActSessions:     2,
+					AnnounceCoveragePct:       f32(50.0),
+					AnnounceCoverageAnnounced: 1,
+					AnnounceCoverageWriteOps:  2,
+					WriteBackPer100CallOps:    f32(50.0),
+					WriteBackAddCalls:         1,
+					WriteBackCallOperations:   2,
+				},
+				{
+					Surface:                   api.SurfaceMetricsSurfaceCliRest,
+					ReadBeforeActPct:          nil,
+					ReadBeforeActSessions:     0,
+					AnnounceCoveragePct:       f32(0.0),
+					AnnounceCoverageWriteOps:  1,
+					AnnounceCoverageAnnounced: 0,
+					WriteBackPer100CallOps:    nil,
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runReflex(cmd, reflexOptions{Since: "30d", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runReflex: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"agent", "cli_rest", "read-before-act", "announce-coverage", "write-back rate",
+		"50.00%", "n/a",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunReflexJSONRoundTrips — --json emits the raw server bytes; the
+// typed ReflexReport shape parses back cleanly.
+func TestRunReflexJSONRoundTrips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/reflex", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ReflexReport{
+			Since:    mustTS(t, "2026-08-01T00:00:00Z"),
+			Until:    mustTS(t, "2026-08-20T00:00:00Z"),
+			Surfaces: []api.SurfaceMetrics{},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runReflex(cmd, reflexOptions{Since: "7d", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runReflex --json: %v", err)
+	}
+	var decoded api.ReflexReport
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+}
+
+// TestRunReflexForbiddenSurfacesAsInsufficientRole — a 403 (cross-tenant
+// gate) routes to the insufficient_role category, matching the sibling
+// audit verbs.
+func TestRunReflexForbiddenSurfacesAsInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/reflex", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"cross_tenant_requires_platform_admin"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	err := runReflex(cmd, reflexOptions{
+		Since:             "7d",
+		Tenant:            "00000000-0000-0000-0000-0000000000ff",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for 403")
+	}
+}

--- a/docs/codebase/reflex-adoption.md
+++ b/docs/codebase/reflex-adoption.md
@@ -1,0 +1,156 @@
+# Reflex-adoption KPIs
+
+## Overview
+
+The reflex work (tool-group descriptions, plugin hooks, dispatch
+advisory) is behavioural: its point is to change what an agent does
+*first* in a session — read the broadcast feed before acting, announce
+intent before a write, write learnings back to knowledge/memory. This
+subsystem measures whether that change is happening, directly from the
+synchronous, append-only, session-tagged `audit_log` (plus the #2544
+`AgentAnnouncement` store) MEHO already keeps. No separate metrics
+pipeline: the numbers are re-derivable at any time from the same
+canonical record the G8 audit-trail surface queries.
+
+It reuses the #444 usage-telemetry seam exactly — a `compute_*` service
+behind a REST route + CLI verb, aggregating `audit_log` in Python for
+SQLite/PostgreSQL portability — and adds a new metric family on that
+seam rather than a parallel mechanism.
+
+Surface: `GET /api/v1/audit/reflex` (operator role min; `tenant_filter`
+gated behind `platform_admin`) and `meho audit reflex`.
+
+## Key types
+
+### `compute_reflex_report(...)` (`meho_backplane.reflex.adoption`)
+
+The service. Three tenant-scoped fetches, then per-surface Python
+correlation:
+
+- `_fetch_meta_tool_rows` — successful (`status_code == 200`) MCP
+  meta-tool **envelope** rows in the window: `method="MCP"`,
+  `path = f"/mcp/tools/call/{tool}"` for `call_operation`,
+  `broadcast_recent`, `add_to_knowledge`, `add_to_memory` (the same
+  path-prefix filter #444 uses).
+- `_fetch_dispatch_rows` — successful **dispatch** rows
+  (`method="DISPATCH"`, `path = op_id`); the write-class filter is
+  applied in Python via `classify_op` because the classifier is
+  match-order-significant Python, not portable SQL.
+- `_fetch_announce_first_seen` — `run_id -> earliest created_at` over
+  `AgentAnnouncement` (`created_at <= until`, no lower bound so an
+  announce made before the window can still cover an in-window op).
+
+### `ReflexReport` / `SurfaceMetrics`
+
+Frozen Pydantic models. `ReflexReport.surfaces` is always ordered
+`[agent, cli_rest]`. Each `SurfaceMetrics` carries the three ratios
+plus their raw numerator + denominator; a ratio is `None` (N/A) when
+its denominator is 0, so a zero-activity surface never reads as a
+misleading `0.0`.
+
+## Metric definitions (v1)
+
+Precise enough that a second implementation reproduces the numbers.
+Only successful rows (`status_code == 200`) count. Let a *session* be a
+distinct non-null `agent_session_id`.
+
+**Surface split.** Every metric is reported for two surfaces,
+partitioned by the presence of `agent_session_id` on the row:
+
+- `agent` — rows **with** `agent_session_id` (MCP/agent-run traffic,
+  where client-side reflex levers such as plugin hooks apply).
+- `cli_rest` — rows **without** `agent_session_id` (CLI/REST traffic,
+  which can only ever get server-side levers).
+
+The MCP-meta-tool metrics (read-before-act, write-back) are structurally
+computable only on the `agent` surface (envelope rows always carry a
+session), so `cli_rest` reports them as `None` — that absence *is* the
+signal that a surface has no client-side reflex lever.
+
+1. **read-before-act** — of the sessions with ≥1 `call_operation`, the
+   fraction whose **first** `call_operation` is *strictly preceded*, in
+   the same session, by a `broadcast_recent`. Denominator: sessions
+   with ≥1 `call_operation`. `None` when 0 (the whole `cli_rest`
+   surface).
+
+2. **announce-coverage** — of the write-class dispatch rows
+   (`classify_op(op_id) ∈ {write, credential_write, credential_mint}`),
+   the fraction executed with an announce claim earlier in the same
+   session: an `AgentAnnouncement` whose `run_id == agent_session_id`
+   and whose `created_at <= occurred_at`. A `cli_rest` write op has no
+   session to correlate a claim, so it is never covered. Denominator:
+   write-class dispatch rows. `None` when 0.
+
+3. **write-back rate** — the count of `add_to_knowledge` +
+   `add_to_memory` calls per 100 `call_operation` calls on the surface.
+   `None` when there are 0 `call_operation` calls.
+
+## Control flow
+
+### API surface (`GET /api/v1/audit/reflex`)
+
+`meho_backplane.api.v1.audit_reflex`. Resolves the effective tenant via
+`authorize_tenant_scope` (own tenant, or a `platform_admin` filter →
+403 otherwise), parses `since` / `until` (relative `<N>d`/`<N>h` or
+ISO-8601, reusing `retrieval.usage.parse_since`; `until` defaults to
+now; malformed → 400), binds the audit overrides
+(`audit_op_id="meho.audit.reflex"`, `audit_op_class="audit_query"`)
+so the row broadcasts aggregate-only per decision #3, then calls
+`compute_reflex_report`. `audit_row_count` is bound to the total
+write-class ops scored.
+
+### CLI (`meho audit reflex`)
+
+`cli/internal/cmd/audit/reflex.go`. Wraps the route via the generated
+typed client (`ReflexEndpointApiV1AuditReflexGetWithResponse`), renders
+a per-surface table (or `--json` for the raw envelope). Nil ratios read
+`n/a`.
+
+## Dependencies
+
+- `audit_log` (`meho_backplane.db.models.AuditLog`) — the
+  `agent_session_id` column (migration `0014`) is the session key.
+- `AgentAnnouncement` (#2544) — the structured announce-claim store;
+  `run_id` is the session correlation key (the agent run id doubles as
+  the session id).
+- `classify_op` (`meho_backplane.broadcast.events`) — the op-class
+  classifier that decides write-vs-read on dispatch rows.
+- `retrieval.usage.parse_since` — the shared `--since` grammar (#444).
+
+## Known issues
+
+- **Direct-MCP operator writes are attributed to `cli_rest`.** A
+  write op dispatched over a bare MCP session *without* an agent loop
+  gets no `agent_session_id` on its dispatch row (the dispatcher reads
+  `agent_session_id_var`, bound only by the agent-run invoker), so it
+  lands in `cli_rest` and reads as uncovered. Agents running in the
+  bounded loop — the reflex work's target population — are unaffected.
+- **TTL is not yet enforced on announce coverage.** v1 correlates a
+  claim by session identity + `created_at <= occurred_at` ("an announce
+  earlier in the same session"). The stricter "active claim" reading
+  (bounded by `AgentAnnouncement.ttl_minutes`) is a future refinement;
+  it is a subset of the current boolean, so v1 is the looser, simpler
+  definition.
+- **Emission wiring may lag the metric.** As with #444's usage surface,
+  the metric is defined against audit-row shapes that some meta-tools
+  may not yet emit; the report degrades to all-`None`/zero gracefully.
+
+## Delineation from meho-internal#200 (taint metrics)
+
+These reflex KPIs measure *in-session discipline* (did the agent read /
+announce / write back). meho-internal#200's taint metrics measure
+meho-vs-local-fallback *adoption* (is work going through MEHO at all).
+Related, not merged — the reflex numbers may feed that monthly roll-up
+later, but the two are computed from different signals and answer
+different questions.
+
+## References
+
+- Task #3134; parent Initiative #3128.
+- #444 — the `audit_log` aggregation + REST + CLI precedent reused here
+  (`docs/codebase/retrieval.md`, `meho_backplane.retrieval.usage`).
+- #2544 — the `AgentAnnouncement` structured announce-claim store.
+- `docs/codebase/audit_query.md` — the sibling G8 audit-trail surface
+  whose tenant-scoping posture this route mirrors.
+- Decision #3 (`docs/decisions/locked-decisions.md`) — the
+  audit-on-audit-query aggregate-only broadcast posture.


### PR DESCRIPTION
## Summary
- Adds a read-only **reflex-adoption KPI** report over the append-only `audit_log` + the #2544 announce store, reusing the #444 usage-telemetry seam (a `compute_*` service behind a REST route + CLI verb — no parallel metrics pipeline).
- Four v1 metrics, each split by surface (`agent` vs `cli_rest`), per tenant, over a `--since`/`--until` window: **read-before-act** (first `call_operation` preceded by a `broadcast_recent`), **announce coverage** (write-class ops with an earlier same-session announce claim, `classify_op`-classified), **write-back rate** (`add_to_knowledge` + `add_to_memory` per 100 `call_operation`), and the **surface split** itself.
- The surface split is the point: the MCP-meta-tool metrics are structurally N/A on the CLI/REST surface (no `agent_session_id` session), which is exactly the "server-side-levers-only" signal the reflex work needs to compare against.

## What landed
- **backend**: `meho_backplane.reflex.compute_reflex_report` + `GET /api/v1/audit/reflex` (operator-min RBAC; `tenant_filter` gated behind `platform_admin`; binds `audit_op_id=meho.audit.reflex` / `audit_op_class=audit_query` so the row broadcasts aggregate-only per decision #3, mirroring the audit-query + usage surfaces).
- **cli**: `meho audit reflex` (`--since`/`--until`/`--tenant`/`--json`). Regenerated the OpenAPI snapshot + typed Go client so the route lands in `cli/api/openapi.json` (stale snapshot is a known CI red).
- **docs**: `docs/codebase/reflex-adoption.md` — precise, reproducible metric definitions (so a second implementation produces the same numbers) + the meho-internal#200 delineation.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (new backend files + `main.py`)
- [x] `mypy` — clean (new backend modules)
- [x] `pytest tests/test_reflex_adoption.py` — 13 passed; `+ test_retrieval_usage.py` regression — 49 passed total
- [x] Seeded `audit_log` fixture proves every metric with hand-computable values, incl. the **session-with-no-`broadcast_recent`** and **CLI-row** cases; **tenant isolation** covered by a test (no cross-tenant leakage)
- [x] `GET /api/v1/audit/reflex` route registered in the full app (`app.openapi()` paths); RBAC (read_only 403, operator+`tenant_filter` 403, platform_admin+`tenant_filter` 200), malformed `since` → 400
- [x] `go build ./...`, `go vet`, `go test ./...` — all green (CLI); OpenAPI snapshot regenerated (additions only, no drift)
- [x] code-quality `--diff` gate — 0 blockers

## Delineation from evoila-bosnia/meho-internal#200
Taint metrics measure meho-vs-local-fallback **adoption**; these reflex KPIs measure **in-session discipline**. Related, not merged — reflex numbers may feed that monthly roll-up later, but they are computed from different signals and answer different questions. Recorded here and on both issues per the acceptance criteria.

## Out of scope (per issue)
- Dashboards/UI, new audit columns / write-path changes, scheduled delivery, and the meho-internal#200 roll-up itself.
- Known limitations documented in the docs page: direct-MCP-operator writes (no agent loop) attribute to `cli_rest`; announce-coverage TTL enforcement is a future refinement.

Closes #3134
