### PR TITLE
docs(broadcast): reflex advisory ships post-v0.30.0 + direct-MCP read-nudge test

### DIFF
--- a/backend/tests/test_reflex_advisory.py
+++ b/backend/tests/test_reflex_advisory.py
@@ -18,7 +18,9 @@ Coverage mirrors the acceptance criteria on the issue, by name:
 * the fragment is session-scoped -- a dispatch with no agent session
   (CLI / non-MCP) gets no nudge;
 * read-before-act fires when the session has no prior
-  ``meho_broadcast_recent`` audit row and stays silent once it does;
+  ``meho_broadcast_recent`` audit row and stays silent once it does, and
+  fires for a direct MCP session resolved via the ``Mcp-Session-Id``
+  header fallback -- the live field shape (#3149);
 * announce-before-mutate fires for a write-class op with no covering
   claim and stays silent when a claim covers it; read-class ops never
   trip it;
@@ -43,6 +45,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
+import structlog
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
@@ -115,6 +118,22 @@ def _bound_session(session_id: UUID | None) -> Iterator[None]:
         yield
     finally:
         agent_session_id_var.reset(token)
+
+
+@contextmanager
+def _bound_mcp_session(session_id: UUID) -> Iterator[None]:
+    """Bind only the ``mcp_session_id`` header contextvar for the block.
+
+    Reproduces a *direct* MCP client's request context: no in-process
+    agent loop bound :data:`agent_session_id_var`, so the session is
+    carried solely by the ``mcp_session_id`` structlog contextvar the
+    transport binds from the ``Mcp-Session-Id`` header
+    (:func:`meho_backplane.mcp.server._bind_mcp_session_id`). This is the
+    live field shape :func:`resolve_agent_session_id` resolves via its
+    header fallback (#3149).
+    """
+    with structlog.contextvars.bound_contextvars(mcp_session_id=str(session_id)):
+        yield
 
 
 async def _seed_tenant(tenant_id: UUID = _TENANT) -> None:
@@ -295,6 +314,27 @@ async def test_read_nudge_is_per_session() -> None:
     with _patch_set(store), _bound_session(other):
         advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
     assert advisory == {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+
+
+async def test_read_nudge_fires_for_direct_mcp_session_via_header_fallback() -> None:
+    """Live field shape (#3149): a direct MCP session -- no agent-run
+    contextvar, session carried only by the ``Mcp-Session-Id`` header --
+    still fires the read nudge.
+
+    :func:`resolve_agent_session_id` resolves this session through its
+    ``mcp_session_id`` fallback rather than :data:`agent_session_id_var`;
+    the sibling read tests only exercise the agent-run path. The F5 field
+    test (#3143) saw ``extras: {}`` for exactly this shape *not* because
+    the resolution fails but because the lab ran ``v0.30.0``, which
+    predates the feature (PR #3141 landed after the tag). This locks in
+    that a header-resolved session emits, so the next deploy past
+    ``v0.30.0`` is the only thing the field re-verification waits on.
+    """
+    store = _FakeSetStore()
+    with _patch_set(store), _bound_session(None), _bound_mcp_session(_SESSION):
+        advisory = await build_reflex_advisory(_operator(), op_id="vault.kv.list", target_name=None)
+    assert advisory == {REFLEX_ADVISORY_EXTRAS_KEY: _READ_NUDGE}
+    assert store.ex_values[0] == 30 * 60
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/reflex-advisory.md
+++ b/docs/codebase/reflex-advisory.md
@@ -167,7 +167,47 @@ administration, and a management verb is a clean follow-up.
   `resolve_agent_session_id()`, which prefers the agent-run id and falls
   back to the MCP header session. A direct MCP agent session (the primary
   target) correlates cleanly; a nested agent-run-over-MCP may correlate
-  imperfectly.
+  imperfectly. The header fallback is the shape a standalone MCP client
+  exercises — it has no in-process agent loop, so `agent_session_id_var`
+  is unset and the whole nudge hinges on the `Mcp-Session-Id` header
+  being present (see "When the advisory does *not* fire" below).
+
+## When the advisory does *not* fire (qualifying shape)
+
+The fragment is present on a response only when **all** of these hold.
+Any one absent is a silent, correct `{}` — never a defect:
+
+1. **The feature is deployed.** `build_reflex_advisory` and the
+   `reflex_advisory_window_minutes` setting ship in **PR #3141**
+   (merge `6367f7`), which landed **after** the `v0.30.0` tag
+   (`d33419f`). A backplane running `v0.30.0` or earlier has no
+   `meho_backplane.broadcast.reflex` module and no
+   `reflex_advisory_window_minutes` setting, so **`extras` never carries
+   `reflex_advisory`** — the merge seam calls a builder that isn't there.
+   This is the root cause of the F5 field observation (#3149): the lab
+   ran `v0.30.0`, one release behind the feature. The advisory first
+   fires on the release *after* `v0.30.0`. Confirm the deployment is on
+   that release before treating an absent fragment as a bug — a live
+   read of the running image settles it:
+   `python -c "import meho_backplane.broadcast.reflex"` succeeds only
+   where the feature is deployed.
+2. **The window is non-zero.** `REFLEX_ADVISORY_WINDOW_MINUTES=0`
+   short-circuits to `{}` before any session resolution or I/O.
+3. **The dispatch has an agent session.** `resolve_agent_session_id()`
+   is non-`None` — an agent-run id (`agent_session_id_var`) *or* a
+   direct MCP session's `Mcp-Session-Id` header. An operator CLI / REST
+   call, a system sweep, **and a header-less MCP client that POSTed
+   `tools/call` without completing `initialize`** all resolve to `None`
+   and get no nudge (`audit_log.agent_session_id` lands NULL for that
+   same header-less call — see `mcp_session_id_capture_mode`).
+4. **The dispatch succeeded.** The fragment rides an already-ok
+   response, built after the audit commit — never a denied / error /
+   awaiting-approval envelope.
+5. **A heuristic both qualifies and wins its dedupe claim.** Read: no
+   prior `meho_broadcast_recent` row for the session. Announce:
+   write-class op with no covering active claim. And the
+   `(session, heuristic)` key must be unclaimed this window — a second
+   `call_operation` in the same session+window is silent by design.
 
 ## Operator reach (JSON only today)
 


### PR DESCRIPTION
## Summary

- **Root cause of field finding F5 (#3143) is deployment lag, not a code defect.** The live lab backplane runs `v0.30.0` (GIT_SHA `d33419f8`), which predates PR #3141 (`6367f717`, merged *after* the `v0.30.0` tag) that introduced the reflex advisory. The running image has no `meho_backplane.broadcast.reflex` module and no `reflex_advisory_window_minutes` setting — verified by `kubectl exec` against the live pod — so the dispatcher merge seam builds no fragment and `extras` is empty. Expected, given the deployment is one release behind the feature.
- **The heuristic is correct.** The read-before-act probe keys on the real audit path `/mcp/tools/call/meho_broadcast_recent` (the broadcast tool *does* carry the `meho_` prefix), and `resolve_agent_session_id` resolves a direct MCP session via its `Mcp-Session-Id` header fallback. So the F3-style `meho_`-prefix asymmetry does **not** apply here, and the probe does not match too much (it excludes the current `call_operation` row).
- **Closed the one real gap:** the existing tests only bound the agent-run contextvar (`agent_session_id_var`); the live field shape resolves the session through the `mcp_session_id` header fallback and was untested. Added a regression test reproducing exactly that shape, and documented the full qualifying/non-qualifying conditions — including the minimum-version caveat — in `docs/codebase/reflex-advisory.md`.

## Test plan

- [x] `ruff check tests/test_reflex_advisory.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` (CI gate) — no new errors (the lone `icmp.py MSG_ERRQUEUE` is a pre-existing Darwin-only false positive; CI runs Linux; this change touches only `tests/` + `docs/`)
- [x] `pytest tests/test_reflex_advisory.py` — 15 passed (14 existing + the new `test_read_nudge_fires_for_direct_mcp_session_via_header_fallback`)
- [x] `code-quality.py --files` — clean
- [x] Root cause evidenced live (read-only SELECTs + `kubectl exec`) and stated on #3149

## Out of scope

- No new heuristics; the announce gate (default-OFF) untouched.
- Live re-verification of a qualifying session observing `reflex_advisory` on the lab must wait on the next deploy past `v0.30.0` — the doc states the precise qualifying shape and the regression test proves the header-resolved session emits.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3149
