### PR TITLE
docs(clients): document first-connect MCP startup-timeout race (#3148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — document the first-connect MCP startup-timeout race for both Claude clients (#3148)
+
+- A fresh machine's **first** connect through either client onramp raced Claude
+  Code's default 30 s MCP startup timeout: `mcp-remote` opens the Keycloak login
+  tab behind the terminal (or the Claude Desktop window), and the shim — with its
+  short-lived OAuth callback server — was torn down before a human could finish
+  the browser login (field-test finding F2, #3143). The plugin cannot raise the
+  budget mechanically: `MCP_TIMEOUT` is the *startup* timeout Claude Code reads
+  from its **own** process environment, not a `.mcp.json` key (the `.mcp.json`
+  `timeout` field is a per-call tool-execution limit, not startup). Both client
+  READMEs now carry a prominent "First connect" section — `MCP_TIMEOUT=120000
+  claude` for the plugin, complete-promptly-then-retry for Desktop — plus the
+  browser-tab-behind-the-window note and the `~/.mcp-auth` token-cache reason it
+  only bites the very first connect.
+
 ## [0.30.0] - 2026-08-25
 
 ### Added — air-gapped depot lifecycle ops on the installer connector (#3121 / #3125)

--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -118,6 +118,38 @@ the scope is therefore safe: the session behaves exactly as the default.
 - If the backplane URL is not configured, `bin/meho-mcp-remote` exits with a
   message naming the variables to set.
 
+## First connect — raise the MCP startup timeout
+
+The **first** time a fresh machine connects, `mcp-remote` has to complete the
+full Keycloak OAuth 2.1 + PKCE login before the `meho` server reports ready. It
+opens a browser tab for that login — **behind the terminal window** — and
+Claude Code's default **30-second MCP startup timeout** kills the shim (and its
+short-lived OAuth callback server) if the browser login has not finished in
+time. On a vanilla `claude` first run the login reliably loses that race.
+
+Start the **first** session with a longer startup budget:
+
+```bash
+MCP_TIMEOUT=120000 claude
+```
+
+Then switch to the browser tab that opened **behind** your terminal and
+complete the Keycloak login. `mcp-remote` caches the tokens under
+`~/.mcp-auth`, so **every later session connects instantly** — the raised
+timeout is only needed for that one first connect (once per fresh machine, or
+again after you clear `~/.mcp-auth`).
+
+**Why the plugin can't set this for you.** `MCP_TIMEOUT` is the MCP *startup*
+timeout, and Claude Code reads it from **its own process environment** at
+launch — before it spawns any server. The plugin's `.mcp.json` can only set the
+*server child's* environment, which the CLI never consults for the startup
+deadline, so no `.mcp.json` key raises it. (The per-server `timeout` field that
+`.mcp.json` *does* accept is a **tool-execution** timeout — a per-call
+wall-clock limit that overrides `MCP_TOOL_TIMEOUT` — not the startup timeout, so
+it does not help here.) The variable has to live in the shell that launches
+`claude`. See the
+[Claude Code MCP docs](https://code.claude.com/docs/en/mcp.md).
+
 ## Layer-2 skills → template sections
 
 The skills migrate the routing rules from the

--- a/clients/claude-desktop-mcpb/README.md
+++ b/clients/claude-desktop-mcpb/README.md
@@ -109,6 +109,33 @@ already exist on the realm — see
 No system Node or `npx` on `PATH` is required at run time — the bundle
 carries its dependencies and Claude Desktop supplies the runtime.
 
+## First connect — the OAuth login race
+
+The **first** time a fresh machine enables this bundle, the vendored
+`mcp-remote` runs the full Keycloak OAuth 2.1 + PKCE login before the server
+reports ready. It opens a browser tab for that login **behind the Claude
+Desktop window**, and Claude Desktop enforces its **own MCP startup timeout** on
+the `.mcpb` server — if the browser login has not finished before that elapses,
+Desktop marks the extension disconnected and tears the shim (and its OAuth
+callback server) down mid-handshake.
+
+Unlike the Claude Code CLI, Desktop's startup timeout is **not** operator-
+settable — the CLI's `MCP_TIMEOUT` env var
+([Claude Code MCP docs](https://code.claude.com/docs/en/mcp.md)) does not apply
+to Desktop — so the recipe is *finish the login promptly, then retry if it
+lapsed*:
+
+1. Right after enabling the extension, switch to the browser tab that opened
+   **behind** the Claude Desktop window and complete the Keycloak login without
+   delay.
+2. If the first attempt timed out (the extension shows disconnected), toggle it
+   off and back on — or fully quit and relaunch Claude Desktop — to restart the
+   handshake, then complete the login.
+
+`mcp-remote` caches the tokens under `~/.mcp-auth`, so once the first login
+succeeds **every later launch connects instantly** — the race only bites the
+very first connect on a fresh machine (or again after you clear `~/.mcp-auth`).
+
 ## Elevated operator mode (opt-in)
 
 By default a session lists only the **working surface** — status,


### PR DESCRIPTION
## Summary

- The **first** connect on a fresh machine races Claude Code's default **30 s
  MCP startup timeout**: `mcp-remote` opens the Keycloak login tab *behind* the
  terminal (or Claude Desktop window), and the shim — with its short-lived OAuth
  callback server — is torn down before a human can finish the browser login
  (field-test finding **F2**, #3143; credit @ilhan-karic).
- **Researched fresh, no mechanical seam exists.** Per the current
  [Claude Code MCP docs](https://code.claude.com/docs/en/mcp.md): `MCP_TIMEOUT`
  is the *startup* timeout Claude Code reads from **its own process
  environment** at launch — not a `.mcp.json` key. The `.mcp.json` `timeout`
  field that *does* exist is a per-call **tool-execution** limit (overrides
  `MCP_TOOL_TIMEOUT`), not the startup deadline. A plugin's `.mcp.json` can only
  set the *server child's* env, which the CLI never consults for startup, so the
  plugin **cannot** raise its own first-connect budget. Corroborated by
  [anthropics/claude-code-action#1152](https://github.com/anthropics/claude-code-action/issues/1152)
  ("MCP_TIMEOUT not passed to Claude CLI subprocess").
- Chose the documentation branch the issue specifies for that outcome: a
  prominent **"First connect"** section in **both** client READMEs —
  `MCP_TIMEOUT=120000 claude` for the Claude Code plugin, and a
  complete-promptly-then-retry recipe for Claude Desktop (whose own startup
  timeout the CLI env var does not reach) — each with the browser-tab-behind-
  the-window note and the `~/.mcp-auth` token-cache reason the race only bites
  the very first connect.

## Test plan

- [x] `git diff --stat` — 3 files, +74/-0 (`clients/claude-code-plugin/README.md`,
      `clients/claude-desktop-mcpb/README.md`, `CHANGELOG.md`); no code touched.
- [x] Hygiene (mirrors the pre-commit hooks CI runs): no trailing whitespace in
      added lines, all files end with a newline, markdown fences balanced.
- [x] **AC1 — documented, both READMEs carry the recipe with the exact env var
      and value.** Plugin README "First connect" section ships
      `MCP_TIMEOUT=120000 claude`; Desktop README ships the promptly-then-retry
      recipe. No mechanical config assertion test because research proved no
      `.mcp.json` startup-timeout key exists to assert on.
- [x] **AC2 — citation to current Claude Code docs, no guessed keys.** Both
      sections and the commit body cite
      <https://code.claude.com/docs/en/mcp.md>, distinguishing the startup
      `MCP_TIMEOUT` (CLI process env) from the per-server tool-execution
      `timeout` field.
- [ ] **AC3 — #3143 testers re-test on a fresh profile.** @ilhan-karic,
      @ddzafic, @setaelmedin: please **clear `~/.mcp-auth`** first (so it is a
      true first-connect), then follow the new "First connect" section — plugin
      with `MCP_TIMEOUT=120000 claude`, Desktop with the promptly-then-retry
      steps — and confirm the OAuth login now completes without the shim being
      killed mid-handshake.

## Out of scope

- Changing `mcp-remote`'s browser-opening behaviour (upstream).
- Backend / Keycloak changes.
- CIMD / native-HTTP MCP migration of `.mcp.json`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3148
