### PR TITLE
feat(clients): client scope-elevation seam (MEHO_MCP_SCOPES + .mcpb scopes)

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Claude Code plugin — PR behavioral test.
+#
+# The plugin's stdio shim wrapper (clients/claude-code-plugin/bin/meho-mcp-remote)
+# is a bash launcher that `exec`s `npx -y mcp-remote@… <url> --static-oauth-…`.
+# The one contract worth pinning is the argv it hands to npx — in particular
+# the OAuth scope metadata, which the MEHO_MCP_SCOPES elevation seam makes
+# operator-configurable. This workflow runs the stubbed-argv suite (a stub
+# `npx` on a controlled PATH echoes the argv) whenever a PR touches the
+# plugin sources. No network / npm install: the suite stubs npx.
+#
+# Advisory (non-required) and path-scoped, mirroring mcpb-bundle.yml. A
+# required check would need the `changes`-job + job-`if:` shape ci.yml uses
+# to skip cleanly, which this dry-run does not warrant.
+
+name: plugin-test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'clients/claude-code-plugin/**'
+      - '.github/workflows/plugin-test.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Plugin shim stubbed-argv suite
+    # Fork-PR guard mirrors ci.yml / mcpb-bundle.yml: `meho-runners-ci` is
+    # internal infra, so fork PRs skip rather than execute plugin sources
+    # on the self-hosted pool.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: meho-runners-ci
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: Behavioral test — shim argv contract
+        run: node --test clients/claude-code-plugin/test/meho-mcp-remote.test.mjs

--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -50,6 +50,7 @@ to point it at a tenant:
 | `MEHO_INSTANCE` | Backplane base URL, e.g. `https://meho.internal.example`. The wrapper appends `/mcp`. |
 | `MEHO_CA_CERT` | Path to an internal-CA bundle; exported as `NODE_EXTRA_CA_CERTS` for the Node-based shim. Only needed on internal-CA deploys. |
 | `MEHO_MCP_CLIENT_ID` | Pre-registered public OAuth client id the shim presents to Keycloak (default `meho-mcp`). Override only if the realm registers the client under a different name. |
+| `MEHO_MCP_SCOPES` | Space-separated OAuth scopes the shim requests (default `mcp:read mcp:execute`, the working surface). Set it to opt into [elevated operator mode](#elevated-operator-mode-opt-in). Empty or whitespace-only falls back to the default. |
 | `MEHO_PLUGIN_CONFIG` | Override the config-file location (default `${XDG_CONFIG_HOME:-~/.config}/meho/plugin.env`). |
 
 Set the variables in your shell profile, or drop them in the config file:
@@ -62,6 +63,45 @@ MEHO_INSTANCE="https://meho.evba.lab"
 
 With either configured, the `meho` MCP server connects on the next Claude
 Code session — zero edits inside the installed plugin.
+
+### Elevated operator mode (opt-in)
+
+By default a session lists only the **working surface** — do-work and
+coordinate: status, connector/operation discovery, `call_operation` /
+`preview_operation` / `result_query`, knowledge, memory, the broadcast
+trio, target/topology reads, and the runbook run family. Everything an
+agent or a plain operator needs to get work done.
+
+`MEHO_MCP_SCOPES` is the deliberate opt-in to **operator mode**. Add the
+elevated scope to the request:
+
+```bash
+MEHO_MCP_SCOPES="mcp:read mcp:execute mcp:admin"
+```
+
+An elevated session additionally lists the **operator planes**: the
+agents / principals registry and grants, connector lifecycle, broadcast
+overrides, the scheduler, sensors, runbook template authoring, and the
+approvals **read** views (`meho_approvals_list` / `meho_approvals_get`).
+
+Elevation **never** exposes the human-only verbs. `meho_approvals_approve`,
+`meho_approvals_reject`, and `meho_agents_grant_elevate` have no MCP path
+under any scope — approving a parked operation and granting elevation are
+human decisions made through the console or CLI only (#3155). A model
+holding the approve button would collapse the four-eyes gate, so the button
+is not on the wire.
+
+**Realm prerequisite (and the fallback if it is missing).** `mcp:admin`
+must be offered as an **optional** (requestable, non-default) client scope
+on the realm's `meho-mcp` client before elevation takes effect — tracked as
+[`evoila-bosnia/claude-rdc-hetzner-dc#2734`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2734).
+Until it lands, requesting `mcp:admin` **degrades to the default working
+surface**: per OAuth 2.1 (RFC 6749 §3.3) the authorization server may
+ignore a scope it does not grant, and Keycloak drops any requested scope
+that is not an assigned default/optional client scope — so the token comes
+back without `mcp:admin`, no error is raised, and the operator planes simply
+do not appear. Setting `MEHO_MCP_SCOPES` on a realm that does not yet offer
+the scope is therefore safe: the session behaves exactly as the default.
 
 ### Prerequisites
 

--- a/clients/claude-code-plugin/bin/meho-mcp-remote
+++ b/clients/claude-code-plugin/bin/meho-mcp-remote
@@ -54,6 +54,22 @@ fi
 # named public client without editing the installed plugin; the scope
 # metadata matches what the backplane's token audience mappers expect.
 client_id="${MEHO_MCP_CLIENT_ID:-meho-mcp}"
+
+# OAuth scope metadata presented during the handshake. The default is the
+# working surface (mcp:read mcp:execute). MEHO_MCP_SCOPES lets an operator
+# DELIBERATELY request an elevated surface — append mcp:admin to reach the
+# operator planes — never by default. Requesting a scope the realm does not
+# offer degrades to the default surface: per OAuth 2.1 (RFC 6749 §3.3) the
+# authorization server may ignore an ungranted scope, and Keycloak drops a
+# scope that is not an assigned default/optional client scope, so the token
+# never carries it and the elevated tools simply do not list (realm
+# prerequisite tracked as evoila-bosnia/claude-rdc-hetzner-dc#2734). An
+# empty or whitespace-only value falls back to the default.
+scopes="${MEHO_MCP_SCOPES:-mcp:read mcp:execute}"
+if [ -z "${scopes//[[:space:]]/}" ]; then
+  scopes="mcp:read mcp:execute"
+fi
+
 exec npx -y mcp-remote@0.1.38 "$url" \
   --static-oauth-client-info "{\"client_id\": \"$client_id\"}" \
-  --static-oauth-client-metadata '{"scope": "mcp:read mcp:execute"}'
+  --static-oauth-client-metadata "{\"scope\": \"$scopes\"}"

--- a/clients/claude-code-plugin/test/meho-mcp-remote.test.mjs
+++ b/clients/claude-code-plugin/test/meho-mcp-remote.test.mjs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Stubbed-argv suite for bin/meho-mcp-remote — the Claude Code plugin's
+// stdio shim wrapper. The wrapper ends in `exec npx -y mcp-remote@… "$url"
+// --static-oauth-client-info … --static-oauth-client-metadata …`, so the
+// contract worth pinning is the exact argv (and, in particular, the scope
+// metadata) it hands to npx.
+//
+// npx is stubbed: a fake `npx` on a controlled PATH prints each argument on
+// its own line, then exits 0. The wrapper `exec`s it, so the stub replaces
+// the process and its stdout is the wrapper's stdout — letting the suite
+// assert the child contract without a live backplane or a real mcp-remote.
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, test } from "node:test";
+import assert from "node:assert/strict";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WRAPPER = join(HERE, "..", "bin", "meho-mcp-remote");
+const URL = "https://meho.internal.example/mcp";
+const DEFAULT_SCOPE = "mcp:read mcp:execute";
+
+// A temp bin dir holding a stub `npx` that echoes its argv, one arg per
+// line. /usr/bin:/bin keeps `env`/`bash` resolvable under the controlled
+// PATH (the wrapper is `#!/usr/bin/env bash`).
+const STUB_BIN = mkdtempSync(join(tmpdir(), "meho-plugin-test-"));
+writeFileSync(
+  join(STUB_BIN, "npx"),
+  '#!/usr/bin/env bash\nfor a in "$@"; do printf "%s\\n" "$a"; done\n',
+);
+chmodSync(join(STUB_BIN, "npx"), 0o755);
+const PATH_WITH_STUB = `${STUB_BIN}:/usr/bin:/bin`;
+
+after(() => rmSync(STUB_BIN, { recursive: true, force: true }));
+
+// Run the wrapper with the stub npx on PATH and no operator config file
+// (MEHO_PLUGIN_CONFIG points at a path that does not exist, so the
+// wrapper's optional `. "$config_file"` sourcing is skipped).
+function runWrapper(extraEnv = {}) {
+  return spawnSync(WRAPPER, [], {
+    encoding: "utf8",
+    env: {
+      PATH: PATH_WITH_STUB,
+      MEHO_MCP_URL: URL,
+      MEHO_PLUGIN_CONFIG: join(STUB_BIN, "does-not-exist.env"),
+      ...extraEnv,
+    },
+  });
+}
+
+// Parse the stub's line-per-arg output into the metadata JSON that follows
+// the --static-oauth-client-metadata flag.
+function scopeMetadataFrom(stdout) {
+  const args = stdout.split("\n").filter((l) => l.length > 0);
+  const i = args.indexOf("--static-oauth-client-metadata");
+  assert.notEqual(i, -1, `metadata flag absent in argv: ${stdout}`);
+  return JSON.parse(args[i + 1]);
+}
+
+test("default: scope metadata is the working surface, url passed through", () => {
+  const res = runWrapper();
+  assert.equal(res.status, 0, `wrapper exited non-zero: ${res.stderr}`);
+  const args = res.stdout.split("\n").filter((l) => l.length > 0);
+  // npx invocation shape: -y mcp-remote@<v> <url> --static-oauth-client-info
+  // {…} --static-oauth-client-metadata {…}
+  assert.equal(args[0], "-y");
+  assert.match(args[1], /^mcp-remote@/);
+  assert.equal(args[2], URL);
+  assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
+});
+
+test("override: MEHO_MCP_SCOPES sets the requested scope verbatim", () => {
+  const elevated = "mcp:read mcp:execute mcp:admin";
+  const res = runWrapper({ MEHO_MCP_SCOPES: elevated });
+  assert.equal(res.status, 0, res.stderr);
+  assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: elevated });
+});
+
+test("empty MEHO_MCP_SCOPES falls back to the default surface", () => {
+  const res = runWrapper({ MEHO_MCP_SCOPES: "" });
+  assert.equal(res.status, 0, res.stderr);
+  assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
+});
+
+test("whitespace-only MEHO_MCP_SCOPES falls back to the default surface", () => {
+  const res = runWrapper({ MEHO_MCP_SCOPES: "   " });
+  assert.equal(res.status, 0, res.stderr);
+  assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
+});

--- a/clients/claude-desktop-mcpb/README.md
+++ b/clients/claude-desktop-mcpb/README.md
@@ -62,8 +62,9 @@ and [`.github/workflows/cli-release.yml`](../../.github/workflows/cli-release.ym
 
 The manifest's `mcp_config.command` is `node`, running `server/index.mjs`
 with the operator's backplane URL as its argument, the optional CA path
-delivered as the `MEHO_CA_CERT` environment variable, and the OAuth
-client id delivered as `MEHO_MCP_CLIENT_ID`. The launcher:
+delivered as the `MEHO_CA_CERT` environment variable, the OAuth client id
+delivered as `MEHO_MCP_CLIENT_ID`, and the requested OAuth scopes delivered
+as `MEHO_MCP_SCOPES`. The launcher:
 
 1. Validates that the URL is a well-formed `https` URL.
 2. Exports `NODE_EXTRA_CA_CERTS` to the child **only** when a non-empty
@@ -75,9 +76,15 @@ client id delivered as `MEHO_MCP_CLIENT_ID`. The launcher:
    `meho-mcp` when the host substitutes an empty value for the untouched
    optional `client_id` config — so an operator who never opens the
    advanced field still authenticates.
-4. Spawns the vendored `mcp-remote@0.1.38` with inherited stdio, passing
+4. Resolves the requested OAuth scopes from `MEHO_MCP_SCOPES`, falling back
+   to the default working surface `mcp:read mcp:execute` when the host
+   substitutes an empty/whitespace value for the untouched optional
+   `scopes` config. Setting it to an elevated value (e.g.
+   `mcp:read mcp:execute mcp:admin`) is the deliberate opt-in to
+   [operator mode](#elevated-operator-mode-opt-in).
+5. Spawns the vendored `mcp-remote@0.1.38` with inherited stdio, passing
    `--static-oauth-client-info '{"client_id": "…"}'` and
-   `--static-oauth-client-metadata '{"scope": "mcp:read mcp:execute"}'`.
+   `--static-oauth-client-metadata '{"scope": "<resolved scopes>"}'`.
    The static client info is load-bearing: MEHO's Keycloak realm blocks
    anonymous RFC 7591 Dynamic Client Registration (default Trusted Hosts
    policy → `403 "Host not trusted"`), so a bare `mcp-remote` could never
@@ -101,6 +108,46 @@ already exist on the realm — see
 [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md).
 No system Node or `npx` on `PATH` is required at run time — the bundle
 carries its dependencies and Claude Desktop supplies the runtime.
+
+## Elevated operator mode (opt-in)
+
+By default a session lists only the **working surface** — status,
+connector/operation discovery, `call_operation` / `preview_operation` /
+`result_query`, knowledge, memory, the broadcast trio, target/topology
+reads, and the runbook run family. That is everything an operator needs to
+get work done, and it is what every session gets with the `scopes` field
+left at its default `mcp:read mcp:execute`.
+
+The advanced `scopes` user_config is the deliberate opt-in to **operator
+mode**. Set it to add the elevated scope:
+
+```
+mcp:read mcp:execute mcp:admin
+```
+
+An elevated session additionally lists the **operator planes**: the agents
+/ principals registry and grants, connector lifecycle, broadcast overrides,
+the scheduler, sensors, runbook template authoring, and the approvals
+**read** views (`meho_approvals_list` / `meho_approvals_get`).
+
+Elevation **never** exposes the human-only verbs. `meho_approvals_approve`,
+`meho_approvals_reject`, and `meho_agents_grant_elevate` have no MCP path
+under any scope — approving a parked operation and granting elevation are
+human decisions made through the console or CLI only (#3155). A model
+holding the approve button would collapse the four-eyes gate, so it is
+never on the wire.
+
+**Realm prerequisite (and the fallback if it is missing).** `mcp:admin`
+must be offered as an **optional** (requestable, non-default) client scope
+on the realm's `meho-mcp` client before elevation takes effect — tracked as
+[`evoila-bosnia/claude-rdc-hetzner-dc#2734`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2734).
+Until it lands, requesting `mcp:admin` **degrades to the default working
+surface**: per OAuth 2.1 (RFC 6749 §3.3) the authorization server may ignore
+a scope it does not grant, and Keycloak drops any requested scope that is
+not an assigned default/optional client scope — so the token comes back
+without `mcp:admin`, no error is raised, and the operator planes simply do
+not appear. Setting the `scopes` field on a realm that does not yet offer
+the scope is therefore safe: the session behaves exactly as the default.
 
 ## Verifying a built bundle
 

--- a/clients/claude-desktop-mcpb/manifest.json
+++ b/clients/claude-desktop-mcpb/manifest.json
@@ -17,7 +17,8 @@
       "args": ["${__dirname}/server/index.mjs", "${user_config.backplane_url}"],
       "env": {
         "MEHO_CA_CERT": "${user_config.ca_cert}",
-        "MEHO_MCP_CLIENT_ID": "${user_config.client_id}"
+        "MEHO_MCP_CLIENT_ID": "${user_config.client_id}",
+        "MEHO_MCP_SCOPES": "${user_config.scopes}"
       }
     }
   },
@@ -39,6 +40,13 @@
       "title": "OAuth client id (advanced)",
       "description": "Pre-registered public OAuth client the shim presents to Keycloak. Leave as the default unless your realm registered the client under a different name.",
       "default": "meho-mcp",
+      "required": false
+    },
+    "scopes": {
+      "type": "string",
+      "title": "OAuth scopes (advanced)",
+      "description": "Space-separated OAuth scopes the shim requests during login. Leave as the default working surface; add an elevated scope (e.g. \"mcp:read mcp:execute mcp:admin\") only to deliberately opt into operator mode. Requesting a scope your realm does not grant degrades to the default surface.",
+      "default": "mcp:read mcp:execute",
       "required": false
     }
   },

--- a/clients/claude-desktop-mcpb/server/index.mjs
+++ b/clients/claude-desktop-mcpb/server/index.mjs
@@ -73,6 +73,21 @@ delete env.MEHO_CA_CERT;
 const clientId = (process.env.MEHO_MCP_CLIENT_ID ?? "").trim() || "meho-mcp";
 delete env.MEHO_MCP_CLIENT_ID;
 
+// OAuth scope metadata presented during the handshake. The default is the
+// working surface; the optional `scopes` user_config (delivered as
+// MEHO_MCP_SCOPES) lets an operator deliberately request an elevated
+// surface — append mcp:admin to reach the operator planes. Fall back to the
+// default when the host substitutes an empty/whitespace value for the
+// untouched optional field. Requesting a scope the realm does not grant
+// degrades to the default surface: per OAuth 2.1 (RFC 6749 §3.3) the
+// authorization server may ignore an ungranted scope, and Keycloak drops a
+// scope that is not an assigned default/optional client scope, so the token
+// never carries it and the elevated tools simply do not list. Stripped from
+// the child env like the other config seams.
+const scopes =
+  (process.env.MEHO_MCP_SCOPES ?? "").trim() || "mcp:read mcp:execute";
+delete env.MEHO_MCP_SCOPES;
+
 // Run the child as a plain Node process even when process.execPath is
 // Claude Desktop's Electron helper rather than a standalone `node`:
 // ELECTRON_RUN_AS_NODE=1 "starts the process as a normal Node.js process"
@@ -106,7 +121,7 @@ const child = spawn(
     "--static-oauth-client-info",
     JSON.stringify({ client_id: clientId }),
     "--static-oauth-client-metadata",
-    JSON.stringify({ scope: "mcp:read mcp:execute" }),
+    JSON.stringify({ scope: scopes }),
   ],
   { stdio: "inherit", env },
 );

--- a/clients/claude-desktop-mcpb/test/index.test.mjs
+++ b/clients/claude-desktop-mcpb/test/index.test.mjs
@@ -63,6 +63,7 @@ writeFileSync(
     "    nodeExtraCaCerts: process.env.NODE_EXTRA_CA_CERTS ?? null,",
     "    mehoCaCert: process.env.MEHO_CA_CERT ?? null,",
     "    mehoClientId: process.env.MEHO_MCP_CLIENT_ID ?? null,",
+    "    mehoScopes: process.env.MEHO_MCP_SCOPES ?? null,",
     "  }) + '\\n',",
     ");",
     "",
@@ -148,6 +149,29 @@ test("guard: an empty client_id falls back to meho-mcp", () => {
   assert.equal(res.status, 0, res.stderr);
   const diag = JSON.parse(res.stdout);
   assert.deepEqual(JSON.parse(diag.argv[4]), { client_id: "meho-mcp" });
+});
+
+test("guard: scopes override applied to metadata and MEHO_MCP_SCOPES scrubbed", () => {
+  const elevated = "mcp:read mcp:execute mcp:admin";
+  const res = runLauncher(["https://meho.internal.example/mcp"], {
+    MEHO_MCP_SCOPES: elevated,
+  });
+  assert.equal(res.status, 0, res.stderr);
+  const diag = JSON.parse(res.stdout);
+  assert.deepEqual(JSON.parse(diag.argv[6]), { scope: elevated });
+  assert.equal(diag.mehoScopes, null); // scrubbed from the child env
+});
+
+test("guard: an empty or whitespace-only scopes falls back to the default surface", () => {
+  for (const value of ["", "   "]) {
+    const res = runLauncher(["https://meho.internal.example/mcp"], {
+      MEHO_MCP_SCOPES: value,
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(JSON.parse(res.stdout).argv[6]), {
+      scope: "mcp:read mcp:execute",
+    });
+  }
 });
 
 test("guard: a non-https endpoint is rejected before spawning", () => {


### PR DESCRIPTION
## Summary

- Adds a **client-side scope-override seam** so an operator can deliberately request the `mcp:admin` elevation the two stdio-shim onramps previously hardcoded away — **defaults unchanged** (`mcp:read mcp:execute`). This is the T3 client seam of #3153.
- **Plugin wrapper** (`bin/meho-mcp-remote`): new `MEHO_MCP_SCOPES` env feeds `--static-oauth-client-metadata`; empty/whitespace falls back to the default. Mirrors the #3138 `client_id` seam.
- **Desktop bundle**: optional `scopes` user_config → `MEHO_MCP_SCOPES` env → launcher argv (`server/index.mjs`, which spawns the vendored `mcp-remote` via `process.execPath` after #3146).
- Both READMEs document elevation: what it **adds** (operator planes) and what it **never adds** — approval verbs and grant-elevate have no MCP path under any scope (#3155).

## Test plan

- [x] `node --test clients/claude-code-plugin/test/meho-mcp-remote.test.mjs` — 4 passed (default unchanged, override honored, empty → default, whitespace → default)
- [x] `node --test clients/claude-desktop-mcpb/test/index.test.mjs` — 10 passed (2 new: scope override + env scrub, empty/whitespace → default; existing default/CA/client_id guards unchanged)
- [x] `clients/claude-desktop-mcpb/build.sh 0.0.0-dev` — pack dry-run green, "Manifest schema validation passes!" (the new `scopes` user_config is schema-valid)
- [x] `shellcheck clients/claude-code-plugin/bin/meho-mcp-remote` — clean; `bash -n` — clean
- [x] New `.github/workflows/plugin-test.yml` runs the plugin stubbed-argv suite on PRs touching the plugin (the plugin had no CI runner before; mirrors `mcpb-bundle.yml`)

### Ungranted-scope fallback

Requesting a scope the realm does not offer **degrades to the default working surface**: per OAuth 2.1 ([RFC 6749 §3.3](https://www.rfc-editor.org/rfc/rfc6749#section-3.3)) the authorization server may ignore an unassigned scope, and Keycloak drops a requested scope that is not an assigned default/optional client scope — the token comes back without `mcp:admin`, no error is raised, and the operator planes simply do not list. So setting `MEHO_MCP_SCOPES` / `scopes` on today's realm (which does not yet offer `mcp:admin`) is a safe no-op. Live token-inspection verification lands with the realm change.

## Out of scope

- Realm bootstrap change (`meho-mcp` client optional `mcp:admin` scope) — rdc repo, tracked as [`evoila-bosnia/claude-rdc-hetzner-dc#2734`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2734); **not a blocker for this merge**.
- Backend `tools/list` surface filter (#3154) and de-registering approval/grant verbs (#3155).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3156
