### PR TITLE
feat(mcp): human-only approval + grant-elevate verbs (no MCP path) (#3155)

### DIFF
--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -95,6 +95,7 @@ from meho_backplane.broadcast import (
     redact_payload,
 )
 from meho_backplane.mcp.audit import compute_params_hash, write_mcp_audit_row
+from meho_backplane.mcp.human_only import human_only_remediation
 from meho_backplane.mcp.registry import (
     ResourceTemplateDefinition,
     ToolDefinition,
@@ -288,6 +289,17 @@ async def handle_tools_call(
 
         audit_payload["params_hash"] = compute_params_hash(arguments)
 
+        # Human-only surface (#3155): approve / reject / grant-elevate
+        # have no MCP path under any claim set — deciding a parked op and
+        # elevating an agent grant are human actions (v0.1-spec §7). The
+        # check runs *before* the registry lookup so an accidental future
+        # re-registration can never make them callable; the remediation
+        # string names the operator console / CLI path instead.
+        remediation = human_only_remediation(name)
+        if remediation is not None:
+            status_code = 404
+            raise McpInvalidParamsError(remediation)
+
         entry = get_tool(name)
         if entry is None:
             status_code = 404
@@ -381,8 +393,8 @@ async def handle_tools_call(
         # Class-wide audit-status correction (#1481). A tool handler can
         # raise ``McpInvalidParamsError`` *after* all the explicit
         # pre-dispatch gates (name/arguments/unknown-tool/RBAC/schema)
-        # — e.g. ``_approve_handler`` rejecting a self-approval,
-        # ``approval_request_not_found``, or ``approval_unauthorized``.
+        # — e.g. ``_get_handler`` raising ``approval_request_not_found``,
+        # or a grant handler mapping a ``GrantValidationError``.
         # Those raises bypass every branch that set ``status_code``, so
         # it is still the init 500 — a server-fault projection of what is
         # actually a JSON-RPC ``-32602`` parameter/policy rejection on

--- a/backend/src/meho_backplane/mcp/human_only.py
+++ b/backend/src/meho_backplane/mcp/human_only.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The human-only MCP surface — decision verbs with no agent-facing path.
+
+Three verbs are deliberately absent from the MCP tool registry under
+**every** claim set (including an elevated operator token): approving or
+rejecting a parked operation, and granting a time-bounded privilege
+elevation to an agent. They are *not* registered by
+:mod:`meho_backplane.mcp.tools.approvals` /
+:mod:`meho_backplane.mcp.tools.agent_grants`, so they never appear in
+``tools/list`` and cannot be dispatched by ``tools/call`` (#3155,
+Initiative #3153).
+
+Why these three and not the whole write surface:
+
+* **Approve / reject** exist to force a *human* decision on a parked
+  operation (v0.1-spec §7). The same MCP session that parked an op
+  must not be able to approve it — a model holding the approve button
+  collapses the gate (#3143 F4 evidence: all three were listed for a
+  ``tenant_admin`` session).
+* **Grant elevation** is model-invocable privilege escalation. A
+  registered agent principal must not be able to widen its own (or a
+  sibling's) grant window over the agent surface.
+
+The read halves (``meho_approvals_list`` / ``meho_approvals_get``) and
+the non-elevation grant verbs (``meho_agents_grant_list`` / ``.show`` /
+``.create`` / ``.revoke``) keep their MCP registration — reading a
+queue is not deciding it, and grant *administration* stays on the
+operator plane per the T1 surface classification (#3154).
+
+This module is the single source of truth for two consumers:
+
+* :func:`meho_backplane.mcp.handlers.handle_tools_call` consults
+  :data:`HUMAN_ONLY_MCP_TOOLS` *before* the registry lookup, so an
+  accidental future re-registration can never make one of these
+  callable — a ``tools/call`` on any of the three is denied with the
+  remediation string naming the console / CLI path.
+* The guard test ``tests/test_mcp_human_only_surface.py`` asserts none
+  of these names is registered and that no tool module wires a handler
+  to an approval-decision or grant-elevation endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: Wire names that have **no** MCP path, mapped to the remediation
+#: string the dispatcher returns on a ``tools/call`` attempt. Each
+#: message names both the operator console and the ``meho`` CLI verb so
+#: an agent that reaches for the removed tool is told exactly where the
+#: human decision is made instead.
+HUMAN_ONLY_MCP_TOOLS: Final[dict[str, str]] = {
+    "meho_approvals_approve": (
+        "meho_approvals_approve has no MCP path under any claim set: "
+        "approving a parked operation is a human decision (v0.1-spec §7). "
+        "Approve via the operator console approvals queue, or the CLI: "
+        "`meho approvals approve <request-id>`."
+    ),
+    "meho_approvals_reject": (
+        "meho_approvals_reject has no MCP path under any claim set: "
+        "rejecting a parked operation is a human decision (v0.1-spec §7). "
+        "Reject via the operator console approvals queue, or the CLI: "
+        "`meho approvals reject <request-id> --reason <text>`."
+    ),
+    "meho_agents_grant_elevate": (
+        "meho_agents_grant_elevate has no MCP path under any claim set: "
+        "granting a time-bounded privilege elevation is a human-only "
+        "operator action. Elevate via the operator console, or the CLI: "
+        "`meho agent grant elevate --principal <sub> --op <pattern> "
+        "--verdict <v> --expires <iso8601>`."
+    ),
+}
+
+
+def human_only_remediation(name: str) -> str | None:
+    """Return the remediation string for a human-only tool *name*, else ``None``.
+
+    ``None`` means *name* is not a human-only verb — the caller falls
+    through to the normal registry lookup (and its generic
+    ``unknown tool`` rejection when the name resolves to nothing).
+    """
+    return HUMAN_ONLY_MCP_TOOLS.get(name)

--- a/backend/src/meho_backplane/mcp/tools/agent_grants.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_grants.py
@@ -3,7 +3,7 @@
 
 """Admin MCP tools for the agent permission grant surface.
 
-G11.2-T6 (#819) under Initiative #803 — five ``meho_agents_grant_*``
+G11.2-T6 (#819) under Initiative #803 — four ``meho_agents_grant_*``
 tools that mirror the REST surface
 (``/api/v1/agents/grants``) onto the MCP transport:
 
@@ -13,10 +13,17 @@ tools that mirror the REST surface
   Role: ``tenant_admin``.
 * ``meho_agents_grant_create`` — create a grant (permanent or
   time-bounded). Role: ``tenant_admin``.
-* ``meho_agents_grant_elevate`` — create a time-bounded elevation
-  (``expires_at`` required). Role: ``tenant_admin``.
 * ``meho_agents_grant_revoke`` — revoke (delete) a grant.
   Role: ``tenant_admin``.
+
+The dedicated elevation verb — ``meho_agents_grant_elevate`` — has
+**no MCP path under any claim set** (#3155, Initiative #3153):
+granting a time-bounded privilege elevation is a human-only operator
+action, so it is not agent-invocable. It stays on the REST / CLI /
+console surfaces (``POST /api/v1/agents/grants/elevate``, ``meho agent
+grant elevate``), which are untouched. The wire name is pinned in
+:mod:`meho_backplane.mcp.human_only` so a ``tools/call`` on it returns
+a remediation naming those paths.
 
 RBAC enforcement
 ================
@@ -53,7 +60,6 @@ import structlog
 from pydantic import ValidationError
 
 from meho_backplane.agents.grant_schemas import (
-    AgentElevationCreate,
     AgentGrantCreate,
     AgentGrantRead,
     GrantVerdict,
@@ -69,7 +75,6 @@ _GRANT_OP_IDS: Final[dict[str, str]] = {
     "list": "agent.grant.list",
     "show": "agent.grant.show",
     "create": "agent.grant.create",
-    "elevate": "agent.grant.elevate",
     "revoke": "agent.grant.revoke",
 }
 
@@ -290,84 +295,6 @@ register_mcp_tool(
         op_class="write",
     ),
     handler=_create_grant_handler,
-)
-
-
-# ---------------------------------------------------------------------------
-# meho_agents_grant_elevate
-# ---------------------------------------------------------------------------
-
-
-async def _elevate_grant_handler(
-    operator: Operator,
-    arguments: dict[str, Any],
-) -> dict[str, Any]:
-    try:
-        payload = AgentElevationCreate.model_validate(arguments)
-    except ValidationError as exc:
-        raise McpInvalidParamsError(str(exc)) from exc
-    structlog.contextvars.bind_contextvars(
-        audit_op_id=_GRANT_OP_IDS["elevate"],
-        audit_op_class="write",
-        audit_agent_name=payload.principal_sub,
-    )
-    service = AgentGrantService()
-    try:
-        entry = await service.grant(operator.tenant_id, operator.sub, payload)
-    except GrantValidationError as exc:
-        raise McpInvalidParamsError(exc.message) from exc
-    return _row_to_dict(entry)
-
-
-register_mcp_tool(
-    definition=ToolDefinition(
-        feature="agent_runtime",
-        name="meho_agents_grant_elevate",
-        description=(
-            "Grant a time-bounded elevation to an agent principal (G11.2-T6). "
-            "expires_at is required. The grant-expiry sweeper reverts the "
-            "agent to baseline automatically after the window ends. The "
-            "created row carries `grant_id` (accepted verbatim by "
-            "meho_agents_grant_show / meho_agents_grant_revoke) alongside the native `id`. "
-            "Enforcement scope: elevations gate ONLY tokens carrying the "
-            "principal_kind=agent claim (registered agent principals); "
-            "human/service tokens are never gated. principal_sub must name a "
-            "registered, non-revoked agent principal (its agent:<name> "
-            "handle) or creation is rejected."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "principal_sub": {
-                    "type": "string",
-                    "description": "JWT sub of the agent principal.",
-                },
-                "op_pattern": {
-                    "type": "string",
-                    "description": "fnmatch glob matching operation IDs.",
-                },
-                "target_scope": {
-                    "type": "string",
-                    "description": "Target UUID or '*' for any target (optional).",
-                },
-                "verdict": {
-                    "type": "string",
-                    "enum": [v.value for v in GrantVerdict],
-                    "description": "Permission verdict for the elevation window.",
-                },
-                "expires_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Required UTC expiry for the elevation.",
-                },
-            },
-            "required": ["principal_sub", "op_pattern", "verdict", "expires_at"],
-            "additionalProperties": False,
-        },
-        required_role=TenantRole.TENANT_ADMIN,
-        op_class="write",
-    ),
-    handler=_elevate_grant_handler,
 )
 
 

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -3,7 +3,7 @@
 
 """MCP tools for the approval surfacing channel (G11.2-T5 / #818).
 
-Four ``meho_approvals_*`` tools that mirror the REST routes
+Two **read** ``meho_approvals_*`` tools that mirror the REST routes
 (:mod:`meho_backplane.api.v1.approvals`) onto the MCP transport:
 
 * ``meho_approvals_list`` — list approval requests, optionally filtered
@@ -11,32 +11,24 @@ Four ``meho_approvals_*`` tools that mirror the REST routes
 * ``meho_approvals_get`` — inspect one approval request by id. Returns
   the ``proposed_effect`` so an operator can decide before approving.
   Role: ``operator``.
-* ``meho_approvals_approve`` — approve a pending request (operator
-  decision: status flip + audit + broadcast; **no** params required —
-  the agent's REST path retains the params-hash check).
-  Role: ``operator``.
-* ``meho_approvals_reject`` — reject a pending request. Role:
-  ``operator``.
 
-All four tools drive
+The decision verbs — approve and reject — have **no MCP path under any
+claim set** (#3155, Initiative #3153). Approving or rejecting a parked
+operation is a *human* decision (v0.1-spec §7); a model session that
+parked an op must not be able to approve it (the self-approval hole
+#3143 F4 surfaced). Both stay reachable on the REST / CLI / console
+surfaces, which are untouched:
+:mod:`meho_backplane.api.v1.approvals`, ``meho approvals
+approve|reject``, and the operator console approvals queue. The wire
+names are pinned in :mod:`meho_backplane.mcp.human_only` so a
+``tools/call`` on them returns a remediation naming those paths.
+
+Both read tools drive
 :mod:`meho_backplane.operations.approval_queue` — the single source of
-truth that T4 (#817) shipped — so a decision made over MCP is
-reflected in the REST/CLI view immediately and writes the same
-synchronous "decision" audit row and ``approval_decided`` broadcast
-event as the REST path. RBAC is enforced at two layers: the registry
-filter hides write tools from non-admins in ``tools/list``, and the
-MCP dispatcher re-checks ``required_role`` at call time.
-
-MCP elicitation URL-mode (forward-looking)
-------------------------------------------
-
-When an in-loop agent hits a ``needs-approval`` verdict, the agent
-runtime can use the row's ``id`` (returned from ``meho_approvals_get``)
-to construct an elicitation URL of the form
-``meho://approvals/{request_id}/decide``. MCP-2025-11-25 hosts that
-support elicitation URL-mode open this URL in the operator's decision
-UI; until that lands the operator approves/rejects via the explicit
-``meho_approvals_{approve,reject}`` tools above.
+truth that T4 (#817) shipped — so the MCP view matches the REST/CLI
+view immediately. RBAC is enforced at two layers: the registry filter
+hides tools from non-operators in ``tools/list``, and the MCP
+dispatcher re-checks ``required_role`` at call time.
 
 Error mapping
 -------------
@@ -44,10 +36,6 @@ Error mapping
 * :class:`~meho_backplane.operations.approval_queue.ApprovalNotFoundError`
   → :class:`~meho_backplane.mcp.server.McpInvalidParamsError` with code
   ``approval_request_not_found``.
-* :class:`~meho_backplane.operations.approval_queue.ApprovalRequestAlreadyDecidedError`
-  → ``approval_request_not_pending``.
-* :class:`~meho_backplane.operations.approval_queue.UnauthorizedApprovalError`
-  → ``approval_unauthorized``.
 """
 
 from __future__ import annotations
@@ -64,25 +52,14 @@ from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
-    ApprovalRequestAlreadyDecidedError,
-    SelfApprovalForbiddenError,
-    UnauthorizedApprovalError,
-    approve_request,
     get_request,
     list_pending,
-    publish_approval_event,
-    reject_request,
-    resume_dispatch_after_approval,
 )
-
-_log = structlog.get_logger(__name__)
 
 #: Canonical op ids — same as the REST routes for transport-independent audit rows.
 _OP_IDS: Final[dict[str, str]] = {
     "list": "approval.list",
     "get": "approval.get",
-    "approve": "approval.approve",
-    "reject": "approval.reject",
 }
 
 #: Allowed ``status`` filter values on ``meho_approvals_list``. Mirrors
@@ -347,214 +324,4 @@ register_mcp_tool(
         required_role=TenantRole.OPERATOR,
     ),
     handler=_get_handler,
-)
-
-
-# ---------------------------------------------------------------------------
-# meho_approvals_approve
-# ---------------------------------------------------------------------------
-
-
-async def _approve_handler(
-    operator: Operator,
-    arguments: dict[str, Any],
-) -> dict[str, Any]:
-    request_id = _require_id(arguments)
-    reason = arguments.get("reason")
-    reason_str = str(reason) if reason is not None else ""
-    structlog.contextvars.bind_contextvars(
-        audit_op_id=_OP_IDS["approve"],
-        audit_op_class="write",
-        audit_approval_request_id=str(request_id),
-    )
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        try:
-            # Operator-decision path: no params supplied → approve_request
-            # skips the hash check and just flips status + writes the
-            # decision audit row. The params for the re-dispatch are read
-            # back from the row (stored at park time, #1503).
-            row = await approve_request(
-                session,
-                request_id,
-                operator=operator,
-                params=None,
-                reason=reason_str,
-            )
-            await session.commit()
-        except ApprovalNotFoundError as exc:
-            raise McpInvalidParamsError("approval_request_not_found") from exc
-        except ApprovalRequestAlreadyDecidedError as exc:
-            raise McpInvalidParamsError(
-                f"approval_request_not_pending: current status is {exc.status!r}"
-            ) from exc
-        except SelfApprovalForbiddenError as exc:
-            # G11.7-T1 #1401: requester != approver. Surfaced as an
-            # invalid-params error so the operator sees the refusal
-            # reason rather than a generic role failure. Append
-            # ``str(exc)`` so the message also carries the
-            # ``APPROVAL_ALLOW_SELF_APPROVAL=true`` break-glass hint the
-            # exception already constructs (#1483).
-            raise McpInvalidParamsError(f"self_approval_forbidden: {exc}") from exc
-        except UnauthorizedApprovalError as exc:
-            raise McpInvalidParamsError(
-                f"approval_unauthorized: role {exc.role!r} cannot approve"
-            ) from exc
-    # Publish AFTER commit (fail-open).
-    await publish_approval_event(
-        tenant_id=operator.tenant_id,
-        request=row,
-        decision="approved",
-        principal_sub=operator.sub,
-        audit_id=row._audit_id,  # type: ignore[attr-defined]
-    )
-
-    result = _row_to_dict(row)
-
-    # Every approval drives the execute (#1503, #2293): the committed
-    # approval is the authorization; the stored params re-hydrate the
-    # dispatch. The exactly-one-resumer claim inside
-    # resume_dispatch_after_approval arbitrates against the in-process
-    # agent waiter for a run-bound request — this MCP path executes only
-    # when the claim is free (the waiter had died: wait-timeout, pod
-    # restart, run cancelled), else it no-ops with status
-    # "already_resumed". The old run_id-is-not-None skip was the source of
-    # the silent-non-execution seam when the waiter was gone.
-    dispatch_result = await resume_dispatch_after_approval(
-        operator=operator, request=row, params=None
-    )
-    _log.info(
-        "approval_request_redispatched",
-        approval_request_id=str(request_id),
-        op_id=row.op_id,
-        dispatch_status=dispatch_result.status,
-        operator_sub=operator.sub,
-        via="mcp",
-    )
-    result["dispatch"] = {
-        "status": dispatch_result.status,
-        "op_id": dispatch_result.op_id,
-        "result": dispatch_result.result,
-        "error": dispatch_result.error,
-    }
-
-    return result
-
-
-register_mcp_tool(
-    definition=ToolDefinition(
-        feature="approvals",
-        name="meho_approvals_approve",
-        description=(
-            "Approve a pending approval request (G11.2-T5 / #818; #1503; "
-            "#2293). Operator-level. Flips the request to 'approved', writes "
-            "the decision audit row, and announces approval_decided on the "
-            "broadcast feed. It then re-dispatches the op using the params "
-            "stored at park time and returns the outcome under `dispatch`. "
-            "The exactly-one-resumer claim makes this safe for an agent-run "
-            "request: `dispatch.status` is 'ok' when this approve executed "
-            "it (a direct op, or the fallback when the in-process agent "
-            "waiter was gone), or 'already_resumed' when the live waiter "
-            "executed it first — so the approved write lands exactly once. "
-            "Only pending requests may be approved; any other status "
-            "returns approval_request_not_pending. Pass either "
-            "`approval_request_id` (canonical name; G0.18-T5 #1358) or the "
-            "deprecated `id` alias."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "approval_request_id": _APPROVAL_REQUEST_ID_PROPERTY,
-                "id": _APPROVAL_LEGACY_ID_PROPERTY,
-                "reason": {
-                    "type": "string",
-                    "description": "Optional rationale recorded on the decision audit row.",
-                },
-            },
-            "anyOf": _APPROVAL_ID_ANYOF,
-            "additionalProperties": False,
-        },
-        required_role=TenantRole.OPERATOR,
-    ),
-    handler=_approve_handler,
-)
-
-
-# ---------------------------------------------------------------------------
-# meho_approvals_reject
-# ---------------------------------------------------------------------------
-
-
-async def _reject_handler(
-    operator: Operator,
-    arguments: dict[str, Any],
-) -> dict[str, Any]:
-    request_id = _require_id(arguments)
-    reason = arguments.get("reason")
-    reason_str = str(reason) if reason is not None else ""
-    structlog.contextvars.bind_contextvars(
-        audit_op_id=_OP_IDS["reject"],
-        audit_op_class="write",
-        audit_approval_request_id=str(request_id),
-    )
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        try:
-            row = await reject_request(
-                session,
-                request_id,
-                operator=operator,
-                reason=reason_str,
-            )
-            await session.commit()
-        except ApprovalNotFoundError as exc:
-            raise McpInvalidParamsError("approval_request_not_found") from exc
-        except ApprovalRequestAlreadyDecidedError as exc:
-            raise McpInvalidParamsError(
-                f"approval_request_not_pending: current status is {exc.status!r}"
-            ) from exc
-        except UnauthorizedApprovalError as exc:
-            raise McpInvalidParamsError(
-                f"approval_unauthorized: role {exc.role!r} cannot reject"
-            ) from exc
-    # Publish AFTER commit (fail-open).
-    await publish_approval_event(
-        tenant_id=operator.tenant_id,
-        request=row,
-        decision="rejected",
-        principal_sub=operator.sub,
-        audit_id=row._audit_id,  # type: ignore[attr-defined]
-    )
-    return _row_to_dict(row)
-
-
-register_mcp_tool(
-    definition=ToolDefinition(
-        feature="approvals",
-        name="meho_approvals_reject",
-        description=(
-            "Reject a pending approval request (G11.2-T5 / #818). "
-            "Operator-level. Flips the request to 'rejected', writes the "
-            "decision audit row, and announces approval_decided on the "
-            "broadcast feed. The original op is not executed. Only "
-            "pending requests may be rejected. Pass either "
-            "`approval_request_id` (canonical name; G0.18-T5 #1358) or "
-            "the deprecated `id` alias."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "approval_request_id": _APPROVAL_REQUEST_ID_PROPERTY,
-                "id": _APPROVAL_LEGACY_ID_PROPERTY,
-                "reason": {
-                    "type": "string",
-                    "description": "Optional rationale recorded on the decision audit row.",
-                },
-            },
-            "anyOf": _APPROVAL_ID_ANYOF,
-            "additionalProperties": False,
-        },
-        required_role=TenantRole.OPERATOR,
-    ),
-    handler=_reject_handler,
 )

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -2245,55 +2245,13 @@ async def test_decide_approve_redispatches_direct_op_with_stored_params(
     clear_registry()
 
 
-@pytest.mark.asyncio
-async def test_mcp_approve_redispatches_direct_op_with_stored_params(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A parked direct op approved via MCP by-id executes once (#1503, AC1).
-
-    Mirrors the ``/decide`` test for the MCP ``meho_approvals_approve``
-    surface: approve by id alone → the handler re-dispatches with the
-    stored params, runs once, and returns the dispatch outcome under
-    ``dispatch``.
-    """
-    from meho_backplane.connectors.registry import clear_registry
-    from meho_backplane.mcp.tools.approvals import _approve_handler
-    from meho_backplane.operations import dispatch, reset_dispatcher_caches
-
-    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
-    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
-    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
-    get_settings.cache_clear()
-
-    _RECORDED_EXECUTIONS.clear()
-    reset_dispatcher_caches()
-    clear_registry()
-    await _register_recording_requires_approval_op(monkeypatch)
-
-    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
-    params = {"path": "secret/api", "value": "tok-123"}
-
-    result1 = await dispatch(
-        operator=requester,
-        connector_id="rectest-1.x",
-        op_id="rectest.write",
-        target=None,
-        params=params,
-    )
-    assert result1.status == "awaiting_approval", result1.error
-    approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
-
-    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
-    out = await _approve_handler(reviewer, {"approval_request_id": str(approval_request_id)})
-
-    assert out["status"] == ApprovalRequestStatus.APPROVED.value
-    assert out["dispatch"]["status"] == "ok", out["dispatch"]["error"]
-    assert out["dispatch"]["op_id"] == "rectest.write"
-    assert len(_RECORDED_EXECUTIONS) == 1
-    assert _RECORDED_EXECUTIONS[0]["params"] == params
-
-    reset_dispatcher_caches()
-    clear_registry()
+# NOTE (#3155): the MCP-approve twin of the ``/decide`` direct-op
+# stored-params test was removed with the MCP approve tool — approving a
+# parked operation is human-only now (console/CLI), with no
+# ``meho_approvals_approve`` handler. The #1503 AC1 re-dispatch-with-stored-
+# params behaviour stays covered by
+# ``test_decide_approve_redispatches_direct_op_with_stored_params`` on the
+# ``/decide`` REST surface that still exists.
 
 
 async def _park_agent_run_request(monkeypatch: pytest.MonkeyPatch) -> uuid.UUID:

--- a/backend/tests/test_mcp_human_only_surface.py
+++ b/backend/tests/test_mcp_human_only_surface.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The human-only MCP surface has no agent-facing path (#3155 / #3153).
+
+Three decision verbs — ``meho_approvals_approve``,
+``meho_approvals_reject``, ``meho_agents_grant_elevate`` — must be
+absent from ``tools/list`` under **every** claim set (including an
+elevated ``tenant_admin`` token) and must reject a direct
+``tools/call`` with a remediation naming the console / CLI path. The
+REST / CLI / console surfaces are untouched; this file pins only the
+MCP-side removal.
+
+Three complementary guards:
+
+* **Registry absence** — after the full eager import, none of the
+  three names resolves to a registered tool. This is claim-independent:
+  a name that is not in the registry cannot surface for any role,
+  capability, or future elevation claim.
+* **Wire behaviour** — ``tools/list`` never lists them (parametrised
+  over every role, up to and including ``tenant_admin``), and
+  ``tools/call`` on each returns ``-32602`` ``INVALID_PARAMS`` whose
+  message names the operator console and the ``meho`` CLI verb.
+* **Static re-add guard** — no module under ``mcp/tools/`` that
+  registers a tool may reference an approval-decision or
+  grant-elevation endpoint symbol, so a future registration wiring one
+  of those handlers back onto the agent surface fails CI at unit time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import meho_backplane.mcp.tools as mcp_tools_pkg
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.human_only import HUMAN_ONLY_MCP_TOOLS
+from meho_backplane.mcp.registry import (
+    clear_registries,
+    eager_import_mcp_modules,
+    get_tool,
+)
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+#: The three verbs that have no MCP path under any claim set.
+_HUMAN_ONLY_NAMES: tuple[str, ...] = (
+    "meho_approvals_approve",
+    "meho_approvals_reject",
+    "meho_agents_grant_elevate",
+)
+
+#: Substrings the remediation for each verb MUST carry — the operator
+#: console and the concrete ``meho`` CLI verb (AC: "a remediation naming
+#: the CLI/console path"). Pins the message so a future edit that drops
+#: the actionable path fails here.
+_REMEDIATION_TOKENS: dict[str, tuple[str, ...]] = {
+    "meho_approvals_approve": ("console", "meho approvals approve"),
+    "meho_approvals_reject": ("console", "meho approvals reject"),
+    "meho_agents_grant_elevate": ("console", "meho agent grant elevate"),
+}
+
+#: Endpoint symbols whose presence in a tool module means a handler is
+#: wired to an approval-decision or grant-elevation surface. A file that
+#: both registers a tool and references one of these is a re-add of a
+#: human-only verb onto the agent surface.
+_FORBIDDEN_ENDPOINT_SYMBOLS: tuple[str, ...] = (
+    "approve_request",  # approval-decision (status flip + audit + broadcast)
+    "reject_request",  # approval-decision
+    "resume_dispatch_after_approval",  # executes the approved op
+    "AgentElevationCreate",  # grant-elevation schema
+)
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a JSON-RPC ``tools/call`` envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+def test_human_only_map_pins_exactly_the_three_verbs() -> None:
+    """:data:`HUMAN_ONLY_MCP_TOOLS` names exactly the three de-registered verbs."""
+    assert set(HUMAN_ONLY_MCP_TOOLS) == set(_HUMAN_ONLY_NAMES)
+
+
+def test_human_only_tools_are_not_registered() -> None:
+    """After a full eager import, none of the three verbs is a registered tool.
+
+    Registry absence is the load-bearing "no MCP path under any claim
+    set" guarantee — a tool that is not in the registry can never be
+    listed or dispatched for any role, capability, or future elevation
+    claim. Runs the production eager import directly (not the fixture
+    reload) so a real boot is exercised.
+    """
+    clear_registries()
+    try:
+        eager_import_mcp_modules()
+        for name in _HUMAN_ONLY_NAMES:
+            assert get_tool(name) is None, (
+                f"{name!r} must have no MCP registration (human-only, #3155)"
+            )
+    finally:
+        clear_registries()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY, TenantRole.OPERATOR, TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_human_only_tools_absent_from_tools_list_for_every_role(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """No role — including the highest, ``tenant_admin`` — sees the three verbs.
+
+    Parametrised across the whole role ladder to prove the removal is
+    not a role-gate (which an elevated token could clear) but a true
+    de-registration.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert resp.status_code == 200, resp.text
+    names = {t["name"] for t in resp.json()["result"]["tools"]}
+    leaked = names & set(_HUMAN_ONLY_NAMES)
+    assert leaked == set(), f"human-only verbs must never appear on tools/list; saw {leaked!r}"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.parametrize("tool_name", _HUMAN_ONLY_NAMES)
+def test_human_only_tools_call_is_denied_with_remediation(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    tool_name: str,
+) -> None:
+    """A direct ``tools/call`` (even as ``tenant_admin``) is denied with remediation.
+
+    The dispatcher denies before the registry lookup, so knowing the
+    name out-of-band cannot dispatch the verb. The message must name the
+    operator console and the concrete ``meho`` CLI verb so an agent that
+    reached for the removed tool is redirected to the human path.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call(tool_name, {}))
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS, body
+    message = body["error"]["message"]
+    assert "no MCP path" in message, message
+    for token in _REMEDIATION_TOKENS[tool_name]:
+        assert token in message, f"{tool_name}: remediation missing {token!r} — {message!r}"
+
+
+def test_no_tool_module_wires_a_decision_or_elevation_endpoint() -> None:
+    """Static guard: no tool module registers a tool AND references a forbidden endpoint.
+
+    Grep/static enforcement of the AC. A future PR that re-adds an MCP
+    tool whose handler resolves to an approval-decision
+    (``approve_request`` / ``reject_request`` /
+    ``resume_dispatch_after_approval``) or grant-elevation
+    (``AgentElevationCreate``) endpoint would reference one of those
+    symbols in the tool module, tripping this test — regardless of the
+    tool's wire name.
+    """
+    tools_dir = Path(mcp_tools_pkg.__path__[0])
+    patterns = {sym: re.compile(rf"\b{re.escape(sym)}\b") for sym in _FORBIDDEN_ENDPOINT_SYMBOLS}
+    offenders: list[str] = []
+    for path in sorted(tools_dir.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "register_mcp_tool(" not in source:
+            continue
+        hits = [sym for sym, pat in patterns.items() if pat.search(source)]
+        if hits:
+            offenders.append(f"{path.name}: {', '.join(hits)}")
+    assert offenders == [], (
+        "tool module(s) register a tool and reference an approval-decision / "
+        f"grant-elevation endpoint (human-only, #3155): {offenders}"
+    )

--- a/backend/tests/test_mcp_tool_agent_grants.py
+++ b/backend/tests/test_mcp_tool_agent_grants.py
@@ -3,8 +3,13 @@
 
 """Negative RBAC tests for ``meho_agents_grant_*`` MCP tools.
 
-G11.2-T6 (#819) registers five agent-grant MCP tools, each declared
-with ``required_role=TenantRole.TENANT_ADMIN`` on the
+G11.2-T6 (#819) registered five agent-grant MCP tools; #3155
+(Initiative #3153) de-registered the dedicated elevation verb
+(``meho_agents_grant_elevate``) — it has no MCP path under any claim
+set and is covered by ``test_mcp_human_only_surface.py``. This file
+covers the four surviving tools (``list`` / ``show`` / ``create`` /
+``revoke``), each declared with
+``required_role=TenantRole.TENANT_ADMIN`` on the
 :class:`~meho_backplane.mcp.registry.ToolDefinition`. Two gates
 enforce that role:
 
@@ -51,17 +56,17 @@ from tests.mcp_test_fixtures import (
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
 )
 
-#: Every ``meho_agents_grant_*`` tool registered by
+#: The surviving ``meho_agents_grant_*`` tools registered by
 #: :mod:`meho_backplane.mcp.tools.agent_grants`. The list pins the wire
 #: names so a rename surfaces as a test break (test_mcp_tool_agent_grants
 #: misses the tool) rather than as a silent coverage gap. Paired with the
 #: ``required_role=TENANT_ADMIN`` declaration on each
-#: :class:`~meho_backplane.mcp.registry.ToolDefinition`.
+#: :class:`~meho_backplane.mcp.registry.ToolDefinition`. The elevation
+#: verb is deliberately absent — see ``test_mcp_human_only_surface``.
 _GRANT_TOOL_NAMES: tuple[str, ...] = (
     "meho_agents_grant_list",
     "meho_agents_grant_show",
     "meho_agents_grant_create",
-    "meho_agents_grant_elevate",
     "meho_agents_grant_revoke",
 )
 
@@ -134,10 +139,8 @@ def test_operator_tools_call_grant_is_rejected_with_forbidden(
     [TenantRole.TENANT_ADMIN],
     indirect=True,
 )
-@pytest.mark.parametrize("tool_name", ["meho_agents_grant_create", "meho_agents_grant_elevate"])
 def test_admin_grant_for_unregistered_principal_is_rejected(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    tool_name: str,
 ) -> None:
     """A tenant-admin grant for an unregistered principal → -32602 naming the scope (#2489).
 
@@ -146,7 +149,9 @@ def test_admin_grant_for_unregistered_principal_is_rejected(
     tenant. The MCP boundary maps that :exc:`GrantValidationError` to
     JSON-RPC ``-32602`` ``INVALID_PARAMS``; the message names the
     ``principal_kind=agent`` enforcement scope so the caller learns why a
-    grant on a non-agent sub can never fire.
+    grant on a non-agent sub can never fire. The elevation variant that
+    used to share this case is gone (de-registered, #3155); ``create``
+    remains the sole agent-invocable grant-write path.
     """
     client, _op = client_with_operator
     arguments: dict[str, Any] = {
@@ -154,9 +159,7 @@ def test_admin_grant_for_unregistered_principal_is_rejected(
         "op_pattern": "*",
         "verdict": "needs-approval",
     }
-    if tool_name.endswith("elevate"):
-        arguments["expires_at"] = "2099-01-01T00:00:00+00:00"
-    resp = post_mcp(client, _tools_call(tool_name, arguments))
+    resp = post_mcp(client, _tools_call("meho_agents_grant_create", arguments))
     body = resp.json()
     assert "error" in body, body
     assert body["error"]["code"] == INVALID_PARAMS

--- a/backend/tests/test_mcp_tool_approvals.py
+++ b/backend/tests/test_mcp_tool_approvals.py
@@ -1,35 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Negative RBAC tests for ``meho_approvals_*`` MCP tools.
+"""Negative RBAC tests for the ``meho_approvals_*`` read MCP tools.
 
-G11.2-T5 (#818) registers four approval MCP tools, each declared
-with ``required_role=TenantRole.OPERATOR`` on the
-:class:`~meho_backplane.mcp.registry.ToolDefinition`. Two gates
-enforce that role (same as the agent-grants surface):
+G11.2-T5 (#818) registered four approval MCP tools; #3155 (Initiative
+#3153) de-registered the two decision verbs (``approve`` / ``reject``)
+— they have no MCP path under any claim set and are covered by
+``test_mcp_human_only_surface.py``. This file covers the surviving
+**read** tools, ``meho_approvals_list`` / ``meho_approvals_get``, each
+declared with ``required_role=TenantRole.OPERATOR``. Two gates enforce
+that role:
 
 * **List-time filter** in
   :func:`~meho_backplane.mcp.registry.all_tools_for`.
 * **Call-time re-check** in :mod:`~meho_backplane.mcp.handlers`.
 
-The existing service-layer suite (``test_approval_queue.py``)
-exercises
-:func:`~meho_backplane.operations.approval_queue.approve_request` /
-:func:`~meho_backplane.operations.approval_queue.reject_request`
-directly. This file closes the gap by asserting:
+This file asserts:
 
-* A ``read_only`` role does NOT see any ``meho_approvals_*`` tool in
-  the ``tools/list`` response (list-time filter intact).
-* A ``read_only`` direct ``tools/call`` against each tool name
+* A ``read_only`` role does NOT see either read tool in the
+  ``tools/list`` response (list-time filter intact).
+* A ``read_only`` direct ``tools/call`` against each read tool name
   returns the dispatcher's structured rejection — JSON-RPC
   ``-32602`` ``INVALID_PARAMS`` with "forbidden" in the message
   (call-time re-check intact).
 
 Out of scope:
 
-* Happy-path operator coverage — separate task; the re-dispatch +
-  audit + broadcast plumbing is exercised by the service-layer
-  suite.
+* Happy-path operator coverage — separate task.
+* The de-registered decision verbs — ``test_mcp_human_only_surface.py``.
 """
 
 from __future__ import annotations
@@ -39,7 +37,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.operator import Operator
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from tests.mcp_test_fixtures import (
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -48,16 +46,15 @@ from tests.mcp_test_fixtures import (
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
 )
 
-#: Every ``meho_approvals_*`` tool registered by
+#: The surviving ``meho_approvals_*`` read tools registered by
 #: :mod:`meho_backplane.mcp.tools.approvals`. Pinning the wire names
 #: catches both a rename (test breaks for a missing tool) and a new
 #: addition without RBAC review (the matrix below would not exercise
-#: the new tool until added here).
+#: the new tool until added here). The decision verbs (approve /
+#: reject) are deliberately absent — see ``test_mcp_human_only_surface``.
 _APPROVAL_TOOL_NAMES: tuple[str, ...] = (
     "meho_approvals_list",
     "meho_approvals_get",
-    "meho_approvals_approve",
-    "meho_approvals_reject",
 )
 
 
@@ -113,48 +110,3 @@ def test_read_only_tools_call_approval_is_rejected_with_forbidden(
     assert "error" in body, body
     assert body["error"]["code"] == INVALID_PARAMS
     assert "forbidden" in body["error"]["message"].lower(), body
-
-
-# ---------------------------------------------------------------------------
-# T6 (#1483) — self_approval_forbidden MCP error must carry the
-# APPROVAL_ALLOW_SELF_APPROVAL break-glass hint the exception constructs.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
-def test_self_approval_forbidden_message_carries_break_glass_hint(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``meho_approvals_approve`` self-approval error names ``APPROVAL_ALLOW_SELF_APPROVAL``.
-
-    The role gate passes for ``operator``; the handler then raises
-    :class:`SelfApprovalForbiddenError`, whose message already names the
-    break-glass flag. The MCP ``INVALID_PARAMS`` envelope must keep the
-    ``self_approval_forbidden`` token prefix **and** carry the env-var
-    hint so an agent/operator sees the escape hatch rather than a bare
-    token (#1483).
-    """
-    import uuid
-
-    from meho_backplane.mcp.tools import approvals as approvals_tool
-    from meho_backplane.operations.approval_queue import SelfApprovalForbiddenError
-
-    request_id = uuid.UUID("66666666-6666-6666-6666-666666666666")
-
-    async def _raise_self_approval(*_a: object, **_kw: object) -> None:
-        raise SelfApprovalForbiddenError(request_id, principal_sub="op-test")
-
-    monkeypatch.setattr(approvals_tool, "approve_request", _raise_self_approval)
-
-    client, _op = client_with_operator
-    resp = post_mcp(
-        client,
-        _tools_call("meho_approvals_approve", {"approval_request_id": str(request_id)}),
-    )
-    body = resp.json()
-    assert "error" in body, body
-    assert body["error"]["code"] == INVALID_PARAMS
-    message = body["error"]["message"]
-    assert message.startswith("self_approval_forbidden"), message
-    assert "APPROVAL_ALLOW_SELF_APPROVAL" in message, message

--- a/backend/tests/test_mcp_tools_list_shape_conventions.py
+++ b/backend/tests/test_mcp_tools_list_shape_conventions.py
@@ -192,7 +192,7 @@ def test_broadcast_watch_required_anyof_accepts_either_alias() -> None:
 
 @pytest.mark.parametrize(
     "tool_name",
-    ("meho_approvals_get", "meho_approvals_approve", "meho_approvals_reject"),
+    ("meho_approvals_get",),
 )
 def test_approvals_tools_expose_approval_request_id_canonical_name(
     tool_name: str,
@@ -204,6 +204,9 @@ def test_approvals_tools_expose_approval_request_id_canonical_name(
     `audit_id`). The v0.8.0 wire shape used a bare `id` on the
     approvals tools — the only sibling-drift remaining at that point.
     The bare `id` is retained as a deprecated alias for one cycle.
+    `meho_approvals_get` is the sole surviving approvals tool that
+    names this UUID — the decision verbs (approve / reject) were
+    de-registered from MCP (#3155).
     """
     properties = _properties(tool_name)
     assert "approval_request_id" in properties, (

--- a/backend/tests/test_secret_move_approval.py
+++ b/backend/tests/test_secret_move_approval.py
@@ -680,52 +680,11 @@ async def test_decide_run_bound_no_ops_when_waiter_already_claimed(
     assert fake.secrets.kv.v2.put_calls == []
 
 
-@pytest.mark.asyncio
-async def test_mcp_approve_redispatches_run_bound_move_when_claim_free(
-    monkeypatch: pytest.MonkeyPatch,
-    _registered_secret_broker_op: None,
-    captured_broadcasts: list[BroadcastEvent],
-) -> None:
-    """MCP by-id approve re-dispatches a run-bound approval on a free claim (#2293).
-
-    The MCP ``meho_approvals_approve`` twin of the ``/decide`` waiter-gone
-    fallback: the run_id-is-not-None skip is gone, so the approve wins the
-    free exactly-one-resumer claim and executes the move once, returning the
-    outcome under ``dispatch``.
-    """
-    from meho_backplane.mcp.tools.approvals import _approve_handler
-
-    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
-    request_id = await _park_run_bound_move(requester_sub="agent:requester")
-
-    decider = _make_operator(sub="operator:mcp-decider")
-    result = await _approve_handler(decider, {"approval_request_id": str(request_id)})
-
-    assert result["dispatch"]["status"] == "ok", result
-    assert len(fake.secrets.kv.v2.put_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_mcp_approve_run_bound_no_ops_when_waiter_already_claimed(
-    monkeypatch: pytest.MonkeyPatch,
-    _registered_secret_broker_op: None,
-    captured_broadcasts: list[BroadcastEvent],
-) -> None:
-    """MCP approve no-ops (no second write) when the waiter already claimed (#2293).
-
-    Waiter-alive dedup on the MCP surface: the in-process waiter has already
-    won the claim and executed the move, so the MCP approve loses the claim
-    and reports ``dispatch.status="already_resumed"`` with no second write.
-    """
-    from meho_backplane.mcp.tools.approvals import _approve_handler
-    from meho_backplane.operations.approval_queue import claim_resume
-
-    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
-    request_id = await _park_run_bound_move(requester_sub="agent:requester")
-    assert await claim_resume(request_id) is True
-
-    decider = _make_operator(sub="operator:mcp-decider")
-    result = await _approve_handler(decider, {"approval_request_id": str(request_id)})
-
-    assert result["dispatch"]["status"] == "already_resumed", result
-    assert fake.secrets.kv.v2.put_calls == []
+# NOTE (#3155): the MCP-approve twins of the two ``/decide`` run-bound
+# tests above were removed with the MCP approve tool — approving a parked
+# operation is human-only now (console/CLI), with no ``meho_approvals_approve``
+# handler. The exactly-one-resumer claim behaviour they asserted stays
+# covered by the ``/decide`` REST tests
+# (``test_decide_redispatches_run_bound_move_when_claim_free`` and
+# ``test_decide_run_bound_no_ops_when_waiter_already_claimed``) on the
+# surface that still exists.

--- a/docs/codebase/agent-permission-grants.md
+++ b/docs/codebase/agent-permission-grants.md
@@ -96,7 +96,9 @@ Mirrors the G5.2 memory-expiry sweeper pattern verbatim.
 
 ## MCP surface
 
-Five tools under `meho_agents_grant_*`: `list`, `show`, `create`, `elevate`, `revoke`. Registered via `register_mcp_tool` (auto-discovered by `eager_import_mcp_modules`).
+Four tools under `meho_agents_grant_*`: `list`, `show`, `create`, `revoke`. Registered via `register_mcp_tool` (auto-discovered by `eager_import_mcp_modules`).
+
+The dedicated elevation verb — `meho_agents_grant_elevate` — has **no MCP path under any claim set** (#3155, Initiative #3153): granting a time-bounded privilege elevation is a human-only operator action, not agent-invocable. It stays on the REST / CLI / console surfaces above (`POST /api/v1/agents/grants/elevate`, `meho agent grant elevate`), unchanged. Its wire name is pinned in `backend/src/meho_backplane/mcp/human_only.py`, so a `tools/call` on it is denied with a remediation naming the CLI/console path. (Note: `meho_agents_grant_create` accepts an `expires_at` and can create a time-bounded grant; it stays on the operator plane per the T1 surface classification — only the dedicated `elevate` verb is removed.)
 
 ## CLI surface
 

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -368,17 +368,18 @@ Two changes close that gap, scoped to the **direct**-op path:
    stored target by id (G11.7-T1 fail-closed semantics preserved) and
    re-dispatches with `dispatch(..., _approved=True)`, falling back to
    the stored `request.params` when the surface supplies none. REST
-   `/approve` (caller params, hash-verified), REST `/decide`, and the
-   MCP `meho_approvals_approve` tool all route through it. `/decide` and
-   the MCP tool return the dispatch outcome (`dispatch_*` fields /
-   `dispatch` block) alongside the decision.
+   `/approve` (caller params, hash-verified) and REST `/decide` both
+   route through it; `/decide` returns the dispatch outcome (`dispatch_*`
+   fields) alongside the decision. (The decision itself is REST / CLI /
+   console only — there is no MCP approve verb; see the MCP section
+   below.)
 
 **The `run_id` gate (no double-execution / agent-run regression
-guard).** `/decide` and the MCP approve tool re-dispatch **only when
+guard).** `/decide` re-dispatches **only when
 `run_id IS NULL`** — i.e. a direct operator op. An **agent-run** request
 (`run_id` set) is still resumed in-process by the agent runtime off the
 `approval.approved` broadcast (the must-not-regress path); re-dispatching
-it from `/decide`/MCP too would execute the op twice. So the agent-run
+it from `/decide` too would execute the op twice. So the agent-run
 resume path is untouched: it keeps its in-memory params, ignores the new
 column, and remains the sole re-dispatcher for `run_id`-bearing requests.
 
@@ -389,7 +390,7 @@ the same row hits the already-decided guard (409 / `not_pending`), so the
 stored params drive exactly one execution.
 
 **Pre-0036 rows.** A row parked before migration 0036 has `params IS
-NULL`. Approving it via `/decide`/MCP (no in-band params) finds nothing
+NULL`. Approving it via `/decide` (no in-band params) finds nothing
 to re-dispatch, so `resume_dispatch_after_approval` **fails closed** with
 a structured `denied` result naming the gap — the operator resumes it via
 REST `/approve` + params, exactly as before 0036.
@@ -639,22 +640,25 @@ the same grant.
 
 ### MCP (`backend/src/meho_backplane/mcp/tools/approvals.py`)
 
-Four `meho_approvals_*` tools (all `TenantRole.OPERATOR`-gated):
+Two **read** `meho_approvals_*` tools (both `TenantRole.OPERATOR`-gated):
 
 - `meho_approvals_list` — `status` filter (`pending` default), `limit`/`offset`.
 - `meho_approvals_get` — full detail by id.
-- `meho_approvals_approve` — operator-decision path (status flip + audit +
-  `approval.approved` broadcast; **no `params` required** —
-  `approve_request` skips the hash check when called without params). For
-  an approved **direct** op (`run_id IS NULL`) it then re-dispatches using
-  the stored params (#1503) and returns the outcome under `dispatch`; for
-  an agent-run request the in-process agent runtime resumes the op off the
-  broadcast, so the tool only records the decision.
-- `meho_approvals_reject` — same shape; optional `reason`.
 
-RBAC is enforced at two layers: the MCP registry filter hides write
-tools from non-admins in `tools/list`, and the dispatcher re-checks
-`required_role` at `tools/call`.
+The decision verbs — `approve` and `reject` — have **no MCP path under
+any claim set** (#3155, Initiative #3153). Approving or rejecting a
+parked operation is a *human* decision (v0.1-spec §7); a model session
+that parked an op must not hold the button that clears its own gate (the
+self-approval hole `#3143` F4 surfaced). They stay on the REST / CLI /
+console surfaces above, unchanged. Their wire names are pinned in
+`backend/src/meho_backplane/mcp/human_only.py`, so a `tools/call` on
+`meho_approvals_approve` / `meho_approvals_reject` is denied before the
+registry lookup with a remediation naming `meho approvals approve|reject`
+and the operator console.
+
+RBAC on the surviving read tools is enforced at two layers: the MCP
+registry filter hides them from non-operators in `tools/list`, and the
+dispatcher re-checks `required_role` at `tools/call`.
 
 ### CLI (`cli/internal/cmd/approvals/`)
 

--- a/docs/cross-repo/github-connector.md
+++ b/docs/cross-repo/github-connector.md
@@ -588,12 +588,15 @@ approve / reject with a free-form reason.
 
 ### Operator path — MCP
 
-The MCP tool surface exposes
-`meho_approvals_list`, `meho_approvals_get`,
-`meho_approvals_approve`, `meho_approvals_reject` for
-agent-driven approval workflows (a senior operator's agent
-approving a junior operator's agent's request). Same shape as
-the CLI verbs; the agent runs them under operator identity.
+The MCP tool surface exposes the **read** tools
+`meho_approvals_list` and `meho_approvals_get` so an agent can
+surface and inspect pending requests. The **decision** verbs
+(`meho_approvals_approve` / `meho_approvals_reject`) have no MCP
+path under any claim set (#3155): approving or rejecting a parked
+operation is a human decision (v0.1-spec §7), made on the REST /
+CLI / console surfaces — a model holding the approve button would
+collapse the very gate the approval exists to enforce. An agent
+reads the queue over MCP; a human decides it.
 
 ### Approval bypass for read-only first-day operators
 

--- a/examples/r2-approval-gate/README.md
+++ b/examples/r2-approval-gate/README.md
@@ -265,18 +265,22 @@ execution on the broadcast event, not on the REST round-trip.
 
 ### MCP
 
-For operators driving Claude Code (or any other MCP-aware client):
+For operators driving Claude Code (or any other MCP-aware client),
+the MCP surface exposes the **read** half only:
 
 ```
 meho_approvals_list                            # pending requests
 meho_approvals_get(request_id="…")             # inspect proposed_effect
-meho_approvals_approve(request_id="…")         # approve
-meho_approvals_reject(request_id="…", reason="…")  # reject
 ```
 
-Same wire format as the REST surface; tools auto-load when the
-operator's MCP client connects to `$MEHO_INSTANCE/mcp`. Tool
-definitions live in [`mcp/tools/approvals.py`][mcp].
+The **decision** verbs (approve / reject) have no MCP path under any
+claim set (#3155): approving or rejecting a parked operation is a human
+decision (v0.1-spec §7), so a model session — even one holding an
+elevated operator token — cannot approve its own parked op. Decide via
+the CLI (`meho approvals approve|reject <request-id>`) or the operator
+console instead; a `tools/call` on `meho_approvals_approve` /
+`meho_approvals_reject` returns a not-found error naming those paths.
+Read-tool definitions live in [`mcp/tools/approvals.py`][mcp].
 
 ### CLI
 


### PR DESCRIPTION
## Summary
- De-registers three human-only decision verbs from the MCP tool surface — `meho_approvals_approve`, `meho_approvals_reject`, `meho_agents_grant_elevate` — so they have **no MCP path under any claim set** (including an elevated `tenant_admin` token). Closes the self-approval hole (#3143 F4): a model session that parked an op can no longer hold the button that clears its own gate (v0.1-spec §7).
- Adds `mcp/human_only.py` as the single source of truth. `handle_tools_call` consults it **before** the registry lookup, so an accidental future re-registration can never make these callable; a `tools/call` on any of the three is denied (`-32602`) with a remediation naming the operator console + the concrete `meho` CLI verb.
- Keeps the read halves (`meho_approvals_list` / `_get`) and the operator-plane grant verbs (`list` / `show` / `create` / `revoke`). REST / CLI / console approval + grant paths are untouched.
- Adds a static/grep guard test: fails if any tool module both registers a tool and references an approval-decision (`approve_request` / `reject_request` / `resume_dispatch_after_approval`) or grant-elevation (`AgentElevationCreate`) endpoint — so a re-add fails CI regardless of the wire name.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean on all 14 changed files
- [x] `mypy src/meho_backplane/mcp/` — clean (48 files)
- [x] `code-quality.py --diff` — 0 blockers (1 pre-existing warning in `_publish_mcp_event`, untouched)
- [x] **AC1** absent from `tools/list` for read_only/operator/tenant_admin + registry-absence (claim-independent) + `tools/call` returns remediation naming CLI/console — `tests/test_mcp_human_only_surface.py`
- [x] **AC2** static re-add guard — `test_no_tool_module_wires_a_decision_or_elevation_endpoint`
- [x] **AC3** `meho_approvals_list` / `_get` remain — verified at runtime + `test_mcp_tool_approvals.py`
- [x] **AC4** REST/CLI/service suites green — `test_approval_queue`, `test_secret_move_approval`, `test_examples_r2_approval_gate`, `test_api_v1_agent_grants`, `test_ui_agent_grants`, `test_agent_grants` (164 + 105 targeted tests pass)
- [x] Removed two MCP-approve twin tests; their `/decide` REST equivalents preserve exactly-one-resumer + stored-params coverage

## Docs
- `docs/codebase/approvals.md`, `docs/codebase/agent-permission-grants.md`, `docs/cross-repo/github-connector.md`, `examples/r2-approval-gate/README.md` updated to reflect the read-only MCP surface + human-only decision path.

## Out of scope
- Sibling #3154 owns the claim-driven `tools/list` surface filter and `docs/codebase/mcp.md` — deliberately not touched here to keep the serial-merge rebase trivial (no surface-classification apparatus introduced).
- Adjacent findings (not fixed): stale MCP-clause in `agents/grant_schemas.py:103` docstring (REST model — would ripple to `cli/api/openapi.json`); stale `_approve_handler` prose in `tests/test_mcp_audit.py:200`; pre-existing size warning on `handlers.py::_publish_mcp_event`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3155
