### PR TITLE
feat(connectors): pfsense write ops — named gateway + static-route add

### DIFF
--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -192,6 +192,20 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "more hosts on a segment. Rows carry the client IP, MAC, hostname, "
         "lease start/end, and effective binding state."
     ),
+    "routing": (
+        "Use for pfSense routing-plane provisioning writes: appending a "
+        "named gateway (``pfsense.gateway.add``) or a static route "
+        "(``pfsense.route.static.add``) to ``config.xml``. Call "
+        "``pfsense.gateway.add`` to define a next-hop -- including a "
+        "pre-staged one (``monitor_disable``) whose upstream device does "
+        "not exist yet -- then ``pfsense.route.static.add`` to point a "
+        "CIDR at it. Both are idempotent (re-adding an existing gateway "
+        "name or route network is a reported no-op) and surgical (they "
+        "touch only the gateway / static-route config, never interfaces), "
+        "so they are safe against a perimeter firewall carrying the "
+        "operator's own access path. Read the current state first with "
+        "``pfsense.gateway.list`` / ``pfsense.config.show``."
+    ),
 }
 
 
@@ -609,6 +623,42 @@ class PfSenseConnector(SshConnector):
         )
 
         return await _pfsense_dhcp_leases(self, target, params, operator)
+
+    async def gateway_add(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.gateway.add`` (#3090).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_write.pfsense_gateway_add`.
+        Guarded + idempotent additive config write (``safety_level=caution``).
+        """
+        from meho_backplane.connectors.pfsense.ops_write import (
+            pfsense_gateway_add as _pfsense_gateway_add,
+        )
+
+        return await _pfsense_gateway_add(self, target, params, operator)
+
+    async def route_static_add(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.route.static.add`` (#3090).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_write.pfsense_route_static_add`.
+        Guarded + idempotent additive config write (``safety_level=caution``).
+        """
+        from meho_backplane.connectors.pfsense.ops_write import (
+            pfsense_route_static_add as _pfsense_route_static_add,
+        )
+
+        return await _pfsense_route_static_add(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/pfsense/ops.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops.py
@@ -121,20 +121,24 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
     ops: ``pfsense.version``, ``pfsense.firewall.rules``,
     ``pfsense.firewall.state``, ``pfsense.nat.rules``,
     ``pfsense.interface.list``, ``pfsense.gateway.list``,
-    ``pfsense.config.show``, and ``pfsense.dhcp.leases`` (#2849)).
-    Nine ops total -- the T2 read surface plus the DHCP-lease read op.
+    ``pfsense.config.show``, and ``pfsense.dhcp.leases`` (#2849)) +
+    ``WRITE_OPS`` (``pfsense.gateway.add`` and
+    ``pfsense.route.static.add``, #3090). Eleven ops total.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
-    :class:`PfSenseOp` + ``_PFSENSE_ABOUT_OP``, then imports the T2
-    read ops from :mod:`meho_backplane.connectors.pfsense.ops_read`.
+    :class:`PfSenseOp` + ``_PFSENSE_ABOUT_OP``, then imports the read
+    ops from :mod:`meho_backplane.connectors.pfsense.ops_read` and the
+    write ops from :mod:`meho_backplane.connectors.pfsense.ops_write`.
     The arrangement keeps the canary op co-located with the dataclass
-    while the larger read surface lives in its own module next to its
-    parsers. Mirrors :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
+    while the larger read / write surfaces live in their own modules
+    next to their parsers. Mirrors
+    :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
     """
     from meho_backplane.connectors.pfsense.ops_read import READ_OPS
+    from meho_backplane.connectors.pfsense.ops_write import WRITE_OPS
 
-    return (_PFSENSE_ABOUT_OP, *READ_OPS)
+    return (_PFSENSE_ABOUT_OP, *READ_OPS, *WRITE_OPS)
 
 
 #: The ops :class:`PfSenseConnector` registers at lifespan startup.
@@ -142,8 +146,9 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
 #: (``pfsense.version``, ``pfsense.firewall.rules``,
 #: ``pfsense.firewall.state``, ``pfsense.nat.rules``,
 #: ``pfsense.interface.list``, ``pfsense.gateway.list``,
-#: ``pfsense.config.show``); #2849 adds ``pfsense.dhcp.leases`` --
-#: 9 ops total. The shape of each
+#: ``pfsense.config.show``); #2849 adds ``pfsense.dhcp.leases``; #3090
+#: adds the first write ops (``pfsense.gateway.add``,
+#: ``pfsense.route.static.add``) -- 11 ops total. The shape of each
 #: follow-on PR is "import a new module-level tuple and splat it
 #: into :data:`PFSENSE_OPS` via :func:`_pfsense_ops`" -- the
 #: registration walk in

--- a/backend/src/meho_backplane/connectors/pfsense/ops_write.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_write.py
@@ -1,0 +1,775 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: declarative op module (parsers + small handlers + agent-facing
+# op metadata / JSON schemas / llm_instructions) mirroring the ops_read.py sibling's
+# single-module-per-op-group convention; all functions are small + low-complexity.
+
+"""pfSense write ops -- named gateway + static-route add (#3090).
+
+Adds the first two mutating typed ops to :class:`PfSenseConnector`:
+
+* ``pfsense.gateway.add`` -- append a named ``gateway_item`` (interface,
+  gateway IP, name, optional ``monitor_disable`` for a pre-staged gateway
+  whose upstream device does not exist yet) to ``config.xml`` and call
+  ``write_config()``.
+* ``pfsense.route.static.add`` -- append a ``staticroutes/route`` entry
+  (CIDR network -> gateway name) to ``config.xml``, then ``write_config()``
+  followed by ``system_routing_configure()`` to apply the new route.
+
+The config mutation runs through pfSense's ``pfSsh.php playback`` idiom --
+the same mechanism the read op ``pfsense.gateway.list`` already uses to
+read live ``dpinger`` status (``pfSsh.php playback gatewaystatus``).
+``pfSsh.php playback`` resolves its argument through ``basename()`` against
+``/etc/phpshellsessions/``, so the write path stages a raw-PHP fragment
+into that directory, plays it back, and removes it. The fragment is
+prepended by ``playback_text`` with ``require_once`` of the pfSense config
+libraries and ``eval``-ed inside a function scope, so the fragment opens
+with ``global $config;`` (mirroring the shipped ``gatewaystatus`` script's
+``global $argv;``) and carries no ``<?php`` tag and no trailing ``exec``.
+
+Guarded + idempotent
+--------------------
+
+Both handlers read ``/cf/conf/config.xml`` first (via the same
+``cat /cf/conf/config.xml`` the read ops use) and parse the relevant block
+before staging any change. Adding a gateway whose ``name`` already exists,
+or a route whose (canonicalised) ``network`` already exists, is reported as
+a structured already-present outcome (``existed_before=True``,
+``applied=False``, ``existing`` carrying the pre-existing row) and stages
+no playback -- no duplicate is ever appended. A gateway add that is
+actually applied is read back afterwards; a fragment that failed to persist
+(non-zero playback exit, or a silent ``write_config`` failure that leaves
+the entry absent) raises rather than reporting a false success.
+
+Injection safety
+----------------
+
+Every operator-supplied value is validated and re-serialised before it
+reaches the PHP fragment: names/interfaces are matched against a strict
+character-class allowlist, IPs are parsed and re-emitted through
+:mod:`ipaddress`, and CIDRs are normalised to their canonical network
+form. The validated tokens carry none of the shell metacharacters or PHP
+string-literal terminators an interpolation attack would need; on top of
+that the fragment is transmitted inside a quoted heredoc (no shell
+expansion) and each value is emitted through :func:`_php_squote`
+(backslash + single-quote escaped). Anything outside the allowlist is
+rejected before a single SSH round-trip.
+
+Surgical contract
+-----------------
+
+The handlers touch only ``gateways/gateway_item`` and
+``staticroutes/route``. They never re-enumerate or reconfigure interfaces:
+the perimeter pfSense frequently carries the operator's own access path, so
+an interface stun would sever the very session issuing the change.
+``pfsense.route.static.add`` calls ``system_routing_configure()`` (route
+table apply only); ``pfsense.gateway.add`` calls neither that nor any
+interface apply -- a pre-staged gateway is inert config until a route or
+policy references it.
+
+References
+----------
+
+* Task: #3090.
+* Read-op precedent: G3.7 (#844 / #847 / #850);
+  :mod:`meho_backplane.connectors.pfsense.ops_read`.
+* Classification precedent (additive config write, ``caution`` /
+  no-approval): :mod:`meho_backplane.connectors.bind9.ops_record`
+  (``bind9.record.add``).
+* pfSense PHP shell:
+  https://docs.netgate.com/pfsense/en/latest/development/php-shell.html
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import TYPE_CHECKING, Any
+
+from defusedxml.ElementTree import ParseError, fromstring
+
+from meho_backplane.connectors.pfsense.ops import PfSenseOp
+from meho_backplane.connectors.pfsense.ops_read import parse_gateways_xml
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.pfsense.connector import PfSenseConnector
+
+__all__ = [
+    "WRITE_OPS",
+    "parse_static_routes_xml",
+    "pfsense_gateway_add",
+    "pfsense_route_static_add",
+]
+
+# pfSense stages playback scripts under this directory; ``pfSsh.php
+# playback <name>`` resolves the argument through ``basename()`` against
+# it, so only a bare filename (no path) is ever accepted.
+_PHPSHELLSESSIONS_DIR = "/etc/phpshellsessions"
+
+# Quoted heredoc delimiter -- the single quotes make the remote shell
+# treat the body verbatim (no ``$config`` / backtick expansion), so the
+# PHP fragment crosses the wire byte-for-byte.
+_HEREDOC_DELIM = "MEHO_PFSENSE_PLAYBACK_EOF"
+
+# Strict input allowlists. pfSense gateway names use alphanumerics, dash,
+# and underscore (its own defaults look like ``WAN_DHCP``); logical
+# interface names are alphanumerics + underscore (``wan`` / ``lan`` /
+# ``opt1``). Anything else is rejected before any SSH round-trip.
+_GATEWAY_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_INTERFACE_RE = re.compile(r"^[A-Za-z0-9_]{1,32}$")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_gateway_name(value: Any) -> str:
+    """Return *value* if it is a valid pfSense gateway name, else raise.
+
+    Allowlist: ``^[A-Za-z0-9_-]{1,64}$`` (alphanumeric, dash, underscore).
+    """
+    if not isinstance(value, str) or not _GATEWAY_NAME_RE.match(value):
+        raise ValueError(
+            "gateway name must match ^[A-Za-z0-9_-]{1,64}$ "
+            f"(alphanumeric, dash, underscore); got {value!r}"
+        )
+    return value
+
+
+def _validate_interface(value: Any) -> str:
+    """Return *value* if it is a valid pfSense logical interface, else raise.
+
+    Allowlist: ``^[A-Za-z0-9_]{1,32}$`` -- the internal pfSense interface
+    handle (``wan`` / ``lan`` / ``opt1``), not the OS device name.
+    """
+    if not isinstance(value, str) or not _INTERFACE_RE.match(value):
+        raise ValueError(
+            "interface must match ^[A-Za-z0-9_]{1,32}$ "
+            "(pfSense logical interface handle, e.g. 'wan', 'lan', 'opt1'); "
+            f"got {value!r}"
+        )
+    return value
+
+
+def _validate_gateway_ip(value: Any) -> tuple[str, str]:
+    """Parse *value* as an IP address; return ``(canonical_ip, ipprotocol)``.
+
+    ``ipprotocol`` is ``inet`` for IPv4 and ``inet6`` for IPv6 -- the value
+    pfSense stores on ``gateway_item`` to select the address family.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"gateway must be a string IP address; got {value!r}")
+    try:
+        addr = ipaddress.ip_address(value.strip())
+    except ValueError as exc:
+        raise ValueError(f"gateway must be a valid IPv4 or IPv6 address; got {value!r}") from exc
+    return str(addr), ("inet6" if addr.version == 6 else "inet")
+
+
+def _validate_network_cidr(value: Any) -> str:
+    """Parse *value* as a CIDR network; return its canonical string form.
+
+    ``strict=False`` accepts a host-bit-set input (``10.9.0.5/24``) and
+    canonicalises it to the network address (``10.9.0.0/24``) -- the form a
+    static route stores and the form idempotency compares against.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"network must be a string CIDR; got {value!r}")
+    try:
+        net = ipaddress.ip_network(value.strip(), strict=False)
+    except ValueError as exc:
+        raise ValueError(
+            f"network must be a valid CIDR, e.g. '10.9.0.0/24'; got {value!r}"
+        ) from exc
+    return str(net)
+
+
+def _php_squote(value: str) -> str:
+    """Return *value* as a single-quoted PHP string literal.
+
+    Defence-in-depth: the callers already validate every interpolated value
+    against a metacharacter-free allowlist, so the escape is a no-op in
+    practice, but emitting through here keeps the fragment safe even if a
+    future caller widens an allowlist.
+    """
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
+# ---------------------------------------------------------------------------
+# config.xml parsing (idempotency guard)
+# ---------------------------------------------------------------------------
+
+
+def parse_static_routes_xml(xml_text: str) -> list[dict[str, Any]]:
+    """Parse the ``<staticroutes>`` block from ``/cf/conf/config.xml``.
+
+    Accepts either the full ``config.xml`` text or a ``<staticroutes>``
+    snippet. Returns one dict per ``<route>`` child with ``network``,
+    ``gateway``, and ``descr`` keys (``None`` for a missing tag). Returns an
+    empty list on any parse failure. Mirrors
+    :func:`meho_backplane.connectors.pfsense.ops_read.parse_gateways_xml`.
+
+    >>> xml = (
+    ...     "<staticroutes><route>"
+    ...     "<network>10.9.0.0/24</network><gateway>LAB_GW</gateway>"
+    ...     "</route></staticroutes>"
+    ... )
+    >>> parse_static_routes_xml(xml)[0]["network"]
+    '10.9.0.0/24'
+    """
+    if not xml_text.strip():
+        return []
+    try:
+        root = fromstring(xml_text)
+    except ParseError:
+        return []
+    sr_root = root if root.tag == "staticroutes" else root.find(".//staticroutes")
+    if sr_root is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in sr_root.findall("route"):
+        rows.append(
+            {
+                "network": _child_text(item, "network"),
+                "gateway": _child_text(item, "gateway"),
+                "descr": _child_text(item, "descr"),
+            }
+        )
+    return rows
+
+
+def _child_text(element: Any, tag: str) -> str | None:
+    """Return the text of *tag* under *element*, or ``None``.
+
+    *element* is a ``defusedxml``-parsed node; defusedxml ships no type
+    stubs, so it surfaces as ``Any`` (annotating it with the stdlib
+    ``Element`` type would re-introduce the ``xml.etree`` import Semgrep
+    flags as an XXE vector).
+    """
+    child = element.find(tag)
+    return child.text if child is not None else None
+
+
+def _find_gateway(xml_text: str, name: str) -> dict[str, Any] | None:
+    """Return the ``gateway_item`` row named *name*, or ``None``."""
+    for row in parse_gateways_xml(xml_text):
+        if row.get("name") == name:
+            return row
+    return None
+
+
+def _find_static_route(xml_text: str, network: str) -> dict[str, Any] | None:
+    """Return the ``route`` row whose canonical network equals *network*.
+
+    Both the stored network and the query are canonicalised before
+    comparison, so ``10.9.0.5/24`` and ``10.9.0.0/24`` match the same route.
+    """
+    for row in parse_static_routes_xml(xml_text):
+        stored = row.get("network")
+        if not isinstance(stored, str):
+            continue
+        try:
+            if str(ipaddress.ip_network(stored.strip(), strict=False)) == network:
+                return row
+        except ValueError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# pfSsh.php playback fragment construction + apply
+# ---------------------------------------------------------------------------
+
+
+def _build_gateway_playback(
+    *,
+    name: str,
+    interface: str,
+    gateway: str,
+    ipprotocol: str,
+    monitor_disable: bool,
+) -> str:
+    """Return the raw-PHP playback fragment that appends one gateway_item."""
+    lines = [
+        "global $config;",
+        "if (!is_array($config['gateways'])) { $config['gateways'] = array(); }",
+        "if (!is_array($config['gateways']['gateway_item'])) "
+        "{ $config['gateways']['gateway_item'] = array(); }",
+        "$gw = array();",
+        f"$gw['interface'] = {_php_squote(interface)};",
+        f"$gw['gateway'] = {_php_squote(gateway)};",
+        f"$gw['name'] = {_php_squote(name)};",
+        "$gw['weight'] = '1';",
+        f"$gw['ipprotocol'] = {_php_squote(ipprotocol)};",
+        f"$gw['descr'] = {_php_squote('meho: pre-staged gateway ' + name)};",
+    ]
+    if monitor_disable:
+        lines.append("$gw['monitor_disable'] = '';")
+    lines.append("$config['gateways']['gateway_item'][] = $gw;")
+    lines.append(f"write_config({_php_squote('meho: add gateway ' + name)});")
+    return "\n".join(lines) + "\n"
+
+
+def _build_route_playback(*, network: str, gateway: str) -> str:
+    """Return the raw-PHP playback fragment that appends one static route."""
+    lines = [
+        "global $config;",
+        "if (!is_array($config['staticroutes'])) { $config['staticroutes'] = array(); }",
+        "if (!is_array($config['staticroutes']['route'])) "
+        "{ $config['staticroutes']['route'] = array(); }",
+        "$route = array();",
+        f"$route['network'] = {_php_squote(network)};",
+        f"$route['gateway'] = {_php_squote(gateway)};",
+        f"$route['descr'] = {_php_squote('meho: static route ' + network)};",
+        "$config['staticroutes']['route'][] = $route;",
+        f"write_config({_php_squote('meho: add static route ' + network)});",
+        "system_routing_configure();",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _install_script_command(script_name: str, script_body: str) -> str:
+    """Return the shell command that stages *script_body* for playback.
+
+    A quoted-delimiter heredoc writes the fragment verbatim into
+    ``/etc/phpshellsessions/<script_name>``; the single-quoted delimiter
+    stops the remote shell expanding ``$config`` or anything else.
+    """
+    path = f"{_PHPSHELLSESSIONS_DIR}/{script_name}"
+    return f"cat > {path} <<'{_HEREDOC_DELIM}'\n{script_body}{_HEREDOC_DELIM}\n"
+
+
+async def _read_config_xml(self: PfSenseConnector, target: Any, operator: Operator | None) -> str:
+    """Read ``/cf/conf/config.xml`` and return its text; raise on read failure."""
+    proc = await self._run_command(target, "cat /cf/conf/config.xml", operator=operator)
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    content = stdout if isinstance(stdout, str) else ""
+    if proc.exit_status != 0 and not content.strip():
+        raise RuntimeError(f"cat /cf/conf/config.xml exit {proc.exit_status}")
+    return content
+
+
+async def _apply_playback(
+    self: PfSenseConnector,
+    target: Any,
+    *,
+    script_name: str,
+    script_body: str,
+    operator: Operator | None,
+) -> None:
+    """Stage, play back, and clean up a pfSsh.php playback fragment.
+
+    Raises :exc:`RuntimeError` when staging or playback exits non-zero. The
+    staged script is removed in a ``finally`` so a failed playback never
+    leaves the fragment behind.
+    """
+    path = f"{_PHPSHELLSESSIONS_DIR}/{script_name}"
+    staged = await self._run_command(
+        target, _install_script_command(script_name, script_body), operator=operator
+    )
+    if staged.exit_status != 0:
+        raise RuntimeError(
+            f"failed to stage pfSense playback script {path!r}: exit {staged.exit_status}"
+        )
+    try:
+        played = await self._run_command(
+            target, f"pfSsh.php playback {script_name}", operator=operator
+        )
+    finally:
+        await self._run_command(target, f"rm -f {path}", operator=operator)
+    if played.exit_status != 0:
+        raise RuntimeError(f"pfSsh.php playback {script_name!r} failed: exit {played.exit_status}")
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def pfsense_gateway_add(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.gateway.add`` -- guarded, idempotent gateway write.
+
+    Sequence: validate inputs -> read ``config.xml`` -> if a gateway with
+    the same ``name`` already exists, return the already-present outcome
+    without staging anything -> otherwise stage + play back the append
+    fragment, then read ``config.xml`` back and confirm the row landed.
+
+    Returns ``{op_class, resource, name, interface, gateway, ipprotocol,
+    monitor_disable, existed_before, applied, existing}``. ``existing`` is
+    the pre-existing ``gateway_item`` row when ``existed_before`` is true
+    (surfacing a name collision whose interface / IP may differ from the
+    request), else ``None``.
+    """
+    name = _validate_gateway_name(params.get("name"))
+    interface = _validate_interface(params.get("interface"))
+    gateway, ipprotocol = _validate_gateway_ip(params.get("gateway"))
+    monitor_disable = bool(params.get("monitor_disable", False))
+
+    before = await _read_config_xml(self, target, operator)
+    existing = _find_gateway(before, name)
+    result: dict[str, Any] = {
+        "op_class": "write",
+        "resource": "gateway",
+        "name": name,
+        "interface": interface,
+        "gateway": gateway,
+        "ipprotocol": ipprotocol,
+        "monitor_disable": monitor_disable,
+    }
+    if existing is not None:
+        return {**result, "existed_before": True, "applied": False, "existing": existing}
+
+    body = _build_gateway_playback(
+        name=name,
+        interface=interface,
+        gateway=gateway,
+        ipprotocol=ipprotocol,
+        monitor_disable=monitor_disable,
+    )
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_gateway_add_{name}",
+        script_body=body,
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    if _find_gateway(after, name) is None:
+        raise RuntimeError(
+            f"gateway {name!r} was not present in config.xml after write_config; "
+            "the pfSsh.php playback did not persist"
+        )
+    return {**result, "existed_before": False, "applied": True, "existing": None}
+
+
+async def pfsense_route_static_add(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.route.static.add`` -- guarded, idempotent route write.
+
+    Sequence: validate inputs -> read ``config.xml`` -> require the named
+    gateway to already exist (a route to an undefined gateway is a
+    guaranteed misconfiguration; pre-stage it with ``pfsense.gateway.add``
+    first) -> if a route with the same canonical ``network`` already exists,
+    return the already-present outcome without staging anything -> otherwise
+    stage + play back the append fragment (which also runs
+    ``system_routing_configure()``), then read ``config.xml`` back and
+    confirm the row landed.
+
+    Returns ``{op_class, resource, network, gateway, existed_before,
+    applied, existing}``.
+    """
+    network = _validate_network_cidr(params.get("network"))
+    gateway = _validate_gateway_name(params.get("gateway"))
+
+    before = await _read_config_xml(self, target, operator)
+    if _find_gateway(before, gateway) is None:
+        raise ValueError(
+            f"static route references gateway {gateway!r}, which is not defined "
+            "in config.xml; add it first with pfsense.gateway.add"
+        )
+    existing = _find_static_route(before, network)
+    result: dict[str, Any] = {
+        "op_class": "write",
+        "resource": "static_route",
+        "network": network,
+        "gateway": gateway,
+    }
+    if existing is not None:
+        return {**result, "existed_before": True, "applied": False, "existing": existing}
+
+    body = _build_route_playback(network=network, gateway=gateway)
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_route_add_{_route_script_token(network)}",
+        script_body=body,
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    if _find_static_route(after, network) is None:
+        raise RuntimeError(
+            f"static route {network!r} was not present in config.xml after "
+            "write_config; the pfSsh.php playback did not persist"
+        )
+    return {**result, "existed_before": False, "applied": True, "existing": None}
+
+
+def _route_script_token(network: str) -> str:
+    """Return a filename-safe token for a CIDR (``/``, ``.``, ``:`` -> ``_``)."""
+    return re.sub(r"[^A-Za-z0-9]", "_", network)
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` for the ``routing`` group -- the operator-facing
+#: prose ``list_operation_groups`` surfaces. Mirrored into
+#: ``_WHEN_TO_USE_BY_GROUP`` in ``connector.py`` (the authoritative copy the
+#: registration walk reads).
+_WHEN_TO_USE_ROUTING = (
+    "Use for pfSense routing-plane provisioning writes: appending a named "
+    "gateway (``pfsense.gateway.add``) or a static route "
+    "(``pfsense.route.static.add``) to ``config.xml``. Call "
+    "``pfsense.gateway.add`` to define a next-hop -- including a pre-staged "
+    "one (``monitor_disable``) whose upstream device does not exist yet -- "
+    "then ``pfsense.route.static.add`` to point a CIDR at it. Both are "
+    "idempotent: re-adding an existing gateway name or route network is a "
+    "reported no-op, never a duplicate. Both are surgical -- they touch only "
+    "the gateway / static-route config and never re-enumerate interfaces, so "
+    "they are safe to run against a perimeter firewall that carries the "
+    "operator's own access path. Read the current state first with "
+    "``pfsense.gateway.list`` / ``pfsense.config.show``."
+)
+
+_GATEWAY_ADD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$",
+            "description": (
+                "Gateway name, e.g. ``LAB_GW``. Alphanumeric, dash, and "
+                "underscore only. Idempotency key: a gateway with this name "
+                "already present is a reported no-op."
+            ),
+        },
+        "interface": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_]{1,32}$",
+            "description": (
+                "pfSense logical interface handle the gateway lives on, e.g. "
+                "``wan`` / ``lan`` / ``opt1`` (not the OS device name)."
+            ),
+        },
+        "gateway": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Next-hop IP address (IPv4 or IPv6). Parsed and "
+                "re-serialised; the address family selects ``ipprotocol``."
+            ),
+        },
+        "monitor_disable": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, set ``monitor_disable`` on the gateway so "
+                "``dpinger`` does not mark it down -- use for a pre-staged "
+                "gateway whose upstream device is not up yet."
+            ),
+        },
+    },
+    "required": ["name", "interface", "gateway"],
+    "additionalProperties": False,
+}
+
+_GATEWAY_ADD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["write"]},
+        "resource": {"type": "string", "enum": ["gateway"]},
+        "name": {"type": "string"},
+        "interface": {"type": "string"},
+        "gateway": {"type": "string"},
+        "ipprotocol": {"type": "string", "enum": ["inet", "inet6"]},
+        "monitor_disable": {"type": "boolean"},
+        "existed_before": {"type": "boolean"},
+        "applied": {"type": "boolean"},
+        "existing": {"type": ["object", "null"]},
+    },
+    "required": [
+        "op_class",
+        "resource",
+        "name",
+        "interface",
+        "gateway",
+        "ipprotocol",
+        "monitor_disable",
+        "existed_before",
+        "applied",
+        "existing",
+    ],
+    "additionalProperties": False,
+}
+
+_GATEWAY_ADD_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Add a named routing gateway to pfSense. Guarded + idempotent: the "
+        "handler reads ``config.xml`` first and, if a gateway with the same "
+        "``name`` already exists, returns ``existed_before=true`` / "
+        "``applied=false`` without appending a duplicate. WARNING: "
+        "``write_config()`` persists to the live ``config.xml`` for the whole "
+        "firewall. safety_level=caution. The op is surgical -- it never "
+        "touches interface config, so it will not stun the operator's own "
+        "access path on a perimeter firewall. Use ``pfsense.gateway.list`` "
+        "first to see existing gateways."
+    ),
+    "parameter_hints": {
+        "name": "Required. Gateway name (alphanumeric / dash / underscore).",
+        "interface": "Required. pfSense logical interface handle (``wan`` / ``lan`` / ``opt1``).",
+        "gateway": "Required. Next-hop IPv4 or IPv6 address.",
+        "monitor_disable": (
+            "Optional (default false). Disable dpinger monitoring for a "
+            "pre-staged gateway whose upstream is not up yet."
+        ),
+    },
+    "output_shape": (
+        "``{op_class: 'write', resource: 'gateway', name, interface, "
+        "gateway, ipprotocol, monitor_disable, existed_before, applied, "
+        "existing}``. ``ipprotocol`` is ``inet`` / ``inet6`` from the IP "
+        "family. When ``existed_before`` is true, ``applied`` is false and "
+        "``existing`` carries the pre-existing gateway row (whose interface "
+        "/ IP may differ from the request); otherwise ``existing`` is null."
+    ),
+}
+
+_ROUTE_ADD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "network": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Destination network in CIDR form, e.g. ``10.9.0.0/24``. "
+                "Canonicalised to the network address; the idempotency key."
+            ),
+        },
+        "gateway": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$",
+            "description": (
+                "Name of an already-defined gateway the route points at. "
+                "Must exist in ``config.xml`` (pre-stage it with "
+                "``pfsense.gateway.add``); a route to an undefined gateway is "
+                "rejected."
+            ),
+        },
+    },
+    "required": ["network", "gateway"],
+    "additionalProperties": False,
+}
+
+_ROUTE_ADD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["write"]},
+        "resource": {"type": "string", "enum": ["static_route"]},
+        "network": {"type": "string"},
+        "gateway": {"type": "string"},
+        "existed_before": {"type": "boolean"},
+        "applied": {"type": "boolean"},
+        "existing": {"type": ["object", "null"]},
+    },
+    "required": [
+        "op_class",
+        "resource",
+        "network",
+        "gateway",
+        "existed_before",
+        "applied",
+        "existing",
+    ],
+    "additionalProperties": False,
+}
+
+_ROUTE_ADD_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Add a static route (CIDR -> named gateway) to pfSense and apply it "
+        "(``write_config()`` + ``system_routing_configure()``). Guarded + "
+        "idempotent: the handler reads ``config.xml`` first, requires the "
+        "named gateway to already exist, and returns ``existed_before=true`` "
+        "/ ``applied=false`` when a route for the same network is already "
+        "present rather than appending a duplicate. WARNING: this changes "
+        "the live routing table for the whole firewall. safety_level=caution. "
+        "Surgical -- it touches only the static-route config, never "
+        "interfaces."
+    ),
+    "parameter_hints": {
+        "network": "Required. Destination CIDR, e.g. ``10.9.0.0/24`` (canonicalised).",
+        "gateway": (
+            "Required. Name of an existing gateway (add it first with ``pfsense.gateway.add``)."
+        ),
+    },
+    "output_shape": (
+        "``{op_class: 'write', resource: 'static_route', network, gateway, "
+        "existed_before, applied, existing}``. ``network`` is the "
+        "canonical CIDR. When ``existed_before`` is true, ``applied`` is "
+        "false and ``existing`` carries the pre-existing route row; "
+        "otherwise ``existing`` is null."
+    ),
+}
+
+#: The write ops :class:`PfSenseConnector` registers alongside the read
+#: surface. Both are additive config mutations classified
+#: ``safety_level='caution'`` / ``requires_approval=False`` -- the same
+#: posture ``bind9.record.add`` / ``windns.record.add`` carry for an
+#: additive, recoverable, idempotent write.
+WRITE_OPS: tuple[PfSenseOp, ...] = (
+    PfSenseOp(
+        op_id="pfsense.gateway.add",
+        handler_attr="gateway_add",
+        summary="Append a named routing gateway to config.xml (guarded, idempotent).",
+        description=(
+            "Reads ``/cf/conf/config.xml`` for the ``<gateways>`` block, and "
+            "if no ``gateway_item`` with the requested ``name`` exists, "
+            "stages a ``pfSsh.php playback`` fragment that appends one "
+            "(interface, gateway IP, name, ``ipprotocol`` from the IP family, "
+            "optional ``monitor_disable`` for a pre-staged gateway) and calls "
+            "``write_config()``, then reads the config back to confirm the "
+            "row landed. A name that already exists is a reported no-op "
+            "(``existed_before=true``, ``applied=false``) -- never a "
+            "duplicate. Surgical: touches only ``gateways/gateway_item``, "
+            "never interface config. Inputs are validated (name / interface "
+            "allowlist, IP parsed) before any SSH round-trip. "
+            "safety_level=caution; recoverable by removing the gateway_item "
+            "and re-running write_config."
+        ),
+        parameter_schema=_GATEWAY_ADD_PARAMETER_SCHEMA,
+        response_schema=_GATEWAY_ADD_RESPONSE_SCHEMA,
+        group_key="routing",
+        tags=("write", "routing", "gateway", "pfsense"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_GATEWAY_ADD_LLM_INSTRUCTIONS,
+    ),
+    PfSenseOp(
+        op_id="pfsense.route.static.add",
+        handler_attr="route_static_add",
+        summary="Append a static route (CIDR -> gateway) to config.xml (guarded, idempotent).",
+        description=(
+            "Reads ``/cf/conf/config.xml`` for the ``<staticroutes>`` block, "
+            "requires the named gateway to already exist, and if no route for "
+            "the same canonical ``network`` exists, stages a ``pfSsh.php "
+            "playback`` fragment that appends one (network -> gateway name), "
+            "calls ``write_config()`` then ``system_routing_configure()`` to "
+            "apply it, and reads the config back to confirm. A route for a "
+            "network already present is a reported no-op "
+            "(``existed_before=true``, ``applied=false``) -- never a "
+            "duplicate. Surgical: touches only ``staticroutes/route``. The "
+            "CIDR is parsed and canonicalised, the gateway name allowlisted, "
+            "before any SSH round-trip. safety_level=caution."
+        ),
+        parameter_schema=_ROUTE_ADD_PARAMETER_SCHEMA,
+        response_schema=_ROUTE_ADD_RESPONSE_SCHEMA,
+        group_key="routing",
+        tags=("write", "routing", "static-route", "pfsense"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_ROUTE_ADD_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/src/meho_backplane/connectors/pfsense/ops_write.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_write.py
@@ -304,7 +304,7 @@ def _build_gateway_playback(
         f"$gw['name'] = {_php_squote(name)};",
         "$gw['weight'] = '1';",
         f"$gw['ipprotocol'] = {_php_squote(ipprotocol)};",
-        f"$gw['descr'] = {_php_squote('meho: pre-staged gateway ' + name)};",
+        f"$gw['descr'] = {_php_squote('meho: gateway ' + name)};",
     ]
     if monitor_disable:
         lines.append("$gw['monitor_disable'] = '';")

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -296,6 +296,12 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "pfsense.dhcp.leases",
 )
 
+#: The mutating ops (#3090). Held separate from ``EXPECTED_OP_IDS`` because
+#: the empty-params dispatch/audit sweep below only exercises the read
+#: surface -- the write ops require real params + a mocked config.xml guard
+#: (covered by ``test_connectors_pfsense_write_ops.py``).
+_WRITE_OP_IDS: frozenset[str] = frozenset({"pfsense.gateway.add", "pfsense.route.static.add"})
+
 # ---------------------------------------------------------------------------
 # Target + connector seeding helpers
 # ---------------------------------------------------------------------------
@@ -406,34 +412,36 @@ async def pfsense_e2e(
 
 
 def test_pfsense_ops_registration_count() -> None:
-    """All 9 pfSense ops are registered in PFSENSE_OPS."""
+    """All 11 pfSense ops are registered in PFSENSE_OPS (9 read/identity + 2 write)."""
     op_ids = {op.op_id for op in PFSENSE_OPS}
-    missing = set(EXPECTED_OP_IDS) - op_ids
+    missing = (set(EXPECTED_OP_IDS) | _WRITE_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(PFSENSE_OPS) == 9, f"Expected 9 ops, got {len(PFSENSE_OPS)}"
+    assert len(PFSENSE_OPS) == 11, f"Expected 11 ops, got {len(PFSENSE_OPS)}"
 
 
-def test_pfsense_ops_all_safe_and_no_approval_required() -> None:
-    """All read ops carry safety_level='safe' and requires_approval=False."""
+def test_pfsense_ops_safety_levels_and_no_approval_required() -> None:
+    """Read ops are 'safe', the write ops (#3090) are 'caution'; none require approval."""
     for op in PFSENSE_OPS:
-        assert op.safety_level == "safe", f"{op.op_id} should be safe"
+        expected = "caution" if op.op_id in _WRITE_OP_IDS else "safe"
+        assert op.safety_level == expected, f"{op.op_id} should be safety_level={expected!r}"
         assert not op.requires_approval, f"{op.op_id} should not require approval"
 
 
-def test_pfsense_ops_parameter_schemas_are_empty() -> None:
-    """All read ops accept no parameters (empty schema, additionalProperties=False)."""
+def test_pfsense_read_ops_parameter_schemas_are_empty() -> None:
+    """Read ops accept no parameters; every op keeps additionalProperties=False."""
     for op in PFSENSE_OPS:
         schema = op.parameter_schema
         assert schema.get("additionalProperties") is False, (
             f"{op.op_id}: parameter_schema must have additionalProperties=False"
         )
-        assert schema.get("properties") == {}, (
-            f"{op.op_id}: parameter_schema must have empty properties"
-        )
+        if op.op_id not in _WRITE_OP_IDS:
+            assert schema.get("properties") == {}, (
+                f"{op.op_id}: read-op parameter_schema must have empty properties"
+            )
 
 
 def test_pfsense_ops_all_have_llm_instructions() -> None:
-    """All 9 ops carry non-empty llm_instructions for agent discoverability."""
+    """All ops carry non-empty llm_instructions for agent discoverability."""
     for op in PFSENSE_OPS:
         assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
         instr = op.llm_instructions

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -31,14 +31,20 @@ Coverage matrix (per Task #847 acceptance criteria):
   nullable; log-structured de-dup to the last block per IP.
 * Malformed command output → structured result (no crash); error field
   set on non-zero exit with empty stdout.
-* ``PFSENSE_OPS`` registration shape -- all 9 ops carry
-  ``safety_level='safe'``, ``additionalProperties=False`` on the
-  parameter schema, non-empty ``llm_instructions``, and pfsense-
-  namespace op_ids; ``firewall``, ``nat``, ``network``, ``config``,
-  ``dhcp`` groups are present.
-* Idempotency contract -- the ``PFSENSE_OPS`` tuple length matches 9
-  (T2 read ops + ``pfsense.dhcp.leases``, #2849); the ``pfsense.about``
-  canary remains at index 0.
+* ``PFSENSE_OPS`` registration shape -- every op carries
+  ``additionalProperties=False`` on the parameter schema, non-empty
+  ``llm_instructions``, and a pfsense-namespace op_id; the read /
+  identity ops are ``safety_level='safe'`` and the two write ops
+  (#3090) are ``safety_level='caution'``; ``firewall``, ``nat``,
+  ``network``, ``config``, ``dhcp``, ``routing`` groups are present.
+* Registration count -- the ``PFSENSE_OPS`` tuple length matches 11
+  (T2 read ops + ``pfsense.dhcp.leases`` #2849 + the two write ops
+  #3090); the ``pfsense.about`` canary remains at index 0.
+
+The ``pfsense.gateway.add`` / ``pfsense.route.static.add`` write-op
+behaviour (validation, idempotency guards, config-write failure
+propagation, playback-fragment construction) is covered in
+``test_connectors_pfsense_write_ops.py``.
 """
 
 from __future__ import annotations
@@ -1031,9 +1037,9 @@ async def test_pfsense_dhcp_leases_response_schema_matches_handler_rows() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_pfsense_ops_has_nine_entries() -> None:
-    """T1 canary + 7 T2 read ops + pfsense.dhcp.leases (#2849) = 9 total."""
-    assert len(PFSENSE_OPS) == 9
+def test_pfsense_ops_has_eleven_entries() -> None:
+    """T1 canary + 7 T2 read ops + pfsense.dhcp.leases (#2849) + 2 write ops (#3090) = 11."""
+    assert len(PFSENSE_OPS) == 11
 
 
 def test_pfsense_ops_about_is_first() -> None:
@@ -1045,9 +1051,19 @@ def test_pfsense_ops_all_have_pfsense_namespace() -> None:
         assert op.op_id.startswith("pfsense."), f"{op.op_id!r} lacks pfsense. prefix"
 
 
-def test_pfsense_ops_all_safe() -> None:
+#: The mutating ops (#3090) -- classified ``caution`` (additive config
+#: write), unlike the read/identity surface which is ``safe``.
+_WRITE_OP_IDS = {"pfsense.gateway.add", "pfsense.route.static.add"}
+
+
+def test_pfsense_read_ops_safe_write_ops_caution() -> None:
     for op in PFSENSE_OPS:
-        assert op.safety_level == "safe", f"{op.op_id!r} has safety_level != 'safe'"
+        if op.op_id in _WRITE_OP_IDS:
+            assert op.safety_level == "caution", (
+                f"{op.op_id!r} write op should be safety_level='caution'"
+            )
+        else:
+            assert op.safety_level == "safe", f"{op.op_id!r} has safety_level != 'safe'"
 
 
 def test_pfsense_ops_all_parameter_schemas_have_additional_properties_false() -> None:
@@ -1077,6 +1093,8 @@ def test_pfsense_ops_covers_expected_op_ids() -> None:
         "pfsense.gateway.list",
         "pfsense.config.show",
         "pfsense.dhcp.leases",
+        "pfsense.gateway.add",
+        "pfsense.route.static.add",
     }
     assert op_ids == expected
 
@@ -1089,6 +1107,7 @@ def test_pfsense_ops_group_keys_include_new_groups() -> None:
     assert "network" in group_keys
     assert "config" in group_keys
     assert "dhcp" in group_keys
+    assert "routing" in group_keys
 
 
 def test_pfsense_ops_handler_attrs_exist_on_connector() -> None:

--- a/backend/tests/test_connectors_pfsense_write_ops.py
+++ b/backend/tests/test_connectors_pfsense_write_ops.py
@@ -1,0 +1,543 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the pfSense write op group (#3090).
+
+Coverage matrix:
+
+* ``pfsense.gateway.add`` / ``pfsense.route.static.add`` happy path --
+  the guard reads ``config.xml``, the append fragment is staged +
+  played back + cleaned up, the config is read back, and the handler
+  returns ``existed_before=False`` / ``applied=True``.
+* Already-present -- an existing gateway name / route network is a
+  reported no-op (``existed_before=True`` / ``applied=False`` /
+  ``existing`` populated) and stages NO playback.
+* Config-write failure propagation -- a non-zero playback exit, and a
+  silent ``write_config`` failure that leaves the entry absent on
+  read-back, both raise rather than reporting success.
+* Input-validation rejections -- bad gateway name / interface / IP /
+  CIDR, and a route to an undefined gateway, raise before (or, for the
+  undefined-gateway guard, immediately after) the first SSH round-trip.
+* Escaping / injection safety -- validation rejects shell / PHP
+  metacharacters, and ``_php_squote`` escapes defensively.
+* ``parse_static_routes_xml`` -- parses the ``<staticroutes>`` block.
+* Response-schema conformance for both ops.
+* Registration classification -- both ops are ``caution`` /
+  ``requires_approval=False`` with a ``write`` tag in the ``routing``
+  group.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import meho_backplane.connectors.pfsense  # noqa: F401 -- import for registry side-effects
+from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
+from meho_backplane.connectors.pfsense.ops_write import (
+    _php_squote,
+    parse_static_routes_xml,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Environment fixture (mirrors test_connectors_pfsense_ops.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="pfsense-test",
+    host="pfsense.test.invalid",
+    port=22,
+    secret_ref="meho/testing/pfsense/pfsense-test",
+)
+
+
+def _proc(stdout: str = "", exit_status: int = 0) -> Any:
+    """Stub mimicking asyncssh's SSHCompletedProcess."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.exit_status = exit_status
+    return proc
+
+
+# Neutral placeholder config.xml fixtures (RFC 5737 / RFC 1918 addresses;
+# no real hostnames or IPs). The public repo must never carry lab values.
+_CONFIG_NO_GW = (
+    "<pfsense><gateways>"
+    "<gateway_item><name>WAN_DHCP</name><interface>wan</interface>"
+    "<gateway>192.0.2.1</gateway></gateway_item>"
+    "</gateways><staticroutes></staticroutes></pfsense>"
+)
+
+_CONFIG_WITH_LAB_GW = (
+    "<pfsense><gateways>"
+    "<gateway_item><name>WAN_DHCP</name><interface>wan</interface>"
+    "<gateway>192.0.2.1</gateway></gateway_item>"
+    "<gateway_item><name>LAB_GW</name><interface>lan</interface>"
+    "<gateway>10.0.0.1</gateway></gateway_item>"
+    "</gateways><staticroutes></staticroutes></pfsense>"
+)
+
+_CONFIG_GW_NO_ROUTE = (
+    "<pfsense><gateways>"
+    "<gateway_item><name>LAB_GW</name><interface>lan</interface>"
+    "<gateway>10.0.0.1</gateway></gateway_item>"
+    "</gateways><staticroutes></staticroutes></pfsense>"
+)
+
+_CONFIG_GW_WITH_ROUTE = (
+    "<pfsense><gateways>"
+    "<gateway_item><name>LAB_GW</name><interface>lan</interface>"
+    "<gateway>10.0.0.1</gateway></gateway_item>"
+    "</gateways><staticroutes>"
+    "<route><network>10.9.0.0/24</network><gateway>LAB_GW</gateway></route>"
+    "</staticroutes></pfsense>"
+)
+
+_GW_SCRIPT = "meho_gateway_add_LAB_GW"
+_ROUTE_SCRIPT = "meho_route_add_10_9_0_0_24"
+
+
+def _commands(mock_cmd: AsyncMock) -> list[str]:
+    return [call.args[1] for call in mock_cmd.await_args_list]
+
+
+# ---------------------------------------------------------------------------
+# pfsense.gateway.add -- happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_gateway_add_happy_path_stages_and_applies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_NO_GW),  # guard read
+            _proc("", 0),  # stage script
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm cleanup
+            _proc(_CONFIG_WITH_LAB_GW),  # read-back verify
+        ]
+        result = await connector.gateway_add(
+            _TARGET, {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1"}
+        )
+
+    assert result["existed_before"] is False
+    assert result["applied"] is True
+    assert result["existing"] is None
+    assert result["ipprotocol"] == "inet"
+    assert result["op_class"] == "write"
+    assert result["resource"] == "gateway"
+
+    cmds = _commands(mock_cmd)
+    assert cmds[0] == "cat /cf/conf/config.xml"
+    assert cmds[1].startswith(
+        f"cat > /etc/phpshellsessions/{_GW_SCRIPT} <<'MEHO_PFSENSE_PLAYBACK_EOF'"
+    )
+    assert cmds[2] == f"pfSsh.php playback {_GW_SCRIPT}"
+    assert cmds[3] == f"rm -f /etc/phpshellsessions/{_GW_SCRIPT}"
+    assert cmds[4] == "cat /cf/conf/config.xml"
+
+    body = cmds[1]
+    assert body.startswith("cat >")
+    assert "global $config;" in body
+    assert "$gw['name'] = 'LAB_GW';" in body
+    assert "$gw['interface'] = 'lan';" in body
+    assert "$gw['gateway'] = '10.0.0.1';" in body
+    assert "$gw['ipprotocol'] = 'inet';" in body
+    assert "write_config('meho: add gateway LAB_GW');" in body
+    # monitor_disable defaults off; the flag line must be absent.
+    assert "monitor_disable" not in body
+    # A playback fragment carries no <?php tag and no trailing exec.
+    assert "<?php" not in body
+    assert "\nexec" not in body
+
+
+async def test_gateway_add_ipv6_sets_inet6() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_NO_GW),
+            _proc("", 0),
+            _proc("", 0),
+            _proc("", 0),
+            _proc(_CONFIG_WITH_LAB_GW),
+        ]
+        result = await connector.gateway_add(
+            _TARGET,
+            {"name": "LAB_GW", "interface": "lan", "gateway": "2001:db8::1"},
+        )
+    assert result["ipprotocol"] == "inet6"
+    assert "$gw['ipprotocol'] = 'inet6';" in _commands(mock_cmd)[1]
+
+
+async def test_gateway_add_monitor_disable_emits_flag() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_NO_GW),
+            _proc("", 0),
+            _proc("", 0),
+            _proc("", 0),
+            _proc(_CONFIG_WITH_LAB_GW),
+        ]
+        await connector.gateway_add(
+            _TARGET,
+            {
+                "name": "LAB_GW",
+                "interface": "lan",
+                "gateway": "10.0.0.1",
+                "monitor_disable": True,
+            },
+        )
+    assert "$gw['monitor_disable'] = '';" in _commands(mock_cmd)[1]
+
+
+# ---------------------------------------------------------------------------
+# pfsense.gateway.add -- already present
+# ---------------------------------------------------------------------------
+
+
+async def test_gateway_add_already_present_is_noop() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_WITH_LAB_GW)]
+        result = await connector.gateway_add(
+            _TARGET, {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1"}
+        )
+    assert result["existed_before"] is True
+    assert result["applied"] is False
+    assert result["existing"]["name"] == "LAB_GW"
+    # Only the single guard read ran -- no staging, playback, or cleanup.
+    assert mock_cmd.await_count == 1
+    assert _commands(mock_cmd) == ["cat /cf/conf/config.xml"]
+
+
+# ---------------------------------------------------------------------------
+# pfsense.gateway.add -- config-write failure propagation
+# ---------------------------------------------------------------------------
+
+
+async def test_gateway_add_playback_nonzero_exit_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_NO_GW),  # guard read
+            _proc("", 0),  # stage
+            _proc("playback error", 1),  # playback FAILS
+            _proc("", 0),  # rm cleanup (finally)
+        ]
+        with pytest.raises(RuntimeError, match="playback"):
+            await connector.gateway_add(
+                _TARGET, {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1"}
+            )
+    # Cleanup still ran despite the failed playback.
+    assert _commands(mock_cmd)[3] == f"rm -f /etc/phpshellsessions/{_GW_SCRIPT}"
+
+
+async def test_gateway_add_not_persisted_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_NO_GW),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback (exit 0, but write_config silently lost it)
+            _proc("", 0),  # rm cleanup
+            _proc(_CONFIG_NO_GW),  # read-back: still absent
+        ]
+        with pytest.raises(RuntimeError, match="did not persist"):
+            await connector.gateway_add(
+                _TARGET, {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1"}
+            )
+
+
+async def test_gateway_add_config_read_failure_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc("", 1)]  # guard read fails
+        with pytest.raises(RuntimeError, match="config"):
+            await connector.gateway_add(
+                _TARGET, {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1"}
+            )
+
+
+# ---------------------------------------------------------------------------
+# pfsense.gateway.add -- input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"name": "bad name", "interface": "lan", "gateway": "10.0.0.1"},
+        {"name": "bad;name", "interface": "lan", "gateway": "10.0.0.1"},
+        {"name": "gw'; write_config(", "interface": "lan", "gateway": "10.0.0.1"},
+        {"name": "LAB_GW", "interface": "lan rm", "gateway": "10.0.0.1"},
+        {"name": "LAB_GW", "interface": "lan", "gateway": "not-an-ip"},
+        {"name": "LAB_GW", "interface": "lan", "gateway": "10.0.0.1; rm -rf /"},
+        {"name": "LAB_GW", "interface": "lan"},  # missing gateway
+    ],
+)
+async def test_gateway_add_rejects_bad_input_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.gateway_add(_TARGET, params)
+    # A rejected input never reaches the wire.
+    assert mock_cmd.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# pfsense.route.static.add -- happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_route_add_happy_path_stages_and_applies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_GW_NO_ROUTE),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm cleanup
+            _proc(_CONFIG_GW_WITH_ROUTE),  # read-back verify
+        ]
+        result = await connector.route_static_add(
+            _TARGET, {"network": "10.9.0.0/24", "gateway": "LAB_GW"}
+        )
+
+    assert result["existed_before"] is False
+    assert result["applied"] is True
+    assert result["existing"] is None
+    assert result["network"] == "10.9.0.0/24"
+    assert result["resource"] == "static_route"
+
+    cmds = _commands(mock_cmd)
+    assert cmds[0] == "cat /cf/conf/config.xml"
+    assert cmds[1].startswith(
+        f"cat > /etc/phpshellsessions/{_ROUTE_SCRIPT} <<'MEHO_PFSENSE_PLAYBACK_EOF'"
+    )
+    assert cmds[2] == f"pfSsh.php playback {_ROUTE_SCRIPT}"
+    assert cmds[3] == f"rm -f /etc/phpshellsessions/{_ROUTE_SCRIPT}"
+
+    body = cmds[1]
+    assert "global $config;" in body
+    assert "$route['network'] = '10.9.0.0/24';" in body
+    assert "$route['gateway'] = 'LAB_GW';" in body
+    assert "write_config('meho: add static route 10.9.0.0/24');" in body
+    assert "system_routing_configure();" in body
+
+
+async def test_route_add_canonicalises_host_bits() -> None:
+    # 10.9.0.5/24 canonicalises to 10.9.0.0/24, which already exists.
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_GW_WITH_ROUTE)]
+        result = await connector.route_static_add(
+            _TARGET, {"network": "10.9.0.5/24", "gateway": "LAB_GW"}
+        )
+    assert result["network"] == "10.9.0.0/24"
+    assert result["existed_before"] is True
+    assert result["applied"] is False
+    assert mock_cmd.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# pfsense.route.static.add -- already present + guards
+# ---------------------------------------------------------------------------
+
+
+async def test_route_add_already_present_is_noop() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_GW_WITH_ROUTE)]
+        result = await connector.route_static_add(
+            _TARGET, {"network": "10.9.0.0/24", "gateway": "LAB_GW"}
+        )
+    assert result["existed_before"] is True
+    assert result["applied"] is False
+    assert result["existing"]["network"] == "10.9.0.0/24"
+    assert mock_cmd.await_count == 1
+
+
+async def test_route_add_unknown_gateway_raises_after_read() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_GW_NO_ROUTE)]
+        with pytest.raises(ValueError, match="not defined"):
+            await connector.route_static_add(
+                _TARGET, {"network": "10.9.0.0/24", "gateway": "NOPE_GW"}
+            )
+    # The gateway-existence guard reads config once, then refuses -- no staging.
+    assert mock_cmd.await_count == 1
+
+
+async def test_route_add_playback_nonzero_exit_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_GW_NO_ROUTE),
+            _proc("", 0),
+            _proc("boom", 1),
+            _proc("", 0),
+        ]
+        with pytest.raises(RuntimeError, match="playback"):
+            await connector.route_static_add(
+                _TARGET, {"network": "10.9.0.0/24", "gateway": "LAB_GW"}
+            )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"network": "not-a-cidr", "gateway": "LAB_GW"},
+        {"network": "10.9.0.0/24", "gateway": "bad gateway"},
+        {"network": "10.9.0.0/24", "gateway": "gw'; drop"},
+        {"gateway": "LAB_GW"},  # missing network
+    ],
+)
+async def test_route_add_rejects_bad_input_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.route_static_add(_TARGET, params)
+    assert mock_cmd.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Escaping / injection safety
+# ---------------------------------------------------------------------------
+
+
+def test_php_squote_escapes_quote_and_backslash() -> None:
+    assert _php_squote("plain") == "'plain'"
+    assert _php_squote("a'b") == "'a\\'b'"
+    assert _php_squote("a\\b") == "'a\\\\b'"
+
+
+# ---------------------------------------------------------------------------
+# parse_static_routes_xml
+# ---------------------------------------------------------------------------
+
+
+def test_parse_static_routes_xml_extracts_rows() -> None:
+    rows = parse_static_routes_xml(_CONFIG_GW_WITH_ROUTE)
+    assert rows == [{"network": "10.9.0.0/24", "gateway": "LAB_GW", "descr": None}]
+
+
+def test_parse_static_routes_xml_empty_and_malformed() -> None:
+    assert parse_static_routes_xml("") == []
+    assert parse_static_routes_xml("<broken") == []
+    assert parse_static_routes_xml("<pfsense></pfsense>") == []
+
+
+# ---------------------------------------------------------------------------
+# Response-schema conformance
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_add_response_schema_accepts_both_outcomes() -> None:
+    from jsonschema import Draft202012Validator
+
+    op = next(o for o in PFSENSE_OPS if o.op_id == "pfsense.gateway.add")
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "write",
+            "resource": "gateway",
+            "name": "LAB_GW",
+            "interface": "lan",
+            "gateway": "10.0.0.1",
+            "ipprotocol": "inet",
+            "monitor_disable": False,
+            "existed_before": False,
+            "applied": True,
+            "existing": None,
+        }
+    )
+    validator.validate(
+        {
+            "op_class": "write",
+            "resource": "gateway",
+            "name": "LAB_GW",
+            "interface": "lan",
+            "gateway": "10.0.0.1",
+            "ipprotocol": "inet",
+            "monitor_disable": False,
+            "existed_before": True,
+            "applied": False,
+            "existing": {"name": "LAB_GW", "interface": "lan"},
+        }
+    )
+
+
+def test_route_add_response_schema_accepts_both_outcomes() -> None:
+    from jsonschema import Draft202012Validator
+
+    op = next(o for o in PFSENSE_OPS if o.op_id == "pfsense.route.static.add")
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "write",
+            "resource": "static_route",
+            "network": "10.9.0.0/24",
+            "gateway": "LAB_GW",
+            "existed_before": False,
+            "applied": True,
+            "existing": None,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration classification
+# ---------------------------------------------------------------------------
+
+
+def test_write_ops_are_caution_no_approval_with_write_tag() -> None:
+    write_ids = {"pfsense.gateway.add", "pfsense.route.static.add"}
+    seen = set()
+    for op in PFSENSE_OPS:
+        if op.op_id not in write_ids:
+            continue
+        seen.add(op.op_id)
+        assert op.safety_level == "caution", op.op_id
+        assert op.requires_approval is False, op.op_id
+        assert "write" in op.tags, op.op_id
+        assert op.group_key == "routing", op.op_id
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+        assert op.llm_instructions and op.llm_instructions.get("when_to_use"), op.op_id
+    assert seen == write_ids

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -10,11 +10,14 @@ and is the second typed-SSH tier child of the `SshConnector` adapter (G0.2-T4
 release series (FreeBSD 14.1 base, as of 2.7.2).
 
 The connector replaces the operator's `scripts/pfsense.sh` wrapper in the
-`claude-rdc-hetzner-dc` consumer repository. The G3.7-T1 (#844) skeleton ships
+consumer repository. The G3.7-T1 (#844) skeleton ships
 only the `pfsense.about` canary op, the key-only auth enforcement, the
 fingerprint, and the probe. G3.7-T2 (#847) adds the 7 read ops
 (`pfctl`/config.xml parsed); G3.7-T3 (#850) ships the CLI verbs + E2E
-acceptance suite + onboarding doc.
+acceptance suite + onboarding doc. #2849 adds `pfsense.dhcp.leases`. #3090
+adds the first two write ops (`pfsense.gateway.add`,
+`pfsense.route.static.add`) via the `pfSsh.php playback` config-mutation
+idiom.
 
 Source: `backend/src/meho_backplane/connectors/pfsense/`.
 
@@ -24,8 +27,9 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   attributes: `product="pfsense"`, `version="2.7"`, `impl_id="pfsense-ssh"`.
   Inherits the per-target asyncssh connection pool and `aclose()` from the
   adapter; overrides `_auth_config` to reject password auth, plus `fingerprint`,
-  `probe`, `execute`, `about`, and the read-op bound-method shims (the 7 T2 ops
-  plus `dhcp_leases`, #2849).
+  `probe`, `execute`, `about`, the read-op bound-method shims (the 7 T2 ops
+  plus `dhcp_leases`, #2849), and the write-op bound-method shims (`gateway_add`,
+  `route_static_add`, #3090).
 
 - **`_auth_config()` override** — the load-bearing auth constraint. Requires
   `ssh_private_key` in the target's **Vault secret** (`target.secret_ref` is a
@@ -38,9 +42,18 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   REPL) instead of a POSIX shell, causing any subsequent command to hang.
 
 - **Op metadata** (`ops.py`) — the `PfSenseOp` dataclass, the `_pfsense_ops()`
-  composition function, and the `PFSENSE_OPS` tuple (9 ops total). T1 shipped
+  composition function, and the `PFSENSE_OPS` tuple (11 ops total). T1 shipped
   `pfsense.about`; T2 (#847) adds 7 read ops via the `ops_read` module; #2849
-  appends `pfsense.dhcp.leases`.
+  appends `pfsense.dhcp.leases`; #3090 appends the two write ops via the
+  `ops_write` module.
+
+- **Write op handlers** (`ops_write.py`, #3090) — input validators
+  (`_validate_gateway_name` / `_validate_interface` / `_validate_gateway_ip` /
+  `_validate_network_cidr`), the `parse_static_routes_xml` config parser, the
+  `pfSsh.php playback` fragment builders (`_build_gateway_playback` /
+  `_build_route_playback`), the stage/playback/cleanup helper (`_apply_playback`),
+  and the handler functions `pfsense_gateway_add` / `pfsense_route_static_add`
+  plus the `WRITE_OPS` tuple.
 
 - **Read op parsers** (`ops_read.py`) — pure parsers for pfctl, config.xml, and
   the ISC dhcpd lease DB, plus the handler functions and the `READ_OPS` tuple:
@@ -157,21 +170,26 @@ Two-phase registration, identical to the bind9 pattern:
   (`connectors/registry.py`, `operations/typed_register.py`) — registration
   infrastructure.
 
-## Op surface (9 ops)
+## Op surface (11 ops)
 
-| Op ID | Command | Group |
-|---|---|---|
-| `pfsense.about` | `cat /etc/version` | `identity` |
-| `pfsense.version` | `cat /etc/version` | `config` |
-| `pfsense.firewall.rules` | `pfctl -sr` | `firewall` |
-| `pfsense.firewall.state` | `pfctl -ss` | `firewall` |
-| `pfsense.nat.rules` | `pfctl -sn` | `nat` |
-| `pfsense.interface.list` | `ifconfig -a` | `network` |
-| `pfsense.gateway.list` | `cat /cf/conf/config.xml` (gateways block) + `pfSsh.php playback gatewaystatus` (live dpinger status) | `network` |
-| `pfsense.config.show` | `cat /cf/conf/config.xml` (full) | `config` |
-| `pfsense.dhcp.leases` | `cat /var/dhcpd/var/db/dhcpd.leases` (ISC dhcpd lease DB) | `dhcp` |
+| Op ID | Command | Group | Safety |
+|---|---|---|---|
+| `pfsense.about` | `cat /etc/version` | `identity` | `safe` |
+| `pfsense.version` | `cat /etc/version` | `config` | `safe` |
+| `pfsense.firewall.rules` | `pfctl -sr` | `firewall` | `safe` |
+| `pfsense.firewall.state` | `pfctl -ss` | `firewall` | `safe` |
+| `pfsense.nat.rules` | `pfctl -sn` | `nat` | `safe` |
+| `pfsense.interface.list` | `ifconfig -a` | `network` | `safe` |
+| `pfsense.gateway.list` | `cat /cf/conf/config.xml` (gateways block) + `pfSsh.php playback gatewaystatus` (live dpinger status) | `network` | `safe` |
+| `pfsense.config.show` | `cat /cf/conf/config.xml` (full) | `config` | `safe` |
+| `pfsense.dhcp.leases` | `cat /var/dhcpd/var/db/dhcpd.leases` (ISC dhcpd lease DB) | `dhcp` | `safe` |
+| `pfsense.gateway.add` | `cat /cf/conf/config.xml` guard + `pfSsh.php playback` fragment (append `gateway_item` + `write_config()`) | `routing` | `caution` |
+| `pfsense.route.static.add` | `cat /cf/conf/config.xml` guard + `pfSsh.php playback` fragment (append `staticroutes/route` + `write_config()` + `system_routing_configure()`) | `routing` | `caution` |
 
-All 9 ops are `safety_level="safe"`, `requires_approval=False`.
+The 9 read / identity ops are `safety_level="safe"`; the 2 write ops (#3090)
+are `safety_level="caution"`. All 11 are `requires_approval=False` — the same
+posture `bind9.record.add` / `windns.record.add` carry for an additive,
+recoverable, idempotent config write.
 
 `pfsense.firewall.state` and `pfsense.dhcp.leases` both return `{rows, total}`
 and are the JSONFlux reduction candidates: connection-state tables and busy
@@ -199,6 +217,53 @@ interface `dpinger` is not monitoring) keeps its row with all five health
 fields `null`; a failure of the status command degrades the whole set to
 `null` health rather than failing the op.
 
+## Write ops (#3090)
+
+`pfsense.gateway.add` and `pfsense.route.static.add` are the connector's first
+mutating ops. pfSense CE 2.7 has no REST surface, so the mutation runs through
+the **`pfSsh.php playback` idiom** — the same mechanism the `pfsense.gateway.list`
+read op already uses (`pfSsh.php playback gatewaystatus`). Because
+`pfSsh.php playback <name>` resolves its argument through `basename()` against
+`/etc/phpshellsessions/` (and piped stdin does not drive the interactive `exec`
+loop reliably), each write:
+
+1. reads `/cf/conf/config.xml` and parses the relevant block (the guard);
+2. if the entry is absent, stages a raw-PHP fragment into
+   `/etc/phpshellsessions/<script>` via a **quoted-delimiter heredoc** (no shell
+   expansion), plays it back with `pfSsh.php playback <script>`, and removes the
+   file in a `finally`;
+3. reads `config.xml` back and confirms the entry landed.
+
+The fragment carries no `<?php` tag and no trailing `exec`, and opens with
+`global $config;` — `playback_text` prepends `require_once` of the pfSense
+config libraries and `eval`s the text inside a function scope, so the config
+libraries populate the `$config` global and the fragment must pull it into
+scope (mirroring the shipped `gatewaystatus` script's `global $argv;`).
+
+**Guarded + idempotent.** A gateway whose `name` already exists, or a route
+whose canonical `network` already exists, is reported as
+`{existed_before: true, applied: false, existing: <row>}` and stages **no**
+playback — never a duplicate. `pfsense.route.static.add` additionally requires
+the referenced gateway to already exist (pre-stage it with
+`pfsense.gateway.add`, whose `monitor_disable` flag suits a gateway whose
+upstream device is not up yet). A non-zero playback exit, or a silent
+`write_config` failure that leaves the entry absent on read-back, raises rather
+than reporting success.
+
+**Injection safety.** Every operator value is validated and re-serialised before
+it reaches the fragment: names / interfaces against a strict character-class
+allowlist (`^[A-Za-z0-9_-]{1,64}$` / `^[A-Za-z0-9_]{1,32}$`), IPs parsed and
+re-emitted through `ipaddress`, CIDRs canonicalised. Anything outside the
+allowlist is rejected before a single SSH round-trip; `_php_squote` escapes
+defensively on top.
+
+**Surgical contract.** The handlers touch only `gateways/gateway_item` and
+`staticroutes/route` — never interface config. The perimeter pfSense frequently
+carries the operator's own access path, so an interface re-enumeration would
+sever the very session issuing the change. `pfsense.route.static.add` calls
+`system_routing_configure()` (route-table apply only); `pfsense.gateway.add`
+applies nothing — a pre-staged gateway is inert config until referenced.
+
 ## Known issues
 
 - `known_hosts=None` in the SSH adapter disables host-key verification for
@@ -215,6 +280,10 @@ fields `null`; a failure of the status command degrades the whole set to
   chroot path confirmed against pfSense's `status_dhcp_leases.php`.
 - Task #2850: project live `dpinger` status (up/RTT/loss) onto
   `pfsense.gateway.list` via `pfSsh.php playback gatewaystatus`.
+- Task #3090: `pfsense.gateway.add` + `pfsense.route.static.add` — the first
+  write ops, via the `pfSsh.php playback` config-mutation idiom. Classification
+  mirrors `bind9.record.add` (`caution` / no-approval). pfSense PHP shell:
+  https://docs.netgate.com/pfsense/en/latest/development/php-shell.html.
 - Parent initiative: #370 (G3.7 tier-3 standalone connectors).
 - Bind9 connector (canonical typed-SSH reference): `docs/codebase/connectors-bind9.md`.
 - `SshConnector` adapter: `backend/src/meho_backplane/connectors/adapters/ssh.py`.


### PR DESCRIPTION
## Summary

- Add the first two **write** ops to the `pfsense-ssh-2.7` typed SSH connector:
  - **`pfsense.gateway.add`** — append a named `gateway_item` (interface, gateway IP, `ipprotocol` derived from the IP family, optional `monitor_disable` for a pre-staged gateway) and `write_config()`.
  - **`pfsense.route.static.add`** — append a `staticroutes/route` (CIDR → gateway name), `write_config()` + `system_routing_configure()`.
- pfSense CE 2.7 has no REST, so the mutation rides the **`pfSsh.php playback`** idiom the `gateway.list` read op already uses. Because `pfSsh.php playback` resolves its arg through `basename()` against `/etc/phpshellsessions/` (and piped stdin doesn't drive the interactive `exec` loop), each write stages a raw-PHP fragment there via a quoted-delimiter heredoc, plays it back, cleans up, then reads `config.xml` back to confirm the entry landed.
- **Guarded + idempotent**: both read `config.xml` first; an existing gateway name / route network returns `{existed_before: true, applied: false, existing: <row>}` with **no** duplicate appended. A route additionally requires its gateway to already exist. A non-zero playback exit or a silent `write_config` failure raises rather than reporting success.
- **Injection-safe**: names/interfaces allowlisted (`^[A-Za-z0-9_-]{1,64}$` / `^[A-Za-z0-9_]{1,32}$`), IPs/CIDRs parsed and re-serialised via `ipaddress`, values emitted through a PHP single-quote escaper — never raw interpolation of operator input. **Surgical**: only `gateways/gateway_item` and `staticroutes/route` are touched, never interface config (a perimeter firewall carrying the operator's own path is not stunned).
- Classified `safety_level=caution` / `requires_approval=False`, mirroring `bind9.record.add` / `windns.record.add` for an additive, recoverable, idempotent config write. New `routing` op group.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean for the change (only a pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` error, unrelated, passes on Linux CI)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_connectors_pfsense_write_ops.py tests/test_connectors_pfsense_ops.py tests/test_connectors_pfsense_e2e.py tests/test_connectors_pfsense_auth.py` — 171 passed
- [x] **Happy path both ops** — mocked SSH: guard read → stage → playback → cleanup → read-back verify; asserts fragment content + command sequence.
- [x] **Already-present both ops** — no playback staged, `existed_before=true`; route canonicalises host bits (`10.9.0.5/24` → `10.9.0.0/24`).
- [x] **Config-write failure propagation** — non-zero playback exit and read-back-still-absent both raise; config-read failure raises.
- [x] **Input-validation rejections** — bad name / interface / IP / CIDR, and a route to an undefined gateway, rejected before (or immediately after, for the gateway-existence guard) the first SSH round-trip.
- [x] Response-schema conformance for both outcomes; `parse_static_routes_xml` unit tests; classification/registration invariants (11 ops, `routing` group, `caution`/no-approval).
- [x] `docs/codebase/connectors-pfsense.md` updated (op-surface table 9→11, Write ops section).

## Out of scope

- E2E fake-shell dispatch coverage for the write ops (the generic dispatch/register/audit path is already proven by the 9 read ops; write-specific logic is unit-tested with a mocked transport).
- Gateway/route **remove/update** ops, IPv4/IPv6 protocol-match validation between a route and its gateway — follow-ups.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3090

🤖 Generated with [Claude Code](https://claude.com/claude-code)
