### PR TITLE
fix(connectors): scope datastore.usage VM placement per datastore off vim (#2975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975)
+### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975 / PR #3184)
 
 - `vmware.composite.datastore.usage` enriched every datastore row with the
   **whole-inventory** VM list — identical `vm_count` (the cluster-wide total)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975)
+
+- `vmware.composite.datastore.usage` enriched every datastore row with the
+  **whole-inventory** VM list — identical `vm_count` (the cluster-wide total)
+  and identical `vm_names` on all rows — because it scoped placement with a
+  per-datastore `GET:/vcenter/vm?datastores=<ds>` filter that some vCenter
+  builds silently ignore, returning the unfiltered list on every call. The
+  classic "which VMs live on this filling-up datastore?" triage question got
+  the same wrong answer on every row. The composite now resolves placement
+  authoritatively: one unfiltered `GET:/vcenter/vm` (moid + name) plus one
+  `RetrievePropertiesEx` over the vim `VirtualMachine.datastore` property,
+  joined client-side into per-datastore `vm_count`/`vm_names`. Each row carries
+  only the VMs vim reports on that datastore regardless of whether any REST
+  filter is honoured (a VM whose disks span two datastores appears under both),
+  and the two batched reads replace N per-datastore calls. The #3049
+  identical-sets guard stays as belt-and-braces; authoritative placement makes
+  its firing condition impossible in practice.
+
 ### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179 / PR #3181)
 
 - `POST /api/v1/operations/call` can *mint* a reduced result handle for any

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -204,6 +204,15 @@ _PROP_DRS_CONFIG = "configurationEx.drsConfig"
 # vm.migrate DRS lookup already relies on.
 _PROP_DRS_RECOMMENDATION = "drsRecommendation"
 
+# vim constants for the datastore-usage VM-placement read. The
+# ``VirtualMachine.datastore`` property is the vim-authoritative set of
+# datastores a VM's files sit on (config + disks + snapshots + swap,
+# unioned) -- the placement source the datastore-usage composite scopes
+# each row from, instead of trusting a server-side ``GET:/vcenter/vm``
+# datastore filter that some builds silently ignore (#2975).
+_VIRTUAL_MACHINE_MO_TYPE = "VirtualMachine"
+_PROP_VM_DATASTORE = "datastore"
+
 # Per-composite sub-op-id tuples. Each tuple lists the raw-REST /
 # vi-json sub-ops the composite issues directly on the connector
 # session. Pre-#2253 these fed the L2 pre-flight check that guarded a
@@ -229,6 +238,7 @@ _SUB_OPS_DATASTORE_USAGE: tuple[str, ...] = (
     _OP_LIST_DATASTORES,
     _OP_GET_DATASTORE,
     _OP_LIST_VMS,
+    _OP_RETRIEVE_PROPERTIES,
 )
 _SUB_OPS_NETWORK_PORTGROUP_AUDIT: tuple[str, ...] = (
     _OP_LIST_NETWORK,
@@ -345,6 +355,37 @@ def _extract_object_props(retrieve_result: Any) -> dict[str, Any]:
             if isinstance(name, str):
                 props[name] = unwrap_vim_value(entry.get("val"))
     return props
+
+
+def _extract_props_by_moid(retrieve_result: Any) -> dict[str, dict[str, Any]]:
+    """Flatten a multi-object ``RetrievePropertiesEx`` result to ``{moid: {name: val}}``.
+
+    Unlike :func:`_extract_object_props` (which merges every object's
+    ``propSet`` into one flat dict), this keeps per-object identity by
+    keying on the object's MoRef ``value`` -- what a batched read over
+    many objects of the same type (every VM's ``datastore`` property)
+    needs. vim omits unset properties from ``propSet``, so an object with
+    no matching property simply carries an empty inner dict.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    by_moid: dict[str, dict[str, Any]] = {}
+    if not isinstance(objects, list):
+        return by_moid
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        ref = obj.get("obj")
+        moid = ref.get("value") if isinstance(ref, dict) else None
+        if not isinstance(moid, str):
+            continue
+        props: dict[str, Any] = {}
+        for entry in obj.get("propSet", []) or []:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if isinstance(name, str):
+                props[name] = unwrap_vim_value(entry.get("val"))
+        by_moid[moid] = props
+    return by_moid
 
 
 async def cluster_drs_recommendations_composite(
@@ -547,10 +588,75 @@ async def performance_summary_composite(
     }
 
 
-# Pre-existing >100-line handler from G3.1-T5 #508; G0.27 #1908 made the
-# per-datastore VM-placement leg best-effort. Refactor (e.g. extracting
-# the per-datastore row builder) is out of scope here.
-# code-quality-allow: pre-existing G3.1-T5 #508 handler; #1908 best-effort enrichment only
+async def _read_vm_placement(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+) -> tuple[dict[str, list[str]] | None, str | None]:
+    """Resolve authoritative ``{datastore_moid: [vm_name, ...]}`` placement.
+
+    #2975: the placement source is the vim ``VirtualMachine.datastore``
+    property, **not** a server-side ``GET:/vcenter/vm`` datastore filter.
+    Some vCenter builds silently ignore that filter and return the whole
+    inventory on every row -- the reported symptom -- so the composite no
+    longer trusts it. Two batched reads, joined client-side:
+
+    1. ``GET:/vcenter/vm`` (global, unfiltered) -- every VM's moid + name.
+    2. one ``RetrievePropertiesEx`` over every VM moid reading
+       ``datastore`` (the union of datastores the VM's files sit on). A VM
+       with disks spanning two datastores therefore appears under both --
+       genuine placement, unlike the ignored-filter global list.
+
+    VM-listing order is preserved so the per-datastore ``vm_names`` sample
+    is deterministic. Returns ``({}, None)`` when there are no VMs. The
+    read is **best-effort** (#1908): any transport error returns
+    ``(None, note)`` so the caller nulls enrichment on every row while
+    keeping the capacity data the storage-usage use case needs.
+    """
+    try:
+        vms_raw = await _read_sub_op(connector, target, operator, _OP_LIST_VMS)
+        vm_entries = _unwrap_value(vms_raw)
+        if not isinstance(vm_entries, list):
+            vm_entries = []
+        names_by_moid: dict[str, str] = {}
+        for vm in vm_entries:
+            if not isinstance(vm, dict):
+                continue
+            moid = vm.get("vm")
+            name = vm.get("name")
+            if isinstance(moid, str) and isinstance(name, str):
+                names_by_moid[moid] = name
+        if not names_by_moid:
+            return {}, None
+        retrieve = await _read_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_RETRIEVE_PROPERTIES,
+            path_params={"moId": _PROPERTY_COLLECTOR_MOID},
+            body=retrieve_properties_body(
+                _VIRTUAL_MACHINE_MO_TYPE, list(names_by_moid), [_PROP_VM_DATASTORE]
+            ),
+        )
+    except httpx.HTTPError as exc:
+        return None, (
+            f"vm-placement enrichment skipped: authoritative placement read "
+            f"failed with {type(exc).__name__}: {exc}"
+        )
+
+    props_by_vm = _extract_props_by_moid(retrieve)
+    placement: dict[str, list[str]] = {}
+    for moid, name in names_by_moid.items():
+        ds_refs = props_by_vm.get(moid, {}).get(_PROP_VM_DATASTORE)
+        if not isinstance(ds_refs, list):
+            continue
+        for ref in ds_refs:
+            ds_moid = ref.get("value") if isinstance(ref, dict) else None
+            if isinstance(ds_moid, str):
+                placement.setdefault(ds_moid, []).append(name)
+    return placement, None
+
+
 async def datastore_usage_composite(
     *,
     operator: Operator,
@@ -562,36 +668,34 @@ async def datastore_usage_composite(
 
     Op-id: ``vmware.composite.datastore.usage``.
 
-    Sub-ops read directly on the connector session (per-datastore, sequential):
+    Sub-ops read directly on the connector session:
 
     1. ``GET:/vcenter/datastore`` -- list every datastore (optionally
        narrowed via ``filter.names``).
-    2. For each datastore:
-       a. ``GET:/vcenter/datastore/{datastore}`` -- detailed capacity /
-          free / type / accessible flag (load-bearing: a failure here
-          sinks the composite).
-       b. ``GET:/vcenter/vm`` filtered by datastore -- VMs whose
-          working directory sits on this datastore. Drives the
-          ``vm_count`` + ``vm_names`` aggregation. The datastore filter
-          is authored as ``filter.datastores`` and keyed off the mount
-          flavor at the sub-call seam (bare ``datastores`` on modern
-          ``/api``, ``filter.datastores`` on legacy ``/rest``); before
-          #2298 it was sent prefixed on every mount, so real vCenter 8.x
-          400'd this leg on every row. It is also **best-effort**
-          (#1908): the capacity/free/type read -- the data the "which
-          datastores are filling up?" use case needs -- is already done
-          by the time it runs, so any residual VM-lookup error still
-          returns the row with ``vm_count`` / ``vm_names`` set to
-          ``null`` and an ``enrichment_note`` recording why, rather than
-          failing the whole composite.
+    2. For each datastore, ``GET:/vcenter/datastore/{datastore}`` --
+       detailed capacity / free / type / accessible flag (load-bearing:
+       a failure here sinks the composite).
+    3. VM-placement enrichment, resolved **once** for the whole result
+       (see :func:`_read_vm_placement`): ``GET:/vcenter/vm`` (global,
+       unfiltered) for every VM's moid + name, then one
+       ``RetrievePropertiesEx`` over every VM reading the vim-authoritative
+       ``VirtualMachine.datastore`` property. The two are joined
+       client-side into per-datastore ``vm_count`` + ``vm_names``.
 
-    Sequential dispatch is intentional: each datastore's detail call
-    inherits the prior call's authentication state, and the audit
-    chain reads cleanly as ``listing -> detail(ds1) -> vms(ds1) ->
-    detail(ds2) -> vms(ds2) -> ...``. A future v0.2.next optimisation
-    could ``asyncio.gather`` the per-datastore detail + VM calls
-    pairwise, but the simpler shape is easier to audit-trace through
-    operator UIs.
+    Why vim placement and not a ``GET:/vcenter/vm`` datastore filter
+    (#2975): a server-side per-datastore filter is silently ignored by
+    some builds, which returns the whole-inventory VM list on every row --
+    the reported bug. ``VirtualMachine.datastore`` is authoritative
+    (config + disks + snapshots + swap, unioned), so each row carries only
+    the VMs vim reports on that datastore regardless of whether any REST
+    filter is honoured. A VM whose disks span two datastores legitimately
+    appears under both.
+
+    The enrichment is **best-effort** (#1908): the capacity/free/type read
+    already satisfies the "which datastores are filling up?" use case, so a
+    transport error on the batched placement read nulls ``vm_count`` /
+    ``vm_names`` on every row and records an ``enrichment_note``, rather
+    than sinking the whole composite.
 
     Returns
     -------
@@ -600,17 +704,14 @@ async def datastore_usage_composite(
         "capacity": ..., "free_space": ..., "vm_count": ...,
         "vm_names": [...]}, ...]}``. The ``capacity`` / ``free_space``
         fields may be ``None`` if the upstream payload omits them
-        (e.g. a partially-mounted datastore). When the per-datastore
-        VM-placement enrichment errors, ``vm_count`` and ``vm_names``
-        are ``None`` and the row carries an ``enrichment_note`` string
+        (e.g. a partially-mounted datastore). When the batched
+        VM-placement read errors, ``vm_count`` and ``vm_names`` are
+        ``None`` and every row carries an ``enrichment_note`` string
         describing the skipped enrichment; on success the row has no
-        ``enrichment_note`` key. The same null + ``enrichment_note``
-        treatment is applied to every enriched row when the per-row VM
-        sets come back identical across all datastores -- the symptom of
-        an upstream per-datastore filter that was silently ignored and
-        returned the whole-inventory VM list on each row (#2975) -- so a
-        populated-but-wrong global list is never emitted as per-datastore
-        placement.
+        ``enrichment_note`` key. As belt-and-braces (#3049), the same null
+        + ``enrichment_note`` treatment is applied when the per-row VM sets
+        somehow come back identical and non-empty across every datastore --
+        a shape authoritative placement cannot produce in practice.
 
         ``vm_count`` is the exact VM total; ``vm_names`` is bounded to a
         sample of at most
@@ -635,10 +736,9 @@ async def datastore_usage_composite(
             f"got {type(entries).__name__}"
         )
 
-    aggregated: list[dict[str, Any]] = []
-    # Each successfully-enriched row paired with the full (pre-cap) set of VM
-    # names on it, for the cross-row identical-sets guard after the loop (#2975).
-    enriched: list[tuple[dict[str, Any], frozenset[str]]] = []
+    # Each datastore row paired with its moid, so the batched VM-placement
+    # read below can scope names onto it after the detail loop.
+    rows: list[tuple[dict[str, Any], str]] = []
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -674,55 +774,46 @@ async def datastore_usage_composite(
             "capacity": capacity,
             "free_space": free_space,
         }
+        rows.append((row, ds_id))
 
-        # VM-placement enrichment is best-effort (#1908). The
-        # capacity/free/type read above already satisfies the
-        # storage-usage use case, so any residual failure on the optional
-        # VM lookup nulls vm_count/vm_names and records why, rather than
-        # propagating the transport error and sinking every datastore row.
-        # The datastore filter is keyed off the mount flavor in
-        # ``_read_sub_op`` (#2298); the pre-#2298 unconditional
-        # ``filter.datastores`` was itself what 400'd this leg on modern
-        # ``/api`` vCenter, not an environmental vCenter quirk.
-        try:
-            vms_raw = await _read_sub_op(
-                connector, target, operator, _OP_LIST_VMS, query={"filter.datastores": [ds_id]}
-            )
-        except httpx.HTTPError as exc:
+    aggregated = [row for row, _ in rows]
+    if not rows:
+        return {"datastores": aggregated}
+
+    # VM-placement enrichment (#2975): scope each row to only the VMs vim
+    # reports on that datastore, resolved once from the authoritative
+    # ``VirtualMachine.datastore`` property rather than a per-datastore
+    # server-side filter some builds silently ignore. Best-effort (#1908):
+    # a transport error nulls enrichment on every row but keeps capacity.
+    placement, note = await _read_vm_placement(connector, target, operator)
+    if placement is None:
+        for row, _ in rows:
             row["vm_count"] = None
             row["vm_names"] = None
-            row["enrichment_note"] = (
-                f"vm-placement enrichment skipped: sub-op {_OP_LIST_VMS!r} "
-                f"failed with {type(exc).__name__}: {exc}"
-            )
-        else:
-            vm_entries = _unwrap_value(vms_raw)
-            if not isinstance(vm_entries, list):
-                vm_entries = []
-            vm_names = [
-                v["name"]
-                for v in vm_entries
-                if isinstance(v, dict) and isinstance(v.get("name"), str)
-            ]
-            # vm_count is the exact total, taken before the cap; vm_names is
-            # bounded to a sample so a one-name filter_names result stays
-            # inline under the dispatcher's 4096-byte JSONFlux threshold and
-            # a per-datastore Sensor can still select free_space (#2758).
-            # vm_count > len(vm_names) is the truncation signal.
-            row["vm_count"] = len(vm_names)
-            row["vm_names"] = vm_names[:DATASTORE_USAGE_MAX_VM_NAMES]
-            enriched.append((row, frozenset(vm_names)))
-        aggregated.append(row)
+            row["enrichment_note"] = note
+        return {"datastores": aggregated}
 
-    # Cross-row identical-sets guard (#2975). A VM's working directory lives on
-    # exactly one datastore, so genuinely-distinct datastores never share a
-    # non-empty VM set. An identical non-empty set across *every* enriched row
-    # is therefore not real placement data -- it is the global-list symptom of
-    # an upstream per-datastore filter that was silently ignored, returning the
-    # whole-inventory VM list on every row. Emitting that populated-but-wrong
-    # answer is worse than emitting none, so treat it as failed enrichment:
-    # null vm_count/vm_names and record why, the same best-effort contract used
-    # for a transport error above (#1908). The all-empty case (every datastore
+    # Each enriched row paired with its full (pre-cap) VM-name set, for the
+    # cross-row identical-sets guard below (#3049).
+    enriched: list[tuple[dict[str, Any], frozenset[str]]] = []
+    for row, ds_id in rows:
+        vm_names = placement.get(ds_id, [])
+        # vm_count is the exact total, taken before the cap; vm_names is
+        # bounded to a sample so a large result stays inline under the
+        # dispatcher's 4096-byte JSONFlux threshold and a per-datastore
+        # Sensor can still select free_space (#2758). vm_count >
+        # len(vm_names) is the truncation signal.
+        row["vm_count"] = len(vm_names)
+        row["vm_names"] = vm_names[:DATASTORE_USAGE_MAX_VM_NAMES]
+        enriched.append((row, frozenset(vm_names)))
+
+    # Cross-row identical-sets guard (#3049), retained as belt-and-braces.
+    # With authoritative ``VirtualMachine.datastore`` placement an identical
+    # non-empty VM set across *every* datastore cannot arise in practice (it
+    # would require every VM to sit on every datastore), so the guard's
+    # firing condition is effectively impossible now -- but it stays to
+    # refuse any populated-but-identical shape rather than emit it as
+    # per-datastore placement. The all-empty case (every datastore
     # legitimately has zero VMs) is excluded by the non-empty check.
     if len(enriched) > 1:
         vm_sets = [vm_set for _, vm_set in enriched]
@@ -730,10 +821,9 @@ async def datastore_usage_composite(
         if shared and all(vm_set == shared for vm_set in vm_sets[1:]):
             note = (
                 "vm-placement enrichment discarded: the VM set was identical "
-                f"across all {len(enriched)} enriched datastores, so the "
-                "upstream per-datastore filter was not applied (the "
-                "whole-inventory VM list was returned on every row); "
-                "vm_count/vm_names are unreliable and have been nulled."
+                f"across all {len(enriched)} enriched datastores, which is not "
+                "real per-datastore placement; vm_count/vm_names are "
+                "unreliable and have been nulled."
             )
             for row, _ in enriched:
                 row["vm_count"] = None

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -391,64 +391,79 @@ _DATASTORE_DETAIL: dict[str, dict[str, Any]] = {
     "datastore-22": {"capacity": 5000, "free_space": 2500, "type": "NFS"},
 }
 
-#: Per-datastore ``GET /vcenter/vm`` placement bodies. Distinct per datastore
-#: (a VM's working directory lives on exactly one datastore), so the composite's
-#: cross-row identical-sets guard (#2975) sees real placement rather than the
-#: global-list symptom it discards -- a single VM shared across every datastore
-#: would trip that guard.
-_DATASTORE_VMS: dict[str, list[dict[str, str]]] = {
-    "datastore-11": [{"name": "vm-x"}],
-    "datastore-22": [{"name": "vm-y"}],
+#: Global ``GET /vcenter/vm`` inventory (moid + name). The composite reads this
+#: unfiltered, then scopes each datastore row off vim placement (#2975) rather
+#: than a server-side datastore filter some builds silently ignore.
+_DATASTORE_GLOBAL_VMS: list[dict[str, str]] = [
+    {"vm": "vm-11", "name": "vm-x"},
+    {"vm": "vm-22", "name": "vm-y"},
+]
+
+#: Authoritative ``VirtualMachine.datastore`` placement (vim). One datastore per
+#: VM here, so the two rows get disjoint lists -- real placement, not the
+#: global-list symptom the belt-and-braces guard (#3049) discards.
+_DATASTORE_VM_PLACEMENT: dict[str, list[str]] = {
+    "vm-11": ["datastore-11"],
+    "vm-22": ["datastore-22"],
 }
 
 
-def _register_datastore_composite_routes(
-    mock: respx.MockRouter, *, mount: str, reject_prefixed_filter: bool = False
-) -> None:
+def _placement_retrieve_result() -> dict[str, Any]:
+    """A ``RetrieveResult`` carrying each VM's boxed ``datastore`` MoRef array.
+
+    Array-valued props arrive boxed on live VI-JSON 8.0.3 (#3106); the body
+    mirrors that so the composite's ``unwrap_vim_value`` path is exercised.
+    """
+    return {
+        "objects": [
+            {
+                "obj": {"type": "VirtualMachine", "value": vm},
+                "propSet": [
+                    {
+                        "name": "datastore",
+                        "val": {
+                            "_typeName": "ArrayOfManagedObjectReference",
+                            "_value": [
+                                {
+                                    "_typeName": "ManagedObjectReference",
+                                    "type": "Datastore",
+                                    "value": ds,
+                                }
+                                for ds in dses
+                            ],
+                        },
+                    }
+                ],
+            }
+            for vm, dses in _DATASTORE_VM_PLACEMENT.items()
+        ]
+    }
+
+
+def _register_datastore_composite_routes(mock: respx.MockRouter, *, mount: str) -> None:
     """Register the datastore-usage composite's sub-op surface under *mount*.
 
     The composite issues, directly on the session (no ingested descriptor,
-    no dispatch_child): the datastore listing, one per-datastore detail
-    GET, and one per-datastore VM-placement GET filtered by datastore.
-    All are mounted onto ``mount`` (``/api`` modern or ``/rest`` legacy) by
-    ``mount_op_path``.
-
-    When *reject_prefixed_filter* is set (modern ``/api``), the VM route
-    mimics real vCenter 8.x: it returns HTTP 400 for the legacy
-    ``filter.``-prefixed query and 200 only for the bare param name. This
-    is the regression guard for #2298 — before the fix the composite sent
-    ``filter.datastores`` on every mount and 400'd this leg on real
-    vCenter, which the path-only respx route previously masked.
+    no dispatch_child): the datastore listing, one per-datastore detail GET,
+    one **global unfiltered** ``GET /vcenter/vm`` listing, and one
+    ``RetrievePropertiesEx`` reading each VM's authoritative
+    ``VirtualMachine.datastore`` placement (#2975). The REST legs mount onto
+    ``mount`` (``/api`` modern or ``/rest`` legacy) via ``mount_op_path``;
+    the vmomi RetrievePropertiesEx rides the VI-JSON seam
+    (``/sdk/vim25/{release}`` modern, ``/rest`` legacy; #2466).
     """
     mock.get(f"{mount}/vcenter/datastore").respond(200, json=_DATASTORE_LISTING)
     for ds_id, detail in _DATASTORE_DETAIL.items():
         mock.get(f"{mount}/vcenter/datastore/{ds_id}").respond(200, json=detail)
-
-    def _vms_for(request: httpx.Request) -> list[dict[str, str]]:
-        # Serve this datastore's own VMs, keyed off the placement filter the
-        # composite sends (bare ``datastores`` on /api, ``filter.datastores``
-        # on legacy /rest). Distinct per-datastore sets keep the cross-row
-        # identical-sets guard (#2975) from tripping on the fixture.
-        params = request.url.params
-        ds_id = params.get("datastores") or params.get("filter.datastores") or ""
-        return _DATASTORE_VMS.get(ds_id, [])
-
-    if reject_prefixed_filter:
-
-        def _vm_route(request: httpx.Request) -> httpx.Response:
-            # Modern /api addresses the FilterSpec field by its bare name
-            # and 400s the legacy ``filter.``-prefixed form.
-            if "filter." in request.url.query.decode():
-                return httpx.Response(400, json={"messages": ["unknown query parameter"]})
-            return httpx.Response(200, json=_vms_for(request))
-
-        mock.get(f"{mount}/vcenter/vm").mock(side_effect=_vm_route)
-    else:
-
-        def _vm_route_legacy(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=_vms_for(request))
-
-        mock.get(f"{mount}/vcenter/vm").mock(side_effect=_vm_route_legacy)
+    # Global, unfiltered VM listing -- scoping is client-side off vim placement.
+    mock.get(f"{mount}/vcenter/vm").respond(200, json=_DATASTORE_GLOBAL_VMS)
+    # Authoritative placement read (vmomi RetrievePropertiesEx).
+    vmomi_path = (
+        "/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        if mount == "/api"
+        else "/rest/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    )
+    mock.post(vmomi_path).respond(200, json=_placement_retrieve_result())
 
 
 @pytest.mark.asyncio
@@ -478,7 +493,10 @@ async def test_datastore_usage_composite_over_modern_mount(
         assert_all_mocked=False,
     ) as mock:
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
-        _register_datastore_composite_routes(mock, mount="/api", reject_prefixed_filter=True)
+        # The vmomi placement read derives its VI-JSON {release} from
+        # about.version (#2466 / #2975).
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
+        _register_datastore_composite_routes(mock, mount="/api")
         mock.delete("/api/session").respond(204)
         try:
             out = await datastore_usage_composite(
@@ -494,12 +512,14 @@ async def test_datastore_usage_composite_over_modern_mount(
     assert [r["id"] for r in rows] == ["datastore-11", "datastore-22"]
     assert rows[0]["capacity"] == 1000
     assert rows[0]["free_space"] == 400
-    # VM-placement enrichment populated on every row: the bare-param query
-    # the fix (#2298) sends is accepted (no 400 -> no enrichment_note skip).
+    # VM-placement enrichment scoped per datastore off authoritative vim
+    # placement (#2975): each row carries only its own VMs, disjoint across
+    # rows, so no enrichment_note skip and the identical-sets guard is silent.
     assert rows[0]["vm_count"] == 1
     assert rows[0]["vm_names"] == ["vm-x"]
     assert "enrichment_note" not in rows[0]
     assert rows[1]["vm_count"] == 1
+    assert rows[1]["vm_names"] == ["vm-y"]
     assert "enrichment_note" not in rows[1]
 
 
@@ -548,6 +568,11 @@ async def test_datastore_usage_composite_over_legacy_mount_routes_to_rest(
     rows = out["datastores"]
     assert [r["id"] for r in rows] == ["datastore-11", "datastore-22"]
     assert rows[1]["capacity"] == 5000
+    # The vmomi placement read routes through the legacy /rest mount too, so
+    # each row is scoped per datastore off vim placement (#2466 / #2975).
+    assert rows[0]["vm_names"] == ["vm-x"]
+    assert rows[1]["vm_names"] == ["vm-y"]
+    assert all("enrichment_note" not in r for r in rows)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -49,6 +49,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
+from meho_backplane.connectors.vmware_rest.vim_body import vim_moref
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -206,6 +207,38 @@ def _retrieve_result(prop_sets: dict[str, Any]) -> dict[str, Any]:
                 "propSet": [{"name": name, "val": val} for name, val in prop_sets.items()],
             }
         ]
+    }
+
+
+def _retrieve_result_multi(
+    objects: dict[tuple[str, str], dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a multi-object ``RetrievePropertiesEx`` result payload.
+
+    Keyed by ``(mo_type, moid)`` so a single read can carry per-object
+    property sets -- the shape the datastore-usage placement read
+    (``VirtualMachine.datastore`` across every VM) consumes.
+    """
+    return {
+        "objects": [
+            {
+                "obj": {"type": mo_type, "value": moid},
+                "propSet": [{"name": name, "val": val} for name, val in props.items()],
+            }
+            for (mo_type, moid), props in objects.items()
+        ]
+    }
+
+
+def _vm_placement(datastore_moids: list[str]) -> dict[str, Any]:
+    """A boxed ``VirtualMachine.datastore`` prop value: an array of Datastore MoRefs.
+
+    Mirrors the live VI-JSON 8.0.3 boxing (#3106): array-valued props
+    arrive as ``{"_typeName": "ArrayOf...", "_value": [...]}``.
+    """
+    return {
+        "_typeName": "ArrayOfManagedObjectReference",
+        "_value": [vim_moref("Datastore", moid) for moid in datastore_moids],
     }
 
 
@@ -581,26 +614,34 @@ async def test_performance_summary_passes_through_interval_and_custom_perf_mgr()
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() -> None:
-    """Listing + per-DS detail + per-DS VM-listing; aggregated payload matches spec."""
+async def test_datastore_usage_aggregates_capacity_and_authoritative_placement() -> None:
+    """Listing + per-DS detail + one batched authoritative placement read;
+    aggregated payload matches spec (#2975)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
         {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
     ]
-    detail_by_id = {
-        "datastore-1": {"capacity": 100, "free_space": 40, "type": "VMFS"},
-        "datastore-2": {"capacity": 500, "free_space": 250, "type": "NFS"},
-    }
-    vms_by_ds: dict[str, list[dict[str, Any]]] = {
-        "datastore-1": [{"name": "vm-a"}, {"name": "vm-b"}],
-        "datastore-2": [{"name": "vm-c"}],
-    }
-
-    sequence: list[Any] = [listing]
-    for entry in listing:
-        sequence.append(detail_by_id[entry["datastore"]])
-        sequence.append(vms_by_ds[entry["datastore"]])
-    conn = _RecordingConnector(sequence)
+    global_vms = [
+        {"vm": "vm-1", "name": "vm-a"},
+        {"vm": "vm-2", "name": "vm-b"},
+        {"vm": "vm-3", "name": "vm-c"},
+    ]
+    placement = _retrieve_result_multi(
+        {
+            ("VirtualMachine", "vm-1"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-2"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-3"): {"datastore": _vm_placement(["datastore-2"])},
+        }
+    )
+    conn = _RecordingConnector(
+        [
+            listing,
+            {"capacity": 100, "free_space": 40, "type": "VMFS"},
+            {"capacity": 500, "free_space": 250, "type": "NFS"},
+            global_vms,
+            placement,
+        ]
+    )
 
     out = await datastore_usage_composite(
         operator=_make_operator(),
@@ -609,18 +650,21 @@ async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() ->
         connector=conn,  # type: ignore[arg-type]
     )
 
-    # 1 listing + 2 datastores * 2 sub-ops each = 5 calls total.
+    # 1 listing + 2 per-DS detail + 1 global VM listing + 1 placement read.
     assert len(conn.calls) == 5
     assert conn.calls[0]["method"] == "GET"
     assert conn.calls[0]["path"] == "/api/vcenter/datastore"
     # No filter -> no query string.
     assert conn.calls[0]["query"] is None
-    # Per-DS detail call embeds the datastore moid in the mounted path.
+    # Per-DS detail calls embed the datastore moid in the mounted path;
+    # they run consecutively before the batched placement read.
     assert conn.calls[1]["path"] == "/api/vcenter/datastore/datastore-1"
-    # Per-DS VM call filters by datastore; on the modern /api mount the
-    # param is sent bare (#2298), not ``filter.datastores``.
-    assert conn.calls[2]["path"] == "/api/vcenter/vm"
-    assert conn.calls[2]["query"] == {"datastores": ["datastore-1"]}
+    assert conn.calls[2]["path"] == "/api/vcenter/datastore/datastore-2"
+    # The VM listing is global -- no per-datastore scoping query is sent
+    # upstream; scoping is done client-side off vim placement (#2975).
+    assert conn.calls[3]["path"] == "/api/vcenter/vm"
+    assert conn.calls[3]["query"] is None
+    assert conn.calls[4]["path"] == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
     # Final aggregated shape.
     assert out == {
         "datastores": [
@@ -722,10 +766,11 @@ async def test_datastore_usage_filter_names_passes_through_to_listing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_filter_params_keep_prefix_on_legacy_mount() -> None:
-    """On the legacy/vcsim ``/rest`` mount, filter params keep the ``filter.`` prefix (#2298)."""
+async def test_datastore_usage_listing_filter_keeps_prefix_on_legacy_mount() -> None:
+    """On the legacy/vcsim ``/rest`` mount the listing filter keeps the
+    ``filter.`` prefix (#2298); the global VM listing carries no filter."""
     listing = [{"datastore": "datastore-1", "name": "ds-1", "type": "VMFS", "capacity": 10}]
-    sequence = [listing, {"capacity": 10, "free_space": 4}, [{"name": "vm-a"}]]
+    sequence = [listing, {"capacity": 10, "free_space": 4}, []]
     conn = _RecordingConnector(sequence, mount_prefix="/rest")
     await datastore_usage_composite(
         operator=_make_operator(),
@@ -733,19 +778,25 @@ async def test_datastore_usage_filter_params_keep_prefix_on_legacy_mount() -> No
         params={"filter_names": ["ds-prod-1"]},
         connector=conn,  # type: ignore[arg-type]
     )
-    # Listing keeps ``filter.names``; per-DS VM leg keeps ``filter.datastores``.
+    # Listing keeps ``filter.names`` on /rest; the global VM leg is unfiltered
+    # (per-datastore placement is resolved off vim, not a REST filter, #2975).
     assert conn.calls[0]["path"] == "/rest/vcenter/datastore"
     assert conn.calls[0]["query"] == {"filter.names": ["ds-prod-1"]}
-    assert conn.calls[2]["query"] == {"filter.datastores": ["datastore-1"]}
+    assert conn.calls[2]["path"] == "/rest/vcenter/vm"
+    assert conn.calls[2]["query"] is None
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_tolerates_legacy_envelope_on_listing() -> None:
-    """``{"value": [...]}`` listing envelope is unwrapped."""
+async def test_datastore_usage_tolerates_legacy_envelope_on_reads() -> None:
+    """``{"value": [...]}`` envelopes on the listing / detail / VM legs are unwrapped."""
+    placement = _retrieve_result_multi(
+        {("VirtualMachine", "vm-1"): {"datastore": _vm_placement(["datastore-1"])}}
+    )
     sequence = [
         {"value": [{"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"}]},
         {"value": {"capacity": 10, "free_space": 5}},
-        {"value": [{"name": "vm-x"}]},
+        {"value": [{"vm": "vm-1", "name": "vm-x"}]},
+        placement,
     ]
     conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
@@ -782,19 +833,21 @@ async def test_datastore_usage_skips_malformed_listing_entries() -> None:
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() -> None:
-    """A failed VM-placement sub-op keeps the row; vm_count/vm_names null + note (#1908)."""
+async def test_datastore_usage_placement_read_error_is_best_effort() -> None:
+    """A failed batched placement read keeps every row's capacity but nulls
+    vm_count/vm_names + records a note on all rows (best-effort, #1908 / #2975)."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+    ]
     sequence = [
-        [
-            {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
-            {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
-        ],
-        # datastore-1: detail OK, VM enrichment 400s -> best-effort skip.
+        listing,
         {"capacity": 100, "free_space": 40},
-        _http_error(400, "https://vc/api/vcenter/vm?filter.datastores=datastore-1"),
-        # datastore-2: detail OK, VM enrichment OK -> fully enriched.
         {"capacity": 500, "free_space": 250},
-        [{"name": "vm-c"}],
+        # The global VM listing succeeds; the placement RetrievePropertiesEx
+        # 403s -> the whole batched enrichment degrades on every row.
+        [{"vm": "vm-1", "name": "vm-a"}],
+        _http_error(403, "https://vc/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"),
     ]
     conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
@@ -804,49 +857,52 @@ async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() ->
         connector=conn,  # type: ignore[arg-type]
     )
 
-    # All 5 sub-ops fired -- the failed VM leg did not short-circuit.
+    # All 5 sub-ops fired -- the failed placement read did not short-circuit
+    # the load-bearing capacity reads.
     assert len(conn.calls) == 5
     rows = out["datastores"]
     assert len(rows) == 2
 
-    # datastore-1: core data preserved, enrichment skipped.
-    ds1 = rows[0]
-    assert ds1["id"] == "datastore-1"
-    assert ds1["capacity"] == 100
-    assert ds1["free_space"] == 40
-    assert ds1["type"] == "VMFS"
-    assert ds1["vm_count"] is None
-    assert ds1["vm_names"] is None
-    note = ds1["enrichment_note"]
-    # The note names the sub-op, the 400, and the offending URL.
-    assert "GET:/vcenter/vm" in note
-    assert "400 Bad Request" in note
-    assert "filter.datastores=datastore-1" in note
-
-    # datastore-2: enriched normally, no note key.
-    ds2 = rows[1]
-    assert ds2["id"] == "datastore-2"
-    assert ds2["vm_count"] == 1
-    assert ds2["vm_names"] == ["vm-c"]
-    assert "enrichment_note" not in ds2
+    for row, cap, free in ((rows[0], 100, 40), (rows[1], 500, 250)):
+        # Core capacity data preserved; only the enrichment is dropped.
+        assert row["capacity"] == cap
+        assert row["free_space"] == free
+        assert row["vm_count"] is None
+        assert row["vm_names"] is None
+        note = row["enrichment_note"]
+        assert "placement read failed" in note
+        assert "403 Forbidden" in note
 
 
 @pytest.mark.asyncio
 async def test_datastore_usage_identical_vm_sets_across_rows_trip_guard() -> None:
-    """Identical VM sets on every row = the upstream per-datastore filter was
-    ignored (whole-inventory list returned per row); the guard nulls
-    vm_count/vm_names and records why on every enriched row (#2975)."""
+    """Identical non-empty VM sets on every row -- an anomaly authoritative
+    placement cannot produce in practice -- still trip the belt-and-braces
+    guard: vm_count/vm_names nulled + note on every row (#3049 / #2975)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
         {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
         {"datastore": "datastore-3", "name": "ds-3", "type": "vSAN"},
     ]
-    # Every per-datastore VM leg returns the SAME whole-inventory list.
-    global_vms = [{"name": "vm-a"}, {"name": "vm-b"}, {"name": "vm-c"}]
+    global_vms = [
+        {"vm": "vm-1", "name": "vm-a"},
+        {"vm": "vm-2", "name": "vm-b"},
+        {"vm": "vm-3", "name": "vm-c"},
+    ]
+    # Every VM reports it sits on all three datastores -> identical set per row.
+    all_three = ["datastore-1", "datastore-2", "datastore-3"]
+    placement = _retrieve_result_multi(
+        {
+            ("VirtualMachine", "vm-1"): {"datastore": _vm_placement(all_three)},
+            ("VirtualMachine", "vm-2"): {"datastore": _vm_placement(all_three)},
+            ("VirtualMachine", "vm-3"): {"datastore": _vm_placement(all_three)},
+        }
+    )
     sequence: list[Any] = [listing]
     for _ in listing:
         sequence.append({"capacity": 100, "free_space": 40})
-        sequence.append(global_vms)
+    sequence.append(global_vms)
+    sequence.append(placement)
     conn = _RecordingConnector(sequence)
 
     out = await datastore_usage_composite(
@@ -878,15 +934,27 @@ async def test_datastore_usage_distinct_vm_sets_across_rows_left_populated() -> 
         {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
         {"datastore": "datastore-3", "name": "ds-3", "type": "vSAN"},
     ]
-    vms_by_ds: dict[str, list[dict[str, Any]]] = {
-        "datastore-1": [{"name": "vm-a"}, {"name": "vm-b"}],
-        "datastore-2": [{"name": "vm-c"}],
-        "datastore-3": [{"name": "vm-d"}, {"name": "vm-e"}],
-    }
+    global_vms = [
+        {"vm": "vm-1", "name": "vm-a"},
+        {"vm": "vm-2", "name": "vm-b"},
+        {"vm": "vm-3", "name": "vm-c"},
+        {"vm": "vm-4", "name": "vm-d"},
+        {"vm": "vm-5", "name": "vm-e"},
+    ]
+    placement = _retrieve_result_multi(
+        {
+            ("VirtualMachine", "vm-1"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-2"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-3"): {"datastore": _vm_placement(["datastore-2"])},
+            ("VirtualMachine", "vm-4"): {"datastore": _vm_placement(["datastore-3"])},
+            ("VirtualMachine", "vm-5"): {"datastore": _vm_placement(["datastore-3"])},
+        }
+    )
     sequence: list[Any] = [listing]
-    for entry in listing:
+    for _ in listing:
         sequence.append({"capacity": 100, "free_space": 40})
-        sequence.append(vms_by_ds[entry["datastore"]])
+    sequence.append(global_vms)
+    sequence.append(placement)
     conn = _RecordingConnector(sequence)
 
     out = await datastore_usage_composite(
@@ -905,17 +973,34 @@ async def test_datastore_usage_distinct_vm_sets_across_rows_left_populated() -> 
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_all_empty_vm_sets_do_not_trip_guard() -> None:
-    """Every datastore legitimately having zero VMs is real data, not the
-    global-list symptom; the guard's non-empty check excludes it (#2975)."""
+async def test_datastore_usage_vm_spanning_two_datastores_appears_in_both() -> None:
+    """A VM whose files span two datastores is real placement on both, so it
+    appears in both rows -- the union semantics of ``VirtualMachine.datastore``
+    (#2975)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
         {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
     ]
-    sequence: list[Any] = [listing]
-    for _ in listing:
-        sequence.append({"capacity": 100, "free_space": 40})
-        sequence.append([])  # no VMs on this datastore
+    global_vms = [
+        {"vm": "vm-1", "name": "vm-a"},
+        {"vm": "vm-2", "name": "vm-span"},
+    ]
+    placement = _retrieve_result_multi(
+        {
+            ("VirtualMachine", "vm-1"): {"datastore": _vm_placement(["datastore-1"])},
+            # vm-span has disks on both datastores.
+            ("VirtualMachine", "vm-2"): {
+                "datastore": _vm_placement(["datastore-1", "datastore-2"])
+            },
+        }
+    )
+    sequence: list[Any] = [
+        listing,
+        {"capacity": 100, "free_space": 40},
+        {"capacity": 500, "free_space": 250},
+        global_vms,
+        placement,
+    ]
     conn = _RecordingConnector(sequence)
 
     out = await datastore_usage_composite(
@@ -925,6 +1010,118 @@ async def test_datastore_usage_all_empty_vm_sets_do_not_trip_guard() -> None:
         connector=conn,  # type: ignore[arg-type]
     )
 
+    rows = out["datastores"]
+    assert rows[0]["vm_names"] == ["vm-a", "vm-span"]
+    assert rows[1]["vm_names"] == ["vm-span"]
+    assert all("enrichment_note" not in r for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_scopes_vms_per_datastore_from_authoritative_placement() -> None:
+    """Reproduction of #2975: the raw VM listing is the WHOLE inventory (the
+    upstream per-datastore filter is not honoured), yet each row must carry
+    only the VMs actually placed on that datastore.
+
+    The composite scopes client-side off the authoritative vim
+    ``VirtualMachine.datastore`` property (one batched
+    ``RetrievePropertiesEx`` over every VM), never the server-side filter.
+    Two datastores hosting disjoint VM sets therefore get DIFFERENT lists
+    and the identical-sets guard (#3049) never fires -- the guard's firing
+    condition is made impossible in practice by the real fix."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+    ]
+    # The raw ``GET:/vcenter/vm`` listing carries the whole inventory with
+    # zero per-datastore scoping -- the exact symptom shape (#2975).
+    global_vms = [
+        {"vm": "vm-1", "name": "vm-a"},
+        {"vm": "vm-2", "name": "vm-b"},
+        {"vm": "vm-3", "name": "vm-c"},
+    ]
+    # Authoritative placement (vim ``VirtualMachine.datastore``): disjoint.
+    placement = _retrieve_result_multi(
+        {
+            ("VirtualMachine", "vm-1"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-2"): {"datastore": _vm_placement(["datastore-1"])},
+            ("VirtualMachine", "vm-3"): {"datastore": _vm_placement(["datastore-2"])},
+        }
+    )
+    sequence: list[Any] = [
+        listing,
+        {"capacity": 100, "free_space": 40},
+        {"capacity": 500, "free_space": 250},
+        global_vms,
+        placement,
+    ]
+    conn = _RecordingConnector(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    # Call shape: listing -> per-DS detail x2 -> global VM listing (NO
+    # per-datastore filter) -> one RetrievePropertiesEx placement read.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/datastore"),
+        ("GET", "/api/vcenter/datastore/datastore-1"),
+        ("GET", "/api/vcenter/datastore/datastore-2"),
+        ("GET", "/api/vcenter/vm"),
+        ("POST", "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"),
+    ]
+    # The VM listing is global -- no scoping query is sent upstream.
+    assert conn.calls[3]["query"] is None
+    # The placement read scopes VirtualMachine.datastore over every VM moid.
+    body = conn.calls[4]["body"]
+    prop = body["specSet"][0]["propSet"][0]
+    assert prop["type"] == "VirtualMachine"
+    assert prop["pathSet"] == ["datastore"]
+    assert {o["obj"]["value"] for o in body["specSet"][0]["objectSet"]} == {
+        "vm-1",
+        "vm-2",
+        "vm-3",
+    }
+
+    rows = out["datastores"]
+    ds1, ds2 = rows[0], rows[1]
+    assert ds1["vm_count"] == 2
+    assert ds1["vm_names"] == ["vm-a", "vm-b"]
+    assert ds2["vm_count"] == 1
+    assert ds2["vm_names"] == ["vm-c"]
+    assert "enrichment_note" not in ds1
+    assert "enrichment_note" not in ds2
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_all_empty_vm_sets_do_not_trip_guard() -> None:
+    """No VMs anywhere is real data, not the global-list symptom; the guard's
+    non-empty check excludes it and the placement read short-circuits (#2975)."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+    ]
+    sequence: list[Any] = [
+        listing,
+        {"capacity": 100, "free_space": 40},
+        {"capacity": 100, "free_space": 40},
+        [],  # global VM listing empty -> every datastore has zero VMs
+    ]
+    conn = _RecordingConnector(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    # An empty inventory skips the RetrievePropertiesEx placement read.
+    assert len(conn.calls) == 4
+    retrieve_path = "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    assert all(c["path"] != retrieve_path for c in conn.calls)
     rows = out["datastores"]
     assert [r["vm_count"] for r in rows] == [0, 0]
     assert [r["vm_names"] for r in rows] == [[], []]

--- a/backend/tests/test_datastore_usage_per_entity_sensor.py
+++ b/backend/tests/test_datastore_usage_per_entity_sensor.py
@@ -95,19 +95,25 @@ def _make_operator() -> Operator:
 
 
 class _SequenceConnector:
-    """Minimal ``VmwareRestConnector`` stand-in serving canned GETs in order.
+    """Minimal ``VmwareRestConnector`` stand-in serving canned sub-ops in order.
 
-    ``datastore.usage`` issues only GET sub-ops (list datastores -> per-DS
-    detail -> per-DS VM list), each routed through ``_read_sub_op``'s
-    ``mount_op_path`` -> ``adapt_op_query`` -> ``_get_json`` seam. This double
-    serves the responses sequentially and records each call's ``(path, query)``
-    so a test can assert the ``filter.names`` narrowing flowed to the listing.
+    ``datastore.usage`` issues GET sub-ops (list datastores -> per-DS detail ->
+    global VM listing) plus one vmomi ``RetrievePropertiesEx`` POST reading the
+    authoritative ``VirtualMachine.datastore`` placement (#2975), each routed
+    through ``_read_sub_op``. This double serves the responses sequentially and
+    records each GET call's ``(path, query)`` so a test can assert the
+    ``filter.names`` narrowing flowed to the listing.
     """
 
     def __init__(self, responses: list[Any]) -> None:
         self._responses = responses
         self._index = 0
         self.calls: list[dict[str, Any]] = []
+
+    def _next(self) -> Any:
+        payload = self._responses[self._index]
+        self._index += 1
+        return payload
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         del target, operator
@@ -129,9 +135,45 @@ class _SequenceConnector:
     ) -> Any:
         del target, operator
         self.calls.append({"path": path, "query": params})
-        payload = self._responses[self._index]
-        self._index += 1
-        return payload
+        return self._next()
+
+    async def _post_vmomi_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, path, operator, json
+        return self._next()
+
+
+def _placement_on_one_datastore(vm_moids: list[str], ds_moid: str) -> dict[str, Any]:
+    """A ``RetrieveResult`` pinning every VM to a single datastore (boxed MoRefs)."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "VirtualMachine", "value": vm},
+                "propSet": [
+                    {
+                        "name": "datastore",
+                        "val": {
+                            "_typeName": "ArrayOfManagedObjectReference",
+                            "_value": [
+                                {
+                                    "_typeName": "ManagedObjectReference",
+                                    "type": "Datastore",
+                                    "value": ds_moid,
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+            for vm in vm_moids
+        ]
+    }
 
 
 async def _usage_one_datastore(
@@ -144,8 +186,14 @@ async def _usage_one_datastore(
     """Run the real handler for a single filtered datastore, return (payload, conn)."""
     listing = [{"datastore": "datastore-42", "name": name, "type": "vSAN"}]
     detail = {"capacity": capacity, "free_space": free_space, "type": "vSAN"}
-    vms = [{"name": vm_name} for vm_name in vm_names]
-    conn = _SequenceConnector([listing, detail, vms])
+    # Global VM inventory (moid + name), then vim placement pinning every VM to
+    # this datastore -- the authoritative scoping the composite joins on (#2975).
+    vm_moids = [f"vm-{i}" for i in range(len(vm_names))]
+    global_vms = [
+        {"vm": moid, "name": vm_name} for moid, vm_name in zip(vm_moids, vm_names, strict=True)
+    ]
+    placement = _placement_on_one_datastore(vm_moids, "datastore-42")
+    conn = _SequenceConnector([listing, detail, global_vms, placement])
     payload = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1040,41 +1040,53 @@ wraps into a `connector_error` envelope -- the whole composite fails.
 An optional enrichment failure must **not** sink the composite: the
 leg degrades and the rows the core use case needs are still returned.
 
-`datastore.usage` is the canonical example. Its per-datastore layout is
+`datastore.usage` is the canonical example. Its layout is
 `GET:/vcenter/datastore` (listing, load-bearing) → per row
 `GET:/vcenter/datastore/{datastore}` (capacity/free/type, load-bearing)
-→ `GET:/vcenter/vm?filter.datastores=...` (VM placement, **best-effort**).
-The "which datastores are filling up?" use case is satisfied by the
-capacity/free/type read, which has already succeeded by the time the VM
-lookup runs. So when the VM lookup errors -- e.g. an 8.0 vCenter that
-400s the `filter.datastores` query the 9.0 spec emits -- the row is
-still returned with `capacity`/`free_space`/`type` intact,
-`vm_count`/`vm_names` set to `null`, and an `enrichment_note` string
-recording the failing sub-op, its status, and the underlying error.
+→ a **single batched VM-placement read** (`_read_vm_placement`,
+**best-effort**) resolved once for the whole result. The "which
+datastores are filling up?" use case is satisfied by the
+capacity/free/type reads, which have already succeeded by the time the
+placement read runs. So when that read errors, every row is still
+returned with `capacity`/`free_space`/`type` intact, `vm_count`/`vm_names`
+set to `null`, and an `enrichment_note` string recording the failure.
 The response schema marks `vm_count`/`vm_names` as nullable and adds the
-optional `enrichment_note` key (present only on a skipped row).
+optional `enrichment_note` key (present only when enrichment was skipped
+or discarded).
 
-The same null + `enrichment_note` treatment is extended to a second,
-subtler failure mode by the **cross-row identical-sets guard** (#2975).
-A per-datastore VM leg can *succeed* (HTTP 200) yet still be wrong: if
-the target silently ignores the per-datastore filter, `GET:/vcenter/vm`
-returns the whole-inventory VM list, so every datastore row is
-enriched with the identical global list — `vm_count` equal to the
-cluster-wide VM total and an identical `vm_names` sample on all rows.
-That poisons the classic "which VMs live on this filling-up datastore?"
-triage question with the same wrong answer on every row. Because a VM's
-working directory lives on exactly one datastore, genuinely-distinct
-datastores never share a non-empty VM set; so an identical **non-empty**
-set across *every* enriched row is treated as failed enrichment — all
-those rows are nulled and carry an `enrichment_note` explaining the
-filter was not applied — rather than emitting the populated-but-wrong
-global list. The non-empty condition excludes the legitimate all-empty
-case (every datastore really has zero VMs), and the guard needs at least
-two enriched rows to compare, so a single-datastore result is never
-touched. The guard is defence-in-depth: it stands regardless of *why*
-the filter was ignored (the upstream root cause is diagnosed separately
-from the dispatch audit row), so it protects the data even when a target
-build mishandles the filter param.
+**Placement is vim-authoritative, not a server-side filter (#2975).**
+The original layout scoped each row with
+`GET:/vcenter/vm?filter.datastores=<ds>` — one filtered call per
+datastore — and trusted the target to honour it. Some builds silently
+ignore that filter and return the whole-inventory VM list on every call,
+so every datastore row was enriched with the identical global list
+(`vm_count` = cluster-wide total, identical `vm_names` on every row),
+poisoning the classic "which VMs live on this filling-up datastore?"
+triage question with the same wrong answer everywhere. The seam that
+strips the `filter.` prefix on modern mounts (#2298) is not the cause;
+the code cannot emit `/api` + `filter.datastores`, and the real cause is
+undetermined from code (legacy `/rest` mount vs the build ignoring the
+bare `datastores=` param). The fix stops depending on the filter
+altogether: `_read_vm_placement` reads `GET:/vcenter/vm` **unfiltered**
+(every VM's moid + name), then one `RetrievePropertiesEx` over every VM
+reading the vim-authoritative `VirtualMachine.datastore` property (the
+union of datastores a VM's config/disks/snapshots/swap sit on), and
+joins the two client-side into per-datastore `vm_count`/`vm_names`. Each
+row therefore carries only the VMs vim reports on that datastore
+regardless of whether any REST filter is honoured; a VM whose disks span
+two datastores legitimately appears under both. This also replaces N
+per-datastore calls with two batched reads.
+
+The **cross-row identical-sets guard** (#3049) is retained as
+belt-and-braces: an identical **non-empty** VM set across *every*
+enriched row is nulled + noted rather than emitted as per-datastore
+placement. With authoritative placement that shape cannot arise in
+practice (it would require every VM to sit on every datastore), so the
+guard's firing condition is effectively impossible — but it stays to
+refuse any populated-but-identical anomaly. The non-empty condition
+excludes the legitimate all-empty case (every datastore really has zero
+VMs), and the guard needs at least two enriched rows to compare, so a
+single-datastore result is never touched.
 
 ### Per-entity capacity sensing (`filter_names`, #2758)
 


### PR DESCRIPTION
## Summary

- `vmware.composite.datastore.usage` returned the **GLOBAL** VM list on every
  datastore row (identical `vm_count`/`vm_names`), because its VM-placement
  enrichment scoped each row with a per-datastore
  `GET:/vcenter/vm?datastores=<ds>` filter that some vCenter builds silently
  ignore — returning the whole inventory on every call. The classic "which VMs
  live on this filling-up datastore?" triage question got the same wrong answer
  on every row (#2975).
- Per @damir-topic's grounding pass, the originally-filed param-style root cause
  is **refuted**: the code cannot emit `/api` + `filter.datastores` (the #2298
  seam strips the prefix on modern mounts off the same recorded session path),
  and the real cause is undetermined from code (legacy `/rest` mount vs the
  build ignoring the bare `datastores=` param). So the fix stops depending on
  the server-side filter altogether.
- **The real fix:** `_read_vm_placement` resolves placement authoritatively —
  one unfiltered `GET:/vcenter/vm` (moid + name) plus one `RetrievePropertiesEx`
  over the vim `VirtualMachine.datastore` property (the union of datastores a
  VM's config/disks/snapshots/swap sit on), joined client-side into
  per-datastore `vm_count`/`vm_names`. Each row now carries only the VMs vim
  reports on that datastore regardless of whether any REST filter is honoured; a
  VM whose disks span two datastores legitimately appears under both. Two
  batched reads replace N per-datastore calls.
- The **#3049 identical-sets guard stays** as belt-and-braces. With
  authoritative placement an identical non-empty set across every row cannot
  arise in practice (it would require every VM to sit on every datastore), so
  the guard's firing condition is made **impossible in practice** — exactly the
  ask — while the guard remains to refuse any populated-but-identical anomaly.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `mypy src/meho_backplane/connectors/vmware_rest/composites/` — Success, no issues
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing/adjacent function-size warnings)
- [x] **Reproduction test written first, failed on old code, passes on the fix:**
  `test_datastore_usage_scopes_vms_per_datastore_from_authoritative_placement`
  — a fixture where the raw VM listing is the whole inventory (filter ignored)
  yet two datastores hosting disjoint VM sets get different lists.
- [x] New/updated unit tests: authoritative-placement happy path, spanning-VM
  union semantics, batched best-effort degradation, all-empty short-circuit,
  belt-and-braces guard via identical placement, legacy-envelope tolerance,
  legacy-mount listing filter — all green.
- [x] vcsim (respx) integration: modern + legacy mounts assert per-datastore
  scoping off the vim placement read.
- [x] Targeted suite (composites read/reconcile/register + vcsim + per-entity
  sensor): 73 passed, 2 skipped.
- [x] Broad `-k "vmware_rest or datastore or composite"`: 721 passed, 36 skipped.

## Out of scope

- The `network_portgroup_audit` composite has the same per-row `vm_names`
  pattern on a different (networks) surface — untouched, not part of #2975.
- Live-appliance reverification against a real 8.0.3 target (the deploy that
  reported the symptom).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
