### PR TITLE
ci: coverage pod-limit record correction (#3172) + .mcpb attach draft-narrative fix (#3171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,14 +735,16 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'ci-coverage-validate'))
     runs-on: meho-runners-ci-heavy
-    # TODO(ops): the durable fix for the recurring ~47-min OOM / runner-loss on
-    # this pool (which silently killed coverage on every main push from
-    # 2026-06-20, collapsing SonarCloud coverage 65.8% -> ~24%; see the memory
-    # table above and docs/codebase/sonarcloud.md) is a larger-memory runner pool
-    # — a gha-runner-scale-set on the rke2-ci cluster (ops-owned, out of band).
-    # Move this `runs-on:` to the new pool once provisioned. Until then an OOM
-    # skips one coverage upload; quality-gate.yml now makes that skip
-    # fail-visible via an error annotation (#2513).
+    # RESOLVED 2026-08-27 (#3172; formerly a TODO(ops) asking for a new
+    # larger-memory pool + a runs-on move): the recurring ~47-min OOM /
+    # runner-loss on this pool — which silently killed coverage on every main
+    # push from 2026-06-20, collapsing SonarCloud coverage 65.8% -> ~24% (see
+    # the memory table above and docs/codebase/sonarcloud.md) — was the pool's
+    # 8Gi runner limit vs this job's 12.48-GiB serial sweep. Fixed IN PLACE by
+    # rdc-gitops#115 (heavy pool resized to 14Gi request==limit); this
+    # `runs-on:` label is correct and stays. An OOM would still only skip one
+    # coverage upload (job stays non-blocking); quality-gate.yml makes that
+    # skip fail-visible via an error annotation (#2513).
     # THREE-LAYER hang defense (#2800 → #2806 → #2865). Ordered inner→outer;
     # each layer catches what the one inside it structurally cannot:
     #   1. IN-PROCESS, per test — pytest-timeout `--timeout=300` (signal) on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,14 +705,26 @@ jobs:
     # across 8306 tests — and barely shrinks with xdist worker count, so the
     # session-end combine is NOT the peak (offline combine alone did not
     # avoid the OOM at -n 3). The lever that actually fits the pod is dropping
-    # base suite memory via low parallelism: -n 1 peaks at 12.48 GiB, ~1.2 GiB
-    # under the <13.67 GiB pod limit that #1982's --cov run (13.67 GiB) tripped.
+    # base suite memory via low parallelism: -n 1 peaks at 12.48 GiB.
+    # CORRECTION (#3172, 2026-08-27): the "<13.67 GiB pod limit" this job was
+    # originally sized against NEVER existed — 13.67 GiB was #1982's measured
+    # local peak, mistaken for the runner's cap. The live heavy-pool runner
+    # container limit (rdc-gitops apps/rke2-ci/meho-runners-heavy) was 8Gi,
+    # so the 12.48-GiB serial sweep never fit: every main-push run since
+    # ~2026-06-20 died as an OOM runner-loss (absorbed job failure, null step
+    # telemetry) or a memory-thrash wedge (pytest crawls to the 45-min step
+    # cap, combine hangs on the debris — the v0.31.0 tag-gate blocker).
+    # rdc-gitops#115 resizes the pool to 14Gi (request == limit,
+    # node-exclusive by memory), giving the sweep ~1.5 GiB of real headroom
+    # on this same runs-on label.
     # The "offline" shape (per-worker parallel data + `coverage combine`/`xml`
     # AFTER pytest exits, pytest invoked with `-p no:cov` so pytest-cov's
     # in-process combine never runs) keeps the combine memory-cheap regardless.
-    # If the suite grows enough to push -n 1 over the limit, the durable fix is
-    # a larger-memory runner pool (infra, out of band) — this job is
-    # non-blocking so an OOM merely skips one coverage upload until then.
+    # If the suite grows enough to push -n 1 over ~13 GiB, the durable fix is
+    # sharding this sweep into sequential pytest invocations (each with its
+    # own parallel data files; combine already merges across them) — 14Gi is
+    # the ceiling the current 15.62-GiB-allocatable nodes support — and this
+    # job stays non-blocking so an OOM merely skips one coverage upload.
     # Runs on push to main, OR on a PR explicitly opted in via the
     # `ci-coverage-validate` label (the on-runner validation escape hatch
     # described above). The fork-PR guard still applies on the PR path so

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,7 +7,8 @@
 #   On every `v*` tag push, build four single-static tarballs
 #   (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), produce a
 #   combined SHA256SUMS file, and publish them as assets on a new
-#   draft GitHub Release at https://github.com/evoila/meho/releases.
+#   GitHub Release (auto-published, `draft: false` since #1127) at
+#   https://github.com/evoila/meho/releases.
 #
 # Tag-driven only — main branch pushes never publish a release. The
 # release tag is the authoritative version stamp: GoReleaser strips
@@ -248,8 +249,8 @@ jobs:
           # step above). When the file is empty (no matching section)
           # GoReleaser logs a warning and uses the empty body; the
           # warning step above surfaces this loudly in the workflow
-          # log so a maintainer can spot the missing CHANGELOG
-          # update before flipping the draft Release to public. The
+          # log so a maintainer can spot a missing CHANGELOG update
+          # on the (auto-published, #1127) Release right away. The
           # fallback `changelog:` block in cli/.goreleaser.yaml still
           # serves snapshot builds (`make release-dry-run`) where no
           # CHANGELOG section exists.
@@ -373,8 +374,8 @@ jobs:
             echo "\`sha256sum -c SHA256SUMS\` against the tarballs you"
             echo "actually downloaded (two-step trust chain)."
             echo ""
-            echo "The release is created in **draft** mode — a maintainer"
-            echo "must flip it to public via the GitHub Releases UI after"
-            echo "verifying the four tarballs + bundles are present and"
+            echo "The release is **live** the moment this workflow ends"
+            echo "(auto-published, #1127) — verify the four tarballs +"
+            echo "bundles and the .mcpb asset are present and that"
             echo "\`meho version\` reports the expected tag."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -291,37 +291,41 @@ jobs:
           echo "MCPB_BUNDLE=${OUT_DIR}/meho-claude-desktop-${VERSION}.mcpb" >> "${GITHUB_ENV}"
 
       - name: Attach Claude Desktop .mcpb bundle to the Release
-        # GoReleaser created the draft Release above; attach the bundle as a
-        # fifth asset through the GitHub API. The self-hosted
+        # GoReleaser created the Release above — PUBLISHED, not draft:
+        # cli/.goreleaser.yaml has `draft: false` (auto-publish since #1127;
+        # the v0.31.0 Release was live the moment GoReleaser finished, which
+        # is what the release-asset distribution channel depends on). Attach
+        # the bundle as a fifth asset through the GitHub API: the self-hosted
         # `meho-runners-ci` image ships without the `gh` CLI, so the previous
         # `gh release upload` line died with `gh: command not found` (exit
         # 127) on the first tag run to include this step, v0.31.0 (#3171).
         # This action calls the API directly and needs no CLI on the runner.
-        # `draft: true` keeps the Release a draft — the action publishes a
-        # reused draft on upload unless told to keep it, and the Release must
-        # stay draft for a maintainer to flip it (see "Emit release
-        # summary"); omitting `body`/`name` preserves the GoReleaser-set
-        # release notes. `overwrite_files` (default true) lets a re-tag
-        # replace the asset, matching the previous `--clobber`;
-        # `fail_on_unmatched_files` keeps the step fail-closed if the bundle
-        # glob matches nothing.
+        # No `draft:` input: on the update path this pinned version ignores
+        # it anyway (v3.0.2 `github.ts` preserves `existingRelease.draft`),
+        # and the #3174 comment claiming the Release "must stay draft for a
+        # maintainer to flip it" described a flow that has not existed since
+        # #1127 — the input was dead config wrapped in a false narrative
+        # (#3171 record correction). Omitting `body`/`name` preserves the
+        # GoReleaser-set release notes. `overwrite_files` (default true)
+        # lets a re-tag replace the asset, matching the previous
+        # `--clobber`; `fail_on_unmatched_files` keeps the step fail-closed
+        # if the bundle glob matches nothing.
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           files: ${{ env.MCPB_BUNDLE }}
-          draft: true
           fail_on_unmatched_files: true
 
       - name: Emit release summary
         # Surface the published artefact list in the workflow run
-        # summary so a maintainer flipping the draft Release to
-        # public can spot a missing target at a glance.
+        # summary so a maintainer verifying the (auto-published,
+        # #1127) Release can spot a missing target at a glance.
         if: success()
         env:
           TAG: ${{ github.ref_name }}
         run: |
           {
-            echo "## CLI release published (draft)"
+            echo "## CLI release published"
             echo ""
             echo "Tag: \`${TAG}\`"
             echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,37 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `.mcpb` release attach no longer assumes a `gh` CLI on the runner (#3171 / PR #3175)
+
+- The v0.31.0 tag run — the first ever to reach the `cli-release.yml`
+  "Build + attach Claude Desktop `.mcpb` bundle" step (it shipped inside
+  v0.31.0 via #3138) — died with `gh: command not found`: the job runs on
+  the self-hosted `meho-runners-ci` pool, whose image is upstream
+  `actions-runner` plus `python3-yaml`/`gettext-base` and carries no `gh`.
+  The bundle had to be attached by hand. The step now drives the GitHub
+  Releases REST API directly with python3 stdlib (guaranteed by the
+  image): resolve the release by tag, delete a same-name asset first (the
+  old `--clobber` re-tag semantics), then upload — no CLI assumed on any
+  runner the job may land on.
+
+### Fixed — coverage job sized against a pod limit that never existed; real limit fixed on the pool (#3172 / PR #3175)
+
+- The `python-coverage` job's memory table claimed its serial sweep
+  (measured 12.48 GiB at 8306 tests) ran "~1.2 GiB under the <13.67 GiB
+  pod limit" — but 13.67 GiB was #1982's measured local peak, never the
+  runner's cap. The live heavy-pool runner limit was **8Gi**
+  (rdc-gitops `apps/rke2-ci/meho-runners-heavy`), so the sweep never
+  fit: every main-push coverage run since ~2026-06-20 died as an OOM
+  runner-loss (absorbed job failure, null step telemetry, purged logs)
+  or a memory-thrash wedge — the latter being the v0.31.0 tag-gate
+  `cancelled` blocker that #3173 hardened against. The ci.yml comment
+  now records the real history; the durable fix is rdc-gitops#115
+  (heavy pool resized to 14Gi request==limit, node-exclusive by
+  memory, ~1.5 GiB real headroom), with sweep-sharding named as the
+  next lever if the suite outgrows ~13 GiB — 14Gi is the ceiling of
+  the current 15.62-GiB-allocatable nodes. #3172 stays open for the
+  post-resize verification (coverage job green + SonarCloud recovery).
+
 ### Fixed — deploying.md v0.31.0 upgrade row names both shipped migrations (PR #3173)
 
 - The version-specific upgrade-notes row added by the v0.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,18 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Fixed — `.mcpb` release attach no longer assumes a `gh` CLI on the runner (#3171 / PR #3175)
+### Fixed — `.mcpb` attach step sheds the false draft-Release narrative (#3171 / PR #3175)
 
-- The v0.31.0 tag run — the first ever to reach the `cli-release.yml`
-  "Build + attach Claude Desktop `.mcpb` bundle" step (it shipped inside
-  v0.31.0 via #3138) — died with `gh: command not found`: the job runs on
-  the self-hosted `meho-runners-ci` pool, whose image is upstream
-  `actions-runner` plus `python3-yaml`/`gettext-base` and carries no `gh`.
-  The bundle had to be attached by hand. The step now drives the GitHub
-  Releases REST API directly with python3 stdlib (guaranteed by the
-  image): resolve the release by tag, delete a same-name asset first (the
-  old `--clobber` re-tag semantics), then upload — no CLI assumed on any
-  runner the job may land on.
+- The #3174 attach step carried `draft: true` plus a comment claiming the
+  Release "must stay draft for a maintainer to flip it" — a flow that has
+  not existed since #1127: `cli/.goreleaser.yaml` sets `draft: false`, so
+  every release (v0.31.0 included) is live-published the moment GoReleaser
+  finishes, which is what the `.mcpb` release-asset distribution channel
+  depends on. Functionally benign — the pinned `action-gh-release` v3.0.2
+  ignores the `draft` input on its update path (`github.ts` preserves
+  `existingRelease.draft`, verified at the pinned SHA) — but dead config
+  wrapped in a false narrative invites a future "fix" that would actually
+  un-publish releases. The input is removed and the step + release-summary
+  comments now state the published-release reality.
 
 ### Fixed — coverage job sized against a pod limit that never existed; real limit fixed on the pool (#3172 / PR #3175)
 
@@ -150,7 +151,7 @@ connector-related release-notes line.
   and lossy coverage — the job's documented contract (#2800). The
   underlying serial-lane hang investigation stays open on #3172.
 
-### Fixed — `cli-release.yml` attaches the `.mcpb` bundle without the `gh` CLI (#3171)
+### Fixed — `cli-release.yml` attaches the `.mcpb` bundle without the `gh` CLI (#3171 / #3174)
 
 - The v0.31.0 tag run of `cli-release.yml` built the Claude Desktop
   `.mcpb` bundle but failed to attach it: the `gh release upload` line

--- a/docs/codebase/sonarcloud.md
+++ b/docs/codebase/sonarcloud.md
@@ -104,14 +104,20 @@ dedicated job was the sole coverage producer and nothing else caught the gap.
 3. The artifact list on the CI run — a present `python-coverage` artifact rules
    out this failure mode.
 
-**The durable fix is ops-owned.** The coverage tax is intrinsic (~12.5 GiB peak
-at `-n 1`, only ~1.2 GiB under the pod limit) and barely moves with parallelism,
-so the job is one suite-growth increment away from OOM again. The durable fix —
-named in both the job's own header comment and its `# TODO(ops)` at `runs-on:` —
-is a **larger-memory runner pool** (a gha-runner-scale-set on the rke2-ci
-cluster, provisioned out of band); once it exists, move the job's `runs-on:` to
-it. Until then the job stays non-blocking and the fail-visible annotation above
-surfaces every skipped upload instead of letting it rot silently.
+**The durable fix landed 2026-08-27 (#3172 / rdc-gitops#115).** The coverage
+tax is intrinsic (~12.5 GiB peak at `-n 1`) and barely moves with parallelism —
+and the "~1.2 GiB under the pod limit" this section used to claim was fiction:
+the live heavy-pool runner limit was **8Gi** (13.67 GiB was #1982's measured
+local peak, mistaken for the cap), so the sweep never fit and every main-push
+coverage run since ~2026-06-20 died as an OOM runner-loss or a memory-thrash
+wedge. rdc-gitops#115 resized the pool in place to **14Gi** (request==limit,
+node-exclusive by memory on the 15.62-GiB-allocatable workers) — the job's
+`runs-on:` stays. Real headroom is now ~1.5 GiB; if the suite outgrows
+~13 GiB serial, the next lever is sharding the sweep into sequential pytest
+invocations (`coverage combine` already merges across parallel data files),
+not a bigger limit — 14Gi is this node size's ceiling. The job stays
+non-blocking and the fail-visible annotation above surfaces every skipped
+upload instead of letting it rot silently.
 
 ## New-code period + scan trigger — how they're configured
 


### PR DESCRIPTION
## Rescoped after the #3174 collision

The original cli-release.yml half (python3-stdlib REST upload) was superseded mid-flight: #3174 (factory session, concurrent) landed the action-based fix for #3171 first. This PR is rebased over it; the surviving scope is the **record corrections**:

1. **cli-release.yml** — #3174's step carried `draft: true` + a comment claiming the Release "must stay draft for a maintainer to flip it" — a flow that hasn't existed since #1127 (`cli/.goreleaser.yaml` `draft: false`; v0.31.0 was live-published, which the `.mcpb` release-asset channel depends on). Functionally benign at the pinned action version — v3.0.2's update path preserves `existingRelease.draft`, verified in `github.ts` at the pinned SHA — but dead config wrapped in a false narrative invites a future "fix" that would actually un-publish releases. Input removed; step + release-summary comments corrected.
2. **ci.yml** (iter-1 B1) — the memory-table comment correction (the "<13.67 GiB pod limit" fiction; real limit was 8Gi vs the 12.48-GiB sweep — #3172's root cause) AND the formerly-contradicting `TODO(ops)` block now records the resolution: **in-place** resize via rdc-gitops#115 (merged, ArgoCD-synced, 14Gi pods verified live), `runs-on:` stays, sharding named as the next lever.
3. **docs/codebase/sonarcloud.md** (iter-1 B2) — the same "~1.2 GiB under the pod limit" fiction and superseded "new pool + move runs-on" fix replaced with the real history + landed fix.
4. **CHANGELOG** — reconciled: superseded bullet dropped, #3174's bullet gains its PR anchor, new bullet for the draft-narrative correction.

Refs #3171, #3172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)