### PR TITLE
fix(clients): drop sensor rows from SessionStart digest window

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -3,16 +3,21 @@
 
 # Claude Code plugin — PR behavioral + conformance tests.
 #
-# The plugin's stdio shim wrapper (clients/claude-code-plugin/bin/meho-mcp-remote)
-# is a bash launcher that `exec`s `npx -y mcp-remote@… <url> --static-oauth-…`.
-# One contract worth pinning is the argv it hands to npx — in particular
-# the OAuth scope metadata, which the MEHO_MCP_SCOPES elevation seam makes
-# operator-configurable — verified by a stubbed-argv suite (a stub `npx` on a
-# controlled PATH echoes the argv). A second suite is a static guard that
-# every plugin-scoped hooks.json matcher names a tool actually registered
-# under backend/src/meho_backplane/mcp/tools/ (the meho_ prefix asymmetry
-# silently disarmed the announce hook once — F3, #3143). This workflow runs
-# both whenever a PR touches the plugin sources. No network / npm install.
+# Three suites pin the plugin's behavioural contracts, each stubbing the
+# binary it drives (`npx` / `meho`) on a controlled PATH:
+#   1. The stdio shim wrapper (bin/meho-mcp-remote) `exec`s
+#      `npx -y mcp-remote@… <url> --static-oauth-…` — its argv is the
+#      contract, in particular the OAuth scope metadata the MEHO_MCP_SCOPES
+#      elevation seam makes operator-configurable (stubbed-argv suite).
+#   2. A static guard that every plugin-scoped hooks.json matcher names a
+#      tool actually registered under backend/src/meho_backplane/mcp/tools/
+#      (the meho_ prefix asymmetry silently disarmed the announce hook
+#      once — F3, #3143).
+#   3. The SessionStart reflex hook (bin/session-start.sh) shells out to
+#      the `meho` CLI and injects a digest whose recent-activity window
+#      must exclude `__sensor__` heartbeat rows.
+# This workflow runs every `test/*.test.mjs` suite whenever a PR touches
+# the plugin sources. No network / npm install.
 #
 # Advisory (non-required) and path-scoped, mirroring mcpb-bundle.yml. A
 # required check would need the `changes`-job + job-`if:` shape ci.yml uses
@@ -52,5 +57,5 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Plugin tests — shim argv contract + hooks matcher conformance
+      - name: Plugin tests — shim argv, hooks matcher conformance, session-start digest
         run: node --test clients/claude-code-plugin/test/*.test.mjs

--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -188,6 +188,11 @@ present. The live broadcast feed (`meho status --watch`) is an SSE stream and
 unsuitable for a hook that must return promptly, so the digest uses the
 audit log — every MEHO op writes an audit row and emits a broadcast event, so
 `meho audit recent` is the bounded, non-streaming read of the same window.
+The recent-activity window fetches a wide page and drops rows written under
+the reserved `__sensor__` principal (the checks plane's continuous sensor
+executions) *before* truncating to the display budget, so on a checks-enabled
+tenant those machine heartbeats can't evict the operator/agent activity the
+window exists to surface.
 These hooks **enforce** the broadcast discipline the server-assembled tenant
 preamble already states; they don't restate it.
 

--- a/clients/claude-code-plugin/bin/session-start.sh
+++ b/clients/claude-code-plugin/bin/session-start.sh
@@ -55,7 +55,21 @@ status_out="$(meho_read 2 status)"
 # `meho audit recent` is the bounded, non-streaming read of "what the
 # tenant has been doing". (`meho status --watch` is the live SSE feed —
 # unusable from a hook that must return promptly.)
-activity="$(meho_read 3 audit recent --limit 10 | head -n 12)"
+#
+# The checks plane runs sensor pins continuously under the `__sensor__`
+# principal, so on any checks-enabled tenant those machine heartbeats
+# dominate the newest audit rows and evict the operator/agent activity
+# this window exists to surface. Fetch a wide page, drop the
+# sensor-principal rows, THEN cut to the window budget — filtering
+# before the truncation keeps the window full of real activity instead
+# of collapsing to heartbeats (filter-after-truncate would show an all-
+# sensor or empty window on a sensor-heavy tenant). `__sensor__` is a
+# reserved sentinel the backplane forbids any operator from adopting,
+# so a fixed-string drop of the token cannot suppress a real principal's
+# rows. No CLI/backend change: the audit `--principal` filter is
+# include-only (no invert) and server-side exclusion is out of scope,
+# so the cheapest correct mechanism is a client-side drop here.
+activity="$(meho_read 3 audit recent --limit 100 | grep -vF '__sensor__' | head -n 12)"
 
 # Scoped memory recall — the operator's own notes/preferences in scope.
 memory="$(meho_read 3 list --limit 8 | head -n 10)"

--- a/clients/claude-code-plugin/test/session-start.test.mjs
+++ b/clients/claude-code-plugin/test/session-start.test.mjs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Stubbed-`meho` behavioral suite for bin/session-start.sh — the SessionStart
+// reflex hook. The hook shells out to the `meho` CLI four times (status gate,
+// audit recent, memory list, kb list) and prints a compact digest to stdout
+// that Claude Code injects as session context.
+//
+// `meho` is stubbed: a fake `meho` on a controlled PATH dispatches on its
+// first arg and prints a per-subcommand fixture the test writes. No live
+// backplane, no CLI build. The fixtures let the suite assert the one contract
+// this task pins — the recent-activity window excludes `__sensor__`
+// (sensor-principal) rows and stays full of real activity via
+// filter-then-truncate — plus the hook's fail-open guarantees.
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, test } from "node:test";
+import assert from "node:assert/strict";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOK = join(HERE, "..", "bin", "session-start.sh");
+
+// The hook budget: `head -n 12` keeps one table header + 11 data rows.
+const WINDOW_ROWS = 11;
+
+// One temp dir per suite holds the stub `meho` plus the per-subcommand
+// fixture files it cats. /usr/bin:/bin keeps sh/grep/head/cat/env/bash (and
+// coreutils `timeout` on the Linux CI runner) resolvable under the stub PATH.
+const STUB_DIR = mkdtempSync(join(tmpdir(), "meho-session-start-test-"));
+writeFileSync(
+  join(STUB_DIR, "meho"),
+  [
+    "#!/usr/bin/env bash",
+    // Fixture dir is passed by env, not derived from $0: PATH resolution
+    // (and `timeout`) exec the stub with argv[0]=\"meho\", so $0 is not a path.
+    'd="${MEHO_STUB_DIR:-/nonexistent}"',
+    'case "$1" in',
+    '  status) [ -f "$d/status.txt" ] && cat "$d/status.txt" ;;',
+    '  audit)  [ -f "$d/audit.txt" ]  && cat "$d/audit.txt" ;;',
+    '  list)   [ -f "$d/list.txt" ]   && cat "$d/list.txt" ;;',
+    '  kb)     [ -f "$d/kb.txt" ]     && cat "$d/kb.txt" ;;',
+    "esac",
+    "exit 0",
+    "",
+  ].join("\n"),
+);
+chmodSync(join(STUB_DIR, "meho"), 0o755);
+const PATH_WITH_STUB = `${STUB_DIR}:/usr/bin:/bin`;
+
+after(() => rmSync(STUB_DIR, { recursive: true, force: true }));
+
+// Render one `meho audit recent` table row the way the Go CLI's
+// printQueryTable does (space-padded columns). Only the PRINCIPAL column is
+// load-bearing for the filter; the rest is realistic filler.
+function auditRow(principal, opID) {
+  return [
+    "2026-08-27T12:00:00Z ",
+    principal.padEnd(12),
+    "vcenter-01".padEnd(18),
+    opID.padEnd(26),
+    "read".padEnd(16),
+    "ok",
+  ].join(" ");
+}
+
+// A page shaped like the field-test pathology: a burst of sensor heartbeats
+// FIRST, then the real operator/agent activity. A naive `--limit 10 | head`
+// (filter-after-truncate) would surface only sensor rows; filter-then-
+// truncate must instead fill the window with the op-NN rows that trail them.
+function mixedAuditPage(sensorCount, realCount) {
+  const lines = [
+    "TIME                   PRINCIPAL    TARGET             OP_ID                      CLASS            STATUS",
+  ];
+  for (let i = 0; i < sensorCount; i++) {
+    lines.push(auditRow("__sensor__", "checks.sensor.eval"));
+  }
+  for (let n = 1; n <= realCount; n++) {
+    const id = String(n).padStart(2, "0");
+    lines.push(auditRow(`op-${id}`, "vsphere.vm.list"));
+  }
+  return lines.join("\n") + "\n";
+}
+
+// Write the per-subcommand fixtures the stub cats. Absent keys => that
+// subcommand prints nothing (drives the fail-open / empty-section paths).
+function seedFixtures({ status, audit, list, kb }) {
+  for (const name of ["status", "audit", "list", "kb"]) {
+    rmSync(join(STUB_DIR, `${name}.txt`), { force: true });
+  }
+  if (status !== undefined) writeFileSync(join(STUB_DIR, "status.txt"), status);
+  if (audit !== undefined) writeFileSync(join(STUB_DIR, "audit.txt"), audit);
+  if (list !== undefined) writeFileSync(join(STUB_DIR, "list.txt"), list);
+  if (kb !== undefined) writeFileSync(join(STUB_DIR, "kb.txt"), kb);
+}
+
+function runHook(pathOverride = PATH_WITH_STUB) {
+  return spawnSync(HOOK, [], {
+    encoding: "utf8",
+    env: { PATH: pathOverride, MEHO_STUB_DIR: STUB_DIR },
+  });
+}
+
+test("recent-activity window drops __sensor__ rows and fills with real activity", () => {
+  // 20 sensor rows precede 15 real rows: without filter-then-truncate the
+  // window would be all heartbeats.
+  seedFixtures({
+    status: "operator=tester  backplane=https://meho.example  health=ok\n",
+    audit: mixedAuditPage(20, 15),
+  });
+  const res = runHook();
+  assert.equal(res.status, 0, `hook exited non-zero: ${res.stderr}`);
+
+  // (1) No sensor-principal row survives into the injected digest.
+  assert.ok(
+    !res.stdout.includes("__sensor__"),
+    `sensor rows leaked into the digest:\n${res.stdout}`,
+  );
+
+  // (2) The window filled with real rows despite the sensor burst leading the
+  // page — filter happened BEFORE the truncation, not after.
+  assert.match(res.stdout, /op-01\b/, `op-01 absent:\n${res.stdout}`);
+  assert.match(
+    res.stdout,
+    new RegExp(`op-${String(WINDOW_ROWS).padStart(2, "0")}\\b`),
+    `window did not fill to the budget (op-${WINDOW_ROWS} absent):\n${res.stdout}`,
+  );
+
+  // (3) Truncation still bounds the window: the 12th real row is cut
+  // (header + 11 rows = 12 lines), so it is filter-THEN-truncate, not a
+  // filter that forgot to cap.
+  assert.ok(
+    !res.stdout.includes(`op-${String(WINDOW_ROWS + 1).padStart(2, "0")}`),
+    `window exceeded the ${WINDOW_ROWS}-row budget:\n${res.stdout}`,
+  );
+});
+
+test("real activity shorter than the budget survives intact (no sensor rows)", () => {
+  seedFixtures({
+    status: "health=ok\n",
+    audit: mixedAuditPage(5, 3),
+  });
+  const res = runHook();
+  assert.equal(res.status, 0, res.stderr);
+  assert.ok(!res.stdout.includes("__sensor__"), res.stdout);
+  for (const id of ["op-01", "op-02", "op-03"]) {
+    assert.ok(res.stdout.includes(id), `${id} absent:\n${res.stdout}`);
+  }
+});
+
+test("the other digest sections are untouched by the activity filter", () => {
+  seedFixtures({
+    status: "health=ok\n",
+    audit: mixedAuditPage(3, 2),
+    list: "memory-note-alpha\nmemory-note-beta\n",
+    kb: "kb-entry-gamma\nkb-entry-delta\n",
+  });
+  const res = runHook();
+  assert.equal(res.status, 0, res.stderr);
+  // Activity window filtered as before.
+  assert.ok(!res.stdout.includes("__sensor__"), res.stdout);
+  assert.match(res.stdout, /op-01\b/, res.stdout);
+  // Memory + knowledge sections render verbatim (the filter is scoped to the
+  // activity window only — it never touches these two).
+  assert.match(res.stdout, /## Your MEHO memory \(scoped\)/, res.stdout);
+  assert.ok(res.stdout.includes("memory-note-alpha"), res.stdout);
+  assert.match(res.stdout, /## Recent MEHO knowledge/, res.stdout);
+  assert.ok(res.stdout.includes("kb-entry-gamma"), res.stdout);
+});
+
+test("fail-open: no `meho` on PATH => silent, exit 0", () => {
+  // A PATH without the stub dir: the hook's `command -v meho` guard fires.
+  const res = runHook("/usr/bin:/bin");
+  assert.equal(res.status, 0, res.stderr);
+  assert.equal(res.stdout, "", `expected no output, got:\n${res.stdout}`);
+});
+
+test("fail-open: empty `meho status` gate => silent, exit 0", () => {
+  // status.txt absent => the status gate reads empty => hook exits before the
+  // activity/memory/knowledge reads, printing nothing.
+  seedFixtures({ audit: mixedAuditPage(3, 5) });
+  const res = runHook();
+  assert.equal(res.status, 0, res.stderr);
+  assert.equal(res.stdout, "", `expected no output, got:\n${res.stdout}`);
+});
+
+test("all-sensor page => no sensor rows leak (window may be header-only)", () => {
+  // Degenerate tenant: every recent row is a heartbeat. The contract that
+  // must hold is that no `__sensor__` row is ever injected as context.
+  seedFixtures({
+    status: "health=ok\n",
+    audit: mixedAuditPage(30, 0),
+  });
+  const res = runHook();
+  assert.equal(res.status, 0, res.stderr);
+  assert.ok(
+    !res.stdout.includes("__sensor__"),
+    `sensor rows leaked on an all-sensor page:\n${res.stdout}`,
+  );
+});


### PR DESCRIPTION
## Summary
- The SessionStart reflex digest's recent-activity window was almost entirely `__sensor__` principal rows on any checks-enabled tenant — the checks plane runs sensor pins continuously, so machine heartbeats evict the operator/agent activity the window exists to surface, defeating the read-before-start reflex (field report #3143).
- `bin/session-start.sh` now fetches a wide page (`--limit 100`), drops sensor-principal rows with `grep -vF '__sensor__'`, **then** truncates to the display budget — filter-before-truncate keeps the window full instead of collapsing to heartbeats.
- Client-side by necessity and design: the audit `--principal` CLI filter is include-only (no invert) and server-side exclusion is out of scope, so **no CLI/backend/OpenAPI change** — nothing to regen.
- Adds a stubbed-`meho` digest suite and broadens `plugin-test.yml` to run every `test/*.test.mjs`.

## Test plan
- [x] `shellcheck clients/claude-code-plugin/bin/session-start.sh` — clean
- [x] `node --test clients/claude-code-plugin/test/*.test.mjs` — 10 passed (4 existing shim + 6 new digest)
- [x] **Filter-then-truncate proven** — fixture leads with 20 `__sensor__` rows then 15 real rows; asserts no `__sensor__` in output, `op-01`..`op-11` fill the window, `op-12` truncated (a filter-after-truncate would surface 0 real rows)
- [x] **Fail-open preserved** — no-`meho`-on-PATH and empty-`meho status` gate both exit 0 with no output; all-sensor page leaks no sensor rows
- [x] **Other sections untouched** — memory + knowledge sections still render verbatim alongside the filtered activity window
- [x] YAML valid; no trailing whitespace / missing final newlines

## Out of scope
- No CLI flag / OpenAPI-snapshot regen needed (the human-table + `grep` mechanism already exists; a flag was to be added *only if nothing existed*).
- Stray `NEXT: --cursor=…` line the audit table can emit when >100 rows exist in 24h — pre-existing digest behavior, a separate cosmetic concern (adjacent finding, not touched).
- kb-list preview formatting and digest operator-visibility — explicitly deferred by the issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3145
