### PR TITLE
fix(ci): attach .mcpb bundle without the gh CLI on the release runner (#3171)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -25,10 +25,12 @@
 #
 # The Claude Desktop MCPB bundle (clients/claude-desktop-mcpb/) is built
 # with the tag version and attached to the same Release as a fifth asset
-# by the "Build + attach Claude Desktop .mcpb bundle" step below. It is
-# not a CLI tarball and is not cosign-signed; distribution is the GitHub
-# Release asset channel only (#3129). The step runs after GoReleaser has
-# created the Release so `gh release upload` has a Release to attach to.
+# by the build + attach steps below. It is not a CLI tarball and is not
+# cosign-signed; distribution is the GitHub Release asset channel only
+# (#3129). The steps run after GoReleaser has created the Release; the
+# attach step uses softprops/action-gh-release (GitHub API, no `gh` CLI)
+# so it works on the self-hosted runner image, which ships without `gh`
+# (#3171).
 #
 # Permissions design follows the same per-job least-privilege posture
 # as chart.yml + image.yml:
@@ -274,24 +276,41 @@ jobs:
           # standard sigstore.dev CI guidance.
           COSIGN_YES: "true"
 
-      - name: Build + attach Claude Desktop .mcpb bundle
-        # GoReleaser has created the Release above; attach the Claude
-        # Desktop MCPB bundle to it as a fifth asset. `build.sh` runs the
-        # pinned `mcpb pack` (which validates the manifest) with the tag
-        # version stripped of its leading `v` — matching GoReleaser's
-        # `meho_<version>_...` file-name convention. `--clobber` lets a
-        # re-tag replace the asset instead of failing on a name clash.
+      - name: Build Claude Desktop .mcpb bundle
+        # `build.sh` runs the pinned `mcpb pack` (which validates the
+        # manifest) with the tag version stripped of its leading `v` —
+        # matching GoReleaser's `meho_<version>_...` file-name convention.
+        # The built bundle path is exported for the attach step that follows.
         env:
           TAG: ${{ github.ref_name }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
           OUT_DIR="${RUNNER_TEMP}/mcpb"
           clients/claude-desktop-mcpb/build.sh "${VERSION}" "${OUT_DIR}"
-          BUNDLE="${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb"
-          gh release upload "${TAG}" "${BUNDLE}" --clobber --repo "${GITHUB_REPOSITORY}"
+          echo "MCPB_BUNDLE=${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb" >> "${GITHUB_ENV}"
+
+      - name: Attach Claude Desktop .mcpb bundle to the Release
+        # GoReleaser created the draft Release above; attach the bundle as a
+        # fifth asset through the GitHub API. The self-hosted
+        # `meho-runners-ci` image ships without the `gh` CLI, so the previous
+        # `gh release upload` line died with `gh: command not found` (exit
+        # 127) on the first tag run to include this step, v0.31.0 (#3171).
+        # This action calls the API directly and needs no CLI on the runner.
+        # `draft: true` keeps the Release a draft — the action publishes a
+        # reused draft on upload unless told to keep it, and the Release must
+        # stay draft for a maintainer to flip it (see "Emit release
+        # summary"); omitting `body`/`name` preserves the GoReleaser-set
+        # release notes. `overwrite_files` (default true) lets a re-tag
+        # replace the asset, matching the previous `--clobber`;
+        # `fail_on_unmatched_files` keeps the step fail-closed if the bundle
+        # glob matches nothing.
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: ${{ env.MCPB_BUNDLE }}
+          draft: true
+          fail_on_unmatched_files: true
 
       - name: Emit release summary
         # Surface the published artefact list in the workflow run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,21 @@ connector-related release-notes line.
   and lossy coverage — the job's documented contract (#2800). The
   underlying serial-lane hang investigation stays open on #3172.
 
+### Fixed — `cli-release.yml` attaches the `.mcpb` bundle without the `gh` CLI (#3171)
+
+- The v0.31.0 tag run of `cli-release.yml` built the Claude Desktop
+  `.mcpb` bundle but failed to attach it: the `gh release upload` line
+  died with `gh: command not found` (exit 127). v0.31.0 was the **first**
+  tag run to include the attach step (it landed in #3138, after v0.30.0
+  tagged), and the self-hosted `meho-runners-ci` image ships without the
+  `gh` CLI — the step had assumed `gh` was present, as it is on
+  GitHub-hosted `ubuntu-latest`. The attach now
+  goes through `softprops/action-gh-release` (SHA-pinned, GitHub API, no
+  CLI on the runner). `draft: true` keeps the GoReleaser-created Release a
+  draft for a maintainer to flip, omitting `body`/`name` preserves its
+  release notes, and `fail_on_unmatched_files` keeps the step fail-closed.
+  Next tag run publishes all five assets without manual intervention.
+
 ## [0.31.0] - 2026-08-27
 
 ### Breaking changes — MCP agent surface is claim-gated: default drops to the 25-tool working surface (#3154 / #3160)


### PR DESCRIPTION
Closes #3171

## Problem

The v0.31.0 tag run of `cli-release.yml` ([run 33104966559](https://github.com/evoila/meho/actions/runs/33104966559)) built the Claude Desktop `.mcpb` bundle fine (726 files, manifest validated) but failed to attach it:

```
line 6: gh: command not found
##[error]Process completed with exit code 127
```

GoReleaser's own assets (four tarballs + SHA256SUMS + cosign bundles) published; only the fifth asset was missing. It was remediated out-of-band; this PR fixes the workflow so v0.32.0 doesn't repeat it.

## Why it first bit at v0.31.0 (not a runner change)

The issue speculated the runner label or image changed between v0.30.0 and v0.31.0. It did not — `runs-on: meho-runners-ci` has been unchanged since the #715 CI cutover. The real cause: **the attach step is new.** It landed in #3138 (commit `c174cacf`, 2026-08-26), *after* v0.30.0 was tagged (2026-08-25). So v0.30.0's release run never executed the step — v0.31.0 is the **first** tag run to include it. The self-hosted `meho-runners-ci` ARC image simply has no preinstalled `gh` (unlike GitHub-hosted `ubuntu-latest`), and the step assumed it did.

## Fix

The issue offered two options (install `gh`, or use an action that hits the API directly). I picked the **action** — the more robust choice, and the one the repo's conventions point to: every action in this repo is pinned by commit SHA, and `apt-get install gh` is fiddly (the GitHub CLI isn't in Ubuntu's default repos; it needs the `cli.github.com` apt source added via curl+gpg first).

- Split the single "Build + attach" step into a `run:` **build** step (which exports the bundle path via `GITHUB_ENV`, the same pattern the `RELEASE_NOTES_FILE` step already uses in this file) and a `uses:` **attach** step.
- Attach via `softprops/action-gh-release@3d0d988…` (**v3.0.2**, SHA-pinned per repo convention). It calls the GitHub API directly — no CLI on the runner.

### Behavior preserved (verified against the action's source at the pinned SHA)

The release is created by GoReleaser as a **draft**, and a maintainer flips it to public. The action must not disturb that:

- **`draft: true` is required.** In `finalizeRelease()`, when `input_draft` is not `true` and the release is a draft, the action **publishes** it (`draft:false`). Passing `draft: true` makes it return early — the draft is preserved.
- **Body/name preserved.** In the existing-release update path, `body = workflowBody || existingReleaseBody` and `name = input_name || existingRelease.name` — omitting both keeps the GoReleaser-set release notes and name. The update call also passes `draft: existingRelease.draft`, so it never changes draft state on its own.
- **`overwrite_files` (default `true`)** reproduces the previous `--clobber` (a re-tag replaces the asset).
- **`fail_on_unmatched_files: true`** keeps the step fail-closed if the bundle glob matches nothing (default is a warning).

Nothing else in the job changes; the `env` no longer carries `GH_TOKEN`/`GITHUB_REPOSITORY` (the action defaults `token` to `github.token` and the repo to the current one).

## Notes

- The IDE may warn "Context access might be invalid: MCPB_BUNDLE" — a known false positive from the VS Code Actions extension for env vars set at runtime via `$GITHUB_ENV`. actionlint does not flag it, and the identical `env.RELEASE_NOTES_FILE` pattern already ships in this same file. The repo runs no actionlint/zizmor CI job; `check-yaml` (pre-commit) passes.

## Acceptance criteria

- [x] Attach step no longer depends on a preinstalled `gh` — it uses the GitHub API via a SHA-pinned action.
- [x] Draft state, release notes, and clobber-on-retag behavior preserved.
- [ ] Next tag run publishes all five assets without manual intervention (verifiable only on the next `v*` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)