### PR TITLE
fix(clients): vendor mcp-remote in the .mcpb bundle, spawn via the bundle runtime (#3144)

### DIFF
--- a/.github/workflows/mcpb-bundle.yml
+++ b/.github/workflows/mcpb-bundle.yml
@@ -61,6 +61,14 @@ jobs:
             exit 1
           fi
 
+      - name: Behavioral test — launcher spawn contract
+        # Runs the launcher under a minimal PATH (imposed inside the suite)
+        # to prove the vendored-runtime spawn never reaches for npx —
+        # `spawn npx ENOENT` under Claude Desktop's GUI PATH is the field-
+        # test failure this bundle fixes (#3143/#3144). No network / npm
+        # install: the suite stubs mcp-remote.
+        run: node --test clients/claude-desktop-mcpb/test/index.test.mjs
+
       - name: Pack bundle (dry-run)
         # The PR number gives a valid pre-release semver so each dry-run
         # bundle is identifiable; the real version is the git tag on the

--- a/clients/claude-desktop-mcpb/.gitignore
+++ b/clients/claude-desktop-mcpb/.gitignore
@@ -1,3 +1,8 @@
 # Built bundles (produced by build.sh / CI, attached to GitHub Releases).
 /dist/
 *.mcpb
+
+# Vendored dependency tree. Populated by `npm ci` — into the pack staging
+# dir by build.sh, or here by a developer testing locally. Only the pinned
+# package.json + package-lock.json are committed; node_modules is rebuilt.
+/node_modules/

--- a/clients/claude-desktop-mcpb/README.md
+++ b/clients/claude-desktop-mcpb/README.md
@@ -31,8 +31,10 @@ because the shim runs on a machine already on the VPN.
 | Path | Role |
 |---|---|
 | `manifest.json` | MCPB manifest (`manifest_version` 0.3). Committed with a `0.0.0` placeholder version; `build.sh` injects the real version at pack time. |
-| `server/index.mjs` | The bundle's entry point. A thin stdio launcher for `npx -y mcp-remote@0.1.38 <url> …` that guards the internal-CA path and presents the pre-registered `meho-mcp` OAuth client. |
-| `build.sh` | Validates + packs the bundle via the pinned `@anthropic-ai/mcpb` CLI. |
+| `server/index.mjs` | The bundle's entry point. A thin stdio launcher that spawns the vendored `mcp-remote` through the bundle's own runtime, guards the internal-CA path, and presents the pre-registered `meho-mcp` OAuth client. |
+| `package.json` + `package-lock.json` | Pin `mcp-remote@0.1.38` and its full, integrity-checked dependency tree. `build.sh` runs `npm ci --omit=dev` from the lock to vendor `node_modules` into the bundle. Never committed: `node_modules/`. |
+| `test/index.test.mjs` | Behavioral suite (`node --test`) for the launcher's spawn contract and guards. Runs on every PR (`mcpb-bundle.yml`); not shipped in the bundle. |
+| `build.sh` | Vendors dependencies, then validates + packs the bundle via the pinned `@anthropic-ai/mcpb` CLI. |
 
 ## Building locally
 
@@ -41,9 +43,11 @@ because the shim runs on a machine already on the VPN.
 ./build.sh 0.31.0 /tmp/out   # or choose the output directory
 ```
 
-Requires Node.js (for `npx`) and `jq`. The pinned `@anthropic-ai/mcpb`
-CLI validates `manifest.json` against the MANIFEST 0.3 schema before
-zipping, so a malformed manifest fails the build.
+Requires Node.js / `npm` (`build.sh` runs `npm ci --omit=dev` to vendor
+`mcp-remote`, and `npx` for the pinned `@anthropic-ai/mcpb` CLI) and `jq`.
+The `@anthropic-ai/mcpb` CLI validates `manifest.json` against the
+MANIFEST 0.3 schema before zipping, so a malformed manifest fails the
+build.
 
 In CI the same script runs two ways (see
 [`.github/workflows/mcpb-bundle.yml`](../../.github/workflows/mcpb-bundle.yml)
@@ -71,8 +75,8 @@ client id delivered as `MEHO_MCP_CLIENT_ID`. The launcher:
    `meho-mcp` when the host substitutes an empty value for the untouched
    optional `client_id` config — so an operator who never opens the
    advanced field still authenticates.
-4. Spawns the smoke-tested `npx -y mcp-remote@0.1.38 <url>` with inherited
-   stdio, passing `--static-oauth-client-info '{"client_id": "…"}'` and
+4. Spawns the vendored `mcp-remote@0.1.38` with inherited stdio, passing
+   `--static-oauth-client-info '{"client_id": "…"}'` and
    `--static-oauth-client-metadata '{"scope": "mcp:read mcp:execute"}'`.
    The static client info is load-bearing: MEHO's Keycloak realm blocks
    anonymous RFC 7591 Dynamic Client Registration (default Trusted Hosts
@@ -81,17 +85,28 @@ client id delivered as `MEHO_MCP_CLIENT_ID`. The launcher:
    `meho-mcp` client skips DCR entirely. `mcp-remote` then runs its OAuth
    2.1 + PKCE flow and forwards Streamable-HTTP calls to `/mcp`.
 
+The spawn is a direct `process.execPath` + args-array call — the same
+runtime already executing `index.mjs`, with `ELECTRON_RUN_AS_NODE=1` in
+the child env so it runs as plain Node whether `execPath` is a standalone
+`node` or Claude Desktop's Electron helper. There is **no `npx`, no PATH
+lookup, and no per-platform shell**: `mcp-remote` is vendored in the
+bundle's `node_modules` (MCPB Node servers ship their dependencies), and
+the launcher resolves its entry from there. This is what fixes the
+field-test failure where Claude Desktop's UtilityProcess GUI PATH (no
+Homebrew / nvm entries) made the old `npx` spawn die with
+`spawn npx ENOENT` before OAuth (#3143).
+
 The `meho-mcp` client (or whatever name `client_id` overrides it to) must
 already exist on the realm — see
 [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md).
-The operator's machine needs system Node.js / `npx` on `PATH` (the same
-prerequisite the raw shim recipe has).
+No system Node or `npx` on `PATH` is required at run time — the bundle
+carries its dependencies and Claude Desktop supplies the runtime.
 
 ## Verifying a built bundle
 
 ```bash
 ./build.sh 0.0.0-dev /tmp/out
-unzip -l /tmp/out/meho-claude-desktop-0.0.0-dev.mcpb   # manifest.json + server/index.mjs
+unzip -l /tmp/out/meho-claude-desktop-0.0.0-dev.mcpb | grep -i mcp-remote  # vendored
 ```
 
 Then open the `.mcpb` in Claude Desktop on a VPN-connected machine, enter

--- a/clients/claude-desktop-mcpb/build.sh
+++ b/clients/claude-desktop-mcpb/build.sh
@@ -33,16 +33,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUT_DIR="${2:-${SCRIPT_DIR}/dist}"
 mkdir -p "${OUT_DIR}"
 
-# Stage only the runtime files (manifest + server/) so build.sh, the
-# README, and the .gitignore never end up inside the shipped bundle.
-# The manifest is committed with a placeholder version (0.0.0); the real
-# version is injected into the staged copy so the source tree stays clean.
+# Stage only the runtime files (manifest + server/ + the pinned
+# dependency manifests) so build.sh, the README, the test suite, and the
+# .gitignore never end up inside the shipped bundle. The manifest is
+# committed with a placeholder version (0.0.0); the real version is
+# injected into the staged copy so the source tree stays clean.
 STAGE="$(mktemp -d)"
 trap 'rm -rf "${STAGE}"' EXIT
 
 jq --arg v "${VERSION}" '.version = $v' "${SCRIPT_DIR}/manifest.json" \
   > "${STAGE}/manifest.json"
 cp -R "${SCRIPT_DIR}/server" "${STAGE}/server"
+
+# Vendor mcp-remote into the bundle. MCPB Node servers must ship their
+# dependencies in node_modules (MANIFEST spec) — there is no `npx` fetch
+# at runtime. `npm ci` installs the exact, integrity-checked tree pinned
+# in package-lock.json; `--omit=dev` prunes it to the production deps the
+# launcher actually spawns. The launcher resolves the entry from this
+# node_modules at run time via process.execPath.
+cp "${SCRIPT_DIR}/package.json" "${SCRIPT_DIR}/package-lock.json" "${STAGE}/"
+( cd "${STAGE}" && npm ci --omit=dev --no-audit --no-fund )
 
 OUT_FILE="${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb"
 npx --yes "@anthropic-ai/mcpb@${MCPB_VERSION}" pack "${STAGE}" "${OUT_FILE}"

--- a/clients/claude-desktop-mcpb/package-lock.json
+++ b/clients/claude-desktop-mcpb/package-lock.json
@@ -1,0 +1,1008 @@
+{
+  "name": "meho-claude-desktop-mcpb",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meho-claude-desktop-mcpb",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mcp-remote": "0.1.38"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-remote": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/mcp-remote/-/mcp-remote-0.1.38.tgz",
+      "integrity": "sha512-w+JU4U3CfG29TawXR4JLNQ9d1Un5nT8AGI65f/juCaqUdF/V6fS7wE4o7xNPbB8X58o46hRXEJgYglQMAKQs4w==",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.21.2",
+        "open": "^10.1.0",
+        "strict-url-sanitise": "^0.0.1",
+        "undici": "^7.12.0"
+      },
+      "bin": {
+        "mcp-remote": "dist/proxy.js",
+        "mcp-remote-client": "dist/client.js"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-url-sanitise": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/strict-url-sanitise/-/strict-url-sanitise-0.0.1.tgz",
+      "integrity": "sha512-nuFtF539K8jZg3FjaWH/L8eocCR6gegz5RDOsaWxfdbF5Jqr2VXWxZayjTwUzsWJDC91k2EbnJXp6FuWW+Z4hg==",
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/clients/claude-desktop-mcpb/package.json
+++ b/clients/claude-desktop-mcpb/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "meho-claude-desktop-mcpb",
+  "version": "0.0.0",
+  "description": "Vendored runtime dependencies for the MEHO for Claude Desktop .mcpb bundle. Not published; build.sh runs `npm ci --omit=dev` to pack node_modules into the bundle.",
+  "private": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "mcp-remote": "0.1.38"
+  }
+}

--- a/clients/claude-desktop-mcpb/server/index.mjs
+++ b/clients/claude-desktop-mcpb/server/index.mjs
@@ -3,10 +3,19 @@
 //
 // Claude Desktop runs this file with its bundled Node runtime (the
 // manifest's server.mcp_config.command is "node"). It is a thin stdio
-// pass-through to the proven onramp `npx -y mcp-remote@0.1.38 <url> …`
+// pass-through to the proven onramp `mcp-remote@0.1.38 <url> …`
 // (recipe: docs/cross-repo/mcp-client-setup.md, proven by #2666).
 //
-// It adds two things over invoking npx directly:
+// mcp-remote is vendored into the bundle's node_modules at pack time
+// (build.sh runs `npm ci --omit=dev`) and launched through the same
+// runtime already executing this file — `process.execPath` — so there is
+// no `npx`, no PATH lookup, and no per-platform shell. Under Claude
+// Desktop the entry point runs inside a UtilityProcess whose PATH is the
+// GUI PATH (no /opt/homebrew/bin, no nvm shims), so the old `npx` spawn
+// died with `spawn npx ENOENT` before OAuth (field-test #3143); a direct
+// `process.execPath` spawn cannot hit that failure.
+//
+// It adds two things over invoking mcp-remote directly:
 //
 //  1. A guard on the internal-CA path: the optional `ca_cert` user_config
 //     is delivered as MEHO_CA_CERT, and NODE_EXTRA_CA_CERTS is exported to
@@ -24,6 +33,9 @@
 //     MEHO_MCP_CLIENT_ID) without editing the installed bundle.
 
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 
 const rawUrl = process.argv[2];
 
@@ -61,28 +73,42 @@ delete env.MEHO_CA_CERT;
 const clientId = (process.env.MEHO_MCP_CLIENT_ID ?? "").trim() || "meho-mcp";
 delete env.MEHO_MCP_CLIENT_ID;
 
-// On Windows `npx` resolves to `npx.cmd`, which Node refuses to spawn
-// without a shell (CVE-2024-27980 mitigation). The URL is validated above,
-// and the OAuth flags are JSON produced by JSON.stringify from a trimmed
-// client id — no interpolated argument can inject a shell token.
-//
-// Pin the smoke-tested `mcp-remote@0.1.38` and present the static
-// `meho-mcp` client via --static-oauth-client-info so the shim skips the
-// DCR the realm blocks; the scope metadata matches what the backplane's
-// token audience mappers expect.
-const isWindows = process.platform === "win32";
+// Run the child as a plain Node process even when process.execPath is
+// Claude Desktop's Electron helper rather than a standalone `node`:
+// ELECTRON_RUN_AS_NODE=1 "starts the process as a normal Node.js process"
+// (Electron docs). Harmless no-op when execPath is already `node`.
+env.ELECTRON_RUN_AS_NODE = "1";
+
+// Resolve the vendored mcp-remote CLI entry from the bundle's node_modules
+// (populated by `npm ci --omit=dev` at pack time). Read the package's own
+// `bin` mapping rather than hardcoding a path, so a future pinned version
+// that relocates its entry script keeps working.
+const require = createRequire(import.meta.url);
+const mcpRemotePkgPath = require.resolve("mcp-remote/package.json");
+const mcpRemotePkg = JSON.parse(readFileSync(mcpRemotePkgPath, "utf8"));
+const mcpRemoteBin =
+  typeof mcpRemotePkg.bin === "string"
+    ? mcpRemotePkg.bin
+    : mcpRemotePkg.bin["mcp-remote"];
+const mcpRemoteEntry = join(dirname(mcpRemotePkgPath), mcpRemoteBin);
+
+// Spawn the pinned mcp-remote through this process's own runtime — a
+// direct binary + args-array spawn on every platform (no external
+// launcher, no PATH resolution, no shell). Present the static `meho-mcp`
+// client via --static-oauth-client-info so the shim skips the DCR the
+// realm blocks; the scope metadata matches what the backplane's token
+// audience mappers expect.
 const child = spawn(
-  isWindows ? "npx.cmd" : "npx",
+  process.execPath,
   [
-    "-y",
-    "mcp-remote@0.1.38",
+    mcpRemoteEntry,
     url.href,
     "--static-oauth-client-info",
     JSON.stringify({ client_id: clientId }),
     "--static-oauth-client-metadata",
     JSON.stringify({ scope: "mcp:read mcp:execute" }),
   ],
-  { stdio: "inherit", env, shell: isWindows },
+  { stdio: "inherit", env },
 );
 
 child.on("error", (err) => {

--- a/clients/claude-desktop-mcpb/test/index.test.mjs
+++ b/clients/claude-desktop-mcpb/test/index.test.mjs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Behavioral suite for server/index.mjs — the .mcpb launcher.
+//
+// The launcher spawns the vendored mcp-remote through this process's own
+// runtime (process.execPath), so these tests run index.mjs under a
+// deliberately minimal PATH (/usr/bin:/bin — no /opt/homebrew/bin, no nvm
+// shims) to reproduce Claude Desktop's UtilityProcess GUI PATH. If the
+// launcher still reached for `npx`, the spawn would die with
+// `spawn npx ENOENT` (field-test #3143) and the stub below would never run.
+//
+// mcp-remote is stubbed: a fake node_modules/mcp-remote whose bin prints a
+// JSON diagnostic of the argv + env it was invoked with, then exits 0. That
+// lets the suite assert the exact child contract without a live backplane.
+
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, test } from "node:test";
+import assert from "node:assert/strict";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REAL_INDEX = join(HERE, "..", "server", "index.mjs");
+
+// A minimal PATH with no Homebrew/nvm entries — the GUI PATH shape.
+const MINIMAL_PATH = "/usr/bin:/bin";
+
+// Build one isolated bundle copy: a standalone index.mjs plus a stub
+// mcp-remote whose bin echoes how it was launched.
+const BUNDLE = mkdtempSync(join(tmpdir(), "meho-mcpb-test-"));
+mkdirSync(join(BUNDLE, "server"), { recursive: true });
+cpSync(REAL_INDEX, join(BUNDLE, "server", "index.mjs"));
+
+const STUB_DIR = join(BUNDLE, "node_modules", "mcp-remote");
+mkdirSync(join(STUB_DIR, "dist"), { recursive: true });
+writeFileSync(
+  join(STUB_DIR, "package.json"),
+  JSON.stringify({
+    name: "mcp-remote",
+    version: "0.1.38",
+    type: "module",
+    bin: { "mcp-remote": "dist/proxy.js", "mcp-remote-client": "dist/client.js" },
+  }),
+);
+writeFileSync(
+  join(STUB_DIR, "dist", "proxy.js"),
+  [
+    "process.stdout.write(",
+    "  JSON.stringify({",
+    "    argv: process.argv,",
+    "    execPath: process.execPath,",
+    "    runAsNode: process.env.ELECTRON_RUN_AS_NODE ?? null,",
+    "    nodeExtraCaCerts: process.env.NODE_EXTRA_CA_CERTS ?? null,",
+    "    mehoCaCert: process.env.MEHO_CA_CERT ?? null,",
+    "    mehoClientId: process.env.MEHO_MCP_CLIENT_ID ?? null,",
+    "  }) + '\\n',",
+    ");",
+    "",
+  ].join("\n"),
+);
+
+const INDEX = join(BUNDLE, "server", "index.mjs");
+// require.resolve inside the launcher returns the realpath, so compare
+// against the realpath here (macOS maps /var → /private/var via a symlink).
+const STUB_ENTRY = realpathSync(join(STUB_DIR, "dist", "proxy.js"));
+
+after(() => rmSync(BUNDLE, { recursive: true, force: true }));
+
+// Run the launcher with a controlled env; PATH defaults to the minimal set.
+function runLauncher(args, extraEnv = {}) {
+  return spawnSync(process.execPath, [INDEX, ...args], {
+    encoding: "utf8",
+    env: { PATH: MINIMAL_PATH, ...extraEnv },
+  });
+}
+
+test("minimal PATH: no ENOENT, child argv is [execPath, bundled mcp-remote, url, --static-oauth…]", () => {
+  const url = "https://meho.internal.example/mcp";
+  const res = runLauncher([url]);
+
+  assert.equal(res.status, 0, `launcher exited non-zero: ${res.stderr}`);
+  const diag = JSON.parse(res.stdout);
+
+  // The child ran through process.execPath (argv[0] is that same runtime),
+  // proving a direct binary spawn rather than a PATH-resolved npx.
+  assert.equal(diag.argv[0], diag.execPath);
+  assert.equal(diag.argv[1], STUB_ENTRY);
+  assert.equal(diag.argv[2], url);
+  assert.equal(diag.argv[3], "--static-oauth-client-info");
+  assert.deepEqual(JSON.parse(diag.argv[4]), { client_id: "meho-mcp" });
+  assert.equal(diag.argv[5], "--static-oauth-client-metadata");
+  assert.deepEqual(JSON.parse(diag.argv[6]), { scope: "mcp:read mcp:execute" });
+  assert.equal(diag.argv.length, 7);
+});
+
+test("ELECTRON_RUN_AS_NODE=1 is set in the child env", () => {
+  const res = runLauncher(["https://meho.internal.example/mcp"]);
+  assert.equal(res.status, 0, res.stderr);
+  assert.equal(JSON.parse(res.stdout).runAsNode, "1");
+});
+
+test("guard: NODE_EXTRA_CA_CERTS exported only on a non-empty CA path, MEHO_CA_CERT scrubbed", () => {
+  const withCa = runLauncher(["https://meho.internal.example/mcp"], {
+    MEHO_CA_CERT: "/etc/ssl/internal-ca.pem",
+  });
+  assert.equal(withCa.status, 0, withCa.stderr);
+  const a = JSON.parse(withCa.stdout);
+  assert.equal(a.nodeExtraCaCerts, "/etc/ssl/internal-ca.pem");
+  assert.equal(a.mehoCaCert, null); // scrubbed from the child env
+
+  for (const caValue of ["", "   "]) {
+    const res = runLauncher(["https://meho.internal.example/mcp"], {
+      MEHO_CA_CERT: caValue,
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(JSON.parse(res.stdout).nodeExtraCaCerts, null);
+  }
+
+  // Unset entirely — NODE_EXTRA_CA_CERTS must not leak in.
+  const unset = runLauncher(["https://meho.internal.example/mcp"]);
+  assert.equal(JSON.parse(unset.stdout).nodeExtraCaCerts, null);
+});
+
+test("guard: client_id override applied and MEHO_MCP_CLIENT_ID scrubbed", () => {
+  const res = runLauncher(["https://meho.internal.example/mcp"], {
+    MEHO_MCP_CLIENT_ID: "meho-mcp-lab",
+  });
+  assert.equal(res.status, 0, res.stderr);
+  const diag = JSON.parse(res.stdout);
+  assert.deepEqual(JSON.parse(diag.argv[4]), { client_id: "meho-mcp-lab" });
+  assert.equal(diag.mehoClientId, null); // scrubbed from the child env
+});
+
+test("guard: an empty client_id falls back to meho-mcp", () => {
+  const res = runLauncher(["https://meho.internal.example/mcp"], {
+    MEHO_MCP_CLIENT_ID: "   ",
+  });
+  assert.equal(res.status, 0, res.stderr);
+  const diag = JSON.parse(res.stdout);
+  assert.deepEqual(JSON.parse(diag.argv[4]), { client_id: "meho-mcp" });
+});
+
+test("guard: a non-https endpoint is rejected before spawning", () => {
+  const res = runLauncher(["http://meho.internal.example/mcp"]);
+  assert.equal(res.status, 1);
+  assert.equal(res.stdout, ""); // never reached the child
+  assert.match(res.stderr, /https/);
+});
+
+test("guard: a malformed URL is rejected before spawning", () => {
+  const res = runLauncher(["not a url"]);
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /valid URL/);
+});
+
+test("guard: a missing URL argument is rejected", () => {
+  const res = runLauncher([]);
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /valid URL/);
+});


### PR DESCRIPTION
## Summary

- The `.mcpb` launcher spawned bare `npx` from PATH. Under Claude Desktop's UtilityProcess (GUI PATH — no `/opt/homebrew/bin`, no nvm shims) that died with `spawn npx ENOENT` **before OAuth**, parking Part B of the field test (#3143) for every Homebrew/nvm macOS machine.
- Fix: **vendor `mcp-remote@0.1.38` inside the bundle** at pack time (`npm ci --omit=dev` from a committed, integrity-pinned `package-lock.json`) and spawn it through the bundle's **own runtime** — `process.execPath` + the resolved entry script, with `ELECTRON_RUN_AS_NODE=1` in the child env so it runs as plain Node whether `execPath` is a standalone `node` or Desktop's Electron helper.
- This removes **npx, the PATH lookup, and the Windows `shell:true` branch** entirely — a direct binary + args-array spawn on every platform. Kills the ENOENT, the first-launch network fetch, and the win32 JSON-argv quoting risk (PR #3138 iter-2 note) in one move.
- All existing guards and the static-OAuth invocation contract are preserved **byte-for-byte**; a `node:test` behavioral suite proves them and is wired into the mcpb-bundle PR lane.

**Bundle size:** `1.4 MB` compressed `.mcpb` (4.5 MB / 726 files uncompressed) with production-pruned `node_modules` (`--omit=dev`); `mcpb pack`'s default `.mcpbignore` additionally drops 168 dev-only files (`.d.ts`, source maps).

## Test plan

- [x] `node --test clients/claude-desktop-mcpb/test/index.test.mjs` — 8/8 pass (run with outer `PATH=/usr/bin:/bin` and absolute node; the suite also imposes the minimal PATH on the launcher subprocess internally)
- [x] **AC — no ENOENT under minimal PATH:** launcher runs to completion; child argv is `[process.execPath, <bundled mcp-remote entry>, <url>, --static-oauth-client-info, {…}, --static-oauth-client-metadata, {…}]`; `ELECTRON_RUN_AS_NODE=1` present in the child env
- [x] **AC — npx/shell gone:** `grep -n "npx\|shell:" server/index.mjs` → the only `npx` hits are comments recording the fixed symptom; no spawn-relevant match; `isWindows`/`win32`/`npx.cmd`/`shell:` count = 0
- [x] **AC — guards unchanged and tested:** https-URL validation (non-https + malformed + missing → exit 1); `NODE_EXTRA_CA_CERTS` only on a non-empty CA (empty / whitespace / unset → not exported); `MEHO_CA_CERT` and `MEHO_MCP_CLIENT_ID` scrubbed from the child env; `client_id` override + default fallback
- [x] **AC — vendored dependency packs:** `./build.sh 0.0.0-dev /tmp/out` then `unzip -l /tmp/out/*.mcpb | grep -i mcp-remote` shows `node_modules/mcp-remote/dist/proxy.js` + `package.json`
- [x] **AC — README launcher section updated:** the "system Node / `npx` on PATH" run-time prerequisite is removed; the vendored-runtime spawn is documented
- [x] Dependency licenses of the full vendored tree verified with the CI's pinned `license-checker@25.0.1 --onlyAllow "Apache-2.0;MIT;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;0BSD;Unlicense;MPL-2.0"` → clean (MIT 78 / ISC 3 / BSD-3-Clause 1)
- [x] `mcpb-bundle.yml` dry-run lane green locally (wording guard clean, behavioral test green, pack succeeds); YAML + JSON + `bash -n` valid; code-quality `--diff` gate clean
- [ ] **#3143 testers: re-test Part B** — re-build (`./build.sh <ver>`), re-install the `.mcpb`, retry connect through the Keycloak OAuth flow on a VPN machine; confirm no `spawn npx ENOENT` and a read op round-trips (the #2666 bar). Windows testers especially wanted — the `shell:true`/argv-quoting risk is now removed, so that path should connect too.

## Out of scope

- The Claude Code plugin wrapper (`clients/claude-code-plugin/bin/meho-mcp-remote`) — terminal sessions have a real PATH; unchanged.
- Live Windows verification (rides #3143 / the rdc Windows probe).
- Signing/notarizing the bundle (separate field-test follow-up).

## Notes / adjacent findings

- The repo's required **NPM License Check** runs `license-checker` from the repo root (no root `package.json`/`node_modules`), so it exits 0 without actually scanning this subdir's vendored tree. Licenses were therefore verified manually (above). Wiring the bundle subdir into that check is a possible follow-up, deliberately left out to avoid touching a required workflow.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3144
