### PR TITLE
fix(image): patch openssl family for CVE-2026-14456 via the targeted --only-upgrade layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,21 @@ connector-related release-notes line.
   grant-elevation (`AgentElevationCreate`) endpoint, so a re-add is
   caught regardless of the wire name it picks.
 
+### Security — base image openssl family patched for CVE-2026-14456 (PR #3170)
+
+- The runtime image's pinned `python:3.14-slim` base ships
+  `openssl 3.5.6-1~deb13u2`, which trivy flags as a fixable **HIGH**
+  (`CVE-2026-14456`) across `openssl`, `libssl3t64`, and
+  `openssl-provider-legacy` — the advisory landed between the PR-lane
+  builds and the release-roll merge, turning the `main` image run red at
+  the scan gate. The upstream base manifest has not been rebuilt against
+  the Debian fix yet, so the usual base-digest bump cannot clear it; the
+  three packages join the existing targeted `apt-get --only-upgrade`
+  security layer (the CVE-2026-53615 pattern from PR #3053), pulling
+  `3.5.7-1~deb13u2` from `trixie-security` with apt indexes dropped
+  in-layer. No new package enters the image. Removable once a rebuilt
+  base already carries openssl >= `3.5.7-1~deb13u2`.
+
 ### Added — Claude Code plugin + in-repo marketplace: one-command MEHO onramp (#3130 / #3136)
 
 - A Claude Code team's MEHO onramp was manual and drift-prone: wire MCP by

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -157,22 +157,26 @@ RUN set -eux; \
 FROM python:3.14-slim@sha256:d3400aa122fa42cf0af0dbe8ec3091b047eac5c8f7e3539f7135e86d855dc015 AS runtime
 
 # ---------- Base-OS security patch: util-linux family (CVE-2026-53615) -------
+# ----------                        + openssl family    (CVE-2026-14456) ------
 # The pinned base still carries util-linux 2.41-5, which Trivy flags as a
 # fixable HIGH (CVE-2026-53615). Debian trixie-security already serves the fix
 # (2.41.5-0+deb13u1), but the upstream python:3.14-slim manifest has not been
 # rebuilt against it yet, so the digest bump the Dependabot docker block would
-# normally carry cannot clear it. Rather than publish a release image with a
-# known fixable HIGH, upgrade just the util-linux binary family to the security
+# normally carry cannot clear it. Same story for openssl 3.5.6-1~deb13u2,
+# flagged as fixable HIGH CVE-2026-14456 with the fix (3.5.7-1~deb13u2)
+# already in trixie-security. Rather than publish a release image with a
+# known fixable HIGH, upgrade just those binary families to the security
 # version in one apt layer (indexes dropped in the same RUN, so no apt metadata
 # persists in the image). This is a targeted --only-upgrade of packages already
 # present — no new package enters the image — and is the sibling in intent of
 # the pip uninstall below: keep the Trivy scan clean. Remove this layer once
 # the base-digest bump lands a rebuilt base already carrying util-linux
-# >= 2.41.5-0+deb13u1.
+# >= 2.41.5-0+deb13u1 and openssl >= 3.5.7-1~deb13u2.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends --only-upgrade \
       util-linux libuuid1 libmount1 libblkid1 libsmartcols1 liblastlog2-2 \
       mount bsdutils login \
+      openssl libssl3t64 openssl-provider-legacy \
  && rm -rf /var/lib/apt/lists/*
 
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).


### PR DESCRIPTION
## What

The `main` `image.yml` run on the v0.31.0 release-roll merge commit (58847aaf) failed the trivy gate (fails on fixable CRITICAL/HIGH): **CVE-2026-14456, HIGH, fixable** on `openssl` / `libssl3t64` / `openssl-provider-legacy` — installed `3.5.6-1~deb13u2` from the pinned `python:3.14-slim` base, fixed `3.5.7-1~deb13u2` already served by trixie-security (verified via the code-scanning SARIF alerts). The upstream base manifest has not been rebuilt, so a digest bump cannot clear it.

## How

Adds the three openssl packages to the existing targeted `apt-get --only-upgrade` security layer in `backend/Dockerfile` (the exact CVE-2026-53615 / PR #3053 pattern: no new package enters the image, indexes dropped in-layer, remove once a rebuilt base carries the fix) and extends the comment block accordingly. Second commit adds the `[0.31.0]` **Security** changelog entry — this commit ships inside the v0.31.0 tag, which moves to this PR's merge commit (RELEASING.md step 4: tag the release-cutting state, never a red-image SHA).

## Verification

- `image.yml` runs on this PR (Dockerfile path filter) — its trivy step is the gate that failed on main and must go green here.
- Release blocker: v0.31.0 tag waits on this PR + a green main image run on its merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)