### PR TITLE
feat(fleet-lcm): Vault-staged Bearer token seam + operator onboarding runbook (#3047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,26 @@ connector-related release-notes line.
   release notes, and `fail_on_unmatched_files` keeps the step fail-closed.
   Next tag run publishes all five assets without manual intervention.
 
+### Added — `fleet-lcm` Bearer token-provisioning seam + operator onboarding runbook (#3047)
+
+- The modern `fleet-lcm-9.0` connector's `auth_headers` already preferred
+  `Authorization: Bearer <token>` (the spec's primary `bearerToken` scheme)
+  when the loaded credentials carried a `token`, but its default Vault loader
+  only ever surfaced the `username`/`password` pair, so Bearer was
+  unreachable in production. The default `load_credentials_from_vault` now
+  reads the raw KV-v2 payload and surfaces an **optional** `token` alongside
+  the required pair — so an operator opts a target into Bearer simply by
+  staging a `token` field in its Vault secret, no `auth_model` change (the
+  proxmox / github field-discriminator shape). Proven end to end through the
+  real default loader against a Vault fake (Basic without a token, Bearer with
+  one, whitespace-strip, fail-closed on a missing pair). The **live**
+  `basicAuth` → mint-`bearerToken` exchange and Bearer verification against a
+  real appliance remain the documented follow-up, gated on reachable hardware
+  (#1002 / #995). A new operator runbook
+  ([`docs/cross-repo/fleet-lcm-onboarding.md`](docs/cross-repo/fleet-lcm-onboarding.md))
+  documents target registration, the token seam, and the optional
+  `meho connector ingest` of the wider 51-op `/v1/*` breadth.
+
 ## [0.31.0] - 2026-08-27
 
 ### Breaking changes — MCP agent surface is claim-gated: default drops to the 25-tool working surface (#3154 / #3160)

--- a/backend/src/meho_backplane/connectors/fleet_lcm/session.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/session.py
@@ -14,9 +14,8 @@ defined as an alternative — a genuine departure from the legacy
 ``/lcm/*`` surface.
 
 This module mirrors the legacy ``vcf_fleet.session`` shape and reuses the
-shared :mod:`meho_backplane.connectors._shared.vcf_auth` scaffolding (the
-#841 cross-cutting module) so the two impls share one credential-loading
-contract:
+shared :mod:`meho_backplane.connectors._shared.vault_creds` scaffolding so
+the two impls share one credential-loading contract:
 
 * :data:`FleetLcmTargetLike` — the minimum target shape the connector
   reads. Aliased to the shared
@@ -28,38 +27,57 @@ contract:
 * :data:`FleetLcmCredentialsLoader` — the async ``(target, operator) ->
   dict[str, str]`` loader type. Injectable on connector construction so
   unit tests pass a stub, integration tests pass a lab-account loader,
-  and production uses the default Vault read.
-* :func:`load_credentials_from_vault` — the shared operator-context
-  KV-v2 read, re-exported here so the package's public API reads
-  cohesively.
+  and production uses :func:`load_credentials_from_vault`.
+* :func:`load_credentials_from_vault` — the fleet-lcm default loader: a
+  Vault KV-v2 read that surfaces the ``{username, password}`` pair plus an
+  **optional** ``token`` (the token-provisioning seam, below).
 
-The Bearer seam
----------------
+The Bearer token-provisioning seam (#3047)
+==========================================
 
-The shared :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
-enforces the ``{"username": str, "password": str}`` contract (it raises
-:exc:`RuntimeError` on a missing key), so the loader **always** returns
-those two keys — the appliance also accepts ``basicAuth`` per the spec —
-and may **additionally** carry an optional ``"token"`` key. When the
-loaded credentials carry a non-empty ``"token"``,
+The connector's
 :meth:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector.auth_headers`
-emits ``Authorization: Bearer <token>`` (the spec's primary scheme);
-otherwise it falls back to ``Authorization: Basic <b64>`` off the
-username/password pair. The default :func:`load_credentials_from_vault`
-surfaces only the username/password pair today (the shared basic-creds
-read), so the live default is the Basic alternative until the
-Bearer-token provisioning seam lands — see the connector's class
-docstring for the live-verify follow-up (a fleet-lcm loader surfacing a
-Vault-stored token, or a POST-``basicAuth`` → mint-``bearerToken``
-session flow gated on a stood-up appliance).
+emits ``Authorization: Bearer <token>`` when the loaded credentials carry
+a non-empty ``"token"`` (the spec's primary ``bearerToken`` scheme), and
+otherwise falls back to ``Authorization: Basic <b64>`` off the
+username/password pair (the spec's ``basicAuth`` alternative, which the
+appliance also accepts).
+
+:func:`load_credentials_from_vault` is what makes the Bearer path
+reachable in production: it reads the raw KV-v2 payload via
+:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`
+and surfaces a ``token`` field **when the operator has staged one**,
+alongside the always-required username/password pair. So an operator opts
+a target into Bearer simply by adding a ``token`` to its Vault secret — no
+target-row / ``auth_model`` change. This mirrors the field-discriminator
+loaders the proxmox (``token_id`` + ``token_secret`` vs ``username`` +
+``password``) and github (App-installation vs PAT) connectors ship, which
+also pick the upstream credential protocol by inspecting which fields the
+operator stored rather than surfacing it on ``auth_model``.
+
+**Seam — the live ``basicAuth`` → mint-``bearerToken`` exchange is
+deferred.** This loader surfaces a *pre-staged* Vault token only; it does
+**not** perform the alternative provisioning path where the connector
+POSTs ``basicAuth`` to the appliance's token endpoint to mint a
+short-lived ``bearerToken`` on the fly (the github-App JWT→installation-
+token shape). That live exchange — and confirming whether the 9.x
+appliance is Bearer-only or also honours ``basicAuth`` — is the #3047
+live-verify follow-up, gated on a reachable Fleet LCM appliance
+(#1002 / #995). Until it lands, a target with no staged token
+authenticates with the Basic alternative.
 """
 
 from __future__ import annotations
 
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import (
+    VaultCredentialsReadError,
+    load_vault_secret_data,
+    strip_credential_value,
+)
 from meho_backplane.connectors._shared.vcf_auth import (
     VcfCredentialsLoader,
     VcfTargetLike,
-    load_credentials_from_vault,
 )
 
 __all__ = [
@@ -80,3 +98,85 @@ FleetLcmTargetLike = VcfTargetLike
 #: fleet-lcm-flavoured name so ``FleetLcmConnector(credentials_loader=...)``
 #: reads cohesively without exposing the shared module at the boundary.
 FleetLcmCredentialsLoader = VcfCredentialsLoader
+
+#: KV-v2 secret field names the fleet-lcm loader reads. ``username`` +
+#: ``password`` are **required** (the appliance accepts ``basicAuth`` and the
+#: shared ``CredentialsCache`` contract requires the pair); ``token`` is
+#: **optional** and, when present, activates the spec's primary
+#: ``bearerToken`` scheme. Kept as module constants so the loader, the
+#: connector, and the tests share one source of truth for what an operator
+#: stores under ``target.secret_ref``.
+_USERNAME_FIELD = "username"
+_PASSWORD_FIELD = "password"
+_TOKEN_FIELD = "token"
+
+
+async def load_credentials_from_vault(
+    target: FleetLcmTargetLike,
+    operator: Operator,
+) -> dict[str, str]:
+    """Default fleet-lcm loader — basic pair + optional pre-staged Bearer token.
+
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) via
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`,
+    then surfaces:
+
+    * the always-required ``{username, password}`` pair (the ``basicAuth``
+      alternative the appliance accepts, and the shared
+      :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+      contract), and
+    * an **optional** ``token`` when the operator has staged one — which
+      opts the target into the spec's primary ``bearerToken`` scheme
+      (:meth:`FleetLcmConnector.auth_headers` emits
+      ``Authorization: Bearer <token>`` whenever a non-empty ``token`` is
+      present).
+
+    A missing / blank username-or-password pair raises
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    naming the target, so a half-configured secret fails closed with an
+    operator-actionable message rather than a bare ``KeyError`` at request
+    time. Vault login-phase failures
+    (:class:`~meho_backplane.auth.vault.VaultClientError` subclasses)
+    propagate verbatim.
+
+    See the module docstring for the deferred live ``basicAuth`` →
+    mint-``bearerToken`` exchange (the #3047 live-verify follow-up); this
+    loader surfaces a *pre-staged* token only.
+    """
+    secret_data = await load_vault_secret_data(target, operator)
+
+    username = _optional_field(secret_data, _USERNAME_FIELD)
+    password = _optional_field(secret_data, _PASSWORD_FIELD)
+    if not (username and password):
+        raise VaultCredentialsReadError(
+            f"fleet-lcm target {target.name!r}: secret at secret_ref must carry a "
+            f"{_USERNAME_FIELD!r} + {_PASSWORD_FIELD!r} pair (the appliance accepts "
+            f"basicAuth). Optionally add a {_TOKEN_FIELD!r} field to authenticate via "
+            f"the spec's primary Bearer scheme instead."
+        )
+
+    credentials = {_USERNAME_FIELD: username, _PASSWORD_FIELD: password}
+    token = _optional_field(secret_data, _TOKEN_FIELD)
+    if token:
+        credentials[_TOKEN_FIELD] = token
+    return credentials
+
+
+def _optional_field(secret_data: dict[str, object], field: str) -> str | None:
+    """Return *field* from the KV-v2 payload as a stripped str, or ``None``.
+
+    A missing key, an empty string, or a whitespace-only value all map to
+    ``None`` so the loader treats a blank field as "not configured" rather
+    than a valid-but-empty credential — the proxmox ``_optional_field``
+    shape. Present values run through
+    :func:`~meho_backplane.connectors._shared.vault_creds.strip_credential_value`
+    so a trailing newline (the most common secret-storage artifact) never
+    reaches a Basic-auth header or a ``Bearer`` token verbatim.
+    """
+    raw = secret_data.get(field)
+    if raw is None:
+        return None
+    value = strip_credential_value(raw)
+    return value or None

--- a/backend/tests/test_connectors_fleet_lcm_credread.py
+++ b/backend/tests/test_connectors_fleet_lcm_credread.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture credential-read chain for the modern fleet-lcm loader (#3047).
+
+Proves the fleet-lcm connector's **default (non-injected)** credential loader
+end to end against an in-process Vault fake:
+
+    FleetLcmConnector()                                  # default loader
+      -> auth_headers
+      -> load_credentials_from_vault (session.py)        # the fleet-lcm loader
+      -> load_vault_secret_data (G3.9-T2)                # operator-context read
+      -> {"Authorization": "Bearer <token>"}  when the Vault secret carries a
+         non-empty ``token`` (the spec's primary ``bearerToken`` scheme),
+         else {"Authorization": "Basic <b64>"} (the ``basicAuth`` alternative).
+
+The Bearer branch is the **#3047 token-provisioning seam**: an operator opts a
+target into Bearer by staging a ``token`` field alongside username/password in
+the target's Vault secret; the loader surfaces it and ``auth_headers`` prefers
+it. No live appliance is reached (#1002 / #995) — the transport is a Vault fake
+— so this proves the *loader → header* seam, not the live appliance handshake
+(the documented live-verify follow-up).
+
+Complements :mod:`tests.test_connectors_fleet_lcm_auth`, which exercises the
+same header branches through **injected** loader stubs; this module drives the
+**real** default loader so a regression in the Vault-read wiring (fields read,
+operator-context login, whitespace strip) is caught. Layout mirrors
+:mod:`tests.test_connectors_vcf_fleet_credread` (the legacy impl's live
+cred-read gate) and reuses the shared :mod:`tests._vault_fakes` scaffold.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import pytest
+from structlog.testing import capture_logs
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.fleet_lcm import FleetLcmConnector
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential values — asserted to NEVER leak into logs. Fleet's local
+# user store uses ``admin@local`` verbatim (the @local is part of the
+# username, not a realm decoration).
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "admin@local"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-fleet-lcm"
+_CANARY_TOKEN = "brr-canary-token-must-not-leak"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env vars Settings + the Vault client read."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str = "fleet-lcm-credread"
+    host: str = "fleet-lcm-credread.test.invalid"
+    port: int | None = 443
+    secret_ref: str = "fleet-lcm/credread"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt so the fail-closed Vault gate passes."""
+    return Operator(
+        sub="op-credread-fleet-lcm",
+        name="Cred Read Fleet LCM Operator",
+        email=None,
+        raw_jwt="op.credread.fleet-lcm.jwt",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[len("Basic ") :]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+@pytest.mark.asyncio
+async def test_default_loader_emits_basic_when_secret_has_no_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Vault secret with only username/password → Basic, read under the operator."""
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = FleetLcmConnector()  # default loader — the real Vault read
+    target = _StubTarget()
+    operator = _make_operator()
+
+    headers = await connector.auth_headers(target, operator)
+
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == _CANARY_USERNAME
+    assert password == _CANARY_PASSWORD
+    # The default loader read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.fleet-lcm.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_loader_emits_bearer_when_secret_carries_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Vault secret carrying a ``token`` → Bearer (the token-provisioning seam)."""
+    install_fake_client(
+        monkeypatch,
+        secret={
+            "username": _CANARY_USERNAME,
+            "password": _CANARY_PASSWORD,
+            "token": _CANARY_TOKEN,
+        },
+    )
+    connector = FleetLcmConnector()  # default loader
+    headers = await connector.auth_headers(_StubTarget(), _make_operator())
+
+    assert headers == {"Authorization": f"Bearer {_CANARY_TOKEN}"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_loader_strips_whitespace_around_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token stored with a trailing newline is stripped before the Bearer header."""
+    install_fake_client(
+        monkeypatch,
+        secret={
+            "username": _CANARY_USERNAME,
+            "password": _CANARY_PASSWORD,
+            "token": f"  {_CANARY_TOKEN}\n",
+        },
+    )
+    connector = FleetLcmConnector()
+    headers = await connector.auth_headers(_StubTarget(), _make_operator())
+
+    assert headers == {"Authorization": f"Bearer {_CANARY_TOKEN}"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_loader_blank_token_falls_back_to_basic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only ``token`` counts as unconfigured → Basic, not an empty Bearer."""
+    install_fake_client(
+        monkeypatch,
+        secret={
+            "username": _CANARY_USERNAME,
+            "password": _CANARY_PASSWORD,
+            "token": "   ",
+        },
+    )
+    connector = FleetLcmConnector()
+    headers = await connector.auth_headers(_StubTarget(), _make_operator())
+
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_loader_missing_password_raises_naming_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token-only secret (no username/password pair) fails closed naming the target."""
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+    connector = FleetLcmConnector()
+
+    with pytest.raises(VaultCredentialsReadError) as exc_info:
+        await connector.auth_headers(_StubTarget(), _make_operator())
+
+    message = str(exc_info.value)
+    assert "fleet-lcm-credread" in message
+    assert "username" in message and "password" in message
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_loader_never_leaks_credential_values_in_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential *value* (password or token) appears in any structlog event.
+
+    The shared reader logs only the field *names* present, never a value; this
+    confirms the discipline survives the fleet-lcm loader's raw-payload read
+    even on the Bearer path (where the token is the live credential).
+    """
+    install_fake_client(
+        monkeypatch,
+        secret={
+            "username": _CANARY_USERNAME,
+            "password": _CANARY_PASSWORD,
+            "token": _CANARY_TOKEN,
+        },
+    )
+    connector = FleetLcmConnector()
+
+    with capture_logs() as captured:
+        await connector.auth_headers(_StubTarget(), _make_operator())
+
+    log_blob = repr(captured)
+    assert _CANARY_PASSWORD not in log_blob
+    assert _CANARY_TOKEN not in log_blob
+    await connector.aclose()

--- a/docs/codebase/connectors-fleet-lcm.md
+++ b/docs/codebase/connectors-fleet-lcm.md
@@ -77,9 +77,13 @@ real hardware is the #3047 follow-up (see "Auth" below).
   type (the modern impl reads the same target fields as the legacy). The
   loader is injectable on construction
   (`FleetLcmConnector(credentials_loader=...)`) for unit / integration tests.
-- **`load_credentials_from_vault`** (`session.py`) — the shared
-  operator-context KV-v2 read, re-exported. Returns the `{username, password}`
-  pair (the shared basic-creds read).
+- **`load_credentials_from_vault`** (`session.py`) — the fleet-lcm default
+  loader (#3047). An operator-context KV-v2 read (via the shared
+  `load_vault_secret_data`) that surfaces the required `{username, password}`
+  pair **plus an optional `token`** when the operator has staged one — the
+  Bearer token-provisioning seam. Mirrors the proxmox / github
+  field-discriminator loaders (pick the upstream credential protocol by
+  inspecting which fields the secret carries, not via `auth_model`).
 - Canonical constants (`__init__.py`): `FLEET_LCM_PRODUCT`,
   `FLEET_LCM_VERSION`, `FLEET_LCM_IMPL_ID`, `FLEET_LCM_CONNECTOR_ID`.
 
@@ -113,13 +117,19 @@ Per the pinned spec's `securitySchemes`, the global scheme is `bearerToken`
    returns `Authorization: Basic <b64>` off the username/password pair (the
    spec's `basicAuth` alternative), reusing the shared `basic_auth_header`.
 
-**Bearer is a documented seam, not live-verified.** The default Vault loader
-surfaces only the username/password pair, so the live default is the Basic
-alternative (the appliance accepts `basicAuth` per the spec). The Bearer
-*header shape* is unit-tested via an injected loader returning a `"token"`; the
-Bearer-token **provisioning** — a fleet-lcm loader surfacing a Vault-stored
-token, or a POST-`basicAuth` → mint-`bearerToken` session flow — is the
-live-verify follow-up gated on a stood-up appliance.
+**The token-provisioning seam has landed; the live mint + verify has not
+(#3047).** The default `load_credentials_from_vault` now surfaces a
+Vault-staged `token`, so an operator opts a target into Bearer by adding a
+`token` field to its secret — no `auth_model` change. This is unit-tested end
+to end through the **real** default loader against an in-process Vault fake
+(`test_connectors_fleet_lcm_credread.py`: Basic when no token, Bearer when a
+token is staged, whitespace-strip, fail-closed on a missing pair) as well as
+via injected loaders (`test_connectors_fleet_lcm_auth.py`). What remains a
+seam is the **live** alternative provisioning path — a `POST`-`basicAuth` →
+mint-`bearerToken` exchange against the appliance's token endpoint — and the
+**live Bearer verification** against real hardware; both are gated on a
+reachable Fleet LCM appliance (#1002 / #995). Until then a target with no
+staged token authenticates with the Basic alternative.
 
 ### Fingerprint / probe
 
@@ -205,17 +215,20 @@ from is tautological.)
 
 ## Known issues / follow-ups
 
-- **Bearer auth not live-verified.** See "Auth" — the header shape ships and is
-  unit-tested (dispatch through the Bearer seam against a respx mock); token
-  provisioning + live dispatch against a real appliance are the #3047 follow-up
-  gated on reachable hardware. Until then the live default is the Basic
-  alternative the appliance also accepts.
+- **Live Bearer not verified; the token-provisioning seam has landed.** See
+  "Auth" — the default loader now surfaces a Vault-staged `token` (Bearer
+  opt-in), unit-tested through the real loader against a Vault fake. What
+  remains the #3047 follow-up, gated on reachable hardware (#1002 / #995), is
+  the **live** `basicAuth` → mint-`bearerToken` exchange and the live Bearer
+  handshake against a real appliance. Until then a target with no staged token
+  authenticates with the Basic alternative.
 - **Read core only; ingested breadth + writes are a follow-up.** The 13-op
   typed read core dispatches on a fresh boot. The wider 51-op `/v1/*` surface
   (as `source_kind="ingested"` breadth) and the component / upgrade / task
   writes are enabled operationally through the generic review flow
   (`meho connector ingest` of `fleet-lcm-openapi.yaml` → `ReviewService.enable_reads`),
-  not shipped here.
+  not shipped here — see the operator runbook
+  [`docs/cross-repo/fleet-lcm-onboarding.md`](../cross-repo/fleet-lcm-onboarding.md).
 
 ## References
 
@@ -228,6 +241,12 @@ from is tautological.)
   (dispatch + registration) and
   [`test_connectors_fleet_lcm_spec_reconcile.py`](../../backend/tests/test_connectors_fleet_lcm_spec_reconcile.py)
   (13-path reconcile lane).
+- Auth tests:
+  [`test_connectors_fleet_lcm_auth.py`](../../backend/tests/test_connectors_fleet_lcm_auth.py)
+  (injected-loader header shapes) and
+  [`test_connectors_fleet_lcm_credread.py`](../../backend/tests/test_connectors_fleet_lcm_credread.py)
+  (the real default loader's Bearer/Basic paths through a Vault fake).
+- Operator runbook: [`fleet-lcm-onboarding.md`](../cross-repo/fleet-lcm-onboarding.md).
 - Legacy impl: [`connectors-vcf-fleet.md`](connectors-vcf-fleet.md)
 - Spec provenance: `vmware/vcf-api-specs@c3f3b52c` (Apache-2.0); shelf
   `docs/fleet-lcm-9.0/MANIFEST.md`.

--- a/docs/cross-repo/fleet-lcm-onboarding.md
+++ b/docs/cross-repo/fleet-lcm-onboarding.md
@@ -1,0 +1,250 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# VCF Fleet LCM (modern) op surface onboarding — operator recipe
+
+> Operator-facing recipe for the **modern** `fleet-lcm-9.0` op surface — the
+> VCF 9 Fleet LCM Service (`/v1/*`), its typed read core, Bearer/Basic auth,
+> and the optional wider-breadth spec ingest. The connector implementation
+> lives in
+> [`backend/src/meho_backplane/connectors/fleet_lcm/`](../../backend/src/meho_backplane/connectors/fleet_lcm/);
+> the engineering-facing companion is
+> [`docs/codebase/connectors-fleet-lcm.md`](../codebase/connectors-fleet-lcm.md).
+> For the **legacy** `fleet-rest-9.0` surface (the vRSLCM-derived `/lcm/*`
+> API an 8.x target resolves to) see
+> [`docs/cross-repo/vcf-fleet-onboarding.md`](./vcf-fleet-onboarding.md).
+> This doc is the cookbook an operator reads when onboarding a VCF Fleet
+> **9.x** target.
+
+## What this surface is
+
+`fleet-lcm-9.0` is the **modern** generic implementation of `product=fleet`,
+registered under the `(product="fleet", version="9.0", impl_id="fleet-lcm")`
+triple. It dispatches the VCF 9 Fleet LCM Service — the successor to vRealize
+Suite Lifecycle Manager (vRSLCM) 8.x — at
+`https://vcf.broadcom.com/fleet-lcm` → `/v1/*`.
+
+It is the **first real two-implementation case** in the codebase: it coexists
+with the legacy typed `fleet-rest` impl, and the two are resolved **per
+target by fingerprint** (not by the operator). A VCF Fleet **9.0** target
+resolves here by most-specific-version (`fleet-lcm`'s narrower `>=9.0,<10.0`
+band wins over `fleet-rest`'s `>=8.0,<10.0`); an 8.x target resolves to
+`fleet-rest`. See the "Dual implementation" section of
+[`connectors-vcf-fleet.md`](../codebase/connectors-vcf-fleet.md) for the
+resolution matrix.
+
+### Typed read core (live at boot — no ingest needed)
+
+The connector ships a curated **13-op typed read core** (`source_kind='typed'`,
+#3047) that registers at backplane startup (`run_typed_op_registrars`) and
+dispatches on a **fresh boot with zero catalog ingest**. This is what restores
+9.0 fleet read dispatch under the "modern default now" resolver decision
+(initiative [#3033](https://github.com/evoila/meho/issues/3033)). The read
+core spans five operator-reviewed groups — its `group_key` + `when_to_use`
+pairing **is** the curation (there is no separate ingest/curation step to run
+for the reads):
+
+| Group (`group_key`) | `op_id` | Reads |
+| --- | --- | --- |
+| `fleet-lcm-system` | `fleet-lcm.health` | Service liveness (`GET /v1/health`) |
+| `fleet-lcm-system` | `fleet-lcm.system.info` | Fleet-wide summary: in-flight upgrade + bundles |
+| `fleet-lcm-system` | `fleet-lcm.config.info` | Service configuration (flavor, bound cluster, status) |
+| `fleet-lcm-sddc` | `fleet-lcm.sddc-lcm.list` | SDDC lifecycle managers the fleet governs |
+| `fleet-lcm-sddc` | `fleet-lcm.sddc-lcm.info` | One SDDC LCM by id |
+| `fleet-lcm-components` | `fleet-lcm.component.list` | Deployed components inventory |
+| `fleet-lcm-components` | `fleet-lcm.component.info` | One component by id |
+| `fleet-lcm-components` | `fleet-lcm.component.status` | One component's runtime status |
+| `fleet-lcm-tasks` | `fleet-lcm.task.list` | Async operation tasks |
+| `fleet-lcm-tasks` | `fleet-lcm.task.info` | One task by id |
+| `fleet-lcm-lifecycle` | `fleet-lcm.upgrade-plan.list` | Planned upgrades |
+| `fleet-lcm-lifecycle` | `fleet-lcm.upgrade-plan.info` | One upgrade plan by id |
+| `fleet-lcm-lifecycle` | `fleet-lcm.release-version.list` | Targetable release versions |
+
+There is **no dedicated `meho fleet-lcm …` CLI verb tree** — the modern
+surface is dispatched through the generic `meho operation …` /
+`meho connector …` verbs and the agent meta-tools (below).
+
+## Auth — Bearer primary, Basic fallback
+
+Per the pinned `fleet-lcm-openapi.yaml` `securitySchemes`, the global scheme
+is `bearerToken` (HTTP Bearer), with `basicAuth` (HTTP Basic) defined as an
+alternative the appliance also accepts.
+`FleetLcmConnector.auth_headers` picks the scheme by inspecting the loaded
+credentials:
+
+- **Bearer (primary)** — when the target's Vault secret carries a non-empty
+  `token` field, the connector sends `Authorization: Bearer <token>`.
+- **Basic (fallback)** — otherwise it sends `Authorization: Basic <b64>` off
+  the `username` / `password` pair.
+
+An operator opts a target into Bearer simply by **staging a `token` field**
+in its Vault secret — no target-row or `auth_model` change. The
+`username` / `password` pair is always required (the appliance accepts
+`basicAuth`, and the shared `CredentialsCache` contract requires it); the
+`token` is optional and additive. This mirrors the field-discriminator
+loaders the proxmox and github connectors ship.
+
+> **Live-verify follow-up (still open, #3047).** The default loader surfaces a
+> **pre-staged** Vault token only. The alternative provisioning path — where
+> the connector POSTs `basicAuth` to the appliance's token endpoint to **mint**
+> a short-lived `bearerToken` on the fly — is a documented seam that is **not**
+> implemented, and Bearer has **not** been verified against a live appliance
+> (no reachable Fleet LCM appliance, #1002 / #995). Until that lands, a target
+> with no staged token authenticates with the Basic alternative.
+
+## Prerequisites
+
+- **A reachable VCF Fleet 9.x appliance.** The connector derives the base URL
+  from `target.host` + `target.port`; the `/fleet-lcm` service base is an
+  operator target-configuration concern carried on `host`.
+- **Service-account credentials in Vault.** The connector reads
+  `{"username", "password"}` (required) — and, optionally, `token` (to opt
+  into Bearer) — from Vault at `target.secret_ref`, under the **operator's**
+  identity (operator-context Vault read).
+- **A registered VCF Fleet 9.x target** with `product="fleet"`,
+  `auth_model="shared_service_account"`, and a fingerprint that resolves to
+  version 9.x (so the resolver picks `fleet-lcm`, not `fleet-rest`).
+- **An operator session.** `meho login <backplane-url>` writes the session
+  token the CLI reuses.
+
+## Target registration
+
+### `targets.yaml` entry
+
+```yaml
+targets:
+  - name: fleet-9x
+    product: fleet
+    host: fleet.example.internal
+    port: 443
+    secret_ref: fleet-lcm/fleet-9x
+    auth_model: shared_service_account
+    notes: "VCF Fleet 9.x — resolves to fleet-lcm by fingerprint"
+```
+
+```bash
+meho targets import fleet-9x.yaml   # add --update to PATCH an existing target
+```
+
+Verify the fingerprint resolved to 9.x (so `fleet-lcm` is selected):
+
+```bash
+meho targets probe fleet-9x --json | jq '{product, version, reachable}'
+# expected: {"product": "fleet", "version": "9.x.y.z" | null, "reachable": true}
+```
+
+### Credentials in Vault
+
+Basic (default) — username/password only:
+
+```bash
+vault kv put secret/fleet-lcm/fleet-9x \
+  username="admin@local" \
+  password="<service-account-password>"
+```
+
+Bearer (optional) — add a `token` to opt the target into the primary scheme:
+
+```bash
+vault kv patch secret/fleet-lcm/fleet-9x \
+  token="<pre-staged-bearer-token>"
+```
+
+`secret_ref` is the **logical** KV-v2 path relative to the mount (e.g.
+`fleet-lcm/fleet-9x`), not the API-path-shaped `secret/data/...` form.
+
+## Quick-start — the typed read core
+
+Once the target is registered and its credentials are in Vault, every read
+core op works end to end with zero ingest:
+
+```bash
+# Is the fleet up?
+meho operation call fleet-lcm-9.0 fleet-lcm.health --target fleet-9x
+
+# What SDDCs does this fleet manage?
+meho operation call fleet-lcm-9.0 fleet-lcm.sddc-lcm.list --target fleet-9x
+
+# What is deployed, and is it running?
+meho operation call fleet-lcm-9.0 fleet-lcm.component.list --target fleet-9x
+
+# What can we upgrade to?
+meho operation call fleet-lcm-9.0 fleet-lcm.release-version.list --target fleet-9x
+
+# Discover ops by intent (hybrid BM25 + cosine search)
+meho operation search fleet-lcm-9.0 "what upgrades are planned"
+meho operation groups fleet-lcm-9.0
+```
+
+## Optional — ingest the wider `/v1/*` breadth
+
+The typed read core is the curated, always-on read surface. The **full 51-op**
+`/v1/*` surface — the wider read breadth plus the component / upgrade-plan /
+task **writes** — is **not** code-shipped; it is enabled operationally by
+ingesting the pinned `fleet-lcm-openapi.yaml` through the generic G0.7
+pipeline and reviewing the operator-facing groups. Do this only when the read
+core is insufficient (e.g. you need a write op or a niche read).
+
+Follow the connector-agnostic runbook in
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md); the
+fleet-lcm specifics are:
+
+```bash
+# 1. Ingest the pinned spec under the SAME connector id (fleet-lcm-9.0). The
+#    ingested rows are source_kind="ingested" and ride the already-registered
+#    FleetLcmConnector.auth_headers (Bearer/Basic), so no auth wiring is needed.
+meho connector ingest \
+  --product fleet --version 9.0 --impl fleet-lcm \
+  --spec docs:fleet-lcm-9.0/fleet-lcm-openapi.yaml \
+  --json
+
+# 2. Review the LLM-summarised, operator-reviewable groups the ingest derived.
+meho connector review fleet-lcm-9.0
+
+# 3. Enable the ingested read breadth (writes stay default-deny until an
+#    operator enables the specific group). enable_reads flips every GET/HEAD
+#    ingested op to is_enabled=True.
+meho connector enable-reads fleet-lcm-9.0
+```
+
+The read core's typed ops and the ingested breadth coexist under one
+connector id: the typed ops keep their curated `group_key`s
+(`fleet-lcm-system`, …), and the ingested ops land in the groups
+`run_llm_grouping` derives during the ingest, which the operator reviews and
+enables per group. Reconciling ingested rows against the spec they were
+ingested from is tautological, so only the hand-coded typed paths are
+guarded by the spec-reconcile lane.
+
+## Agent meta-tool path
+
+Agents use `search_operations` / `call_operation` with
+`connector_id="fleet-lcm-9.0"`; the connector is never a per-op MCP tool
+(CLAUDE.md postulate 5). A typical sequence:
+
+1. `list_operation_groups(connector_id="fleet-lcm-9.0")` → the five read-core
+   groups (plus any enabled ingested groups) with their `when_to_use` hints.
+2. `search_operations(connector_id="fleet-lcm-9.0", query="what is deployed", group="fleet-lcm-components")`
+   → `fleet-lcm.component.list` / `.info` hits.
+3. `call_operation(connector_id="fleet-lcm-9.0", op_id="fleet-lcm.component.list", target="fleet-9x")`
+   → the component inventory (reduced to a JSONFlux handle when large).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| A 9.x target dispatches `/lcm/*` legacy ops | Fingerprint resolved to 8.x → `fleet-rest` | `meho targets probe fleet-9x` — confirm version 9.x so `fleet-lcm` is selected |
+| `VaultCredentialsReadError` naming the target on any read | The Vault secret is missing `username`/`password` | Stage the pair (`vault kv put …`); a token-only secret is rejected |
+| Basic sent when Bearer expected | No non-empty `token` in the Vault secret | `vault kv patch … token=<...>` and re-dispatch (credentials are cached per target; restart or wait for cache eviction if just staged) |
+| `op_id unknown_op` for a write op | Writes are the ingested-breadth follow-up, not shipped in the read core | Ingest + enable the breadth (above), or use a read core op |
+| Bearer 401 against a real appliance | Live Bearer is unverified (#1002 / #995) | Fall back to Basic; the live Bearer handshake is the #3047 follow-up |
+
+## Related resources
+
+- [`docs/codebase/connectors-fleet-lcm.md`](../codebase/connectors-fleet-lcm.md) — engineering reference
+- [`backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py`](../../backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py) — typed read-op metadata + registrar
+- [`backend/src/meho_backplane/connectors/fleet_lcm/session.py`](../../backend/src/meho_backplane/connectors/fleet_lcm/session.py) — the credential loader (Bearer token seam)
+- [`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md) — the connector-agnostic ingest runbook
+- [`docs/cross-repo/vcf-fleet-onboarding.md`](./vcf-fleet-onboarding.md) — the legacy `fleet-rest` (8.x) surface
+- Task: [#3047](https://github.com/evoila/meho/issues/3047); parent initiative [#3033](https://github.com/evoila/meho/issues/3033)


### PR DESCRIPTION
## Summary

Advances **#3047** by landing the two remaining code-shippable pieces after PR
#3055 already restored 9.0 fleet read dispatch via the 13-op typed read core:

- **Bearer token-provisioning seam.** `FleetLcmConnector.auth_headers` already
  preferred `Authorization: Bearer <token>` when the loaded credentials carried
  a `token`, but the default Vault loader only surfaced `{username, password}`,
  so Bearer was unreachable in production. `session.py`'s
  `load_credentials_from_vault` now reads the raw KV-v2 payload (via the shared
  `load_vault_secret_data`) and surfaces an **optional** `token` alongside the
  required pair — the proxmox / github field-discriminator shape. An operator
  opts a target into Bearer just by staging a `token` in its Vault secret; no
  `auth_model` change.
- **Operator onboarding runbook** (`docs/cross-repo/fleet-lcm-onboarding.md`):
  target registration + auth (Basic default, optional `token` → Bearer), the
  always-on typed read core (5 groups, kebab-case `group_key`s — the shipped
  convention), and the **optional** `meho connector ingest` of the wider 51-op
  `/v1/*` breadth via the generic ingest flow (`connector-ingestion.md` →
  `enable_reads`). The 51-op breadth is not a code artifact in this public repo
  (the vendor spec lives on the private shelf; ingest is an operator runtime
  action), so it ships as the operator runbook — the modern equivalent of the
  nsx/harbor onboarding docs.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (fleet_lcm src) — clean
- [x] `pytest` fleet_lcm suite (auth + credread + typed_reads + spec_reconcile
      + dual_impl_resolution) — 93 passed, 1 skipped (shelf-gated reconcile lane)
- [x] New `test_connectors_fleet_lcm_credread.py` drives the **real** default
      loader against a Vault fake: Basic without a token, Bearer with one,
      whitespace-strip, blank-token fallback, fail-closed on a missing pair,
      no credential value in logs
- [x] Cross-connector sweeps: `test_typed_connectors_metadata.py`,
      `test_secret_leak_checks.py`, `test_mcp_surface_conformance.py` — 27 passed
- [x] `code-quality.py` — exit 0

## Acceptance mapping (#3047)

- [x] Curated read core enabled + a 9.0 fleet target dispatches a modern read op
      end-to-end (status=`ok`) — **landed in #3055** (typed read core).
- [x] Token-provisioning seam landed — **this PR** (Vault-staged `token` → Bearer,
      proven through the real loader).
- [ ] **Bearer (or verified-Basic) auth confirmed against a LIVE appliance** —
      deferred. No reachable Fleet LCM appliance (#1002 / #995). The live
      `basicAuth` → mint-`bearerToken` exchange is a clearly-marked seam (not
      implemented); the orchestrator drives the live verify against real
      hardware after this lands. **This is why the PR uses `Refs`, not `Closes`.**

## Out of scope / follow-up

- Live Bearer verification + the live basic→bearer mint exchange (the open
  acceptance box above).
- The ingested 51-op breadth is enabled operationally (runbook), not
  code-shipped — the vendor spec is not vendored in this public repo.

## Note on the task brief

The dispatcher's "snake_case group_keys" hint does not match the shipped
codebase convention: nsx / harbor / vcd / fleet-lcm all use **kebab-case**
`group_key`s (e.g. `fleet-lcm-system`), which #3055 already merged. Introducing
snake_case would contradict that convention, so the read core's kebab-case keys
are kept and documented as-is.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs #3047
