### PR TITLE
feat(clients): plugin reflex hooks (session digest, announce nudges)

### DIFF
--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -33,6 +33,10 @@ marketplace at a local checkout instead of `evoila/meho`.
 - **`skills/`** — the Layer-2 routing discipline as model-invoked skills,
   namespaced `meho:<skill>`: `meho:prefer-meho`, `meho:knowledge`,
   `meho:memory`, `meho:operations`, `meho:broadcast`.
+- **`hooks/`** — deterministic reflex hooks (`hooks/hooks.json` + scripts
+  under `bin/`) that the harness runs without model initiative: a
+  session-start digest and advisory announce/report reminders. See
+  [Reflex hooks](#reflex-hooks).
 
 ## Configuration — no edits inside the installed plugin
 
@@ -89,16 +93,63 @@ Continue, CI bots); Claude Code consumers get the same discipline as skills:
 | Targets + Connectors + Audit | `meho:operations` |
 | Live awareness + Broadcast discipline | `meho:broadcast` |
 
+## Reflex hooks
+
+Skills and MCP descriptions are advisory — the model chooses whether to
+follow them. Hooks are deterministic: the Claude Code harness runs them, no
+model initiative required. `hooks/hooks.json` wires three reflexes, every one
+**fail-open** (missing `meho` CLI, expired login, no VPN, or timeout ⇒ silent
+no-op, exit 0 — the session never breaks) and **warn-only** (no hook denies or
+blocks a tool call; enforcement with teeth is the server-side announce gate's
+job):
+
+| Event | Script | Behaviour |
+|---|---|---|
+| `SessionStart` | `bin/session-start.sh` | Fetches a compact digest — recent tenant activity (the durable form of the broadcast window), scoped memory, and recent knowledge — via the `meho` CLI and prints it to stdout. Claude Code injects a SessionStart hook's stdout as session context, so read-before-start is automatic instead of a discipline the model must remember. |
+| `PreToolUse` on `call_operation` | `bin/pre-call-operation.sh` | If the session hasn't announced intent yet, emits a one-time advisory reminder naming `broadcast_announce`, returned as `hookSpecificOutput.additionalContext` (no `permissionDecision`, so the normal permission flow proceeds). |
+| `PostToolUse` on `broadcast_announce` | `bin/post-announce.sh` | Records that the session announced/reported, so the `PreToolUse` and `Stop` reminders fall silent. |
+| `Stop` | `bin/stop-report.sh` | If the session invoked `call_operation` but never announced/reported, emits a one-line report-on-completion reminder (exit 0 — never exit 2, which would block the stop). |
+
+The digest reads `meho status` (gate), `meho audit recent`, `meho list`
+(memory), and `meho kb list`, each bounded by `timeout`/`gtimeout` when
+present. The live broadcast feed (`meho status --watch`) is an SSE stream and
+unsuitable for a hook that must return promptly, so the digest uses the
+audit log — every MEHO op writes an audit row and emits a broadcast event, so
+`meho audit recent` is the bounded, non-streaming read of the same window.
+These hooks **enforce** the broadcast discipline the server-assembled tenant
+preamble already states; they don't restate it.
+
+### Scoped matcher form (the gotcha)
+
+A tool from a **plugin-bundled** MCP server does not get the bare
+`mcp__<server>__<tool>` name. It is scoped with the plugin name:
+
+```
+mcp__plugin_<plugin-name>_<server-name>__<tool>
+```
+
+Both the plugin and its bundled MCP server are named `meho`, so
+`call_operation` is `mcp__plugin_meho_meho__call_operation` and
+`broadcast_announce` is `mcp__plugin_meho_meho__broadcast_announce`. A bare
+`mcp__meho__call_operation` matcher **never fires** for a plugin-bundled
+server. Add a `.*` suffix (`mcp__plugin_meho_meho__.*`) when a server-wide
+match is wanted; the matchers here target the two exact tool names.
+
+Session state (announced / reminded / used) lives in per-session marker files
+under `${TMPDIR:-/tmp}/meho-plugin-hooks`, keyed by `session_id`, so the
+announce reminder fires at most once per session.
+
 ## Out of scope
 
-- Reflex hooks (SessionStart injection, announce/report reminders) — a
-  follow-up that builds on this skeleton.
 - CIMD / native-HTTP MCP migration of `.mcp.json`.
 
 ## References
 
 - [Claude Code plugins](https://code.claude.com/docs/en/plugins.md)
 - [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces.md)
+- [Claude Code hooks](https://code.claude.com/docs/en/hooks.md) — SessionStart
+  stdout-as-context, `PreToolUse` / `PostToolUse` / `Stop` semantics, the
+  plugin-scoped MCP tool-name form, and `${CLAUDE_PLUGIN_ROOT}`.
 - [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md)
   — the `client_id` gap that motivates the stdio-shim form, and the
   internal-only posture.

--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -108,7 +108,7 @@ job):
 | `SessionStart` | `bin/session-start.sh` | Fetches a compact digest — recent tenant activity (the durable form of the broadcast window), scoped memory, and recent knowledge — via the `meho` CLI and prints it to stdout. Claude Code injects a SessionStart hook's stdout as session context, so read-before-start is automatic instead of a discipline the model must remember. |
 | `PreToolUse` on `call_operation` | `bin/pre-call-operation.sh` | If the session hasn't announced intent yet, emits a one-time advisory reminder naming `broadcast_announce`, returned as `hookSpecificOutput.additionalContext` (no `permissionDecision`, so the normal permission flow proceeds). |
 | `PostToolUse` on `broadcast_announce` | `bin/post-announce.sh` | Records that the session announced/reported, so the `PreToolUse` and `Stop` reminders fall silent. |
-| `Stop` | `bin/stop-report.sh` | If the session invoked `call_operation` but never announced/reported, emits a one-line report-on-completion reminder (exit 0 — never exit 2, which would block the stop). |
+| `Stop` | `bin/stop-report.sh` | If the session invoked `call_operation` but never announced/reported, emits a one-line report-on-completion reminder as `additionalContext`. This *continues* the turn once so Claude can act on it (Stop `additionalContext` does not let the turn end — it runs under the same loop protections as `decision: block`). It is bounded to a single nudge: the hook no-ops when `stop_hook_active` is `true` and writes a once-per-session marker, then lets the session stop. It never exits 2 (which would hard-block the stop). |
 
 The digest reads `meho status` (gate), `meho audit recent`, `meho list`
 (memory), and `meho kb list`, each bounded by `timeout`/`gtimeout` when
@@ -135,9 +135,10 @@ Both the plugin and its bundled MCP server are named `meho`, so
 server. Add a `.*` suffix (`mcp__plugin_meho_meho__.*`) when a server-wide
 match is wanted; the matchers here target the two exact tool names.
 
-Session state (announced / reminded / used) lives in per-session marker files
-under `${TMPDIR:-/tmp}/meho-plugin-hooks`, keyed by `session_id`, so the
-announce reminder fires at most once per session.
+Session state (`used` / `announced` / `reminded` / `stop_reminded`) lives in
+per-session marker files under `${TMPDIR:-/tmp}/meho-plugin-hooks`, keyed by
+`session_id`, so the `PreToolUse` announce reminder (`reminded`) and the `Stop`
+report reminder (`stop_reminded`) each fire at most once per session.
 
 ## Out of scope
 

--- a/clients/claude-code-plugin/bin/post-announce.sh
+++ b/clients/claude-code-plugin/bin/post-announce.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# PostToolUse reflex hook for the plugin's `broadcast_announce` tool.
+# Records that this session has announced (or reported) intent by writing
+# a session-scoped marker. pre-call-operation.sh reads the marker to
+# suppress its announce reminder, and stop-report.sh reads it to suppress
+# its report reminder. `broadcast_announce` serves both the start and
+# completion phases, so a single marker covers "announced/reported".
+#
+# Matcher (hooks.json): `mcp__plugin_meho_meho__broadcast_announce` —
+# the plugin-scoped tool-name form (see pre-call-operation.sh). Pure
+# side effect; the hook emits no decision and cannot block (PostToolUse
+# runs after the tool has already executed).
+
+state_dir="${TMPDIR:-/tmp}/meho-plugin-hooks"
+mkdir -p "$state_dir" 2>/dev/null || true
+
+payload="$(cat 2>/dev/null || true)"
+sid="$(printf '%s' "$payload" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+sid="$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9._-')"
+[ -n "$sid" ] || sid="nosession"
+
+: > "${state_dir}/${sid}.announced" 2>/dev/null || true
+
+exit 0

--- a/clients/claude-code-plugin/bin/pre-call-operation.sh
+++ b/clients/claude-code-plugin/bin/pre-call-operation.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# PreToolUse reflex hook for the plugin's `call_operation` tool. If this
+# session has not announced intent yet, it emits a one-time, advisory
+# reminder naming `broadcast_announce`. It never denies or blocks the
+# call — enforcement with teeth is the server-side announce gate's job;
+# this is a warn-only nudge.
+#
+# Matcher note (hooks.json): a tool from a plugin-bundled MCP server is
+# scoped as `mcp__plugin_<plugin>_<server>__<tool>`. Both the plugin and
+# the MCP server here are named `meho`, so the tool is
+# `mcp__plugin_meho_meho__call_operation`. A bare `mcp__meho__...`
+# matcher never fires for a plugin-bundled server.
+#
+# Reminder channel: PreToolUse plain stdout goes to the debug log, so the
+# nudge is returned as `hookSpecificOutput.additionalContext` in a JSON
+# object on stdout. `permissionDecision` is deliberately omitted so the
+# normal permission flow proceeds (no allow/deny side effect).
+#
+# Session state lives in marker files keyed by session_id under a
+# tmp dir, written by this hook and by post-announce.sh.
+
+# Session-scoped marker directory. tmp is the right home for ephemeral
+# per-session state; keying on session_id keeps parallel sessions apart.
+state_dir="${TMPDIR:-/tmp}/meho-plugin-hooks"
+mkdir -p "$state_dir" 2>/dev/null || true
+
+# Pull session_id out of the hook's JSON stdin without a jq dependency.
+# An unparseable payload falls back to a fixed bucket so dedupe still
+# holds within this process's view.
+payload="$(cat 2>/dev/null || true)"
+sid="$(printf '%s' "$payload" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+sid="$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9._-')"
+[ -n "$sid" ] || sid="nosession"
+
+used_marker="${state_dir}/${sid}.used"
+announced_marker="${state_dir}/${sid}.announced"
+reminded_marker="${state_dir}/${sid}.reminded"
+
+# Record that this session reached for call_operation — the Stop hook
+# reads this to decide whether a report reminder is due.
+: > "$used_marker" 2>/dev/null || true
+
+# One nudge per session: skip if the session already announced, or if the
+# reminder already fired once.
+if [ ! -e "$announced_marker" ] && [ ! -e "$reminded_marker" ]; then
+  : > "$reminded_marker" 2>/dev/null || true
+  msg="MEHO reflex: this session is calling call_operation without having announced intent. Call broadcast_announce (phase=start) so other operators watching the tenant feed see your work, and report with phase=completion when you finish. Advisory only — this appears once per session and does not block the call."
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$msg"
+fi
+
+exit 0

--- a/clients/claude-code-plugin/bin/session-start.sh
+++ b/clients/claude-code-plugin/bin/session-start.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# SessionStart reflex hook. Fetches a compact digest of the tenant's
+# recent activity plus the operator's scoped memory and knowledge, and
+# prints it to stdout. Claude Code injects a SessionStart hook's stdout
+# into the session as context, so read-before-start stops being a
+# discipline the model has to remember — the digest is simply there.
+#
+# Fail-open is the whole contract. A missing `meho` CLI, an expired
+# login, an unreachable backplane (no VPN), or a slow call all resolve
+# to "print nothing, exit 0". The session must never break because this
+# hook ran, and a half-fetched or error digest is worse than none.
+#
+# Not blocking-capable by design: SessionStart cannot block a session,
+# and this hook has no reason to try.
+
+# First line of defence and the fast path for the "no CLI" case: if
+# `meho` is not on PATH we exit immediately using only shell builtins,
+# so the hook stays silent and sub-second even when PATH is empty.
+command -v meho >/dev/null 2>&1 || exit 0
+
+# Bound every backplane call. Prefer coreutils `timeout` (Linux) or
+# `gtimeout` (macOS + coreutils); if neither is present, run unbounded
+# and rely on the per-hook `timeout` in hooks.json as the backstop.
+timeout_bin=""
+if command -v timeout >/dev/null 2>&1; then
+  timeout_bin="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  timeout_bin="gtimeout"
+fi
+
+meho_read() {
+  # meho_read SECONDS ARG...  — run `meho ARG...` under the timeout
+  # wrapper, discarding stderr. Any failure surfaces as empty stdout.
+  secs="$1"
+  shift
+  if [ -n "$timeout_bin" ]; then
+    "$timeout_bin" "$secs" meho "$@" 2>/dev/null
+  else
+    meho "$@" 2>/dev/null
+  fi
+}
+
+# Connectivity + auth gate. `meho status` renders identity + backplane
+# health on success (non-empty stdout) and errors to stderr on failure.
+# Bounded at 2s so the no-VPN / expired-login paths exit well under the
+# 2s fail-open budget; a healthy /api/v1/health answers far faster.
+status_out="$(meho_read 2 status)"
+[ -n "$status_out" ] || exit 0
+
+# Recent tenant activity is the durable form of the broadcast window:
+# every MEHO op writes an audit row and emits a broadcast event, so
+# `meho audit recent` is the bounded, non-streaming read of "what the
+# tenant has been doing". (`meho status --watch` is the live SSE feed —
+# unusable from a hook that must return promptly.)
+activity="$(meho_read 3 audit recent --limit 10 | head -n 12)"
+
+# Scoped memory recall — the operator's own notes/preferences in scope.
+memory="$(meho_read 3 list --limit 8 | head -n 10)"
+
+# Knowledge recall — the tenant's most recent knowledge-base entries.
+knowledge="$(meho_read 3 kb list --limit 8 | head -n 10)"
+
+body=""
+if [ -n "$activity" ]; then
+  body="${body}
+## Recent tenant activity (broadcast window)
+${activity}
+"
+fi
+if [ -n "$memory" ]; then
+  body="${body}
+## Your MEHO memory (scoped)
+${memory}
+"
+fi
+if [ -n "$knowledge" ]; then
+  body="${body}
+## Recent MEHO knowledge
+${knowledge}
+"
+fi
+
+# Only emit the digest when at least one section carries content — an
+# empty header is noise.
+if [ -n "$body" ]; then
+  printf '%s\n' "== MEHO reflex digest (auto-injected at session start; source: meho CLI) =="
+  printf '%s\n' "$body"
+fi
+
+exit 0

--- a/clients/claude-code-plugin/bin/stop-report.sh
+++ b/clients/claude-code-plugin/bin/stop-report.sh
@@ -4,10 +4,21 @@
 #
 # Stop reflex hook. If this session invoked call_operation but never
 # announced or reported via broadcast_announce, it emits a one-line
-# report-on-completion reminder. Advisory only: it returns the nudge as
-# `hookSpecificOutput.additionalContext` and exits 0, so the session
-# stops normally. (Exit 2 would prevent stopping — a blocking decision
-# this hook must never make.)
+# report-on-completion reminder as `hookSpecificOutput.additionalContext`.
+#
+# Semantics (do not misread): additionalContext on a Stop hook does NOT
+# let the turn end. Per the Claude Code hooks docs it continues the
+# conversation so Claude can act on the feedback, under the same loop
+# protections as `decision: block` — the `stop_hook_active` input and the
+# harness's 8-consecutive-continuation cap. That one extra turn is the
+# intended mechanism (it is how the report-on-completion nudge gets a
+# chance to fire), but it must fire at most once. Two guards bound it:
+#   1. `stop_hook_active` == true → the harness is already continuing
+#      because of a stop hook; no-op so continuations never stack.
+#   2. a per-session `.stop_reminded` marker → emit at most once per
+#      session, even across independent Stop events after a clean stop.
+# The hook never exits 2 (that would hard-block the stop); the single
+# bounded continuation above is the only nudge it makes.
 #
 # State is the same session-scoped marker set the call_operation and
 # broadcast_announce hooks maintain: remind only when `.used` exists and
@@ -21,10 +32,19 @@ sid="$(printf '%s' "$payload" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]
 sid="$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9._-')"
 [ -n "$sid" ] || sid="nosession"
 
+# If the harness is already continuing because of a stop hook, adding
+# another continuation would re-nag toward the 8-continuation cap. Bail
+# before emitting anything. (Match the boolean literal directly; avoid
+# sed alternation for BSD/GNU portability.)
+stop_active="$(printf '%s' "$payload" | sed -n 's/.*"stop_hook_active"[[:space:]]*:[[:space:]]*true.*/true/p' | head -n 1)"
+[ "$stop_active" = "true" ] && exit 0
+
 used_marker="${state_dir}/${sid}.used"
 announced_marker="${state_dir}/${sid}.announced"
+reminded_marker="${state_dir}/${sid}.stop_reminded"
 
-if [ -e "$used_marker" ] && [ ! -e "$announced_marker" ]; then
+if [ -e "$used_marker" ] && [ ! -e "$announced_marker" ] && [ ! -e "$reminded_marker" ]; then
+  : > "$reminded_marker" 2>/dev/null || true
   msg="MEHO reflex: this session invoked call_operation but never announced or reported via broadcast_announce. Before ending, consider a broadcast_announce with phase=completion and a short result summary so the tenant feed reflects what changed. Advisory only."
   printf '{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"%s"}}\n' "$msg"
 fi

--- a/clients/claude-code-plugin/bin/stop-report.sh
+++ b/clients/claude-code-plugin/bin/stop-report.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Stop reflex hook. If this session invoked call_operation but never
+# announced or reported via broadcast_announce, it emits a one-line
+# report-on-completion reminder. Advisory only: it returns the nudge as
+# `hookSpecificOutput.additionalContext` and exits 0, so the session
+# stops normally. (Exit 2 would prevent stopping — a blocking decision
+# this hook must never make.)
+#
+# State is the same session-scoped marker set the call_operation and
+# broadcast_announce hooks maintain: remind only when `.used` exists and
+# `.announced` does not.
+
+state_dir="${TMPDIR:-/tmp}/meho-plugin-hooks"
+mkdir -p "$state_dir" 2>/dev/null || true
+
+payload="$(cat 2>/dev/null || true)"
+sid="$(printf '%s' "$payload" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+sid="$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9._-')"
+[ -n "$sid" ] || sid="nosession"
+
+used_marker="${state_dir}/${sid}.used"
+announced_marker="${state_dir}/${sid}.announced"
+
+if [ -e "$used_marker" ] && [ ! -e "$announced_marker" ]; then
+  msg="MEHO reflex: this session invoked call_operation but never announced or reported via broadcast_announce. Before ending, consider a broadcast_announce with phase=completion and a short result summary so the tenant feed reflects what changed. Advisory only."
+  printf '{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"%s"}}\n' "$msg"
+fi
+
+exit 0

--- a/clients/claude-code-plugin/hooks/hooks.json
+++ b/clients/claude-code-plugin/hooks/hooks.json
@@ -1,0 +1,55 @@
+{
+  "description": "MEHO reflex hooks — SessionStart injects a broadcast/memory/knowledge digest so read-before-start is automatic, and advisory reminders nudge announce-before-mutate / report-on-completion. Every hook is fail-open (missing meho CLI, no auth, no VPN, or timeout => silent no-op, exit 0) and warn-only: no hook blocks or denies a tool call. Enforcement with teeth is the server-side gate's job.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/session-start.sh",
+            "args": [],
+            "timeout": 12
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__plugin_meho_meho__call_operation",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/pre-call-operation.sh",
+            "args": [],
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__plugin_meho_meho__broadcast_announce",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/post-announce.sh",
+            "args": [],
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/stop-report.sh",
+            "args": [],
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds three **fail-open, warn-only** Claude Code reflex hooks to the `meho` plugin (`clients/claude-code-plugin/hooks/hooks.json` + scripts under `bin/`), turning the advisory Layer-2 discipline into deterministic, harness-run behavior.
- **SessionStart** injects a compact digest (recent tenant activity as the durable broadcast window, scoped memory, recent knowledge) via the `meho` CLI's stdout — read-before-start stops being a discipline the model must remember.
- **PreToolUse** on `call_operation` emits a one-time announce reminder naming `broadcast_announce`; **PostToolUse** on `broadcast_announce` records the announce; **Stop** reminds to report when `call_operation` ran but nothing was announced/reported.
- No hook ever denies or blocks — enforcement with teeth is the server-side announce gate's job (sibling #3133). Every failure path (missing CLI / expired login / no VPN / timeout) exits 0 silently.

## Design notes

- **Broadcast window source.** The live feed (`meho status --watch`) is an SSE stream, unusable from a hook that must return promptly. Every MEHO op writes an audit row and emits a broadcast event, so `meho audit recent` is the bounded, non-streaming read of the same window.
- **Scoped-matcher gotcha.** A plugin-bundled MCP server's tools are named `mcp__plugin_<plugin>_<server>__<tool>`. Both the plugin and its server are `meho`, so the matchers target `mcp__plugin_meho_meho__call_operation` / `mcp__plugin_meho_meho__broadcast_announce`; a bare `mcp__meho__...` never fires. The formula is documented in the plugin README.
- **Dedupe.** Session state (`used` / `announced` / `reminded` / `stop_reminded`) lives in per-`session_id` marker files under `${TMPDIR:-/tmp}/meho-plugin-hooks`, so the PreToolUse announce reminder and the Stop report reminder each fire at most once per session.
- **Non-blocking channels.** PreToolUse/Stop return the nudge as `hookSpecificOutput.additionalContext` (no `permissionDecision`), and neither ever exits 2. Note the real Stop semantics: `additionalContext` on a Stop hook does **not** end the turn — per the hooks docs it *continues* the conversation once (so report-on-completion gets a chance to fire), under the same loop protections as `decision: block` (the `stop_hook_active` input + the 8-consecutive-continuation cap). The Stop hook bounds that to a single nudge: it no-ops when `stop_hook_active` is `true` and writes a once-per-session `.stop_reminded` marker, then lets the session stop. SessionStart uses plain stdout, which Claude Code injects as context.
- Reminders **enforce** the broadcast discipline the server-assembled tenant preamble already states; they don't restate it.

## Test plan

- [x] `jq . clients/claude-code-plugin/hooks/hooks.json` — valid; all 4 hook entries carry an explicit `timeout` (12/5/5/5).
- [x] `PATH=/nonexistent clients/claude-code-plugin/bin/session-start.sh; echo $?` — exit `0`, silent, sub-second (CLI-absent fast path via a `command -v meho` builtin guard).
- [x] SessionStart happy path (stub `meho` on PATH) prints the three-section digest to stdout; when `meho status` errors (no auth/VPN) it prints nothing and exits 0.
- [x] PreToolUse on `call_operation` (not yet announced) emits valid-JSON `additionalContext` naming `broadcast_announce`; a second call is silent (marker-file dedupe → at most once per session).
- [x] Announce-first (PostToolUse `broadcast_announce`) suppresses the PreToolUse reminder.
- [x] Stop emits a report reminder only when `call_operation` was used but nothing was announced/reported; silent otherwise.
- [x] Stop is bounded to a single nudge (B1): `stop_hook_active=true` → silent exit 0 (no marker consumed); a second Stop in the same session after the first reminder → silent (`.stop_reminded` marker); the first used-but-not-announced Stop → exactly one valid-JSON reminder.
- [x] Empty / garbage stdin and an unwritable tmp dir all exit 0 (fail-open).
- [x] `shellcheck -s sh bin/*.sh` — clean. Scripts committed `100755`.
- [x] No blocking decision anywhere: grep of `hooks.json` + scripts shows no `deny` / `permissionDecision:deny` / `exit 2` / `escalate` — warn/context output only.

## Out of scope

- Server-side nudges / gating (sibling #3133, merged).
- Claude Desktop (no hook mechanism; covered by descriptions + server advisory).
- Auto-installing or configuring the `meho` CLI.

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-26)

Addressed review finding from `pr-3142-iter-1`:

- **B1** `67f4b196` — `bin/stop-report.sh` emitted `additionalContext` on Stop unconditionally, which per the hooks docs *continues* the turn (not a passive no-op), re-nagging the used-but-not-announced path toward the 8-continuation cap. Now reads `stop_hook_active` and no-ops when true, writes a once-per-session `.stop_reminded` marker so the reminder fires at most once, and the header comment + README Stop row / marker note now state the real continuation semantics. Re-ran `shellcheck -s sh bin/*.sh` (clean) plus extended behavioral checks (`stop_hook_active=true` → silent; second Stop in-session → silent; first used-but-not-announced Stop → single reminder).

<!-- auto-implement-issue: continue, iteration 1 -->

Closes #3131

