### PR TITLE
fix(auth): classify IdP service-account tokens as principal_kind=service (#3178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — service-principal grants inert: client-credentials tokens now classify as `service` (#3178)
+
+- An OAuth2 client-credentials (service-account) token carries no
+  interactive user and, unless the realm sets an explicit `principal_kind`
+  mapper, arrived with the claim absent — so the classifier fell back to
+  `principal_kind=user`, the #3152 standing-grants gate never evaluated,
+  and every governed dispatch by an automation principal parked for
+  approval (then self-approved). The absent-claim path now positively
+  identifies a service-account token by its username marker (Keycloak's
+  reserved `service-account-<clientId>` naming on `preferred_username`,
+  both the claim and the prefix configurable via
+  `JWT_SERVICE_ACCOUNT_USERNAME_CLAIM` / `_PREFIX`) and classifies it
+  `service` so standing grants are honoured. Fail-closed and policy-safe:
+  an explicit `principal_kind` claim always wins, and only a positive
+  marker upgrades — any unrecognised token shape stays `user`. A new WARN
+  (`policy_gate_grant_holder_classified_non_service`) fires when a parking
+  non-service principal still holds ≥1 live grant, surfacing any residual
+  misclassification.
+
 ### Changed — coverage sweep sharded into a 3-way matrix + fan-in combine (#3172 / PR #3177)
 
 - With the heavy-pool OOM class closed by the 14Gi resize

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -658,24 +658,68 @@ def _extract_tenant_role(claims: Any, settings: Settings) -> TenantRole:
         raise _http_401("unknown_tenant_role") from exc
 
 
+def _is_service_account_token(claims: Any, settings: Settings) -> bool:
+    """Positively identify an IdP service-account (client-credentials) token.
+
+    Fix for #3178. An OAuth2 ``client_credentials`` grant carries no
+    interactive user, so an IdP mints the client its own *service account*
+    identity. Keycloak names that identity deterministically —
+    ``service-account-<clientId>`` — and stamps it on the username claim
+    (default ``preferred_username``). That naming is a documented Keycloak
+    invariant (the prefix is reserved for service-account users), so a
+    username claim bearing the configured prefix is an **explicit positive
+    marker** of a service-account token, not a fuzzy heuristic.
+
+    Fail-closed by construction (this is the policy path): the function
+    returns ``True`` **only** on a positive prefix match, so a token whose
+    shape we cannot positively identify falls through to the ``user``
+    default in :func:`_extract_principal_kind`. A false negative is safe —
+    the #3152 grants gate is fail-open into the human approval flow — but a
+    false positive would silently upgrade an ordinary user into the
+    unattended-dispatch surface, so the marker must be a positive signal
+    only. An empty configured prefix disables the marker (every token stays
+    ``user`` unless it carries an explicit ``principal_kind`` claim).
+
+    Both the claim name (``JWT_SERVICE_ACCOUNT_USERNAME_CLAIM``) and the
+    prefix (``JWT_SERVICE_ACCOUNT_USERNAME_PREFIX``) are configurable so a
+    realm that surfaces the marker differently is accommodated without a
+    code change — mirroring the configurable-claim convention every other
+    extractor here follows.
+    """
+    prefix = settings.jwt_service_account_username_prefix
+    if not prefix:
+        return False
+    username = claims.get(settings.jwt_service_account_username_claim)
+    return isinstance(username, str) and username.startswith(prefix)
+
+
 def _extract_principal_kind(claims: Any, settings: Settings) -> PrincipalKind:
-    """Extract ``principal_kind`` from *claims*, absent claim → ``user``.
+    """Extract ``principal_kind`` from *claims*.
 
-    G11.2-T1 (#815): the ``principal_kind`` claim is **optional** — a
-    JWT that carries no ``principal_kind`` claim is treated as a human
-    user (the pre-G11.2 default). This keeps all existing human-operator
-    tokens working without a Keycloak mapper update.
+    G11.2-T1 (#815): the ``principal_kind`` claim is **optional**. An
+    **explicit** claim always wins — including an explicit ``user`` — and
+    only the three enum values ``user`` / ``service`` / ``agent`` (plus the
+    ``runner`` kind) are accepted; a claim that is **present but
+    unrecognised** is logged and rejected with a 401
+    (``unknown_principal_kind``), mirroring :func:`_extract_tenant_role`'s
+    unknown-role handling at this layer. ``principal_kind`` is the
+    discriminator agent-vs-human authorization branches on (per-kind
+    permission model, approval gate, agent dispatch), so silently coercing
+    an issuer-signed value the enum doesn't model to the human-user default
+    would be a fail-open authorization decision. A realm that emits a
+    custom kind needs the enum widened first — exactly like an out-of-enum
+    ``tenant_role``.
 
-    Only three values are accepted: ``user``, ``service``, ``agent``.
-    A claim that is **present but unrecognised** is logged and rejected
-    with a 401 (``unknown_principal_kind``), mirroring
-    :func:`_extract_tenant_role`'s unknown-role handling at this layer.
-    ``principal_kind`` is the discriminator agent-vs-human authorization
-    branches on (per-kind permission model, approval gate, agent
-    dispatch), so silently coercing an issuer-signed value the enum
-    doesn't model to the human-user default would be a fail-open
-    authorization decision. A realm that emits a custom kind needs the
-    enum widened first — exactly like an out-of-enum ``tenant_role``.
+    When the claim is **absent**, the classification is inferred (#3178):
+    an IdP service-account (client-credentials) token — positively
+    identified by :func:`_is_service_account_token` — resolves to
+    ``service`` so the #3152 standing-grants gate evaluates it, and any
+    other token falls back to the pre-G11.2 human-``user`` default (which
+    keeps every existing human-operator token working without a Keycloak
+    mapper update). The inference runs **only** for the absent-claim case
+    and only *upgrades* on a positive marker, so it never overrides an
+    explicit claim and never downgrades — the fail-closed direction for the
+    policy path.
 
     The claim name is configurable via ``JWT_PRINCIPAL_KIND_CLAIM_NAME``
     (default ``principal_kind``) in :class:`~meho_backplane.settings.Settings`
@@ -685,7 +729,12 @@ def _extract_principal_kind(claims: Any, settings: Settings) -> PrincipalKind:
     claim_name = settings.jwt_principal_kind_claim_name
     raw = claims.get(claim_name)
     if raw is None:
-        # Claim absent → legacy human-operator token. Graceful fallback.
+        # Claim absent. An explicit Keycloak ``principal_kind`` mapper is
+        # the canonical way to set this, but a client-credentials client
+        # often lacks it — so positively test for a service-account token
+        # before defaulting to the legacy human-``user`` fallback (#3178).
+        if _is_service_account_token(claims, settings):
+            return PrincipalKind.SERVICE
         return PrincipalKind.USER
     try:
         return PrincipalKind(raw)

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -185,6 +185,53 @@ def _service_safety_gate_reason(descriptor: EndpointDescriptor) -> str | None:
     return None
 
 
+async def _warn_if_grant_holding_non_service(operator: Operator) -> None:
+    """Emit a WARN when a **non-service** principal that is about to park
+    holds a live standing grant (#3178).
+
+    That combination is almost certainly the #3178 misclassification bug: a
+    service account whose client-credentials token missed the
+    service-account marker classified as ``user`` (or, rarely, a genuine
+    human who was mistakenly issued a grant). Either way the grant is
+    silently inert and the op is parking — exactly the pattern #3151/#3152
+    exists to eliminate — so it warrants an operator-visible signal.
+
+    Scoped to the **park** path only (already the slow path): the extra
+    count query never touches the auto-execute hot path. Fail-open — a
+    diagnostic must never block a dispatch, so any lookup error is
+    swallowed after logging.
+    """
+    from meho_backplane.operations.service_grants import count_live_grants_for_principal
+
+    try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            live_grants = await count_live_grants_for_principal(
+                session,
+                tenant_id=operator.tenant_id,
+                principal_sub=operator.sub,
+            )
+        if live_grants > 0:
+            _log.warning(
+                "policy_gate_grant_holder_classified_non_service",
+                operator_sub=operator.sub,
+                principal_kind=operator.principal_kind.value,
+                tenant_id=str(operator.tenant_id),
+                live_grant_count=live_grants,
+                hint=(
+                    "principal holds >=1 active standing grant but is not "
+                    "classified 'service'; the grants gate cannot evaluate it "
+                    "(likely a client-credentials token missing the "
+                    "service-account marker -- see #3178)"
+                ),
+            )
+    except Exception:
+        _log.exception(
+            "policy_gate_grant_holder_check_failed",
+            operator_sub=operator.sub,
+        )
+
+
 async def _non_agent_verdict(
     *,
     operator: Operator,
@@ -250,6 +297,11 @@ async def _non_agent_verdict(
                 grant_id=str(grant_id),
             )
             return PermissionVerdict.AUTO_EXECUTE, f"auto-granted by standing grant {grant_id}"
+
+    if not is_service:
+        # The op is parking for a non-service principal. If that principal
+        # holds a live standing grant, surface the #3178 misclassification.
+        await _warn_if_grant_holding_non_service(operator)
 
     _log.info(
         "policy_gate_needs_approval",

--- a/backend/src/meho_backplane/operations/service_grants.py
+++ b/backend/src/meho_backplane/operations/service_grants.py
@@ -50,7 +50,7 @@ from fnmatch import fnmatchcase
 from typing import Any
 
 import structlog
-from sqlalchemy import or_, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -63,6 +63,7 @@ __all__ = [
     "GrantValidationError",
     "ServicePrincipalGrantService",
     "consult_and_record_grant",
+    "count_live_grants_for_principal",
     "find_live_grant",
 ]
 
@@ -429,6 +430,42 @@ async def find_live_grant(
         stmt = stmt.where(ServicePrincipalGrant.target_id == target_id)
     result = await session.execute(stmt)
     return result.scalar_one_or_none()
+
+
+async def count_live_grants_for_principal(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    principal_sub: str,
+    now: datetime | None = None,
+) -> int:
+    """Count this principal's live standing grants across **all** scopes.
+
+    Liveness matches :func:`find_live_grant` (``revoked_at IS NULL`` and
+    (``expires_at IS NULL`` or ``expires_at > now``)) but ignores the
+    op/connector/target scope — it answers only "does this ``sub`` hold any
+    grant that *should* be evaluated". Used solely by the misclassification
+    WARN in :func:`~meho_backplane.operations._validate._non_agent_verdict`
+    (#3178): a non-service principal holding a live grant is almost
+    certainly a service account whose token missed the service-account
+    marker. Never on the auto-execute hot path.
+    """
+    cutoff = now or datetime.now(UTC)
+    stmt = (
+        select(func.count())
+        .select_from(ServicePrincipalGrant)
+        .where(
+            ServicePrincipalGrant.tenant_id == tenant_id,
+            ServicePrincipalGrant.principal_sub == principal_sub,
+            ServicePrincipalGrant.revoked_at.is_(None),
+            or_(
+                ServicePrincipalGrant.expires_at.is_(None),
+                ServicePrincipalGrant.expires_at > cutoff,
+            ),
+        )
+    )
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
 
 
 async def consult_and_record_grant(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -266,8 +266,27 @@ class Settings(BaseModel):
         G11.2-T1 (#815). Default ``principal_kind`` matches the agent-
         client protocol-mapper recipe in
         ``docs/cross-repo/keycloak-agent-client.md``. The claim is
-        **optional** — tokens that carry no claim resolve to ``user``
-        (graceful fallback for all pre-G11.2 human-operator tokens).
+        **optional** — tokens that carry no claim resolve to ``user``,
+        unless the token is positively identified as an IdP service
+        account (see :attr:`jwt_service_account_username_prefix`), in
+        which case it resolves to ``service`` (#3178).
+    jwt_service_account_username_claim:
+        Name of the JWT claim carrying the principal's username, read
+        only to classify a client-credentials token whose
+        ``principal_kind`` claim is absent (#3178). Default
+        ``preferred_username`` matches Keycloak's built-in username
+        mapper. Override when the realm surfaces the username elsewhere.
+    jwt_service_account_username_prefix:
+        Prefix that positively marks an IdP service-account
+        (OAuth2 client-credentials) token on the
+        :attr:`jwt_service_account_username_claim` value (#3178). Default
+        ``service-account-`` is Keycloak's reserved naming for the
+        service-account user it mints per client (``service-account-
+        <clientId>``). A token whose username bears this prefix and that
+        carries **no** explicit ``principal_kind`` claim classifies as
+        ``service`` so the #3152 standing-grants gate evaluates it;
+        every other token stays ``user`` (fail-closed — only a positive
+        marker upgrades). An empty string disables the marker entirely.
     jwt_capabilities_claim_name:
         Name of the JWT claim that carries the tenant-provisioned
         capability keys (a JSON array of strings) added by G4.5-T1
@@ -1001,6 +1020,8 @@ class Settings(BaseModel):
     jwt_tenant_claim_name: str = Field(default="tenant_id", min_length=1)
     jwt_tenant_role_claim_name: str = Field(default="tenant_role", min_length=1)
     jwt_principal_kind_claim_name: str = Field(default="principal_kind", min_length=1)
+    jwt_service_account_username_claim: str = Field(default="preferred_username", min_length=1)
+    jwt_service_account_username_prefix: str = Field(default="service-account-")
     jwt_capabilities_claim_name: str = Field(default="capabilities", min_length=1)
     jwt_scopes_claim_name: str = Field(default="scope", min_length=1)
     jwt_platform_admin_claim_name: str = Field(default="platform_admin", min_length=1)
@@ -1786,6 +1807,14 @@ def get_settings() -> Settings:
         jwt_principal_kind_claim_name=os.environ.get(
             "JWT_PRINCIPAL_KIND_CLAIM_NAME",
             "principal_kind",
+        ),
+        jwt_service_account_username_claim=os.environ.get(
+            "JWT_SERVICE_ACCOUNT_USERNAME_CLAIM",
+            "preferred_username",
+        ),
+        jwt_service_account_username_prefix=os.environ.get(
+            "JWT_SERVICE_ACCOUNT_USERNAME_PREFIX",
+            "service-account-",
         ),
         jwt_capabilities_claim_name=os.environ.get(
             "JWT_CAPABILITIES_CLAIM_NAME",

--- a/backend/tests/test_auth_principal_kind.py
+++ b/backend/tests/test_auth_principal_kind.py
@@ -80,6 +80,7 @@ def _mint(
     *,
     principal_kind: str | None = None,
     claim_name: str = "principal_kind",
+    extra_claims: dict[str, Any] | None = None,
 ) -> str:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -97,6 +98,8 @@ def _mint(
         }
         if principal_kind is not None:
             payload[claim_name] = principal_kind
+        if extra_claims is not None:
+            payload.update(extra_claims)
         header = {"alg": "RS256", "kid": key.as_dict()["kid"], "typ": "JWT"}
         token: bytes | str = jwt.encode(header, payload, key)
         return token.decode("ascii") if isinstance(token, bytes) else token
@@ -216,6 +219,108 @@ def test_absent_claim_defaults_to_user() -> None:
             resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200, resp.text
     assert resp.json()["principal_kind"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Service-account (client-credentials) classification (#3178)
+# ---------------------------------------------------------------------------
+#
+# An OAuth2 client-credentials token carries no interactive user and often
+# no ``principal_kind`` claim; it must classify as ``service`` (not the
+# ``user`` default) so the #3152 standing-grants gate evaluates it. The
+# positive marker is Keycloak's reserved ``service-account-<clientId>``
+# username on ``preferred_username``. Fail-closed: only a positive marker
+# upgrades; an explicit claim always wins; every other shape stays ``user``.
+
+
+def _classify(token: str, key: Any, *, monkeypatch: pytest.MonkeyPatch | None = None) -> str:
+    """Drive a token through ``verify_jwt`` and return the resolved kind."""
+    if monkeypatch is not None:
+        get_settings.cache_clear()
+        clear_jwks_cache()
+    app = _make_app()
+    with respx.mock as r:
+        r.get(_DISCOVERY_URL).mock(
+            return_value=httpx.Response(200, json={"issuer": _ISSUER, "jwks_uri": _JWKS_URL})
+        )
+        r.get(_JWKS_URL).mock(return_value=httpx.Response(200, json=_public_jwks(key)))
+        with TestClient(app) as client:
+            resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["principal_kind"]
+
+
+def test_client_credentials_marker_classifies_service() -> None:
+    """No ``principal_kind`` claim + ``service-account-*`` username → ``service``."""
+    key = _make_key("kid-svc-marker")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "service-account-deploy-bot"},
+    )
+    assert _classify(token, key) == "service"
+
+
+def test_ordinary_username_without_marker_stays_user() -> None:
+    """No claim + a non-service-account username → ``user`` (fail-closed default)."""
+    key = _make_key("kid-user-marker")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "alice"},
+    )
+    assert _classify(token, key) == "user"
+
+
+def test_explicit_user_claim_overrides_service_marker() -> None:
+    """An explicit ``principal_kind=user`` wins even when the marker is present.
+
+    The marker inference runs **only** for the absent-claim case, so an
+    issuer that deliberately stamps ``user`` is never silently upgraded.
+    """
+    key = _make_key("kid-explicit-user")
+    token = _mint(
+        key,
+        principal_kind="user",
+        extra_claims={"preferred_username": "service-account-deploy-bot"},
+    )
+    assert _classify(token, key) == "user"
+
+
+def test_custom_service_account_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`` retargets the marker prefix."""
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "svc:")
+    key = _make_key("kid-custom-prefix")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "svc:deploy-bot"},
+    )
+    assert _classify(token, key, monkeypatch=monkeypatch) == "service"
+
+
+def test_custom_service_account_username_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``JWT_SERVICE_ACCOUNT_USERNAME_CLAIM`` retargets which claim carries the marker."""
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_CLAIM", "client_id")
+    key = _make_key("kid-custom-claim")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"client_id": "service-account-deploy-bot"},
+    )
+    assert _classify(token, key, monkeypatch=monkeypatch) == "service"
+
+
+def test_empty_prefix_disables_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty configured prefix disables the marker — a service account stays ``user``."""
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "")
+    key = _make_key("kid-empty-prefix")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "service-account-deploy-bot"},
+    )
+    assert _classify(token, key, monkeypatch=monkeypatch) == "user"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_service_principal_grant_gate.py
+++ b/backend/tests/test_service_principal_grant_gate.py
@@ -338,6 +338,81 @@ async def test_user_principal_requires_approval_parks_and_ignores_grant() -> Non
 
 
 # ---------------------------------------------------------------------------
+# misclassification WARN (#3178) — grant-holding non-service principal parks
+# ---------------------------------------------------------------------------
+#
+# A client-credentials token that missed the service-account marker
+# classifies ``user``; its standing grants are then silently inert and its
+# ops park (then self-approve). When such a principal parks while holding a
+# live grant, the gate emits a WARN so an operator can spot the residual
+# misclassification. Scoped to the park path — never on auto-execute.
+
+_WARN_EVENT = "policy_gate_grant_holder_classified_non_service"
+
+
+@pytest.mark.asyncio
+async def test_grant_holding_user_park_emits_misclassification_warn(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """A parking non-service principal that holds a live grant → WARN."""
+    await _seed_grant(principal_sub="human-op")
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="safe",
+        requires_approval=True,  # a USER only parks on requires_approval
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    out, _ = capfd.readouterr()
+    assert _WARN_EVENT in out, f"expected {_WARN_EVENT!r} in structlog stdout; got: {out!r}"
+
+
+@pytest.mark.asyncio
+async def test_parking_user_without_grant_emits_no_warn(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """A parking non-service principal holding NO grant → no misclassification WARN."""
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="safe",
+        requires_approval=True,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    out, _ = capfd.readouterr()
+    assert _WARN_EVENT not in out
+
+
+@pytest.mark.asyncio
+async def test_service_principal_park_emits_no_misclassification_warn(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """A correctly-classified SERVICE principal parking → no misclassification WARN."""
+    await _seed_grant(op_id="other.op")  # a live grant on a different op → still parks
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    out, _ = capfd.readouterr()
+    assert _WARN_EVENT not in out
+
+
+# ---------------------------------------------------------------------------
 # classification helper unit tests (method-based branch)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -375,6 +375,49 @@ def test_result_handle_max_spill_rows_env_override_takes_effect(
 
 
 # ---------------------------------------------------------------------------
+# #3178 — service-account marker claim / prefix env round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_service_account_marker_defaults_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset markers → Keycloak's ``preferred_username`` / ``service-account-`` defaults."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("JWT_SERVICE_ACCOUNT_USERNAME_CLAIM", raising=False)
+    monkeypatch.delenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", raising=False)
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.jwt_service_account_username_claim == "preferred_username"
+        assert settings.jwt_service_account_username_prefix == "service-account-"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_service_account_marker_env_overrides_take_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``JWT_SERVICE_ACCOUNT_USERNAME_CLAIM`` / ``_PREFIX`` flow through ``get_settings()``.
+
+    The same inert-mapping trap the other round-trips pin: ``Settings`` is a
+    plain ``BaseModel`` whose ``get_settings()`` hand-maps every env var, so
+    a field declared without its mapping would leave the #3178 service-account
+    classification knobs a silent no-op.
+    """
+    _base_env(monkeypatch)
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_CLAIM", "client_id")
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "svc:")
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.jwt_service_account_username_claim == "client_id"
+        assert settings.jwt_service_account_username_prefix == "svc:"
+    finally:
+        get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
 # G11.5-T6 #1080 — AGENT_RUNS_DISABLED_TENANTS UUID validation
 # ---------------------------------------------------------------------------
 

--- a/docs/codebase/service-principal-grants.md
+++ b/docs/codebase/service-principal-grants.md
@@ -47,6 +47,21 @@ is distinguished from "service principal": the `principal_kind` claim
 (`user` vs `service`, `auth/jwt.py::_extract_principal_kind`). Agents are
 unaffected — they keep the `AgentPermission` verdict model.
 
+**Classifying `SERVICE` (#3178).** An explicit `principal_kind` claim
+always wins, but a Keycloak client-credentials client often carries **no**
+such claim (no `principal_kind` mapper), which historically fell back to
+the `user` default and left this whole gate — and any standing grants —
+silently inert. `_extract_principal_kind` therefore infers `service` for
+the **absent-claim** case when the token is positively identified as an IdP
+service account: its username claim (default `preferred_username`,
+`JWT_SERVICE_ACCOUNT_USERNAME_CLAIM`) bears Keycloak's reserved
+`service-account-<clientId>` prefix (default `service-account-`,
+`JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`). Fail-closed for the policy path:
+only a positive marker *upgrades*; any unrecognised shape stays `user`. As
+a residual-drift signal, `_non_agent_verdict` emits a WARN
+(`policy_gate_grant_holder_classified_non_service`) whenever a **parking**
+non-service principal still holds ≥1 live grant.
+
 **"Mutating" is grounded in existing descriptor fields** (no new column,
 `_is_mutating`): an ingested op is read-class iff its HTTP `method` ∈
 `{GET, HEAD}` (the `READ_HTTP_METHODS` set); a typed / composite op
@@ -160,6 +175,7 @@ after any signature change).
 
 - There is **no server-side service-principal registry** to validate
   `principal_sub` against (a service principal is any Keycloak
-  client-credentials client carrying `principal_kind=service`), so — unlike
+  client-credentials client classified `principal_kind=service` — by an
+  explicit claim or the #3178 service-account marker), so — unlike
   `AgentGrantService`, which rejects an unregistered agent principal — a
   grant whose `principal_sub` never authenticates simply sits inert.


### PR DESCRIPTION
## What & why

Closes #3178.

Standing service-principal grants (#3151/#3152) never engaged for a principal that authenticates via an OAuth2 client-credentials (service-account) token. Such a token carries no interactive user and — unless the realm installs an explicit `principal_kind` mapper — arrives with the claim **absent**, so `auth/jwt.py::_extract_principal_kind` fell back to `principal_kind=user`. The #3152 gate is service-principal-only, so it never evaluated, every governed dispatch parked for approval, and the automation principal then self-approved (`approval_self_approval_break_glass`). Grants created for that principal were silently inert — the exact pattern #3151/#3152 exists to eliminate.

## The fix

The **absent-claim** path now positively identifies an IdP service-account token by its username marker: Keycloak mints the service account user as `service-account-<clientId>` and stamps it on `preferred_username`. A username claim bearing that reserved prefix classifies the token `service` so the grants gate honours it. Both the claim name and the prefix are configurable (`JWT_SERVICE_ACCOUNT_USERNAME_CLAIM` / `JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`), matching the codebase's every-claim-configurable convention.

**Fail-closed for the policy path** (stated in a code comment): an explicit `principal_kind` claim always wins, and only a positive marker *upgrades*. Any token shape we cannot positively identify stays `user`. A false negative is safe (the gate is fail-open into human approval); a false positive would silently widen the unattended-dispatch surface, so the marker is a positive signal only — never a downgrade, never a heuristic guess.

**WARN diagnostic (issue's ask):** `_non_agent_verdict` emits `policy_gate_grant_holder_classified_non_service` when a **parking** non-service principal still holds >=1 live standing grant — the residual-misclassification signal. Scoped to the park path so the count query never touches the auto-execute hot path.

## Tests

- `test_auth_principal_kind.py` — client-credentials-shaped token classifies `service` end-to-end through `verify_jwt`; explicit claim overrides the marker; ordinary username / empty prefix stay `user`; custom claim + custom prefix env round-trips.
- `test_service_principal_grant_gate.py` — the parking grant-holder WARN fires for a non-service principal, and **not** for a correctly-classified `SERVICE` principal or a grant-less USER.
- `test_settings.py` — env round-trips for both new marker settings (guards the inert-mapping trap).
- The existing #3152 gate matrix already covers the SERVICE dispatch behaviour the issue lists (grant → no park, no grant → park, expiry / target-scope mismatch → park), now reachable by real client-credentials tokens.

Docs: `docs/codebase/service-principal-grants.md` updated with the classification rule + WARN. CHANGELOG `[Unreleased]` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)