### PR TITLE
feat(operations): REST + CLI parity for result_query handle read-back (#3179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179)
+### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179 / PR #3181)
 
 - `POST /api/v1/operations/call` can *mint* a reduced result handle for any
   set-shaped response over the 50-row / 4 KB thresholds, but until now only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179)
+
+- `POST /api/v1/operations/call` can *mint* a reduced result handle for any
+  set-shaped response over the 50-row / 4 KB thresholds, but until now only
+  the MCP `result_query` tool could read one back — a REST consumer that
+  received a handle was at a dead end (a real automation add-on had to fail
+  closed on a 181-row inventory and hand the drill-in to a human over MCP).
+  New route **`POST /api/v1/operations/result-query`** (body: `handle_id`,
+  `offset`, `limit`) pages the full spilled set back over REST, wrapping the
+  exact same windowed-read core as the MCP tool — identical tenant/principal
+  scoping and the same recoverable not-found miss (`404` /
+  `reason=handle_not_found`, the REST twin of the tool's `-32602`).
+- New CLI verb **`meho operation result-query <handle_id> [--offset N]
+  [--limit N]`** on the new route — making the `meho operation result-query`
+  hint the `vcf-logs` result-handle render already printed finally truthful
+  (the narrow-waist postulate says every meta-tool has a CLI verb;
+  `result_query` was the lone exception).
+- The reduced envelope's `fetch_more.drill_in.rationale` now names the REST
+  route alongside the MCP tool, so a consumer that got the handle over REST
+  (never touching MCP) learns how to page it without a discovery dance.
+
 ### Fixed — service-principal grants inert: client-credentials tokens now classify as `service` (#3178)
 
 - An OAuth2 client-credentials (service-account) token carries no

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -19,6 +19,12 @@ the agent transport.
   (``query`` is the deprecated alias, #1854). Operator role.
 * ``POST /api/v1/operations/call`` (body: ``CallOperationBody``) --
   invoke the dispatcher. Operator role.
+* ``POST /api/v1/operations/result-query`` (body: ``ResultQueryBody``) --
+  read a window of rows back from a JSONFlux result handle (#3179). The
+  REST twin of the MCP ``result_query`` tool: both wrap the same
+  transport-neutral core (:func:`read_result_window`), so a REST consumer
+  that receives a reduced ``handle`` from ``/call`` is no longer at a dead
+  end. Operator role.
 * ``GET /api/v1/operations/{descriptor_id}`` -- inspect a single
   descriptor row including ``llm_instructions``. Tenant-admin role
   because ``llm_instructions`` is the per-op agent prompt (leaking it
@@ -37,6 +43,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.openapi.models import Example
+from pydantic import BaseModel, ConfigDict, Field
 
 from meho_backplane.api.v1._freetext_filter import (
     FREE_TEXT_Q_DESCRIPTION,
@@ -55,6 +62,11 @@ from meho_backplane.operations.meta_tools import (
     list_operation_groups,
     preview_operation,
     search_operations,
+)
+from meho_backplane.operations.result_query import (
+    MAX_LIMIT,
+    ResultHandleNotFoundError,
+    read_result_window,
 )
 
 #: Shared OpenAPI metadata for the ``connector_id`` query param on the
@@ -278,6 +290,91 @@ async def post_call(
     consumer's error handling is a single switch on ``extras.error_code``.
     """
     return await call_operation(operator, body.model_dump())
+
+
+class ResultQueryBody(BaseModel):
+    """POST body for ``/api/v1/operations/result-query`` (#3179).
+
+    The REST twin of the MCP ``result_query`` tool's ``inputSchema``:
+    ``handle_id`` is the UUID minted onto a reduced ``/call`` response's
+    ``result.handle.handle_id`` / ``fetch_more.drill_in.example_call``, and
+    ``offset`` / ``limit`` window the spilled set. The bounds mirror the MCP
+    schema (``offset >= 0``; ``1 <= limit <= MAX_LIMIT``) so the two surfaces
+    validate identically. ``extra="forbid"`` rejects unknown body fields with
+    a 422, matching the sibling ``CallOperationBody`` posture.
+
+    Filtering / projection is out of scope (issue #3179 non-goal): parity is
+    the same offset/limit window the MCP tool serves, not more.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    handle_id: uuid.UUID = Field(
+        description=(
+            "The result handle's UUID, taken from a reduced `/call` "
+            "response's `result.handle.handle_id` or "
+            "`fetch_more.drill_in.example_call.args.handle_id`."
+        ),
+    )
+    offset: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Zero-based index of the first row to return. Page by advancing "
+            "this by the previous `limit`."
+        ),
+    )
+    limit: int = Field(
+        default=50,
+        ge=1,
+        le=MAX_LIMIT,
+        description=(
+            f"Page size. Default 50; max {MAX_LIMIT}. Matches the "
+            "`result_query` MCP tool's upper bound."
+        ),
+    )
+
+
+@router.post("/result-query")
+async def post_result_query(
+    body: ResultQueryBody,
+    operator: Operator = _require_operator,
+) -> dict[str, Any]:
+    """Read a ``[offset : offset+limit]`` window of a JSONFlux result handle.
+
+    Delegates to :func:`read_result_window` — the same transport-neutral
+    core the MCP ``result_query`` tool wraps — so REST and MCP share the
+    tenant/principal scoping and not-found semantics exactly. The tenant +
+    principal come from the JWT-validated :class:`Operator`; the body carries
+    no tenant, by design.
+
+    Closes the REST dead-end #3179 named: ``POST /api/v1/operations/call``
+    can *mint* a reduced ``handle`` for any set-shaped result over the
+    50-row / 4 KB thresholds, but before this route a REST consumer had no
+    way to read it back and had to fail closed or hand the drill-in to a
+    human over MCP.
+
+    A handle that is unknown, expired (TTL elapsed), or belongs to a
+    different operator is a ``404`` with a structured ``detail`` carrying
+    ``reason="handle_not_found"`` — the recoverable-miss twin of the MCP
+    tool's ``-32602`` / ``data.reason=handle_not_found`` (the caller re-runs
+    the operation for a fresh handle). Cross-operator access is deliberately
+    indistinguishable from "not found" so the store leaks no existence
+    signal across the operator boundary. A malformed ``handle_id`` (not a
+    UUID) or an out-of-range ``offset`` / ``limit`` is a ``422`` at the
+    Pydantic layer before the handler runs.
+    """
+    try:
+        return await read_result_window(operator, body.handle_id, body.offset, body.limit)
+    except ResultHandleNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "message": str(exc),
+                "reason": "handle_not_found",
+                "handle_id": str(body.handle_id),
+            },
+        ) from exc
 
 
 @router.post("/preview")

--- a/backend/src/meho_backplane/mcp/tools/result_query.py
+++ b/backend/src/meho_backplane/mcp/tools/result_query.py
@@ -39,17 +39,21 @@ from typing import Any
 from uuid import UUID
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.connectors.result_handle_store import get_result_handle_store
 from meho_backplane.mcp.registry import ToolDefinition, ToolSurface, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.operations.result_query import (
+    MAX_LIMIT,
+    ResultHandleNotFoundError,
+    read_result_window,
+)
 
 __all__: list[str] = []
 
 #: Mirror of the inline-sample upper bound's sibling list tools: a single
 #: page returns at most this many rows so one read-back can't pull an
-#: unbounded slice in one call. Matches the ``search_operations`` /
-#: ``list_targets`` max-page convention.
-_MAX_LIMIT = 500
+#: unbounded slice in one call. Sourced from the transport-neutral core so
+#: the MCP ``inputSchema`` and the REST body share one ceiling (#3179).
+_MAX_LIMIT = MAX_LIMIT
 
 
 async def _result_query_handler(
@@ -60,9 +64,10 @@ async def _result_query_handler(
 
     The MCP dispatcher has already validated ``arguments`` against the
     tool's ``inputSchema`` (``handle_id`` required, ``offset`` / ``limit``
-    bounded), so the body parses the UUID and fetches the window. The
-    tenant comes from ``operator.tenant_id`` — the arguments carry no
-    tenant, by design.
+    bounded), so the body parses the UUID and delegates the windowed read
+    to the shared :func:`read_result_window` core (the same core the REST
+    ``POST /api/v1/operations/result-query`` route wraps). The tenant comes
+    from ``operator.tenant_id`` — the arguments carry no tenant, by design.
     """
     raw_handle = arguments["handle_id"]
     try:
@@ -73,35 +78,13 @@ async def _result_query_handler(
             data={"reason": "invalid_handle_id", "handle_id": str(raw_handle)},
         ) from exc
 
-    if operator.tenant_id is None:
-        # An operator with no tenant can never own a spilled handle
-        # (the reducer keys the spill on tenant_id). Treat as not-found
-        # rather than leaking a distinct "no tenant" signal.
-        raise _handle_not_found(handle_id)
-
     offset = int(arguments.get("offset", 0))
     limit = int(arguments.get("limit", 50))
 
-    window = await get_result_handle_store().fetch_window(
-        tenant_id=operator.tenant_id,
-        operator_sub=operator.sub,
-        handle_id=handle_id,
-        offset=offset,
-        limit=limit,
-    )
-    if window is None:
-        raise _handle_not_found(handle_id)
-
-    return {
-        "handle_id": str(handle_id),
-        "rows": window.rows,
-        "offset": offset,
-        "limit": limit,
-        "returned_rows": len(window.rows),
-        "total_rows": window.total_rows,
-        "stored_rows": window.stored_rows,
-        "truncated": window.truncated,
-    }
+    try:
+        return await read_result_window(operator, handle_id, offset, limit)
+    except ResultHandleNotFoundError as exc:
+        raise _handle_not_found(handle_id) from exc
 
 
 def _handle_not_found(handle_id: UUID) -> McpInvalidParamsError:

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -94,6 +94,14 @@ _log = structlog.get_logger(__name__)
 #: prose every time) and so the tests can assert against a stable anchor.
 _RESULT_QUERY_TOOL = "result_query"
 
+#: REST route that reads the same spilled handle back — the sibling of the
+#: ``result_query`` MCP tool (#3179). Named in the drill-in rationale
+#: alongside the MCP tool so a REST consumer that received the handle over
+#: ``POST /api/v1/operations/call`` (never touching MCP) still learns how to
+#: page it. Must match the route mounted in
+#: :mod:`meho_backplane.api.v1.operations`.
+_RESULT_QUERY_REST_ROUTE = "POST /api/v1/operations/result-query"
+
 #: Shared workaround tail for every no-spill rationale: whatever the
 #: cause, the recovery the agent can act on is the same.
 _DRILL_IN_WORKAROUND = (
@@ -134,7 +142,8 @@ def _drill_in_available_rationale(handle_id: UUID, stored_rows: int, total_rows:
     )
     return (
         f"The full result set ({total_rows} rows) is retrievable over MCP "
-        f"via the ``{_RESULT_QUERY_TOOL}`` tool. Call it with "
+        f"via the ``{_RESULT_QUERY_TOOL}`` tool or over REST via "
+        f"``{_RESULT_QUERY_REST_ROUTE}``. Call either with "
         f"``handle_id={handle_id}`` plus ``offset`` / ``limit`` to page "
         f"beyond the inline sample.{tail_note}"
     )

--- a/backend/src/meho_backplane/operations/result_query.py
+++ b/backend/src/meho_backplane/operations/result_query.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Transport-neutral core for the ``result_query`` JSONFlux read-back surface.
+
+The windowed spill read that both operator fronts share (#3179). When
+``call_operation`` reduces a large set-shaped response, the caller gets an
+inline sample plus a
+:class:`~meho_backplane.connectors.schemas.ResultHandle`; the full set is
+spilled to the
+:class:`~meho_backplane.connectors.result_handle_store.ResultHandleStore`
+(Valkey) keyed by ``(tenant_id, handle_id)`` with a bounded TTL. This module
+owns the read over that store — the same logic the MCP ``result_query`` tool
+(:mod:`meho_backplane.mcp.tools.result_query`) and the REST route
+``POST /api/v1/operations/result-query``
+(:mod:`meho_backplane.api.v1.operations`) both wrap, so the two surfaces
+cannot drift on scoping or not-found semantics.
+
+Isolation
+=========
+
+The tenant is taken from the operator's authenticated identity (each
+transport resolves it from the JWT), **never** from the arguments — a
+cross-tenant probe cannot read another tenant's handle. The store
+additionally checks the spilling operator's ``sub`` so another operator in
+the same tenant gets the same not-found miss as a stranger, leaking no
+existence signal across the operator boundary.
+
+Not-found is recoverable
+========================
+
+A handle that is unknown, expired (TTL elapsed), or belongs to a different
+operator raises :class:`ResultHandleNotFoundError`. Each transport maps it to
+its own recoverable-error shape (MCP: a typed ``-32602`` with
+``data.reason=handle_not_found``; REST: a ``404`` with a structured
+``detail``). The caller learns the handle is gone (re-run the operation)
+rather than getting an opaque internal error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.result_handle_store import get_result_handle_store
+
+__all__ = ["MAX_LIMIT", "ResultHandleNotFoundError", "read_result_window"]
+
+#: Upper bound on a single read-back page: one call returns at most this many
+#: rows so a reader can't pull an unbounded slice in one request. Matches the
+#: ``search_operations`` / ``list_targets`` max-page convention; both the MCP
+#: tool's ``inputSchema`` and the REST body's Pydantic bound import this so
+#: the two surfaces share one ceiling.
+MAX_LIMIT = 500
+
+
+class ResultHandleNotFoundError(Exception):
+    """A handle is not readable: unknown, expired, or another operator's.
+
+    Transport-neutral: the MCP tool maps it to a typed ``-32602``
+    (``data.reason=handle_not_found``) and the REST route to a ``404`` with
+    a structured ``detail``. Carries the ``handle_id`` so each mapper can
+    echo it back in its own error shape.
+    """
+
+    def __init__(self, handle_id: UUID) -> None:
+        self.handle_id = handle_id
+        super().__init__(
+            f"handle {handle_id} is not readable: it does not exist, has "
+            "expired, or belongs to a different operator. Re-run the "
+            "operation to get a fresh handle."
+        )
+
+
+async def read_result_window(
+    operator: Operator,
+    handle_id: UUID,
+    offset: int = 0,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Return the ``[offset : offset+limit]`` window of a spilled handle.
+
+    The tenant + principal come from *operator* (JWT-resolved), never from
+    the request — the arguments carry no tenant, by design. *offset* and
+    *limit* are validated by each transport's own edge (the MCP
+    ``inputSchema``; the REST body's Pydantic bounds), so this core takes
+    them as given.
+
+    Raises :class:`ResultHandleNotFoundError` when the operator has no tenant
+    (it can never own a spilled handle — the reducer keys the spill on
+    ``tenant_id``) or when the store returns no window (unknown, expired, or
+    cross-operator handle). The two causes are deliberately indistinguishable
+    so the store leaks no existence signal.
+    """
+    if operator.tenant_id is None:
+        raise ResultHandleNotFoundError(handle_id)
+
+    window = await get_result_handle_store().fetch_window(
+        tenant_id=operator.tenant_id,
+        operator_sub=operator.sub,
+        handle_id=handle_id,
+        offset=offset,
+        limit=limit,
+    )
+    if window is None:
+        raise ResultHandleNotFoundError(handle_id)
+
+    return {
+        "handle_id": str(handle_id),
+        "rows": window.rows,
+        "offset": offset,
+        "limit": limit,
+        "returned_rows": len(window.rows),
+        "total_rows": window.total_rows,
+        "stored_rows": window.stored_rows,
+        "truncated": window.truncated,
+    }

--- a/backend/tests/test_api_v1_operations.py
+++ b/backend/tests/test_api_v1_operations.py
@@ -38,16 +38,19 @@ import respx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import meho_backplane.operations.result_query as result_query_core
 from meho_backplane.api.v1.operations import router as operations_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.result_handle_store import SpilledWindow
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.result_query import MAX_LIMIT
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -823,3 +826,305 @@ def test_get_descriptor_unknown_id_returns_404(client: TestClient) -> None:
             headers={"Authorization": f"Bearer {_admin_token(key)}"},
         )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/operations/result-query  (#3179 — REST parity for result_query)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResultStore:
+    """In-memory result-handle store the route reads windows out of.
+
+    Keyed by ``(tenant_id, operator_sub, handle_id)`` so the tests can assert
+    the route threads the operator identity from the JWT — never the body —
+    exactly as the MCP ``result_query`` tool's fake does. The two surfaces
+    share the transport-neutral core, so mirroring the fake keeps their
+    scoping + not-found behaviour provably identical.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+
+    def seed(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        handle_id: uuid.UUID,
+        rows: list[dict[str, Any]],
+    ) -> None:
+        self._rows[(str(tenant_id), operator_sub, str(handle_id))] = rows
+
+    async def fetch_window(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        handle_id: uuid.UUID,
+        offset: int,
+        limit: int,
+    ) -> SpilledWindow | None:
+        rows = self._rows.get((str(tenant_id), operator_sub, str(handle_id)))
+        if rows is None:
+            return None
+        window = rows[offset : offset + limit] if limit > 0 else []
+        return SpilledWindow(
+            rows=window,
+            total_rows=len(rows),
+            stored_rows=len(rows),
+            truncated=False,
+        )
+
+
+@pytest.fixture
+def fake_result_store(monkeypatch: pytest.MonkeyPatch) -> _FakeResultStore:
+    """Replace the production store getter (on the shared core) with a fake."""
+    store = _FakeResultStore()
+    monkeypatch.setattr(result_query_core, "get_result_handle_store", lambda: store)
+    return store
+
+
+def test_post_result_query_requires_authentication(client: TestClient) -> None:
+    """No Bearer header -> 401 (before any handle lookup)."""
+    response = client.post(
+        "/api/v1/operations/result-query",
+        json={"handle_id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 401
+
+
+def test_post_result_query_returns_window_beyond_inline_sample(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A >50-row spilled set is fully retrievable over REST by paging.
+
+    The REST twin of ``test_result_query_returns_window_beyond_inline_sample``
+    in the MCP tool suite: rows past the inline sample and the tail are both
+    reachable, and the envelope carries the same metadata keys.
+    """
+    handle = uuid.uuid4()
+    rows = [{"i": i, "name": f"row-{i}"} for i in range(60)]
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=rows,
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle), "offset": 5, "limit": 50},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["handle_id"] == str(handle)
+        assert body["total_rows"] == 60
+        assert body["returned_rows"] == 50
+        assert body["truncated"] is False
+        assert [r["i"] for r in body["rows"]] == list(range(5, 55))
+
+        # The tail (rows 55..59) is reachable too — the full set, not a sample.
+        tail = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle), "offset": 55, "limit": 50},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert tail.status_code == 200
+    assert [r["i"] for r in tail.json()["rows"]] == list(range(55, 60))
+
+
+def test_post_result_query_defaults_offset_and_limit(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """Omitting offset/limit windows [0:50] — the documented defaults."""
+    handle = uuid.uuid4()
+    rows = [{"i": i} for i in range(120)]
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=rows,
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle)},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["offset"] == 0
+    assert body["limit"] == 50
+    assert body["returned_rows"] == 50
+    assert [r["i"] for r in body["rows"]] == list(range(50))
+
+
+def test_post_result_query_unknown_handle_returns_typed_404(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """An unknown/expired handle -> 404 with reason=handle_not_found.
+
+    The REST twin of the MCP tool's recoverable ``-32602`` /
+    ``data.reason=handle_not_found`` miss.
+    """
+    handle = uuid.uuid4()
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle)},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["reason"] == "handle_not_found"
+    assert detail["handle_id"] == str(handle)
+
+
+def test_post_result_query_cross_operator_is_a_miss(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A handle spilled by a different operator in the same tenant -> 404.
+
+    Principal scoping: the store keys on the spilling operator's ``sub``, so a
+    stranger in the same tenant gets the same not-found miss (no existence
+    signal leaks across the operator boundary).
+    """
+    handle = uuid.uuid4()
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="some-other-operator",
+        handle_id=handle,
+        rows=[{"i": i} for i in range(60)],
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle)},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"]["reason"] == "handle_not_found"
+
+
+def test_post_result_query_cross_tenant_is_a_miss(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A handle spilled under a different tenant -> 404 (tenant scoping).
+
+    The tenant comes from the JWT, never the body, so an operator in tenant B
+    cannot read tenant A's handle even with the right handle_id + sub.
+    """
+    handle = uuid.uuid4()
+    other_tenant = uuid.UUID("00000000-0000-0000-0000-0000000000b0")
+    fake_result_store.seed(
+        tenant_id=other_tenant,
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=[{"i": i} for i in range(60)],
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle)},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"]["reason"] == "handle_not_found"
+
+
+def test_post_result_query_invalid_uuid_returns_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A malformed handle_id is a 422 at the Pydantic layer (before the handler)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": "not-a-uuid"},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+def test_post_result_query_negative_offset_returns_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """offset < 0 is rejected at the Pydantic bound (ge=0)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(uuid.uuid4()), "offset": -1},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+def test_post_result_query_zero_limit_returns_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """limit < 1 is rejected at the Pydantic bound (ge=1)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(uuid.uuid4()), "limit": 0},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+def test_post_result_query_over_max_limit_returns_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """limit above the shared MAX_LIMIT ceiling is rejected (le=MAX_LIMIT)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(uuid.uuid4()), "limit": MAX_LIMIT + 1},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+def test_post_result_query_rejects_extra_body_field(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """extra='forbid' rejects an unknown body field with a 422 (typo-loud)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(uuid.uuid4()), "bogus": 1},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422

--- a/backend/tests/test_mcp_output_schema_conformance.py
+++ b/backend/tests/test_mcp_output_schema_conformance.py
@@ -40,7 +40,7 @@ import jsonschema
 import pytest
 from fastapi.testclient import TestClient
 
-import meho_backplane.mcp.tools.result_query as result_query_module
+import meho_backplane.operations.result_query as result_query_core
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.connectors.result_handle_store import SpilledWindow
 from meho_backplane.db.engine import get_sessionmaker
@@ -448,7 +448,9 @@ def test_result_query_conforms(
                 truncated=False,
             )
 
-    monkeypatch.setattr(result_query_module, "get_result_handle_store", lambda: _StubStore())
+    # Patch the shared core's store getter — the windowed read moved there in
+    # #3179 and the MCP handler now delegates to it.
+    monkeypatch.setattr(result_query_core, "get_result_handle_store", lambda: _StubStore())
     payload = _assert_conforms(
         "result_query",
         _call(client, "result_query", {"handle_id": str(handle_id), "limit": 5}),

--- a/backend/tests/test_mcp_tool_result_query.py
+++ b/backend/tests/test_mcp_tool_result_query.py
@@ -24,7 +24,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi.testclient import TestClient
 
-import meho_backplane.mcp.tools.result_query as result_query_module
+import meho_backplane.operations.result_query as result_query_core
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.result_handle_store import SpilledWindow
 from meho_backplane.mcp.schemas import INVALID_PARAMS
@@ -84,9 +84,14 @@ class _FakeStore:
 
 @pytest.fixture
 def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
-    """Replace the production store getter with an in-memory fake."""
+    """Replace the production store getter with an in-memory fake.
+
+    Patched on the shared core module (:mod:`meho_backplane.operations.
+    result_query`) where the getter is now called (#3179) rather than on the
+    MCP tool module — the MCP handler delegates the windowed read to the core.
+    """
     store = _FakeStore()
-    monkeypatch.setattr(result_query_module, "get_result_handle_store", lambda: store)
+    monkeypatch.setattr(result_query_core, "get_result_handle_store", lambda: store)
     return store
 
 

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -1079,6 +1079,10 @@ async def test_reduce_spills_full_rows_and_flips_drill_in_available() -> None:
     assert drill_in.example_call["args"]["handle_id"] == str(handle.handle_id)
     assert drill_in.expires_at is not None
     assert "result_query" in drill_in.rationale
+    # #3179: the available-branch rationale names the REST read-back route
+    # too, so a consumer that got the handle over REST (never touching MCP)
+    # learns how to page it without a discovery dance.
+    assert "POST /api/v1/operations/result-query" in drill_in.rationale
 
 
 async def test_recovery_unchanged_when_inline_sample_is_byte_bounded() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3428,6 +3428,62 @@
         }
       }
     },
+    "/api/v1/operations/result-query": {
+      "post": {
+        "tags": [
+          "operations"
+        ],
+        "summary": "Post Result Query",
+        "description": "Read a ``[offset : offset+limit]`` window of a JSONFlux result handle.\n\nDelegates to :func:`read_result_window` \u2014 the same transport-neutral\ncore the MCP ``result_query`` tool wraps \u2014 so REST and MCP share the\ntenant/principal scoping and not-found semantics exactly. The tenant +\nprincipal come from the JWT-validated :class:`Operator`; the body carries\nno tenant, by design.\n\nCloses the REST dead-end #3179 named: ``POST /api/v1/operations/call``\ncan *mint* a reduced ``handle`` for any set-shaped result over the\n50-row / 4 KB thresholds, but before this route a REST consumer had no\nway to read it back and had to fail closed or hand the drill-in to a\nhuman over MCP.\n\nA handle that is unknown, expired (TTL elapsed), or belongs to a\ndifferent operator is a ``404`` with a structured ``detail`` carrying\n``reason=\"handle_not_found\"`` \u2014 the recoverable-miss twin of the MCP\ntool's ``-32602`` / ``data.reason=handle_not_found`` (the caller re-runs\nthe operation for a fresh handle). Cross-operator access is deliberately\nindistinguishable from \"not found\" so the store leaks no existence\nsignal across the operator boundary. A malformed ``handle_id`` (not a\nUUID) or an out-of-range ``offset`` / ``limit`` is a ``422`` at the\nPydantic layer before the handler runs.",
+        "operationId": "post_result_query_api_v1_operations_result_query_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResultQueryBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Result Query Api V1 Operations Result Query Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/operations/preview": {
       "post": {
         "tags": [
@@ -28048,6 +28104,38 @@
         ],
         "title": "ResultIngestResponse",
         "description": "``POST /checks/results`` response \u2014 idempotency accounting.\n\n``accepted`` counts rows newly persisted; ``duplicates`` counts rows\nwhose ``result_uid`` was already ingested for this runner (a re-posted\nspool batch). ``accepted + duplicates`` equals the batch length."
+      },
+      "ResultQueryBody": {
+        "properties": {
+          "handle_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Handle Id",
+            "description": "The result handle's UUID, taken from a reduced `/call` response's `result.handle.handle_id` or `fetch_more.drill_in.example_call.args.handle_id`."
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "description": "Zero-based index of the first row to return. Page by advancing this by the previous `limit`.",
+            "default": 0
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "description": "Page size. Default 50; max 500. Matches the `result_query` MCP tool's upper bound.",
+            "default": 50
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "handle_id"
+        ],
+        "title": "ResultQueryBody",
+        "description": "POST body for ``/api/v1/operations/result-query`` (#3179).\n\nThe REST twin of the MCP ``result_query`` tool's ``inputSchema``:\n``handle_id`` is the UUID minted onto a reduced ``/call`` response's\n``result.handle.handle_id`` / ``fetch_more.drill_in.example_call``, and\n``offset`` / ``limit`` window the spilled set. The bounds mirror the MCP\nschema (``offset >= 0``; ``1 <= limit <= MAX_LIMIT``) so the two surfaces\nvalidate identically. ``extra=\"forbid\"`` rejects unknown body fields with\na 422, matching the sibling ``CallOperationBody`` posture.\n\nFiltering / projection is out of scope (issue #3179 non-goal): parity is\nthe same offset/limit window the MCP tool serves, not more."
       },
       "RetireChecklistReport": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -5784,6 +5784,29 @@ type ResultIngestResponse struct {
 	Duplicates int `json:"duplicates"`
 }
 
+// ResultQueryBody POST body for “/api/v1/operations/result-query“ (#3179).
+//
+// The REST twin of the MCP “result_query“ tool's “inputSchema“:
+// “handle_id“ is the UUID minted onto a reduced “/call“ response's
+// “result.handle.handle_id“ / “fetch_more.drill_in.example_call“, and
+// “offset“ / “limit“ window the spilled set. The bounds mirror the MCP
+// schema (“offset >= 0“; “1 <= limit <= MAX_LIMIT“) so the two surfaces
+// validate identically. “extra="forbid"“ rejects unknown body fields with
+// a 422, matching the sibling “CallOperationBody“ posture.
+//
+// Filtering / projection is out of scope (issue #3179 non-goal): parity is
+// the same offset/limit window the MCP tool serves, not more.
+type ResultQueryBody struct {
+	// HandleId The result handle's UUID, taken from a reduced `/call` response's `result.handle.handle_id` or `fetch_more.drill_in.example_call.args.handle_id`.
+	HandleId openapi_types.UUID `json:"handle_id"`
+
+	// Limit Page size. Default 50; max 500. Matches the `result_query` MCP tool's upper bound.
+	Limit *int `json:"limit,omitempty"`
+
+	// Offset Zero-based index of the first row to return. Page by advancing this by the previous `limit`.
+	Offset *int `json:"offset,omitempty"`
+}
+
 // RetireChecklistReport Top-level shape returned by :func:`compute_retire_checklist`.
 //
 // Frozen + “extra="forbid"“ so the CLI's “--json“ consumers can
@@ -8750,6 +8773,11 @@ type PostPreviewApiV1OperationsPreviewPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// PostResultQueryApiV1OperationsResultQueryPostParams defines parameters for PostResultQueryApiV1OperationsResultQueryPost.
+type PostResultQueryApiV1OperationsResultQueryPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // GetSearchApiV1OperationsSearchGetParams defines parameters for GetSearchApiV1OperationsSearchGet.
 type GetSearchApiV1OperationsSearchGetParams struct {
 	// ConnectorId Connector implementation id in `<impl_id>-<version>` form — e.g. `vmware-rest-9.0`, `vault-1.x`, `k8s-1.x`. NOT the bare product name (`vault`, `vmware`): a bare product slug names no connector and returns 404. Discover valid ids via `GET /api/v1/connectors`.
@@ -9582,6 +9610,9 @@ type PostCallApiV1OperationsCallPostJSONRequestBody = CallOperationBody
 
 // PostPreviewApiV1OperationsPreviewPostJSONRequestBody defines body for PostPreviewApiV1OperationsPreviewPost for application/json ContentType.
 type PostPreviewApiV1OperationsPreviewPostJSONRequestBody = PreviewOperationBody
+
+// PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody defines body for PostResultQueryApiV1OperationsResultQueryPost for application/json ContentType.
+type PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody = ResultQueryBody
 
 // RetrieveEndpointApiV1RetrievePostJSONRequestBody defines body for RetrieveEndpointApiV1RetrievePost for application/json ContentType.
 type RetrieveEndpointApiV1RetrievePostJSONRequestBody = RetrieveRequest
@@ -11608,6 +11639,11 @@ type ClientInterface interface {
 	PostPreviewApiV1OperationsPreviewPostWithBody(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PostPreviewApiV1OperationsPreviewPost(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostResultQueryApiV1OperationsResultQueryPostWithBody request with any body
+	PostResultQueryApiV1OperationsResultQueryPostWithBody(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostResultQueryApiV1OperationsResultQueryPost(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSearchApiV1OperationsSearchGet request
 	GetSearchApiV1OperationsSearchGet(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14157,6 +14193,30 @@ func (c *Client) PostPreviewApiV1OperationsPreviewPostWithBody(ctx context.Conte
 
 func (c *Client) PostPreviewApiV1OperationsPreviewPost(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostPreviewApiV1OperationsPreviewPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostResultQueryApiV1OperationsResultQueryPostWithBody(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostResultQueryApiV1OperationsResultQueryPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostResultQueryApiV1OperationsResultQueryPost(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostResultQueryApiV1OperationsResultQueryPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -24817,6 +24877,61 @@ func NewPostPreviewApiV1OperationsPreviewPostRequestWithBody(server string, para
 	}
 
 	operationPath := fmt.Sprintf("/api/v1/operations/preview")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPostResultQueryApiV1OperationsResultQueryPostRequest calls the generic PostResultQueryApiV1OperationsResultQueryPost builder with application/json body
+func NewPostResultQueryApiV1OperationsResultQueryPostRequest(server string, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostResultQueryApiV1OperationsResultQueryPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewPostResultQueryApiV1OperationsResultQueryPostRequestWithBody generates requests for PostResultQueryApiV1OperationsResultQueryPost with any type of body
+func NewPostResultQueryApiV1OperationsResultQueryPostRequestWithBody(server string, params *PostResultQueryApiV1OperationsResultQueryPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/operations/result-query")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -39797,6 +39912,11 @@ type ClientWithResponsesInterface interface {
 
 	PostPreviewApiV1OperationsPreviewPostWithResponse(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPreviewApiV1OperationsPreviewPostResponse, error)
 
+	// PostResultQueryApiV1OperationsResultQueryPostWithBodyWithResponse request with any body
+	PostResultQueryApiV1OperationsResultQueryPostWithBodyWithResponse(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error)
+
+	PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error)
+
 	// GetSearchApiV1OperationsSearchGetWithResponse request
 	GetSearchApiV1OperationsSearchGetWithResponse(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*GetSearchApiV1OperationsSearchGetResponse, error)
 
@@ -42974,6 +43094,29 @@ func (r PostPreviewApiV1OperationsPreviewPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostPreviewApiV1OperationsPreviewPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostResultQueryApiV1OperationsResultQueryPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PostResultQueryApiV1OperationsResultQueryPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostResultQueryApiV1OperationsResultQueryPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -49978,6 +50121,23 @@ func (c *ClientWithResponses) PostPreviewApiV1OperationsPreviewPostWithResponse(
 	return ParsePostPreviewApiV1OperationsPreviewPostResponse(rsp)
 }
 
+// PostResultQueryApiV1OperationsResultQueryPostWithBodyWithResponse request with arbitrary body returning *PostResultQueryApiV1OperationsResultQueryPostResponse
+func (c *ClientWithResponses) PostResultQueryApiV1OperationsResultQueryPostWithBodyWithResponse(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error) {
+	rsp, err := c.PostResultQueryApiV1OperationsResultQueryPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostResultQueryApiV1OperationsResultQueryPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error) {
+	rsp, err := c.PostResultQueryApiV1OperationsResultQueryPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostResultQueryApiV1OperationsResultQueryPostResponse(rsp)
+}
+
 // GetSearchApiV1OperationsSearchGetWithResponse request returning *GetSearchApiV1OperationsSearchGetResponse
 func (c *ClientWithResponses) GetSearchApiV1OperationsSearchGetWithResponse(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*GetSearchApiV1OperationsSearchGetResponse, error) {
 	rsp, err := c.GetSearchApiV1OperationsSearchGet(ctx, params, reqEditors...)
@@ -56408,6 +56568,39 @@ func ParsePostPreviewApiV1OperationsPreviewPostResponse(rsp *http.Response) (*Po
 	}
 
 	response := &PostPreviewApiV1OperationsPreviewPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostResultQueryApiV1OperationsResultQueryPostResponse parses an HTTP response from a PostResultQueryApiV1OperationsResultQueryPostWithResponse call
+func ParsePostResultQueryApiV1OperationsResultQueryPostResponse(rsp *http.Response) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostResultQueryApiV1OperationsResultQueryPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	"github.com/evoila/meho/cli/internal/api"
 )
 
@@ -30,25 +32,29 @@ type fakeOperationsClient struct {
 	// Recorded params from the most recent call to each verb. Tests
 	// inspect these to verify that typed params are passed (not
 	// raw-string URL concatenation).
-	lastCallParams   *api.PostCallApiV1OperationsCallPostParams
-	lastCallBody     *api.CallOperationBody
-	lastGroupsParams *api.GetGroupsApiV1OperationsGroupsGetParams
-	lastSearchParams *api.GetSearchApiV1OperationsSearchGetParams
+	lastCallParams        *api.PostCallApiV1OperationsCallPostParams
+	lastCallBody          *api.CallOperationBody
+	lastGroupsParams      *api.GetGroupsApiV1OperationsGroupsGetParams
+	lastSearchParams      *api.GetSearchApiV1OperationsSearchGetParams
+	lastResultQueryParams *api.PostResultQueryApiV1OperationsResultQueryPostParams
+	lastResultQueryBody   *api.ResultQueryBody
 
 	// Sequenced canned responses — pop one per call (per verb). Tests
 	// register two responses on the auth-refresh scenarios (first a
 	// 401, then the post-refresh outcome) and one on every other
 	// path.
-	callResponses   []*api.PostCallApiV1OperationsCallPostResponse
-	groupsResponses []*api.GetGroupsApiV1OperationsGroupsGetResponse
-	searchResponses []*api.GetSearchApiV1OperationsSearchGetResponse
+	callResponses        []*api.PostCallApiV1OperationsCallPostResponse
+	groupsResponses      []*api.GetGroupsApiV1OperationsGroupsGetResponse
+	searchResponses      []*api.GetSearchApiV1OperationsSearchGetResponse
+	resultQueryResponses []*api.PostResultQueryApiV1OperationsResultQueryPostResponse
 
 	// Per-verb transport-error queues. Drain in the same order as
 	// the response queues so a refresh-then-transport-failure scenario
 	// can be authored.
-	callErrors   []error
-	groupsErrors []error
-	searchErrors []error
+	callErrors        []error
+	groupsErrors      []error
+	searchErrors      []error
+	resultQueryErrors []error
 
 	// refreshCount tracks how many times Refresh was invoked across
 	// the whole client's lifetime. The 401 dance asserts this hits
@@ -89,9 +95,32 @@ func (f *fakeOperationsClient) GetSearchApiV1OperationsSearchGetWithResponse(
 	return popSearchResp(&f.searchResponses), popErr(&f.searchErrors)
 }
 
+func (f *fakeOperationsClient) PostResultQueryApiV1OperationsResultQueryPostWithResponse(
+	_ context.Context,
+	params *api.PostResultQueryApiV1OperationsResultQueryPostParams,
+	body api.PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody,
+	_ ...api.RequestEditorFn,
+) (*api.PostResultQueryApiV1OperationsResultQueryPostResponse, error) {
+	f.lastResultQueryParams = params
+	bodyCopy := body
+	f.lastResultQueryBody = &bodyCopy
+	return popResultQueryResp(&f.resultQueryResponses), popErr(&f.resultQueryErrors)
+}
+
 func (f *fakeOperationsClient) Refresh(_ context.Context) error {
 	f.refreshCount++
 	return f.refreshErr
+}
+
+func popResultQueryResp(
+	q *[]*api.PostResultQueryApiV1OperationsResultQueryPostResponse,
+) *api.PostResultQueryApiV1OperationsResultQueryPostResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
 }
 
 func popCallResp(q *[]*api.PostCallApiV1OperationsCallPostResponse) *api.PostCallApiV1OperationsCallPostResponse {
@@ -672,5 +701,177 @@ func TestCallHumanRenderOmitsExtrasOnOK(t *testing.T) {
 		t.Errorf("human render printed extras on status=ok — the CLI gap closed; "+
 			"update docs/codebase/checks-advisory.md § Operator reach and the "+
 			"CHANGELOG bullet, then flip this assertion. Output: %q", out.String())
+	}
+}
+
+// ---- postResultQuery (#3179) ----
+
+func makeHandleUUID(t *testing.T, s string) openapi_types.UUID {
+	t.Helper()
+	var u openapi_types.UUID
+	if err := u.UnmarshalText([]byte(s)); err != nil {
+		t.Fatalf("parse handle uuid %q: %v", s, err)
+	}
+	return u
+}
+
+// TestPostResultQueryPassesTypedBody — the happy path asserts the typed
+// body carries HandleId + Offset + Limit pointers (no raw URL/body
+// concatenation) and the 200 envelope decodes into ResultQueryResult.
+func TestPostResultQueryPassesTypedBody(t *testing.T) {
+	rq, _ := json.Marshal(ResultQueryResult{
+		HandleID:     "11111111-1111-1111-1111-111111111111",
+		Rows:         []json.RawMessage{json.RawMessage(`{"i":5}`)},
+		Offset:       5,
+		Limit:        50,
+		ReturnedRows: 1,
+		TotalRows:    60,
+		StoredRows:   60,
+		Truncated:    false,
+	})
+	f := &fakeOperationsClient{
+		resultQueryResponses: []*api.PostResultQueryApiV1OperationsResultQueryPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: rq},
+		},
+	}
+	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
+	got, err := postResultQuery(context.Background(), f, handle, 5, 50)
+	if err != nil {
+		t.Fatalf("postResultQuery: %v", err)
+	}
+	b := f.lastResultQueryBody
+	if b == nil {
+		t.Fatalf("postResultQuery should populate body")
+	}
+	if b.HandleId != handle {
+		t.Fatalf("body should carry typed HandleId=%v; got %v", handle, b.HandleId)
+	}
+	if b.Offset == nil || *b.Offset != 5 {
+		t.Fatalf("body should carry Offset=5; got %+v", b.Offset)
+	}
+	if b.Limit == nil || *b.Limit != 50 {
+		t.Fatalf("body should carry Limit=50; got %+v", b.Limit)
+	}
+	if got.TotalRows != 60 || got.ReturnedRows != 1 || got.Offset != 5 {
+		t.Fatalf("decoded result-query envelope wrong shape: %+v", got)
+	}
+}
+
+// TestPostResultQueryRefreshOn401 — same one-shot refresh dance as the
+// sibling verbs, exercised through postResultQuery.
+func TestPostResultQueryRefreshOn401(t *testing.T) {
+	rq, _ := json.Marshal(ResultQueryResult{HandleID: "h", TotalRows: 0})
+	f := &fakeOperationsClient{
+		resultQueryResponses: []*api.PostResultQueryApiV1OperationsResultQueryPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: rq},
+		},
+	}
+	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
+	if _, err := postResultQuery(context.Background(), f, handle, 0, 50); err != nil {
+		t.Fatalf("postResultQuery after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestPostResultQueryNotFoundClassifiesAsApiResponseError — the 404
+// handle-not-found miss wraps as *apiResponseError (so renderRequestError
+// maps it to unexpected_response) and preserves the structured
+// reason=handle_not_found detail in the body for the operator to read.
+func TestPostResultQueryNotFoundClassifiesAsApiResponseError(t *testing.T) {
+	notFound := `{"detail":{"reason":"handle_not_found","handle_id":"11111111-1111-1111-1111-111111111111"}}`
+	f := &fakeOperationsClient{
+		resultQueryResponses: []*api.PostResultQueryApiV1OperationsResultQueryPostResponse{
+			{HTTPResponse: makeHTTPResp(404), Body: []byte(notFound)},
+		},
+	}
+	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
+	_, err := postResultQuery(context.Background(), f, handle, 0, 50)
+	if err == nil {
+		t.Fatalf("expected non-2xx error; got nil")
+	}
+	var apiErr *apiResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 404 {
+		t.Fatalf("expected *apiResponseError{StatusCode:404}; got %+v", err)
+	}
+	if !strings.Contains(apiErr.Body, "handle_not_found") {
+		t.Fatalf("404 body should preserve the reason=handle_not_found detail; got %q", apiErr.Body)
+	}
+}
+
+// TestPostResultQueryTransportErrorPropagates — a pure transport failure
+// returns verbatim so renderRequestError can classify it as unreachable.
+func TestPostResultQueryTransportErrorPropagates(t *testing.T) {
+	transportErr := errors.New("dial tcp: connection refused")
+	f := &fakeOperationsClient{resultQueryErrors: []error{transportErr}}
+	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
+	_, err := postResultQuery(context.Background(), f, handle, 0, 50)
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error to propagate verbatim; got %v", err)
+	}
+	var apiErr *apiResponseError
+	if errors.As(err, &apiErr) {
+		t.Fatalf("transport error should not wrap as *apiResponseError")
+	}
+}
+
+// TestRunResultQueryInvalidUUIDShortCircuits — a malformed handle_id is
+// caught CLI-side (before the backplane is even resolved), surfacing as
+// unexpected_response with the "not a valid UUID" hint. No client call
+// is made.
+func TestRunResultQueryInvalidUUIDShortCircuits(t *testing.T) {
+	f := &fakeOperationsClient{}
+	withFakeClient(t, f)
+
+	cmd := newResultQueryCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"not-a-uuid", "--backplane", "https://x"})
+	// The invalid-UUID branch returns the rendered StructuredError (nil
+	// process error on the human path); assert the diagnostic reached stderr.
+	_ = cmd.Execute()
+	if !strings.Contains(errBuf.String(), "not a valid UUID") {
+		t.Fatalf("expected 'not a valid UUID' diagnostic on stderr; got %q", errBuf.String())
+	}
+	if f.lastResultQueryBody != nil {
+		t.Fatalf("invalid UUID should short-circuit before any client call; got body %+v", f.lastResultQueryBody)
+	}
+}
+
+// TestRunResultQueryHappyPathRendersWindow — the full runResultQuery path
+// (real cobra command + fake client) renders the window header + rows on
+// stdout and exits 0.
+func TestRunResultQueryHappyPathRendersWindow(t *testing.T) {
+	rq, _ := json.Marshal(ResultQueryResult{
+		HandleID:     "11111111-1111-1111-1111-111111111111",
+		Rows:         []json.RawMessage{json.RawMessage(`{"i":0}`), json.RawMessage(`{"i":1}`)},
+		Offset:       0,
+		Limit:        50,
+		ReturnedRows: 2,
+		TotalRows:    2,
+		StoredRows:   2,
+	})
+	f := &fakeOperationsClient{
+		resultQueryResponses: []*api.PostResultQueryApiV1OperationsResultQueryPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: rq},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newResultQueryCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"11111111-1111-1111-1111-111111111111", "--backplane", "https://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"rows 0..2 of 2", `"i": 0`, `"i": 1`} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("result-query render missing %q in output:\n%s", want, out.String())
+		}
 	}
 }

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -12,6 +12,10 @@
 //     GET /api/v1/operations/search.
 //   - `meho operation call <connector_id> <op_id> --target <slug> [--params ...]`
 //     — invoke the dispatcher via POST /api/v1/operations/call.
+//   - `meho operation result-query <handle_id> [--offset N] [--limit N]`
+//     — page rows back from a JSONFlux result handle via
+//     POST /api/v1/operations/result-query (#3179), the REST twin of the
+//     MCP `result_query` tool.
 //
 // Each verb wraps one backplane route and renders the response in
 // either a human-readable table or `--json` mode. Authentication
@@ -54,6 +58,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newGroupsCmd())
 	cmd.AddCommand(newSearchCmd())
 	cmd.AddCommand(newCallCmd())
+	cmd.AddCommand(newResultQueryCmd())
 	return cmd
 }
 
@@ -81,6 +86,12 @@ type operationsAPI interface {
 		params *api.GetSearchApiV1OperationsSearchGetParams,
 		reqEditors ...api.RequestEditorFn,
 	) (*api.GetSearchApiV1OperationsSearchGetResponse, error)
+	PostResultQueryApiV1OperationsResultQueryPostWithResponse(
+		ctx context.Context,
+		params *api.PostResultQueryApiV1OperationsResultQueryPostParams,
+		body api.PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.PostResultQueryApiV1OperationsResultQueryPostResponse, error)
 	Refresh(ctx context.Context) error
 }
 

--- a/cli/internal/cmd/operation/operation_test.go
+++ b/cli/internal/cmd/operation/operation_test.go
@@ -331,3 +331,66 @@ func TestPrettyJSONRejectsInvalid(t *testing.T) {
 		t.Fatalf("expected unmarshal error; got nil")
 	}
 }
+
+// TestPrintResultQueryResultWindow — happy-path render shows the window
+// header (position + counts) and pretty-prints the rows.
+func TestPrintResultQueryResultWindow(t *testing.T) {
+	r := &ResultQueryResult{
+		HandleID:     "11111111-1111-1111-1111-111111111111",
+		Rows:         []json.RawMessage{json.RawMessage(`{"i":5,"name":"row-5"}`)},
+		Offset:       5,
+		Limit:        50,
+		ReturnedRows: 1,
+		TotalRows:    60,
+		StoredRows:   60,
+	}
+	var buf bytes.Buffer
+	printResultQueryResult(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"rows 5..6 of 60", "stored 60", "returned 1", `"name"`, "row-5"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printResultQueryResult missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintResultQueryResultEmptyWindow — an offset past the end returns
+// zero rows; the render announces the end-of-set rather than an error.
+func TestPrintResultQueryResultEmptyWindow(t *testing.T) {
+	r := &ResultQueryResult{
+		HandleID:     "h",
+		Rows:         nil,
+		Offset:       100,
+		Limit:        50,
+		ReturnedRows: 0,
+		TotalRows:    60,
+		StoredRows:   60,
+	}
+	var buf bytes.Buffer
+	printResultQueryResult(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "empty window") {
+		t.Errorf("empty window should announce end-of-set; got:\n%s", out)
+	}
+}
+
+// TestPrintResultQueryResultTruncated — a spill capped below total surfaces
+// the truncation note so the operator knows the tail is unreachable.
+func TestPrintResultQueryResultTruncated(t *testing.T) {
+	r := &ResultQueryResult{
+		HandleID:     "h",
+		Rows:         []json.RawMessage{json.RawMessage(`{"i":0}`)},
+		Offset:       0,
+		Limit:        50,
+		ReturnedRows: 1,
+		TotalRows:    100,
+		StoredRows:   40,
+		Truncated:    true,
+	}
+	var buf bytes.Buffer
+	printResultQueryResult(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "capped at 40 of 100") {
+		t.Errorf("truncated render should flag the spill cap; got:\n%s", out)
+	}
+}

--- a/cli/internal/cmd/operation/resultquery.go
+++ b/cli/internal/cmd/operation/resultquery.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ResultQueryResult mirrors the backend result-query envelope — the
+// `dict[str, Any]` returned by POST /api/v1/operations/result-query
+// (read_result_window). Hand-written for the same reason as CallResult /
+// GroupSummary: the FastAPI route types its return as `dict[str, Any]`, so
+// the oapi-codegen generator emits `*map[string]interface{}` with no typed
+// model worth using. Rows stay `[]json.RawMessage` so the renderer pretty-
+// prints each row without imposing a per-vendor row shape.
+type ResultQueryResult struct {
+	HandleID     string            `json:"handle_id"`
+	Rows         []json.RawMessage `json:"rows"`
+	Offset       int               `json:"offset"`
+	Limit        int               `json:"limit"`
+	ReturnedRows int               `json:"returned_rows"`
+	TotalRows    int               `json:"total_rows"`
+	StoredRows   int               `json:"stored_rows"`
+	Truncated    bool              `json:"truncated"`
+}
+
+// newResultQueryCmd returns the `meho operation result-query` command —
+// the CLI verb the vcf-logs result-handle hint already advertises
+// (cli/internal/cmd/vcf-logs/query.go), made truthful by #3179.
+//
+// CLI shape:
+//
+//	meho operation result-query <handle_id> \
+//	  [--offset N]                             # zero-based first row (default 0)
+//	  [--limit N]                              # page size (default 50, max 500)
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// It wraps POST /api/v1/operations/result-query, the REST twin of the MCP
+// `result_query` tool: after `meho operation call` reduces a large list
+// response, the reduced envelope carries a `handle` (`result.handle.
+// handle_id`); this verb pages the FULL set back beyond the inline sample.
+//
+// Exit codes mirror `meho operation groups`:
+//   - 0   window returned cleanly (including the past-the-end empty window)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. a 404 handle-not-found miss, which
+//     carries the backplane's structured `reason=handle_not_found` detail)
+func newResultQueryCmd() *cobra.Command {
+	var (
+		offset            int
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "result-query <handle_id>",
+		Short: "Page rows back from a JSONFlux result handle",
+		Long: "result-query calls POST /api/v1/operations/result-query — the " +
+			"REST twin of the MCP `result_query` tool. After `meho operation " +
+			"call` reduces a large list response, the reduced envelope carries " +
+			"a `handle` (`result.handle.handle_id`); this verb pages the FULL " +
+			"set back beyond the inline sample.\n\n" +
+			"--offset advances the window (page by adding the previous --limit); " +
+			"--limit sets the page size (default 50, max 500). A window whose " +
+			"offset is past the stored row count returns an empty `rows` list — " +
+			"that's the end of the set, not an error.\n\n" +
+			"A handle that does not exist, has expired (TTL elapsed), or belongs " +
+			"to a different operator is a 404 carrying a structured " +
+			"`reason=handle_not_found` detail: re-run the original operation to " +
+			"mint a fresh handle.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResultQuery(cmd, resultQueryOptions{
+				HandleID:          args[0],
+				Offset:            offset,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&offset, "offset", 0,
+		"zero-based index of the first row to return (page by advancing this by --limit)")
+	cmd.Flags().IntVar(&limit, "limit", 50,
+		"page size; default 50, max 500 (matches the result_query MCP tool)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full result-query envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type resultQueryOptions struct {
+	HandleID          string
+	Offset            int
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runResultQuery(cmd *cobra.Command, opts resultQueryOptions) error {
+	// Parse the handle UUID CLI-side so a malformed value surfaces locally
+	// rather than as a 422 round-trip; the generated body requires
+	// `openapi_types.UUID`. Same idiom as `meho scheduler cancel`.
+	var handleID openapi_types.UUID
+	if err := handleID.UnmarshalText([]byte(opts.HandleID)); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("handle_id is not a valid UUID: %v", err)),
+			opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	client, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result, err := postResultQuery(cmd.Context(), client, handleID, opts.Offset, opts.Limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printResultQueryResult(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// postResultQuery issues the typed POST via the generated client, runs the
+// one-shot 401-refresh dance via the AuthedClient's Refresh hook (mirroring
+// postCall), and unmarshals the 200 body into ResultQueryResult. Non-2xx
+// outcomes — including the 404 handle-not-found miss — wrap as
+// *apiResponseError for renderRequestError to classify.
+func postResultQuery(
+	ctx context.Context,
+	client operationsAPI,
+	handleID openapi_types.UUID,
+	offset int,
+	limit int,
+) (*ResultQueryResult, error) {
+	body := api.ResultQueryBody{
+		HandleId: handleID,
+		Offset:   &offset,
+		Limit:    &limit,
+	}
+	apiParams := &api.PostResultQueryApiV1OperationsResultQueryPostParams{}
+	resp, err := client.PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx, apiParams, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx, apiParams, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
+	var out ResultQueryResult
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		return nil, fmt.Errorf("decode result-query response: %w", err)
+	}
+	return &out, nil
+}
+
+// printResultQueryResult renders a ResultQueryResult as a human-readable
+// header line plus the pretty-printed rows window. The header states the
+// window position + the full/stored counts so the operator knows how far
+// they've paged and whether the tail was truncated at spill time; --json
+// carries the raw envelope.
+func printResultQueryResult(w io.Writer, r *ResultQueryResult) {
+	end := r.Offset + r.ReturnedRows
+	fmt.Fprintf(w, "%s — rows %d..%d of %d (stored %d), returned %d\n",
+		r.HandleID, r.Offset, end, r.TotalRows, r.StoredRows, r.ReturnedRows)
+	if r.Truncated {
+		fmt.Fprintf(w, "  note: spill was capped at %d of %d rows; rows past %d are not retrievable\n",
+			r.StoredRows, r.TotalRows, r.StoredRows)
+	}
+	if r.ReturnedRows == 0 {
+		fmt.Fprintln(w, "  (empty window — offset is at or past the end of the stored set)")
+		return
+	}
+	for _, row := range r.Rows {
+		pretty, err := prettyJSON(row)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(row))
+		}
+	}
+}

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -9,9 +9,11 @@ bounded inline `sample` plus a self-documenting `fetch_more` envelope. The
 **full** materialized set is spilled to a Valkey-backed
 `ResultHandleStore` (keyed by `(tenant_id, handle_id)`, server-enforced
 TTL, row count capped by `RESULT_HANDLE_MAX_SPILL_ROWS`), and the
-`result_query` MCP meta-tool pages it back beyond the inline sample. When
+`result_query` read surface — the MCP meta-tool and the REST route `POST
+/api/v1/operations/result-query`, both wrapping one shared core (#3179) —
+pages it back beyond the inline sample. When
 the spill succeeds the handle's `fetch_more.drill_in` is `available=true`
-and names that tool; when it is skipped or the store is unreachable the
+and names that surface; when it is skipped or the store is unreachable the
 envelope still tells the agent how to act on more than the sample (re-call
 with narrower params / native pagination) and the reduce path is
 unaffected (fail-open).
@@ -338,7 +340,11 @@ triage runbook). The spill
 + read-back are described under *"Read-back: the `ResultHandleStore`"*
 below; the `mcp_resource_uri` field stays `None` in the current
 tool-only surface. `rationale` always carries the operator/agent-facing
-prose explaining the current state.
+prose explaining the current state — on the `available=True` branch it
+names both the `result_query` MCP tool and the `POST /api/v1/operations/
+result-query` REST route (#3179), so a consumer that received the handle
+over either transport learns how to page it; the structured `mcp_tool`
+field stays MCP-only (the REST route lives in the prose, not a new field).
 
 **`native_pagination: FetchMoreNativePagination`** — *"what params
 let the underlying op return the next slice?"* When the op
@@ -423,16 +429,24 @@ is unreachable. Both skip shapes surface in the response as
 `jsonflux_spill_skipped` warning; the store-level failure additionally
 logs `result_handle_spill_failed` with the underlying error.
 
-The `result_query` MCP meta-tool
+The read surface is dual — MCP and REST share one windowed-read core
+([`operations/result_query.py`](../../backend/src/meho_backplane/operations/result_query.py),
+`read_result_window`), so the two transports cannot drift on scoping or
+not-found semantics (#3179). The `result_query` MCP meta-tool
 ([`mcp/tools/result_query.py`](../../backend/src/meho_backplane/mcp/tools/result_query.py))
-is the read surface: `result_query(handle_id, offset, limit)` returns the
+and the REST route `POST /api/v1/operations/result-query`
+([`api/v1/operations.py`](../../backend/src/meho_backplane/api/v1/operations.py))
+both wrap it: `result_query(handle_id, offset, limit)` returns the
 requested window plus `total_rows` / `stored_rows` / `truncated`. The
 tenant comes from the operator's JWT (never the arguments) and the
 spilling operator's `sub` is checked, so a cross-tenant or cross-operator
-read is an indistinguishable `handle_not_found` miss — the same
-recoverable `-32602` taxonomy an expired handle surfaces. This is the
-design first drafted as the `HandleStore` in G3.1-T4 (#304,
-closed-superseded), revived and narrowed to the reduce-time spill case.
+read is an indistinguishable `handle_not_found` miss — surfaced as the
+recoverable `-32602` taxonomy over MCP and as a `404` with
+`reason=handle_not_found` over REST. Before #3179 the read-back was
+MCP-only: a REST consumer that received a handle off `POST /api/v1/
+operations/call` was at a dead end. This is the design first drafted as
+the `HandleStore` in G3.1-T4 (#304, closed-superseded), revived and
+narrowed to the reduce-time spill case.
 
 ### Sample ordering — head vs tail (G0.19-T1, #1479)
 

--- a/docs/architecture/operations-substrate.md
+++ b/docs/architecture/operations-substrate.md
@@ -413,7 +413,7 @@ Frozen Pydantic model with `MappingProxyType`-wrapped nested mappings (via `@mod
 
 `fetch_more` is the G0.15-T8 (#1219) self-documenting drill-in / pagination envelope. Every handle the production reducer mints carries it (the two branches `drill_in` and `native_pagination` are always populated) so an agent reading the response can answer *"how do I get more rows"* from the envelope itself — no MCP-tool / resource-URI / REST-route discovery dance. The shape, the drill-in branch (`available=True` naming the `result_query` tool when the full set was spilled to the `ResultHandleStore`, `available=False` with the narrower-params workaround when it was skipped or the store was unreachable — G0.20-T7 #1507), and the `llm_instructions.pagination_hint` registration slot the reducer reads to build `native_pagination` are documented in [`jsonflux.md` § fetch_more envelope](jsonflux.md#fetch_more-envelope-g015-t8-1219). `None` only on legacy code paths that build a `ResultHandle` directly without going through the reducer (test fixtures); production reduce paths always populate it.
 
-`JsonFluxReducer` populates `handle` for large set-shaped responses (G0.6.1, #750) and spills the full row set to the Valkey-backed `ResultHandleStore`; the `result_query` MCP meta-tool reads windows back from it (G0.20-T7 #1507). See [`jsonflux.md` § Read-back](jsonflux.md#read-back-the-resulthandlestore-g020-t7-1507).
+`JsonFluxReducer` populates `handle` for large set-shaped responses (G0.6.1, #750) and spills the full row set to the Valkey-backed `ResultHandleStore`; the `result_query` MCP meta-tool **and** the REST route `POST /api/v1/operations/result-query` read windows back from it through the shared `read_result_window` core (G0.20-T7 #1507; REST parity #3179). See [`jsonflux.md` § Read-back](jsonflux.md#read-back-the-resulthandlestore-g020-t7-1507).
 
 ## The three operation meta-tools
 
@@ -448,6 +448,7 @@ Per [CLAUDE.md](../../CLAUDE.md) postulate 5, the agent never sees per-op MCP to
 - `GET /api/v1/operations/groups?connector_id=...` — `list_operation_groups`
 - `GET /api/v1/operations/search?connector_id=...&query=...&group=...&limit=...` — `search_operations`
 - `POST /api/v1/operations/call` (body: `CallOperationBody`) — `call_operation`
+- `POST /api/v1/operations/result-query` (body: `ResultQueryBody`) — the REST twin of the MCP `result_query` tool; both wrap the shared `read_result_window` core so a REST consumer that received a reduced handle off `/call` can page it back (#3179)
 - `GET /api/v1/operations/{descriptor_id}` — inspect a single descriptor (gated on `tenant_admin` because `llm_instructions` is the per-op agent prompt and reading it amounts to a prompt leak)
 
 The CLI `meho operation ...` verbs mirror the same surface. Wire identity across MCP + REST + CLI is the contract every CLI verb relies on.

--- a/docs/codebase/result-spill.md
+++ b/docs/codebase/result-spill.md
@@ -21,9 +21,11 @@ threshold (>50 rows or >4 KB by default), the caller gets back:
   `fetch_more` envelope.
 
 The **full** normalized row list is spilled to the Valkey-backed
-`ResultHandleStore` keyed by `(tenant_id, handle_id)`; the
-`result_query` MCP meta-tool pages it back. Whether that spill happened
-is reported on `handle.fetch_more.drill_in`:
+`ResultHandleStore` keyed by `(tenant_id, handle_id)`; the `result_query`
+read surface pages it back over **both** transports — the MCP meta-tool
+and the REST route `POST /api/v1/operations/result-query`, which share the
+`read_result_window` core (#3179). Whether that spill happened is reported
+on `handle.fetch_more.drill_in`:
 
 | State | `available` | `reason` | What the agent can do |
 |---|---|---|---|
@@ -42,7 +44,9 @@ branch to `available=false`.
 | `JsonFluxReducer._spill` / `_SpillOutcome` | `backend/src/meho_backplane/operations/jsonflux_reducer.py` | Persists the materialized rows; reports `stored_rows` **or** a machine-readable `skip_reason` |
 | `FetchMoreDrillIn.reason` / `DrillInUnavailableReason` | `backend/src/meho_backplane/connectors/schemas.py` | The two-valued no-spill cause on the wire (#1629) |
 | `ResultHandleStore.spill` / `fetch_window` | `backend/src/meho_backplane/connectors/result_handle_store.py` | Fail-open Valkey persistence + operator/tenant-scoped read-back |
-| `result_query` | `backend/src/meho_backplane/mcp/tools/result_query.py` | MCP read surface; misses surface as recoverable `handle_not_found` |
+| `read_result_window` / `ResultHandleNotFoundError` | `backend/src/meho_backplane/operations/result_query.py` | Transport-neutral windowed-read core both surfaces wrap (#3179); misses raise the recoverable not-found error |
+| `result_query` (MCP) | `backend/src/meho_backplane/mcp/tools/result_query.py` | MCP read surface; misses surface as recoverable `handle_not_found` (`-32602`) |
+| `POST /api/v1/operations/result-query` | `backend/src/meho_backplane/api/v1/operations.py` | REST read surface; misses surface as a `404` with `reason=handle_not_found` (#3179) |
 | `_reduce_or_error` | `backend/src/meho_backplane/operations/dispatcher.py` | Builds `reducer_context` (`tenant_id`, `operator_sub`, `op_id`, hints) from the authenticated `Operator` |
 
 ## Control flow (dispatch path)


### PR DESCRIPTION
## What & why

`POST /api/v1/operations/call` can **mint** a reduced JSONFlux result handle for any set-shaped response over the 50-row / 4 KB thresholds, but the read-back was **MCP-only**. A REST consumer that received a handle was at a dead end — a real automation add-on had to fail closed on a 181-row inventory and document "REST has no result_query drill-in" as a permanent constraint, with a human doing the drill-in over MCP by hand. Separately, the CLI already printed a `meho operation result-query` hint (`cli/internal/cmd/vcf-logs/query.go`) for a verb that **did not exist** — violating the narrow-waist postulate that every meta-tool has a CLI verb.

This ships REST + CLI parity for the read-back, with zero new capability beyond what the MCP tool already does (offset/limit windowing — filtering/projection stays out of scope per the issue's non-goal).

## Changes

- **Shared core.** Extracted the windowed spill read into a transport-neutral `operations/result_query.py::read_result_window` (plus `MAX_LIMIT` and the recoverable `ResultHandleNotFoundError`). Both surfaces wrap it, so they cannot drift on tenant/principal scoping or not-found semantics. The MCP `result_query` tool now delegates to it instead of owning the store call.
- **REST route.** `POST /api/v1/operations/result-query` (body: `handle_id` UUID required, `offset` >= 0 default 0, `limit` 1..500 default 50). Tenant + principal come from the JWT, never the body. A handle that is unknown / expired / another operator's is a `404` with a structured `detail` carrying `reason=handle_not_found` — the REST twin of the MCP tool's recoverable `-32602`. Malformed UUID / out-of-range offset/limit / unknown body field are `422` at the Pydantic layer.
- **CLI verb.** `meho operation result-query <handle_id> [--offset N] [--limit N] [--json] [--backplane URL]` on the new route, making the vcf-logs hint truthful.
- **Self-documenting envelope.** The reduced envelope's `fetch_more.drill_in.rationale` now names the REST route alongside the MCP tool, so a REST-only consumer learns how to page without a discovery dance. (No new schema field — the route lives in the prose, matching the issue's scope.)
- **Codegen + docs.** Regenerated the CLI OpenAPI snapshot (`cli/api/openapi.json`) and typed Go client (`cli/internal/api/client.gen.go`) for the new route; refreshed `docs/architecture/jsonflux.md`, `docs/architecture/operations-substrate.md`, and `docs/codebase/result-spill.md`.

## Tests

- **Backend REST** (`test_api_v1_operations.py`): happy-path window beyond the inline sample + tail, offset/limit defaults, typed `404` not-found, cross-operator miss (principal scoping), cross-tenant miss (tenant scoping), invalid-UUID / negative-offset / zero-limit / over-max-limit / extra-field `422`s, and the unauthenticated `401`. Mirrors the MCP tool's suite via the same fake store keyed on `(tenant, sub, handle)`.
- **Backend MCP** (`test_mcp_tool_result_query.py`): unchanged behaviour, monkeypatch retargeted to the shared core (the store getter moved).
- **Reducer** (`test_operations_jsonflux_reducer.py`): the available-branch rationale now asserts the REST route is named.
- **CLI** (`client_test.go` / `operation_test.go`): typed-body round-trip, 401-refresh dance, `404` handle-not-found classification (structured detail preserved), transport-error propagation, invalid-UUID client-side short-circuit, full run-path render, and the window/empty/truncated render cases.

## Verification

- Backend: `ruff check` + `ruff format --check` clean, `mypy --strict` clean, affected pytest lanes green (incl. `test_maturity_surface_drift` — the new route inherits the already-mapped `operations` tag).
- CLI: `gofmt` clean, `go vet ./...` clean, `go test ./...` green; OpenAPI snapshot regen is idempotent (no drift vs the "CLI API snapshot freshness" CI gate).

## Changelog

Added under `[Unreleased]` → **Added — REST + CLI parity for `result_query`** (#3179).

Closes #3179

🤖 Generated with [Claude Code](https://claude.com/claude-code)