### PR TITLE
fix(clients): plugin PostToolUse matcher names the real broadcast tool

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,15 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-# Claude Code plugin — PR behavioral test.
+# Claude Code plugin — PR behavioral + conformance tests.
 #
 # The plugin's stdio shim wrapper (clients/claude-code-plugin/bin/meho-mcp-remote)
 # is a bash launcher that `exec`s `npx -y mcp-remote@… <url> --static-oauth-…`.
-# The one contract worth pinning is the argv it hands to npx — in particular
+# One contract worth pinning is the argv it hands to npx — in particular
 # the OAuth scope metadata, which the MEHO_MCP_SCOPES elevation seam makes
-# operator-configurable. This workflow runs the stubbed-argv suite (a stub
-# `npx` on a controlled PATH echoes the argv) whenever a PR touches the
-# plugin sources. No network / npm install: the suite stubs npx.
+# operator-configurable — verified by a stubbed-argv suite (a stub `npx` on a
+# controlled PATH echoes the argv). A second suite is a static guard that
+# every plugin-scoped hooks.json matcher names a tool actually registered
+# under backend/src/meho_backplane/mcp/tools/ (the meho_ prefix asymmetry
+# silently disarmed the announce hook once — F3, #3143). This workflow runs
+# both whenever a PR touches the plugin sources. No network / npm install.
 #
 # Advisory (non-required) and path-scoped, mirroring mcpb-bundle.yml. A
 # required check would need the `changes`-job + job-`if:` shape ci.yml uses
@@ -49,5 +52,5 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Behavioral test — shim argv contract
-        run: node --test clients/claude-code-plugin/test/meho-mcp-remote.test.mjs
+      - name: Plugin tests — shim argv contract + hooks matcher conformance
+        run: node --test clients/claude-code-plugin/test/*.test.mjs

--- a/clients/claude-code-plugin/bin/post-announce.sh
+++ b/clients/claude-code-plugin/bin/post-announce.sh
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 #
-# PostToolUse reflex hook for the plugin's `broadcast_announce` tool.
+# PostToolUse reflex hook for the plugin's `meho_broadcast_announce` tool.
 # Records that this session has announced (or reported) intent by writing
 # a session-scoped marker. pre-call-operation.sh reads the marker to
 # suppress its announce reminder, and stop-report.sh reads it to suppress
-# its report reminder. `broadcast_announce` serves both the start and
+# its report reminder. `meho_broadcast_announce` serves both the start and
 # completion phases, so a single marker covers "announced/reported".
 #
-# Matcher (hooks.json): `mcp__plugin_meho_meho__broadcast_announce` —
+# Matcher (hooks.json): `mcp__plugin_meho_meho__meho_broadcast_announce` —
 # the plugin-scoped tool-name form (see pre-call-operation.sh). Pure
 # side effect; the hook emits no decision and cannot block (PostToolUse
 # runs after the tool has already executed).

--- a/clients/claude-code-plugin/bin/pre-call-operation.sh
+++ b/clients/claude-code-plugin/bin/pre-call-operation.sh
@@ -4,7 +4,7 @@
 #
 # PreToolUse reflex hook for the plugin's `call_operation` tool. If this
 # session has not announced intent yet, it emits a one-time, advisory
-# reminder naming `broadcast_announce`. It never denies or blocks the
+# reminder naming `meho_broadcast_announce`. It never denies or blocks the
 # call — enforcement with teeth is the server-side announce gate's job;
 # this is a warn-only nudge.
 #
@@ -47,7 +47,7 @@ reminded_marker="${state_dir}/${sid}.reminded"
 # reminder already fired once.
 if [ ! -e "$announced_marker" ] && [ ! -e "$reminded_marker" ]; then
   : > "$reminded_marker" 2>/dev/null || true
-  msg="MEHO reflex: this session is calling call_operation without having announced intent. Call broadcast_announce (phase=start) so other operators watching the tenant feed see your work, and report with phase=completion when you finish. Advisory only — this appears once per session and does not block the call."
+  msg="MEHO reflex: this session is calling call_operation without having announced intent. Call meho_broadcast_announce (phase=start) so other operators watching the tenant feed see your work, and report with phase=completion when you finish. Advisory only — this appears once per session and does not block the call."
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$msg"
 fi
 

--- a/clients/claude-code-plugin/bin/stop-report.sh
+++ b/clients/claude-code-plugin/bin/stop-report.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 evoila Group
 #
 # Stop reflex hook. If this session invoked call_operation but never
-# announced or reported via broadcast_announce, it emits a one-line
+# announced or reported via meho_broadcast_announce, it emits a one-line
 # report-on-completion reminder as `hookSpecificOutput.additionalContext`.
 #
 # Semantics (do not misread): additionalContext on a Stop hook does NOT
@@ -21,7 +21,7 @@
 # bounded continuation above is the only nudge it makes.
 #
 # State is the same session-scoped marker set the call_operation and
-# broadcast_announce hooks maintain: remind only when `.used` exists and
+# meho_broadcast_announce hooks maintain: remind only when `.used` exists and
 # `.announced` does not.
 
 state_dir="${TMPDIR:-/tmp}/meho-plugin-hooks"
@@ -45,7 +45,7 @@ reminded_marker="${state_dir}/${sid}.stop_reminded"
 
 if [ -e "$used_marker" ] && [ ! -e "$announced_marker" ] && [ ! -e "$reminded_marker" ]; then
   : > "$reminded_marker" 2>/dev/null || true
-  msg="MEHO reflex: this session invoked call_operation but never announced or reported via broadcast_announce. Before ending, consider a broadcast_announce with phase=completion and a short result summary so the tenant feed reflects what changed. Advisory only."
+  msg="MEHO reflex: this session invoked call_operation but never announced or reported via meho_broadcast_announce. Before ending, consider a meho_broadcast_announce with phase=completion and a short result summary so the tenant feed reflects what changed. Advisory only."
   printf '{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"%s"}}\n' "$msg"
 fi
 

--- a/clients/claude-code-plugin/hooks/hooks.json
+++ b/clients/claude-code-plugin/hooks/hooks.json
@@ -28,7 +28,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__plugin_meho_meho__broadcast_announce",
+        "matcher": "mcp__plugin_meho_meho__meho_broadcast_announce",
         "hooks": [
           {
             "type": "command",

--- a/clients/claude-code-plugin/test/hooks-matcher-conformance.test.mjs
+++ b/clients/claude-code-plugin/test/hooks-matcher-conformance.test.mjs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Static conformance guard for the plugin's hooks.json matchers.
+//
+// A plugin-bundled MCP tool is matched as `mcp__plugin_meho_meho__<tool>`,
+// where `<tool>` must be the tool's *exact* registered name. The prefix
+// asymmetry is a trap: some MEHO tools carry the `meho_` prefix
+// (`meho_broadcast_announce`) and some do not (`call_operation`), so a
+// matcher that names `broadcast_announce` compiles fine yet matches nothing
+// — the hook silently never fires (field-test finding F3, #3143).
+//
+// This guard cross-checks, statically and in-repo, that every
+// `mcp__plugin_meho_meho__<tool>` matcher in hooks.json names a `<tool>`
+// that is actually registered under
+// `backend/src/meho_backplane/mcp/tools/`. No live server, no MCP round
+// trip: the registered set is derived from the `register_mcp_tool(...)`
+// call sites the same way the deploy does — from source.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..");
+const HOOKS_JSON = join(HERE, "..", "hooks", "hooks.json");
+const TOOLS_DIR = join(
+  REPO_ROOT,
+  "backend",
+  "src",
+  "meho_backplane",
+  "mcp",
+  "tools",
+);
+
+// The plugin and its bundled MCP server are both named `meho`, so a
+// plugin-scoped tool name is `mcp__plugin_meho_meho__<tool>`. A tool name
+// is a lowercase snake identifier; the character class stops naturally at a
+// regex metachar, so a wildcard matcher (`...__.*`) captures nothing and is
+// correctly ignored (it is a server-wide match, not a single-tool claim).
+const SCOPED_MATCHER = /mcp__plugin_meho_meho__([a-z][a-z0-9_]*)/g;
+
+// Collect every `matcher` string across all hook events in hooks.json.
+function matcherStrings(hooksDoc) {
+  const out = [];
+  for (const events of Object.values(hooksDoc.hooks ?? {})) {
+    for (const group of events ?? []) {
+      if (typeof group.matcher === "string") out.push(group.matcher);
+    }
+  }
+  return out;
+}
+
+// Derive the set of registered MCP tool names from the tool source files.
+// Registration is `register_mcp_tool(definition=ToolDefinition(... name=X
+// ...))`, where X is either a string literal or a module-level
+// `Final[str]` constant (e.g. audit.py, topology.py). Resolve both so a
+// future matcher that legitimately targets a variable-registered tool does
+// not trip a false failure.
+function registeredToolNames() {
+  const names = new Set();
+  for (const entry of readdirSync(TOOLS_DIR)) {
+    if (!entry.endsWith(".py")) continue;
+    const src = readFileSync(join(TOOLS_DIR, entry), "utf8");
+
+    // Module-level string constants: `NAME[: ann] = "literal"`. Keys are
+    // constant-case (optionally leading underscore) so lowercase params
+    // like `name=name` are never mistaken for a tool-name source.
+    const consts = new Map();
+    const constRe = /^\s*(_?[A-Z][A-Za-z0-9_]*)\s*(?::[^=\n]+)?=\s*"([^"]+)"/gm;
+    for (const m of src.matchAll(constRe)) consts.set(m[1], m[2]);
+
+    // `name="<literal>"` — the common direct registration. `\bname`
+    // excludes `audit_agent_name=`, `agent_name=`, etc.
+    for (const m of src.matchAll(/\bname\s*=\s*"([a-z][a-z0-9_]*)"/g)) {
+      names.add(m[1]);
+    }
+    // `name=<CONST>` — variable registration; resolve via the const map.
+    for (const m of src.matchAll(/\bname\s*=\s*(_?[A-Z][A-Za-z0-9_]*)\b/g)) {
+      const resolved = consts.get(m[1]);
+      if (resolved) names.add(resolved);
+    }
+  }
+  return names;
+}
+
+test("every plugin-scoped hooks.json matcher names a registered MCP tool", () => {
+  const hooksDoc = JSON.parse(readFileSync(HOOKS_JSON, "utf8"));
+  const registered = registeredToolNames();
+
+  // Guard the guard: a broken path or a format change must fail loudly,
+  // not vacuously pass.
+  assert.ok(
+    registered.size > 0,
+    `no registered tool names derived from ${TOOLS_DIR}`,
+  );
+
+  const scopedTools = matcherStrings(hooksDoc)
+    .flatMap((m) => [...m.matchAll(SCOPED_MATCHER)].map((g) => g[1]));
+  assert.ok(
+    scopedTools.length > 0,
+    "no mcp__plugin_meho_meho__<tool> matcher found in hooks.json",
+  );
+
+  for (const tool of scopedTools) {
+    assert.ok(
+      registered.has(tool),
+      `hooks.json matches mcp__plugin_meho_meho__${tool}, but no tool ` +
+        `named "${tool}" is registered under backend/src/meho_backplane/` +
+        `mcp/tools/. The plugin-scoped name must be the exact registered ` +
+        `tool name (mind the meho_ prefix asymmetry).`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- The plugin's PostToolUse hook matched `mcp__plugin_meho_meho__broadcast_announce`, but the registered tool is `meho_broadcast_announce` (`backend/src/meho_backplane/mcp/tools/broadcast.py`), so the correct plugin-scoped name is `mcp__plugin_meho_meho__meho_broadcast_announce`. The bare name matched nothing, so `post-announce.sh` never wrote the `.announced` marker and the announce/report reminders never fell silent after an announce (field-test F3, #3143).
- Fixes the matcher and the two reminder texts (plus the surrounding comments in all three `bin/` hooks) to name `meho_broadcast_announce`. The `PreToolUse` `call_operation` matcher is left unchanged — it was already correct because `call_operation` registers *without* the `meho_` prefix; that asymmetry is what hid the bug.
- Adds a static conformance guard (`test/hooks-matcher-conformance.test.mjs`): every `mcp__plugin_meho_meho__<tool>` matcher in `hooks.json` must name a tool registered under `backend/src/meho_backplane/mcp/tools/`. The registered set is derived in-repo from the `register_mcp_tool` call sites (both string-literal and `Final[str]`-constant names) — no live server. Wired into the existing `plugin-test` lane so the next rename can't silently disarm a hook.

## Test plan
- [x] `node --test clients/claude-code-plugin/test/*.test.mjs` — 5 passed (4 existing shim-argv + 1 new conformance guard)
- [x] Guard is non-vacuous: verified it FAILS on the pre-fix bare `broadcast_announce` and PASSES on `meho_broadcast_announce`; resolves the 4 variable-registered tools (`query_audit`, `meho_audit_replay`, `query_topology`, `list_targets`)
- [x] No bare `broadcast_announce` remains in `clients/claude-code-plugin/bin/` (grep clean)
- [x] `hooks.json` valid JSON; `plugin-test.yml` valid YAML; `sh -n` + `shellcheck` clean on the three hooks
- [x] Code-quality gate (`code-quality.py --diff`) — exit 0

## Out of scope
- Skill-body / README tool-name references (`skills/broadcast/SKILL.md`, `clients/claude-code-plugin/README.md` L149/L150/L173 still say `broadcast_announce`) — the issue defers these to a separate docs-conformance task.
- Renaming backend tools for `meho_`-prefix consistency — a surface-policy discussion, out of scope per the issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3147
