### PR TITLE
feat(policy): standing auto-approval grants + safety_level gate for service principals (#3151, #3152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,33 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- Operator-managed **standing scoped auto-approval grants for service
+  principals** (#3151). A service principal (OAuth2 client-credentials)
+  driving a long unattended run no longer parks a dozen times before its
+  modeled approval gate: an operator issues a
+  `(principal_sub, op_id, connector_id, target_id)` grant — the persistent
+  form of an approve decision — via the operator-role REST surface
+  `/api/v1/service-principals/grants` (create / list / revoke). Every scope
+  is explicit (no wildcards on principal or op), creating the grant IS the
+  upfront review (`reason` required), delete-shaped ops are never grantable,
+  revocation is a soft-delete (history retained), and each use writes an
+  `approval.decision` / `auto-approved` audit row carrying the `grant_id` —
+  same ledger visibility as a human decision. Expiry and revocation are
+  honoured at dispatch time.
+
+### Changed
+
+- The non-agent policy gate now **consults `safety_level` for service
+  principals** (#3152, resolved as option 1). A mutating `caution` op — and
+  any `dangerous` op — carried by a service principal now parks (routed to
+  the approval queue) even without `requires_approval`, where before only
+  `requires_approval` gated a non-agent op. Standing grants (#3151) are the
+  sanctioned path to run such mutations unattended. Human `USER` operators
+  are unaffected (they remain their own approver); the agent verdict path is
+  untouched.
+
 ### Fixed — document the first-connect MCP startup-timeout race for both Claude clients (#3148)
 
 - A fresh machine's **first** connect through either client onramp raced Claude

--- a/backend/alembic/versions/0078_create_service_principal_grant.py
+++ b/backend/alembic/versions/0078_create_service_principal_grant.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``service_principal_grant`` table (#3151 / #3152).
+
+An operator-managed **standing scoped auto-approval grant** for a
+non-agent **service principal** (OAuth2 client-credentials, ``principal_kind
+= service``). One row authorises exactly one
+``(principal_sub, op_id, connector_id, target_id)`` tuple in a tenant to
+run **unattended** — the non-agent policy gate
+(:func:`meho_backplane.operations._validate._non_agent_verdict`) consults
+these rows for a service principal that would otherwise park a
+``requires_approval`` op or a mutating ``caution`` / ``dangerous`` op
+(#3152 option 1). No wildcards on ``principal_sub`` or ``op_id``: creating
+a grant IS the operator's upfront review, so every scope is explicit.
+
+Additive-only (migration-compat contract): a fresh table plus its
+indexes, no ALTER of an existing object.
+
+Uniqueness is enforced by two **partial** unique indexes rather than one
+constraint because ``target_id`` is nullable (a targetless / tenant-wide
+op keys ``target_id IS NULL``) and Postgres treats ``NULL != NULL``, so a
+single unique index would not catch duplicate targetless grants. Both
+indexes are scoped to ``revoked_at IS NULL`` so a revoked grant does not
+block re-granting the same scope (revocation is a soft-delete — the row
+is retained for audit visibility).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0078"
+down_revision: str | None = "0077"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "service_principal_grant",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), sa.ForeignKey("tenant.id"), nullable=False),
+        sa.Column("principal_sub", sa.Text(), nullable=False),
+        sa.Column("op_id", sa.Text(), nullable=False),
+        sa.Column("connector_id", sa.Text(), nullable=False),
+        # Nullable: a targetless / tenant-wide op keys ``target_id IS NULL``.
+        sa.Column("target_id", sa.Uuid(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("created_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_by_sub", sa.Text(), nullable=True),
+    )
+
+    # Dominant dispatch-time query: "a live grant for principal P, op O in
+    # tenant T" (connector_id + target_id are matched in the WHERE tail).
+    op.create_index(
+        "service_principal_grant_lookup_idx",
+        "service_principal_grant",
+        ["tenant_id", "principal_sub", "op_id"],
+        postgresql_using="btree",
+    )
+    # At most one ACTIVE grant per fully-scoped key. Two partial indexes so
+    # the nullable ``target_id`` does not defeat uniqueness on the
+    # targetless case (NULL != NULL in Postgres).
+    op.create_index(
+        "uq_service_principal_grant_targeted",
+        "service_principal_grant",
+        ["tenant_id", "principal_sub", "op_id", "connector_id", "target_id"],
+        unique=True,
+        postgresql_where=sa.text("target_id IS NOT NULL AND revoked_at IS NULL"),
+        sqlite_where=sa.text("target_id IS NOT NULL AND revoked_at IS NULL"),
+    )
+    op.create_index(
+        "uq_service_principal_grant_targetless",
+        "service_principal_grant",
+        ["tenant_id", "principal_sub", "op_id", "connector_id"],
+        unique=True,
+        postgresql_where=sa.text("target_id IS NULL AND revoked_at IS NULL"),
+        sqlite_where=sa.text("target_id IS NULL AND revoked_at IS NULL"),
+    )
+    # Drives listing / dispatch filtering of still-live grants.
+    op.create_index(
+        "service_principal_grant_expires_at_idx",
+        "service_principal_grant",
+        ["expires_at"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "service_principal_grant_expires_at_idx",
+        table_name="service_principal_grant",
+    )
+    op.drop_index(
+        "uq_service_principal_grant_targetless",
+        table_name="service_principal_grant",
+    )
+    op.drop_index(
+        "uq_service_principal_grant_targeted",
+        table_name="service_principal_grant",
+    )
+    op.drop_index(
+        "service_principal_grant_lookup_idx",
+        table_name="service_principal_grant",
+    )
+    op.drop_table("service_principal_grant")

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -90,6 +90,10 @@ TAG_FEATURE: Final[dict[str, str]] = {
     "runner-principals": "satellite_gateway",
     "scheduler": "scheduler",
     "sensors": "sensors",
+    # Standing scoped auto-approval grants for service principals (#3151 /
+    # #3152) are the persistent form of an operator approve decision --
+    # same substrate, same maturity tier as the approval queue.
+    "service-principal-grants": "approvals",
     "targets": "targets",
     "topology": "topology",
 }

--- a/backend/src/meho_backplane/api/v1/service_grants.py
+++ b/backend/src/meho_backplane/api/v1/service_grants.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/service-principals/grants*`` — REST surface for standing grants (#3151).
+
+Operator-only CRUD over
+:class:`~meho_backplane.operations.service_grants.ServicePrincipalGrantService`.
+Creating a grant IS the operator's upfront approval of an unattended
+operation for a service principal (the review flow — ``reason`` is
+required); listing and revoking manage the grant history.
+
+Route inventory
+---------------
+
+* ``GET /api/v1/service-principals/grants`` — list grants in the operator's
+  tenant. Query: ``principal_sub``, ``include_revoked``, ``limit``,
+  ``offset``. Role: ``operator``.
+* ``GET /api/v1/service-principals/grants/{grant_id}`` — fetch one grant.
+  404 when absent / cross-tenant. Role: ``operator``.
+* ``POST /api/v1/service-principals/grants`` — create a grant. Body:
+  :class:`~meho_backplane.operations.service_grant_schemas.ServiceGrantCreate`.
+  201 on success; 422 on a wildcard, a delete-shaped op, a past expiry, or
+  a duplicate active grant. Role: ``operator``.
+* ``DELETE /api/v1/service-principals/grants/{grant_id}`` — revoke
+  (soft-delete). 204 on success; 404 when absent / already revoked /
+  cross-tenant. Role: ``operator``.
+
+Role: ``operator`` (not ``tenant_admin``) — mirrors the approvals surface,
+because a standing grant is the persistent form of the same approve
+decision an operator already makes on the approval queue.
+
+Tenant scoping: every route derives ``tenant_id`` from the JWT-validated
+:class:`~meho_backplane.auth.operator.Operator`; no surface accepts a
+tenant id from the body or query string. Every route binds ``audit_op_id``
++ ``audit_op_class`` so the write lands on the audit ledger.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Final
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import status as http_status
+from fastapi.responses import Response
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.operations.service_grant_schemas import (
+    ServiceGrantCreate,
+    ServiceGrantListResponse,
+    ServiceGrantRead,
+)
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/service-principals/grants", tags=["service-principal-grants"])
+
+#: Module-level Depends closure — avoids ruff B008 (mutable call in a
+#: default-argument position). Same pattern as ``api.v1.approvals``.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+_GRANT_OP_IDS: Final[dict[str, str]] = {
+    "list": "service_grant.list",
+    "show": "service_grant.show",
+    "create": "service_grant.create",
+    "revoke": "service_grant.revoke",
+}
+
+
+@router.get("", response_model=ServiceGrantListResponse)
+async def list_grants(
+    operator: Operator = _require_operator,
+    principal_sub: str | None = Query(default=None),
+    include_revoked: bool = Query(default=False),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> ServiceGrantListResponse:
+    """List standing grants for the operator's tenant.
+
+    ``principal_sub`` filters to one service principal's grants;
+    ``include_revoked`` surfaces the revoked history. Tenant-scoped to the
+    operator's JWT — no cross-tenant access.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_GRANT_OP_IDS["list"],
+        audit_op_class="read",
+    )
+    service = ServicePrincipalGrantService()
+    grants = await service.list_(
+        operator.tenant_id,
+        principal_sub=principal_sub,
+        include_revoked=include_revoked,
+        limit=limit,
+        offset=offset,
+    )
+    return ServiceGrantListResponse(grants=grants)
+
+
+@router.get("/{grant_id}", response_model=ServiceGrantRead)
+async def show_grant(
+    grant_id: Annotated[UUID, Path()],
+    operator: Operator = _require_operator,
+) -> ServiceGrantRead:
+    """Return one grant by id. Cross-tenant probes return 404 (never 403)."""
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_GRANT_OP_IDS["show"],
+        audit_op_class="read",
+    )
+    service = ServicePrincipalGrantService()
+    entry = await service.get(operator.tenant_id, grant_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="grant_not_found",
+        )
+    return entry
+
+
+@router.post("", response_model=ServiceGrantRead, status_code=http_status.HTTP_201_CREATED)
+async def create_grant(
+    payload: ServiceGrantCreate,
+    operator: Operator = _require_operator,
+) -> ServiceGrantRead:
+    """Create a standing grant (the operator's upfront review).
+
+    Returns 422 when the op is delete-shaped, a scope field carries a
+    wildcard, ``expires_at`` is in the past, or an active grant for the
+    same fully-scoped key already exists. Audited via the audit middleware.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_GRANT_OP_IDS["create"],
+        audit_op_class="write",
+        audit_agent_name=payload.principal_sub,
+    )
+    service = ServicePrincipalGrantService()
+    try:
+        entry = await service.create(operator.tenant_id, operator.sub, payload)
+    except GrantValidationError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.message,
+        ) from exc
+    return entry
+
+
+@router.delete("/{grant_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+async def revoke_grant(
+    grant_id: Annotated[UUID, Path()],
+    operator: Operator = _require_operator,
+) -> Response:
+    """Revoke (soft-delete) a standing grant.
+
+    Returns 204 on success; 404 when the grant is absent, already revoked,
+    or belongs to another tenant. Audited via the audit middleware.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_GRANT_OP_IDS["revoke"],
+        audit_op_class="write",
+    )
+    service = ServicePrincipalGrantService()
+    revoked = await service.revoke(operator.tenant_id, grant_id, operator.sub)
+    if not revoked:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="grant_not_found",
+        )
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4301,6 +4301,150 @@ class AgentPermission(Base):
     )
 
 
+class ServicePrincipalGrant(Base):
+    """Standing scoped auto-approval grant for a service principal (#3151 / #3152).
+
+    A paired consumer add-on drives long multi-step workflows through the
+    backplane as a **service principal** (OAuth2 client-credentials,
+    ``principal_kind = service``). Its own workflow model has a single
+    deliberate human-approval gate near the end, but the run never reaches
+    it unattended: the non-agent policy gate
+    (:func:`meho_backplane.operations._validate._non_agent_verdict`) parks
+    every ``requires_approval`` op — and, since #3152, every mutating
+    ``caution`` / ``dangerous`` op — so a ~10-step build parks a dozen
+    times before the modeled gate.
+
+    One row authorises exactly one
+    ``(principal_sub, op_id, connector_id, target_id)`` tuple in a tenant
+    to run **unattended**. Creating the grant IS the operator's upfront
+    review (deny-by-default absent a match), so every scope is explicit —
+    **no wildcards** on ``principal_sub`` or ``op_id`` (contrast
+    :class:`AgentPermission`, whose ``op_pattern`` is an fnmatch glob for
+    the *agent* verdict model). The grant list is the **floor** of what
+    runs unattended, never a bypass of a modeled gate: delete-shaped ops
+    are refused at creation
+    (:func:`meho_backplane.operations.service_grants.ServicePrincipalGrantService.create`).
+
+    Design decisions
+    ----------------
+
+    **Principal is ``sub``, not an FK.** Same soft-reference discipline as
+    :attr:`AgentPermission.principal_sub`. Unlike agent grants there is no
+    server-side service-principal registry to validate against (a service
+    principal is any Keycloak client-credentials client carrying
+    ``principal_kind=service``), so an unenforceable-principal check is not
+    possible; a grant whose ``principal_sub`` never authenticates simply
+    sits inert.
+
+    **Enforcement is SERVICE-only.** The gate consults these rows solely
+    for ``principal_kind == service`` tokens. A human ``USER`` operator
+    keeps the v0.2 default-allow + queue-on-``requires_approval`` contract
+    (they are their own approver); agents use :class:`AgentPermission`.
+
+    **Revocation is a soft-delete.** ``revoked_at`` (+ ``revoked_by_sub``)
+    is stamped rather than the row deleted, so a revoked grant stays
+    visible in the grant history — same forensic visibility as a human
+    approval decision. Expiry (``expires_at``) and revocation are both
+    honoured **at dispatch time** by the lookup filter; no sweeper is
+    needed (an expired / revoked row simply stops matching).
+
+    Indexes / constraints
+    ---------------------
+
+    * ``service_principal_grant_lookup_idx`` — b-tree on
+      ``(tenant_id, principal_sub, op_id)`` — the dispatch-time query.
+    * ``uq_service_principal_grant_targeted`` / ``…_targetless`` — two
+      **partial** unique indexes (``target_id IS [NOT] NULL AND revoked_at
+      IS NULL``) enforcing "at most one active grant per fully-scoped
+      key". Split because the nullable ``target_id`` would otherwise defeat
+      a single unique index on the targetless case (``NULL != NULL``), and
+      scoped to ``revoked_at IS NULL`` so a revoked scope can be re-granted.
+    """
+
+    __tablename__ = "service_principal_grant"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    # JWT ``sub`` of the service principal the grant authorises. Soft
+    # reference (no FK) -- same discipline as AgentPermission.principal_sub.
+    principal_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    # Exactly one operation id (no glob). Raw HTTP ops are ``"POST:/path"``;
+    # typed / composite ops are dotted (``"vmware.composite.vm.create"``).
+    op_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # The ``"<impl_id>-<version>"`` connector string the dispatcher resolves
+    # (same shape as ApprovalRequest.connector_id).
+    connector_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # NULL keys a targetless / tenant-wide op; a UUID keys exactly one
+    # target. Matched exactly at dispatch (no any-target wildcard).
+    target_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(), nullable=True)
+    # Operator's upfront justification (the review flow requires it).
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    # NULL = a standing (permanent) grant; a future UTC timestamp bounds it.
+    # The dispatch lookup ignores rows past their ``expires_at``.
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    # Soft-delete marker: NULL = live, non-NULL = revoked at that time.
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    revoked_by_sub: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "service_principal_grant_lookup_idx",
+            "tenant_id",
+            "principal_sub",
+            "op_id",
+            postgresql_using="btree",
+        ),
+        Index(
+            "uq_service_principal_grant_targeted",
+            "tenant_id",
+            "principal_sub",
+            "op_id",
+            "connector_id",
+            "target_id",
+            unique=True,
+            postgresql_where=sa.text("target_id IS NOT NULL AND revoked_at IS NULL"),
+            sqlite_where=sa.text("target_id IS NOT NULL AND revoked_at IS NULL"),
+        ),
+        Index(
+            "uq_service_principal_grant_targetless",
+            "tenant_id",
+            "principal_sub",
+            "op_id",
+            "connector_id",
+            unique=True,
+            postgresql_where=sa.text("target_id IS NULL AND revoked_at IS NULL"),
+            sqlite_where=sa.text("target_id IS NULL AND revoked_at IS NULL"),
+        ),
+        Index(
+            "service_principal_grant_expires_at_idx",
+            "expires_at",
+            postgresql_using="btree",
+        ),
+    )
+
+
 class ScheduledTriggerKind(StrEnum):
     """Closed enum of trigger shapes the G11.3 scheduler dispatches.
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -107,6 +107,7 @@ from meho_backplane.api.v1.runner_principals import (
 from meho_backplane.api.v1.scheduler import router as api_v1_scheduler_router
 from meho_backplane.api.v1.search_docs import router as api_v1_search_docs_router
 from meho_backplane.api.v1.sensors import router as api_v1_sensors_router
+from meho_backplane.api.v1.service_grants import router as api_v1_service_grants_router
 from meho_backplane.api.v1.targets import router as api_v1_targets_router
 from meho_backplane.api.v1.topology import router as api_v1_topology_router
 from meho_backplane.api.well_known import router as well_known_router
@@ -1047,6 +1048,9 @@ app.include_router(api_v1_checks_dashboards_router)
 # (T5) so a ``broadcast_watch`` operator session learns of pending
 # requests without polling. Operator-level; tenant-scoped via the JWT.
 app.include_router(api_v1_approvals_router)
+# #3151 -- operator-managed standing scoped auto-approval grants for
+# service principals (the persistent form of an approve decision).
+app.include_router(api_v1_service_grants_router)
 # G7.1-T2 (#314) -- tenant-conventions CRUD + history (list / show /
 # create / update / delete / history). Reads gated to operator+;
 # writes gated to tenant_admin. Tenant-scoped via the JWT's

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any
+from typing import Any, Final
 
 import structlog
 from jsonschema import Draft202012Validator
@@ -37,6 +37,12 @@ from meho_backplane.auth.operator import Operator, PrincipalKind
 from meho_backplane.auth.permissions import _more_restrictive, resolve_verdict
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
+
+# Read-class HTTP verbs — the same set the ingest layer pins as
+# ``READ_HTTP_METHODS`` (``operations/ingest/_internals.py``). Duplicated as
+# a two-element literal here so the gate carries no import into the ingest
+# package (which would risk an import cycle on the hot dispatch path).
+_READ_METHODS: Final[frozenset[str]] = frozenset({"GET", "HEAD"})
 
 _log = structlog.get_logger(__name__)
 
@@ -137,24 +143,81 @@ def validate_params(
     return out
 
 
-def _non_agent_verdict(
+def _is_mutating(descriptor: EndpointDescriptor) -> bool:
+    """Whether *descriptor* names a mutating (non-read) operation.
+
+    Grounded in the fields the repo already carries — no invented column:
+
+    * an ingested op declares an HTTP ``method``; it is read-class iff the
+      verb is in :data:`_READ_METHODS` (``GET`` / ``HEAD``), mutating
+      otherwise (``POST`` / ``PUT`` / ``PATCH`` / ``DELETE``);
+    * a typed / composite op carries no ``method``, so its curated
+      ``safety_level`` stands in — a ``safe`` typed op is a read, a
+      ``caution`` / ``dangerous`` one is a write by convention.
+    """
+    method = descriptor.method
+    if method:
+        return method.upper() not in _READ_METHODS
+    return descriptor.safety_level != "safe"
+
+
+def _service_safety_gate_reason(descriptor: EndpointDescriptor) -> str | None:
+    """Extra gating a **service** principal gets from ``safety_level`` (#3152).
+
+    Resolution of #3152 as its option 1: the non-agent gate now consults
+    ``safety_level`` for a service principal on a ``requires_approval=False``
+    op. A ``dangerous`` op parks always; a mutating ``caution`` op parks;
+    ``safe`` (and any non-mutating) op is unchanged (auto-executes). A
+    standing grant is the sanctioned path to run either unattended.
+
+    Returns the park reason, or ``None`` when the op stays auto-execute.
+    """
+    if descriptor.safety_level == "dangerous":
+        return (
+            "safety_level=dangerous; service-principal mutations park "
+            "(routed to the approval queue) unless a standing grant covers them (#3152)"
+        )
+    if descriptor.safety_level == "caution" and _is_mutating(descriptor):
+        return (
+            "safety_level=caution mutating op; service-principal mutations park "
+            "unless a standing grant covers them (#3152)"
+        )
+    return None
+
+
+async def _non_agent_verdict(
     *,
     operator: Operator,
     descriptor: EndpointDescriptor,
     target: Any,
+    connector_id: str | None,
 ) -> tuple[PermissionVerdict, str | None]:
     """Resolve the verdict for a human / service (non-agent) principal.
 
-    Preserves the v0.2 default-allow contract for ordinary ops, but
-    routes a ``requires_approval`` op to ``needs-approval`` (the approval
-    queue) rather than hard-denying it (G11.7-T1 #1401). Self-approval is
-    blocked at decide time by ``approve_request``'s requester != approver
-    guard — the gate's job here is only to park the call.
+    Preserves the v0.2 default-allow contract for a human ``USER`` operator
+    — an ordinary op auto-executes and a ``requires_approval`` op routes to
+    the approval queue (G11.7-T1 #1401); they are their own approver.
+
+    For a **service** principal (client-credentials, ``principal_kind =
+    service``) the gate additionally consults ``safety_level`` (#3152) so a
+    mutating ``caution`` / ``dangerous`` op parks even without
+    ``requires_approval``, and — for any parked service-principal op — a
+    live matching **standing grant** (#3151) auto-approves it: the grant
+    use is recorded on the approvals audit ledger and the gate clears to
+    ``AUTO_EXECUTE``. Absent a grant the op parks for a human decision.
     """
     target_id_str = str(getattr(target, "id", None)) if target is not None else None
+    is_service = operator.principal_kind is PrincipalKind.SERVICE
+
+    gate_reason: str | None = None
     if descriptor.requires_approval:
+        gate_reason = "requires_approval is True; routed to the approval queue (G11.7-T1)"
+    elif is_service:
+        gate_reason = _service_safety_gate_reason(descriptor)
+
+    if gate_reason is None:
         _log.info(
-            "policy_gate_needs_approval",
+            "policy_gate_default_allow",
             operator_sub=operator.sub,
             principal_kind=operator.principal_kind.value,
             tenant_id=str(operator.tenant_id),
@@ -162,12 +225,34 @@ def _non_agent_verdict(
             safety_level=descriptor.safety_level,
             target_id=target_id_str,
         )
-        return (
-            PermissionVerdict.NEEDS_APPROVAL,
-            "requires_approval is True; routed to the approval queue (G11.7-T1)",
+        return PermissionVerdict.AUTO_EXECUTE, None
+
+    # The op would park. A service principal can clear the gate with a live
+    # standing grant (recorded as an auto-approval on the audit ledger).
+    if is_service and connector_id is not None:
+        from meho_backplane.operations.service_grants import consult_and_record_grant
+
+        grant_id = await consult_and_record_grant(
+            operator=operator,
+            descriptor=descriptor,
+            target=target,
+            connector_id=connector_id,
         )
+        if grant_id is not None:
+            _log.info(
+                "policy_gate_standing_grant_auto_approved",
+                operator_sub=operator.sub,
+                principal_kind=operator.principal_kind.value,
+                tenant_id=str(operator.tenant_id),
+                op_id=descriptor.op_id,
+                safety_level=descriptor.safety_level,
+                target_id=target_id_str,
+                grant_id=str(grant_id),
+            )
+            return PermissionVerdict.AUTO_EXECUTE, f"auto-granted by standing grant {grant_id}"
+
     _log.info(
-        "policy_gate_default_allow",
+        "policy_gate_needs_approval",
         operator_sub=operator.sub,
         principal_kind=operator.principal_kind.value,
         tenant_id=str(operator.tenant_id),
@@ -175,7 +260,7 @@ def _non_agent_verdict(
         safety_level=descriptor.safety_level,
         target_id=target_id_str,
     )
-    return PermissionVerdict.AUTO_EXECUTE, None
+    return PermissionVerdict.NEEDS_APPROVAL, gate_reason
 
 
 async def policy_gate(
@@ -183,6 +268,7 @@ async def policy_gate(
     operator: Operator,
     descriptor: EndpointDescriptor,
     target: Any,
+    connector_id: str | None = None,
 ) -> tuple[PermissionVerdict, str | None]:
     """G11.2-T3 per-(principal, op, target) policy gate.
 
@@ -216,23 +302,21 @@ async def policy_gate(
     The per-(principal, op, target) agent-permission model gates **agent
     principals** (``principal_kind == agent``) through
     :func:`~meho_backplane.auth.permissions.resolve_verdict`. Human
-    operators and service accounts keep the v0.2 default-allow contract
-    for ordinary ops, but a ``requires_approval`` op now routes them to
-    the **approval queue** (``needs-approval``) rather than hard-denying.
+    operators keep the v0.2 default-allow contract for ordinary ops, but a
+    ``requires_approval`` op now routes them to the **approval queue**
+    (``needs-approval``) rather than hard-denying.
 
-    G11.7-T1 (#1401) closes the Phase-C gap: ops-team operators
-    authenticate as ``USER`` principals
-    (:func:`meho_backplane.auth.operator`), so the old hard-deny meant
-    every governed connector write returned ``denied`` to the very
-    people meant to run it. Routing them to ``needs-approval`` reuses
-    the already-built queue/approve/resume substrate
-    (:func:`~meho_backplane.operations.approval_queue.create_pending_request`
-    accepts any operator; the REST/MCP/CLI approve surfaces and the
-    ``_approved=True`` resume path are unchanged) — it is a one-branch
-    policy change, not new infrastructure. A non-``requires_approval``
-    op a human has always been able to run still auto-executes, so no
-    existing human-runnable op regresses.
+    **Service principals** (client-credentials, ``principal_kind ==
+    service``) additionally consult ``safety_level`` (#3152): a mutating
+    ``caution`` / ``dangerous`` op parks even without ``requires_approval``.
+    Any parked service-principal op is auto-approved when a live matching
+    **standing grant** exists (#3151), which requires *connector_id* to be
+    supplied so the grant's connector scope can be matched; the grant use
+    is recorded on the approvals audit ledger. See :func:`_non_agent_verdict`.
 
+    G11.7-T1 (#1401) routes ``USER`` operators to ``needs-approval`` on a
+    ``requires_approval`` op (reusing the queue/approve/resume substrate)
+    rather than hard-denying — so no existing human-runnable op regresses.
     The agent path additionally folds ``requires_approval`` into the
     verdict as a ``needs-approval`` floor, so an op the connector author
     marked as requiring approval is never auto-executed by an agent
@@ -241,12 +325,17 @@ async def policy_gate(
     The function is **async** — it opens its own DB session to load the
     caller's :class:`~meho_backplane.db.models.AgentPermission` rows,
     mirroring the same pattern :func:`audit_and_broadcast_safe` uses.
-    The dispatcher's call site changes only in adding ``await``; the
-    signature (operator / descriptor / target) stays identical to v0.2.
     """
     # --- Human / service principals: default-allow, queue on approval --
+    # (a service principal additionally consults safety_level + standing
+    # grants — see :func:`_non_agent_verdict`).
     if operator.principal_kind is not PrincipalKind.AGENT:
-        return _non_agent_verdict(operator=operator, descriptor=descriptor, target=target)
+        return await _non_agent_verdict(
+            operator=operator,
+            descriptor=descriptor,
+            target=target,
+            connector_id=connector_id,
+        )
 
     # --- Agent principals: per-(principal, op, target) verdict ----------
     target_id = getattr(target, "id", target) if target is not None else None

--- a/backend/src/meho_backplane/operations/composite.py
+++ b/backend/src/meho_backplane/operations/composite.py
@@ -363,6 +363,9 @@ def get_dispatch_child(
     return _dispatch_child
 
 
+# code-quality-allow: pre-existing 118-line function (predates #3151); this
+# change adds only the `connector_id=connector_id` pass-through to the
+# policy_gate call so a service-principal standing grant can be matched.
 async def enforce_subop_policy(
     *,
     operator: Operator,
@@ -445,7 +448,9 @@ async def enforce_subop_policy(
         parameter_schema={},
     )
 
-    verdict, reason = await policy_gate(operator=operator, descriptor=descriptor, target=target)
+    verdict, reason = await policy_gate(
+        operator=operator, descriptor=descriptor, target=target, connector_id=connector_id
+    )
     if verdict is PermissionVerdict.AUTO_EXECUTE:
         return None
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -2211,7 +2211,10 @@ async def dispatch(
             # / deny). The call site signature is unchanged; the function now
             # awaits a DB read to load the principal's AgentPermission rows.
             verdict, gate_reason = await policy_gate(
-                operator=operator, descriptor=descriptor, target=target
+                operator=operator,
+                descriptor=descriptor,
+                target=target,
+                connector_id=connector_id,
             )
             policy_decision_var.set(verdict.value)
             if verdict == PermissionVerdict.DENY:

--- a/backend/src/meho_backplane/operations/service_grant_schemas.py
+++ b/backend/src/meho_backplane/operations/service_grant_schemas.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic v2 shapes for the service-principal standing-grant surface (#3151).
+
+Three shapes for the operator-only REST surface
+(:mod:`meho_backplane.api.v1.service_grants`):
+
+* :class:`ServiceGrantCreate` — body for creating a grant. Creating a
+  grant IS the operator's upfront approval, so ``reason`` is **required**;
+  ``op_id`` and ``connector_id`` are exact (no glob), and ``target_id`` is
+  the explicit target UUID or ``None`` for a targetless / tenant-wide op.
+* :class:`ServiceGrantRead` — row shape every accessor returns.
+* :class:`ServiceGrantListResponse` — list-endpoint envelope.
+
+All shapes set ``extra="forbid"`` so an unknown field is a 422 at the
+boundary rather than a silent no-op — the same strictness the agent-grant
+schemas apply.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "ServiceGrantCreate",
+    "ServiceGrantListResponse",
+    "ServiceGrantRead",
+]
+
+
+class ServiceGrantCreate(BaseModel):
+    """Body for creating a standing scoped auto-approval grant.
+
+    ``extra="forbid"`` rejects unknown fields with 422. There are
+    deliberately **no wildcards**: ``op_id`` and ``connector_id`` name one
+    exact operation on one exact connector, and ``target_id`` is either a
+    concrete target UUID or ``None`` for a targetless op. The service layer
+    refuses delete-shaped ops (a grant is the floor of what runs
+    unattended, not a bypass of a modeled destructive gate).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    principal_sub: str = Field(
+        min_length=1,
+        max_length=512,
+        description="JWT sub of the service principal the grant authorises (no wildcard).",
+    )
+    op_id: str = Field(
+        min_length=1,
+        max_length=512,
+        description="Exact operation id, no glob (e.g. 'POST:/vcenter/vm').",
+    )
+    connector_id: str = Field(
+        min_length=1,
+        max_length=256,
+        description="Exact '<impl_id>-<version>' connector id, e.g. 'vmware-rest-9.0'.",
+    )
+    target_id: UUID | None = Field(
+        default=None,
+        description="Target UUID the grant is scoped to, or null for a targetless op.",
+    )
+    reason: str = Field(
+        min_length=1,
+        max_length=2048,
+        description="Operator's upfront justification (creating the grant is the review).",
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        description="Optional UTC expiry; null = standing (permanent) grant; must be future.",
+    )
+
+
+class ServiceGrantRead(BaseModel):
+    """Row shape every accessor returns.
+
+    ``from_attributes=True`` allows direct construction from an ORM row.
+    Exposes ``revoked_at`` / ``revoked_by_sub`` so callers can tell a live
+    grant from a revoked one in the history.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    tenant_id: UUID
+    principal_sub: str
+    op_id: str
+    connector_id: str
+    target_id: UUID | None
+    reason: str
+    created_by_sub: str
+    created_at: datetime
+    expires_at: datetime | None
+    revoked_at: datetime | None
+    revoked_by_sub: str | None
+
+
+class ServiceGrantListResponse(BaseModel):
+    """Response envelope for ``GET /api/v1/service-principals/grants``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    grants: list[ServiceGrantRead]

--- a/backend/src/meho_backplane/operations/service_grants.py
+++ b/backend/src/meho_backplane/operations/service_grants.py
@@ -1,0 +1,581 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Standing scoped auto-approval grants for service principals (#3151 / #3152).
+
+Two layers over the :class:`~meho_backplane.db.models.ServicePrincipalGrant`
+table:
+
+* **CRUD service** — :class:`ServicePrincipalGrantService`, the single code
+  path the operator-only REST surface
+  (:mod:`meho_backplane.api.v1.service_grants`) dispatches through. Create
+  IS the review (``reason`` required, deny-by-default absent a match, no
+  wildcards, delete-shaped ops refused), list, and revoke (soft-delete).
+
+* **Enforcement** — :func:`consult_and_record_grant`, called by the
+  non-agent policy gate
+  (:func:`meho_backplane.operations._validate._non_agent_verdict`) for a
+  **service** principal whose op would otherwise park. It looks up a live
+  matching grant and, when one exists, records the use in the **approvals
+  audit ledger** ("auto-granted by standing grant ``<id>``") with the same
+  ``method='APPROVAL'`` / ``path='approval.decision'`` shape a human
+  approval decision writes — so a grant use is as visible on the ledger as
+  a human clicking Approve — then returns the grant id so the gate can
+  clear.
+
+Enforcement is **service-principal-only** (mirroring how
+:class:`AgentPermission` is consulted only for ``principal_kind=agent``):
+a human ``USER`` operator keeps the default-allow + queue-on-approval
+contract, and agents use the agent-permission model.
+
+Delete-shaped guardrail
+-----------------------
+
+A grant is the *floor* of what runs unattended, never a bypass of a
+modeled destructive gate, so :meth:`ServicePrincipalGrantService.create`
+refuses delete-shaped ops: op ids matching a configured pattern set
+(``Settings.service_grant_delete_shaped_patterns`` — at minimum
+``DELETE:*`` raw ops plus ``*.delete`` / ``*.destroy`` / ``*.remove`` /
+``*.purge`` typed ops) and, best-effort when a descriptor resolves,
+anything whose descriptor carries ``method='DELETE'`` or a ``destructive``
+tag.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from fnmatch import fnmatchcase
+from typing import Any
+
+import structlog
+from sqlalchemy import or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, ServicePrincipalGrant
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate, ServiceGrantRead
+
+__all__ = [
+    "GrantValidationError",
+    "ServicePrincipalGrantService",
+    "consult_and_record_grant",
+    "find_live_grant",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Default paging cap for :meth:`ServicePrincipalGrantService.list_`.
+DEFAULT_LIST_LIMIT: int = 100
+
+#: Synthetic audit fields mirroring an ``approval.decision`` row so a grant
+#: use is queryable identically to a human decision (see
+#: :func:`~meho_backplane.operations.approval_queue._write_audit_row`).
+_GRANT_USE_METHOD: str = "APPROVAL"
+_GRANT_USE_PATH: str = "approval.decision"
+_GRANT_USE_STATUS_CODE: int = 200
+
+
+class GrantValidationError(Exception):
+    """Raised for semantic validation failures on grant creation.
+
+    Covers: a wildcard in ``op_id`` / ``connector_id`` / ``principal_sub``;
+    a delete-shaped op (never grantable); a past / naive ``expires_at``; or
+    a duplicate active grant for the same fully-scoped key. The REST route
+    maps this to HTTP 422.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Create-time validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _reject_wildcards(payload: ServiceGrantCreate) -> None:
+    """Refuse any glob metacharacter in the exact-scope fields (#3151).
+
+    Creating a grant is the operator's explicit per-op review, so
+    ``op_id``, ``connector_id``, and ``principal_sub`` must each name one
+    exact value — a ``*`` / ``?`` would silently widen the unattended
+    surface past what the operator reviewed.
+    """
+    for field, value in (
+        ("op_id", payload.op_id),
+        ("connector_id", payload.connector_id),
+        ("principal_sub", payload.principal_sub),
+    ):
+        if "*" in value or "?" in value:
+            raise GrantValidationError(
+                f"{field} must be an exact value; wildcards are not permitted "
+                f"(got {value!r}). A standing grant is the operator's explicit "
+                "per-op review, not a pattern."
+            )
+
+
+def _validate_expires_at(expires_at: datetime | None) -> None:
+    """Raise :exc:`GrantValidationError` when *expires_at* is naive or past."""
+    if expires_at is None:
+        return
+    if expires_at.tzinfo is None:
+        raise GrantValidationError("expires_at must be a timezone-aware datetime (UTC preferred)")
+    if expires_at <= datetime.now(UTC):
+        raise GrantValidationError(
+            f"expires_at {expires_at.isoformat()} is in the past; "
+            "a time-bounded grant must expire in the future"
+        )
+
+
+def _delete_shaped_reason_by_pattern(op_id: str, patterns: tuple[str, ...]) -> str | None:
+    """Return a refusal reason if *op_id* matches a configured delete-shaped glob.
+
+    Case-sensitive ``fnmatchcase`` over the exact op id — raw HTTP ops are
+    upper-cased (``DELETE:/path``) and typed ops are dotted lower-case
+    (``vault.sys.policy.delete``), so the default pattern set is spelled to
+    match both without case folding.
+    """
+    for pattern in patterns:
+        if fnmatchcase(op_id, pattern):
+            return (
+                f"op {op_id!r} is delete-shaped (matches configured pattern "
+                f"{pattern!r}); delete-shaped operations are never grantable — "
+                "a standing grant is the floor of what runs unattended, not a "
+                "bypass of a destructive gate"
+            )
+    return None
+
+
+def _delete_shaped_reason_by_descriptor(descriptor: EndpointDescriptor) -> str | None:
+    """Return a refusal reason if the resolved descriptor marks destruction.
+
+    Best-effort second check (only when a descriptor resolves): the HTTP
+    ``DELETE`` verb, or a hand-authored ``destructive`` tag on a typed op.
+    """
+    method = (descriptor.method or "").upper()
+    if method == "DELETE":
+        return (
+            f"op {descriptor.op_id!r} is a DELETE operation; delete-shaped "
+            "operations are never grantable"
+        )
+    tags = descriptor.tags or []
+    if "destructive" in tags:
+        return (
+            f"op {descriptor.op_id!r} carries the 'destructive' tag; "
+            "delete-shaped operations are never grantable"
+        )
+    return None
+
+
+async def _resolve_descriptor_for_classification(
+    tenant_id: uuid.UUID,
+    connector_id: str,
+    op_id: str,
+) -> EndpointDescriptor | None:
+    """Best-effort descriptor lookup for the delete-shaped tag/method check.
+
+    Returns ``None`` (skip the descriptor-level check, keep the pattern
+    check authoritative) when ``connector_id`` does not parse or no
+    descriptor resolves — a grant must not be blocked purely on ingestion
+    timing / version drift.
+    """
+    from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
+
+    product, version, impl_id = parse_connector_id(connector_id)
+    return await lookup_descriptor(
+        tenant_id=tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD service (operator-only REST surface)
+# ---------------------------------------------------------------------------
+
+
+class ServicePrincipalGrantService:
+    """Tenant-scoped CRUD over :class:`~meho_backplane.db.models.ServicePrincipalGrant`.
+
+    Stateless and async; each public method opens its own session, commits,
+    and closes (mirrors :class:`~meho_backplane.agents.grants.AgentGrantService`).
+    Callers own the ``require_role(TenantRole.OPERATOR)`` gate — the service
+    does not enforce roles.
+    """
+
+    def __init__(self) -> None:
+        self._log = structlog.get_logger()
+
+    async def create(
+        self,
+        tenant_id: uuid.UUID,
+        created_by_sub: str,
+        payload: ServiceGrantCreate,
+    ) -> ServiceGrantRead:
+        """Create one standing grant row after the full create-time review.
+
+        Refuses wildcards, delete-shaped ops, and past/naive expiries;
+        raises :exc:`GrantValidationError` (→ 422) on any of those or on a
+        duplicate active grant for the same fully-scoped key.
+        """
+        from meho_backplane.settings import get_settings
+
+        _reject_wildcards(payload)
+        _validate_expires_at(payload.expires_at)
+
+        pattern_reason = _delete_shaped_reason_by_pattern(
+            payload.op_id, get_settings().service_grant_delete_shaped_patterns
+        )
+        if pattern_reason is not None:
+            raise GrantValidationError(pattern_reason)
+        descriptor = await _resolve_descriptor_for_classification(
+            tenant_id, payload.connector_id, payload.op_id
+        )
+        if descriptor is not None:
+            descriptor_reason = _delete_shaped_reason_by_descriptor(descriptor)
+            if descriptor_reason is not None:
+                raise GrantValidationError(descriptor_reason)
+
+        row = ServicePrincipalGrant(
+            tenant_id=tenant_id,
+            principal_sub=payload.principal_sub,
+            op_id=payload.op_id,
+            connector_id=payload.connector_id,
+            target_id=payload.target_id,
+            reason=payload.reason,
+            created_by_sub=created_by_sub,
+            expires_at=payload.expires_at,
+        )
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(row)
+            try:
+                await session.flush()
+            except IntegrityError as exc:
+                await session.rollback()
+                raise GrantValidationError(
+                    f"an active grant for principal {payload.principal_sub!r} on "
+                    f"op {payload.op_id!r} / connector {payload.connector_id!r} / "
+                    f"target {payload.target_id} already exists; revoke it first"
+                ) from exc
+            await session.refresh(row)
+            entry = ServiceGrantRead.model_validate(row)
+            await session.commit()
+
+        self._log.info(
+            "service_grant_created",
+            tenant_id=str(tenant_id),
+            grant_id=str(entry.id),
+            principal_sub=payload.principal_sub,
+            op_id=payload.op_id,
+            connector_id=payload.connector_id,
+            target_id=str(payload.target_id) if payload.target_id else None,
+            created_by_sub=created_by_sub,
+            expires_at=payload.expires_at.isoformat() if payload.expires_at else None,
+        )
+        return entry
+
+    async def revoke(
+        self,
+        tenant_id: uuid.UUID,
+        grant_id: uuid.UUID,
+        revoked_by_sub: str,
+    ) -> bool:
+        """Soft-delete the grant matching ``(tenant_id, grant_id)``.
+
+        Stamps ``revoked_at`` / ``revoked_by_sub`` on a still-live row
+        (the row is retained for history). Returns ``True`` when a live row
+        was revoked, ``False`` when none matched (absent, already revoked,
+        or cross-tenant — the ``tenant_id`` predicate hides other tenants).
+        """
+        now = datetime.now(UTC)
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                update(ServicePrincipalGrant)
+                .where(
+                    ServicePrincipalGrant.tenant_id == tenant_id,
+                    ServicePrincipalGrant.id == grant_id,
+                    ServicePrincipalGrant.revoked_at.is_(None),
+                )
+                .values(revoked_at=now, revoked_by_sub=revoked_by_sub)
+                .returning(ServicePrincipalGrant.id)
+            )
+            revoked = result.scalar_one_or_none() is not None
+            await session.commit()
+
+        self._log.info(
+            "service_grant_revoked",
+            tenant_id=str(tenant_id),
+            grant_id=str(grant_id),
+            revoked_by_sub=revoked_by_sub,
+            revoked=revoked,
+        )
+        return revoked
+
+    async def get(
+        self,
+        tenant_id: uuid.UUID,
+        grant_id: uuid.UUID,
+    ) -> ServiceGrantRead | None:
+        """Fetch one grant by ``(tenant_id, grant_id)``; ``None`` if absent."""
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(ServicePrincipalGrant).where(
+                    ServicePrincipalGrant.tenant_id == tenant_id,
+                    ServicePrincipalGrant.id == grant_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return ServiceGrantRead.model_validate(row)
+
+    async def list_(
+        self,
+        tenant_id: uuid.UUID,
+        *,
+        principal_sub: str | None = None,
+        include_revoked: bool = False,
+        limit: int = DEFAULT_LIST_LIMIT,
+        offset: int = 0,
+    ) -> list[ServiceGrantRead]:
+        """Return up to *limit* grants for *tenant_id*, newest-first.
+
+        ``include_revoked=False`` (default) hides soft-deleted rows;
+        ``True`` returns the full history (revoked rows included). Expired
+        rows are always returned (they are history, not deletions).
+        """
+        if limit < 0:
+            raise ValueError(f"limit must be >= 0; got {limit}")
+        if offset < 0:
+            raise ValueError(f"offset must be >= 0; got {offset}")
+        if limit == 0:
+            return []
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = (
+                select(ServicePrincipalGrant)
+                .where(ServicePrincipalGrant.tenant_id == tenant_id)
+                .order_by(ServicePrincipalGrant.created_at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            if principal_sub is not None:
+                stmt = stmt.where(ServicePrincipalGrant.principal_sub == principal_sub)
+            if not include_revoked:
+                stmt = stmt.where(ServicePrincipalGrant.revoked_at.is_(None))
+            result = await session.execute(stmt)
+            rows = result.scalars().all()
+        return [ServiceGrantRead.model_validate(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Enforcement (dispatch-time)
+# ---------------------------------------------------------------------------
+
+
+def _target_uuid(target: Any) -> uuid.UUID | None:
+    """Extract a target's UUID id, or ``None`` for a targetless op."""
+    raw = getattr(target, "id", None) if target is not None else None
+    return raw if isinstance(raw, uuid.UUID) else None
+
+
+async def find_live_grant(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    principal_sub: str,
+    op_id: str,
+    connector_id: str,
+    target_id: uuid.UUID | None,
+    now: datetime | None = None,
+) -> ServicePrincipalGrant | None:
+    """Return the live grant covering this exact dispatch, or ``None``.
+
+    Exact match on every scope — ``target_id`` too, including the
+    targetless (``NULL``) case — with revocation and expiry both honoured
+    **at dispatch time**: ``revoked_at IS NULL`` and (``expires_at IS
+    NULL`` or ``expires_at > now``). No wildcard widening.
+    """
+    cutoff = now or datetime.now(UTC)
+    stmt = (
+        select(ServicePrincipalGrant)
+        .where(
+            ServicePrincipalGrant.tenant_id == tenant_id,
+            ServicePrincipalGrant.principal_sub == principal_sub,
+            ServicePrincipalGrant.op_id == op_id,
+            ServicePrincipalGrant.connector_id == connector_id,
+            ServicePrincipalGrant.revoked_at.is_(None),
+            or_(
+                ServicePrincipalGrant.expires_at.is_(None),
+                ServicePrincipalGrant.expires_at > cutoff,
+            ),
+        )
+        .limit(1)
+    )
+    if target_id is None:
+        stmt = stmt.where(ServicePrincipalGrant.target_id.is_(None))
+    else:
+        stmt = stmt.where(ServicePrincipalGrant.target_id == target_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def consult_and_record_grant(
+    *,
+    operator: Operator,
+    descriptor: EndpointDescriptor,
+    target: Any,
+    connector_id: str,
+) -> uuid.UUID | None:
+    """Look up a live standing grant and, on a hit, record its use.
+
+    Returns the grant id when a live grant authorises this dispatch (the
+    caller then clears the gate to ``AUTO_EXECUTE``), or ``None`` when no
+    grant matches (the caller parks the op). On a hit it writes the
+    grant-use audit row (``approval.decision`` shape) in its own committed
+    transaction and publishes a fail-open broadcast — same visibility as a
+    human approval decision — before returning.
+    """
+    target_id = _target_uuid(target)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        grant = await find_live_grant(
+            session,
+            tenant_id=operator.tenant_id,
+            principal_sub=operator.sub,
+            op_id=descriptor.op_id,
+            connector_id=connector_id,
+            target_id=target_id,
+        )
+    if grant is None:
+        return None
+
+    audit_id = await _record_grant_use(
+        operator=operator,
+        grant=grant,
+        connector_id=connector_id,
+        target_id=target_id,
+    )
+    await _publish_grant_use_event(operator=operator, grant=grant, audit_id=audit_id)
+    _log.info(
+        "service_grant_auto_approved",
+        grant_id=str(grant.id),
+        op_id=grant.op_id,
+        connector_id=connector_id,
+        principal_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+    )
+    return grant.id
+
+
+async def _record_grant_use(
+    *,
+    operator: Operator,
+    grant: ServicePrincipalGrant,
+    connector_id: str,
+    target_id: uuid.UUID | None,
+) -> uuid.UUID:
+    """Write one ``approval.decision`` audit row for a standing-grant use.
+
+    Mirrors :func:`~meho_backplane.operations.approval_queue._write_audit_row`
+    (``method='APPROVAL'``, ``path='approval.decision'``, status ``200``) so
+    the row is indistinguishable in the ledger from a human approval,
+    except the ``reviewed_by`` reads ``grant:<id>`` and the payload carries
+    ``decision='auto-approved'`` + ``grant_id``. Written in its own
+    committed transaction so the authorisation is durable before the op
+    runs (the synchronous-audit invariant).
+    """
+    from meho_backplane.operations._audit import resolve_agent_session_id, work_ref_var
+
+    audit_id = uuid.uuid4()
+    reason = f"auto-granted by standing grant {grant.id}"
+    payload: dict[str, Any] = {
+        "decision": "auto-approved",
+        "reviewed_by": f"grant:{grant.id}",
+        "grant_id": str(grant.id),
+        "op_id": grant.op_id,
+        "connector_id": connector_id,
+        "principal_sub": operator.sub,
+        "reason": reason,
+        "result_status": "decision",
+    }
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = AuditLog(
+            id=audit_id,
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator.sub,
+            tenant_id=operator.tenant_id,
+            target_id=target_id,
+            agent_session_id=resolve_agent_session_id(),
+            method=_GRANT_USE_METHOD,
+            path=_GRANT_USE_PATH,
+            status_code=_GRANT_USE_STATUS_CODE,
+            request_id=None,
+            duration_ms=Decimal("0.00"),
+            payload=payload,
+            work_ref=work_ref_var.get(),
+        )
+        session.add(row)
+        await session.commit()
+    return audit_id
+
+
+async def _publish_grant_use_event(
+    *,
+    operator: Operator,
+    grant: ServicePrincipalGrant,
+    audit_id: uuid.UUID,
+) -> None:
+    """Publish a fail-open ``approval.auto_approved`` broadcast for the grant use.
+
+    Parity with a human decision (which broadcasts ``approval.approved``).
+    Fail-open: a broadcast outage never blocks the durable grant use — the
+    audit row is the source of truth.
+    """
+    try:
+        from meho_backplane.broadcast.events import BroadcastEvent, classify_op
+        from meho_backplane.broadcast.publisher import publish_event
+        from meho_backplane.operations._audit import resolve_broadcast_lineage
+
+        op_id = "approval.auto_approved"
+        lineage = resolve_broadcast_lineage()
+        event = BroadcastEvent(
+            event_id=uuid.uuid4(),
+            ts=datetime.now(UTC),
+            tenant_id=operator.tenant_id,
+            principal_sub=operator.sub,
+            op_id=op_id,
+            op_class=classify_op(op_id),
+            result_status="ok",
+            audit_id=audit_id,
+            payload={
+                "op_class": classify_op(op_id),
+                "result_status": "ok",
+                "decision": "auto-approved",
+                "grant_id": str(grant.id),
+                "connector_id": grant.connector_id,
+                "approval_op_id": grant.op_id,
+            },
+            actor_sub=lineage.actor_sub,
+            agent_session_id=lineage.agent_session_id,
+            work_ref=lineage.work_ref,
+        )
+        await publish_event(event)
+    except Exception:
+        _log.exception(
+            "service_grant_broadcast_failed",
+            grant_id=str(grant.id),
+            op_id=grant.op_id,
+        )

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -91,6 +91,30 @@ def parse_bool_env(value: str | None) -> bool:
     return value.strip().lower() in _TRUTHY_ENV_VALUES
 
 
+#: Default delete-shaped op-id patterns a service-principal standing grant
+#: may never cover (#3151). Case-sensitive ``fnmatchcase`` globs over the
+#: exact op id: raw HTTP DELETE ops (``DELETE:*``) plus the dotted typed
+#: delete/destroy/remove/purge families. Overridable via
+#: ``SERVICE_GRANT_DELETE_SHAPED_PATTERNS`` (comma-separated).
+_DEFAULT_SERVICE_GRANT_DELETE_SHAPED_PATTERNS: tuple[str, ...] = (
+    "DELETE:*",
+    "*.delete",
+    "*.destroy",
+    "*.remove",
+    "*.purge",
+)
+
+
+def _parse_service_grant_delete_shaped_patterns(raw: str) -> tuple[str, ...]:
+    """Parse the comma-separated override, falling back to the default set.
+
+    An empty / whitespace-only value keeps the built-in default patterns so
+    the delete-shaped guardrail never silently disappears on a blank env var.
+    """
+    parts = tuple(chunk.strip() for chunk in raw.split(",") if chunk.strip())
+    return parts or _DEFAULT_SERVICE_GRANT_DELETE_SHAPED_PATTERNS
+
+
 class Settings(BaseModel):
     """Process-wide configuration knobs.
 
@@ -1209,6 +1233,12 @@ class Settings(BaseModel):
     approval_default_ttl_seconds: int = Field(default=14 * 24 * 3600, ge=60)
     approval_expiry_enabled: bool = True
     approval_expiry_tick_interval_seconds: int = Field(default=300, ge=60, le=86400)
+    # #3151 — op-id patterns a service-principal standing grant may never
+    # cover (delete-shaped ops are the floor of what runs unattended, never
+    # grantable). See ``operations.service_grants``.
+    service_grant_delete_shaped_patterns: tuple[str, ...] = (
+        _DEFAULT_SERVICE_GRANT_DELETE_SHAPED_PATTERNS
+    )
     # G11.3-T4 #825 -- agent_run reaper knobs. Same opt-out shape as
     # GRANT_EXPIRY_ENABLED / MEMORY_EXPIRY_ENABLED so an operator
     # running an external lease-reclaim mechanism (DBOS Transact, a
@@ -1936,6 +1966,11 @@ def get_settings() -> Settings:
         ),
         approval_expiry_tick_interval_seconds=int(
             os.environ.get("APPROVAL_EXPIRY_TICK_INTERVAL_SECONDS", "300"),
+        ),
+        # #3151 — delete-shaped op-id patterns never grantable to a service
+        # principal. Comma-separated override; empty keeps the default set.
+        service_grant_delete_shaped_patterns=_parse_service_grant_delete_shaped_patterns(
+            os.environ.get("SERVICE_GRANT_DELETE_SHAPED_PATTERNS", ""),
         ),
         agent_run_reaper_enabled=parse_bool_env(
             os.environ.get("AGENT_RUN_REAPER_ENABLED", "true"),

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -290,6 +290,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # irrelevant in a single non-cascading TRUNCATE).
     "check_dashboard_sensors",
     "check_dashboards",
+    # ``service_principal_grant.tenant_id`` is a real ``REFERENCES tenant(id)``
+    # FK from migration ``0078`` (#3151/#3152 standing grants). PG rejects
+    # truncating ``tenant`` unless every referencing table is listed in the
+    # same statement, so this must appear here or every PG-backed acceptance
+    # test errors at setup with ``cannot truncate a table referenced in a
+    # foreign key constraint``.
+    "service_principal_grant",
     "targets",
     "tenant",
 )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -437,6 +437,10 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   ``EventOutbox`` discipline, not ``Target``'s soft FK); must be listed
         #   here or PG rejects the per-test TRUNCATE with ``cannot truncate a
         #   table referenced in a foreign key constraint``.
+        # * ``service_principal_grant`` — migration 0078 (#3151/#3152 standing
+        #   grants) carries a real ``REFERENCES tenant(id)`` FK; must be listed
+        #   here or PG rejects the per-test TRUNCATE of ``tenant`` with ``cannot
+        #   truncate a table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -445,6 +449,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
+                "service_principal_grant, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -514,6 +519,7 @@ async def pg_engine_empty_tenant(
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
+                "service_principal_grant, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/migrations/test_migration_0078_service_principal_grant.py
+++ b/backend/tests/migrations/test_migration_0078_service_principal_grant.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0078_create_service_principal_grant``.
+
+#3151 / #3152. Creates the ``service_principal_grant`` table — the durable
+store of operator-issued standing scoped auto-approval grants for service
+principals — plus its lookup index and two **partial** unique indexes
+(targeted / targetless, both scoped to ``revoked_at IS NULL``).
+
+Idempotency pinning: every forward / round-trip step targets this
+migration's own revision (``0078``) and its ``down_revision`` (``0077``),
+never ``head`` — so a future head migration cannot make ``upgrade("head")``
+re-run this ``create_table`` on a schema that already has it. SQLite is the
+test driver and the migration uses only generic DDL (plus SQLite/PG partial
+indexes), so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0078"
+_DOWN_REVISION = "0077"
+_TABLE = "service_principal_grant"
+_EXPECTED_COLUMNS = {
+    "id",
+    "tenant_id",
+    "principal_sub",
+    "op_id",
+    "connector_id",
+    "target_id",
+    "reason",
+    "created_by_sub",
+    "created_at",
+    "expires_at",
+    "revoked_at",
+    "revoked_by_sub",
+}
+_EXPECTED_INDEXES = {
+    "service_principal_grant_lookup_idx",
+    "uq_service_principal_grant_targeted",
+    "uq_service_principal_grant_targetless",
+    "service_principal_grant_expires_at_idx",
+}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0078.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_info(sync_url: str, table: str) -> list[tuple[str, bool]]:
+    """Return ``(column_name, is_not_null)`` pairs for *table*."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return [(str(row[1]), int(row[3]) == 1) for row in rows]
+
+
+def _columns(sync_url: str, table: str) -> set[str]:
+    return {name for name, _ in _table_info(sync_url, table)}
+
+
+def _not_null(sync_url: str, table: str, column: str) -> bool:
+    for name, notnull in _table_info(sync_url, table):
+        if name == column:
+            return notnull
+    raise AssertionError(f"column {column!r} not present on {table}")
+
+
+def _index_meta(sync_url: str, table: str) -> list[tuple[str, bool, bool]]:
+    """Return ``(name, is_unique, is_partial)`` for every index on *table*."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    # PRAGMA index_list columns: (seq, name, unique, origin, partial).
+    return [(str(row[1]), int(row[2]) == 1, int(row[4]) == 1) for row in rows]
+
+
+def _index_names(sync_url: str, table: str) -> set[str]:
+    return {name for name, _, _ in _index_meta(sync_url, table)}
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def test_upgrade_creates_table_with_full_column_set(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0078`` creates the table with every column at the right nullability."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _columns(sync_url, _TABLE) == _EXPECTED_COLUMNS
+    for column in (
+        "id",
+        "tenant_id",
+        "principal_sub",
+        "op_id",
+        "connector_id",
+        "reason",
+        "created_by_sub",
+        "created_at",
+    ):
+        assert _not_null(sync_url, _TABLE, column), f"{column} must be NOT NULL"
+    for column in ("target_id", "expires_at", "revoked_at", "revoked_by_sub"):
+        assert not _not_null(sync_url, _TABLE, column), f"{column} must be nullable"
+
+
+def test_upgrade_creates_partial_unique_indexes(alembic_cfg: tuple[Config, str]) -> None:
+    """Lookup index + two partial unique indexes are created with the right flags."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    meta = {name: (unique, partial) for name, unique, partial in _index_meta(sync_url, _TABLE)}
+    assert set(meta) >= _EXPECTED_INDEXES
+    # Both uniqueness indexes must be UNIQUE and PARTIAL (revoked_at IS NULL scope).
+    for name in ("uq_service_principal_grant_targeted", "uq_service_principal_grant_targetless"):
+        unique, partial = meta[name]
+        assert unique, f"{name} must be UNIQUE"
+        assert partial, f"{name} must be a PARTIAL index"
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0077`` drops the table; ``upgrade 0078`` recreates it identically."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _TABLE not in _table_names(sync_url)
+
+    command.upgrade(cfg, _REVISION)
+    assert _columns(sync_url, _TABLE) == _EXPECTED_COLUMNS
+    assert _index_names(sync_url, _TABLE) >= _EXPECTED_INDEXES

--- a/backend/tests/test_api_v1_service_grants.py
+++ b/backend/tests/test_api_v1_service_grants.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""REST tests for ``/api/v1/service-principals/grants*`` (#3151).
+
+Two contracts:
+
+* **RBAC** — every route is gated by ``require_role(TenantRole.OPERATOR)``;
+  a ``read_only`` JWT gets HTTP 403 ``insufficient_role`` everywhere.
+* **Happy path (operator)** — create → list → show → revoke round-trips,
+  and the create-time review rejects a delete-shaped op / a wildcard with
+  HTTP 422.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_BASE = "/api/v1/service-principals/grants"
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence the broadcast publisher so responses don't stall on Valkey."""
+
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(app)
+
+
+def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(_TENANT_A))
+
+
+_GRANT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
+    ("GET", _BASE, None),
+    ("GET", f"{_BASE}/{_GRANT_ID}", None),
+    (
+        "POST",
+        _BASE,
+        {
+            "principal_sub": "svc:deploy-bot",
+            "op_id": "vmware.composite.vm.create",
+            "connector_id": "vmware-rest-9.0",
+            "reason": "unattended build",
+        },
+    ),
+    ("DELETE", f"{_BASE}/{_GRANT_ID}", None),
+)
+
+
+@pytest.mark.parametrize("method, path, body", _ENDPOINTS)
+def test_read_only_role_is_rejected(
+    client: TestClient, method: str, path: str, body: dict[str, Any] | None
+) -> None:
+    """``read_only`` JWT → HTTP 403 ``insufficient_role`` on every route."""
+    key = make_rsa_keypair("kid-ro")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "insufficient_role"}
+
+
+def test_operator_crud_round_trip(client: TestClient) -> None:
+    """create (201) → list → show → revoke (204) → show-revoked → re-revoke (404)."""
+    key = make_rsa_keypair("kid-op")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+        body = {
+            "principal_sub": "svc:deploy-bot",
+            "op_id": "vmware.composite.vm.power",
+            "connector_id": "vmware-rest-9.0",
+            "reason": "unattended power-on for the build",
+        }
+        created = client.post(_BASE, headers=headers, json=body)
+        assert created.status_code == 201, created.text
+        grant_id = created.json()["id"]
+        assert created.json()["reason"] == body["reason"]
+        assert created.json()["revoked_at"] is None
+
+        listed = client.get(_BASE, headers=headers, params={"principal_sub": "svc:deploy-bot"})
+        assert listed.status_code == 200
+        assert grant_id in {g["id"] for g in listed.json()["grants"]}
+
+        shown = client.get(f"{_BASE}/{grant_id}", headers=headers)
+        assert shown.status_code == 200
+        assert shown.json()["op_id"] == "vmware.composite.vm.power"
+
+        revoked = client.delete(f"{_BASE}/{grant_id}", headers=headers)
+        assert revoked.status_code == 204
+
+        after = client.get(f"{_BASE}/{grant_id}", headers=headers)
+        assert after.status_code == 200
+        assert after.json()["revoked_at"] is not None
+
+        # Re-revoking a soft-deleted grant is a 404 (no live row matched).
+        re_revoke = client.delete(f"{_BASE}/{grant_id}", headers=headers)
+        assert re_revoke.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "op_id, expect_fragment",
+    [
+        ("DELETE:/vcenter/vm/{vm}", "delete-shaped"),
+        ("vmware.composite.vm.*", "wildcard"),
+    ],
+)
+def test_create_review_rejects_bad_op(client: TestClient, op_id: str, expect_fragment: str) -> None:
+    """A delete-shaped op / a wildcard op_id is refused with HTTP 422."""
+    key = make_rsa_keypair("kid-op2")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+        body = {
+            "principal_sub": "svc:deploy-bot",
+            "op_id": op_id,
+            "connector_id": "vmware-rest-9.0",
+            "reason": "should be rejected",
+        }
+        response = client.post(_BASE, headers=headers, json=body)
+    assert response.status_code == 422, response.text
+    assert expect_fragment in response.json()["detail"]

--- a/backend/tests/test_service_grants.py
+++ b/backend/tests/test_service_grants.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Service-layer tests for the service-principal standing-grant CRUD (#3151).
+
+Exercises :class:`~meho_backplane.operations.service_grants.ServicePrincipalGrantService`
+directly (no HTTP): create with the full create-time review (wildcard
+refusal, delete-shaped refusal by pattern and by descriptor tag, past /
+naive expiry, duplicate-active refusal), soft-delete revoke, and list
+filtering (active-only vs full history).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000031a4")
+_OTHER_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000031b5")
+_PRINCIPAL = "svc:deploy-bot"
+_CONNECTOR = "vmware-rest-9.0"
+_CREATOR = "op-admin"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.delenv("SERVICE_GRANT_DELETE_SHAPED_PATTERNS", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _payload(
+    *,
+    op_id: str = "vmware.composite.vm.create",
+    connector_id: str = _CONNECTOR,
+    target_id: uuid.UUID | None = None,
+    reason: str = "unattended substrate build",
+    expires_at: datetime | None = None,
+    principal_sub: str = _PRINCIPAL,
+) -> ServiceGrantCreate:
+    return ServiceGrantCreate(
+        principal_sub=principal_sub,
+        op_id=op_id,
+        connector_id=connector_id,
+        target_id=target_id,
+        reason=reason,
+        expires_at=expires_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_returns_row_with_scopes() -> None:
+    """A well-formed grant is created and echoes its exact scopes."""
+    svc = ServicePrincipalGrantService()
+    entry = await svc.create(_TENANT_ID, _CREATOR, _payload())
+    assert entry.principal_sub == _PRINCIPAL
+    assert entry.op_id == "vmware.composite.vm.create"
+    assert entry.connector_id == _CONNECTOR
+    assert entry.target_id is None
+    assert entry.reason == "unattended substrate build"
+    assert entry.created_by_sub == _CREATOR
+    assert entry.revoked_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field, payload_kwargs",
+    [
+        ("op_id", {"op_id": "*"}),
+        ("op_id", {"op_id": "vmware.composite.vm.*"}),
+        ("connector_id", {"connector_id": "vmware-*"}),
+        ("principal_sub", {"principal_sub": "svc:*"}),
+    ],
+)
+async def test_create_refuses_wildcards(field: str, payload_kwargs: dict[str, str]) -> None:
+    """Any glob in op_id / connector_id / principal_sub is refused (#3151)."""
+    svc = ServicePrincipalGrantService()
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, _payload(**payload_kwargs))
+    assert field in str(exc.value)
+    assert "wildcard" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op_id",
+    [
+        "DELETE:/vcenter/vm/{vm}",
+        "vault.sys.policy.delete",
+        "argocd.app.destroy",
+        "keycloak.user.remove",
+        "vault.token.purge",
+    ],
+)
+async def test_create_refuses_delete_shaped_by_pattern(op_id: str) -> None:
+    """Delete-shaped ops are never grantable — refused by configured pattern."""
+    svc = ServicePrincipalGrantService()
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op_id))
+    assert "delete-shaped" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_destructive_tagged_descriptor() -> None:
+    """A non-delete-named op whose descriptor carries 'destructive' is refused.
+
+    Belt-and-suspenders beyond the pattern set: the second, descriptor-level
+    check catches a hand-tagged destructive typed op that the name globs miss.
+    """
+    # Seed a descriptor that does NOT match a delete-shaped name pattern but
+    # is tagged destructive (vault-1.x → product/version/impl = vault//vault).
+    async with get_sessionmaker()() as s:
+        s.add(
+            EndpointDescriptor(
+                tenant_id=_TENANT_ID,
+                product="vault",
+                version="1.x",
+                impl_id="vault",
+                op_id="vault.sys.seal",
+                source_kind="typed",
+                method="POST",
+                safety_level="dangerous",
+                tags=["write", "destructive"],
+                is_enabled=True,
+            )
+        )
+        await s.commit()
+
+    svc = ServicePrincipalGrantService()
+    payload = _payload(op_id="vault.sys.seal", connector_id="vault-1.x")
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, payload)
+    assert "destructive" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_past_and_naive_expiry() -> None:
+    """A past or timezone-naive ``expires_at`` is refused."""
+    svc = ServicePrincipalGrantService()
+    with pytest.raises(GrantValidationError):
+        await svc.create(
+            _TENANT_ID, _CREATOR, _payload(expires_at=datetime.now(UTC) - timedelta(hours=1))
+        )
+    # A future but timezone-naive expiry is refused (must be tz-aware).
+    naive_future = datetime(2999, 1, 1)
+    with pytest.raises(GrantValidationError):
+        await svc.create(_TENANT_ID, _CREATOR, _payload(expires_at=naive_future))
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_duplicate_active_grant() -> None:
+    """A second active grant for the same fully-scoped key is refused."""
+    svc = ServicePrincipalGrantService()
+    await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.vm.power"))
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.vm.power"))
+    assert "already exists" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_revoke_is_soft_delete_and_allows_regrant() -> None:
+    """Revoke stamps ``revoked_at`` (retains the row) and frees the key for re-grant."""
+    svc = ServicePrincipalGrantService()
+    op = "vmware.composite.vm.deploy"
+    entry = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op))
+
+    assert await svc.revoke(_TENANT_ID, entry.id, "op-revoker") is True
+    revoked = await svc.get(_TENANT_ID, entry.id)
+    assert revoked is not None
+    assert revoked.revoked_at is not None
+    assert revoked.revoked_by_sub == "op-revoker"
+
+    # Re-revoking an already-revoked grant is a no-op → False (404 at the boundary).
+    assert await svc.revoke(_TENANT_ID, entry.id, "op-revoker") is False
+
+    # The scope is free again: a fresh grant for the same key is accepted.
+    again = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op))
+    assert again.id != entry.id
+
+
+@pytest.mark.asyncio
+async def test_revoke_absent_and_cross_tenant_returns_false() -> None:
+    """Revoke of an absent / cross-tenant id returns False (no cross-tenant leak)."""
+    svc = ServicePrincipalGrantService()
+    entry = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.vm.clone"))
+    assert await svc.revoke(_TENANT_ID, uuid.uuid4(), "x") is False
+    assert await svc.revoke(_OTHER_TENANT, entry.id, "x") is False
+
+
+@pytest.mark.asyncio
+async def test_get_cross_tenant_returns_none() -> None:
+    svc = ServicePrincipalGrantService()
+    entry = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.host.list"))
+    assert await svc.get(_OTHER_TENANT, entry.id) is None
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_revoked_by_default() -> None:
+    """``list_`` hides revoked grants unless ``include_revoked=True``."""
+    svc = ServicePrincipalGrantService()
+    live = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.snap.create"))
+    gone = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id="vmware.composite.snap.list"))
+    await svc.revoke(_TENANT_ID, gone.id, "op-revoker")
+
+    active = await svc.list_(_TENANT_ID, principal_sub=_PRINCIPAL)
+    active_ids = {g.id for g in active}
+    assert live.id in active_ids
+    assert gone.id not in active_ids
+
+    full = await svc.list_(_TENANT_ID, principal_sub=_PRINCIPAL, include_revoked=True)
+    full_ids = {g.id for g in full}
+    assert {live.id, gone.id} <= full_ids

--- a/backend/tests/test_service_principal_grant_gate.py
+++ b/backend/tests/test_service_principal_grant_gate.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Gate-matrix tests for the service-principal safety_level + standing grants (#3151 / #3152).
+
+The non-agent policy gate is exercised through
+:func:`~meho_backplane.operations.composite.enforce_subop_policy` (which
+builds a composite descriptor and calls ``policy_gate`` with the
+``connector_id`` the grant lookup needs). The matrix:
+
+* **service principal x safety_level** — a mutating ``caution`` / a
+  ``dangerous`` / a ``requires_approval`` op **parks** without a grant
+  (#3152 tightening); a ``safe`` read still auto-executes.
+* **service principal x standing grant** — a live matching grant clears
+  the gate (auto-execute) and writes a ``approval.decision`` /
+  ``auto-approved`` audit row carrying the ``grant_id`` (#3151).
+* **expiry / revocation respected at dispatch** — an expired or revoked
+  grant does not clear the gate.
+* **operator-interactive USER is unchanged** — a human ``USER`` operator
+  never consults safety_level or a standing grant.
+
+Plus unit coverage of the two classification helpers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.broadcast.publisher as _publisher
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, ServicePrincipalGrant
+from meho_backplane.operations._validate import _is_mutating, _service_safety_gate_reason
+from meho_backplane.operations.composite import enforce_subop_policy
+from meho_backplane.settings import get_settings
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000032a4")
+_CONNECTOR = "vmware-rest-9.0"
+_PRINCIPAL = "svc:deploy-bot"
+_OP = "vmware.composite.vm.create"
+_PARAMS = {"name": "vm-under-test", "guest_OS": "OTHER"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence the broadcast publisher (park + grant-use both publish)."""
+
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_publisher, "publish_event", _noop)
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _operator(*, principal_kind: PrincipalKind, sub: str = _PRINCIPAL) -> Operator:
+    return Operator(
+        sub=sub,
+        name="svc",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+async def _seed_grant(
+    *,
+    op_id: str = _OP,
+    connector_id: str = _CONNECTOR,
+    target_id: uuid.UUID | None = None,
+    principal_sub: str = _PRINCIPAL,
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+) -> uuid.UUID:
+    grant_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            ServicePrincipalGrant(
+                id=grant_id,
+                tenant_id=_TENANT_ID,
+                principal_sub=principal_sub,
+                op_id=op_id,
+                connector_id=connector_id,
+                target_id=target_id,
+                reason="unattended build",
+                created_by_sub="op-admin",
+                expires_at=expires_at,
+                revoked_at=revoked_at,
+            )
+        )
+        await s.commit()
+    return grant_id
+
+
+async def _grant_use_rows(grant_id: uuid.UUID | None = None) -> list[AuditLog]:
+    async with get_sessionmaker()() as s:
+        result = await s.execute(
+            select(AuditLog).where(
+                AuditLog.method == "APPROVAL",
+                AuditLog.path == "approval.decision",
+            )
+        )
+        rows = [
+            r
+            for r in result.scalars().all()
+            if r.payload.get("decision") == "auto-approved"
+            and (grant_id is None or r.payload.get("grant_id") == str(grant_id))
+        ]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# safety_level tightening (#3152) — service principal parks without a grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "safety_level, requires_approval",
+    [
+        ("caution", False),  # mutating caution — new #3152 tightening
+        ("dangerous", False),  # dangerous — parks always
+        ("safe", True),  # requires_approval — unchanged
+    ],
+)
+async def test_service_principal_parks_without_grant(
+    safety_level: str, requires_approval: bool
+) -> None:
+    """A gated op parks (awaiting_approval) for a service principal absent a grant."""
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level=safety_level,
+        requires_approval=requires_approval,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    assert not await _grant_use_rows()
+
+
+@pytest.mark.asyncio
+async def test_service_principal_safe_read_auto_executes() -> None:
+    """A ``safe`` read still auto-executes for a service principal (unchanged)."""
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id="GET:/vcenter/vm",
+        safety_level="safe",
+        requires_approval=False,
+        target=None,
+        params={"filter.names": ["vm-under-test"]},
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# standing grant clears the gate + records grant-use audit (#3151)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "safety_level, requires_approval",
+    [("caution", False), ("dangerous", False), ("safe", True)],
+)
+async def test_live_grant_auto_approves_and_audits(
+    safety_level: str, requires_approval: bool
+) -> None:
+    """A live matching grant clears the gate and writes a grant-use audit row."""
+    grant_id = await _seed_grant()
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level=safety_level,
+        requires_approval=requires_approval,
+        target=None,
+        params=_PARAMS,
+    )
+    # Gate cleared → seam returns None (proceed to execute).
+    assert result is None
+
+    rows = await _grant_use_rows(grant_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.payload["reviewed_by"] == f"grant:{grant_id}"
+    assert row.payload["op_id"] == _OP
+    assert row.payload["connector_id"] == _CONNECTOR
+    assert row.payload["principal_sub"] == _PRINCIPAL
+    assert f"standing grant {grant_id}" in row.payload["reason"]
+    assert row.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# expiry / revocation respected at dispatch time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_grant_does_not_clear_gate() -> None:
+    """An expired grant does not auto-approve — the op parks."""
+    await _seed_grant(expires_at=datetime.now(UTC) - timedelta(minutes=1))
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    assert not await _grant_use_rows()
+
+
+@pytest.mark.asyncio
+async def test_revoked_grant_does_not_clear_gate() -> None:
+    """A revoked grant does not auto-approve — the op parks."""
+    await _seed_grant(revoked_at=datetime.now(UTC) - timedelta(minutes=1))
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    assert not await _grant_use_rows()
+
+
+@pytest.mark.asyncio
+async def test_grant_target_scope_is_exact() -> None:
+    """A grant scoped to one target does not cover a targetless dispatch."""
+    scoped_target = uuid.uuid4()
+    await _seed_grant(target_id=scoped_target)
+
+    # Targetless dispatch: the targeted grant must NOT match → parks.
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+
+    # Dispatch to the scoped target: the grant matches → auto-executes.
+    matched = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=SimpleNamespace(id=scoped_target, name="dc-target"),
+        params=_PARAMS,
+    )
+    assert matched is None
+
+
+# ---------------------------------------------------------------------------
+# operator-interactive USER is unchanged (their own approver)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_principal_caution_mutation_auto_executes() -> None:
+    """A human USER operator is NOT subject to the safety_level tightening."""
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    # USER keeps the v0.2 default-allow: a caution op with requires_approval=False
+    # auto-executes (the seam returns None). No standing grant is consulted.
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_user_principal_requires_approval_parks_and_ignores_grant() -> None:
+    """A USER hitting requires_approval parks even with a grant on their own sub.
+
+    A standing grant is enforced only for service principals; a human
+    operator keeps the queue-on-approval contract (they are their own
+    approver via a colleague, never via a grant).
+    """
+    await _seed_grant(principal_sub="human-op")
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="safe",
+        requires_approval=True,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    # The grant was NOT consulted → no auto-approved audit row.
+    assert not await _grant_use_rows()
+
+
+# ---------------------------------------------------------------------------
+# classification helper unit tests (method-based branch)
+# ---------------------------------------------------------------------------
+
+
+def _descriptor(*, method: str | None, safety_level: str) -> EndpointDescriptor:
+    return EndpointDescriptor(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        op_id="op",
+        source_kind="ingested" if method else "composite",
+        method=method,
+        safety_level=safety_level,
+    )
+
+
+@pytest.mark.parametrize(
+    "method, safety_level, expected",
+    [
+        ("GET", "safe", False),
+        ("HEAD", "safe", False),
+        ("POST", "caution", True),
+        ("PUT", "caution", True),
+        ("DELETE", "dangerous", True),
+        (None, "safe", False),  # typed/composite: safety_level stands in
+        (None, "caution", True),
+        (None, "dangerous", True),
+    ],
+)
+def test_is_mutating(method: str | None, safety_level: str, expected: bool) -> None:
+    assert _is_mutating(_descriptor(method=method, safety_level=safety_level)) is expected
+
+
+@pytest.mark.parametrize(
+    "method, safety_level, gated",
+    [
+        ("POST", "caution", True),  # mutating caution parks
+        ("GET", "caution", False),  # a caution *read* does not park
+        ("DELETE", "dangerous", True),  # dangerous parks always
+        ("GET", "safe", False),  # safe read unchanged
+    ],
+)
+def test_service_safety_gate_reason(method: str, safety_level: str, gated: bool) -> None:
+    reason = _service_safety_gate_reason(_descriptor(method=method, safety_level=safety_level))
+    assert (reason is not None) is gated

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -31864,6 +31864,10 @@
       "x-maturity": "beta"
     },
     {
+      "name": "service-principal-grants",
+      "x-maturity": "ga"
+    },
+    {
       "name": "targets",
       "x-maturity": "ga"
     },

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9228,6 +9228,244 @@
         }
       }
     },
+    "/api/v1/service-principals/grants": {
+      "get": {
+        "tags": [
+          "service-principal-grants"
+        ],
+        "summary": "List Grants",
+        "description": "List standing grants for the operator's tenant.\n\n``principal_sub`` filters to one service principal's grants;\n``include_revoked`` surfaces the revoked history. Tenant-scoped to the\noperator's JWT \u2014 no cross-tenant access.",
+        "operationId": "list_grants_api_v1_service_principals_grants_get",
+        "parameters": [
+          {
+            "name": "principal_sub",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Principal Sub"
+            }
+          },
+          {
+            "name": "include_revoked",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Revoked"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceGrantListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "service-principal-grants"
+        ],
+        "summary": "Create Grant",
+        "description": "Create a standing grant (the operator's upfront review).\n\nReturns 422 when the op is delete-shaped, a scope field carries a\nwildcard, ``expires_at`` is in the past, or an active grant for the\nsame fully-scoped key already exists. Audited via the audit middleware.",
+        "operationId": "create_grant_api_v1_service_principals_grants_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceGrantCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceGrantRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/service-principals/grants/{grant_id}": {
+      "get": {
+        "tags": [
+          "service-principal-grants"
+        ],
+        "summary": "Show Grant",
+        "description": "Return one grant by id. Cross-tenant probes return 404 (never 403).",
+        "operationId": "show_grant_api_v1_service_principals_grants__grant_id__get",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceGrantRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "service-principal-grants"
+        ],
+        "summary": "Revoke Grant",
+        "description": "Revoke (soft-delete) a standing grant.\n\nReturns 204 on success; 404 when the grant is absent, already revoked,\nor belongs to another tenant. Audited via the audit middleware.",
+        "operationId": "revoke_grant_api_v1_service_principals_grants__grant_id__delete",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/conventions": {
       "get": {
         "tags": [
@@ -29396,6 +29634,158 @@
         ],
         "title": "SensorStatus",
         "description": "Closed lifecycle status of a :class:`Sensor`.\n\n``ScheduledTriggerStatus`` minus the trigger-only terminal states:\na sensor is either eligible for evaluation (:attr:`ACTIVE`) or held\n(:attr:`PAUSED`). This Task never writes ``paused`` -- ``status`` is\nnot accepted at create; #2505 parks a row to ``paused`` (plus a\n``status_reason``) when it hits an unparseable persisted cadence, and\n#2506's rollup derives ``skip`` for paused rows."
+      },
+      "ServiceGrantCreate": {
+        "properties": {
+          "principal_sub": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Principal Sub",
+            "description": "JWT sub of the service principal the grant authorises (no wildcard)."
+          },
+          "op_id": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Op Id",
+            "description": "Exact operation id, no glob (e.g. 'POST:/vcenter/vm')."
+          },
+          "connector_id": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Connector Id",
+            "description": "Exact '<impl_id>-<version>' connector id, e.g. 'vmware-rest-9.0'."
+          },
+          "target_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Target UUID the grant is scoped to, or null for a targetless op."
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Reason",
+            "description": "Operator's upfront justification (creating the grant is the review)."
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Expires At",
+            "description": "Optional UTC expiry; null = standing (permanent) grant; must be future."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "principal_sub",
+          "op_id",
+          "connector_id",
+          "reason"
+        ],
+        "title": "ServiceGrantCreate",
+        "description": "Body for creating a standing scoped auto-approval grant.\n\n``extra=\"forbid\"`` rejects unknown fields with 422. There are\ndeliberately **no wildcards**: ``op_id`` and ``connector_id`` name one\nexact operation on one exact connector, and ``target_id`` is either a\nconcrete target UUID or ``None`` for a targetless op. The service layer\nrefuses delete-shaped ops (a grant is the floor of what runs\nunattended, not a bypass of a modeled destructive gate)."
+      },
+      "ServiceGrantListResponse": {
+        "properties": {
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/ServiceGrantRead"
+            },
+            "type": "array",
+            "title": "Grants"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grants"
+        ],
+        "title": "ServiceGrantListResponse",
+        "description": "Response envelope for ``GET /api/v1/service-principals/grants``."
+      },
+      "ServiceGrantRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "principal_sub": {
+            "type": "string",
+            "title": "Principal Sub"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "target_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Target Id"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
+          "created_by_sub": {
+            "type": "string",
+            "title": "Created By Sub"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Expires At"
+          },
+          "revoked_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Revoked At"
+          },
+          "revoked_by_sub": {
+            "type": "string",
+            "nullable": true,
+            "title": "Revoked By Sub"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "principal_sub",
+          "op_id",
+          "connector_id",
+          "target_id",
+          "reason",
+          "created_by_sub",
+          "created_at",
+          "expires_at",
+          "revoked_at",
+          "revoked_by_sub"
+        ],
+        "title": "ServiceGrantRead",
+        "description": "Row shape every accessor returns.\n\n``from_attributes=True`` allows direct construction from an ORM row.\nExposes ``revoked_at`` / ``revoked_by_sub`` so callers can tell a live\ngrant from a revoked one in the history."
       },
       "ShowTemplateResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -6928,6 +6928,59 @@ type SensorSeverity string
 // #2506's rollup derives “skip“ for paused rows.
 type SensorStatus string
 
+// ServiceGrantCreate Body for creating a standing scoped auto-approval grant.
+//
+// “extra="forbid"“ rejects unknown fields with 422. There are
+// deliberately **no wildcards**: “op_id“ and “connector_id“ name one
+// exact operation on one exact connector, and “target_id“ is either a
+// concrete target UUID or “None“ for a targetless op. The service layer
+// refuses delete-shaped ops (a grant is the floor of what runs
+// unattended, not a bypass of a modeled destructive gate).
+type ServiceGrantCreate struct {
+	// ConnectorId Exact '<impl_id>-<version>' connector id, e.g. 'vmware-rest-9.0'.
+	ConnectorId string `json:"connector_id"`
+
+	// ExpiresAt Optional UTC expiry; null = standing (permanent) grant; must be future.
+	ExpiresAt *time.Time `json:"expires_at"`
+
+	// OpId Exact operation id, no glob (e.g. 'POST:/vcenter/vm').
+	OpId string `json:"op_id"`
+
+	// PrincipalSub JWT sub of the service principal the grant authorises (no wildcard).
+	PrincipalSub string `json:"principal_sub"`
+
+	// Reason Operator's upfront justification (creating the grant is the review).
+	Reason string `json:"reason"`
+
+	// TargetId Target UUID the grant is scoped to, or null for a targetless op.
+	TargetId *openapi_types.UUID `json:"target_id"`
+}
+
+// ServiceGrantListResponse Response envelope for “GET /api/v1/service-principals/grants“.
+type ServiceGrantListResponse struct {
+	Grants []ServiceGrantRead `json:"grants"`
+}
+
+// ServiceGrantRead Row shape every accessor returns.
+//
+// “from_attributes=True“ allows direct construction from an ORM row.
+// Exposes “revoked_at“ / “revoked_by_sub“ so callers can tell a live
+// grant from a revoked one in the history.
+type ServiceGrantRead struct {
+	ConnectorId  string              `json:"connector_id"`
+	CreatedAt    time.Time           `json:"created_at"`
+	CreatedBySub string              `json:"created_by_sub"`
+	ExpiresAt    *time.Time          `json:"expires_at"`
+	Id           openapi_types.UUID  `json:"id"`
+	OpId         string              `json:"op_id"`
+	PrincipalSub string              `json:"principal_sub"`
+	Reason       string              `json:"reason"`
+	RevokedAt    *time.Time          `json:"revoked_at"`
+	RevokedBySub *string             `json:"revoked_by_sub"`
+	TargetId     *openapi_types.UUID `json:"target_id"`
+	TenantId     openapi_types.UUID  `json:"tenant_id"`
+}
+
 // ShowTemplateResponse Full template surface returned by “meho_runbook_show_template“.
 //
 // The complete template including the ordered :attr:`steps` and the
@@ -8915,6 +8968,30 @@ type ListSensorResultsApiV1SensorsSensorIdResultsGetParams struct {
 // ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState defines parameters for ListSensorResultsApiV1SensorsSensorIdResultsGet.
 type ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState string
 
+// ListGrantsApiV1ServicePrincipalsGrantsGetParams defines parameters for ListGrantsApiV1ServicePrincipalsGrantsGet.
+type ListGrantsApiV1ServicePrincipalsGrantsGetParams struct {
+	PrincipalSub   *string `form:"principal_sub,omitempty" json:"principal_sub,omitempty"`
+	IncludeRevoked *bool   `form:"include_revoked,omitempty" json:"include_revoked,omitempty"`
+	Limit          *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset         *int    `form:"offset,omitempty" json:"offset,omitempty"`
+	Authorization  *string `json:"authorization,omitempty"`
+}
+
+// CreateGrantApiV1ServicePrincipalsGrantsPostParams defines parameters for CreateGrantApiV1ServicePrincipalsGrantsPost.
+type CreateGrantApiV1ServicePrincipalsGrantsPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams defines parameters for RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete.
+type RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams defines parameters for ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet.
+type ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ListTargetsApiV1TargetsGetParams defines parameters for ListTargetsApiV1TargetsGet.
 type ListTargetsApiV1TargetsGetParams struct {
 	Product       *string `form:"product,omitempty" json:"product,omitempty"`
@@ -9553,6 +9630,9 @@ type SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody = SearchDocsRequest
 
 // CreateSensorApiV1SensorsPostJSONRequestBody defines body for CreateSensorApiV1SensorsPost for application/json ContentType.
 type CreateSensorApiV1SensorsPostJSONRequestBody = SensorCreate
+
+// CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody defines body for CreateGrantApiV1ServicePrincipalsGrantsPost for application/json ContentType.
+type CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody = ServiceGrantCreate
 
 // CreateTargetApiV1TargetsPostJSONRequestBody defines body for CreateTargetApiV1TargetsPost for application/json ContentType.
 type CreateTargetApiV1TargetsPostJSONRequestBody = TargetCreate
@@ -11650,6 +11730,20 @@ type ClientInterface interface {
 
 	// ListSensorResultsApiV1SensorsSensorIdResultsGet request
 	ListSensorResultsApiV1SensorsSensorIdResultsGet(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListGrantsApiV1ServicePrincipalsGrantsGet request
+	ListGrantsApiV1ServicePrincipalsGrantsGet(ctx context.Context, params *ListGrantsApiV1ServicePrincipalsGrantsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateGrantApiV1ServicePrincipalsGrantsPostWithBody request with any body
+	CreateGrantApiV1ServicePrincipalsGrantsPostWithBody(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateGrantApiV1ServicePrincipalsGrantsPost(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, body CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete request
+	RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete(ctx context.Context, grantId openapi_types.UUID, params *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet request
+	ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTargetsApiV1TargetsGet request
 	ListTargetsApiV1TargetsGet(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14615,6 +14709,66 @@ func (c *Client) DeleteSensorApiV1SensorsSensorIdDelete(ctx context.Context, sen
 
 func (c *Client) ListSensorResultsApiV1SensorsSensorIdResultsGet(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListSensorResultsApiV1SensorsSensorIdResultsGetRequest(c.Server, sensorId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListGrantsApiV1ServicePrincipalsGrantsGet(ctx context.Context, params *ListGrantsApiV1ServicePrincipalsGrantsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListGrantsApiV1ServicePrincipalsGrantsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateGrantApiV1ServicePrincipalsGrantsPostWithBody(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateGrantApiV1ServicePrincipalsGrantsPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateGrantApiV1ServicePrincipalsGrantsPost(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, body CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateGrantApiV1ServicePrincipalsGrantsPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete(ctx context.Context, grantId openapi_types.UUID, params *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteRequest(c.Server, grantId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewShowGrantApiV1ServicePrincipalsGrantsGrantIdGetRequest(c.Server, grantId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -26930,6 +27084,271 @@ func NewListSensorResultsApiV1SensorsSensorIdResultsGetRequest(server string, se
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListGrantsApiV1ServicePrincipalsGrantsGetRequest generates requests for ListGrantsApiV1ServicePrincipalsGrantsGet
+func NewListGrantsApiV1ServicePrincipalsGrantsGetRequest(server string, params *ListGrantsApiV1ServicePrincipalsGrantsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/service-principals/grants")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PrincipalSub != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "principal_sub", runtime.ParamLocationQuery, *params.PrincipalSub); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeRevoked != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_revoked", runtime.ParamLocationQuery, *params.IncludeRevoked); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewCreateGrantApiV1ServicePrincipalsGrantsPostRequest calls the generic CreateGrantApiV1ServicePrincipalsGrantsPost builder with application/json body
+func NewCreateGrantApiV1ServicePrincipalsGrantsPostRequest(server string, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, body CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateGrantApiV1ServicePrincipalsGrantsPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewCreateGrantApiV1ServicePrincipalsGrantsPostRequestWithBody generates requests for CreateGrantApiV1ServicePrincipalsGrantsPost with any type of body
+func NewCreateGrantApiV1ServicePrincipalsGrantsPostRequestWithBody(server string, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/service-principals/grants")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteRequest generates requests for RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete
+func NewRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteRequest(server string, grantId openapi_types.UUID, params *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "grant_id", runtime.ParamLocationPath, grantId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/service-principals/grants/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewShowGrantApiV1ServicePrincipalsGrantsGrantIdGetRequest generates requests for ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet
+func NewShowGrantApiV1ServicePrincipalsGrantsGrantIdGetRequest(server string, grantId openapi_types.UUID, params *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "grant_id", runtime.ParamLocationPath, grantId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/service-principals/grants/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -39500,6 +39919,20 @@ type ClientWithResponsesInterface interface {
 	// ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse request
 	ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error)
 
+	// ListGrantsApiV1ServicePrincipalsGrantsGetWithResponse request
+	ListGrantsApiV1ServicePrincipalsGrantsGetWithResponse(ctx context.Context, params *ListGrantsApiV1ServicePrincipalsGrantsGetParams, reqEditors ...RequestEditorFn) (*ListGrantsApiV1ServicePrincipalsGrantsGetResponse, error)
+
+	// CreateGrantApiV1ServicePrincipalsGrantsPostWithBodyWithResponse request with any body
+	CreateGrantApiV1ServicePrincipalsGrantsPostWithBodyWithResponse(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGrantApiV1ServicePrincipalsGrantsPostResponse, error)
+
+	CreateGrantApiV1ServicePrincipalsGrantsPostWithResponse(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, body CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGrantApiV1ServicePrincipalsGrantsPostResponse, error)
+
+	// RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteWithResponse request
+	RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteWithResponse(ctx context.Context, grantId openapi_types.UUID, params *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams, reqEditors ...RequestEditorFn) (*RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse, error)
+
+	// ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetWithResponse request
+	ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetWithResponse(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse, error)
+
 	// ListTargetsApiV1TargetsGetWithResponse request
 	ListTargetsApiV1TargetsGetWithResponse(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*ListTargetsApiV1TargetsGetResponse, error)
 
@@ -43246,6 +43679,97 @@ func (r ListSensorResultsApiV1SensorsSensorIdResultsGetResponse) Status() string
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListSensorResultsApiV1SensorsSensorIdResultsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListGrantsApiV1ServicePrincipalsGrantsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ServiceGrantListResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListGrantsApiV1ServicePrincipalsGrantsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListGrantsApiV1ServicePrincipalsGrantsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateGrantApiV1ServicePrincipalsGrantsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ServiceGrantRead
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateGrantApiV1ServicePrincipalsGrantsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateGrantApiV1ServicePrincipalsGrantsPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ServiceGrantRead
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -49850,6 +50374,50 @@ func (c *ClientWithResponses) ListSensorResultsApiV1SensorsSensorIdResultsGetWit
 		return nil, err
 	}
 	return ParseListSensorResultsApiV1SensorsSensorIdResultsGetResponse(rsp)
+}
+
+// ListGrantsApiV1ServicePrincipalsGrantsGetWithResponse request returning *ListGrantsApiV1ServicePrincipalsGrantsGetResponse
+func (c *ClientWithResponses) ListGrantsApiV1ServicePrincipalsGrantsGetWithResponse(ctx context.Context, params *ListGrantsApiV1ServicePrincipalsGrantsGetParams, reqEditors ...RequestEditorFn) (*ListGrantsApiV1ServicePrincipalsGrantsGetResponse, error) {
+	rsp, err := c.ListGrantsApiV1ServicePrincipalsGrantsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListGrantsApiV1ServicePrincipalsGrantsGetResponse(rsp)
+}
+
+// CreateGrantApiV1ServicePrincipalsGrantsPostWithBodyWithResponse request with arbitrary body returning *CreateGrantApiV1ServicePrincipalsGrantsPostResponse
+func (c *ClientWithResponses) CreateGrantApiV1ServicePrincipalsGrantsPostWithBodyWithResponse(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGrantApiV1ServicePrincipalsGrantsPostResponse, error) {
+	rsp, err := c.CreateGrantApiV1ServicePrincipalsGrantsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateGrantApiV1ServicePrincipalsGrantsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateGrantApiV1ServicePrincipalsGrantsPostWithResponse(ctx context.Context, params *CreateGrantApiV1ServicePrincipalsGrantsPostParams, body CreateGrantApiV1ServicePrincipalsGrantsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGrantApiV1ServicePrincipalsGrantsPostResponse, error) {
+	rsp, err := c.CreateGrantApiV1ServicePrincipalsGrantsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateGrantApiV1ServicePrincipalsGrantsPostResponse(rsp)
+}
+
+// RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteWithResponse request returning *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse
+func (c *ClientWithResponses) RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteWithResponse(ctx context.Context, grantId openapi_types.UUID, params *RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteParams, reqEditors ...RequestEditorFn) (*RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse, error) {
+	rsp, err := c.RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDelete(ctx, grantId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse(rsp)
+}
+
+// ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetWithResponse request returning *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse
+func (c *ClientWithResponses) ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetWithResponse(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse, error) {
+	rsp, err := c.ShowGrantApiV1ServicePrincipalsGrantsGrantIdGet(ctx, grantId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse(rsp)
 }
 
 // ListTargetsApiV1TargetsGetWithResponse request returning *ListTargetsApiV1TargetsGetResponse
@@ -56839,6 +57407,131 @@ func ParseListSensorResultsApiV1SensorsSensorIdResultsGetResponse(rsp *http.Resp
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SensorResultListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListGrantsApiV1ServicePrincipalsGrantsGetResponse parses an HTTP response from a ListGrantsApiV1ServicePrincipalsGrantsGetWithResponse call
+func ParseListGrantsApiV1ServicePrincipalsGrantsGetResponse(rsp *http.Response) (*ListGrantsApiV1ServicePrincipalsGrantsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListGrantsApiV1ServicePrincipalsGrantsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ServiceGrantListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateGrantApiV1ServicePrincipalsGrantsPostResponse parses an HTTP response from a CreateGrantApiV1ServicePrincipalsGrantsPostWithResponse call
+func ParseCreateGrantApiV1ServicePrincipalsGrantsPostResponse(rsp *http.Response) (*CreateGrantApiV1ServicePrincipalsGrantsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateGrantApiV1ServicePrincipalsGrantsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ServiceGrantRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse parses an HTTP response from a RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteWithResponse call
+func ParseRevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse(rsp *http.Response) (*RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RevokeGrantApiV1ServicePrincipalsGrantsGrantIdDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse parses an HTTP response from a ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetWithResponse call
+func ParseShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse(rsp *http.Response) (*ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ShowGrantApiV1ServicePrincipalsGrantsGrantIdGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ServiceGrantRead
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -836,9 +836,34 @@ for the agent-run substrate's full shape, including the wait timeout
 (`Settings.agent_approval_wait_timeout_seconds`, default 30 min) and the
 fail-open semantics on broadcast outage.
 
+## Service-principal standing grants + safety_level gate (#3151 / #3152)
+
+The non-agent gate (`_non_agent_verdict`, `operations/_validate.py`) gained
+two paired behaviours for **service** principals (`principal_kind =
+service`), leaving the human `USER` path unchanged:
+
+- **`safety_level` is now consulted** (#3152, resolved as option 1): a
+  mutating `caution` op — and any `dangerous` op — parks even without
+  `requires_approval`. Previously only `requires_approval` parked a
+  non-agent op, so a `caution` mutation (`POST:/vcenter/vm/{vm}/hardware/disk`)
+  executed ungated for a service principal. A human `USER` operator is
+  **not** subject to this (they are their own approver).
+- **Standing scoped auto-approval grants** (#3151): an operator issues a
+  `(principal_sub, op_id, connector_id, target_id)` grant — the persistent
+  form of an approve decision — so a service principal's repeated parks
+  during an unattended run auto-approve instead. Each use writes an
+  `approval.decision` / `auto-approved` audit row (this section's shape),
+  carrying `grant_id` — same ledger visibility as a human decision.
+
+Grants are operator-role REST at `/api/v1/service-principals/grants`;
+delete-shaped ops are refused at creation (the grant list is the *floor*
+of what runs unattended, never a bypass of a modeled destructive gate).
+Full design: [`service-principal-grants.md`](service-principal-grants.md).
+
 ## References
 
 - `backend/src/meho_backplane/operations/approval_queue.py` — queue lifecycle (T4) + read helpers + broadcast (T5) + park-time `expires_at` stamping and `expire_stale_requests` coalesce (#2322).
+- `backend/src/meho_backplane/operations/service_grants.py` — service-principal standing grants + the grant-use `approval.decision` audit row (#3151 / #3152); see [`service-principal-grants.md`](service-principal-grants.md).
 - `backend/src/meho_backplane/operations/approval_expiry.py` — periodic per-tenant approval-TTL sweeper (#2322).
 - `backend/src/meho_backplane/api/v1/approvals.py` — REST routes.
 - `backend/src/meho_backplane/mcp/tools/approvals.py` — MCP tools.

--- a/docs/codebase/service-principal-grants.md
+++ b/docs/codebase/service-principal-grants.md
@@ -1,0 +1,165 @@
+# Service-principal standing grants (#3151 + #3152)
+
+**Issues:** #3151 (standing scoped auto-approval grants for service
+principals) + #3152 (non-agent verdict consults `safety_level`). The two
+define one policy model and shipped together.
+
+## Why
+
+A paired consumer add-on drives long multi-step workflows through the
+backplane as a **service principal** (OAuth2 client-credentials,
+`principal_kind = service`). Its workflow model has a single deliberate
+human-approval gate near the end, but the run never reaches it unattended:
+the non-agent policy gate parked **every** `requires_approval` op, so a
+~10-step substrate build parked a dozen times before the modeled gate —
+degrading "review the plan once" into "click approve eleven times" and
+training exactly the wrong reflex.
+
+Separately (#3152), the non-agent gate keyed **only** on
+`requires_approval` and never consulted `safety_level`, so a **mutating**
+`caution` op carrying `requires_approval=False` executed completely
+ungated for a service principal (e.g. `POST:/vcenter/vm/{vm}/hardware/disk`).
+
+## The model (two decisions, one PR)
+
+**Operator decisions recorded at ship time (2026-08-27):**
+
+1. Standing scoped auto-approval grants for service principals are
+   approved as a capability.
+2. #3152 resolves as its **option 1**: the non-agent gate now consults
+   `safety_level`, with standing grants as the sanctioned path for
+   unattended mutations.
+
+### The gate (`operations/_validate.py::_non_agent_verdict`)
+
+Enforcement is **service-principal-only**. The branch structure:
+
+| Principal | `requires_approval` | mutating `caution` / `dangerous` | safe / read |
+|---|---|---|---|
+| `USER` (human, interactive) | park (queue) | **auto-execute** (unchanged) | auto-execute |
+| `SERVICE` (client-credentials) | park unless granted | **park unless granted** (#3152) | auto-execute |
+| `AGENT` | `resolve_verdict` (agent-permission model) — untouched | | |
+
+A human `USER` operator keeps the v0.2 default-allow contract (they are
+their own approver via the approval queue); `safety_level` is consulted
+**only** for a `SERVICE` principal. That is how "operator-interactive"
+is distinguished from "service principal": the `principal_kind` claim
+(`user` vs `service`, `auth/jwt.py::_extract_principal_kind`). Agents are
+unaffected — they keep the `AgentPermission` verdict model.
+
+**"Mutating" is grounded in existing descriptor fields** (no new column,
+`_is_mutating`): an ingested op is read-class iff its HTTP `method` ∈
+`{GET, HEAD}` (the `READ_HTTP_METHODS` set); a typed / composite op
+carries no `method`, so its curated `safety_level` stands in (`safe` =
+read, `caution` / `dangerous` = write). `dangerous` parks always; a
+`caution` op parks only when mutating.
+
+When a `SERVICE` op would park, the gate consults a live standing grant
+(`connector_id` must be supplied so the grant's connector scope can be
+matched — the dispatcher and the composite sub-op gate both pass it; the
+gateway path is safe-only and never needs it). A match auto-approves the
+op and records the use; absent a match, the op parks for a human decision.
+
+### The grant (`db/models.py::ServicePrincipalGrant`, `operations/service_grants.py`)
+
+One row authorises exactly one `(principal_sub, op_id, connector_id,
+target_id)` tuple in a tenant to run unattended. **Every scope is
+explicit — no wildcards** on `principal_sub`, `op_id`, or `connector_id`
+(contrast `AgentPermission`, whose `op_pattern` is a glob for the *agent*
+model). `target_id` is matched **exactly**, including the targetless
+(`NULL`) case — no any-target wildcard. Creating the grant IS the
+operator's upfront review, deny-by-default absent a match.
+
+- **`reason` is required** (the review flow — the body carries the
+  operator's justification).
+- **`expires_at`** optional (a standing grant is permanent by default).
+- **`revoked_at` / `revoked_by_sub`** — revocation is a **soft-delete**:
+  the row is retained so the grant history stays visible (same forensic
+  visibility as a human approval decision). Expiry and revocation are both
+  honoured **at dispatch time** by the lookup filter (`revoked_at IS NULL
+  AND (expires_at IS NULL OR expires_at > now)`); no sweeper is needed — an
+  expired / revoked row simply stops matching.
+
+Uniqueness ("at most one active grant per fully-scoped key") is enforced by
+two **partial** unique indexes — `uq_service_principal_grant_targeted`
+(`WHERE target_id IS NOT NULL AND revoked_at IS NULL`) and
+`…_targetless` (`WHERE target_id IS NULL AND revoked_at IS NULL`) — split
+because the nullable `target_id` would defeat a single unique index on the
+targetless case (`NULL != NULL`), and scoped to `revoked_at IS NULL` so a
+revoked scope can be re-granted.
+
+### Delete-shaped guardrail
+
+A grant is the **floor** of what runs unattended, never a bypass of a
+modeled destructive gate, so `ServicePrincipalGrantService.create` refuses
+delete-shaped ops:
+
+- **by configured pattern** (`Settings.service_grant_delete_shaped_patterns`,
+  env `SERVICE_GRANT_DELETE_SHAPED_PATTERNS`, `fnmatchcase` over the op id;
+  default `DELETE:*`, `*.delete`, `*.destroy`, `*.remove`, `*.purge`), and
+- **by descriptor** (best-effort when a descriptor resolves via
+  `lookup_descriptor`): the HTTP `DELETE` verb, or a hand-authored
+  `destructive` tag on a typed op.
+
+Ops the workflow models as its human gate (e.g. a bring-up start) are
+expected to stay ungranted — the grant list is the floor, not a bypass.
+
+### Grant-use audit (same visibility as a human decision)
+
+Every grant use writes one audit row via
+`service_grants._record_grant_use`, mirroring an approval **decision** row
+exactly (`method='APPROVAL'`, `path='approval.decision'`, `status_code=200`)
+so it is indistinguishable in the ledger from a human Approve — except
+`reviewed_by` reads `grant:<id>` and the payload carries
+`decision='auto-approved'` + `grant_id` + `reason="auto-granted by standing
+grant <id>"`. It is written in its own committed transaction before the op
+runs (the synchronous-audit invariant), and a fail-open
+`approval.auto_approved` broadcast is published for parity with a human
+decision's `approval.approved`.
+
+## REST surface (`api/v1/service_grants.py`)
+
+Role: **`operator`** (not `tenant_admin`) — a standing grant is the
+persistent form of the approve decision an operator already makes on the
+approval queue.
+
+| Verb | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/v1/service-principals/grants` | List (`principal_sub`, `include_revoked`, `limit`, `offset`). |
+| `GET` | `/api/v1/service-principals/grants/{id}` | Show one. 404 cross-tenant. |
+| `POST` | `/api/v1/service-principals/grants` | Create (the review; `reason` required). 422 on wildcard / delete-shaped / past expiry / duplicate. |
+| `DELETE` | `/api/v1/service-principals/grants/{id}` | Revoke (soft-delete). 404 when absent / already revoked / cross-tenant. |
+
+The route surface enters `cli/api/openapi.json` and the generated Go
+client (regenerate with `cd cli && make snapshot-openapi && make generate`
+after any signature change).
+
+## Scope boundaries (this PR)
+
+- **No UI console work** — the console can list grants via the REST surface
+  later; the audit ledger already surfaces grant uses under `method=APPROVAL`
+  / `path=approval.decision`.
+- **No agent-path change** — `resolve_verdict` and the `AgentPermission`
+  model are untouched; agents keep their own grant model.
+
+## Dependencies
+
+- `db/models.py` — `ServicePrincipalGrant` ORM model.
+- `alembic/versions/0078_create_service_principal_grant.py` — table +
+  lookup index + two partial unique indexes.
+- `operations/service_grants.py` — CRUD service + `find_live_grant` +
+  `consult_and_record_grant` + delete-shaped classification.
+- `operations/service_grant_schemas.py` — REST request / response shapes.
+- `operations/_validate.py` — `_non_agent_verdict` (safety_level consult +
+  grant consultation), `policy_gate` (`connector_id` param).
+- `operations/dispatcher.py` / `operations/composite.py` — pass
+  `connector_id` into `policy_gate`.
+- `settings.py` — `service_grant_delete_shaped_patterns`.
+
+## Known limitations
+
+- There is **no server-side service-principal registry** to validate
+  `principal_sub` against (a service principal is any Keycloak
+  client-credentials client carrying `principal_kind=service`), so — unlike
+  `AgentGrantService`, which rejects an unregistered agent principal — a
+  grant whose `principal_sub` never authenticates simply sits inert.


### PR DESCRIPTION
## Summary

Implements #3151 **and** resolves its companion #3152 as one coherent policy model for **non-agent service principals** (OAuth2 client-credentials, `principal_kind = service`).

- **#3151 — standing scoped auto-approval grants.** An operator issues a `(principal_sub, op_id, connector_id, target_id)` grant — the persistent form of an approve decision — so a service principal driving a long unattended run auto-approves instead of parking a dozen times before its modeled gate. New `service_principal_grant` table + operator-role REST at `/api/v1/service-principals/grants` (create / list / show / revoke).
- **#3152 — non-agent verdict consults `safety_level`.** The gate now parks a mutating `caution` op (and any `dangerous` op) for a service principal even without `requires_approval`, closing the hole where `POST:/vcenter/vm/{vm}/hardware/disk` executed ungated. Standing grants are the sanctioned path to run such mutations unattended.

Every scope is explicit (no wildcards on principal/op/connector), creating a grant IS the upfront review (`reason` required), delete-shaped ops are never grantable, revocation is a soft-delete (history retained), and each grant use writes an `approval.decision` / `auto-approved` audit row carrying the `grant_id` — same ledger visibility as a human decision.

## Operator decisions (recorded in the design note)

1. **Standing scoped auto-approval grants for service principals are approved as a capability** (operator sign-off 2026-08-27).
2. **#3152 resolves as its option 1** — the non-agent gate now consults `safety_level`, with standing grants as the sanctioned path for unattended mutations.

## Design notes

- **Who is gated.** Enforcement is service-principal-only. A human `USER` operator keeps the v0.2 default-allow contract (they are their own approver via the approval queue) and is **not** subject to the `safety_level` tightening or standing grants. Operator-interactive vs service principal is distinguished by the `principal_kind` claim (`user` vs `service`, `auth/jwt.py::_extract_principal_kind`). The agent verdict path (`resolve_verdict`, `AgentPermission`) is **untouched**.
- **"Mutating" is grounded in existing descriptor fields** (`_is_mutating`), no new column: read-class iff HTTP `method ∈ {GET, HEAD}` (`READ_HTTP_METHODS`); a typed / composite op carries no `method`, so its curated `safety_level` stands in.
- **Delete-shaped guardrail.** Refused at grant creation by configured `fnmatchcase` patterns (`SERVICE_GRANT_DELETE_SHAPED_PATTERNS`, default `DELETE:*` / `*.delete` / `*.destroy` / `*.remove` / `*.purge`) **and**, best-effort when a descriptor resolves, the HTTP `DELETE` verb or a `destructive` tag. The grant list is the *floor* of what runs unattended, never a bypass of a modeled destructive gate.
- **Uniqueness** of the active grant uses two partial unique indexes (targeted / targetless, both `WHERE revoked_at IS NULL`) because the nullable `target_id` would defeat a single unique index on the targetless case.
- **Bounded scope:** no UI console work (the console can list via REST later; grant uses are already visible on the audit ledger); no agent-path change.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy src/meho_backplane/` — clean (only pre-existing `icmp.py` macOS false-positive)
- [x] `code-quality.py --diff` — 0 blockers (one `# code-quality-allow` on the pre-existing 118-line `enforce_subop_policy`, which only gains the `connector_id` pass-through)
- [x] **Grant CRUD + refusal of delete-shaped / wildcards** — `tests/test_service_grants.py` (17 tests)
- [x] **Gate matrix** (service principal × {granted, ungranted} × {requires_approval, caution-mutation, dangerous, safe-read}) + **grant-use audit rows** + **expiry/revocation respected at dispatch** + USER-unchanged — `tests/test_service_principal_grant_gate.py` (24 tests)
- [x] **REST** RBAC + happy-path CRUD round-trip + 422 validation — `tests/test_api_v1_service_grants.py` (7 tests)
- [x] **Migrations lane** — `tests/migrations/test_migration_0078_service_principal_grant.py` (round-trip + partial-unique-index flags); `check_migration_compat.py` green (additive-only)
- [x] Adjacent suites unregressed — `test_operations_subop_policy_gate`, `test_operations_dispatcher`, `test_approval_queue`, `test_gateway_commands`, `test_examples_r2_approval_gate`, `test_permission_resolver`, `test_broadcast_credential_mint_dispatch`, `test_secret_move_approval`, `test_announce_gate`, `test_connectors_vmware_rest_composites_write_gate`, `test_api_v1_approvals`, `test_settings`, `test_connectors_bind9_config`
- [x] CLI OpenAPI snapshot + Go client regenerated (`cd cli && make snapshot-openapi && make generate`); `go build ./...` clean

## Docs

- New `docs/codebase/service-principal-grants.md` (full model + operator decisions) and a cross-reference section added to `docs/codebase/approvals.md`.
- Paired `Added` / `Changed` bullets under CHANGELOG `[Unreleased]`.

Closes #3151
Closes #3152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
