### PR TITLE
feat(broadcast): dispatch-time reflex advisory + opt-in announce gate (#3133)

### DIFF
--- a/backend/alembic/versions/0077_add_tenant_announce_gate_enabled.py
+++ b/backend/alembic/versions/0077_add_tenant_announce_gate_enabled.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``tenant.announce_gate_enabled`` for the opt-in announce gate.
+
+Revision ID: 0077
+Revises: 0076
+Create Date: 2026-08-26
+
+Task #3133 under Initiative #3128. The dispatch-time announce gate is
+off by default and opt-in per tenant; its enablement is a structured
+per-tenant policy field -- a first-class Boolean column on ``tenant``,
+NOT a free-form ``tenant_conventions`` row. This migration ships the
+storage half: the flag column. The dispatch path that *consumes* it
+(:mod:`meho_backplane.broadcast.announce_gate`) ships in the same task's
+code change; this column stores + exposes the flag.
+
+What this migration adds
+------------------------
+
+* ``tenant.announce_gate_enabled boolean NOT NULL DEFAULT false`` --
+  whether the dispatcher enforces the announce gate for this tenant.
+  ``False`` (the default) keeps dispatch byte-identical to pre-#3133 for
+  every existing tenant; ``True`` is the audited per-tenant opt-in. No
+  index -- the flag is read per-dispatch through a cache-aware resolver
+  (a one-row SELECT on a cache miss, keyed on the ``tenant`` primary
+  key), never a filter predicate.
+
+Why ``server_default=false`` (not the bare ORM ``default``)
+-----------------------------------------------------------
+
+``announce_gate_enabled`` is an ``ADD COLUMN`` on a populated table: a
+``NOT NULL`` add-column with no default is rejected by both PostgreSQL
+and SQLite, so the migration supplies a ``server_default`` to backfill
+every existing row to the OFF state in one DDL statement. The ORM column
+declares the same ``server_default=sa.false()`` so ``MetaData``-driven
+schema creation stays in sync with the migrated schema. Mirrors the
+``targets.verify_tls`` precedent (migration ``0044``).
+
+Dialect-portability decisions
+-----------------------------
+
+* :class:`sqlalchemy.Boolean` on both dialects -- PG renders
+  ``BOOLEAN``, SQLite renders it as an ``INTEGER`` with a ``0``/``1``
+  CHECK. ``server_default=sa.false()`` renders ``false`` on PG and ``0``
+  on SQLite (SQLAlchemy maps the literal per dialect), so the backfill
+  is portable.
+* ``nullable=False`` -- explicit on both dialects; the default is
+  enforced at the DB layer, not only in the ORM.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column. SQLite's ALTER TABLE drop-column has
+been supported since 3.35.0 (we're on 3.45+); Alembic's batch-mode
+fallback isn't required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0077"
+down_revision: str | None = "0076"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``announce_gate_enabled`` column to ``tenant`` (default OFF)."""
+    op.add_column(
+        "tenant",
+        sa.Column(
+            "announce_gate_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``announce_gate_enabled`` column added in :func:`upgrade`."""
+    op.drop_column("tenant", "announce_gate_enabled")

--- a/backend/src/meho_backplane/broadcast/announce_gate.py
+++ b/backend/src/meho_backplane/broadcast/announce_gate.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Opt-in dispatch-time announce gate (#3133, Initiative #3128).
+
+The enforcing companion to the reflex advisory
+(:mod:`meho_backplane.broadcast.reflex`). Where the advisory *nudges*,
+this gate -- **off by default, opt-in per tenant** -- *rejects* a
+write-class operation of ``caution`` safety or higher, before execution,
+when the caller holds no active announce claim covering it. The rejection
+is a structured, fail-loud policy denial naming ``meho_broadcast_announce``
+-- it is **not** a NEEDS_APPROVAL path (no durable approval row, no
+four-eyes queue).
+
+Composition boundary: #2546 rate-limits the announce *call* (anti-flood);
+this gates *dispatch* on announce-*state*. The two compose -- a caller
+announces (subject to the rate limit), then its write dispatches pass the
+gate.
+
+Tenant enablement is a **structured per-tenant policy field** --
+``tenant.announce_gate_enabled`` (Boolean, default ``False``) -- read
+through a cache-aware, fail-open resolver that mirrors the
+``broadcast_override`` precedent
+(:mod:`meho_backplane.broadcast.overrides`): a 60s per-tenant TTL cache
+keeps the flag off the DB per-dispatch, and any read error resolves to
+``False`` (gate disabled). It deliberately does **not** live in
+``tenant_conventions`` (free-form Markdown, unsuitable for a machine-read
+boolean policy). A typed column on the canonical per-tenant row is the
+minimum structured store for a single boolean; a dedicated rules table +
+CRUD/REST/MCP/UI surface (the full ``broadcast_override`` shape) is more
+than a one-flag policy warrants -- opt-in tenants set the flag through
+seeding / tenant administration, and a management verb is a clean
+follow-up.
+
+Fail-open throughout (the #2550 / #2718 advisory mould): a disabled or
+unreadable policy, or an unreachable claim scan, never blocks a
+dispatch -- the gate only ever *adds* a rejection when it can positively
+determine the tenant opted in AND the claim is absent.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.broadcast.history import (
+    WRITE_OP_CLASSES,
+    caller_has_active_announce_claim,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+
+__all__ = [
+    "announce_gate_blocks",
+    "announce_gate_enabled",
+    "reset_announce_gate_cache_for_testing",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Ordinal rank of the closed ``safety_level`` vocabulary (the
+#: ``ck_endpoint_descriptor_safety_level`` CHECK set). The gate applies at
+#: ``caution`` and above; the string type carries no ordering of its own,
+#: so this map is the single place the ``>= caution`` threshold is encoded.
+#: An unknown level (never expected -- the column is CHECK-constrained)
+#: ranks ``0`` so the gate stays permissive (fail-open) on it.
+_SAFETY_RANK: Final[dict[str, int]] = {"safe": 0, "caution": 1, "dangerous": 2}
+_SAFETY_GATE_THRESHOLD: Final[int] = _SAFETY_RANK["caution"]
+
+#: Per-tenant enablement cache, mirroring ``overrides._TENANT_CACHE``.
+#: Value = (enabled, monotonic_expires_at). A hit is a pure dict lookup;
+#: only a miss awaits the one-row SELECT.
+_CACHE_TTL_SECONDS: Final[float] = 60.0
+_TENANT_GATE_CACHE: dict[UUID, tuple[bool, float]] = {}
+
+#: The structured, fail-loud remediation. Names the exact meta-tool and
+#: what to declare, in the remediation style the rest of dispatch uses.
+_ANNOUNCE_REQUIRED_REMEDIATION: Final[str] = (
+    "this tenant requires an active announce claim before a caution-or-higher "
+    "write-class operation. Call meho_broadcast_announce declaring your intent "
+    "(planned_op_class + target), then retry the operation."
+)
+
+
+def reset_announce_gate_cache_for_testing() -> None:
+    """Clear the per-tenant enablement cache (test isolation only)."""
+    _TENANT_GATE_CACHE.clear()
+
+
+async def announce_gate_enabled(tenant_id: UUID) -> bool:
+    """Whether the announce gate is enabled for *tenant_id* (default ``False``).
+
+    Reads ``tenant.announce_gate_enabled`` through a 60s per-tenant TTL
+    cache. Fail-open: a missing tenant row or any DB error resolves to
+    ``False`` (gate disabled), warn-logged as
+    ``announce_gate_enablement_read_failed`` -- an unreadable policy never
+    blocks a dispatch.
+    """
+    now = time.monotonic()
+    cached = _TENANT_GATE_CACHE.get(tenant_id)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+    try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(Tenant.announce_gate_enabled).where(Tenant.id == tenant_id)
+            )
+            enabled = bool(result.scalar_one_or_none())
+    except Exception:
+        _log.warning("announce_gate_enablement_read_failed", tenant_id=str(tenant_id))
+        return False
+    _TENANT_GATE_CACHE[tenant_id] = (enabled, now + _CACHE_TTL_SECONDS)
+    return enabled
+
+
+async def announce_gate_blocks(
+    operator: Operator,
+    *,
+    op_id: str,
+    safety_level: str,
+    target_name: str | None,
+) -> str | None:
+    """Return a remediation string if the announce gate blocks this op, else ``None``.
+
+    Short-circuits (returns ``None`` -- no block) in order, cheapest first:
+
+    * the op is not write-class (:func:`classify_op` not in
+      :data:`~meho_backplane.broadcast.history.WRITE_OP_CLASSES`) -- no
+      policy read;
+    * the op's ``safety_level`` is below ``caution`` -- no policy read;
+    * the tenant has not enabled the gate (:func:`announce_gate_enabled`);
+    * the caller holds an active covering claim
+      (:func:`~meho_backplane.broadcast.history.caller_has_active_announce_claim`).
+
+    Only when the tenant opted in AND the claim is absent does it return
+    :data:`_ANNOUNCE_REQUIRED_REMEDIATION`. Fail-open: any internal error
+    resolves to ``None`` (no block), warn-logged as
+    ``announce_gate_check_failed``.
+    """
+    try:
+        if classify_op(op_id) not in WRITE_OP_CLASSES:
+            return None
+        if _SAFETY_RANK.get(safety_level, 0) < _SAFETY_GATE_THRESHOLD:
+            return None
+        if not await announce_gate_enabled(operator.tenant_id):
+            return None
+        if await caller_has_active_announce_claim(operator, op_id=op_id, target_name=target_name):
+            return None
+        return _ANNOUNCE_REQUIRED_REMEDIATION
+    except Exception:
+        # Fail-open: the gate only ever ADDS a rejection when it can
+        # positively determine the tenant opted in and the claim is
+        # absent. An internal error must never convert a would-be
+        # dispatch into a denial.
+        _log.warning("announce_gate_check_failed", tenant_id=str(operator.tenant_id))
+        return None

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -102,8 +102,10 @@ from meho_backplane.untrusted_text import wrap_untrusted_text
 __all__ = [
     "DEFAULT_WINDOW_MINUTES",
     "OP_CLASS_ENUM",
+    "WRITE_OP_CLASSES",
     "InvalidSinceError",
     "build_target_activity_advisory",
+    "caller_has_active_announce_claim",
     "default_since_ms",
     "dump_event_wire",
     "event_matches",
@@ -1038,14 +1040,23 @@ async def list_recent_events_fail_soft(
         return {"events": [], "next_cursor": None}
 
 
-#: op_class values that carry the dispatch-time target-activity advisory
-#: (#2550). Only mutating classes qualify -- a write is where crossfire
-#: matters. Read-class dispatches (``read`` / ``credential_read`` /
-#: ``audit_query`` / ``other`` / ``approval``) skip the stream read
-#: entirely, keeping the hot read path free of the lookup.
-_ADVISORY_WRITE_OP_CLASSES: Final[frozenset[str]] = frozenset(
+#: The mutating op classes -- ``write`` / ``credential_write`` /
+#: ``credential_mint``. A single source of truth for "is this a
+#: write-class op" shared by the dispatch-time advisories (#2550
+#: target-activity, #3133 reflex) and the #3133 announce gate, so a
+#: change to the mutating-class set lands in one place. Read-class
+#: dispatches (``read`` / ``credential_read`` / ``audit_query`` /
+#: ``other`` / ``approval`` / ``checks``) are not members.
+WRITE_OP_CLASSES: Final[frozenset[str]] = frozenset(
     {"write", "credential_write", "credential_mint"}
 )
+
+#: op_class values that carry the dispatch-time target-activity advisory
+#: (#2550). Only mutating classes qualify -- a write is where crossfire
+#: matters. Read-class dispatches skip the stream read entirely, keeping
+#: the hot read path free of the lookup. Aliases :data:`WRITE_OP_CLASSES`
+#: so the #2550 gate and the #3133 features stay in lockstep.
+_ADVISORY_WRITE_OP_CLASSES: Final[frozenset[str]] = WRITE_OP_CLASSES
 
 #: Maximum advisory entries surfaced on a single dispatch response. The
 #: advisory is an awareness nudge, not an audit -- the caller who needs
@@ -1212,3 +1223,86 @@ async def build_target_activity_advisory(
         return {}
     newest = peers[:_ADVISORY_MAX_ENTRIES]
     return {ADVISORY_EXTRAS_KEY: [_advisory_entry(event) for event in reversed(newest)]}
+
+
+#: Lookback for the caller's own active-claim scan. Announcement TTLs are
+#: bounded at 1440 minutes (``AgentAnnouncementEvent.ttl_minutes`` upper
+#: bound), which is also the stream's retention ceiling, so a claim older
+#: than this window can no longer be active. Paired with
+#: :data:`_ADVISORY_SCAN_LIMIT` (newest-first ``COUNT`` cap), the scan is
+#: one bounded round-trip; a caller who announced more than
+#: :data:`_ADVISORY_SCAN_LIMIT` events ago in a very busy tenant may fall
+#: off the tail (a bounded false-negative acceptable for an awareness
+#: nudge, and unlikely for the announce-then-write flow the gate targets).
+_CLAIM_SCAN_WINDOW_MINUTES: Final[int] = 1440
+
+
+def _claim_covers_target(event: AgentAnnouncementEvent, target_name: str | None) -> bool:
+    """Whether an announce claim's target attribution covers the op's target.
+
+    A claim that named no target (neither ``target`` nor ``targets``) is
+    target-agnostic and covers any op. A target-less op
+    (``target_name is None``) is covered by any claim. Otherwise the claim
+    must name the op's target (exact match via :func:`_target_matches`).
+    """
+    claim_has_target = event.target is not None or bool(event.targets)
+    if not claim_has_target or target_name is None:
+        return True
+    return _target_matches(event, target_name)
+
+
+async def caller_has_active_announce_claim(
+    operator: Operator,
+    *,
+    op_id: str,
+    target_name: str | None,
+) -> bool:
+    """Return ``True`` iff the caller holds an active claim covering this op.
+
+    Reads the caller's own unexpired :class:`AgentAnnouncementEvent`
+    claims off the per-tenant stream (one bounded newest-first
+    ``XREVRANGE``) and returns ``True`` as soon as one covers the
+    dispatched op. Shared by the #3133 reflex advisory's
+    announce-before-mutate heuristic and the #3133 opt-in announce gate,
+    so the two agree on what "an active claim covering this op" means.
+
+    A claim covers the op when all hold:
+
+    * it was authored by this principal (``principal_sub == operator.sub``
+      -- announcements carry no ``actor_sub``, so a delegated agent's
+      claim rides its human principal's ``sub``);
+    * it has not expired (a claim with no ``ttl_minutes`` never expires);
+    * its declared ``planned_op_class`` matches the op's
+      :func:`classify_op` class, or the claim declared no class (a
+      class-agnostic claim covers any op); and
+    * its target attribution covers the op (see :func:`_claim_covers_target`).
+
+    Propagates :class:`redis.exceptions.RedisError` to the caller's
+    fail-open guard: the reflex advisory swallows it to ``{}`` and the
+    announce gate swallows it to "do not block".
+    """
+    client = get_broadcast_client()
+    key = stream_key(operator.tenant_id)
+    since_ms = max(
+        int((datetime.now(UTC) - timedelta(minutes=_CLAIM_SCAN_WINDOW_MINUTES)).timestamp() * 1000),
+        0,
+    )
+    raw_entries = cast(
+        "list[tuple[str, dict[str, str]]]",
+        await client.xrevrange(key, max=_XRANGE_END, min=str(since_ms), count=_ADVISORY_SCAN_LIMIT),
+    )
+    now = datetime.now(UTC)
+    op_class = classify_op(op_id)
+    for entry_id, fields in raw_entries:
+        event = parse_entry(entry_id, fields, stream_key=key)
+        if not isinstance(event, AgentAnnouncementEvent):
+            continue
+        if event.principal_sub != operator.sub:
+            continue
+        if _is_expired_claim(event, now):
+            continue
+        if event.planned_op_class is not None and event.planned_op_class != op_class:
+            continue
+        if _claim_covers_target(event, target_name):
+            return True
+    return False

--- a/backend/src/meho_backplane/broadcast/reflex.py
+++ b/backend/src/meho_backplane/broadcast/reflex.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatch-time reflex advisory (#3133, Initiative #3128).
+
+The **third** in-band ``extras`` fragment on successful dispatch
+responses, beside the #2550 ``target_activity_advisory``
+(:mod:`meho_backplane.broadcast.history`) and the #2718
+``checks_alert_advisory`` (:mod:`meho_backplane.checks.advisory`). It
+nudges an agent toward the coordination discipline the backplane already
+exposes but does not otherwise enforce: read the feed before starting,
+announce before mutating. When a heuristic fires the response carries one
+compact ``extras["reflex_advisory"]`` one-liner; otherwise the key is
+absent.
+
+Heuristics (v1):
+
+* **read-before-act** -- the calling MCP session has no prior
+  ``meho_broadcast_recent`` call recorded in ``audit_log`` (correlated by
+  ``agent_session_id``). A one-liner recommends reading the feed first.
+* **announce-before-mutate** -- the op is write-class
+  (:func:`~meho_backplane.broadcast.events.classify_op` in
+  :data:`~meho_backplane.broadcast.history.WRITE_OP_CLASSES`) and the
+  caller holds no active announce claim covering it
+  (:func:`~meho_backplane.broadcast.history.caller_has_active_announce_claim`).
+  A one-liner names ``meho_broadcast_announce``.
+
+Design contract (mirrors the #2550 / #2718 mould):
+
+* **Advisory only.** Never gates, blocks, or fails a dispatch. The
+  fragment rides an already-successful response, built after the
+  synchronous audit commit -- never on a denied / error /
+  awaiting-approval envelope.
+* **Session-scoped.** The nudge targets an *agent session*, so it is
+  keyed on :func:`~meho_backplane.operations._audit.resolve_agent_session_id`.
+  A dispatch with no session id -- a CLI / REST operator call, a system
+  sweep -- is not an agent session and gets no nudge (returns ``{}``
+  before any I/O). This is a data-driven no-op on the shared dispatch
+  path, not a surface-specific branch: an MCP ``call_operation`` carries
+  a session and an operator ``meho operation call`` does not, so the
+  same code nudges the former and stays silent for the latter.
+* **One line per response.** The fragment is a single string. When more
+  than one heuristic qualifies the builder returns the first (in
+  priority order: read-before-act, then announce-before-mutate) whose
+  per-``(session, heuristic)`` dedupe claim it wins, and leaves the
+  other heuristic's claim untouched so a later response can still carry
+  it.
+* **Deduped.** At most one nudge per ``(agent_session_id, heuristic)``
+  per window, via an atomic Valkey ``SET NX EX`` -- the #2718 dedupe
+  primitive, one key per heuristic.
+* **Fail-open.** Any error -- a DB teardown, a Valkey teardown, a parse
+  bug -- is swallowed by a broad guard, warn-logged as
+  ``reflex_advisory_failed``, and yields ``{}`` (mirroring the
+  ``dispatch_audit_failed`` posture). The nudge never converts a
+  successful dispatch into a failure.
+* **``0`` disables.** ``REFLEX_ADVISORY_WINDOW_MINUTES`` (default 30)
+  short-circuits before any session resolution or I/O when ``0``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Final
+
+import structlog
+from sqlalchemy import exists, select
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.broadcast.history import (
+    WRITE_OP_CLASSES,
+    caller_has_active_announce_claim,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "REFLEX_ADVISORY_EXTRAS_KEY",
+    "build_reflex_advisory",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The ``extras`` key the advisory rides on the ``OperationResult`` --
+#: sibling of ``target_activity_advisory`` (#2550) and
+#: ``checks_alert_advisory`` (#2718).
+REFLEX_ADVISORY_EXTRAS_KEY: Final[str] = "reflex_advisory"
+
+#: The heuristic names -- also the ``SET NX EX`` dedupe-key segment, so a
+#: session is reminded of each discipline at most once per window.
+_HEURISTIC_READ: Final[str] = "read_before_act"
+_HEURISTIC_ANNOUNCE: Final[str] = "announce_before_mutate"
+
+#: The ``audit_log.path`` a ``meho_broadcast_recent`` MCP tool call lands
+#: as -- ``write_mcp_audit_row`` writes ``/mcp/tools/call/{tool_name}``
+#: (:mod:`meho_backplane.mcp.audit`). The read-before-act heuristic keys
+#: on this stable, dialect-portable string column rather than the
+#: JSON ``payload.op_id`` (whose value is the same ``meho_broadcast_recent``
+#: but needs a per-dialect JSON accessor). ``meho_broadcast_watch`` is
+#: deliberately not counted here -- the discipline's read step the issue
+#: names is the recent-feed pull.
+_BROADCAST_RECENT_PATH: Final[str] = "/mcp/tools/call/meho_broadcast_recent"
+
+#: The nudges. One line each, imperative, naming the exact meta-tool.
+_READ_NUDGE: Final[str] = (
+    "This session has not read the broadcast feed yet. Call "
+    "meho_broadcast_recent before acting so you see what other operators "
+    "and agents are already doing in this tenant."
+)
+_ANNOUNCE_NUDGE: Final[str] = (
+    "You are running a write-class operation without an active announce "
+    "claim. Call meho_broadcast_announce first so concurrent operators "
+    "and agents can see your intent."
+)
+
+
+def _dedupe_key(session_id: uuid.UUID, heuristic: str) -> str:
+    """Valkey key deduping one ``(session, heuristic)`` per window."""
+    return f"meho:reflex:advisory:{session_id}:{heuristic}"
+
+
+async def _session_read_broadcast(session_id: uuid.UUID) -> bool:
+    """Whether this MCP session already called ``meho_broadcast_recent``.
+
+    One indexed existence probe on ``audit_log`` -- the
+    ``audit_log_agent_session_id_idx`` b-tree makes the
+    ``agent_session_id`` predicate selective, and the query is
+    ``LIMIT 1``-shaped via ``EXISTS``. The current dispatch's own audit
+    row (a ``call_operation`` / inner-dispatch row) never matches the
+    ``meho_broadcast_recent`` path, so there is no self-match to exclude.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(
+                exists().where(
+                    AuditLog.agent_session_id == session_id,
+                    AuditLog.path == _BROADCAST_RECENT_PATH,
+                )
+            )
+        )
+        return bool(result.scalar())
+
+
+async def _claim(session_id: uuid.UUID, heuristic: str, window_minutes: int) -> bool:
+    """Atomically claim the ``(session, heuristic)`` dedupe key.
+
+    ``SET key 1 NX EX <window-seconds>`` -- returns ``True`` when the key
+    was absent (this response wins the nudge) and ``None`` when it already
+    existed (already nudged this window). One round-trip; at most one
+    claim per response because the builder short-circuits on the first
+    win.
+    """
+    client = get_broadcast_client()
+    claimed = await client.set(
+        _dedupe_key(session_id, heuristic), "1", nx=True, ex=window_minutes * 60
+    )
+    return bool(claimed)
+
+
+async def build_reflex_advisory(
+    operator: Operator,
+    *,
+    op_id: str,
+    target_name: str | None,
+) -> dict[str, Any]:
+    """Build the ``extras`` fragment nudging toward coordination discipline.
+
+    Returns ``{"reflex_advisory": "<one line>"}`` or an empty dict (no key
+    added) when no heuristic both qualifies and wins its dedupe claim. The
+    empty-dict short-circuits, in order:
+
+    * the feature is disabled (``reflex_advisory_window_minutes == 0`` --
+      checked before any session resolution or I/O);
+    * the dispatch has no agent session
+      (:func:`resolve_agent_session_id` returns ``None``);
+    * read-before-act does not qualify (the session already read the
+      feed) and announce-before-mutate does not qualify (the op is
+      read-class, or the caller holds a covering active claim);
+    * every qualifying heuristic was already nudged to this session in
+      the current window (its ``SET NX`` found its key present).
+
+    Fail-open: any error is swallowed by the broad guard, warn-logged as
+    ``reflex_advisory_failed``, and yields ``{}``.
+    """
+    window_minutes = get_settings().reflex_advisory_window_minutes
+    if window_minutes <= 0:
+        return {}
+
+    # Lazy import: ``operations._audit`` imports the ``broadcast`` package,
+    # so a module-level import here would couple the two packages at load
+    # time. The resolver is cheap and this keeps the import graph acyclic.
+    from meho_backplane.operations._audit import resolve_agent_session_id
+
+    session_id = resolve_agent_session_id()
+    if session_id is None:
+        return {}
+
+    try:
+        # read-before-act -- the more fundamental discipline, checked
+        # first. The ``and`` short-circuits so the (write) claim is only
+        # issued when the session has not read the feed; a qualified-but-
+        # already-nudged read falls through to announce with its key
+        # untouched.
+        if not await _session_read_broadcast(session_id) and await _claim(
+            session_id, _HEURISTIC_READ, window_minutes
+        ):
+            return {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+
+        # announce-before-mutate -- only for write-class ops; the claim is
+        # issued only when the op qualifies and holds no covering claim.
+        if (
+            classify_op(op_id) in WRITE_OP_CLASSES
+            and not await caller_has_active_announce_claim(
+                operator, op_id=op_id, target_name=target_name
+            )
+            and await _claim(session_id, _HEURISTIC_ANNOUNCE, window_minutes)
+        ):
+            return {REFLEX_ADVISORY_EXTRAS_KEY: _ANNOUNCE_NUDGE}
+    except Exception:
+        # Advisory is best-effort; any failure (a DB or Valkey teardown, a
+        # parse bug) must never convert a successful dispatch into a failure.
+        _log.warning("reflex_advisory_failed", session_id=str(session_id))
+        return {}
+
+    return {}

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -690,6 +690,22 @@ class Tenant(Base):
         nullable=False,
         default=lambda: datetime.now(UTC),
     )
+    # Opt-in per-tenant policy flag for the #3133 dispatch-time announce
+    # gate. Boolean NOT NULL DEFAULT ``false`` -- OFF by default. When
+    # ``True`` the dispatcher rejects a caution-or-higher write-class op
+    # that lacks an active announce claim (read through the cache-aware,
+    # fail-open resolver in
+    # :mod:`meho_backplane.broadcast.announce_gate`). A first-class typed
+    # column -- the structured per-tenant policy store the boolean belongs
+    # in, deliberately not the free-form ``tenant_conventions`` Markdown.
+    # ``server_default=false`` in migration ``0077`` backfills pre-#3133
+    # rows so the ``NOT NULL`` add-column is safe on a populated table.
+    announce_gate_enabled: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        default=False,
+        server_default=sa.false(),
+    )
 
     __table_args__ = (
         Index(

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -462,6 +462,33 @@ def result_denied(op_id: str, reason: str, duration_ms: float) -> OperationResul
     )
 
 
+def result_announce_required(op_id: str, remediation: str, duration_ms: float) -> OperationResult:
+    """Opt-in announce gate rejected the call before execution (#3133).
+
+    Returned when a tenant has enabled the announce gate
+    (:mod:`meho_backplane.broadcast.announce_gate`) and a write-class op
+    of ``caution`` safety or higher was dispatched without an active
+    announce claim covering it. This is a policy rejection, **not** a
+    NEEDS_APPROVAL path -- there is no durable approval row and no
+    four-eyes queue; the caller self-remediates by announcing intent and
+    retrying.
+
+    The ``remediation`` string is agent-readable and names
+    ``meho_broadcast_announce`` so an agent can resolve the refusal
+    without human intervention. ``status`` is ``"denied"`` -- the same
+    envelope shape as :func:`result_denied` -- with a distinct
+    ``error_code`` so a caller can tell an announce-gate rejection from a
+    policy-gate denial.
+    """
+    return OperationResult(
+        status="denied",
+        op_id=op_id,
+        error=f"denied: {remediation}",
+        duration_ms=duration_ms,
+        extras={"error_code": "announce_required", "remediation": remediation},
+    )
+
+
 def result_awaiting_approval(
     op_id: str,
     approval_request_id: uuid.UUID,

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -249,8 +249,10 @@ import httpx
 import hvac.exceptions
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.announce_gate import announce_gate_blocks
 from meho_backplane.broadcast.events import classify_op, scrub_secret_named_values
 from meho_backplane.broadcast.history import build_target_activity_advisory
+from meho_backplane.broadcast.reflex import build_reflex_advisory
 from meho_backplane.checks.advisory import build_checks_alert_advisory
 from meho_backplane.connectors import (
     OperationResult,
@@ -277,6 +279,7 @@ from meho_backplane.operations._errors import (
     is_auth_failed_status,
     is_probe_refused,
     result_ambiguous_connector,
+    result_announce_required,
     result_awaiting_approval,
     result_connector_auth_failed,
     result_connector_error,
@@ -812,12 +815,21 @@ async def _reduce_and_audit_success(
     # is deduped per (caller, dashboard, state); distinct keys, so a
     # plain merge can never clobber either fragment.
     checks_advisory = await build_checks_alert_advisory(operator)
+    # Third extras fragment (#3133): the reflex advisory nudges an agent
+    # session toward read-before-act / announce-before-mutate discipline,
+    # deduped per (session, heuristic). Distinct key again -- the merge
+    # stays a clobber-free union of the three fragments.
+    reflex_advisory = await build_reflex_advisory(
+        operator,
+        op_id=descriptor.op_id,
+        target_name=getattr(target, "name", None),
+    )
     return wrap_ok_result(
         op_id,
         summary,
         duration_ms,
         handle,
-        extras={**activity_advisory, **checks_advisory},
+        extras={**activity_advisory, **checks_advisory, **reflex_advisory},
     )
 
 
@@ -2253,6 +2265,35 @@ async def dispatch(
                     gate_reason or f"unexpected policy verdict {verdict!r}; denied",
                     duration_ms,
                 )
+
+            # --- Opt-in announce gate (#3133) --------------------------
+            # Verdict is AUTO_EXECUTE. In a tenant that has enabled the
+            # announce gate, a caution-or-higher write-class op is rejected
+            # before execution unless the caller holds an active announce
+            # claim covering it. Off by default and fail-open, so an
+            # ordinary dispatch reaches this line and proceeds unchanged.
+            # Not run on the ``_approved`` resume path -- an operator
+            # already approved that exact call; re-gating it here would
+            # strand an approved op behind an announce it can no longer add.
+            announce_block = await announce_gate_blocks(
+                operator,
+                op_id=op_id,
+                safety_level=descriptor.safety_level,
+                target_name=getattr(target, "name", None),
+            )
+            if announce_block is not None:
+                duration_ms = _elapsed_ms(started)
+                await audit_and_broadcast_safe(
+                    audit_id=uuid.uuid4(),
+                    operator=operator,
+                    descriptor=descriptor,
+                    target=target,
+                    params=params,
+                    params_hash=params_hash,
+                    result_status="denied",
+                    duration_ms=duration_ms,
+                )
+                return result_announce_required(op_id, announce_block, duration_ms)
         else:
             # Approval-queue resume path: the gate is skipped because an
             # operator already approved this exact call. Stamp the row with

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1120,6 +1120,14 @@ class Settings(BaseModel):
     #: state) window. ``0`` disables the feature entirely (no DB read on
     #: any dispatch).
     checks_alert_advisory_window_minutes: int = Field(default=30, ge=0)
+    #: Dedupe window (minutes) for the dispatch-time reflex advisory
+    #: (#3133). A successful MCP-session dispatch that trips a coordination
+    #: heuristic (no prior ``meho_broadcast_recent`` this session, or a
+    #: write-class op with no active announce claim) carries a compact
+    #: ``extras["reflex_advisory"]`` one-liner, once per (session,
+    #: heuristic) window via a Valkey ``SET NX EX``. ``0`` disables the
+    #: feature entirely (no session resolution or I/O on any dispatch).
+    reflex_advisory_window_minutes: int = Field(default=30, ge=0)
     #: Flap-suppression window (minutes) for Dashboard transition email
     #: (#2732). The first crossing into a non-green state mails; repeat
     #: crossings into the *same* state inside the window are suppressed
@@ -1843,6 +1851,9 @@ def get_settings() -> Settings:
         ),
         checks_alert_advisory_window_minutes=int(
             os.environ.get("CHECKS_ALERT_ADVISORY_WINDOW_MINUTES", "30"),
+        ),
+        reflex_advisory_window_minutes=int(
+            os.environ.get("REFLEX_ADVISORY_WINDOW_MINUTES", "30"),
         ),
         checks_notify_suppression_window_minutes=int(
             os.environ.get("CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES", "30"),

--- a/backend/tests/test_announce_gate.py
+++ b/backend/tests/test_announce_gate.py
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Opt-in dispatch-time announce gate (#3133, Initiative #3128).
+
+The enforcing companion to the reflex advisory: off by default and
+opt-in per tenant, it rejects a caution-or-higher write-class op before
+execution when the caller holds no active announce claim covering it, with
+a structured ``announce_required`` denial naming ``meho_broadcast_announce``.
+Fail-open throughout -- a disabled or unreadable policy, or an unreachable
+claim scan, never blocks a dispatch.
+
+Coverage mirrors the acceptance criteria on the issue, by name:
+
+* enablement is a structured per-tenant flag, default OFF, read through a
+  cache-aware fail-open resolver;
+* the gate blocks only for enabled-tenant + write-class + ``safety_level
+  >= caution`` + no covering claim; a covering claim, a read-class op, a
+  ``safe`` op, and a disabled tenant each pass;
+* the gate composes on the shared dispatch path -- an enabled-tenant
+  dispatch is rejected identically with and without an agent session
+  (CLI/MCP parity), and a disabled-tenant dispatch executes;
+* the gate is not a NEEDS_APPROVAL path -- the rejection is a plain
+  ``denied`` envelope.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import update
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.broadcast.announce_gate import (
+    announce_gate_blocks,
+    announce_gate_enabled,
+    reset_announce_gate_cache_for_testing,
+)
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._audit import agent_session_id_var
+from meho_backplane.settings import get_settings
+
+_TENANT = UUID("00000000-0000-0000-0000-000000003133")
+_SESSION = UUID("33333333-3333-3333-3333-333333333333")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    # Silence the reflex advisory (sibling feature) so it never touches the
+    # stubbed Valkey in these gate-focused dispatch tests.
+    monkeypatch.setenv("REFLEX_ADVISORY_WINDOW_MINUTES", "0")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    reset_announce_gate_cache_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    reset_announce_gate_cache_for_testing()
+    get_settings.cache_clear()
+
+
+def _operator(sub: str = "user-b", *, tenant_id: UUID = _TENANT) -> Operator:
+    return Operator(
+        sub=sub,
+        name=sub,
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+
+
+@contextmanager
+def _bound_session(session_id: UUID | None) -> Iterator[None]:
+    token = agent_session_id_var.set(session_id)
+    try:
+        yield
+    finally:
+        agent_session_id_var.reset(token)
+
+
+async def _seed_tenant(*, enabled: bool = False, tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(
+                Tenant(
+                    id=tenant_id,
+                    slug=f"t-{tenant_id.hex[:8]}",
+                    name="Tenant",
+                    announce_gate_enabled=enabled,
+                )
+            )
+        else:
+            await session.execute(
+                update(Tenant).where(Tenant.id == tenant_id).values(announce_gate_enabled=enabled)
+            )
+        await session.commit()
+    reset_announce_gate_cache_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Enablement resolver
+# ---------------------------------------------------------------------------
+
+
+async def test_enablement_defaults_off_for_unset_tenant() -> None:
+    """A tenant with the default flag resolves to OFF."""
+    await _seed_tenant(enabled=False)
+    assert await announce_gate_enabled(_TENANT) is False
+
+
+async def test_enablement_reads_true_when_opted_in() -> None:
+    """An opted-in tenant resolves to ON."""
+    await _seed_tenant(enabled=True)
+    assert await announce_gate_enabled(_TENANT) is True
+
+
+async def test_enablement_missing_tenant_row_is_off() -> None:
+    """No tenant row -> OFF (fail-open default), no exception."""
+    assert await announce_gate_enabled(uuid.uuid4()) is False
+
+
+async def test_enablement_is_cached() -> None:
+    """A second read inside the TTL does not hit the DB again."""
+    await _seed_tenant(enabled=True)
+    assert await announce_gate_enabled(_TENANT) is True
+    # Flip the row directly (no cache reset) -- the cached ON value wins.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(Tenant).where(Tenant.id == _TENANT).values(announce_gate_enabled=False)
+        )
+        await session.commit()
+    assert await announce_gate_enabled(_TENANT) is True
+
+
+async def test_enablement_fails_open_on_db_error() -> None:
+    """A DB teardown resolves to OFF and warn-logs; never raises."""
+    with (
+        patch(
+            "meho_backplane.broadcast.announce_gate.get_sessionmaker",
+            new=MagicMock(side_effect=RuntimeError("db down")),
+        ),
+        patch("meho_backplane.broadcast.announce_gate._log") as mock_log,
+    ):
+        assert await announce_gate_enabled(_TENANT) is False
+    assert any(
+        call.args and call.args[0] == "announce_gate_enablement_read_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate decision (announce_gate_blocks)
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_blocks_enabled_write_caution_no_claim() -> None:
+    """enabled + write-class + caution + no claim -> remediation string."""
+    await _seed_tenant(enabled=True)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+        new=AsyncMock(return_value=False),
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="caution", target_name="vault-1"
+        )
+    assert block is not None
+    assert "meho_broadcast_announce" in block
+
+
+async def test_gate_passes_when_claim_covers_op() -> None:
+    """An active covering claim lets the op through."""
+    await _seed_tenant(enabled=True)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+        new=AsyncMock(return_value=True),
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="caution", target_name="vault-1"
+        )
+    assert block is None
+
+
+async def test_gate_passes_for_disabled_tenant() -> None:
+    """A disabled tenant is unaffected -- no policy read of the claim scan."""
+    await _seed_tenant(enabled=False)
+    claim = AsyncMock(return_value=False)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim", new=claim
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="caution", target_name="vault-1"
+        )
+    assert block is None
+    # Short-circuited on enablement -- the claim scan never ran.
+    claim.assert_not_called()
+
+
+async def test_gate_passes_for_read_class_op() -> None:
+    """A read-class op is never gated, even in an enabled tenant."""
+    await _seed_tenant(enabled=True)
+    claim = AsyncMock(return_value=False)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim", new=claim
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.list", safety_level="caution", target_name="vault-1"
+        )
+    assert block is None
+    claim.assert_not_called()
+
+
+async def test_gate_passes_for_safe_write_op() -> None:
+    """A write-class op below ``caution`` safety is never gated."""
+    await _seed_tenant(enabled=True)
+    claim = AsyncMock(return_value=False)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim", new=claim
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="safe", target_name="vault-1"
+        )
+    assert block is None
+    claim.assert_not_called()
+
+
+async def test_gate_fails_open_on_claim_scan_error() -> None:
+    """A claim-scan teardown resolves to no-block and warn-logs."""
+    await _seed_tenant(enabled=True)
+    with (
+        patch(
+            "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+            new=AsyncMock(side_effect=RuntimeError("valkey down")),
+        ),
+        patch("meho_backplane.broadcast.announce_gate._log") as mock_log,
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="caution", target_name="vault-1"
+        )
+    assert block is None
+    assert any(
+        call.args and call.args[0] == "announce_gate_check_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration + CLI/MCP parity
+# ---------------------------------------------------------------------------
+
+
+class _NoOpVaultConnector(Connector):
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _module_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"echo": params}
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    def __init__(self, *, name: str = "vault-1") -> None:
+        self.product = "vault"
+        self.fingerprint = _FakeFingerprint(version=None)
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT
+        self.name = name
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatch_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def _quiet_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+async def _register_op(
+    op_id: str, stub_embedding_service: AsyncMock, *, safety_level: str = "caution"
+) -> None:
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id=op_id,
+        handler=_module_handler,
+        summary="Test op.",
+        description="Test op.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+        safety_level=safety_level,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("session", [_SESSION, None], ids=["mcp-session", "cli-no-session"])
+async def test_dispatch_rejected_when_gate_enabled_and_no_claim(
+    session: UUID | None,
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """Enabled tenant + caution write + no claim -> denied, both surfaces.
+
+    Parametrised over an MCP session and a session-less CLI dispatch: the
+    gate keys on announce-state, not on the surface, so both are rejected
+    identically -- the shared-dispatch parity the acceptance criteria
+    require.
+    """
+    await _seed_tenant(enabled=True)
+    await _register_op("vault.kv.delete", stub_embedding_service)
+    with (
+        patch(
+            "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+            new=AsyncMock(return_value=False),
+        ),
+        _bound_session(session),
+    ):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.delete",
+            target=_FakeTarget(),
+            params={},
+        )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "announce_required"
+    assert "meho_broadcast_announce" in result.error
+
+
+async def test_dispatch_executes_when_gate_disabled(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """A disabled tenant runs the same op unaffected."""
+    await _seed_tenant(enabled=False)
+    await _register_op("vault.kv.delete", stub_embedding_service)
+    with _bound_session(_SESSION):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.delete",
+            target=_FakeTarget(),
+            params={},
+        )
+    assert result.status == "ok"
+    assert result.result == {"echo": {}}
+
+
+async def test_dispatch_executes_when_claim_present(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """An enabled tenant with a covering claim runs the op."""
+    await _seed_tenant(enabled=True)
+    await _register_op("vault.kv.delete", stub_embedding_service)
+    with (
+        patch(
+            "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+            new=AsyncMock(return_value=True),
+        ),
+        _bound_session(_SESSION),
+    ):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.delete",
+            target=_FakeTarget(),
+            params={},
+        )
+    assert result.status == "ok"

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -347,7 +347,13 @@ def test_migration_installs_tenant_table_and_indexes(
             assert "audit_log_tenant_id_idx" in audit_indexes
 
             tenant_columns = {col["name"] for col in inspector.get_columns("tenant")}
-            assert tenant_columns == {"id", "slug", "name", "created_at"}
+            assert tenant_columns == {
+                "id",
+                "slug",
+                "name",
+                "created_at",
+                "announce_gate_enabled",  # #3133 opt-in announce gate flag
+            }
 
             audit_columns = {col["name"] for col in inspector.get_columns("audit_log")}
             assert "tenant_id" in audit_columns

--- a/backend/tests/test_reflex_advisory.py
+++ b/backend/tests/test_reflex_advisory.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatch-time reflex advisory (#3133, Initiative #3128).
+
+The third in-band ``extras`` fragment on successful dispatch responses,
+beside #2550 ``target_activity_advisory`` and #2718
+``checks_alert_advisory``. It nudges an agent session toward the
+coordination discipline the backplane exposes but does not otherwise
+enforce -- read the feed before acting, announce before mutating -- with
+one compact ``extras["reflex_advisory"]`` one-liner per fired heuristic,
+deduped per (session, heuristic) via Valkey ``SET NX EX``. Advisory only:
+it never gates a dispatch and every failure mode fails open.
+
+Coverage mirrors the acceptance criteria on the issue, by name:
+
+* the ``0`` window knob short-circuits before session resolution / I/O;
+* the fragment is session-scoped -- a dispatch with no agent session
+  (CLI / non-MCP) gets no nudge;
+* read-before-act fires when the session has no prior
+  ``meho_broadcast_recent`` audit row and stays silent once it does;
+* announce-before-mutate fires for a write-class op with no covering
+  claim and stays silent when a claim covers it; read-class ops never
+  trip it;
+* read-before-act has priority over announce-before-mutate, and the two
+  dedupe independently (a deduped read falls through to announce with the
+  announce key untouched);
+* a forced builder exception leaves the dispatch byte-identical and
+  emits a ``reflex_advisory_failed`` structlog event;
+* dispatch integration -- a successful ``dispatch()`` carries the
+  fragment once per session+window, absent thereafter, and the three
+  advisory fragments coexist on one response.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    get_broadcast_client,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.broadcast.announce_gate import reset_announce_gate_cache_for_testing
+from meho_backplane.broadcast.history import ADVISORY_EXTRAS_KEY
+from meho_backplane.broadcast.reflex import (
+    _ANNOUNCE_NUDGE,
+    _READ_NUDGE,
+    REFLEX_ADVISORY_EXTRAS_KEY,
+    build_reflex_advisory,
+)
+from meho_backplane.checks.advisory import CHECKS_ADVISORY_EXTRAS_KEY
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, CheckDashboard, Tenant
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._audit import agent_session_id_var
+from meho_backplane.settings import get_settings
+
+_TENANT = UUID("00000000-0000-0000-0000-000000003133")
+_SESSION = UUID("33333333-3333-3333-3333-333333333333")
+_RECENT_PATH = "/mcp/tools/call/meho_broadcast_recent"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin required settings + a stub broadcast URL; reset caches."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    monkeypatch.setenv("REFLEX_ADVISORY_WINDOW_MINUTES", "30")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    reset_announce_gate_cache_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    reset_announce_gate_cache_for_testing()
+    get_settings.cache_clear()
+
+
+def _operator(sub: str = "user-b", *, tenant_id: UUID = _TENANT) -> Operator:
+    return Operator(
+        sub=sub,
+        name=sub,
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+
+
+@contextmanager
+def _bound_session(session_id: UUID | None) -> Iterator[None]:
+    """Bind (or clear) the agent-run session contextvar for the block."""
+    token = agent_session_id_var.set(session_id)
+    try:
+        yield
+    finally:
+        agent_session_id_var.reset(token)
+
+
+async def _seed_tenant(tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug=f"t-{tenant_id.hex[:8]}", name="Tenant"))
+            await session.commit()
+
+
+async def _seed_broadcast_recent(session_id: UUID, *, sub: str = "user-b") -> None:
+    """Insert an ``audit_log`` row standing for a prior broadcast_recent call."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AuditLog(
+                operator_sub=sub,
+                method="MCP",
+                path=_RECENT_PATH,
+                status_code=200,
+                tenant_id=_TENANT,
+                agent_session_id=session_id,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_dashboard(*, name: str = "prod-health", state: str = "critical") -> UUID:
+    dashboard_id = uuid.uuid4()
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=_TENANT,
+                name=name,
+                created_by_sub="op-admin",
+                last_rollup_state=state,
+            )
+        )
+        await session.commit()
+    return dashboard_id
+
+
+class _FakeSetStore:
+    """Dict-backed ``SET NX EX`` double with the real claim contract.
+
+    ``set`` returns ``True`` when the key was absent (claimed) and ``None``
+    when it already existed -- ``redis-py``'s NX shape. ``calls`` and
+    ``ex_values`` record every attempt so a test can assert claim count
+    and the TTL separately.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ex_values: list[int] = []
+        self.calls: int = 0
+
+    async def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None) -> Any:
+        assert nx, "the reflex advisory must claim with NX"
+        assert ex is not None and ex > 0, "the reflex advisory must set a TTL"
+        self.calls += 1
+        self.ex_values.append(ex)
+        if name in self.store:
+            return None
+        self.store[name] = value
+        return True
+
+
+def _patch_set(store: _FakeSetStore) -> Any:
+    return patch.object(get_broadcast_client(), "set", new=store.set)
+
+
+class _FakeNxPipeline:
+    """Pipelined ``SET NX`` double for the sibling checks advisory (#2718).
+
+    The checks fragment claims through ``client.pipeline(transaction=True)``
+    rather than a bare ``set``; the three-fragment coexistence test needs
+    that path stubbed too so the checks fragment is actually produced. All
+    keys are claimed (this test only asserts the fragment rides the merge,
+    not its dedupe).
+    """
+
+    def __init__(self) -> None:
+        self._staged: list[tuple[str, str]] = []
+
+    def pipeline(self, transaction: bool = True) -> _FakeNxPipeline:
+        self._staged = []
+        return self
+
+    async def __aenter__(self) -> _FakeNxPipeline:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    def set(
+        self, name: str, value: str, *, nx: bool = False, ex: int | None = None
+    ) -> _FakeNxPipeline:
+        self._staged.append((name, value))
+        return self
+
+    async def execute(self) -> list[Any]:
+        staged, self._staged = self._staged, []
+        return [True for _ in staged]
+
+
+# ---------------------------------------------------------------------------
+# Disable knob + session-scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_window_zero_short_circuits_no_session_no_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``0`` disables the feature before any session resolution or I/O."""
+    monkeypatch.setenv("REFLEX_ADVISORY_WINDOW_MINUTES", "0")
+    get_settings.cache_clear()
+    db_stub = MagicMock(side_effect=AssertionError("DB must not be touched"))
+    set_stub = MagicMock(side_effect=AssertionError("Valkey must not be touched"))
+    with (
+        patch("meho_backplane.broadcast.reflex.get_sessionmaker", new=db_stub),
+        patch.object(get_broadcast_client(), "set", new=set_stub),
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {}
+    db_stub.assert_not_called()
+
+
+async def test_no_agent_session_yields_empty_and_no_io() -> None:
+    """A dispatch with no agent session (CLI / non-MCP) gets no nudge."""
+    db_stub = MagicMock(side_effect=AssertionError("DB must not be touched"))
+    with (
+        patch("meho_backplane.broadcast.reflex.get_sessionmaker", new=db_stub),
+        _bound_session(None),
+    ):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {}
+    db_stub.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# read-before-act
+# ---------------------------------------------------------------------------
+
+
+async def test_read_nudge_fires_when_session_never_read_broadcast() -> None:
+    """No prior broadcast_recent row for the session -> the read nudge fires."""
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(_SESSION):
+        first = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+        second = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert first == {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+    # Deduped: same (session, heuristic) is nudged once per window; the
+    # read op does not qualify for the announce heuristic, so no fragment.
+    assert second == {}
+    assert store.ex_values[0] == 30 * 60
+
+
+async def test_read_nudge_silent_once_session_has_read_broadcast() -> None:
+    """A prior broadcast_recent row satisfies the discipline -- no nudge."""
+    await _seed_broadcast_recent(_SESSION)
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(_SESSION):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {}
+    # Heuristic did not qualify, so no claim was ever attempted.
+    assert store.calls == 0
+
+
+async def test_read_nudge_is_per_session() -> None:
+    """A prior read by one session does not satisfy another session."""
+    await _seed_broadcast_recent(_SESSION)
+    other = UUID("44444444-4444-4444-4444-444444444444")
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(other):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+
+
+# ---------------------------------------------------------------------------
+# announce-before-mutate
+# ---------------------------------------------------------------------------
+
+
+async def test_announce_nudge_fires_for_write_without_claim() -> None:
+    """A write-class op with no covering claim fires the announce nudge."""
+    await _seed_broadcast_recent(_SESSION)  # satisfy read so announce is reached
+    store = _FakeSetStore()
+    with (
+        _patch_set(store),
+        patch(
+            "meho_backplane.broadcast.reflex.caller_has_active_announce_claim",
+            new=AsyncMock(return_value=False),
+        ),
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(
+            _operator(), op_id="vault.kv.delete", target_name="vault-1"
+        )
+    assert advisory == {REFLEX_ADVISORY_EXTRAS_KEY: _ANNOUNCE_NUDGE}
+
+
+async def test_announce_nudge_silent_when_claim_covers_op() -> None:
+    """An active covering claim suppresses the announce nudge."""
+    await _seed_broadcast_recent(_SESSION)
+    store = _FakeSetStore()
+    with (
+        _patch_set(store),
+        patch(
+            "meho_backplane.broadcast.reflex.caller_has_active_announce_claim",
+            new=AsyncMock(return_value=True),
+        ),
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(
+            _operator(), op_id="vault.kv.delete", target_name="vault-1"
+        )
+    assert advisory == {}
+    assert store.calls == 0
+
+
+async def test_read_class_op_never_trips_announce() -> None:
+    """A read-class op never trips announce, even with no claim."""
+    await _seed_broadcast_recent(_SESSION)
+    store = _FakeSetStore()
+    claim = AsyncMock(return_value=False)
+    with (
+        _patch_set(store),
+        patch("meho_backplane.broadcast.reflex.caller_has_active_announce_claim", new=claim),
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(
+            _operator(), op_id="vault.kv.list", target_name="vault-1"
+        )
+    assert advisory == {}
+    # Read-class short-circuits before the (expensive) claim scan.
+    claim.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Priority + independent dedupe
+# ---------------------------------------------------------------------------
+
+
+async def test_read_has_priority_then_announce_on_next_call() -> None:
+    """Read wins first; the announce key is untouched so it fires next call."""
+    store = _FakeSetStore()
+    with (
+        _patch_set(store),
+        patch(
+            "meho_backplane.broadcast.reflex.caller_has_active_announce_claim",
+            new=AsyncMock(return_value=False),
+        ),
+        _bound_session(_SESSION),
+    ):
+        # First write-class dispatch: read qualifies (no prior recent) AND
+        # announce qualifies, but read wins and the announce key is left
+        # unclaimed.
+        first = await build_reflex_advisory(
+            _operator(), op_id="vault.kv.delete", target_name="vault-1"
+        )
+        # Second dispatch: read is now deduped, so it falls through to the
+        # still-unclaimed announce heuristic.
+        second = await build_reflex_advisory(
+            _operator(), op_id="vault.kv.delete", target_name="vault-1"
+        )
+    assert first == {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+    assert second == {REFLEX_ADVISORY_EXTRAS_KEY: _ANNOUNCE_NUDGE}
+
+
+# ---------------------------------------------------------------------------
+# Fail-open
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_open_on_db_error() -> None:
+    """A DB teardown mid-read yields ``{}`` and warn-logs; never raises."""
+    with (
+        patch(
+            "meho_backplane.broadcast.reflex.get_sessionmaker",
+            new=MagicMock(side_effect=RuntimeError("db down")),
+        ),
+        patch("meho_backplane.broadcast.reflex._log") as mock_log,
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {}
+    assert any(
+        call.args and call.args[0] == "reflex_advisory_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+async def test_fail_open_on_valkey_error() -> None:
+    """A Valkey teardown mid-claim yields ``{}`` and warn-logs; never raises."""
+    from redis import exceptions as redis_exceptions
+
+    with (
+        patch.object(
+            get_broadcast_client(),
+            "set",
+            new=AsyncMock(side_effect=redis_exceptions.ConnectionError("refused")),
+        ),
+        patch("meho_backplane.broadcast.reflex._log") as mock_log,
+        _bound_session(_SESSION),
+    ):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {}
+    assert any(
+        call.args and call.args[0] == "reflex_advisory_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration + three-fragment coexistence
+# ---------------------------------------------------------------------------
+
+
+class _NoOpVaultConnector(Connector):
+    """Connector class satisfying resolver lookups in typed-dispatch tests."""
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _module_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"echo": params}
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    def __init__(self, *, name: str = "vault-1") -> None:
+        self.product = "vault"
+        self.fingerprint = _FakeFingerprint(version=None)
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT
+        self.name = name
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatch_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def _quiet_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+async def _register_op(
+    op_id: str, stub_embedding_service: AsyncMock, *, safety_level: str = "safe"
+) -> None:
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id=op_id,
+        handler=_module_handler,
+        summary="Test op.",
+        description="Test op.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+        safety_level=safety_level,  # type: ignore[arg-type]
+    )
+
+
+async def test_dispatch_carries_reflex_fragment_then_dedupes(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """A read-class MCP-session dispatch carries the read nudge, then dedupes."""
+    await _seed_tenant()
+    await _register_op("vault.kv.list", stub_embedding_service)
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(_SESSION):
+        first = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+        second = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    assert first.status == "ok"
+    assert first.extras[REFLEX_ADVISORY_EXTRAS_KEY] == _READ_NUDGE
+    assert second.status == "ok"
+    assert REFLEX_ADVISORY_EXTRAS_KEY not in second.extras
+
+
+async def test_dispatch_without_session_carries_no_reflex_fragment(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """An operator CLI-shaped dispatch (no session) carries no reflex nudge."""
+    await _seed_tenant()
+    await _register_op("vault.kv.list", stub_embedding_service)
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(None):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    assert result.status == "ok"
+    assert REFLEX_ADVISORY_EXTRAS_KEY not in result.extras
+    assert store.calls == 0
+
+
+async def test_three_advisory_fragments_coexist_on_one_response(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """#2550 + #2718 + #3133 fragments ride one ``extras`` -- distinct keys.
+
+    A write-class dispatch on a target with peer activity (#2550) by a
+    caller whose tenant has a critical Dashboard (#2718) in an MCP session
+    that never read the feed (#3133 read nudge) carries all three
+    fragments -- the plain dict merge is a clobber-free union.
+    """
+    await _seed_dashboard(state="critical")
+    await _register_op("vault.kv.delete", stub_embedding_service)
+    peer_event = BroadcastEvent(
+        event_id=uuid.uuid4(),
+        ts=datetime.now(UTC),
+        tenant_id=_TENANT,
+        principal_sub="peer-a",
+        target_name="vault-1",
+        op_id="vault.kv.delete",
+        op_class="write",
+        result_status="ok",
+        audit_id=uuid.uuid4(),
+        actor_sub=None,
+        payload={"op_class": "write", "params": {}, "result_status": "ok"},
+    )
+
+    async def _xrevrange(name: str, **kwargs: Any) -> list[tuple[str, dict[str, str]]]:
+        return [("1747800001000-0", {"event": peer_event.model_dump_json()})]
+
+    store = _FakeSetStore()
+    pipe = _FakeNxPipeline()
+    bc = get_broadcast_client()
+    with (
+        _patch_set(store),
+        patch.object(bc, "pipeline", new=pipe.pipeline),
+        patch.object(bc, "xrevrange", new=_xrevrange),
+        _bound_session(_SESSION),
+    ):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.delete",
+            target=_FakeTarget(),
+            params={},
+        )
+    assert result.status == "ok"
+    assert result.extras[ADVISORY_EXTRAS_KEY][0]["principal_sub"] == "peer-a"
+    assert result.extras[CHECKS_ADVISORY_EXTRAS_KEY][0]["state"] == "critical"
+    assert result.extras[REFLEX_ADVISORY_EXTRAS_KEY] == _READ_NUDGE

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -400,11 +400,21 @@ Design contract:
 - **Disable knob.** `DISPATCH_ACTIVITY_ADVISORY_WINDOW_MINUTES` (default
   `30`, `0` = off) gates the whole feature.
 
-A second, independent extras fragment — `checks_alert_advisory`
-(#2718, built in `checks/advisory.py`, deduped per caller via Valkey
-`SET NX EX`, applied to **all** op classes) — merges beside this one at
-the same dispatcher success path; see
-[`docs/codebase/checks-advisory.md`](checks-advisory.md).
+Three independent extras fragments now ride the same dispatcher success
+path, merged as a clobber-free union of distinct keys
+(`extras={**activity, **checks, **reflex}`):
+
+1. `target_activity_advisory` — this fragment (#2550), write-class only.
+2. `checks_alert_advisory` — #2718, built in `checks/advisory.py`,
+   deduped per caller via Valkey `SET NX EX`, applied to **all** op
+   classes; see [`docs/codebase/checks-advisory.md`](checks-advisory.md).
+3. `reflex_advisory` — #3133, built in `broadcast/reflex.py`, a
+   session-scoped coordination nudge (read-before-act /
+   announce-before-mutate) deduped per `(session, heuristic)`; see
+   [`docs/codebase/reflex-advisory.md`](reflex-advisory.md). #3133 also
+   ships the opt-in **announce gate** (`broadcast/announce_gate.py`),
+   which *rejects* — rather than nudges — a caution-or-higher write-class
+   op dispatched without an active claim in a tenant that opted in.
 
 ## Durable announcements (#2547)
 

--- a/docs/codebase/reflex-advisory.md
+++ b/docs/codebase/reflex-advisory.md
@@ -1,0 +1,200 @@
+# Reflex advisory + opt-in announce gate (dispatch-time)
+
+## Overview
+
+The **third** in-band `extras` fragment on successful dispatch responses
+(#3133, Initiative #3128), beside the #2550 `target_activity_advisory`
+and the #2718 `checks_alert_advisory`. It makes the backplane's
+coordination levers a *default reflex* rather than an on-request
+behavior: it nudges an agent session toward the discipline the backplane
+exposes but does not otherwise enforce — read the feed before acting,
+announce before mutating.
+
+`#3133` ships two pieces on the shared `dispatch()` path, so an agent
+`call_operation` and an operator CLI dispatch exercise the same code:
+
+1. **Reflex advisory** (default ON, advisory-only) — a
+   `build_reflex_advisory(...)` fragment merged into the same `extras`
+   dict. Returns `{"reflex_advisory": "<one line>"}` or `{}`.
+2. **Announce gate** (default OFF, opt-in per tenant) — a pre-execution
+   dispatch gate that *rejects* a caution-or-higher write-class op
+   dispatched without an active announce claim, in a tenant that opted
+   in.
+
+The advisory *nudges*; the gate *enforces*. Both copy the established
+#2550 / #2718 advisory mould: fail-open, bounded, Valkey `SET NX EX`
+dedupe where a dedupe applies.
+
+## Key types
+
+- `meho_backplane.broadcast.reflex.build_reflex_advisory(operator, *, op_id, target_name)`
+  — the advisory builder; returns `{"reflex_advisory": "<line>"}` or `{}`.
+- `REFLEX_ADVISORY_EXTRAS_KEY = "reflex_advisory"` — the extras key,
+  sibling of `ADVISORY_EXTRAS_KEY` (`target_activity_advisory`) and
+  `CHECKS_ADVISORY_EXTRAS_KEY` (`checks_alert_advisory`).
+- `settings.reflex_advisory_window_minutes` — dedupe window, default
+  `30`, `ge=0`; `0` disables the advisory before any I/O.
+- `meho_backplane.broadcast.announce_gate.announce_gate_blocks(operator, *, op_id, safety_level, target_name)`
+  — the gate decision; returns a remediation string (block) or `None`.
+- `announce_gate_enabled(tenant_id) -> bool` — the cache-aware, fail-open
+  per-tenant enablement resolver.
+- `tenant.announce_gate_enabled` — the structured per-tenant policy flag
+  (Boolean, default `False`), migration `0077`.
+- `caller_has_active_announce_claim(operator, *, op_id, target_name)`
+  (`broadcast/history.py`) — the shared active-claim scanner used by both
+  the advisory's announce heuristic and the gate.
+- `result_announce_required(op_id, remediation, duration_ms)`
+  (`operations/_errors.py`) — the `denied` envelope the gate returns,
+  `extras.error_code = "announce_required"`.
+
+## Control flow
+
+### Advisory (success path, after the audit commit)
+
+```text
+dispatcher._reduce_and_audit_success(...)   # after audit + broadcast
+  → build_target_activity_advisory(...)     # #2550 fragment (write-gated)
+  → build_checks_alert_advisory(...)        # #2718 fragment (all classes)
+  → build_reflex_advisory(operator, op_id, target_name)   # this fragment
+      [gate — returns {} without any I/O when:]
+        · settings.reflex_advisory_window_minutes == 0
+        · resolve_agent_session_id() is None   # no MCP session (CLI etc.)
+      [otherwise, heuristics in priority order, first winner returns:]
+        · read-before-act:  no audit_log row with
+            agent_session_id == session AND
+            path == "/mcp/tools/call/meho_broadcast_recent"
+          → claim (session, "read_before_act") via SET NX EX → _READ_NUDGE
+        · announce-before-mutate:  classify_op(op_id) is write-class AND
+            not caller_has_active_announce_claim(...)
+          → claim (session, "announce_before_mutate") → _ANNOUNCE_NUDGE
+  → wrap_ok_result(..., extras={**activity, **checks, **reflex})
+```
+
+The fragment is a single line. When more than one heuristic qualifies the
+builder returns the first (read, then announce) whose per-`(session,
+heuristic)` dedupe claim it wins, and leaves the other heuristic's claim
+untouched so a later response can still carry it — a deduped read on one
+response falls through to announce on the next.
+
+### Gate (pre-execution, after the policy gate's AUTO_EXECUTE)
+
+```text
+dispatch(...)   # Step 4, verdict == AUTO_EXECUTE, not the _approved resume
+  → announce_gate_blocks(operator, op_id, safety_level, target_name)
+      [returns None — no block — in order, cheapest first:]
+        · classify_op(op_id) not in WRITE_OP_CLASSES
+        · _SAFETY_RANK[safety_level] < _SAFETY_RANK["caution"]
+        · not announce_gate_enabled(tenant_id)        # cached, fail-open
+        · caller_has_active_announce_claim(...)         # active claim covers it
+      [otherwise:]
+        → remediation string naming meho_broadcast_announce
+  → if blocked: write a "denied" audit row + return result_announce_required(...)
+```
+
+## Design contract
+
+- **Advisory only / gate is a plain denial.** The advisory never blocks;
+  it rides an already-successful response, built after the synchronous
+  audit commit — never on a denied / error / awaiting-approval envelope.
+  The gate is a policy rejection (`status="denied"`), **not** a
+  NEEDS_APPROVAL path: no durable approval row, no four-eyes queue. The
+  caller self-remediates by announcing intent and retrying.
+- **Session-scoped advisory.** The nudge targets an agent session, keyed
+  on `resolve_agent_session_id()`. A dispatch with no session id — an
+  operator CLI / REST call, a system sweep — is not an agent session and
+  gets no nudge (returns `{}` before any I/O). This is a data-driven
+  no-op on the shared dispatch path, not a surface branch: an MCP
+  `call_operation` carries a session and an operator `meho operation
+  call` does not, so the same code nudges the former and stays silent for
+  the latter.
+- **Surface-agnostic gate.** The gate keys on announce-*state*, not the
+  surface, so an enabled-tenant caution write with no claim is rejected
+  identically over MCP and CLI. It composes with #2546 (which
+  rate-limits the announce *call*): announce once, then the write passes.
+- **Deduped advisory.** At most one nudge per `(agent_session_id,
+  heuristic)` per window, via an atomic Valkey `SET NX EX` — the #2718
+  dedupe primitive, one key per heuristic.
+- **Fail-open throughout.** Any advisory error (DB / Valkey teardown,
+  parse bug) is swallowed, warn-logged `reflex_advisory_failed`, and
+  yields `{}`. Any gate error — an unreadable enablement policy
+  (`announce_gate_enablement_read_failed`), an unreachable claim scan
+  (`announce_gate_check_failed`) — resolves to *no block*. The gate only
+  ever *adds* a rejection when it can positively determine the tenant
+  opted in AND the claim is absent.
+- **Bounded.** The read heuristic is one indexed `EXISTS` probe on
+  `audit_log` (the `audit_log_agent_session_id_idx` b-tree). The announce
+  heuristic and the gate share one bounded newest-first `XREVRANGE`
+  (`caller_has_active_announce_claim`), capped at 100 entries over a
+  1440-minute window. The enablement flag is read through a 60s per-tenant
+  TTL cache. A read-class dispatch or a disabled tenant pays nothing on
+  the gate.
+- **`0` disables the advisory.** `REFLEX_ADVISORY_WINDOW_MINUTES` (default
+  30) short-circuits before session resolution or I/O when `0`. The gate
+  has no global knob — it is OFF unless a tenant opts in.
+
+## Enablement store — why a `tenant` column
+
+The gate's per-tenant enablement is a **structured per-tenant policy
+field** — `tenant.announce_gate_enabled` (Boolean, default `False`) —
+deliberately **not** `tenant_conventions` (free-form Markdown, unsuitable
+for a machine-read boolean). A typed column on the canonical per-tenant
+row is the minimum structured store for a single boolean, read through a
+cache-aware fail-open resolver that mirrors the `broadcast_override`
+resolver pattern (`broadcast/overrides.py`: 60s per-tenant TTL cache,
+fail-open-to-default). A dedicated rules table + CRUD/REST/MCP/UI surface
+(the full `broadcast_override` shape) is more than a one-flag policy
+warrants; opt-in tenants set the flag through seeding / tenant
+administration, and a management verb is a clean follow-up.
+
+## Known issues / limitations
+
+- **`meho_broadcast_watch` not counted.** The read-before-act heuristic
+  keys on `meho_broadcast_recent` only (the discipline's read step the
+  issue names). A session that only tailed the feed via
+  `meho_broadcast_watch` still gets the read nudge.
+- **Coarse claim coverage (v1).** A claim covers an op when its declared
+  `planned_op_class` matches the op's `classify_op` class (or the claim
+  declared no class) and its target attribution covers the op (or either
+  is target-agnostic). A claim declared for a different write-class (e.g.
+  `write` vs `credential_write`) does not cover — a deliberate, documented
+  v1 strictness.
+- **Bounded claim scan.** `caller_has_active_announce_claim` reads the
+  newest 100 stream entries in the 1440-minute window; a caller who
+  announced more than 100 events ago in a very busy tenant may fall off
+  the tail (an acceptable false-negative for an awareness nudge, and
+  unlikely for the announce-then-write flow the gate targets).
+- **Session identity.** Both the dedupe key and the read query use
+  `resolve_agent_session_id()`, which prefers the agent-run id and falls
+  back to the MCP header session. A direct MCP agent session (the primary
+  target) correlates cleanly; a nested agent-run-over-MCP may correlate
+  imperfectly.
+
+## Operator reach (JSON only today)
+
+Same as the #2718 fragment: the backend sets `extras` on the response for
+every front, but the human CLI render prints `extras` only on non-ok
+statuses. An agent (MCP `call_operation`) sees `reflex_advisory`
+unprompted; an operator sees it through `meho operation call --json`. A
+gate rejection is a non-ok (`denied`) status, so its remediation *does*
+surface on the human render.
+
+## References
+
+- Task #3133, Initiative #3128 (parent goal #2661).
+- Precedents: `docs/codebase/broadcast.md` "Read path (dispatch-time
+  target-activity advisory)" (#2550); `docs/codebase/checks-advisory.md`
+  (#2718, per-caller Valkey dedupe).
+- Data read: #2544 (structured announce claims: `planned_op_class`, TTL,
+  `run_id`), `audit_log.agent_session_id` (`db/models.py`, MCP-session
+  correlation, migration `0014`). Boundary: #2546 (announce rate limit).
+- Code: `backend/src/meho_backplane/broadcast/reflex.py`,
+  `backend/src/meho_backplane/broadcast/announce_gate.py`,
+  `caller_has_active_announce_claim` in
+  `backend/src/meho_backplane/broadcast/history.py`,
+  the merge seam + gate in
+  `backend/src/meho_backplane/operations/dispatcher.py`,
+  `result_announce_required` in
+  `backend/src/meho_backplane/operations/_errors.py`,
+  `tenant.announce_gate_enabled` (migration `0077`).
+- Tests: `backend/tests/test_reflex_advisory.py`,
+  `backend/tests/test_announce_gate.py`.


### PR DESCRIPTION
## Summary
- Adds the **third** `OperationResult.extras` advisory fragment beside the #2550 `target_activity_advisory` and #2718 `checks_alert_advisory`, merged at the `wrap_ok_result` seam in `operations/dispatcher.py`. `broadcast/reflex.py`'s `build_reflex_advisory` nudges an MCP session toward **read-before-act** (no prior `meho_broadcast_recent` in `audit_log`) and **announce-before-mutate** (write-class op with no active claim) — session-scoped, deduped per `(session, heuristic)` via Valkey `SET NX EX`, fail-open. A session-less CLI/REST dispatch gets no nudge.
- Adds a **default-OFF, opt-in per-tenant announce gate** (`broadcast/announce_gate.py`) at the dispatch pre-execution phase: an enabled tenant rejects a caution-or-higher write-class op with no active announce claim, before execution, with a structured `announce_required` denial naming `meho_broadcast_announce` (not a NEEDS_APPROVAL path). Enablement is the structured `tenant.announce_gate_enabled` flag (migration `0077`) read through a cache-aware fail-open resolver mirroring the `broadcast_override` precedent — deliberately **not** free-form `tenant_conventions`.
- Factors a shared `caller_has_active_announce_claim` scanner + a public `WRITE_OP_CLASSES` constant into `broadcast/history.py`, used by both the advisory heuristic and the gate so they agree on coverage. Both pieces copy the established fail-open, bounded, deduped advisory mould.
- No MCP schema change (`extras` is already an `object`); **`audit_log` gains no `broadcast_event_id` column** — the linkage stays `BroadcastEvent.audit_id`, per the issue's accuracy note.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (all touched src + tests + migration)
- [x] `mypy` (touched modules) — no issues
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (15 warnings are pre-existing legacy debt in touched files, none introduced)
- [x] `uv run pytest backend/tests -k "reflex or advisory"` — 56 passed (the issue's verification command)
- [x] New suites `test_reflex_advisory.py` + `test_announce_gate.py` — 29 passed
- [x] Regression: `test_operations_dispatcher` / `test_broadcast_history` / `test_broadcast_structured_claims` / `test_checks_advisory` / `test_broadcast_target_advisory` — 122 passed
- [x] `test_settings` (69), `test_db_models` (8, tenant-column snapshot updated), migration rollback suite (374), taxonomy/schema-conformance (102) — all green
- [x] `alembic heads` single (`0077`); fresh-SQLite `alembic upgrade head` applies and `tenant.announce_gate_enabled` is present
- [x] Acceptance criteria: `reflex_advisory` appears only when a heuristic fires alongside the two existing fragments (coexistence test); fail-open proven (forced builder exception → byte-identical result + structlog event); dedupe proven (second call → no second nudge); heuristics covered (read nudge, announce nudge, read-class never nudges, CLI-no-session skip); gate enabled/disabled + claim-present/absent both paths; CLI/MCP parity (parametrised); `docs/codebase/reflex-advisory.md` added + `broadcast.md` inventory now lists three

## Out of scope
- Client-side hooks (#3131) and reflex-adoption KPIs (#3134) — sibling tasks.
- A management surface (REST/MCP/UI) for the announce-gate flag: opt-in tenants set `tenant.announce_gate_enabled` via seeding / tenant administration; a management verb is a clean follow-up (documented in `docs/codebase/reflex-advisory.md`).
- `meho_broadcast_watch` is not counted toward read-before-act (v1 keys on `meho_broadcast_recent`, the discipline's named read step).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3133
