### PR TITLE
feat(pairing): add-on pairing handshake + identity over a versioned contract (#3025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,27 @@ connector-related release-notes line.
   identical-sets guard stays as belt-and-braces; authoritative placement makes
   its firing condition impossible in practice.
 
+### Added — add-on pairing handshake + identity: pair once as a scoped service principal over a versioned contract (#3025)
+
+- The backplane gains the foundation of the add-on pairing contract
+  (Initiative #2900): a one-time handshake that registers a sibling add-on
+  product (first consumers meho-automation, meho-ssp) as a confidential
+  Keycloak client-credentials **service** principal
+  (`principal_kind=service`, `tenant_role=read_only` — scoped by
+  construction, no blanket admin) bound to a **negotiated integration
+  contract version**. Negotiation pins minimum-version skew in both
+  directions (add-on-too-old / backplane-too-old), and the negotiated
+  version is persisted. Unpair is reversible: it deletes the Keycloak client
+  then hard-deletes the pairing row, so an unpaired backplane is
+  byte-identical to a never-paired one (the append-only audit log keeps the
+  history). Pair / unpair run at `tenant_admin` over
+  `POST`/`DELETE /api/v1/addons/pairings`; every pairing's contract
+  compatibility (re-evaluated live) and last liveness heartbeat surface in
+  `/api/v1/health` (and so `meho_status` / `meho status`) and a read-only
+  `/ui/pairing` console panel. The agent meta-tool surface is unchanged — an
+  add-on identifier is data, never a tool name. New migration `0079`
+  (`addon_pairing`). See `docs/codebase/addon-pairing.md`.
+
 ### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179 / PR #3181)
 
 - `POST /api/v1/operations/call` can *mint* a reduced result handle for any

--- a/backend/alembic/versions/0079_create_addon_pairing.py
+++ b/backend/alembic/versions/0079_create_addon_pairing.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``addon_pairing`` table (#3025).
+
+The registry of *active* add-on pairings — the foundation of the add-on
+pairing contract (Initiative #2900). One row is one live pairing between the
+backplane and a sibling add-on product: a Keycloak client-credentials
+service principal plus the negotiated integration-contract version. Unpair
+hard-deletes the row (an unpaired backplane is byte-identical to a
+never-paired one), so the table only ever holds live pairings; the
+append-only ``audit_log`` keeps the pair/unpair history.
+
+Additive-only (migration-compat contract): a fresh table plus its two
+unique indexes, no ALTER of an existing object.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0079"
+down_revision: str | None = "0078"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "addon_pairing",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), sa.ForeignKey("tenant.id"), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("keycloak_client_id", sa.Text(), nullable=False),
+        sa.Column("keycloak_internal_id", sa.Text(), nullable=False),
+        sa.Column("owner_sub", sa.Text(), nullable=False),
+        sa.Column("contract_version", sa.Integer(), nullable=False),
+        sa.Column("addon_contract_version", sa.Integer(), nullable=False),
+        sa.Column("addon_min_backplane_version", sa.Integer(), nullable=False),
+        sa.Column("created_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "paired_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        # NULL until the add-on's liveness heartbeat first stamps it.
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+
+    # Per-tenant name uniqueness + the tenant-scoped list / by-name lookup.
+    op.create_index(
+        "addon_pairing_tenant_name_idx",
+        "addon_pairing",
+        ["tenant_id", "name"],
+        unique=True,
+        postgresql_using="btree",
+    )
+    # Globally-unique Keycloak clientId (no per-tenant client-id namespace).
+    op.create_index(
+        "addon_pairing_keycloak_client_id_idx",
+        "addon_pairing",
+        ["keycloak_client_id"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "addon_pairing_keycloak_client_id_idx",
+        table_name="addon_pairing",
+    )
+    op.drop_index(
+        "addon_pairing_tenant_name_idx",
+        table_name="addon_pairing",
+    )
+    op.drop_table("addon_pairing")

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -59,6 +59,7 @@ __all__ = [
 #: Route tag → :data:`FEATURE_MATURITY` key. See module docstring for
 #: the deliberately-unmapped set.
 TAG_FEATURE: Final[dict[str, str]] = {
+    "addon-pairing": "addon_pairing",
     "agent-grants": "agent_runtime",
     "agent-principals": "agent_runtime",
     "agents": "agent_runtime",

--- a/backend/src/meho_backplane/api/v1/addon_pairing.py
+++ b/backend/src/meho_backplane/api/v1/addon_pairing.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/addons/pairings*`` — REST surface for the add-on pairing handshake (#3025).
+
+Operator-facing lifecycle over
+:class:`~meho_backplane.operations.addon_pairing.AddonPairingService`, the
+foundation of Initiative #2900. Pairing registers a sibling add-on product
+as a Keycloak client-credentials **service** principal bound to a negotiated
+integration-contract version; unpairing is reversible and hard-deletes the
+pairing, leaving the backplane byte-identical to a never-paired one. Every
+mutation binds ``audit_op_id`` + ``audit_op_class`` so the synchronous,
+append-only audit middleware records the pair / unpair.
+
+Route inventory
+---------------
+
+* ``POST /api/v1/addons/pairings`` — pair an add-on. Body:
+  :class:`PairAddonRequest`. 201 with a one-time
+  :class:`PairAddonResult` (the freshly-minted ``client_secret``); 409 on a
+  contract-version skew or a duplicate pairing; 422 on a bad name; 503/502
+  when Keycloak admin is unconfigured / failing. Role: ``tenant_admin``.
+* ``GET /api/v1/addons/pairings`` — list active pairings (``{items,
+  next_cursor}`` envelope). Role: ``operator``.
+* ``GET /api/v1/addons/pairings/{name}`` — fetch one pairing. 404 when
+  absent / cross-tenant. Role: ``operator``.
+* ``DELETE /api/v1/addons/pairings/{name}`` — unpair. 204 on success; 404
+  when absent; 503/502 on Keycloak admin failure. Role: ``tenant_admin``.
+* ``POST /api/v1/addons/pairings/{name}/heartbeat`` — the paired add-on
+  reports liveness (stamps ``last_seen_at``). Requires a **service**
+  principal (403 otherwise); 404 when the add-on is not paired.
+
+Tenant scoping: every route derives ``tenant_id`` from the JWT-validated
+:class:`~meho_backplane.auth.operator.Operator`; no surface accepts a tenant
+id from the body or query string.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import status as http_status
+from fastapi.responses import Response
+
+from meho_backplane.auth.keycloak_admin import (
+    KeycloakAdminError,
+    KeycloakAdminNotConfiguredError,
+)
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.middleware import verify_jwt_and_bind
+from meho_backplane.operations.addon_pairing import (
+    AddonAlreadyPairedError,
+    AddonNotPairedError,
+    AddonPairingService,
+)
+from meho_backplane.operations.addon_pairing_contract import ContractSkewError
+from meho_backplane.operations.addon_pairing_schemas import (
+    PairAddonRequest,
+    PairAddonResult,
+    PairedAddonListResponse,
+    PairedAddonRead,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/addons/pairings", tags=["addon-pairing"])
+
+#: Module-level Depends closures — avoid ruff B008 (mutable call in a
+#: default-argument position). Pairing/unpairing is a tenant_admin action
+#: (it mints / revokes an identity and its standing posture); listing is
+#: operator-visible.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+_require_jwt = Depends(verify_jwt_and_bind)
+
+_OP_IDS: Final[dict[str, str]] = {
+    "list": "addon.list",
+    "show": "addon.show",
+    "pair": "addon.pair",
+    "unpair": "addon.unpair",
+    "heartbeat": "addon.heartbeat",
+}
+
+
+def _handle_admin_error(exc: KeycloakAdminError) -> HTTPException:
+    """Map a Keycloak Admin API failure onto the boundary status code.
+
+    ``KeycloakAdminNotConfiguredError`` -> 503 (the deploy has not wired the
+    Keycloak admin client, so the pairing surface is unavailable, not
+    broken); any other ``KeycloakAdminError`` -> 502 (Keycloak reachable but
+    the Admin API call failed). Details carry only the exception class name,
+    never a message, so no infra-topology string leaks.
+    """
+    if isinstance(exc, KeycloakAdminNotConfiguredError):
+        return HTTPException(
+            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="keycloak_admin_not_configured",
+        )
+    return HTTPException(
+        status_code=http_status.HTTP_502_BAD_GATEWAY,
+        detail=f"keycloak_admin_error:{type(exc).__name__}",
+    )
+
+
+@router.post("", response_model=PairAddonResult, status_code=http_status.HTTP_201_CREATED)
+async def pair_addon(
+    payload: PairAddonRequest,
+    operator: Operator = _require_admin,
+) -> PairAddonResult:
+    """Pair an add-on (the one-time handshake).
+
+    Returns 201 with the one-time credentials on success; 409 on a
+    contract-version skew (``detail`` names the direction) or a duplicate
+    pairing; 422 on a malformed name; 503/502 when Keycloak admin is
+    unconfigured / failing. Audited via the audit middleware.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["pair"],
+        audit_op_class="write",
+        audit_addon_name=payload.name,
+    )
+    service = AddonPairingService()
+    try:
+        return await service.pair(operator.tenant_id, operator.sub, payload)
+    except ContractSkewError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=exc.code,
+        ) from exc
+    except AddonAlreadyPairedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="addon_already_paired",
+        ) from exc
+    except KeycloakAdminError as exc:
+        raise _handle_admin_error(exc) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("", response_model=PairedAddonListResponse)
+async def list_pairings(
+    operator: Operator = _require_operator,
+) -> PairedAddonListResponse:
+    """List active pairings for the operator's tenant (tenant-scoped)."""
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["list"],
+        audit_op_class="read",
+    )
+    service = AddonPairingService()
+    items = await service.list_(operator.tenant_id)
+    return PairedAddonListResponse(items=items, next_cursor=None)
+
+
+@router.get("/{name}", response_model=PairedAddonRead)
+async def show_pairing(
+    name: Annotated[str, Path()],
+    operator: Operator = _require_operator,
+) -> PairedAddonRead:
+    """Return one pairing by name. Cross-tenant probes return 404."""
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["show"],
+        audit_op_class="read",
+    )
+    service = AddonPairingService()
+    entry = await service.get(operator.tenant_id, name)
+    if entry is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        )
+    return entry
+
+
+@router.delete("/{name}", status_code=http_status.HTTP_204_NO_CONTENT)
+async def unpair_addon(
+    name: Annotated[str, Path()],
+    operator: Operator = _require_admin,
+) -> Response:
+    """Unpair an add-on (reversible). 204 on success; 404 when not paired."""
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["unpair"],
+        audit_op_class="write",
+        audit_addon_name=name,
+    )
+    service = AddonPairingService()
+    try:
+        unpaired = await service.unpair(operator.tenant_id, name)
+    except KeycloakAdminError as exc:
+        raise _handle_admin_error(exc) from exc
+    if not unpaired:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        )
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{name}/heartbeat", response_model=PairedAddonRead)
+async def heartbeat_pairing(
+    name: Annotated[str, Path()],
+    operator: Operator = _require_jwt,
+) -> PairedAddonRead:
+    """Record an add-on liveness heartbeat (paired service principal only).
+
+    The paired add-on authenticates as its own service principal and stamps
+    ``last_seen_at``. A non-service principal is 403; an unpaired add-on is
+    404. Audited via the audit middleware.
+    """
+    if operator.principal_kind is not PrincipalKind.SERVICE:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="heartbeat_requires_service_principal",
+        )
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["heartbeat"],
+        audit_op_class="write",
+        audit_addon_name=name,
+    )
+    service = AddonPairingService()
+    try:
+        return await service.heartbeat(operator.tenant_id, name)
+    except AddonNotPairedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        ) from exc

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -78,6 +78,7 @@ per-operator Vault tenant-scope exemption in
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -98,6 +99,8 @@ from meho_backplane.mcp.schemas import PROTOCOL_VERSION
 from meho_backplane.mcp.server import mcp_session_id_capture_mode
 from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.operations import dispatch
+from meho_backplane.operations.addon_pairing import AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import is_contract_compatible
 from meho_backplane.settings import get_settings
 
 __all__ = ["build_health_response", "router"]
@@ -240,6 +243,25 @@ class SensorRunnerStatus(BaseModel):
     stall_threshold_seconds: float
 
 
+class PairingHealth(BaseModel):
+    """Health of one active add-on pairing (#3025).
+
+    ``contract_compatible`` re-evaluates the persisted pairing's negotiated
+    version pair against the *current* backplane contract, in both pinning
+    directions — so an add-on left behind by a backplane upgrade (or a
+    backplane rolled back below an add-on's required minimum) reads as
+    ``False`` here without a re-handshake. ``last_seen`` is the add-on's last
+    liveness heartbeat, ``None`` until it first checks in.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    addon: str
+    contract_version: int
+    contract_compatible: bool
+    last_seen: datetime | None
+
+
 class HealthResponse(BaseModel):
     """``GET /api/v1/health`` response body.
 
@@ -286,6 +308,12 @@ class HealthResponse(BaseModel):
     surfaces the same value on the unauthenticated readiness probe so
     a deploy operator can answer "which MCP revision will this server
     negotiate with my clients?" without an authenticated GET.
+
+    ``pairings`` (#3025) carries the tenant's active add-on pairings —
+    each add-on's negotiated contract version, whether it is still
+    contract-compatible with this backplane build, and its last liveness
+    heartbeat. The list is empty when nothing is paired; the empty-default
+    keeps response decoders generated against the pre-#3025 shape working.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -296,6 +324,7 @@ class HealthResponse(BaseModel):
     mcp_session_id_capture: str
     mcp_protocol_version: str = PROTOCOL_VERSION
     sensor_runner: SensorRunnerStatus | None = None
+    pairings: list[PairingHealth] = []
 
 
 class LivenessResponse(BaseModel):
@@ -561,6 +590,29 @@ def _sensor_runner_status() -> SensorRunnerStatus | None:
     )
 
 
+async def _pairing_health(tenant_id: UUID) -> list[PairingHealth]:
+    """Map the tenant's active add-on pairings onto the health wire model.
+
+    Empty list when nothing is paired — an unpaired backplane surfaces no
+    pairing content, keeping the facet's presence-vs-content distinction
+    honest. ``contract_compatible`` is computed per pairing via
+    :func:`~meho_backplane.operations.addon_pairing_contract.is_contract_compatible`.
+    """
+    pairings = await AddonPairingService().list_(tenant_id)
+    return [
+        PairingHealth(
+            addon=pairing.name,
+            contract_version=pairing.contract_version,
+            contract_compatible=is_contract_compatible(
+                addon_contract_version=pairing.addon_contract_version,
+                addon_min_backplane_version=pairing.addon_min_backplane_version,
+            ),
+            last_seen=pairing.last_seen_at,
+        )
+        for pairing in pairings
+    ]
+
+
 async def build_health_response(operator: Operator) -> HealthResponse:
     """Assemble the :class:`HealthResponse` for a validated operator.
 
@@ -589,6 +641,7 @@ async def build_health_response(operator: Operator) -> HealthResponse:
         mcp_session_id_capture=mcp_session_id_capture_mode(),
         mcp_protocol_version=PROTOCOL_VERSION,
         sensor_runner=_sensor_runner_status(),
+        pairings=await _pairing_health(operator.tenant_id),
     )
 
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3939,6 +3939,128 @@ class RunnerPrincipal(Base):
     )
 
 
+class AddonPairing(Base):
+    """A paired add-on product — a Keycloak service principal + a versioned contract.
+
+    Foundation of Initiative #2900 (#3025). Each row is one *active* pairing
+    between the backplane and a sibling add-on product (first consumers:
+    meho-automation, meho-ssp). Pairing is deliberately **not** connector
+    registration: an add-on is a peer control plane beside the narrow waist,
+    integrated through the governance planes, not a managed vendor system
+    below it.
+
+    Lifecycle
+    ---------
+
+    * **pair** negotiates the integration-contract version (both-direction
+      minimum-version pinning; see
+      :mod:`meho_backplane.operations.addon_pairing_contract`), provisions a
+      confidential Keycloak client-credentials client tagged
+      ``kind=service`` (``principal_kind=service``, ``tenant_role=read_only``
+      — no blanket admin; the service-principal gate parks every mutating op
+      by default), and inserts this row.
+    * **unpair** deletes the Keycloak client (the authoritative kill switch)
+      then hard-deletes this row. The row is intentionally *not* soft-kept:
+      an unpaired backplane is byte-identical to a never-paired one, so the
+      table holds only live pairings. The append-only ``audit_log`` retains
+      the full pair/unpair history.
+
+    Schema decisions
+    ----------------
+
+    * ``id`` -- UUID primary key; PG ``gen_random_uuid()`` via the migration,
+      ORM ``default=uuid.uuid4`` for SQLite / out-of-band inserts.
+    * ``tenant_id`` -- UUID NOT NULL, FK to ``tenant.id``. A pairing belongs
+      to a real tenant; the ``NO ACTION`` FK prevents deleting a tenant that
+      still has live pairings.
+    * ``name`` -- Text NOT NULL. The operator-facing add-on handle (e.g.
+      ``automation``). Unique within a tenant
+      (``addon_pairing_tenant_name_idx``).
+    * ``keycloak_client_id`` -- Text NOT NULL UNIQUE. The OAuth ``clientId``
+      in Keycloak — conventionally ``addon:<name>`` to keep add-on clients
+      visually distinct from agent / runner / user clients. Globally unique
+      (Keycloak has no per-tenant client-id namespace).
+    * ``keycloak_internal_id`` -- Text NOT NULL. Keycloak's internal UUID for
+      the client, used by the unpair path to issue the delete without a
+      lookup-by-clientId.
+    * ``owner_sub`` -- Text NOT NULL. The ``sub`` of the responsible party
+      for this add-on (the NHI governance kill-switch model, as for agent
+      principals).
+    * ``contract_version`` -- Integer NOT NULL. The **negotiated** contract
+      version both sides operate on.
+    * ``addon_contract_version`` / ``addon_min_backplane_version`` -- Integer
+      NOT NULL. What the add-on brought to the handshake — its advertised
+      version and its backplane floor. Retained so the health surface can
+      re-evaluate skew against the current backplane version without a
+      re-handshake.
+    * ``created_by_sub`` -- Text NOT NULL. Operator ``sub`` who paired.
+    * ``paired_at`` / ``updated_at`` -- ``timestamptz`` NOT NULL. PG server
+      defaults; ORM ``lambda: datetime.now(UTC)`` for SQLite.
+    * ``last_seen_at`` -- ``timestamptz`` NULL. Stamped by the add-on's
+      liveness heartbeat; ``NULL`` until the add-on first checks in.
+
+    Indexes
+    -------
+
+    * ``addon_pairing_tenant_name_idx`` -- unique composite on
+      ``(tenant_id, name)``. Enforces per-tenant name uniqueness and drives
+      the tenant-scoped list / by-name lookup.
+    * ``addon_pairing_keycloak_client_id_idx`` -- unique on
+      ``keycloak_client_id``.
+    """
+
+    __tablename__ = "addon_pairing"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    keycloak_client_id: Mapped[str] = mapped_column(Text, nullable=False)
+    keycloak_internal_id: Mapped[str] = mapped_column(Text, nullable=False)
+    owner_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    addon_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    addon_min_backplane_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    paired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "addon_pairing_tenant_name_idx",
+            "tenant_id",
+            "name",
+            unique=True,
+            postgresql_using="btree",
+        ),
+        Index(
+            "addon_pairing_keycloak_client_id_idx",
+            "keycloak_client_id",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Initiative #2415 (#2499) — gateway assignment + result-ingest storage
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/features.py
+++ b/backend/src/meho_backplane/features.py
@@ -223,6 +223,16 @@ FEATURE_MATURITY: dict[str, MaturityInfo] = {
         "target_ga": None,
         "tracking": f"{_TRACKER}/2661",
     },
+    # Add-on pairing contract (#2900): the pairing/identity foundation
+    # (#3025) — a sibling add-on paired as a scoped Keycloak service
+    # principal over a versioned integration contract. Experimental: the
+    # contract shape and paired surfaces evolve across the initiative's
+    # remaining tasks.
+    "addon_pairing": {
+        "maturity": "experimental",
+        "target_ga": None,
+        "tracking": f"{_TRACKER}/2900",
+    },
 }
 
 #: Which ``/ready`` entry maps to which :data:`FEATURE_MATURITY` key.

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -61,6 +61,7 @@ from meho_backplane.agents import (
     stop_grant_expiry_sweeper,
 )
 from meho_backplane.api.openapi_maturity import inject_maturity_extensions
+from meho_backplane.api.v1.addon_pairing import router as api_v1_addon_pairing_router
 from meho_backplane.api.v1.agent_grants import router as api_v1_agent_grants_router
 from meho_backplane.api.v1.agent_principals import (
     router as api_v1_agent_principals_router,
@@ -1051,6 +1052,10 @@ app.include_router(api_v1_approvals_router)
 # #3151 -- operator-managed standing scoped auto-approval grants for
 # service principals (the persistent form of an approve decision).
 app.include_router(api_v1_service_grants_router)
+# #3025 -- add-on pairing handshake (pair / unpair / list / heartbeat): a
+# sibling add-on product paired as a scoped Keycloak service principal over a
+# versioned integration contract (Initiative #2900 foundation).
+app.include_router(api_v1_addon_pairing_router)
 # G7.1-T2 (#314) -- tenant-conventions CRUD + history (list / show /
 # create / update / delete / history). Reads gated to operator+;
 # writes gated to tenant_admin. Tenant-scoped via the JWT's

--- a/backend/src/meho_backplane/operations/addon_pairing.py
+++ b/backend/src/meho_backplane/operations/addon_pairing.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add-on pairing lifecycle service — pair / unpair / list / heartbeat (#3025).
+
+The single code path the REST routes
+(:mod:`meho_backplane.api.v1.addon_pairing`) and the operator console call
+through. Foundation of Initiative #2900: it turns a sibling add-on product
+into a first-class paired peer of the backplane — a Keycloak
+client-credentials **service** principal bound to a negotiated
+integration-contract version — while keeping an unpaired backplane
+byte-identical to a never-paired one.
+
+Design
+------
+
+* **Stateless and method-scoped** — each method opens its own DB session,
+  commits, and closes. Same shape as
+  :class:`~meho_backplane.auth.agent_principals.AgentPrincipalService` and
+  :class:`~meho_backplane.operations.service_grants.ServicePrincipalGrantService`.
+* **Keycloak-first on both paths** (Keycloak has no XA participant, so the
+  DB commit and the Keycloak call are not one ACID unit). ``pair`` creates
+  the Keycloak client, then inserts the row (a DB failure rolls the
+  just-created client back); ``unpair`` deletes the Keycloak client first —
+  the authoritative kill switch — then deletes the row, so the backplane
+  never reports an add-on as unpaired while it can still mint tokens.
+* **Scoped principal — no blanket admin.** The client is minted with
+  ``principal_kind=service`` and ``tenant_role=read_only``; the non-agent
+  policy gate parks every mutating op for a service principal by default, so
+  a paired add-on starts with zero standing write authority. Operators widen
+  it per-op via ``ServicePrincipalGrant`` — never here.
+* **``keycloak_client_id`` convention** — ``addon:<name>`` (forward-slash
+  forbidden in Keycloak client ids), keeping add-on clients visually
+  distinct from agent / runner / user clients in the Admin Console.
+* **RBAC not enforced here** — the route / console layers gate the surface;
+  this service assumes that check has already run.
+
+Error contract
+--------------
+
+* :class:`AddonAlreadyPairedError` — pair collided with an existing
+  ``(tenant_id, name)`` or ``keycloak_client_id``.
+* :class:`AddonNotPairedError` — heartbeat on an absent pairing (unpair
+  reports absence via a ``False`` return, not this error).
+* :class:`~meho_backplane.operations.addon_pairing_contract.ContractSkewError`
+  — the contract versions cannot pair (both directions pinned).
+* :class:`~meho_backplane.auth.keycloak_admin.KeycloakAdminNotConfiguredError`
+  / :class:`~meho_backplane.auth.keycloak_admin.KeycloakAdminError`
+  — Keycloak admin unconfigured (503 at the boundary) / any other Keycloak
+  Admin API failure (502 at the boundary).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.auth.keycloak_admin import (
+    KeycloakAdminClient,
+    KeycloakClientConflictError,
+    KeycloakClientNotFoundError,
+)
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing
+from meho_backplane.operations.addon_pairing_contract import negotiate
+from meho_backplane.operations.addon_pairing_schemas import (
+    PairAddonRequest,
+    PairAddonResult,
+    PairedAddonRead,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "AddonAlreadyPairedError",
+    "AddonNotPairedError",
+    "AddonPairingService",
+]
+
+#: Add-on name alphabet: letters, digits, hyphen, underscore, dot. Mirrors
+#: the agent / runner principal name discipline.
+_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_\-\.]+$")
+
+#: Convention: the Keycloak clientId for a paired add-on.
+_CLIENT_ID_PREFIX: str = "addon:"
+
+#: ``tenant_role`` stamped into the add-on client's access token. Read-only
+#: — the add-on carries no coarse write authority; the non-agent service
+#: gate parks mutating ops until an operator issues a scoped grant.
+_ADDON_TENANT_ROLE: str = TenantRole.READ_ONLY.value
+
+
+def _keycloak_client_id(name: str) -> str:
+    """Return the canonical Keycloak clientId for add-on *name*."""
+    return f"{_CLIENT_ID_PREFIX}{name}"
+
+
+def _is_unique_violation(exc: IntegrityError) -> bool:
+    """Return whether *exc* is a unique-constraint violation."""
+    orig = getattr(exc, "orig", None)
+    sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    return sqlstate == "23505" or "UNIQUE constraint failed" in str(orig or exc)
+
+
+class AddonAlreadyPairedError(Exception):
+    """Raised when pair collides with an existing (tenant_id, name)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"add-on {name!r} is already paired for this tenant")
+
+
+class AddonNotPairedError(Exception):
+    """Raised when a heartbeat targets an add-on with no active pairing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"add-on {name!r} is not paired")
+
+
+class AddonPairingService:
+    """Tenant-scoped pair / unpair / list / heartbeat for add-on pairings.
+
+    Stateless; instantiate once per request and call freely.
+    """
+
+    def __init__(self) -> None:
+        self._log = structlog.get_logger()
+
+    async def pair(
+        self,
+        tenant_id: uuid.UUID,
+        created_by_sub: str,
+        payload: PairAddonRequest,
+    ) -> PairAddonResult:
+        """Pair an add-on: negotiate the contract, mint the principal, persist.
+
+        Negotiation runs first (cheap, side-effect-free) so a contract-skew
+        rejection never provisions a Keycloak client. On success a
+        confidential ``kind=service`` client is created and its generated
+        secret captured, then the pairing row is inserted; any failure after
+        the client is created rolls it back so pairing never orphans an
+        un-revocable identity.
+
+        Returns the one-time :class:`PairAddonResult` carrying the freshly
+        minted ``client_secret`` — the add-on's only chance to read it.
+
+        Raises
+        ------
+        ValueError
+            When *name* contains characters outside the safe alphabet.
+        ContractSkewError
+            When the contract versions cannot pair (both directions pinned).
+        AddonAlreadyPairedError
+            Duplicate ``(tenant_id, name)`` (DB unique-index or Keycloak 409).
+        KeycloakAdminNotConfiguredError / KeycloakAdminError
+            Keycloak admin unconfigured / any Admin API failure.
+        """
+        if not _NAME_PATTERN.fullmatch(payload.name):
+            raise ValueError(
+                f"add-on name {payload.name!r} contains characters outside the "
+                "safe set (allowed: letters, digits, hyphen, underscore, dot)"
+            )
+        negotiated = negotiate(
+            addon_contract_version=payload.addon_contract_version,
+            addon_min_backplane_version=payload.addon_min_backplane_version,
+        )
+        owner = payload.owner_sub or created_by_sub
+        client_id = _keycloak_client_id(payload.name)
+        audience = get_settings().keycloak_audience
+
+        internal_id, client_secret = await self._provision_keycloak_client(
+            name=payload.name,
+            tenant_id=tenant_id,
+            owner_sub=owner,
+            audience=audience,
+        )
+
+        row = AddonPairing(
+            tenant_id=tenant_id,
+            name=payload.name,
+            keycloak_client_id=client_id,
+            keycloak_internal_id=internal_id,
+            owner_sub=owner,
+            contract_version=negotiated.negotiated_version,
+            addon_contract_version=payload.addon_contract_version,
+            addon_min_backplane_version=payload.addon_min_backplane_version,
+            created_by_sub=created_by_sub,
+        )
+        entry = await self._insert_row(row, internal_id=internal_id, name=payload.name)
+        self._log.info(
+            "addon_pair",
+            tenant_id=str(tenant_id),
+            name=payload.name,
+            keycloak_client_id=client_id,
+            contract_version=negotiated.negotiated_version,
+            created_by_sub=created_by_sub,
+        )
+        return PairAddonResult(
+            pairing=entry,
+            client_id=client_id,
+            client_secret=client_secret,
+            backplane_contract_version=negotiated.backplane_contract_version,
+            negotiated_contract_version=negotiated.negotiated_version,
+        )
+
+    async def _provision_keycloak_client(
+        self,
+        *,
+        name: str,
+        tenant_id: uuid.UUID,
+        owner_sub: str,
+        audience: str,
+    ) -> tuple[str, str]:
+        """Create the add-on's ``kind=service`` client and read back its secret.
+
+        Isolated so its rollback contract is one unit: if anything after
+        ``create_client`` raises — most importantly ``get_client_secret`` —
+        the just-created live client is deleted before the error propagates.
+        A 409 conflict surfaces as :class:`AddonAlreadyPairedError` (the
+        conflicting client belongs to a prior pairing and is not ours to
+        delete).
+
+        Returns the ``(keycloak_internal_id, client_secret)`` pair.
+        """
+        client_id = _keycloak_client_id(name)
+        internal_id: str | None = None
+        kc_client = KeycloakAdminClient.from_settings()
+        try:
+            async with kc_client:
+                internal_id = await kc_client.create_client(
+                    client_id=client_id,
+                    name=name,
+                    tenant_id=str(tenant_id),
+                    owner_sub=owner_sub,
+                    audience=audience,
+                    tenant_role=_ADDON_TENANT_ROLE,
+                    principal_kind="service",
+                    kind_attribute="service",
+                )
+                client_secret = await kc_client.get_client_secret(internal_id)
+        except KeycloakClientConflictError as exc:
+            raise AddonAlreadyPairedError(name) from exc
+        except BaseException as exc:
+            if internal_id is not None:
+                await self._rollback_orphan_client(
+                    internal_id, tenant_id=tenant_id, name=name, cause=exc
+                )
+            raise
+        return internal_id, client_secret
+
+    async def _insert_row(
+        self,
+        row: AddonPairing,
+        *,
+        internal_id: str,
+        name: str,
+    ) -> PairedAddonRead:
+        """Insert the pairing row; roll back the Keycloak client on failure.
+
+        A created client with no MEHO row is an orphaned, token-issuing
+        identity that can never be listed or unpaired through MEHO — the
+        unreachable-kill-switch failure this lifecycle exists to prevent.
+        """
+        sessionmaker = get_sessionmaker()
+        try:
+            async with sessionmaker() as session:
+                session.add(row)
+                try:
+                    await session.flush()
+                except IntegrityError as exc:
+                    await session.rollback()
+                    if _is_unique_violation(exc):
+                        raise AddonAlreadyPairedError(name) from exc
+                    raise
+                await session.refresh(row)
+                entry = PairedAddonRead.model_validate(row)
+                await session.commit()
+        except BaseException as exc:
+            await self._rollback_orphan_client(
+                internal_id, tenant_id=row.tenant_id, name=name, cause=exc
+            )
+            raise
+        return entry
+
+    async def _rollback_orphan_client(
+        self,
+        internal_id: str,
+        *,
+        tenant_id: uuid.UUID,
+        name: str,
+        cause: BaseException,
+    ) -> None:
+        """Best-effort delete of a Keycloak client whose row failed to write.
+
+        A cleanup failure is logged (the orphan needs manual removal) but
+        never masks the original *cause*, which the caller re-raises.
+        """
+        try:
+            kc_client = KeycloakAdminClient.from_settings()
+            async with kc_client:
+                await kc_client.delete_client(internal_id)
+        except KeycloakClientNotFoundError:
+            return
+        except Exception as cleanup_exc:
+            self._log.error(
+                "addon_pair_orphan_cleanup_failed",
+                tenant_id=str(tenant_id),
+                name=name,
+                keycloak_internal_id=internal_id,
+                cause=type(cause).__name__,
+                error=type(cleanup_exc).__name__,
+            )
+            return
+        self._log.warning(
+            "addon_pair_rolled_back_keycloak_client",
+            tenant_id=str(tenant_id),
+            name=name,
+            keycloak_internal_id=internal_id,
+            cause=type(cause).__name__,
+        )
+
+    async def unpair(
+        self,
+        tenant_id: uuid.UUID,
+        name: str,
+    ) -> bool:
+        """Unpair an add-on: delete the Keycloak client, then the row.
+
+        Reversible: the row is hard-deleted (no soft-kept residue), so the
+        add-on can pair again cleanly and an unpaired backplane is
+        byte-identical to a never-paired one; the append-only ``audit_log``
+        retains the history.
+
+        Keycloak is deleted *before* the row so the backplane never reports
+        an add-on unpaired while it can still mint tokens. A Keycloak
+        *not-found* is treated as success (the client was cleaned up out of
+        band). Returns ``True`` on success, ``False`` when no pairing matches
+        ``(tenant_id, name)``.
+
+        Raises
+        ------
+        KeycloakAdminNotConfiguredError
+            When Keycloak admin credentials are not configured.
+        KeycloakAdminError
+            On a non-404 Keycloak Admin API failure — the row is left in
+            place, so the pairing stays active and the operator can retry.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonPairing).where(
+                    AddonPairing.tenant_id == tenant_id,
+                    AddonPairing.name == name,
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                return False
+            keycloak_internal_id = row.keycloak_internal_id
+            row_id = row.id
+
+        kc_client = KeycloakAdminClient.from_settings()
+        try:
+            async with kc_client:
+                await kc_client.delete_client(keycloak_internal_id)
+        except KeycloakClientNotFoundError:
+            self._log.warning(
+                "addon_unpair_keycloak_not_found",
+                tenant_id=str(tenant_id),
+                name=name,
+                keycloak_internal_id=keycloak_internal_id,
+            )
+
+        async with sessionmaker() as session:
+            await session.execute(delete(AddonPairing).where(AddonPairing.id == row_id))
+            await session.commit()
+
+        self._log.info(
+            "addon_unpair",
+            tenant_id=str(tenant_id),
+            name=name,
+            keycloak_internal_id=keycloak_internal_id,
+        )
+        return True
+
+    async def list_(
+        self,
+        tenant_id: uuid.UUID,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[PairedAddonRead]:
+        """Return active pairings for *tenant_id*, name-sorted."""
+        if limit < 0:
+            raise ValueError(f"limit must be >= 0; got {limit}")
+        if offset < 0:
+            raise ValueError(f"offset must be >= 0; got {offset}")
+        if limit == 0:
+            return []
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            q = (
+                select(AddonPairing)
+                .where(AddonPairing.tenant_id == tenant_id)
+                .order_by(AddonPairing.name)
+                .limit(limit)
+                .offset(offset)
+            )
+            result = await session.execute(q)
+            rows = result.scalars().all()
+        return [PairedAddonRead.model_validate(row) for row in rows]
+
+    async def get(
+        self,
+        tenant_id: uuid.UUID,
+        name: str,
+    ) -> PairedAddonRead | None:
+        """Fetch one pairing by ``(tenant_id, name)``; ``None`` if absent."""
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonPairing).where(
+                    AddonPairing.tenant_id == tenant_id,
+                    AddonPairing.name == name,
+                )
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return PairedAddonRead.model_validate(row)
+
+    async def heartbeat(
+        self,
+        tenant_id: uuid.UUID,
+        name: str,
+    ) -> PairedAddonRead:
+        """Stamp the add-on's liveness ``last_seen_at`` to now.
+
+        Called by the paired add-on itself (authenticating as its service
+        principal). Raises :class:`AddonNotPairedError` when no pairing
+        matches ``(tenant_id, name)``.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonPairing).where(
+                    AddonPairing.tenant_id == tenant_id,
+                    AddonPairing.name == name,
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                raise AddonNotPairedError(name)
+            row.last_seen_at = datetime.now(UTC)
+            row.updated_at = datetime.now(UTC)
+            await session.flush()
+            await session.refresh(row)
+            entry = PairedAddonRead.model_validate(row)
+            await session.commit()
+        return entry

--- a/backend/src/meho_backplane/operations/addon_pairing_contract.py
+++ b/backend/src/meho_backplane/operations/addon_pairing_contract.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add-on pairing contract — version constants + bidirectional negotiation (#3025).
+
+The pairing handshake binds a sibling add-on product (first consumers:
+meho-automation, meho-ssp) to the backplane over a *versioned integration
+contract*. This module is the single source of truth for the backplane's
+contract version and the pure negotiation logic; the service layer
+(:mod:`meho_backplane.operations.addon_pairing`) applies it at pair time
+and the health surface re-applies it to persisted pairings.
+
+Minimum-version pinning is enforced in **both** directions:
+
+* **add-on-too-old** — the add-on advertises a contract version below the
+  oldest the backplane still accepts
+  (:data:`MIN_SUPPORTED_ADDON_CONTRACT_VERSION`). Pairing is refused with
+  code ``addon_contract_below_backplane_minimum``.
+* **backplane-too-old** — the backplane's own contract version is below the
+  minimum the add-on requires (``addon_min_backplane_version``). Pairing is
+  refused with code ``backplane_contract_below_addon_minimum``.
+
+When both floors are satisfied the negotiated version is the lower of the
+two advertised versions — each side must speak it — and is persisted on the
+pairing row.
+
+Versions are monotonic integers, not semver: the contract is a single
+in-house surface with one publisher (this backplane) and a small set of
+first-party consumers, so an ordered counter carries all the pinning
+semantics without the parsing surface of a dotted string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "BACKPLANE_CONTRACT_VERSION",
+    "MIN_SUPPORTED_ADDON_CONTRACT_VERSION",
+    "ContractSkewError",
+    "NegotiatedContract",
+    "is_contract_compatible",
+    "negotiate",
+]
+
+#: The integration-contract version this backplane build speaks. Bump when
+#: the pairing contract's observable shape changes in a way a paired add-on
+#: must adapt to. The first shipped contract is ``1``.
+BACKPLANE_CONTRACT_VERSION: int = 1
+
+#: The oldest add-on contract version this backplane still accepts at pair
+#: time — the backplane's side of minimum-version pinning. Raise it only in
+#: a release that intentionally drops support for an older add-on contract;
+#: raising it can turn a previously-healthy persisted pairing incompatible
+#: (surfaced by :func:`is_contract_compatible`).
+MIN_SUPPORTED_ADDON_CONTRACT_VERSION: int = 1
+
+
+class ContractSkewError(Exception):
+    """Raised when the add-on and backplane contract versions cannot pair.
+
+    Carries a stable machine ``code`` the REST/console surfaces render
+    verbatim, plus the two diagnostic versions for operator triage. The
+    two codes name the direction of the skew so an operator knows which
+    side to upgrade.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        message: str,
+        addon_contract_version: int,
+        addon_min_backplane_version: int,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.addon_contract_version = addon_contract_version
+        self.addon_min_backplane_version = addon_min_backplane_version
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True, slots=True)
+class NegotiatedContract:
+    """The outcome of a successful :func:`negotiate`.
+
+    ``negotiated_version`` is what both sides operate on; the three inputs
+    are retained so the pairing row records exactly what each side brought
+    to the handshake (enabling :func:`is_contract_compatible` to re-evaluate
+    skew after a backplane upgrade).
+    """
+
+    negotiated_version: int
+    backplane_contract_version: int
+    addon_contract_version: int
+    addon_min_backplane_version: int
+
+
+def negotiate(
+    *,
+    addon_contract_version: int,
+    addon_min_backplane_version: int,
+) -> NegotiatedContract:
+    """Negotiate the contract version for a pairing, pinning both directions.
+
+    Raises :class:`ContractSkewError` when either minimum-version floor is
+    violated. On success returns the :class:`NegotiatedContract` whose
+    ``negotiated_version`` is ``min(addon_contract_version,
+    BACKPLANE_CONTRACT_VERSION)`` — the highest version both sides speak.
+    """
+    if addon_contract_version < MIN_SUPPORTED_ADDON_CONTRACT_VERSION:
+        raise ContractSkewError(
+            "addon_contract_below_backplane_minimum",
+            message=(
+                f"add-on contract v{addon_contract_version} is below the "
+                f"backplane minimum v{MIN_SUPPORTED_ADDON_CONTRACT_VERSION}; "
+                "upgrade the add-on"
+            ),
+            addon_contract_version=addon_contract_version,
+            addon_min_backplane_version=addon_min_backplane_version,
+        )
+    if addon_min_backplane_version > BACKPLANE_CONTRACT_VERSION:
+        raise ContractSkewError(
+            "backplane_contract_below_addon_minimum",
+            message=(
+                f"backplane contract v{BACKPLANE_CONTRACT_VERSION} is below "
+                f"the add-on's required minimum v{addon_min_backplane_version}; "
+                "upgrade the backplane"
+            ),
+            addon_contract_version=addon_contract_version,
+            addon_min_backplane_version=addon_min_backplane_version,
+        )
+    return NegotiatedContract(
+        negotiated_version=min(addon_contract_version, BACKPLANE_CONTRACT_VERSION),
+        backplane_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_contract_version=addon_contract_version,
+        addon_min_backplane_version=addon_min_backplane_version,
+    )
+
+
+def is_contract_compatible(
+    *,
+    addon_contract_version: int,
+    addon_min_backplane_version: int,
+) -> bool:
+    """Return whether a persisted pairing still satisfies the current contract.
+
+    The health signal for a pairing: a version pair that negotiated cleanly
+    against an earlier build can drift incompatible after an upgrade that
+    raised :data:`MIN_SUPPORTED_ADDON_CONTRACT_VERSION` past the add-on's
+    advertised version, or a downgrade that dropped
+    :data:`BACKPLANE_CONTRACT_VERSION` below the add-on's required minimum.
+    Both directions are checked, mirroring :func:`negotiate`, so the surface
+    stays truthful across backplane version changes without re-running the
+    handshake.
+    """
+    if addon_contract_version < MIN_SUPPORTED_ADDON_CONTRACT_VERSION:
+        return False
+    return addon_min_backplane_version <= BACKPLANE_CONTRACT_VERSION

--- a/backend/src/meho_backplane/operations/addon_pairing_schemas.py
+++ b/backend/src/meho_backplane/operations/addon_pairing_schemas.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic v2 value types for the add-on pairing surface (#3025).
+
+Intake (:class:`PairAddonRequest`) forbids unknown fields so a typo in the
+handshake body is a 422, not a silently-dropped version claim. The read
+model (:class:`PairedAddonRead`) is built from the ORM row via
+``model_validate``. :class:`PairAddonResult` is the one-time pairing
+response: it carries the freshly-minted ``client_secret`` the add-on needs
+to authenticate as its service principal — returned exactly once, never
+persisted in plaintext, never re-readable through the list/get surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.auth.runner_principals import NAME_MAX_LENGTH
+
+__all__ = [
+    "PairAddonRequest",
+    "PairAddonResult",
+    "PairedAddonListResponse",
+    "PairedAddonRead",
+]
+
+
+class PairAddonRequest(BaseModel):
+    """Intake for :meth:`AddonPairingService.pair` — the handshake body.
+
+    ``addon_contract_version`` is the contract version the add-on speaks;
+    ``addon_min_backplane_version`` is the oldest backplane contract the
+    add-on will accept. Both drive the bidirectional negotiation in
+    :mod:`meho_backplane.operations.addon_pairing_contract`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(max_length=NAME_MAX_LENGTH)
+    owner_sub: str | None = None
+    addon_contract_version: int = Field(ge=1)
+    addon_min_backplane_version: int = Field(ge=1)
+
+
+class PairedAddonRead(BaseModel):
+    """Row representation returned by list / get / heartbeat accessors."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    name: str
+    keycloak_client_id: str
+    owner_sub: str
+    contract_version: int
+    addon_contract_version: int
+    addon_min_backplane_version: int
+    created_by_sub: str
+    paired_at: datetime
+    last_seen_at: datetime | None
+    updated_at: datetime
+
+
+class PairAddonResult(BaseModel):
+    """One-time pairing response carrying the add-on's fresh credentials.
+
+    ``client_secret`` is repr-hidden so it never lands in a log line or an
+    exception render; it is serialised in the HTTP body once (the handshake
+    response) and is unrecoverable afterwards.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    pairing: PairedAddonRead
+    client_id: str
+    client_secret: str = Field(repr=False)
+    backplane_contract_version: int
+    negotiated_contract_version: int
+
+
+class PairedAddonListResponse(BaseModel):
+    """Unified list envelope (api-shape-conventions §2) for paired add-ons."""
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[PairedAddonRead]
+    next_cursor: str | None = None

--- a/backend/src/meho_backplane/ui/maturity.py
+++ b/backend/src/meho_backplane/ui/maturity.py
@@ -66,6 +66,7 @@ MATURITY_INDEX_URL = "https://evoila.github.io/meho/latest/reference/maturity/"
 #: test suite pins this dict against ``base.html``'s registry so the
 #: two cannot drift silently.
 SURFACE_FEATURE: dict[str, str] = {
+    "pairing": "addon_pairing",
     "broadcast": "broadcast",
     "knowledge": "memory_knowledge",
     "corpus": "doc_collections",

--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -104,6 +104,7 @@ from meho_backplane.ui.routes.kb import build_kb_router
 from meho_backplane.ui.routes.keycloak import build_keycloak_router
 from meho_backplane.ui.routes.memory import build_memory_router
 from meho_backplane.ui.routes.operations import build_operations_router
+from meho_backplane.ui.routes.pairing import build_pairing_router
 from meho_backplane.ui.routes.retrieval import build_retrieval_router
 from meho_backplane.ui.routes.runbooks import build_runbooks_router
 from meho_backplane.ui.routes.runners import build_runners_router
@@ -133,6 +134,7 @@ __all__ = [
     "build_keycloak_router",
     "build_memory_router",
     "build_operations_router",
+    "build_pairing_router",
     "build_retrieval_router",
     "build_router",
     "build_runbooks_router",
@@ -275,6 +277,14 @@ def build_router() -> APIRouter:
     # (T2) registered before any ``{param}`` route binds first; included before
     # the stubs aggregate so its concrete paths win the first-match-wins lookup.
     router.include_router(build_keycloak_router())
+    # Add-on pairing registry (#3025, Initiative #2900): read-only
+    # ``/ui/pairing`` — every active add-on pairing with its negotiated
+    # contract version, live contract-compatibility re-evaluation, and last
+    # liveness heartbeat. One literal route, no ``{param}`` sub-path, so no
+    # first-match-wins shadowing concern; included before the stubs aggregate
+    # so its concrete path wins against ``/ui/{slug}``. Pair / unpair are REST
+    # (``/api/v1/addons/pairings``); the console is read-only.
+    router.include_router(build_pairing_router())
     # Audit-query forensic console (G10.15-T1 #1944): ``/ui/audit`` (filter
     # form + first result page) + ``/ui/audit/results`` (filter-submit +
     # forward-cursor "Load more" fragment). Reads dispatch the

--- a/backend/src/meho_backplane/ui/routes/pairing.py
+++ b/backend/src/meho_backplane/ui/routes/pairing.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/pairing`` — the add-on pairing registry + health panel (#3025).
+
+The operator-console face of the add-on pairing contract (Initiative #2900).
+One glance answers "which add-ons are paired / which are still
+contract-compatible with this backplane / which have gone quiet?": each row
+shows a pairing's add-on name, its negotiated contract version, whether that
+version is still compatible with the current backplane build (both-direction
+skew re-evaluated live via
+:func:`~meho_backplane.operations.addon_pairing_contract.is_contract_compatible`),
+its last liveness heartbeat, and when it was paired.
+
+The route serves two response shapes from one handler (the sensors / runners
+mould): the full ``pairing/list.html`` page on a browser navigation, and the
+``pairing/_table_rows.html`` fragment on an ``HX-Request`` (the 30s
+auto-refresh poll).
+
+Reads at ``operator`` visibility through the in-process
+:class:`~meho_backplane.operations.addon_pairing.AddonPairingService`
+``list_`` (the same accessor the Bearer ``GET /api/v1/addons/pairings``
+route uses) rather than the REST surface, because a browser carrying only
+the BFF session cookie cannot authenticate the Bearer route. Tenant scoping
+is non-overrideable — the service's first WHERE clause is the session's
+``tenant_id``. Read-only: pair / unpair stay on the REST surface.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.operations.addon_pairing import AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import (
+    BACKPLANE_CONTRACT_VERSION,
+    is_contract_compatible,
+)
+from meho_backplane.operations.addon_pairing_schemas import PairedAddonRead
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.checks.views import coerce_utc_aware
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_pairing_router"]
+
+#: Hard cap on the pairings a single list render considers. The registry is a
+#: glance surface; a tenant with more paired add-ons than this has a problem
+#: the list view is not the place to page through.
+_LIST_LIMIT = 200
+
+#: Module-level ``Depends`` closure — ruff B008 idiom, matching the sensors /
+#: runners routes.
+_require_session_dep = Depends(require_ui_session)
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when HTMX issued the request (``HX-Request: true``)."""
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def project_pairing_to_row(pairing: PairedAddonRead) -> dict[str, object]:
+    """Project one pairing read-model onto the flat template row.
+
+    ``contract_compatible`` is recomputed against the current backplane
+    contract so a pairing left behind by an upgrade reads as incompatible
+    without a re-handshake; ``compat_badge`` selects the DaisyUI badge class.
+    """
+    compatible = is_contract_compatible(
+        addon_contract_version=pairing.addon_contract_version,
+        addon_min_backplane_version=pairing.addon_min_backplane_version,
+    )
+    return {
+        "addon": pairing.name,
+        "contract_version": pairing.contract_version,
+        "contract_compatible": compatible,
+        "compat_badge": "badge-success" if compatible else "badge-error",
+        "compat_label": "compatible" if compatible else "incompatible",
+        "last_seen": coerce_utc_aware(pairing.last_seen_at),
+        "paired_at": coerce_utc_aware(pairing.paired_at),
+        "owner_sub": pairing.owner_sub,
+    }
+
+
+def build_pairing_router() -> APIRouter:
+    """Construct the add-on pairing registry :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can build
+    parallel routers without sharing route state — the chassis convention.
+    Registers the single ``GET /ui/pairing`` route serving both the full page
+    and the HTMX fragment from one handler.
+    """
+    router = APIRouter(tags=["ui-pairing"])
+
+    async def _handler(
+        request: Request,
+        session_ctx: UISessionContext = _require_session_dep,
+    ) -> HTMLResponse:
+        """Serve ``GET /ui/pairing``. See module docstring."""
+        pairings = await AddonPairingService().list_(
+            session_ctx.tenant_id,
+            limit=_LIST_LIMIT,
+        )
+        rows = [project_pairing_to_row(p) for p in pairings]
+        context: dict[str, object] = {
+            "page_title": "Pairing",
+            "active_surface": "pairing",
+            "rows": rows,
+            "backplane_contract_version": BACKPLANE_CONTRACT_VERSION,
+            "now_utc": datetime.now(UTC),
+        }
+        template_name = (
+            "pairing/_table_rows.html" if _is_htmx_request(request) else "pairing/list.html"
+        )
+        return get_templates().TemplateResponse(request, template_name, context)
+
+    router.add_api_route(
+        "/ui/pairing",
+        _handler,
+        methods=["GET"],
+        name="ui_pairing_list",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -52,6 +52,7 @@
   ("event-source", "/ui/event-sources", "radio-tower", "Event Sources"),
   ("operations", "/ui/operations", "terminal", "Operations"),
   ("keycloak", "/ui/keycloak", "key-round", "Keycloak"),
+  ("pairing", "/ui/pairing", "plug", "Pairing"),
   ("vault", "/ui/vault", "lock", "Vault"),
   ("approvals", "/ui/approvals", "bell", "Approvals"),
   ("audit", "/ui/audit", "scroll-text", "Audit"),

--- a/backend/src/meho_backplane/ui/templates/pairing/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/pairing/_table_rows.html
@@ -1,0 +1,59 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Add-on pairing registry table-rows fragment (#3025).
+
+  Rendered in two contexts:
+    * As a partial ``{% include %}``d by ``list.html`` on the initial
+      full-page render.
+    * As the standalone fragment ``GET /ui/pairing`` returns when the
+      ``HX-Request`` header is set (the 30s auto-refresh poll). HTMX
+      outerHTML-swaps it into the existing ``#pairing-table-body`` element.
+
+  The ``Last seen`` / ``Paired`` columns render a relative string ("3 h ago")
+  with a tooltip carrying the full ISO timestamp — pure server-side via the
+  ``_rel`` macro, no JS. ``contract_compatible`` reuses a server-derived
+  badge class; a pairing whose add-on has never sent a heartbeat has
+  ``last_seen == None`` and renders the em-dash placeholder.
+-#}
+{% macro _rel(ts) -%}
+  {%- set ago = (now_utc - ts).total_seconds() | int -%}
+  {%- if ago < 60 -%}just now
+  {%- elif ago < 3600 -%}{{ (ago // 60) }} min ago
+  {%- elif ago < 86400 -%}{{ (ago // 3600) }} h ago
+  {%- elif ago < 604800 -%}{{ (ago // 86400) }} d ago
+  {%- else -%}{{ ts.strftime("%Y-%m-%d") }}
+  {%- endif -%}
+{%- endmacro %}
+<tbody id="pairing-table-body">
+  {% if rows %}
+    {% for row in rows %}
+      <tr data-addon-name="{{ row.addon }}">
+        <td class="font-medium">{{ row.addon }}</td>
+        <td class="text-xs"><span class="font-mono">v{{ row.contract_version }}</span></td>
+        <td>
+          <span class="badge {{ row.compat_badge }} badge-sm">{{ row.compat_label }}</span>
+        </td>
+        <td>
+          {% if row.last_seen %}
+            <span class="text-xs" title="{{ row.last_seen.isoformat() }}">{{ _rel(row.last_seen) }}</span>
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <span class="text-xs" title="{{ row.paired_at.isoformat() }}">{{ _rel(row.paired_at) }}</span>
+        </td>
+        <td class="text-xs"><span class="font-mono">{{ row.owner_sub }}</span></td>
+      </tr>
+    {% endfor %}
+  {% else %}
+    <tr>
+      <td colspan="6" class="text-center text-sm opacity-60 py-6">
+        No add-ons paired. Pair one via
+        <code>POST /api/v1/addons/pairings</code>.
+      </td>
+    </tr>
+  {% endif %}
+</tbody>

--- a/backend/src/meho_backplane/ui/templates/pairing/list.html
+++ b/backend/src/meho_backplane/ui/templates/pairing/list.html
@@ -1,0 +1,59 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the add-on pairing registry (#3025, Initiative #2900).
+  Extends ``base.html`` so the chrome matches the rest of the console. One
+  glance answers "which add-ons are paired / which are still contract-
+  compatible with this backplane / which have gone quiet?": each row shows a
+  pairing's add-on name, its negotiated contract version, a compatibility
+  badge (both-direction skew re-evaluated live against the current backplane
+  contract), its last liveness heartbeat, when it was paired, and its owner.
+
+  Auto-refresh: the table arms an ``hx-trigger="every 30s"`` poll so the
+  liveness + compatibility projection stays live. Read-only — pair / unpair
+  stay on the REST surface (``/api/v1/addons/pairings``).
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Pairing &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="flex items-center gap-2 text-2xl font-semibold">Pairing{% include "_maturity_badge.html" %}</h1>
+      <p class="text-sm opacity-70">
+        Paired add-on products — each a scoped Keycloak service principal on a
+        versioned integration contract. This backplane speaks contract
+        <span class="font-mono">v{{ backplane_contract_version }}</span>.
+        Pairing / unpairing is a <code>tenant_admin</code> action on the REST
+        surface; this console is read-only.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Table ---------- #}
+  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+    <table
+      class="table table-sm"
+      hx-get="/ui/pairing"
+      hx-trigger="every 30s"
+      hx-target="#pairing-table-body"
+      hx-swap="outerHTML"
+    >
+      <thead>
+        <tr>
+          <th>Add-on</th>
+          <th>Contract</th>
+          <th>Compatibility</th>
+          <th>Last seen</th>
+          <th>Paired</th>
+          <th>Owner</th>
+        </tr>
+      </thead>
+      {% include "pairing/_table_rows.html" %}
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -297,6 +297,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # test errors at setup with ``cannot truncate a table referenced in a
     # foreign key constraint``.
     "service_principal_grant",
+    # ``addon_pairing.tenant_id`` is a real ``REFERENCES tenant(id)`` FK from
+    # migration ``0079`` (#3025 add-on pairing handshake). PG rejects
+    # truncating ``tenant`` unless every referencing table is listed in the
+    # same statement, so this must appear here or every PG-backed acceptance
+    # test errors at setup with ``cannot truncate a table referenced in a
+    # foreign key constraint``.
+    "addon_pairing",
     "targets",
     "tenant",
 )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -441,6 +441,10 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   grants) carries a real ``REFERENCES tenant(id)`` FK; must be listed
         #   here or PG rejects the per-test TRUNCATE of ``tenant`` with ``cannot
         #   truncate a table referenced in a foreign key constraint``.
+        # * ``addon_pairing`` — migration 0079 (#3025 add-on pairing handshake)
+        #   carries a real ``REFERENCES tenant(id)`` FK; must be listed here or
+        #   PG rejects the per-test TRUNCATE of ``tenant`` with ``cannot
+        #   truncate a table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -449,7 +453,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, "
+                "service_principal_grant, addon_pairing, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -519,7 +523,7 @@ async def pg_engine_empty_tenant(
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, "
+                "service_principal_grant, addon_pairing, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/test_addon_pairing_conformance.py
+++ b/backend/tests/test_addon_pairing_conformance.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Conformance seed for the add-on pairing contract (#3025).
+
+The invariant the rest of Initiative #2900 builds on: an **unpaired**
+backplane is byte-identical to a never-paired one, and pairing grows only an
+operator-plane surface — never the agent's meta-tool waist (postulate 5).
+This is the *seed*: it pins the two properties #3025 must hold, so a later
+task that lights up the paired agent surface extends these assertions rather
+than silently regressing the unpaired baseline.
+
+* **Agent surface unchanged** — pairing registers no MCP meta-tool. The
+  working / operator waist is what it was; an add-on identifier is *data*
+  (``op_id`` / a row), never a tool name.
+* **Unpaired health carries no pairing content** — with zero active
+  pairings the ``/status`` pairings facet is an empty list.
+* **A paired add-on surfaces its health** — including the both-direction
+  contract-skew re-evaluation (the paired side of the seed).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import select
+
+import meho_backplane.main  # noqa: F401 — importing registers the full MCP tool surface
+from meho_backplane.api.v1.health import _pairing_health
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, Tenant
+from meho_backplane.mcp import registry as mcp_registry
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def test_pairing_registers_no_agent_surface_tool() -> None:
+    """The add-on pairing feature grows no MCP meta-tool (byte-identical waist)."""
+    offenders = sorted(
+        name for name in mcp_registry._TOOLS if "addon" in name.lower() or "pairing" in name.lower()
+    )
+    assert not offenders, (
+        f"pairing must not register agent-surface tools, found: {offenders}. "
+        "Add-on identifiers are data (op_id / rows), never tool names (postulate 5)."
+    )
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _insert_pairing(*, name: str, addon_min_backplane_version: int) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AddonPairing(
+                tenant_id=_TENANT,
+                name=name,
+                keycloak_client_id=f"addon:{name}",
+                keycloak_internal_id="kc-internal",
+                owner_sub="op-admin",
+                contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_min_backplane_version=addon_min_backplane_version,
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_unpaired_health_has_empty_pairing_facet() -> None:
+    """Zero active pairings -> the /status pairings facet is empty."""
+    await _seed_tenant()
+    assert await _pairing_health(_TENANT) == []
+
+
+@pytest.mark.asyncio
+async def test_paired_addon_surfaces_compatible_health() -> None:
+    await _seed_tenant()
+    await _insert_pairing(name="automation", addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION)
+    facet = await _pairing_health(_TENANT)
+    assert len(facet) == 1
+    assert facet[0].addon == "automation"
+    assert facet[0].contract_version == BACKPLANE_CONTRACT_VERSION
+    assert facet[0].contract_compatible is True
+    assert facet[0].last_seen is None
+
+
+@pytest.mark.asyncio
+async def test_paired_addon_health_flags_contract_skew() -> None:
+    """A pairing whose add-on now out-requires this backplane reads incompatible."""
+    await _seed_tenant()
+    await _insert_pairing(name="ssp", addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1)
+    facet = await _pairing_health(_TENANT)
+    assert len(facet) == 1
+    assert facet[0].contract_compatible is False

--- a/backend/tests/test_addon_pairing_contract.py
+++ b/backend/tests/test_addon_pairing_contract.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the add-on pairing contract negotiation (#3025).
+
+Pins the bidirectional minimum-version pinning: an add-on below the
+backplane's floor is refused one way, a backplane below the add-on's floor
+the other, and a compatible pair negotiates to the lower advertised version.
+The health-side re-evaluation (:func:`is_contract_compatible`) mirrors the
+same two directions. Boundary inputs derive from the module constants so a
+future version bump keeps the tests meaningful.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.operations.addon_pairing_contract import (
+    BACKPLANE_CONTRACT_VERSION,
+    MIN_SUPPORTED_ADDON_CONTRACT_VERSION,
+    ContractSkewError,
+    is_contract_compatible,
+    negotiate,
+)
+
+
+def test_negotiate_equal_versions_returns_that_version() -> None:
+    result = negotiate(
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+    assert result.negotiated_version == BACKPLANE_CONTRACT_VERSION
+    assert result.backplane_contract_version == BACKPLANE_CONTRACT_VERSION
+
+
+def test_negotiate_addon_ahead_of_backplane_negotiates_down_to_backplane() -> None:
+    """An add-on speaking a newer contract negotiates to what the backplane speaks."""
+    result = negotiate(
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION + 5,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+    assert result.negotiated_version == BACKPLANE_CONTRACT_VERSION
+
+
+def test_negotiate_addon_below_backplane_minimum_is_skew() -> None:
+    """Direction 1: add-on advertises below the backplane's floor -> refused."""
+    with pytest.raises(ContractSkewError) as exc_info:
+        negotiate(
+            addon_contract_version=MIN_SUPPORTED_ADDON_CONTRACT_VERSION - 1,
+            addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+        )
+    assert exc_info.value.code == "addon_contract_below_backplane_minimum"
+
+
+def test_negotiate_backplane_below_addon_minimum_is_skew() -> None:
+    """Direction 2: add-on requires a newer backplane than this build -> refused."""
+    with pytest.raises(ContractSkewError) as exc_info:
+        negotiate(
+            addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+            addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1,
+        )
+    assert exc_info.value.code == "backplane_contract_below_addon_minimum"
+
+
+def test_skew_error_carries_diagnostic_versions() -> None:
+    with pytest.raises(ContractSkewError) as exc_info:
+        negotiate(
+            addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+            addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 3,
+        )
+    err = exc_info.value
+    assert err.addon_contract_version == BACKPLANE_CONTRACT_VERSION
+    assert err.addon_min_backplane_version == BACKPLANE_CONTRACT_VERSION + 3
+    assert err.code in str(err)
+
+
+def test_is_contract_compatible_true_for_a_negotiable_pair() -> None:
+    assert is_contract_compatible(
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+
+
+def test_is_contract_compatible_false_when_addon_below_backplane_minimum() -> None:
+    assert not is_contract_compatible(
+        addon_contract_version=MIN_SUPPORTED_ADDON_CONTRACT_VERSION - 1,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+
+
+def test_is_contract_compatible_false_when_backplane_below_addon_minimum() -> None:
+    assert not is_contract_compatible(
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1,
+    )

--- a/backend/tests/test_addon_pairing_service.py
+++ b/backend/tests/test_addon_pairing_service.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :class:`AddonPairingService` (#3025).
+
+Coverage:
+
+* pair provisions a **scoped** service principal — ``principal_kind=service``,
+  ``kind_attribute=service``, ``tenant_role=read_only``, clientId
+  ``addon:<name>`` — the "no blanket admin" proof, asserted against the
+  recorded Keycloak admin transport.
+* pair persists the negotiated contract + returns the one-time secret.
+* pair -> unpair -> pair round-trip is reversible (unpair hard-deletes the
+  row and the Keycloak client; the name frees up for re-pairing).
+* a contract-version skew refuses the pairing **before** any Keycloak client
+  is created.
+* duplicate pair -> ``AddonAlreadyPairedError``; unpair of an absent add-on
+  -> ``False``.
+* heartbeat stamps ``last_seen_at``; heartbeat on an unpaired add-on raises.
+* a failure after ``create_client`` rolls the just-created Keycloak client back.
+
+The Keycloak admin client is monkey-patched so tests need no live Keycloak.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, Tenant
+from meho_backplane.operations.addon_pairing import (
+    AddonAlreadyPairedError,
+    AddonNotPairedError,
+    AddonPairingService,
+)
+from meho_backplane.operations.addon_pairing_contract import (
+    BACKPLANE_CONTRACT_VERSION,
+    ContractSkewError,
+)
+from meho_backplane.operations.addon_pairing_schemas import PairAddonRequest
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_KC_INTERNAL_ID = "cc000000-0000-0000-0000-00000000dead"
+_PATCH_TARGET = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_ADMIN_URL", "https://keycloak.test/admin/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_ID", "meho-admin")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "s3cr3t")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
+    """A mock KeycloakAdminClient factory that succeeds on create/secret/delete."""
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _fetch(tenant_id: uuid.UUID) -> list[AddonPairing]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(AddonPairing)
+            .where(AddonPairing.tenant_id == tenant_id)
+            .order_by(AddonPairing.name)
+        )
+        return list(rows.scalars().all())
+
+
+def _request(name: str = "automation") -> PairAddonRequest:
+    return PairAddonRequest(
+        name=name,
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pair_provisions_scoped_service_principal() -> None:
+    """The paired principal is a read-only service client — no blanket admin."""
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    with patch(_PATCH_TARGET, factory):
+        result = await AddonPairingService().pair(_TENANT, "op-admin", _request())
+
+    mock_client.create_client.assert_awaited_once()
+    kwargs = mock_client.create_client.await_args.kwargs
+    assert kwargs["principal_kind"] == "service"
+    assert kwargs["kind_attribute"] == "service"
+    assert kwargs["tenant_role"] == "read_only"
+    assert kwargs["client_id"] == "addon:automation"
+    # One-time credentials + the negotiated contract come back to the caller.
+    assert result.client_id == "addon:automation"
+    assert result.client_secret == "generated-secret"
+    assert result.negotiated_contract_version == BACKPLANE_CONTRACT_VERSION
+    assert result.pairing.contract_version == BACKPLANE_CONTRACT_VERSION
+
+
+@pytest.mark.asyncio
+async def test_pair_persists_row() -> None:
+    await _seed_tenant()
+    with patch(_PATCH_TARGET, _mock_kc_ok()):
+        await AddonPairingService().pair(_TENANT, "op-admin", _request())
+    rows = await _fetch(_TENANT)
+    assert len(rows) == 1
+    assert rows[0].name == "automation"
+    assert rows[0].keycloak_client_id == "addon:automation"
+    assert rows[0].keycloak_internal_id == _KC_INTERNAL_ID
+    assert rows[0].last_seen_at is None
+
+
+@pytest.mark.asyncio
+async def test_pair_unpair_pair_is_reversible() -> None:
+    """Unpair hard-deletes; the name frees up so the add-on can pair again."""
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    service = AddonPairingService()
+    with patch(_PATCH_TARGET, factory):
+        await service.pair(_TENANT, "op-admin", _request())
+        assert await service.unpair(_TENANT, "automation") is True
+        mock_client.delete_client.assert_awaited_once_with(_KC_INTERNAL_ID)
+        assert await _fetch(_TENANT) == []
+        # Re-pair: the byte-identical unpaired state accepts the name again.
+        await service.pair(_TENANT, "op-admin", _request())
+    assert len(await _fetch(_TENANT)) == 1
+
+
+@pytest.mark.asyncio
+async def test_pair_contract_skew_never_provisions_keycloak() -> None:
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    payload = PairAddonRequest(
+        name="automation",
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1,
+    )
+    with patch(_PATCH_TARGET, factory), pytest.raises(ContractSkewError):
+        await AddonPairingService().pair(_TENANT, "op-admin", payload)
+    mock_client.create_client.assert_not_awaited()
+    assert await _fetch(_TENANT) == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_pair_raises() -> None:
+    await _seed_tenant()
+    service = AddonPairingService()
+    with patch(_PATCH_TARGET, _mock_kc_ok()):
+        await service.pair(_TENANT, "op-admin", _request())
+        with pytest.raises(AddonAlreadyPairedError):
+            await service.pair(_TENANT, "op-admin", _request())
+
+
+@pytest.mark.asyncio
+async def test_unpair_absent_returns_false() -> None:
+    await _seed_tenant()
+    with patch(_PATCH_TARGET, _mock_kc_ok()):
+        assert await AddonPairingService().unpair(_TENANT, "ghost") is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_stamps_last_seen() -> None:
+    await _seed_tenant()
+    service = AddonPairingService()
+    with patch(_PATCH_TARGET, _mock_kc_ok()):
+        await service.pair(_TENANT, "op-admin", _request())
+        entry = await service.heartbeat(_TENANT, "automation")
+    assert entry.last_seen_at is not None
+    rows = await _fetch(_TENANT)
+    assert rows[0].last_seen_at is not None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_unpaired_raises() -> None:
+    await _seed_tenant()
+    with pytest.raises(AddonNotPairedError):
+        await AddonPairingService().heartbeat(_TENANT, "ghost")
+
+
+@pytest.mark.asyncio
+async def test_secret_readback_failure_rolls_back_keycloak_client() -> None:
+    """A failure after ``create_client`` deletes the client — no orphaned identity."""
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    mock_client.get_client_secret = AsyncMock(side_effect=RuntimeError("kc flap"))
+    with patch(_PATCH_TARGET, factory), pytest.raises(RuntimeError):
+        await AddonPairingService().pair(_TENANT, "op-admin", _request())
+    mock_client.create_client.assert_awaited_once()
+    mock_client.delete_client.assert_awaited_once_with(_KC_INTERNAL_ID)
+    assert await _fetch(_TENANT) == []

--- a/backend/tests/test_api_v1_addon_pairing.py
+++ b/backend/tests/test_api_v1_addon_pairing.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.addon_pairing` (#3025).
+
+Coverage matrix:
+
+* pair -> 201 with the one-time credentials + negotiated contract; the
+  pair / unpair round-trip is audited (``audit_log.payload.op_id``).
+* RBAC: ``operator`` may list but not pair / unpair (403 -> tenant_admin).
+* contract skew -> 409 naming the direction.
+* list returns the ``{items, next_cursor}`` envelope.
+* get / unpair of an absent add-on -> 404.
+* heartbeat: a ``service`` principal stamps liveness (200); a human
+  principal is 403; an unpaired add-on is 404.
+
+Keycloak admin is monkey-patched so tests need no live Keycloak.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Tenant
+from meho_backplane.main import app
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+from ._vault_fakes import install_fake_vault
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_KC_INTERNAL_ID = "cc000000-0000-0000-0000-0000000beef0"
+_PATCH_TARGET = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_URL", "https://keycloak.test/admin/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_ID", "meho-admin")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "s3cr3t")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    install_fake_vault(monkeypatch)
+    yield TestClient(app)
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-admin",
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    principal_kind: str | None = None,
+) -> str:
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=role.value,
+        tenant_id=str(_TENANT),
+        **({"principal_kind": principal_kind} if principal_kind else {}),
+    )
+
+
+def _service_token(key: Any) -> str:
+    """A paired add-on's ``principal_kind=service`` / ``read_only`` token."""
+    return _token(key, sub="addon-svc", role=TenantRole.READ_ONLY, principal_kind="service")
+
+
+def _mock_kc_ok() -> MagicMock:
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _audit_op_ids() -> list[str]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+    return [r.payload.get("op_id") for r in rows if isinstance(r.payload, dict)]
+
+
+def _pair_body(min_backplane: int = BACKPLANE_CONTRACT_VERSION) -> dict[str, object]:
+    return {
+        "name": "automation",
+        "addon_contract_version": BACKPLANE_CONTRACT_VERSION,
+        "addon_min_backplane_version": min_backplane,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pair_round_trip_is_audited(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-pair")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        created = client.post("/api/v1/addons/pairings", json=_pair_body(), headers=headers)
+        assert created.status_code == 201, created.text
+        body = created.json()
+        assert body["client_id"] == "addon:automation"
+        assert body["client_secret"] == "generated-secret"
+        assert body["negotiated_contract_version"] == BACKPLANE_CONTRACT_VERSION
+        assert body["pairing"]["name"] == "automation"
+
+        deleted = client.delete("/api/v1/addons/pairings/automation", headers=headers)
+        assert deleted.status_code == 204, deleted.text
+
+    op_ids = await _audit_op_ids()
+    assert "addon.pair" in op_ids
+    assert "addon.unpair" in op_ids
+
+
+@pytest.mark.asyncio
+async def test_pair_requires_tenant_admin(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-op")
+    headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post("/api/v1/addons/pairings", json=_pair_body(), headers=headers)
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_contract_skew_returns_409(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-skew")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/addons/pairings",
+            json=_pair_body(min_backplane=BACKPLANE_CONTRACT_VERSION + 1),
+            headers=headers,
+        )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == "backplane_contract_below_addon_minimum"
+
+
+@pytest.mark.asyncio
+async def test_list_returns_envelope(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-list")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=headers)
+        listed = client.get("/api/v1/addons/pairings", headers=headers)
+    assert listed.status_code == 200, listed.text
+    body = listed.json()
+    assert isinstance(body["items"], list)
+    assert "next_cursor" in body
+    assert body["items"][0]["name"] == "automation"
+
+
+@pytest.mark.asyncio
+async def test_get_absent_is_404(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-404")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get("/api/v1/addons/pairings/ghost", headers=headers)
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_unpair_absent_is_404(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-unp")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.delete("/api/v1/addons/pairings/ghost", headers=headers)
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_service_principal_ok_human_403(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-hb")
+    admin_headers = {"Authorization": f"Bearer {_token(key)}"}
+    service_headers = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin_headers)
+
+        # A human principal cannot heartbeat.
+        human = client.post("/api/v1/addons/pairings/automation/heartbeat", headers=admin_headers)
+        assert human.status_code == 403, human.text
+
+        # The paired service principal reports liveness.
+        beat = client.post("/api/v1/addons/pairings/automation/heartbeat", headers=service_headers)
+        assert beat.status_code == 200, beat.text
+        assert beat.json()["last_seen_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_unpaired_is_404(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-hb404")
+    headers = {"Authorization": f"Bearer {_service_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post("/api/v1/addons/pairings/ghost/heartbeat", headers=headers)
+    assert resp.status_code == 404, resp.text

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -385,6 +385,8 @@ def test_happy_path_returns_full_federation_response(
             "stalled": False,
             "stall_threshold_seconds": 60.0,
         },
+        # #3025: the add-on pairing facet — empty on an unpaired backplane.
+        "pairings": [],
     }
 
     # Vault was hit with the configured role / mount and the operator's

--- a/backend/tests/test_api_v1_list_envelope_contract.py
+++ b/backend/tests/test_api_v1_list_envelope_contract.py
@@ -127,6 +127,7 @@ async def _seed_tenant() -> None:
 #: convention by returning ``{items, next_cursor?}`` and being added
 #: here.
 _LIST_ENVELOPE_ENDPOINTS = [
+    pytest.param("/api/v1/addons/pairings", None, id="addon-pairings"),
     pytest.param("/api/v1/targets", None, id="targets"),
     pytest.param("/api/v1/connectors", "connectors", id="connectors"),
     pytest.param("/api/v1/conventions", "entries", id="conventions"),

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -423,6 +423,7 @@ def test_maturity_registry_covers_the_2664_classification() -> None:
         "agent_runtime",
         "doc_collections",
         "two_world_ops",
+        "addon_pairing",
     }
 
 

--- a/backend/tests/test_ui_pairing.py
+++ b/backend/tests/test_ui_pairing.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the ``/ui/pairing`` console surface (#3025).
+
+Acceptance:
+
+* The registry is session-authenticated; an unauthenticated request 302s to
+  the BFF login.
+* ``GET /ui/pairing`` renders every active pairing in the tenant with its
+  negotiated contract version and a live contract-compatibility badge.
+* A pairing whose add-on out-requires this backplane renders ``incompatible``
+  (the both-direction skew re-evaluation, surfaced in the console).
+* The surface is tenant-scoped and read-only (no pair / unpair controls).
+
+Harness mirrors :mod:`tests.test_ui_sensors`: a minimal FastAPI app wired with
+the UI session + CSRF middlewares and a ``web_session`` row carrying a real
+Keycloak-minted token, so ``require_ui_session`` re-verifies end-to-end.
+Pairings are seeded directly as ORM rows — the read path is a pure DB read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import timedelta
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import AddonPairing, Tenant
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import clear_discovery_cache, reset_verifier_store_for_testing
+from meho_backplane.ui.auth.session_store import create_session, reset_fernet_cache_for_testing
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+
+from ._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_pairing(
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    addon_min_backplane_version: int = BACKPLANE_CONTRACT_VERSION,
+) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                AddonPairing(
+                    tenant_id=tenant_id,
+                    name=name,
+                    keycloak_client_id=f"addon:{name}",
+                    keycloak_internal_id="kc-internal",
+                    owner_sub="op-admin",
+                    contract_version=BACKPLANE_CONTRACT_VERSION,
+                    addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+                    addon_min_backplane_version=addon_min_backplane_version,
+                    created_by_sub="op-admin",
+                )
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(*, tenant_id: uuid.UUID, access_token: str, operator_sub: str) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _client(tenant_id: uuid.UUID = _TENANT_A) -> tuple[TestClient, respx.MockRouter]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-pairing-test-kid")
+    jwks = _public_jwks(keypair)
+    access_token = _mint_token(
+        keypair, sub="op-operator", tenant_id=str(tenant_id), tenant_role=TenantRole.OPERATOR.value
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id, access_token=access_token, operator_sub="op-operator"
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock
+
+
+def test_list_unauthenticated_redirects_to_login() -> None:
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/pairing")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_list_renders_paired_addon_with_compatibility() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_pairing(tenant_id=_TENANT_A, name="automation")
+    client, mock = _client()
+    try:
+        response = client.get("/ui/pairing")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Pairing" in body
+    assert "automation" in body
+    assert f"v{BACKPLANE_CONTRACT_VERSION}" in body
+    assert "compatible" in body
+
+
+def test_list_flags_incompatible_pairing() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_pairing(
+        tenant_id=_TENANT_A,
+        name="ssp",
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1,
+    )
+    client, mock = _client()
+    try:
+        response = client.get("/ui/pairing")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "incompatible" in response.text
+
+
+def test_empty_state_when_no_pairings() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock = _client()
+    try:
+        response = client.get("/ui/pairing")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "No add-ons paired" in response.text

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9522,6 +9522,252 @@
         }
       }
     },
+    "/api/v1/addons/pairings": {
+      "post": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Pair Addon",
+        "description": "Pair an add-on (the one-time handshake).\n\nReturns 201 with the one-time credentials on success; 409 on a\ncontract-version skew (``detail`` names the direction) or a duplicate\npairing; 422 on a malformed name; 503/502 when Keycloak admin is\nunconfigured / failing. Audited via the audit middleware.",
+        "operationId": "pair_addon_api_v1_addons_pairings_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairAddonRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairAddonResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "List Pairings",
+        "description": "List active pairings for the operator's tenant (tenant-scoped).",
+        "operationId": "list_pairings_api_v1_addons_pairings_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairedAddonListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/pairings/{name}": {
+      "get": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Show Pairing",
+        "description": "Return one pairing by name. Cross-tenant probes return 404.",
+        "operationId": "show_pairing_api_v1_addons_pairings__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairedAddonRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Unpair Addon",
+        "description": "Unpair an add-on (reversible). 204 on success; 404 when not paired.",
+        "operationId": "unpair_addon_api_v1_addons_pairings__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/pairings/{name}/heartbeat": {
+      "post": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Heartbeat Pairing",
+        "description": "Record an add-on liveness heartbeat (paired service principal only).\n\nThe paired add-on authenticates as its own service principal and stamps\n``last_seen_at``. A non-service principal is 403; an unpaired add-on is\n404. Audited via the audit middleware.",
+        "operationId": "heartbeat_pairing_api_v1_addons_pairings__name__heartbeat_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairedAddonRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/conventions": {
       "get": {
         "tags": [
@@ -19075,6 +19321,28 @@
         }
       }
     },
+    "/ui/pairing": {
+      "get": {
+        "tags": [
+          "ui-pairing"
+        ],
+        "summary": "Ui Pairing List",
+        "description": "Serve ``GET /ui/pairing``. See module docstring.",
+        "operationId": "ui_pairing_list_ui_pairing_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/audit/results": {
       "get": {
         "tags": [
@@ -26315,6 +26583,14 @@
           "sensor_runner": {
             "$ref": "#/components/schemas/SensorRunnerStatus",
             "nullable": true
+          },
+          "pairings": {
+            "items": {
+              "$ref": "#/components/schemas/PairingHealth"
+            },
+            "type": "array",
+            "title": "Pairings",
+            "default": []
           }
         },
         "type": "object",
@@ -26325,7 +26601,7 @@
           "mcp_session_id_capture"
         ],
         "title": "HealthResponse",
-        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"when_negotiated\"`` \u2014 a ``Mcp-Session-Id`` header is captured\n  into ``audit_log.agent_session_id`` only when the client\n  negotiated a session via the ``initialize`` handshake and echoes\n  the server-issued id; a header-less call is accepted and its row's\n  session id lands as NULL (invisible to session-lineage replay).\n  This is the default. It reads ``\"when_negotiated\"`` rather than\n  ``\"always\"`` because capture is not a guarantee \u2014 #2700 reported\n  the former ``\"always\"`` label as misleading, since header-less\n  callers stay out of lineage. Distinguish an empty forest from an\n  empty history via the replay surface's\n  ``excluded_null_session_count``.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written, so every accepted MCP call carries a session id. Flipped\n  on by ``MCP_REQUIRE_SESSION_ID=true`` in compliance deploys that\n  forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent).\n\n``sensor_runner`` (#2763) carries the checks evaluation-loop's\nliveness (:class:`SensorRunnerStatus`), and is ``None`` exactly\nwhen ``SENSOR_RUNNER_ENABLED=false`` \u2014 a deliberately disabled\nrunner must not read as stalled. The ``None`` default keeps\nresponse decoders generated against the pre-#2763 shape working;\nthe handler always populates it on an enabled runner.\n\n``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's\npinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.\nMirrors the ``mcp_session_id_capture`` precedent: single-field\noperator visibility into the MCP layer's runtime state. The\nmatching ``mcp.protocol_version`` entry on ``/ready``'s features\nblock (see :func:`meho_backplane.features.build_features_block`)\nsurfaces the same value on the unauthenticated readiness probe so\na deploy operator can answer \"which MCP revision will this server\nnegotiate with my clients?\" without an authenticated GET."
+        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"when_negotiated\"`` \u2014 a ``Mcp-Session-Id`` header is captured\n  into ``audit_log.agent_session_id`` only when the client\n  negotiated a session via the ``initialize`` handshake and echoes\n  the server-issued id; a header-less call is accepted and its row's\n  session id lands as NULL (invisible to session-lineage replay).\n  This is the default. It reads ``\"when_negotiated\"`` rather than\n  ``\"always\"`` because capture is not a guarantee \u2014 #2700 reported\n  the former ``\"always\"`` label as misleading, since header-less\n  callers stay out of lineage. Distinguish an empty forest from an\n  empty history via the replay surface's\n  ``excluded_null_session_count``.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written, so every accepted MCP call carries a session id. Flipped\n  on by ``MCP_REQUIRE_SESSION_ID=true`` in compliance deploys that\n  forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent).\n\n``sensor_runner`` (#2763) carries the checks evaluation-loop's\nliveness (:class:`SensorRunnerStatus`), and is ``None`` exactly\nwhen ``SENSOR_RUNNER_ENABLED=false`` \u2014 a deliberately disabled\nrunner must not read as stalled. The ``None`` default keeps\nresponse decoders generated against the pre-#2763 shape working;\nthe handler always populates it on an enabled runner.\n\n``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's\npinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.\nMirrors the ``mcp_session_id_capture`` precedent: single-field\noperator visibility into the MCP layer's runtime state. The\nmatching ``mcp.protocol_version`` entry on ``/ready``'s features\nblock (see :func:`meho_backplane.features.build_features_block`)\nsurfaces the same value on the unauthenticated readiness probe so\na deploy operator can answer \"which MCP revision will this server\nnegotiate with my clients?\" without an authenticated GET.\n\n``pairings`` (#3025) carries the tenant's active add-on pairings \u2014\neach add-on's negotiated contract version, whether it is still\ncontract-compatible with this backplane build, and its last liveness\nheartbeat. The list is empty when nothing is paired; the empty-default\nkeeps response decoders generated against the pre-#3025 shape working."
       },
       "InCompare": {
         "properties": {
@@ -27399,6 +27675,200 @@
         ],
         "title": "OperatorIdentity",
         "description": "Operator identity surface exposed to the CLI and MCP ``meho_status``.\n\nExcludes ``raw_jwt`` deliberately \u2014 the bearer token must never\nappear in a response body, and the :class:`Operator` model carries\nit for downstream Vault forward-auth only.\n\n``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session\nconfirm *which tenant and role it runs as* from inside the session \u2014\nthe check the clean-room program's \"logged in as operator, not\ntenant_admin\" discipline needs, and the identity the ``meho_status``\ntool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)\nalready promises. Both are always present on the validated\n:class:`Operator` (JWT claims), so the surface can never omit them;\nthey serialise as a UUID string / role value under\n``model_dump(mode=\"json\")`` \u2014 the same wire shape the\n``meho://tenant/<id>/info`` resource returns."
+      },
+      "PairAddonRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Name"
+          },
+          "owner_sub": {
+            "type": "string",
+            "nullable": true,
+            "title": "Owner Sub"
+          },
+          "addon_contract_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Addon Contract Version"
+          },
+          "addon_min_backplane_version": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Addon Min Backplane Version"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "addon_contract_version",
+          "addon_min_backplane_version"
+        ],
+        "title": "PairAddonRequest",
+        "description": "Intake for :meth:`AddonPairingService.pair` \u2014 the handshake body.\n\n``addon_contract_version`` is the contract version the add-on speaks;\n``addon_min_backplane_version`` is the oldest backplane contract the\nadd-on will accept. Both drive the bidirectional negotiation in\n:mod:`meho_backplane.operations.addon_pairing_contract`."
+      },
+      "PairAddonResult": {
+        "properties": {
+          "pairing": {
+            "$ref": "#/components/schemas/PairedAddonRead"
+          },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "type": "string",
+            "title": "Client Secret"
+          },
+          "backplane_contract_version": {
+            "type": "integer",
+            "title": "Backplane Contract Version"
+          },
+          "negotiated_contract_version": {
+            "type": "integer",
+            "title": "Negotiated Contract Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pairing",
+          "client_id",
+          "client_secret",
+          "backplane_contract_version",
+          "negotiated_contract_version"
+        ],
+        "title": "PairAddonResult",
+        "description": "One-time pairing response carrying the add-on's fresh credentials.\n\n``client_secret`` is repr-hidden so it never lands in a log line or an\nexception render; it is serialised in the HTTP body once (the handshake\nresponse) and is unrecoverable afterwards."
+      },
+      "PairedAddonListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PairedAddonRead"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "PairedAddonListResponse",
+        "description": "Unified list envelope (api-shape-conventions \u00a72) for paired add-ons."
+      },
+      "PairedAddonRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "keycloak_client_id": {
+            "type": "string",
+            "title": "Keycloak Client Id"
+          },
+          "owner_sub": {
+            "type": "string",
+            "title": "Owner Sub"
+          },
+          "contract_version": {
+            "type": "integer",
+            "title": "Contract Version"
+          },
+          "addon_contract_version": {
+            "type": "integer",
+            "title": "Addon Contract Version"
+          },
+          "addon_min_backplane_version": {
+            "type": "integer",
+            "title": "Addon Min Backplane Version"
+          },
+          "created_by_sub": {
+            "type": "string",
+            "title": "Created By Sub"
+          },
+          "paired_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Paired At"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Seen At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "name",
+          "keycloak_client_id",
+          "owner_sub",
+          "contract_version",
+          "addon_contract_version",
+          "addon_min_backplane_version",
+          "created_by_sub",
+          "paired_at",
+          "last_seen_at",
+          "updated_at"
+        ],
+        "title": "PairedAddonRead",
+        "description": "Row representation returned by list / get / heartbeat accessors."
+      },
+      "PairingHealth": {
+        "properties": {
+          "addon": {
+            "type": "string",
+            "title": "Addon"
+          },
+          "contract_version": {
+            "type": "integer",
+            "title": "Contract Version"
+          },
+          "contract_compatible": {
+            "type": "boolean",
+            "title": "Contract Compatible"
+          },
+          "last_seen": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Seen"
+          }
+        },
+        "type": "object",
+        "required": [
+          "addon",
+          "contract_version",
+          "contract_compatible",
+          "last_seen"
+        ],
+        "title": "PairingHealth",
+        "description": "Health of one active add-on pairing (#3025).\n\n``contract_compatible`` re-evaluates the persisted pairing's negotiated\nversion pair against the *current* backplane contract, in both pinning\ndirections \u2014 so an add-on left behind by a backplane upgrade (or a\nbackplane rolled back below an add-on's required minimum) reads as\n``False`` here without a re-handshake. ``last_seen`` is the add-on's last\nliveness heartbeat, ``None`` until it first checks in."
       },
       "PermissionVerdict": {
         "type": "string",
@@ -31851,6 +32321,10 @@
     }
   },
   "tags": [
+    {
+      "name": "addon-pairing",
+      "x-maturity": "experimental"
+    },
     {
       "name": "agent-grants",
       "x-maturity": "experimental"

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4539,6 +4539,12 @@ type HTTPValidationError struct {
 // surfaces the same value on the unauthenticated readiness probe so
 // a deploy operator can answer "which MCP revision will this server
 // negotiate with my clients?" without an authenticated GET.
+//
+// “pairings“ (#3025) carries the tenant's active add-on pairings —
+// each add-on's negotiated contract version, whether it is still
+// contract-compatible with this backplane build, and its last liveness
+// heartbeat. The list is empty when nothing is paired; the empty-default
+// keeps response decoders generated against the pre-#3025 shape working.
 type HealthResponse struct {
 	// Db Database migration status.
 	//
@@ -4573,6 +4579,7 @@ type HealthResponse struct {
 	// ``model_dump(mode="json")`` — the same wire shape the
 	// ``meho://tenant/<id>/info`` resource returns.
 	Operator OperatorIdentity `json:"operator"`
+	Pairings *[]PairingHealth `json:"pairings,omitempty"`
 
 	// SensorRunner Liveness of this process's sensor evaluation loop (#2763).
 	//
@@ -5364,6 +5371,71 @@ type OperatorIdentity struct {
 	// ``f"role={role}"`` renders as ``"role=tenant_admin"`` rather than
 	// ``"role=TenantRole.TENANT_ADMIN"``.
 	TenantRole TenantRole `json:"tenant_role"`
+}
+
+// PairAddonRequest Intake for :meth:`AddonPairingService.pair` — the handshake body.
+//
+// “addon_contract_version“ is the contract version the add-on speaks;
+// “addon_min_backplane_version“ is the oldest backplane contract the
+// add-on will accept. Both drive the bidirectional negotiation in
+// :mod:`meho_backplane.operations.addon_pairing_contract`.
+type PairAddonRequest struct {
+	AddonContractVersion     int     `json:"addon_contract_version"`
+	AddonMinBackplaneVersion int     `json:"addon_min_backplane_version"`
+	Name                     string  `json:"name"`
+	OwnerSub                 *string `json:"owner_sub"`
+}
+
+// PairAddonResult One-time pairing response carrying the add-on's fresh credentials.
+//
+// “client_secret“ is repr-hidden so it never lands in a log line or an
+// exception render; it is serialised in the HTTP body once (the handshake
+// response) and is unrecoverable afterwards.
+type PairAddonResult struct {
+	BackplaneContractVersion  int    `json:"backplane_contract_version"`
+	ClientId                  string `json:"client_id"`
+	ClientSecret              string `json:"client_secret"`
+	NegotiatedContractVersion int    `json:"negotiated_contract_version"`
+
+	// Pairing Row representation returned by list / get / heartbeat accessors.
+	Pairing PairedAddonRead `json:"pairing"`
+}
+
+// PairedAddonListResponse Unified list envelope (api-shape-conventions §2) for paired add-ons.
+type PairedAddonListResponse struct {
+	Items      []PairedAddonRead `json:"items"`
+	NextCursor *string           `json:"next_cursor"`
+}
+
+// PairedAddonRead Row representation returned by list / get / heartbeat accessors.
+type PairedAddonRead struct {
+	AddonContractVersion     int                `json:"addon_contract_version"`
+	AddonMinBackplaneVersion int                `json:"addon_min_backplane_version"`
+	ContractVersion          int                `json:"contract_version"`
+	CreatedBySub             string             `json:"created_by_sub"`
+	Id                       openapi_types.UUID `json:"id"`
+	KeycloakClientId         string             `json:"keycloak_client_id"`
+	LastSeenAt               *time.Time         `json:"last_seen_at"`
+	Name                     string             `json:"name"`
+	OwnerSub                 string             `json:"owner_sub"`
+	PairedAt                 time.Time          `json:"paired_at"`
+	TenantId                 openapi_types.UUID `json:"tenant_id"`
+	UpdatedAt                time.Time          `json:"updated_at"`
+}
+
+// PairingHealth Health of one active add-on pairing (#3025).
+//
+// “contract_compatible“ re-evaluates the persisted pairing's negotiated
+// version pair against the *current* backplane contract, in both pinning
+// directions — so an add-on left behind by a backplane upgrade (or a
+// backplane rolled back below an add-on's required minimum) reads as
+// “False“ here without a re-handshake. “last_seen“ is the add-on's last
+// liveness heartbeat, “None“ until it first checks in.
+type PairingHealth struct {
+	Addon              string     `json:"addon"`
+	ContractCompatible bool       `json:"contract_compatible"`
+	ContractVersion    int        `json:"contract_version"`
+	LastSeen           *time.Time `json:"last_seen"`
 }
 
 // PermissionVerdict Three-state verdict returned by the permission resolver.
@@ -8223,6 +8295,31 @@ type MehoBackplaneUiRoutesConnectorsListViewSortColumn string
 // “"_SortColumn.NAME"“).
 type MehoBackplaneUiRoutesTopologyTableSortColumn string
 
+// ListPairingsApiV1AddonsPairingsGetParams defines parameters for ListPairingsApiV1AddonsPairingsGet.
+type ListPairingsApiV1AddonsPairingsGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// PairAddonApiV1AddonsPairingsPostParams defines parameters for PairAddonApiV1AddonsPairingsPost.
+type PairAddonApiV1AddonsPairingsPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// UnpairAddonApiV1AddonsPairingsNameDeleteParams defines parameters for UnpairAddonApiV1AddonsPairingsNameDelete.
+type UnpairAddonApiV1AddonsPairingsNameDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ShowPairingApiV1AddonsPairingsNameGetParams defines parameters for ShowPairingApiV1AddonsPairingsNameGet.
+type ShowPairingApiV1AddonsPairingsNameGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams defines parameters for HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost.
+type HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ListAgentPrincipalsApiV1AgentPrincipalsGetParams defines parameters for ListAgentPrincipalsApiV1AgentPrincipalsGet.
 type ListAgentPrincipalsApiV1AgentPrincipalsGetParams struct {
 	Limit          *int    `form:"limit,omitempty" json:"limit,omitempty"`
@@ -9517,6 +9614,9 @@ type VaultVersionsUiVaultVersionsGetParams struct {
 	Mount  *string `form:"mount,omitempty" json:"mount,omitempty"`
 	Path   *string `form:"path,omitempty" json:"path,omitempty"`
 }
+
+// PairAddonApiV1AddonsPairingsPostJSONRequestBody defines body for PairAddonApiV1AddonsPairingsPost for application/json ContentType.
+type PairAddonApiV1AddonsPairingsPostJSONRequestBody = PairAddonRequest
 
 // RegisterAgentPrincipalApiV1AgentPrincipalsPostJSONRequestBody defines body for RegisterAgentPrincipalApiV1AgentPrincipalsPost for application/json ContentType.
 type RegisterAgentPrincipalApiV1AgentPrincipalsPostJSONRequestBody = AgentPrincipalCreate
@@ -11308,6 +11408,23 @@ type ClientInterface interface {
 	// ProtectedResourceMetadataWellKnownOauthProtectedResourceGet request
 	ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListPairingsApiV1AddonsPairingsGet request
+	ListPairingsApiV1AddonsPairingsGet(ctx context.Context, params *ListPairingsApiV1AddonsPairingsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PairAddonApiV1AddonsPairingsPostWithBody request with any body
+	PairAddonApiV1AddonsPairingsPostWithBody(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PairAddonApiV1AddonsPairingsPost(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, body PairAddonApiV1AddonsPairingsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UnpairAddonApiV1AddonsPairingsNameDelete request
+	UnpairAddonApiV1AddonsPairingsNameDelete(ctx context.Context, name string, params *UnpairAddonApiV1AddonsPairingsNameDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ShowPairingApiV1AddonsPairingsNameGet request
+	ShowPairingApiV1AddonsPairingsNameGet(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost request
+	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListAgentPrincipalsApiV1AgentPrincipalsGet request
 	ListAgentPrincipalsApiV1AgentPrincipalsGet(ctx context.Context, params *ListAgentPrincipalsApiV1AgentPrincipalsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -12508,6 +12625,9 @@ type ClientInterface interface {
 	// OperationsSearchUiOperationsSearchGet request
 	OperationsSearchUiOperationsSearchGet(ctx context.Context, params *OperationsSearchUiOperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UiPairingListUiPairingGet request
+	UiPairingListUiPairingGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RetrievalIndexUiRetrievalGet request
 	RetrievalIndexUiRetrievalGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -12741,6 +12861,78 @@ func (c *Client) RootGet(ctx context.Context, reqEditors ...RequestEditorFn) (*h
 
 func (c *Client) ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProtectedResourceMetadataWellKnownOauthProtectedResourceGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListPairingsApiV1AddonsPairingsGet(ctx context.Context, params *ListPairingsApiV1AddonsPairingsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListPairingsApiV1AddonsPairingsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PairAddonApiV1AddonsPairingsPostWithBody(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPairAddonApiV1AddonsPairingsPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PairAddonApiV1AddonsPairingsPost(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, body PairAddonApiV1AddonsPairingsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPairAddonApiV1AddonsPairingsPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UnpairAddonApiV1AddonsPairingsNameDelete(ctx context.Context, name string, params *UnpairAddonApiV1AddonsPairingsNameDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUnpairAddonApiV1AddonsPairingsNameDeleteRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ShowPairingApiV1AddonsPairingsNameGet(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewShowPairingApiV1AddonsPairingsNameGetRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostRequest(c.Server, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -18163,6 +18355,18 @@ func (c *Client) OperationsSearchUiOperationsSearchGet(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
+func (c *Client) UiPairingListUiPairingGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiPairingListUiPairingGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RetrievalIndexUiRetrievalGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetrievalIndexUiRetrievalGetRequest(c.Server)
 	if err != nil {
@@ -19184,6 +19388,250 @@ func NewProtectedResourceMetadataWellKnownOauthProtectedResourceGetRequest(serve
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListPairingsApiV1AddonsPairingsGetRequest generates requests for ListPairingsApiV1AddonsPairingsGet
+func NewListPairingsApiV1AddonsPairingsGetRequest(server string, params *ListPairingsApiV1AddonsPairingsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPairAddonApiV1AddonsPairingsPostRequest calls the generic PairAddonApiV1AddonsPairingsPost builder with application/json body
+func NewPairAddonApiV1AddonsPairingsPostRequest(server string, params *PairAddonApiV1AddonsPairingsPostParams, body PairAddonApiV1AddonsPairingsPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPairAddonApiV1AddonsPairingsPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewPairAddonApiV1AddonsPairingsPostRequestWithBody generates requests for PairAddonApiV1AddonsPairingsPost with any type of body
+func NewPairAddonApiV1AddonsPairingsPostRequestWithBody(server string, params *PairAddonApiV1AddonsPairingsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewUnpairAddonApiV1AddonsPairingsNameDeleteRequest generates requests for UnpairAddonApiV1AddonsPairingsNameDelete
+func NewUnpairAddonApiV1AddonsPairingsNameDeleteRequest(server string, name string, params *UnpairAddonApiV1AddonsPairingsNameDeleteParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewShowPairingApiV1AddonsPairingsNameGetRequest generates requests for ShowPairingApiV1AddonsPairingsNameGet
+func NewShowPairingApiV1AddonsPairingsNameGetRequest(server string, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostRequest generates requests for HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost
+func NewHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostRequest(server string, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s/heartbeat", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -36723,6 +37171,33 @@ func NewOperationsSearchUiOperationsSearchGetRequest(server string, params *Oper
 	return req, nil
 }
 
+// NewUiPairingListUiPairingGetRequest generates requests for UiPairingListUiPairingGet
+func NewUiPairingListUiPairingGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/pairing")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRetrievalIndexUiRetrievalGetRequest generates requests for RetrievalIndexUiRetrievalGet
 func NewRetrievalIndexUiRetrievalGetRequest(server string) (*http.Request, error) {
 	var err error
@@ -39580,6 +40055,23 @@ type ClientWithResponsesInterface interface {
 	// ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse request
 	ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse, error)
 
+	// ListPairingsApiV1AddonsPairingsGetWithResponse request
+	ListPairingsApiV1AddonsPairingsGetWithResponse(ctx context.Context, params *ListPairingsApiV1AddonsPairingsGetParams, reqEditors ...RequestEditorFn) (*ListPairingsApiV1AddonsPairingsGetResponse, error)
+
+	// PairAddonApiV1AddonsPairingsPostWithBodyWithResponse request with any body
+	PairAddonApiV1AddonsPairingsPostWithBodyWithResponse(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PairAddonApiV1AddonsPairingsPostResponse, error)
+
+	PairAddonApiV1AddonsPairingsPostWithResponse(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, body PairAddonApiV1AddonsPairingsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PairAddonApiV1AddonsPairingsPostResponse, error)
+
+	// UnpairAddonApiV1AddonsPairingsNameDeleteWithResponse request
+	UnpairAddonApiV1AddonsPairingsNameDeleteWithResponse(ctx context.Context, name string, params *UnpairAddonApiV1AddonsPairingsNameDeleteParams, reqEditors ...RequestEditorFn) (*UnpairAddonApiV1AddonsPairingsNameDeleteResponse, error)
+
+	// ShowPairingApiV1AddonsPairingsNameGetWithResponse request
+	ShowPairingApiV1AddonsPairingsNameGetWithResponse(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*ShowPairingApiV1AddonsPairingsNameGetResponse, error)
+
+	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request
+	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error)
+
 	// ListAgentPrincipalsApiV1AgentPrincipalsGetWithResponse request
 	ListAgentPrincipalsApiV1AgentPrincipalsGetWithResponse(ctx context.Context, params *ListAgentPrincipalsApiV1AgentPrincipalsGetParams, reqEditors ...RequestEditorFn) (*ListAgentPrincipalsApiV1AgentPrincipalsGetResponse, error)
 
@@ -40780,6 +41272,9 @@ type ClientWithResponsesInterface interface {
 	// OperationsSearchUiOperationsSearchGetWithResponse request
 	OperationsSearchUiOperationsSearchGetWithResponse(ctx context.Context, params *OperationsSearchUiOperationsSearchGetParams, reqEditors ...RequestEditorFn) (*OperationsSearchUiOperationsSearchGetResponse, error)
 
+	// UiPairingListUiPairingGetWithResponse request
+	UiPairingListUiPairingGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiPairingListUiPairingGetResponse, error)
+
 	// RetrievalIndexUiRetrievalGetWithResponse request
 	RetrievalIndexUiRetrievalGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalIndexUiRetrievalGetResponse, error)
 
@@ -41037,6 +41532,120 @@ func (r ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse) Sta
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListPairingsApiV1AddonsPairingsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PairedAddonListResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListPairingsApiV1AddonsPairingsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListPairingsApiV1AddonsPairingsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PairAddonApiV1AddonsPairingsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *PairAddonResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PairAddonApiV1AddonsPairingsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PairAddonApiV1AddonsPairingsPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UnpairAddonApiV1AddonsPairingsNameDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UnpairAddonApiV1AddonsPairingsNameDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UnpairAddonApiV1AddonsPairingsNameDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ShowPairingApiV1AddonsPairingsNameGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PairedAddonRead
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ShowPairingApiV1AddonsPairingsNameGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ShowPairingApiV1AddonsPairingsNameGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PairedAddonRead
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -47824,6 +48433,27 @@ func (r OperationsSearchUiOperationsSearchGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiPairingListUiPairingGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiPairingListUiPairingGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiPairingListUiPairingGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RetrievalIndexUiRetrievalGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -49061,6 +49691,59 @@ func (c *ClientWithResponses) ProtectedResourceMetadataWellKnownOauthProtectedRe
 		return nil, err
 	}
 	return ParseProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse(rsp)
+}
+
+// ListPairingsApiV1AddonsPairingsGetWithResponse request returning *ListPairingsApiV1AddonsPairingsGetResponse
+func (c *ClientWithResponses) ListPairingsApiV1AddonsPairingsGetWithResponse(ctx context.Context, params *ListPairingsApiV1AddonsPairingsGetParams, reqEditors ...RequestEditorFn) (*ListPairingsApiV1AddonsPairingsGetResponse, error) {
+	rsp, err := c.ListPairingsApiV1AddonsPairingsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListPairingsApiV1AddonsPairingsGetResponse(rsp)
+}
+
+// PairAddonApiV1AddonsPairingsPostWithBodyWithResponse request with arbitrary body returning *PairAddonApiV1AddonsPairingsPostResponse
+func (c *ClientWithResponses) PairAddonApiV1AddonsPairingsPostWithBodyWithResponse(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PairAddonApiV1AddonsPairingsPostResponse, error) {
+	rsp, err := c.PairAddonApiV1AddonsPairingsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePairAddonApiV1AddonsPairingsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) PairAddonApiV1AddonsPairingsPostWithResponse(ctx context.Context, params *PairAddonApiV1AddonsPairingsPostParams, body PairAddonApiV1AddonsPairingsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PairAddonApiV1AddonsPairingsPostResponse, error) {
+	rsp, err := c.PairAddonApiV1AddonsPairingsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePairAddonApiV1AddonsPairingsPostResponse(rsp)
+}
+
+// UnpairAddonApiV1AddonsPairingsNameDeleteWithResponse request returning *UnpairAddonApiV1AddonsPairingsNameDeleteResponse
+func (c *ClientWithResponses) UnpairAddonApiV1AddonsPairingsNameDeleteWithResponse(ctx context.Context, name string, params *UnpairAddonApiV1AddonsPairingsNameDeleteParams, reqEditors ...RequestEditorFn) (*UnpairAddonApiV1AddonsPairingsNameDeleteResponse, error) {
+	rsp, err := c.UnpairAddonApiV1AddonsPairingsNameDelete(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnpairAddonApiV1AddonsPairingsNameDeleteResponse(rsp)
+}
+
+// ShowPairingApiV1AddonsPairingsNameGetWithResponse request returning *ShowPairingApiV1AddonsPairingsNameGetResponse
+func (c *ClientWithResponses) ShowPairingApiV1AddonsPairingsNameGetWithResponse(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*ShowPairingApiV1AddonsPairingsNameGetResponse, error) {
+	rsp, err := c.ShowPairingApiV1AddonsPairingsNameGet(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseShowPairingApiV1AddonsPairingsNameGetResponse(rsp)
+}
+
+// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request returning *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse
+func (c *ClientWithResponses) HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error) {
+	rsp, err := c.HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse(rsp)
 }
 
 // ListAgentPrincipalsApiV1AgentPrincipalsGetWithResponse request returning *ListAgentPrincipalsApiV1AgentPrincipalsGetResponse
@@ -52969,6 +53652,15 @@ func (c *ClientWithResponses) OperationsSearchUiOperationsSearchGetWithResponse(
 	return ParseOperationsSearchUiOperationsSearchGetResponse(rsp)
 }
 
+// UiPairingListUiPairingGetWithResponse request returning *UiPairingListUiPairingGetResponse
+func (c *ClientWithResponses) UiPairingListUiPairingGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiPairingListUiPairingGetResponse, error) {
+	rsp, err := c.UiPairingListUiPairingGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiPairingListUiPairingGetResponse(rsp)
+}
+
 // RetrievalIndexUiRetrievalGetWithResponse request returning *RetrievalIndexUiRetrievalGetResponse
 func (c *ClientWithResponses) RetrievalIndexUiRetrievalGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalIndexUiRetrievalGetResponse, error) {
 	rsp, err := c.RetrievalIndexUiRetrievalGet(ctx, reqEditors...)
@@ -53719,6 +54411,164 @@ func ParseProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse(rs
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListPairingsApiV1AddonsPairingsGetResponse parses an HTTP response from a ListPairingsApiV1AddonsPairingsGetWithResponse call
+func ParseListPairingsApiV1AddonsPairingsGetResponse(rsp *http.Response) (*ListPairingsApiV1AddonsPairingsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListPairingsApiV1AddonsPairingsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PairedAddonListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePairAddonApiV1AddonsPairingsPostResponse parses an HTTP response from a PairAddonApiV1AddonsPairingsPostWithResponse call
+func ParsePairAddonApiV1AddonsPairingsPostResponse(rsp *http.Response) (*PairAddonApiV1AddonsPairingsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PairAddonApiV1AddonsPairingsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest PairAddonResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUnpairAddonApiV1AddonsPairingsNameDeleteResponse parses an HTTP response from a UnpairAddonApiV1AddonsPairingsNameDeleteWithResponse call
+func ParseUnpairAddonApiV1AddonsPairingsNameDeleteResponse(rsp *http.Response) (*UnpairAddonApiV1AddonsPairingsNameDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UnpairAddonApiV1AddonsPairingsNameDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseShowPairingApiV1AddonsPairingsNameGetResponse parses an HTTP response from a ShowPairingApiV1AddonsPairingsNameGetWithResponse call
+func ParseShowPairingApiV1AddonsPairingsNameGetResponse(rsp *http.Response) (*ShowPairingApiV1AddonsPairingsNameGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ShowPairingApiV1AddonsPairingsNameGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PairedAddonRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse parses an HTTP response from a HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse call
+func ParseHeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse(rsp *http.Response) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PairedAddonRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 
@@ -62392,6 +63242,22 @@ func ParseOperationsSearchUiOperationsSearchGetResponse(rsp *http.Response) (*Op
 		}
 		response.JSON422 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseUiPairingListUiPairingGetResponse parses an HTTP response from a UiPairingListUiPairingGetWithResponse call
+func ParseUiPairingListUiPairingGetResponse(rsp *http.Response) (*UiPairingListUiPairingGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiPairingListUiPairingGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/docs-site/reference/maturity.md
+++ b/docs-site/reference/maturity.md
@@ -95,10 +95,17 @@ May change or vanish without notice; sits outside the 1.0 stability promise. No 
 
 | Feature | Target GA | Gaps & promotion gate |
 | --- | --- | --- |
+| [addon_pairing](#addon_pairing) | _none committed_ | [#2900](https://github.com/evoila/meho/issues/2900) |
 | [agent_runtime](#agent_runtime) | _none committed_ | [#2656](https://github.com/evoila/meho/issues/2656) |
 | [connector_ingest](#connector_ingest) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
 | [doc_collections](#doc_collections) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
 | [two_world_ops](#two_world_ops) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
+
+### addon_pairing
+
+- **Tier:** experimental
+- **Target GA milestone:** none committed — outside the 1.0 promise
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2900](https://github.com/evoila/meho/issues/2900).
 
 ### agent_runtime
 

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -1,0 +1,153 @@
+# Add-on pairing
+
+The pairing handshake + identity plane — the foundation of the add-on
+pairing contract (Initiative #2900, Task #3025). It lets a sibling add-on
+product (first consumers: meho-automation, meho-ssp) pair once with the
+backplane and become a first-class, governed peer, while an **unpaired**
+backplane stays byte-identical to a never-paired one.
+
+Pairing is deliberately **not** connector registration. A connector is a
+managed vendor system below the narrow waist; a paired add-on is a peer
+control plane beside it, integrated through the governance planes
+themselves. The agent surface (the meta-tool waist) is untouched by this
+task — an add-on identifier is data (`op_id`, a DB row), never a tool name.
+
+## Overview
+
+Pairing does three things, all audited and reversible:
+
+1. **Identity** — provisions a confidential Keycloak client-credentials
+   client tagged `kind=service` (`principal_kind=service`,
+   `tenant_role=read_only`) and hands the add-on its one-time
+   `client_secret`. The add-on authenticates as this **service** principal.
+   It is scoped by construction: the non-agent policy gate parks every
+   mutating op for a service principal by default, so a paired add-on starts
+   with **no blanket admin** — operators widen it per-op via
+   `ServicePrincipalGrant` (`service-principal-grants.md`), never here.
+2. **Versioned contract negotiation** — the add-on advertises the contract
+   version it speaks and the oldest backplane it will accept; the backplane
+   pins both directions (below) and persists the negotiated version.
+3. **Health / liveness** — the pairing's contract compatibility (re-evaluated
+   live against the current backplane) and last liveness heartbeat surface in
+   `/api/v1/health` (and therefore the `meho_status` MCP tool + `meho status`
+   CLI) and the `/ui/pairing` console panel.
+
+**Unpair** is reversible: it deletes the Keycloak client (the authoritative
+kill switch) then hard-deletes the pairing row. The row is not soft-kept — an
+unpaired backplane is byte-identical to a never-paired one; the append-only
+`audit_log` retains the pair/unpair history. The name frees up for a clean
+re-pair.
+
+## Contract negotiation and version skew
+
+Contract versions are monotonic integers (one publisher, a small set of
+first-party consumers — a counter carries all the pinning semantics without a
+dotted-string parser). The backplane declares:
+
+- `BACKPLANE_CONTRACT_VERSION` — the contract this build speaks.
+- `MIN_SUPPORTED_ADDON_CONTRACT_VERSION` — the oldest add-on contract it
+  still accepts.
+
+The pair request carries `addon_contract_version` (what the add-on speaks)
+and `addon_min_backplane_version` (the add-on's backplane floor).
+`negotiate()` pins **both** directions:
+
+| Direction | Condition | Result |
+|---|---|---|
+| add-on too old | `addon_contract_version < MIN_SUPPORTED_ADDON_CONTRACT_VERSION` | refuse — code `addon_contract_below_backplane_minimum` (409) |
+| backplane too old | `addon_min_backplane_version > BACKPLANE_CONTRACT_VERSION` | refuse — code `backplane_contract_below_addon_minimum` (409) |
+| compatible | both floors satisfied | negotiate `min(addon_contract_version, BACKPLANE_CONTRACT_VERSION)`, persist |
+
+`is_contract_compatible()` re-applies the same two checks to a **persisted**
+pairing against the *current* backplane constants. This is the health signal:
+a pairing that negotiated cleanly against an earlier build can drift
+incompatible after an upgrade that raised the minimum past the add-on's
+advertised version, or a downgrade that dropped the backplane version below
+the add-on's floor. Either way the pairing reads `contract_compatible=false`
+in `/status` and the console without a re-handshake.
+
+## Key types
+
+- `meho_backplane.operations.addon_pairing_contract` — pure negotiation:
+  the two version constants, `negotiate()`, `is_contract_compatible()`,
+  `NegotiatedContract`, and `ContractSkewError` (carries a stable machine
+  `code` + the diagnostic versions).
+- `meho_backplane.operations.addon_pairing.AddonPairingService` — the single
+  lifecycle path (`pair` / `unpair` / `list_` / `get` / `heartbeat`).
+  Stateless, method-scoped sessions; Keycloak-first on both mutating paths
+  (mirrors `AgentPrincipalService` / `runner_principals`). Errors:
+  `AddonAlreadyPairedError`, `AddonNotPairedError`.
+- `meho_backplane.operations.addon_pairing_schemas` — `PairAddonRequest`
+  (intake, `extra="forbid"`), `PairedAddonRead`, `PairAddonResult`
+  (one-time, repr-hidden `client_secret`), `PairedAddonListResponse`
+  (the `{items, next_cursor}` envelope).
+- `meho_backplane.db.models.AddonPairing` — table `addon_pairing`; unique
+  `(tenant_id, name)` and unique `keycloak_client_id`; migration `0079`.
+- `meho_backplane.api.v1.addon_pairing` — the REST surface.
+- `meho_backplane.api.v1.health.PairingHealth` — the `/status` facet.
+- `meho_backplane.ui.routes.pairing` — the read-only `/ui/pairing` console
+  panel.
+
+## Control flow
+
+**Pair** (`POST /api/v1/addons/pairings`, `tenant_admin`):
+
+1. Validate the add-on name; `negotiate()` (cheap, side-effect-free — a skew
+   rejection never provisions Keycloak).
+2. `KeycloakAdminClient.create_client(principal_kind="service",
+   kind_attribute="service", tenant_role="read_only")`, then read back the
+   generated secret. Any failure after create rolls the client back (no
+   orphaned, un-revocable identity).
+3. Insert the `addon_pairing` row (a DB failure rolls the Keycloak client
+   back).
+4. Return the one-time `PairAddonResult` (client id + secret + negotiated
+   contract). The audit middleware records the row synchronously
+   (`op_id=addon.pair`, `op_class=write`).
+
+**Unpair** (`DELETE /api/v1/addons/pairings/{name}`, `tenant_admin`): look up
+the row, `delete_client` in Keycloak first (a non-404 failure aborts before
+the row is touched, so the backplane never reports unpaired while the client
+can still mint tokens), then hard-delete the row. Audited
+(`op_id=addon.unpair`).
+
+**Heartbeat** (`POST /api/v1/addons/pairings/{name}/heartbeat`): the paired
+add-on, authenticating as its own **service** principal (a human principal is
+403), stamps `last_seen_at`.
+
+**Health**: `build_health_response` calls `_pairing_health(tenant_id)`, which
+lists active pairings and maps each to a `PairingHealth`
+(`contract_compatible` recomputed live). Empty list when nothing is paired.
+
+## Dependencies
+
+- `KeycloakAdminClient` (`auth/keycloak_admin.py`) for client-credentials
+  client lifecycle. Keycloak admin unconfigured → 503 at the pair/unpair
+  boundary; other admin failures → 502.
+- The `service`-principal policy gate (`operations/_validate._non_agent_verdict`)
+  + `ServicePrincipalGrant` are what keep a paired add-on scoped.
+- Feature maturity: `addon_pairing` (experimental) in `FEATURE_MATURITY`,
+  mapped by tag (`addon-pairing`) and console surface (`pairing`).
+
+## Known issues / follow-ups
+
+- **Go CLI verbs** (`meho addon pair/unpair/list`) are not shipped here.
+  Pairing management is REST + console; pairing health already flows to
+  `meho status` via `/api/v1/health` and the `meho_status` MCP tool. Adding
+  the Go verbs is a separate change (OpenAPI snapshot + oapi-codegen regen).
+- **Heartbeat principal binding** is coarse: it requires a `service`
+  principal in the pairing's tenant, matched by add-on name. A finer binding
+  (verifying the caller's client id against the pairing's
+  `keycloak_client_id`) is a hardening follow-up for the initiative's
+  security-review DoD item.
+- **Console is read-only**: pair / unpair are REST-only. Console write
+  actions (a pair/unpair button behind CSRF) are a follow-up.
+- Keycloak client provisioning is now duplicated three ways (agent, runner,
+  add-on); a shared helper is an extraction candidate once the pattern
+  stabilises (rule of three), but is out of scope for this task.
+
+## References
+
+- Initiative #2900 (add-on pairing contract), Task #3025 (this foundation).
+- `service-principal-grants.md` — the scoping mechanism the paired principal
+  relies on.
+- `connectors-keycloak.md` — the Keycloak admin client lifecycle.


### PR DESCRIPTION
## Summary

- Foundation of the add-on pairing contract (Initiative #2900): a one-time handshake that registers a sibling add-on product as a **scoped Keycloak client-credentials service principal** (`principal_kind=service`, `tenant_role=read_only` — the non-agent policy gate parks every mutating op by default, so a paired add-on starts with **no blanket admin**) bound to a **negotiated integration-contract version**.
- **Versioned contract negotiation** with minimum-version pinning in **both** directions (add-on-too-old / backplane-too-old); the negotiated version is persisted, and the `/status` health facet re-evaluates that skew live so an add-on left behind by a backplane upgrade reads incompatible without a re-handshake.
- **Reversible unpair**: deletes the Keycloak client (kill switch) then hard-deletes the pairing row, so an unpaired backplane is **byte-identical** to a never-paired one; the append-only `audit_log` keeps the pair/unpair history. Pair/unpair are audited via the synchronous audit middleware.
- **Health/liveness in `/status` and the console**: a `pairings` facet on `/api/v1/health` (flows to the `meho_status` MCP tool + `meho status` CLI) and a read-only `/ui/pairing` panel; a service-principal liveness heartbeat stamps `last_seen`.
- The **agent meta-tool waist is unchanged** — an add-on identifier is data (`op_id`/a DB row), never a tool name (postulate 5); a conformance seed test pins this.

New: migration `0079` (`addon_pairing`), `docs/codebase/addon-pairing.md`, `addon_pairing` (experimental) in the feature-maturity registry.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed modules) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] Contract negotiation, both skew directions + live compatibility — `test_addon_pairing_contract.py`
- [x] Service pair/unpair/heartbeat round-trip, **scoped-principal proof** (service/read_only), rollback — `test_addon_pairing_service.py`
- [x] REST: 201 + one-time secret, `tenant_admin` gate, 409 skew, `{items,next_cursor}` envelope, 404s, heartbeat 200/403/404, **pair+unpair audited** — `test_api_v1_addon_pairing.py`
- [x] Conformance seed: no MCP tool added; unpaired health facet empty; paired facet + skew — `test_addon_pairing_conformance.py`
- [x] Console panel (auth boundary, compatible/incompatible/empty) — `test_ui_pairing.py`
- [x] Impacted existing suites green: list-envelope, feature-maturity (registry/surface-drift/badge), `/api/v1/health` exact shape, MCP surface conformance, migrations

## Out of scope (deferred follow-ups; not required by the acceptance criteria)

- Go CLI `meho addon` verbs (health already flows to `meho status` via REST/MCP; Go regen is separately reviewable).
- Console pair/unpair write actions (panel is read-only; pair/unpair are REST).
- Finer heartbeat principal binding (azp/client-id match) — a hardening item for the initiative's security-review DoD.
- Sibling #2900 tasks: capability advertisement, step-event push, audit parent-linkage, paired-surface activation.

Closes #3025
