### PR TITLE
feat(dispatch): async governed dispatch — durable run handle (202 + poll) for long-running operations (#3079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,35 @@ connector-related release-notes line.
   management-plane-lockdown Goal (evoila-bosnia/meho-internal#234). Implementation
   seams are filed as Tasks under #3183, unimplemented.
 
+### Added — Async governed dispatch: durable run handle (202 + poll) for long-running operations (#3079)
+
+- `POST /api/v1/operations/call` gains an opt-in **`async: true`** mode. Instead
+  of holding the request connection for the operation's full duration, it
+  creates a durable `operation_run` row, launches the governed dispatch on a
+  background task, and returns **HTTP 202 + a run handle** immediately. Sync
+  mode is the default and byte-identical to before. Motivated by a live
+  incident: an 83s vendor call whose 200 response was lost in transit took the
+  (successful) result envelope with it — the caller had to reconstruct the
+  outcome from audit + vendor-side evidence.
+- New handle surface **`GET /api/v1/operations/runs`** (list),
+  **`GET /api/v1/operations/runs/{handle}`** (poll), and
+  **`POST /api/v1/operations/runs/{handle}/cancel`** (cancel). A completed run
+  persists its full `OperationResult` envelope on the row, so a dropped
+  response is retrievable via the handle — the dropped-response class is
+  eliminated.
+- `POST /api/v1/approvals/{id}/approve` gains the same opt-in **`async: true`**:
+  the decision is still recorded + audited synchronously, but the resumed op is
+  dispatched on the background substrate and the route returns 202 + the run
+  handle instead of blocking for the resumed op's full duration.
+- The run substrate reuses the proven `agent_run` shape (durable row + lease /
+  heartbeat + reaper) with one deliberate difference: a governed op can wrap a
+  non-idempotent vendor write, so an orphaned run (worker died mid-flight) is
+  **never** re-dispatched — the `operation_run` reaper drives it to `failed`
+  (an audited terminal state). Audit stays per-operation and append-only: a run
+  is marked `succeeded` only after the dispatch's synchronous audit row commits.
+  New settings: `OPERATION_RUN_REAPER_ENABLED` (default on) + the tick / lease
+  knobs.
+
 ### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179 / PR #3181)
 
 - `POST /api/v1/operations/call` can *mint* a reduced result handle for any

--- a/backend/alembic/versions/0079_create_operation_run.py
+++ b/backend/alembic/versions/0079_create_operation_run.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``operation_run`` table for async governed dispatch.
+
+Revision ID: 0079
+Revises: 0078
+Create Date: 2026-08-29
+
+Schema substrate of async governed dispatch (#3079). Adds the
+``operation_run`` table -- one row per governed operation dispatch
+submitted in async mode. The row makes a long-running dispatch return a
+durable handle (HTTP 202) instead of holding the request connection for
+the op's full duration: execution proceeds on a background task tracked
+here, and the caller polls / cancels via the handle. The full
+:class:`~meho_backplane.connectors.schemas.OperationResult` envelope is
+persisted on ``result`` so a dropped response never loses the outcome
+(the motivating incident: an 83s vendor call whose 200 was lost in
+transit).
+
+The table reuses the *shape* of ``agent_run`` (durable row + lease /
+heartbeat + reaper) without its LLM-loop columns. Two deliberate
+differences from ``agent_run``:
+
+* **No ``in_flight_policy`` column.** A governed op can wrap a
+  non-idempotent vendor write, so an orphaned run is never re-dispatched
+  (that would double-execute the write); the operation-run reaper always
+  drives it to ``failed``. There is no ``resume`` policy to snapshot.
+* **No ``params`` column -- only ``params_hash``.** Persisting raw params
+  would be a new secret surface (the same reason ``audit_log`` stores only
+  a hash), and because the run never resumes nothing needs them
+  re-hydrated. The running task holds params in memory for the single
+  dispatch.
+
+Schema
+------
+
+* ``id`` -- UUID PK; the handle. PG ``gen_random_uuid()`` server default,
+  ORM ``default=uuid.uuid4`` on SQLite.
+* ``tenant_id`` -- UUID NOT NULL, real ``REFERENCES tenant(id)`` FK
+  (clean-slate substrate, same discipline as ``agent_run`` / ``graph_node``).
+* ``identity_sub`` -- Text NOT NULL; RFC 8693 ``sub`` (submitting operator).
+* ``identity_act`` -- Text nullable; RFC 8693 ``act`` (delegated actor).
+* ``origin`` -- Text NOT NULL, portable ``CHECK origin IN (...)`` over the
+  closed :class:`~meho_backplane.db.models.OperationRunOrigin` vocabulary
+  (``direct`` / ``approval_resume``).
+* ``connector_id`` / ``op_id`` -- Text NOT NULL; the dispatch coordinates.
+* ``target_name`` -- Text nullable; the submitted target name (NULL for a
+  target-less op).
+* ``params_hash`` -- Text nullable; hex SHA-256 of the submitted params,
+  the secret-safe correlation to the dispatch audit row.
+* ``approval_request_id`` -- UUID nullable, soft-FK to
+  ``approval_request.id`` for an ``approval_resume`` run.
+* ``status`` -- Text NOT NULL DEFAULT ``'pending'``, portable
+  ``CHECK status IN (...)`` over the closed
+  :class:`~meho_backplane.db.models.OperationRunStatus` lifecycle.
+* ``result`` -- portable JSON -> JSONB nullable; the persisted
+  ``OperationResult`` envelope once ``succeeded``.
+* ``error`` -- Text nullable; run-crash / reaper reason on ``failed``.
+* ``lease_owner`` / ``lease_expires_at`` -- the reaper lease.
+* ``created_at`` -- ``timestamptz`` NOT NULL, PG ``now()`` server default.
+* ``started_at`` / ``ended_at`` -- ``timestamptz`` nullable.
+
+Indexes
+-------
+
+* ``operation_run_tenant_created_at_idx`` -- (tenant_id, created_at); the
+  tenant-scoped "list runs newest first" surface.
+* ``operation_run_status_idx`` -- status; "find running runs".
+* ``operation_run_approval_request_id_idx`` -- approval_request_id; the
+  approval-resume linkage lookup.
+* ``operation_run_lease_expires_at_idx`` -- lease_expires_at, partial on
+  PG (``WHERE status = 'running'``); drives the reaper's claim query.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` creates the table and its four indexes; ``downgrade()``
+drops the indexes then the table in inverse order (explicit index drops
+keep the inverse symmetric across both dialects).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0079"
+down_revision: str | None = "0078"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``operation_run.status`` vocabulary -- kept in lock-step with
+#: :class:`meho_backplane.db.models.OperationRunStatus`. Duplicated here as
+#: a literal tuple (not imported) so the migration's recorded DDL is a
+#: frozen snapshot; the drift guard in
+#: :mod:`tests.test_operation_run_lifecycle` asserts the model enum and the
+#: live ``CHECK`` constraint agree.
+_OPERATION_RUN_STATUSES: tuple[str, ...] = (
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+)
+
+#: Closed ``operation_run.origin`` vocabulary -- lock-step with
+#: :class:`meho_backplane.db.models.OperationRunOrigin`.
+_OPERATION_RUN_ORIGINS: tuple[str, ...] = (
+    "direct",
+    "approval_resume",
+)
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Create the ``operation_run`` table and its indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # Portable JSONB -> JSON variant; same pattern agent_run.output uses.
+    result_type = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+    op.create_table(
+        "operation_run",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        sa.Column("identity_sub", sa.Text(), nullable=False),
+        sa.Column("identity_act", sa.Text(), nullable=True),
+        sa.Column("origin", sa.Text(), nullable=False),
+        sa.Column("connector_id", sa.Text(), nullable=False),
+        sa.Column("op_id", sa.Text(), nullable=False),
+        sa.Column("target_name", sa.Text(), nullable=True),
+        sa.Column("params_hash", sa.Text(), nullable=True),
+        # Soft-FK to approval_request.id (no clause) -- set on resume runs.
+        sa.Column("approval_request_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("result", result_type, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("lease_owner", sa.Text(), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            _check_in("status", _OPERATION_RUN_STATUSES),
+            name="ck_operation_run_status",
+        ),
+        sa.CheckConstraint(
+            _check_in("origin", _OPERATION_RUN_ORIGINS),
+            name="ck_operation_run_origin",
+        ),
+    )
+
+    op.create_index(
+        "operation_run_tenant_created_at_idx",
+        "operation_run",
+        ["tenant_id", "created_at"],
+        postgresql_using="btree",
+    )
+    op.create_index(
+        "operation_run_status_idx",
+        "operation_run",
+        ["status"],
+        postgresql_using="btree",
+    )
+    op.create_index(
+        "operation_run_approval_request_id_idx",
+        "operation_run",
+        ["approval_request_id"],
+        postgresql_using="btree",
+    )
+    # Partial on PG (only ``running`` rows carry a lease); SQLite ignores
+    # ``postgresql_where`` and indexes the whole column.
+    op.create_index(
+        "operation_run_lease_expires_at_idx",
+        "operation_run",
+        ["lease_expires_at"],
+        postgresql_using="btree",
+        postgresql_where=sa.text("status = 'running'"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes then the ``operation_run`` table."""
+    op.drop_index("operation_run_lease_expires_at_idx", table_name="operation_run")
+    op.drop_index("operation_run_approval_request_id_idx", table_name="operation_run")
+    op.drop_index("operation_run_status_idx", table_name="operation_run")
+    op.drop_index("operation_run_tenant_created_at_idx", table_name="operation_run")
+    op.drop_table("operation_run")

--- a/backend/alembic/versions/0080_create_operation_run.py
+++ b/backend/alembic/versions/0080_create_operation_run.py
@@ -3,8 +3,8 @@
 
 """Create the ``operation_run`` table for async governed dispatch.
 
-Revision ID: 0079
-Revises: 0078
+Revision ID: 0080
+Revises: 0079
 Create Date: 2026-08-29
 
 Schema substrate of async governed dispatch (#3079). Adds the
@@ -87,8 +87,8 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = "0079"
-down_revision: str | None = "0078"
+revision: str = "0080"
+down_revision: str | None = "0079"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -57,6 +57,7 @@ from typing import Annotated, Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi import status as http_status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
@@ -76,6 +77,7 @@ from meho_backplane.operations.approval_queue import (
     reject_request,
     resume_dispatch_after_approval,
 )
+from meho_backplane.operations.operation_run_service import get_operation_run_service
 
 __all__ = ["router"]
 
@@ -120,7 +122,7 @@ class ApprovalRequestView(BaseModel):
 class ApproveRequestBody(BaseModel):
     """POST body for ``…/approve``."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     params: dict[str, Any] = Field(
         default_factory=dict,
@@ -132,6 +134,19 @@ class ApproveRequestBody(BaseModel):
     reason: str = Field(
         default="",
         description="Optional human-readable approval reason (recorded in the audit row).",
+    )
+    async_: bool = Field(
+        default=False,
+        alias="async",
+        description=(
+            "Async governed dispatch (#3079). When true, the decision is "
+            "still recorded synchronously, but the resumed op is dispatched "
+            "on a background task and the route returns HTTP 202 + a durable "
+            "run handle immediately instead of blocking for the resumed op's "
+            "full duration. Poll / cancel via "
+            "``/api/v1/operations/runs/{handle}``. Default false — the "
+            "response is byte-identical to the pre-#3079 inline resume."
+        ),
     )
 
 
@@ -369,35 +384,21 @@ async def get_approval_request(
     return _view(row)
 
 
-@router.post(
-    "/{request_id}/approve",
-    response_model=ApproveResponseBody,
-)
-async def approve_approval_request(
-    request_id: Annotated[uuid.UUID, Path()],
+async def _record_approval_decision(
+    request_id: uuid.UUID,
+    *,
+    operator: Operator,
     body: ApproveRequestBody,
-    operator: Operator = _require_operator,
-) -> ApproveResponseBody:
-    """Approve a pending request and re-dispatch the original operation.
+) -> ApprovalRequest:
+    """Commit + audit the approval decision, publish the event, map errors.
 
-    The ``params`` body must be the original params unchanged; the service
-    re-hashes them and rejects with 422 on a mismatch. On a successful
-    approval the original dispatch is re-executed and the result returned.
-
-    HTTP status codes:
-
-    * 200 — approved + re-dispatched successfully.
-    * 403 — operator lacks ``operator`` role, **or** the approver is the
-      requester and self-approval break-glass is disabled (G11.7-T1 #1401).
-    * 404 — request not found (or belongs to another tenant).
-    * 409 — request is already decided.
-    * 422 — params hash mismatch.
+    The synchronous half shared by both the inline-resume and the async
+    (#3079) approve paths: the decision is recorded + audited inside one
+    transaction and the ``approval.approved`` event is published only after
+    commit (G11.2-T5). Extracted so :func:`approve_approval_request` stays a
+    thin dispatcher over the two resume tails. Raises the typed
+    :class:`HTTPException` for each decision-time failure class.
     """
-    structlog.contextvars.bind_contextvars(
-        audit_op_id="approval.approve",
-        audit_op_class="write",
-        audit_approval_request_id=str(request_id),
-    )
     sessionmaker = get_sessionmaker()
     try:
         async with sessionmaker() as session:
@@ -447,6 +448,70 @@ async def approve_approval_request(
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="params_hash_mismatch",
         ) from exc
+    return request
+
+
+@router.post(
+    "/{request_id}/approve",
+    response_model=ApproveResponseBody,
+)
+async def approve_approval_request(
+    request_id: Annotated[uuid.UUID, Path()],
+    body: ApproveRequestBody,
+    operator: Operator = _require_operator,
+) -> ApproveResponseBody | JSONResponse:
+    """Approve a pending request and re-dispatch the original operation.
+
+    The ``params`` body must be the original params unchanged; the service
+    re-hashes them and rejects with 422 on a mismatch. On a successful
+    approval the original dispatch is re-executed and the result returned.
+
+    Async governed dispatch (#3079): with ``async: true`` the decision is
+    still recorded + audited synchronously, but the resumed op is dispatched
+    on a background task and the route returns HTTP 202 + a durable run
+    handle (``{"run_id", "status": "pending", "async": true}``) instead of
+    blocking for the resumed op's full duration. The resume runs through the
+    same exactly-one-resumer claim + policy bypass + audit path the inline
+    resume uses. Default (``async`` absent / false) is byte-identical to the
+    pre-#3079 inline resume below.
+
+    HTTP status codes:
+
+    * 200 — approved + re-dispatched successfully (sync).
+    * 202 — approved; resume launched in the background (``async: true``).
+    * 403 — operator lacks ``operator`` role, **or** the approver is the
+      requester and self-approval break-glass is disabled (G11.7-T1 #1401).
+    * 404 — request not found (or belongs to another tenant).
+    * 409 — request is already decided.
+    * 422 — params hash mismatch.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="approval.approve",
+        audit_op_class="write",
+        audit_approval_request_id=str(request_id),
+    )
+    request = await _record_approval_decision(request_id, operator=operator, body=body)
+
+    # Async governed dispatch (#3079): hand the resume to the background
+    # substrate and return the durable handle at 202 instead of blocking.
+    # The decision is already committed + audited above; the exactly-one-
+    # resumer claim (#2293) still guards the single execution, now won
+    # inside the background task.
+    if body.async_:
+        run_id = await get_operation_run_service().submit_approval_resume(
+            operator, request, params=body.params
+        )
+        _log.info(
+            "approval_request_resume_dispatched_async",
+            approval_request_id=str(request_id),
+            op_id=request.op_id,
+            operation_run_id=str(run_id),
+            operator_sub=operator.sub,
+        )
+        return JSONResponse(
+            content={"run_id": str(run_id), "status": "pending", "async": True},
+            status_code=http_status.HTTP_202_ACCEPTED,
+        )
 
     dispatch_result = await _resume_dispatch_after_approval(
         operator=operator, request=request, params=body.params

--- a/backend/src/meho_backplane/api/v1/operation_runs.py
+++ b/backend/src/meho_backplane/api/v1/operation_runs.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/operations/runs/*`` — async governed dispatch handle surface.
+
+Async governed dispatch (#3079). The poll / list / cancel side of the
+durable run handle a ``POST /api/v1/operations/call`` (with ``async=true``)
+or an async approval resume hands back. The submit side lives on the
+existing ``POST /api/v1/operations/call`` route
+(:mod:`meho_backplane.api.v1.operations`), which returns HTTP 202 + the run
+handle when async mode is requested; this module lets the caller read that
+run's durable state (and, on completion, its full
+:class:`~meho_backplane.connectors.schemas.OperationResult` envelope) back
+after the submitting connection is gone.
+
+Route inventory
+---------------
+
+* ``GET /api/v1/operations/runs`` — list the tenant's runs, newest first;
+  optional ``?status=`` filter. Role: ``operator``.
+* ``GET /api/v1/operations/runs/{handle}`` — poll one run's durable state;
+  the persisted result envelope is present once ``status='succeeded'``. 404
+  for an unknown / cross-tenant handle. Role: ``operator``.
+* ``POST /api/v1/operations/runs/{handle}/cancel`` — cancel a non-terminal
+  run. 404 unknown / cross-tenant; 409 already-terminal. Role: ``operator``.
+
+This router is registered **before** the ``operations`` router in
+:func:`meho_backplane.main` so the literal ``/runs`` list route wins over
+that router's ``/{descriptor_id}`` catch-all (the same ordering the
+agent-runs router uses against the agents definition-CRUD routes).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import status as http_status
+from pydantic import BaseModel, ConfigDict
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.models import OperationRun, OperationRunStatus
+from meho_backplane.operations.operation_run import (
+    IllegalOperationRunTransitionError,
+    OperationRunNotFoundError,
+    UnauthorizedOperationRunCancellationError,
+)
+from meho_backplane.operations.operation_run_service import get_operation_run_service
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/operations", tags=["operations"])
+
+_log = structlog.get_logger(__name__)
+
+#: Operator-minimum gate, module-scoped to satisfy ruff B008.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+#: Canonical op ids bound into ``audit_op_id`` per route.
+_RUN_OP_IDS: Final[dict[str, str]] = {
+    "status": "operation.run_status",
+    "list": "operation.list_runs",
+    "cancel": "operation.cancel_run",
+}
+
+
+class OperationRunStatusResponse(BaseModel):
+    """Poll response for ``GET /operations/runs/{handle}``.
+
+    ``result`` carries the full persisted ``OperationResult`` envelope once
+    the run reaches ``succeeded`` (the dropped-response-class fix); ``error``
+    carries the run-crash / reaper reason on a ``failed`` run. Both are
+    ``None`` while the run is still ``pending`` / ``running``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: uuid.UUID
+    status: OperationRunStatus
+    origin: str
+    connector_id: str
+    op_id: str
+    target_name: str | None
+    approval_request_id: uuid.UUID | None
+    result: dict[str, Any] | None
+    error: str | None
+    created_at: datetime
+    started_at: datetime | None
+    ended_at: datetime | None
+
+
+class OperationRunSummaryResponse(BaseModel):
+    """One row of the operation-run list (``GET /operations/runs``).
+
+    A scannable index row: identity, lifecycle state, dispatch coordinates,
+    timestamps. The full ``result`` envelope is omitted — a caller wanting a
+    run's result polls ``GET /operations/runs/{handle}``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: uuid.UUID
+    status: OperationRunStatus
+    origin: str
+    connector_id: str
+    op_id: str
+    target_name: str | None
+    approval_request_id: uuid.UUID | None
+    created_at: datetime
+    started_at: datetime | None
+    ended_at: datetime | None
+
+
+def _status_response(row: OperationRun) -> OperationRunStatusResponse:
+    """Project an :class:`OperationRun` onto the full poll wire model."""
+    return OperationRunStatusResponse(
+        run_id=row.id,
+        status=OperationRunStatus(row.status),
+        origin=row.origin,
+        connector_id=row.connector_id,
+        op_id=row.op_id,
+        target_name=row.target_name,
+        approval_request_id=row.approval_request_id,
+        result=row.result,
+        error=row.error,
+        created_at=row.created_at,
+        started_at=row.started_at,
+        ended_at=row.ended_at,
+    )
+
+
+def _summary_response(row: OperationRun) -> OperationRunSummaryResponse:
+    """Project an :class:`OperationRun` onto the list-row wire model."""
+    return OperationRunSummaryResponse(
+        run_id=row.id,
+        status=OperationRunStatus(row.status),
+        origin=row.origin,
+        connector_id=row.connector_id,
+        op_id=row.op_id,
+        target_name=row.target_name,
+        approval_request_id=row.approval_request_id,
+        created_at=row.created_at,
+        started_at=row.started_at,
+        ended_at=row.ended_at,
+    )
+
+
+@router.get("/runs", response_model=list[OperationRunSummaryResponse])
+async def list_operation_runs(
+    status: OperationRunStatus | None = Query(
+        default=None,
+        description=(
+            "Filter by lifecycle status (pending / running / succeeded / "
+            "failed / cancelled). Omit for every state."
+        ),
+    ),
+    limit: int = Query(default=100, ge=1, le=500, description="Max runs per page (1..500)."),
+    offset: int = Query(default=0, ge=0, description="Rows to skip for paging."),
+    operator: Operator = _require_operator,
+) -> list[OperationRunSummaryResponse]:
+    """List the operator's tenant's async operation runs, newest first.
+
+    Tenant-isolated server-side via the JWT — cross-tenant runs are
+    invisible. ``?status=running`` narrows to one lifecycle state. Returns
+    ``created_at DESC``.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUN_OP_IDS["list"],
+        audit_op_class="read",
+    )
+    service = get_operation_run_service()
+    rows = await service.list(operator, status=status, limit=limit, offset=offset)
+    return [_summary_response(row) for row in rows]
+
+
+@router.get("/runs/{handle}", response_model=OperationRunStatusResponse)
+async def get_operation_run_status(
+    handle: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> OperationRunStatusResponse:
+    """Poll an async operation run's durable state by handle (the run id).
+
+    Reads the durable ``operation_run`` row, so it works after the request
+    that submitted the run has returned — the dropped-response-class fix: the
+    full result envelope is retrievable here even if the submit response was
+    lost in transit. An unknown / cross-tenant handle is 404.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUN_OP_IDS["status"],
+        audit_op_class="read",
+    )
+    service = get_operation_run_service()
+    try:
+        row = await service.poll(operator, handle)
+    except OperationRunNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="operation_run_not_found",
+        ) from exc
+    return _status_response(row)
+
+
+@router.post("/runs/{handle}/cancel", response_model=OperationRunSummaryResponse)
+async def cancel_operation_run(
+    handle: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> OperationRunSummaryResponse:
+    """Cancel a non-terminal async operation run by handle (the run id).
+
+    Records the durable cancel intent through the shared
+    :func:`~meho_backplane.operations.operation_run.cancel_run` service path.
+    The in-flight task is not torn down synchronously: it loses its lease and
+    its result is discarded when it finalises against the now-terminal row
+    (best-effort cancel — a governed op already dispatched to the vendor may
+    complete, but its own synchronous audit row is the durable record).
+
+    An unknown / cross-tenant handle is 404 (existence is not leaked across
+    tenants). An already-terminal run is 409, not a 500. A ``read_only``
+    operator is rejected by the route's role gate; the service's own role
+    check is a defence-in-depth backstop mapped to 403.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUN_OP_IDS["cancel"],
+        audit_op_class="write",
+    )
+    service = get_operation_run_service()
+    try:
+        row = await service.cancel(operator, handle)
+    except OperationRunNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="operation_run_not_found",
+        ) from exc
+    except UnauthorizedOperationRunCancellationError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="operation_run_cancel_forbidden",
+        ) from exc
+    except IllegalOperationRunTransitionError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="operation_run_not_cancellable",
+        ) from exc
+    return _summary_response(row)

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -41,7 +41,8 @@ import uuid
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import status as http_status
 from fastapi.openapi.models import Example
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -63,6 +64,7 @@ from meho_backplane.operations.meta_tools import (
     preview_operation,
     search_operations,
 )
+from meho_backplane.operations.operation_run_service import get_operation_run_service
 from meho_backplane.operations.result_query import (
     MAX_LIMIT,
     ResultHandleNotFoundError,
@@ -266,6 +268,7 @@ async def get_search(
 @router.post("/call")
 async def post_call(
     body: CallOperationBody,
+    response: Response,
     operator: Operator = _require_operator,
 ) -> dict[str, Any]:
     """Invoke :func:`~meho_backplane.operations.dispatch` for an op id.
@@ -275,6 +278,17 @@ async def post_call(
     envelope (``status='error'`` + ``extras.error_code``) rather than
     HTTP 4xx. The route returns 200 on a structured-error envelope so
     callers see the dispatcher's error_code in ``extras``.
+
+    Async governed dispatch (#3079): when the body carries ``async: true``
+    the route does **not** dispatch inline. It creates a durable
+    ``operation_run`` row, launches the governed dispatch on a background
+    task, and returns HTTP 202 + the run handle immediately —
+    ``{"run_id", "status": "pending", "async": true}``. The caller polls /
+    cancels via ``/api/v1/operations/runs/{handle}``; the completed
+    ``OperationResult`` envelope is persisted on the run, so a dropped
+    response never loses the outcome (the motivating incident: an 83s
+    vendor call whose 200 was lost in transit). Default (``async`` absent /
+    false) is byte-identical to the pre-#3079 synchronous path below.
 
     Target-failure contract (#136, completed by #2110 Option A): **every**
     target-failure mode returns HTTP 200 + the dispatcher envelope — a
@@ -289,7 +303,16 @@ async def post_call(
     the candidate ``matches``. No target-failure mode returns a 4xx: a
     consumer's error handling is a single switch on ``extras.error_code``.
     """
-    return await call_operation(operator, body.model_dump())
+    # Drop the transport-only ``async_`` control before it reaches the
+    # dispatch arguments (``call_operation`` reads connector_id / op_id /
+    # target / params / work_ref; ``async`` is a MEHO submit control, not
+    # an op param).
+    arguments = body.model_dump(exclude={"async_"})
+    if body.async_:
+        run_id = await get_operation_run_service().submit_call(operator, arguments)
+        response.status_code = http_status.HTTP_202_ACCEPTED
+        return {"run_id": str(run_id), "status": "pending", "async": True}
+    return await call_operation(operator, arguments)
 
 
 class ResultQueryBody(BaseModel):

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3814,7 +3814,7 @@ class OperationRun(Base):
       resumes there is nothing that needs them re-hydrated. The running
       task holds them in memory for the single dispatch.
 
-    Schema highlights (full column rationale in migration ``0079``):
+    Schema highlights (full column rationale in migration ``0080``):
 
     * ``id`` -- UUID primary key; **the handle** the 202 hands back and
       the poll / cancel routes resolve.

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3705,6 +3705,243 @@ class AgentRun(Base):
     )
 
 
+class OperationRunStatus(StrEnum):
+    """Closed lifecycle status of an :class:`OperationRun`.
+
+    Async governed dispatch (#3079). A ``POST /api/v1/operations/call``
+    (or ``/approvals/{id}/approve``) submitted in async mode creates one
+    durable ``operation_run`` row whose ``status`` walks an explicit,
+    enforced state machine. The legal transitions live in
+    :data:`meho_backplane.operations.operation_run.ALLOWED_TRANSITIONS`;
+    the service rejects any edge not on that map so an illegal jump cannot
+    land in the DB.
+
+    Members:
+
+    * :attr:`PENDING` -- the row was created but the background task has
+      not started executing the dispatch yet (initial state on insert).
+    * :attr:`RUNNING` -- the background task is executing the governed
+      dispatch (target resolve + policy + connector call + audit).
+    * :attr:`SUCCEEDED` -- the dispatch **completed** and its full
+      :class:`~meho_backplane.connectors.schemas.OperationResult` envelope
+      is persisted on ``result`` (terminal). Note this is the *run*
+      completing, not the op succeeding: a dispatch that returned
+      ``status='error'`` / ``'denied'`` / ``'needs-approval'`` is a
+      ``succeeded`` **run** whose persisted envelope carries that
+      dispatch status. The dropped-response class the feature eliminates
+      is exactly this: the envelope is durable regardless of the caller's
+      connection.
+    * :attr:`FAILED` -- the background task itself did not complete: the
+      worker died mid-flight (lease lapsed, reaped by the operation-run
+      reaper) or the dispatch raised unexpectedly (terminal). Distinct
+      from a persisted error envelope on a ``succeeded`` run.
+    * :attr:`CANCELLED` -- an authorized operator cancelled a non-terminal
+      run (terminal).
+
+    There is deliberately no ``awaiting_approval`` state (unlike
+    :class:`AgentRunStatus`): a governed dispatch runs to a terminal
+    envelope in one shot. A ``needs-approval`` dispatch parks its own
+    :class:`ApprovalRequest` and is recorded as a ``succeeded`` run whose
+    envelope names the parked request.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class OperationRunOrigin(StrEnum):
+    """Closed enum of what created an :class:`OperationRun` (#3079).
+
+    Records the provenance of an async governed-dispatch run so the poll /
+    list surfaces and audit can answer "why does this run exist".
+
+    Members:
+
+    * :attr:`DIRECT` -- an operator submitted ``POST
+      /api/v1/operations/call`` with ``async=true``.
+    * :attr:`APPROVAL_RESUME` -- an operator approved a parked
+      ``needs-approval`` request in async mode; the resumed governed
+      dispatch runs on the background substrate. The parked request id is
+      carried on :attr:`OperationRun.approval_request_id`.
+    """
+
+    DIRECT = "direct"
+    APPROVAL_RESUME = "approval_resume"
+
+
+#: Closed enum of :attr:`OperationRun.status` -- kept in lock-step with
+#: :class:`OperationRunStatus`. The drift guard in
+#: :mod:`tests.test_operation_run_lifecycle` asserts the model enum and the
+#: live ``CHECK`` constraint agree.
+_OPERATION_RUN_STATUSES: tuple[str, ...] = tuple(s.value for s in OperationRunStatus)
+
+#: Closed enum of :attr:`OperationRun.origin` -- lock-step with
+#: :class:`OperationRunOrigin`.
+_OPERATION_RUN_ORIGINS: tuple[str, ...] = tuple(o.value for o in OperationRunOrigin)
+
+
+class OperationRun(Base):
+    """One row per async governed operation dispatch (#3079).
+
+    Async governed dispatch: a ``POST /api/v1/operations/call`` (or an
+    approval resume) submitted in async mode returns a durable handle (HTTP
+    202) instead of holding the connection for the operation's full
+    duration; execution proceeds on a background task tracked by this row,
+    and the caller polls / cancels via the handle. The motivating incident
+    (an 83s vendor call whose 200 was lost in transit) is closed because
+    the full :class:`~meho_backplane.connectors.schemas.OperationResult`
+    envelope is persisted on ``result`` and retrievable via the handle
+    after the submitting connection is gone.
+
+    This reuses the *shape* of :class:`AgentRun` (durable row + lease /
+    heartbeat + reaper) without its LLM-loop semantics. Two differences
+    are load-bearing:
+
+    * **No ``resume`` in-flight policy.** A governed op can wrap a
+      non-idempotent vendor write; auto-re-dispatching a half-executed
+      write on pod death would double-execute it. The
+      operation-run reaper therefore always drives an orphaned run to
+      ``failed`` (audited terminal state) -- never re-runs it. This is the
+      safe half of the #3079 acceptance criterion ("survives pod restart
+      via lease/reaper **or** terminates into an audited terminal state --
+      never silently lost").
+    * **Raw params are not persisted.** Only a ``params_hash`` is stored
+      (the same privacy posture ``audit_log`` takes): a persisted params
+      blob would be a new secret surface, and because the run never
+      resumes there is nothing that needs them re-hydrated. The running
+      task holds them in memory for the single dispatch.
+
+    Schema highlights (full column rationale in migration ``0079``):
+
+    * ``id`` -- UUID primary key; **the handle** the 202 hands back and
+      the poll / cancel routes resolve.
+    * ``tenant_id`` -- real FK to ``tenant.id`` (clean-slate substrate).
+    * ``identity_sub`` / ``identity_act`` -- the RFC 8693 delegation pair
+      captured from the submitting operator.
+    * ``origin`` -- :class:`OperationRunOrigin` (``direct`` /
+      ``approval_resume``), closed ``CHECK``.
+    * ``connector_id`` / ``op_id`` -- the dispatch coordinates, echoed on
+      the poll surface so an operator sees what a run executed.
+    * ``target_name`` -- the submitted target name (NULL for target-less
+      ops); the *name*, not the resolved id, mirroring the ``/call`` body.
+    * ``params_hash`` -- hex SHA-256 of the submitted params (secret-safe
+      correlation to the dispatch audit row's ``params_hash``); NULL for
+      a param-less op.
+    * ``approval_request_id`` -- soft-FK to ``approval_request.id`` for an
+      ``approval_resume`` run; NULL for a ``direct`` run.
+    * ``status`` -- :class:`OperationRunStatus`, closed ``CHECK``,
+      DEFAULT ``pending``.
+    * ``result`` -- portable JSON: the persisted ``OperationResult``
+      envelope (``model_dump(mode="json")``) once the run reaches
+      ``succeeded``; NULL otherwise.
+    * ``error`` -- Text: the run-crash / reaper reason on a ``failed``
+      run; NULL otherwise. Kept distinct from ``result`` so a crashed run
+      never masquerades as an op result.
+    * ``lease_owner`` / ``lease_expires_at`` -- the reaper lease, kept in
+      lock-step by the lifecycle service.
+    * ``created_at`` / ``started_at`` / ``ended_at`` -- lifecycle
+      timestamps.
+    """
+
+    __tablename__ = "operation_run"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    identity_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    identity_act: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    origin: Mapped[str] = mapped_column(Text, nullable=False)
+    connector_id: Mapped[str] = mapped_column(Text, nullable=False)
+    op_id: Mapped[str] = mapped_column(Text, nullable=False)
+    target_name: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    params_hash: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    # Soft-FK to approval_request.id -- set on an approval_resume run.
+    approval_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default=OperationRunStatus.PENDING.value,
+    )
+    result: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    lease_owner: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        Index(
+            "operation_run_tenant_created_at_idx",
+            "tenant_id",
+            "created_at",
+            postgresql_using="btree",
+        ),
+        Index(
+            "operation_run_status_idx",
+            "status",
+            postgresql_using="btree",
+        ),
+        Index(
+            "operation_run_approval_request_id_idx",
+            "approval_request_id",
+            postgresql_using="btree",
+        ),
+        # The reaper's claim query is
+        # ``WHERE status='running' AND lease_expires_at < now()``. The full
+        # index drives it on SQLite; the partial index on PG keeps it
+        # narrow (only ``running`` rows carry a lease).
+        Index(
+            "operation_run_lease_expires_at_idx",
+            "lease_expires_at",
+            postgresql_using="btree",
+            postgresql_where=sa.text("status = 'running'"),
+        ),
+        sa.CheckConstraint(
+            _ck_in("status", _OPERATION_RUN_STATUSES),
+            name="ck_operation_run_status",
+        ),
+        sa.CheckConstraint(
+            _ck_in("origin", _OPERATION_RUN_ORIGINS),
+            name="ck_operation_run_origin",
+        ),
+    )
+
+
 class AgentPrincipal(Base):
     """A MEHO-managed agent principal — a Keycloak client tagged ``kind=agent``.
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -95,6 +95,7 @@ from meho_backplane.api.v1.gateway import router as api_v1_gateway_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.kb import router as api_v1_kb_router
 from meho_backplane.api.v1.memory import router as api_v1_memory_router
+from meho_backplane.api.v1.operation_runs import router as api_v1_operation_runs_router
 from meho_backplane.api.v1.operations import router as api_v1_operations_router
 from meho_backplane.api.v1.retrieve import router as api_v1_retrieve_router
 from meho_backplane.api.v1.retrieve_eval import router as api_v1_retrieve_eval_router
@@ -168,6 +169,10 @@ from meho_backplane.operations.ingest import (
     validate_shipped_artifacts,
 )
 from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+from meho_backplane.operations.operation_run_reaper import (
+    start_operation_run_reaper,
+    stop_operation_run_reaper,
+)
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.scheduler import start_scheduler, stop_scheduler
 from meho_backplane.settings import get_settings, parse_bool_env
@@ -466,6 +471,7 @@ class _BackgroundTasks:
     sensor_runner: asyncio.Task[None] | None
     sensor_watchdog: asyncio.Task[None] | None
     agent_run_reaper: asyncio.Task[None] | None
+    operation_run_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
     gateway_deadman: asyncio.Task[None] | None
 
@@ -555,6 +561,15 @@ def _start_background_tasks() -> _BackgroundTasks:
     agent_run_reaper: asyncio.Task[None] | None = None
     if settings.agent_run_reaper_enabled:
         agent_run_reaper = start_agent_run_reaper()
+    # #3079 — async governed dispatch reaper. Gated on
+    # OPERATION_RUN_REAPER_ENABLED so operators running an external
+    # lease-reclaim mechanism can disable the in-tree reaper. Reclaims a
+    # governed dispatch whose worker died mid-flight, driving it to
+    # ``failed`` (never re-dispatched — a governed op can wrap a
+    # non-idempotent vendor write).
+    operation_run_reaper: asyncio.Task[None] | None = None
+    if settings.operation_run_reaper_enabled:
+        operation_run_reaper = start_operation_run_reaper()
     # G11.3-T3 #824 — event-outbox drain loop. Gated on
     # EVENT_DRAIN_ENABLED so operators using an external orchestrator
     # (or running the test path without the drain) can opt out.
@@ -581,6 +596,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         sensor_runner=sensor_runner,
         sensor_watchdog=sensor_watchdog,
         agent_run_reaper=agent_run_reaper,
+        operation_run_reaper=operation_run_reaper,
         event_drain=event_drain,
         gateway_deadman=gateway_deadman,
     )
@@ -598,6 +614,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
         await stop_gateway_deadman_sweeper(tasks.gateway_deadman)
     if tasks.event_drain is not None:
         await stop_event_drain(tasks.event_drain)
+    if tasks.operation_run_reaper is not None:
+        await stop_operation_run_reaper(tasks.operation_run_reaper)
     if tasks.agent_run_reaper is not None:
         await stop_agent_run_reaper(tasks.agent_run_reaper)
     if tasks.sensor_watchdog is not None:
@@ -839,6 +857,11 @@ app.include_router(api_v1_topology_router)
 # from the JWT's tenant_id claim so cross-tenant subscription is
 # impossible by construction.
 app.include_router(api_v1_feed_router)
+# #3079 -- async governed dispatch handle surface at
+# /api/v1/operations/runs*. Registered BEFORE the operations router so the
+# literal ``/runs`` list route wins over that router's ``/{descriptor_id}``
+# catch-all (the same ordering agent_runs uses against the agents router).
+app.include_router(api_v1_operation_runs_router)
 # G0.6-T8 (#399) -- operation meta-tool surface at /api/v1/operations/*.
 # Four routes mirroring the three MCP meta-tools (list_operation_groups /
 # search_operations / call_operation) plus a tenant-admin-gated descriptor

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -411,13 +411,27 @@ class CallOperationBody(BaseModel):
     tracker API call (Goal #1651 ships the field only).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     connector_id: str = Field(min_length=1)
     op_id: str = Field(min_length=1)
     target: _TargetArg = None
     params: dict[str, Any] = Field(default_factory=dict)
     work_ref: str | None = Field(default=None, min_length=1)
+    async_: bool = Field(
+        default=False,
+        alias="async",
+        description=(
+            "Async governed dispatch (#3079). When true, ``/call`` returns a "
+            "durable run handle (HTTP 202) immediately instead of holding the "
+            "connection for the op's full duration; execution proceeds "
+            "server-side and the caller polls / cancels via "
+            "``/api/v1/operations/runs/{handle}``. The completed "
+            "``OperationResult`` envelope is persisted on the run, so a "
+            "dropped response never loses the outcome. Default false — sync "
+            "mode is byte-identical to the pre-#3079 behaviour."
+        ),
+    )
 
 
 class PreviewOperationBody(BaseModel):

--- a/backend/src/meho_backplane/operations/operation_run.py
+++ b/backend/src/meho_backplane/operations/operation_run.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operation-run record lifecycle + cancellation service (async dispatch).
+
+Async governed dispatch (#3079). A governed operation submitted in async
+mode is one durable ``operation_run`` row
+(:class:`meho_backplane.db.models.OperationRun`). This module owns the
+**lifecycle**: creating the row, walking its ``status`` through an
+explicit, enforced state machine, recording the result envelope / failure
+reason, the lease/heartbeat the reaper reclaims against, and the
+operator-authorized cancellation path.
+
+It is a deliberate trim of :mod:`meho_backplane.operations.agent_run` --
+the same durable-row + lease + state-machine discipline, without the
+LLM-loop concepts (model tier, turns, cost, agent definition) and without
+a ``resume`` in-flight policy. A governed op can wrap a non-idempotent
+vendor write, so an orphaned run is **never** re-dispatched; the reaper
+drives it to ``failed`` instead. That single-policy simplification is why
+this module carries no ``in_flight_policy`` / ``snapshot_in_flight_policy``.
+
+The state machine::
+
+    pending ──> running ──> succeeded   (terminal; result envelope recorded)
+       │           │           │
+       │           ▼           └─────────
+       ├────────> failed                  (terminal; run crashed / reaped)
+       │
+       └──┐
+          ▼
+       cancelled                          (terminal; from any non-terminal
+                                           state, by an authorized operator)
+
+``succeeded`` means the *run* completed and its
+:class:`~meho_backplane.connectors.schemas.OperationResult` envelope is
+durable -- even when that envelope's own ``status`` is ``error`` /
+``denied`` / ``needs-approval``. ``failed`` is reserved for a run that
+never produced an envelope (the worker died, or the dispatch raised).
+
+Transaction discipline
+----------------------
+
+Every mutating function takes an open :class:`AsyncSession`, flushes its
+changes, and returns -- the **caller** owns the commit, the same contract
+:mod:`meho_backplane.operations.agent_run` follows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, Final, cast
+
+from sqlalchemy import select, update
+from sqlalchemy.engine.cursor import CursorResult
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.models import (
+    OperationRun,
+    OperationRunOrigin,
+    OperationRunStatus,
+)
+
+__all__ = [
+    "ALLOWED_TRANSITIONS",
+    "TERMINAL_STATUSES",
+    "IllegalOperationRunTransitionError",
+    "OperationRunError",
+    "OperationRunLeaseLostError",
+    "OperationRunNotFoundError",
+    "UnauthorizedOperationRunCancellationError",
+    "cancel_run",
+    "claim_lease",
+    "create_run",
+    "fail_run",
+    "get_run",
+    "heartbeat",
+    "list_runs",
+    "mark_running",
+    "release_lease",
+    "succeed_run",
+    "transition",
+]
+
+
+#: The terminal lifecycle states -- a run in any of these accepts no
+#: further transition.
+TERMINAL_STATUSES: Final[frozenset[OperationRunStatus]] = frozenset(
+    {
+        OperationRunStatus.SUCCEEDED,
+        OperationRunStatus.FAILED,
+        OperationRunStatus.CANCELLED,
+    }
+)
+
+
+#: The single source of truth for legal ``status`` edges. Cancellation is
+#: modelled as an ordinary edge (every non-terminal state -> ``cancelled``);
+#: :func:`cancel_run` layers the operator authorization on top of the plain
+#: :func:`transition` it calls.
+ALLOWED_TRANSITIONS: Final[dict[OperationRunStatus, frozenset[OperationRunStatus]]] = {
+    OperationRunStatus.PENDING: frozenset(
+        {
+            OperationRunStatus.RUNNING,
+            OperationRunStatus.CANCELLED,
+        }
+    ),
+    OperationRunStatus.RUNNING: frozenset(
+        {
+            OperationRunStatus.SUCCEEDED,
+            OperationRunStatus.FAILED,
+            OperationRunStatus.CANCELLED,
+        }
+    ),
+    OperationRunStatus.SUCCEEDED: frozenset(),
+    OperationRunStatus.FAILED: frozenset(),
+    OperationRunStatus.CANCELLED: frozenset(),
+}
+
+
+#: Minimum tenant role authorized to cancel an operation run. Cancelling
+#: in-flight work is a control action, not a read; mirrors the agent-run
+#: cancel floor.
+_MIN_CANCEL_ROLE: Final[TenantRole] = TenantRole.OPERATOR
+
+#: Linear role ranking -- index = rank. Mirrors
+#: :data:`meho_backplane.operations.agent_run._ROLE_RANK`.
+_ROLE_RANK: Final[tuple[TenantRole, ...]] = (
+    TenantRole.READ_ONLY,
+    TenantRole.OPERATOR,
+    TenantRole.TENANT_ADMIN,
+)
+
+_LIST_RUNS_MAX_LIMIT: Final[int] = 500
+_LIST_RUNS_DEFAULT_LIMIT: Final[int] = 100
+
+
+class OperationRunError(Exception):
+    """Base class for operation-run lifecycle failures."""
+
+
+class OperationRunNotFoundError(OperationRunError):
+    """No ``operation_run`` row exists for the requested id.
+
+    Raised by :func:`cancel_run` when the id does not resolve. The caller
+    maps it to a 404; the service does not silently no-op so a cancel
+    against a typo'd / cross-tenant id surfaces.
+    """
+
+    def __init__(self, run_id: uuid.UUID) -> None:
+        self.run_id = run_id
+        super().__init__(f"no operation_run row for id {run_id}")
+
+
+class IllegalOperationRunTransitionError(OperationRunError):
+    """A requested ``status`` transition is not on :data:`ALLOWED_TRANSITIONS`.
+
+    Raised by :func:`transition` before any DB write. Carries the
+    ``from``/``to`` pair so the caller's error response names the rejected
+    edge precisely (a cancel against an already-terminal run maps to 409).
+    """
+
+    def __init__(self, *, from_status: OperationRunStatus, to_status: OperationRunStatus) -> None:
+        self.from_status = from_status
+        self.to_status = to_status
+        super().__init__(
+            f"illegal operation_run transition {from_status.value!r} -> {to_status.value!r}"
+        )
+
+
+class UnauthorizedOperationRunCancellationError(OperationRunError):
+    """The operator lacks the role required to cancel a run.
+
+    Raised by :func:`cancel_run` when ``operator.tenant_role`` ranks below
+    :data:`_MIN_CANCEL_ROLE`. Distinct from
+    :class:`IllegalOperationRunTransitionError` so the caller maps
+    authorization failures to 403 and state failures to 409.
+    """
+
+    def __init__(self, *, operator_sub: str, role: TenantRole) -> None:
+        self.operator_sub = operator_sub
+        self.role = role
+        super().__init__(
+            f"operator {operator_sub!r} with role {role.value!r} may not cancel an "
+            f"operation run (requires at least {_MIN_CANCEL_ROLE.value!r})"
+        )
+
+
+class OperationRunLeaseLostError(OperationRunError):
+    """The lease this worker thought it held has been reassigned.
+
+    Raised by :func:`heartbeat` when the conditional update touches zero
+    rows -- the row's ``lease_owner`` no longer matches the heartbeating
+    worker (the reaper reclaimed it) or the row reached a terminal status
+    (an operator cancelled it). The worker must stop cleanly on this
+    signal.
+    """
+
+    def __init__(self, *, run_id: uuid.UUID, owner: str) -> None:
+        self.run_id = run_id
+        self.owner = owner
+        super().__init__(
+            f"operation_run {run_id} lease no longer held by {owner!r} "
+            f"(reaper reclaimed or run terminated)"
+        )
+
+
+def _coerce_status(value: OperationRunStatus | str) -> OperationRunStatus:
+    """Normalise a status to :class:`OperationRunStatus`.
+
+    ``OperationRun.status`` is stored as ``str``; a row read from the DB
+    carries the string value. An unknown value raises :class:`ValueError`
+    -- a row whose stored status is outside the closed enum is a
+    corruption the service must not paper over.
+    """
+    if isinstance(value, OperationRunStatus):
+        return value
+    return OperationRunStatus(value)
+
+
+async def create_run(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    identity_sub: str,
+    origin: OperationRunOrigin,
+    connector_id: str,
+    op_id: str,
+    identity_act: str | None = None,
+    target_name: str | None = None,
+    params_hash: str | None = None,
+    approval_request_id: uuid.UUID | None = None,
+) -> OperationRun:
+    """Insert a fresh ``operation_run`` row in the ``pending`` state.
+
+    The returned row's :attr:`OperationRun.id` is the durable handle the
+    202 response hands back. The caller (the run service) claims a lease
+    and launches the background task in the same request.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed (so ``id`` /
+            ``created_at`` are populated), not committed.
+        tenant_id: The tenant the run belongs to (real FK to ``tenant.id``).
+        identity_sub: RFC 8693 ``sub`` -- the submitting operator.
+        origin: What created the run (:class:`OperationRunOrigin`).
+        connector_id: The connector implementation id the dispatch targets.
+        op_id: The operation id being dispatched.
+        identity_act: RFC 8693 ``act`` -- the delegated actor, if any.
+        target_name: The submitted target name (``None`` for a target-less op).
+        params_hash: Hex digest of the submitted params (secret-safe
+            correlation), or ``None`` for a param-less op.
+        approval_request_id: The parked request id for an
+            ``approval_resume`` run; ``None`` for a ``direct`` run.
+
+    Returns:
+        The inserted :class:`OperationRun`, flushed.
+    """
+    row = OperationRun(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        identity_sub=identity_sub,
+        identity_act=identity_act,
+        origin=origin.value,
+        connector_id=connector_id,
+        op_id=op_id,
+        target_name=target_name,
+        params_hash=params_hash,
+        approval_request_id=approval_request_id,
+        status=OperationRunStatus.PENDING.value,
+        created_at=datetime.now(UTC),
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def get_run(session: AsyncSession, run_id: uuid.UUID) -> OperationRun | None:
+    """Load an ``operation_run`` row by id, or ``None`` if absent."""
+    return await session.get(OperationRun, run_id)
+
+
+async def list_runs(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    status: OperationRunStatus | None = None,
+    limit: int = _LIST_RUNS_DEFAULT_LIMIT,
+    offset: int = 0,
+) -> list[OperationRun]:
+    """Page through operation runs in *tenant_id*, newest first.
+
+    Tenant-isolated by the WHERE clause: cross-tenant rows are invisible.
+
+    Args:
+        session: Open :class:`AsyncSession` (read-only).
+        tenant_id: The tenant whose runs to list.
+        status: When supplied, narrows to runs in this lifecycle state.
+        limit: Max rows per page. Clamped to ``[1, 500]``.
+        offset: Rows to skip (paging). Negative offsets clamp to 0.
+
+    Returns:
+        The matching :class:`OperationRun` rows ordered ``created_at DESC``.
+    """
+    bounded_limit = max(1, min(limit, _LIST_RUNS_MAX_LIMIT))
+    bounded_offset = max(0, offset)
+    stmt = select(OperationRun).where(OperationRun.tenant_id == tenant_id)
+    if status is not None:
+        stmt = stmt.where(OperationRun.status == status.value)
+    stmt = stmt.order_by(OperationRun.created_at.desc()).limit(bounded_limit).offset(bounded_offset)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def transition(
+    session: AsyncSession,
+    row: OperationRun,
+    to_status: OperationRunStatus,
+) -> OperationRun:
+    """Move *row* to *to_status*, enforcing the legal state machine.
+
+    The single mutation point for ``status``. Raises
+    :class:`IllegalOperationRunTransitionError` for any edge not on
+    :data:`ALLOWED_TRANSITIONS` -- before any DB write. Stamps
+    ``started_at`` on the first move into ``running`` and ``ended_at`` on
+    any move into a terminal state; clears the lease on terminal
+    transitions so the reaper index does not retain stale metadata.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The attached :class:`OperationRun` to mutate.
+        to_status: The desired next status.
+
+    Returns:
+        The same *row*, mutated and flushed.
+
+    Raises:
+        IllegalOperationRunTransitionError: *to_status* is not a legal
+            successor of the row's current status.
+    """
+    from_status = _coerce_status(row.status)
+    if to_status not in ALLOWED_TRANSITIONS[from_status]:
+        raise IllegalOperationRunTransitionError(from_status=from_status, to_status=to_status)
+
+    now = datetime.now(UTC)
+    if to_status is OperationRunStatus.RUNNING and row.started_at is None:
+        row.started_at = now
+    if to_status in TERMINAL_STATUSES:
+        row.ended_at = now
+        row.lease_owner = None
+        row.lease_expires_at = None
+
+    row.status = to_status.value
+    await session.flush()
+    return row
+
+
+async def mark_running(session: AsyncSession, row: OperationRun) -> OperationRun:
+    """Transition a ``pending`` run to ``running`` (no extra payload)."""
+    return await transition(session, row, OperationRunStatus.RUNNING)
+
+
+async def claim_lease(
+    session: AsyncSession,
+    row: OperationRun,
+    *,
+    owner: str,
+    ttl_seconds: int,
+) -> OperationRun:
+    """Stamp a lease on *row* and record the owning worker.
+
+    The lease columns are pure side-effect (they do not change ``status``).
+    The caller threads :func:`claim_lease` and the ``pending`` insert
+    together so a reader always sees who holds the lease.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The :class:`OperationRun` to claim.
+        owner: A stable worker identifier (e.g. ``"<hostname>:<pid>"``).
+        ttl_seconds: Wall-clock seconds the lease is valid for; the worker
+            must heartbeat within this window or the reaper reclaims.
+
+    Returns:
+        The mutated, flushed row.
+    """
+    row.lease_owner = owner
+    row.lease_expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    await session.flush()
+    return row
+
+
+async def heartbeat(
+    session: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    owner: str,
+    ttl_seconds: int,
+) -> OperationRun:
+    """Extend the lease on *run_id* iff this worker still holds it.
+
+    A single conditional ``UPDATE`` gated on ``lease_owner = owner AND
+    status = 'running'`` -- atomic at the DB layer, so either the worker
+    keeps the lease (one row touched) or it has already lost it (zero rows
+    touched) and we raise. Mirrors
+    :func:`meho_backplane.operations.agent_run.heartbeat`.
+
+    Raises:
+        OperationRunLeaseLostError: The conditional update touched zero
+            rows -- this worker no longer holds the lease.
+    """
+    new_expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    raw_result = await session.execute(
+        update(OperationRun)
+        .where(
+            OperationRun.id == run_id,
+            OperationRun.lease_owner == owner,
+            OperationRun.status == OperationRunStatus.RUNNING.value,
+        )
+        .values(lease_expires_at=new_expires_at)
+        .execution_options(synchronize_session=False)
+    )
+    cursor_result = cast(CursorResult[Any], raw_result)
+    if cursor_result.rowcount == 0:
+        raise OperationRunLeaseLostError(run_id=run_id, owner=owner)
+    await session.flush()
+    row = await session.get(OperationRun, run_id)
+    if row is None:
+        raise OperationRunLeaseLostError(run_id=run_id, owner=owner)
+    return row
+
+
+async def release_lease(session: AsyncSession, row: OperationRun) -> OperationRun:
+    """Clear the lease on *row* without changing its status. Idempotent."""
+    row.lease_owner = None
+    row.lease_expires_at = None
+    await session.flush()
+    return row
+
+
+async def succeed_run(
+    session: AsyncSession,
+    row: OperationRun,
+    *,
+    result: dict[str, Any],
+) -> OperationRun:
+    """Transition a run to ``succeeded`` and persist its result envelope.
+
+    Records ``result`` (the ``OperationResult`` envelope, already
+    ``model_dump(mode="json")``-shaped) before the transition so a reader
+    observing the run as ``succeeded`` always sees the durable envelope.
+    This is the dropped-response-class fix: the envelope survives the
+    submitting connection.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The ``running`` :class:`OperationRun`.
+        result: The dispatch's ``OperationResult`` envelope as a JSON dict.
+
+    Returns:
+        The mutated, flushed row.
+
+    Raises:
+        IllegalOperationRunTransitionError: ``succeeded`` is not reachable
+            from the row's current status (e.g. the run already terminated).
+    """
+    row.result = result
+    return await transition(session, row, OperationRunStatus.SUCCEEDED)
+
+
+async def fail_run(
+    session: AsyncSession,
+    row: OperationRun,
+    *,
+    error: str,
+) -> OperationRun:
+    """Transition a run to ``failed`` and record the failure reason.
+
+    Reserved for a run that never produced an envelope -- the worker died
+    (reaped) or the dispatch raised unexpectedly. ``error`` is kept
+    distinct from ``result`` so a crashed run never masquerades as an op
+    result.
+
+    Raises:
+        IllegalOperationRunTransitionError: ``failed`` is not reachable
+            from the row's current status.
+    """
+    row.error = error
+    return await transition(session, row, OperationRunStatus.FAILED)
+
+
+async def cancel_run(
+    session: AsyncSession,
+    run_id: uuid.UUID,
+    *,
+    operator: Operator,
+) -> OperationRun:
+    """Cancel a running (or pending) run for an authorized operator.
+
+    Loads the run by id, checks the operator holds at least
+    :data:`_MIN_CANCEL_ROLE`, then transitions it to ``cancelled`` via the
+    same :func:`transition` guard every other status change uses -- so a
+    cancel against an already-terminal run surfaces as
+    :class:`IllegalOperationRunTransitionError` (409), not a silent no-op.
+
+    The actual interruption of the in-flight task is best-effort in the run
+    service (it observes the durable ``cancelled`` status / loses its
+    lease); recording the intent durably first is what makes cancellation
+    survive a process restart.
+
+    Raises:
+        OperationRunNotFoundError: No row for *run_id*.
+        UnauthorizedOperationRunCancellationError: The operator's role
+            ranks below :data:`_MIN_CANCEL_ROLE`.
+        IllegalOperationRunTransitionError: The run is already terminal.
+    """
+    if _ROLE_RANK.index(operator.tenant_role) < _ROLE_RANK.index(_MIN_CANCEL_ROLE):
+        raise UnauthorizedOperationRunCancellationError(
+            operator_sub=operator.sub,
+            role=operator.tenant_role,
+        )
+
+    row = await session.get(OperationRun, run_id)
+    if row is None:
+        raise OperationRunNotFoundError(run_id)
+
+    return await transition(session, row, OperationRunStatus.CANCELLED)

--- a/backend/src/meho_backplane/operations/operation_run_reaper.py
+++ b/backend/src/meho_backplane/operations/operation_run_reaper.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""In-flight ``operation_run`` reaper — expired-lease reclaim (#3079).
+
+Async governed dispatch: a governed op submitted in async mode executes on
+a background task that keeps a lease on its ``operation_run`` row fresh via
+a heartbeat sidecar. If that worker dies mid-flight (pod restart, OOM,
+network partition) the heartbeat stops and the lease lapses. This module
+owns the *reclaim* half of the "never silently lost" contract: it scans for
+``status='running' AND lease_expires_at < now()`` on a fixed cadence and
+drives each orphaned run to ``failed`` with a stable interruption reason,
+writing an internal audit row in the same transaction.
+
+Why a single fail-into-audit policy (no ``resume``)
+---------------------------------------------------
+
+Unlike the agent-run reaper (which offers a ``resume`` policy for
+idempotent-friendly LLM loops), a governed operation can wrap a
+non-idempotent vendor write. Re-dispatching a half-executed write on pod
+death would double-execute it. So an orphaned operation run is **never**
+re-dispatched -- it is driven to ``failed`` (an audited terminal state) and
+an operator decides whether to re-submit. This is the conservative,
+safe half of the #3079 acceptance criterion ("survives pod restart via
+lease/reaper semantics **or** terminates into an audited terminal state --
+never silently lost").
+
+The loop/lock/failure-isolation discipline mirrors
+:mod:`meho_backplane.agent.reaper` verbatim (advisory-lock leader election
+per tick on a dedicated pinned connection, ``FOR UPDATE SKIP LOCKED`` claim,
+per-row savepoint isolation, single commit per tick, per-tick ``try`` so a
+transient blip never stalls the loop). See that module's docstring for the
+full rationale; this one is the operation-run-shaped, single-policy trim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.advisory import advisory_lock
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, OperationRun, OperationRunStatus
+from meho_backplane.metrics import note_loop_tick
+from meho_backplane.operations.operation_run import (
+    IllegalOperationRunTransitionError,
+    fail_run,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "OPERATION_RUN_REAPER_INTERRUPTION_REASON",
+    "start_operation_run_reaper",
+    "stop_operation_run_reaper",
+]
+
+
+_log = structlog.get_logger(__name__)
+
+#: The fixed advisory-lock key the reaper holds during a tick. A single
+#: scalar (no per-row key) because the reaper is a singleton sweep. Distinct
+#: from the agent-run reaper's key so the two sweeps never contend.
+_REAPER_ADVISORY_LOCK_KEY: int = (
+    int.from_bytes(
+        hashlib.blake2b(b"operation_run_reaper:v1", digest_size=8).digest(),
+        "big",
+    )
+    & 0x7FFF_FFFF_FFFF_FFFF
+)
+
+#: The synthetic operator ``sub`` recorded on reaper-driven audit rows.
+_SYSTEM_OPERATOR_SUB = "system:operation-run-reaper"
+
+#: Audit ``method`` for reaper writes. Internal events are not HTTP.
+_AUDIT_METHOD = "INTERNAL"
+
+#: Audit ``path`` for reaper writes. Stable identifier for grep / dashboards.
+_AUDIT_PATH_FAIL = "internal/operation-run/reaper/fail-into-audit"
+
+#: The human-readable ``error`` recorded on a ``failed`` run reaped here.
+#: Stable phrasing so dashboards / alerting can match on it.
+OPERATION_RUN_REAPER_INTERRUPTION_REASON = (
+    "interrupted: lease expired -- worker died mid-flight "
+    "(reaped by operation_run_reaper; not re-dispatched)"
+)
+
+
+def _stage_audit_row(
+    *,
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    run_id: uuid.UUID,
+    payload: dict[str, object],
+) -> None:
+    """Stage an :class:`AuditLog` row in *session*; do not commit.
+
+    The reaper's audit row must commit in the *same transaction* as the
+    lifecycle transition so a crash between the two cannot leave a reaped run
+    without an audit row. ``run_id`` is set to the operation-run id (the
+    audit-correlation column, migration ``0034``); ``duration_ms`` is ``0``
+    (the relevant duration is the lease expiry, captured in the payload).
+    """
+    session.add(
+        AuditLog(
+            id=uuid.uuid4(),
+            occurred_at=datetime.now(UTC),
+            operator_sub=_SYSTEM_OPERATOR_SUB,
+            tenant_id=tenant_id,
+            method=_AUDIT_METHOD,
+            path=_AUDIT_PATH_FAIL,
+            status_code=200,
+            duration_ms=Decimal("0"),
+            payload=payload,
+            run_id=run_id,
+        )
+    )
+
+
+async def _reap_one_row(session: AsyncSession, row: OperationRun, *, now: datetime) -> None:
+    """Drive one expired-lease run to ``failed`` + stage its audit row.
+
+    ``fail_run`` transitions ``running`` -> ``failed`` (clearing the lease as
+    the terminal side effect). A status guard is implicit: the row could
+    have transitioned between the claim query and this write (an operator
+    cancel landed) -- ``fail_run`` raises
+    :class:`IllegalOperationRunTransitionError` on the bad edge; the caller's
+    per-row ``try`` catches it.
+    """
+    payload: dict[str, object] = {
+        "run_id": str(row.id),
+        "tenant_id": str(row.tenant_id),
+        "op_id": row.op_id,
+        "connector_id": row.connector_id,
+        "prior_lease_owner": row.lease_owner,
+        "prior_lease_expires_at": (
+            row.lease_expires_at.isoformat() if row.lease_expires_at is not None else None
+        ),
+        "reaped_at": now.isoformat(),
+    }
+    await fail_run(session, row, error=OPERATION_RUN_REAPER_INTERRUPTION_REASON)
+    _stage_audit_row(
+        session=session,
+        tenant_id=row.tenant_id,
+        run_id=row.id,
+        payload=payload,
+    )
+
+
+async def _run_one_tick() -> None:
+    """One sweep: claim expired-lease running rows, fail them, audit.
+
+    Acquire the single advisory lock (skip the tick on PG if another replica
+    won); select up to ``max_per_tick`` expired-lease ``running`` rows;
+    per-row, apply the policy in its own savepoint so a bad row does not
+    stall the batch. Commit once at the end so the whole tick lands
+    atomically.
+    """
+    tick_started = time.perf_counter()
+    now = datetime.now(UTC)
+    settings = get_settings()
+    sessionmaker = get_sessionmaker()
+    async with advisory_lock(_REAPER_ADVISORY_LOCK_KEY, subsystem="operation_run_reaper") as locked:
+        if not locked:
+            _log.debug("operation_run_reaper_tick_skipped_lock_held")
+            return
+        async with sessionmaker() as session:
+            stmt = (
+                select(OperationRun)
+                .where(
+                    OperationRun.status == OperationRunStatus.RUNNING.value,
+                    OperationRun.lease_expires_at.is_not(None),
+                    OperationRun.lease_expires_at < now,
+                )
+                .order_by(OperationRun.lease_expires_at.asc())
+                .limit(settings.operation_run_reaper_max_per_tick)
+                .with_for_update(skip_locked=True)
+            )
+            result = await session.execute(stmt)
+            expired_rows = list(result.scalars().all())
+            if not expired_rows:
+                _log.debug("operation_run_reaper_tick_clean")
+                return
+
+            reaped = 0
+            for row in expired_rows:
+                try:
+                    async with session.begin_nested():
+                        await _reap_one_row(session, row, now=now)
+                    reaped += 1
+                except IllegalOperationRunTransitionError:
+                    # Raced with an operator cancel between claim and reap;
+                    # the run is already terminal. Skip -- the savepoint
+                    # rolled back, the outer session stays valid.
+                    _log.info(
+                        "operation_run_reaper_row_skipped_status_changed",
+                        run_id=str(row.id),
+                    )
+                except Exception:
+                    _log.exception(
+                        "operation_run_reaper_row_failed",
+                        run_id=str(row.id),
+                    )
+
+            await session.commit()
+            duration_ms = (time.perf_counter() - tick_started) * 1000.0
+            _log.info(
+                "operation_run_reaper_tick_done",
+                reaped_total=len(expired_rows),
+                failed=reaped,
+                duration_ms=duration_ms,
+            )
+
+
+async def _reaper_loop() -> None:
+    """The forever loop: sleep one cadence, sweep, repeat.
+
+    Sleep-then-sweep so the first tick after process start does not race the
+    rest of startup. Per-tick ``try`` guards mean a transient DB blip is
+    logged and the loop continues; ``CancelledError`` propagates so lifespan
+    shutdown stops the task cleanly.
+    """
+    interval = get_settings().operation_run_reaper_tick_interval_seconds
+    _log.info("operation_run_reaper_started", interval_seconds=interval)
+    while True:
+        await asyncio.sleep(get_settings().operation_run_reaper_tick_interval_seconds)
+        try:
+            await _run_one_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning("operation_run_reaper_tick_failed", exc_info=True)
+        note_loop_tick(
+            "operation_run_reaper",
+            get_settings().operation_run_reaper_tick_interval_seconds,
+        )
+
+
+def start_operation_run_reaper() -> asyncio.Task[None]:
+    """Start the background reaper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main._start_background_tasks` behind
+    the ``OPERATION_RUN_REAPER_ENABLED`` setting. The returned task is
+    cancelled on lifespan shutdown; returning it (rather than
+    fire-and-forgetting) keeps a strong reference so the task is not
+    GC'd mid-flight.
+    """
+    return asyncio.create_task(_reaper_loop(), name="operation-run-reaper")
+
+
+async def stop_operation_run_reaper(task: asyncio.Task[None]) -> None:
+    """Cancel the reaper task and await its unwind (swallowing the cancel)."""
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/operations/operation_run_service.py
+++ b/backend/src/meho_backplane/operations/operation_run_service.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Async governed dispatch runner — submit / poll / cancel (#3079).
+
+The execution engine behind async governed dispatch. A ``POST
+/api/v1/operations/call`` submitted with ``async=true`` (or an approval
+resumed in async mode) hands off here: the service creates a durable
+:class:`~meho_backplane.db.models.OperationRun` row, launches the governed
+dispatch as a background :class:`asyncio.Task`, and returns the run id (the
+handle) immediately so the HTTP layer can answer 202. The caller then polls
+:meth:`poll` / cancels :meth:`cancel` via the handle; a completed run's full
+:class:`~meho_backplane.connectors.schemas.OperationResult` envelope is
+persisted on the row and returned by the poll -- so a dropped response never
+loses the outcome (the motivating incident: an 83s vendor call whose 200 was
+lost in transit).
+
+This mirrors the shape of
+:class:`meho_backplane.agent.invocation.AgentInvoker`'s background-run
+machinery (durable row + in-process task store + lease heartbeat sidecar +
+reaper reclaim) applied to a single governed dispatch instead of an LLM
+tool-use loop. The governed dispatch runs through the *same*
+:func:`~meho_backplane.operations.meta_tools.call_operation` /
+:func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`
+path a synchronous request uses -- identical policy gate, identical
+synchronous audit write -- so audit stays per-operation, append-only
+(v0.1-spec §6): the run is marked ``succeeded`` only *after* the dispatch
+(and its committed audit row) returns.
+
+Why the dispatch envelope, not an exception, is the success signal
+----------------------------------------------------------------------
+
+``call_operation`` / the resume path are contracted to *always return a
+structured envelope* (``status`` of ``ok`` / ``error`` / ``denied`` /
+``needs-approval``) and never raise for operator-input faults. So a run
+that completes is ``succeeded`` and its envelope -- whatever its own status
+-- is persisted. ``failed`` is reserved for a run whose worker died (reaped)
+or whose dispatch raised unexpectedly (defence-in-depth); those never
+produced an envelope.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    ApprovalRequest,
+    OperationRun,
+    OperationRunOrigin,
+    OperationRunStatus,
+)
+from meho_backplane.operations import operation_run as run_lifecycle
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "OperationRunService",
+    "get_operation_run_service",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: A zero-arg coroutine that runs the governed dispatch and returns its
+#: envelope (either an ``OperationResult`` or its ``model_dump`` dict).
+_DispatchCoro = Callable[[], Awaitable[Any]]
+
+
+@dataclass(slots=True)
+class _RunState:
+    """In-process liveness anchor for one background run.
+
+    Holds a strong reference to the task so it is not garbage-collected
+    mid-flight (asyncio keeps only a weak reference to a bare task). The
+    store evicts the entry on completion via the task's done-callback.
+    """
+
+    task: asyncio.Task[None]
+
+
+def _lease_owner() -> str:
+    """Compute a stable per-process ``lease_owner`` (``"<hostname>:<pid>"``).
+
+    Same shape the agent-run invoker uses; an operator chasing a reaped run
+    maps the reaper-recorded ``prior_lease_owner`` back to the pod/process
+    whose worker died. No PII, no secret material.
+    """
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+def _target_name(target: Any) -> str | None:
+    """Extract the submitted target *name* from a ``/call`` target arg.
+
+    The ``/call`` body accepts a bare string, a ``{"name": ...}`` dict, or
+    ``None`` (target-less op). We persist only the name for display on the
+    poll surface -- not the resolved id (resolution happens per-dispatch).
+    """
+    if isinstance(target, str):
+        return target or None
+    if isinstance(target, dict):
+        name = target.get("name")
+        return name if isinstance(name, str) and name else None
+    return None
+
+
+def _normalize_envelope(value: Any) -> dict[str, Any]:
+    """Coerce a dispatch return (``OperationResult`` | dict) to a JSON dict."""
+    if isinstance(value, dict):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        return dump(mode="json")  # type: ignore[no-any-return]
+    return {"status": "error", "error": "dispatch returned a non-serializable result"}
+
+
+class OperationRunService:
+    """Submit / poll / cancel async governed operation dispatches.
+
+    A process-wide singleton (see :func:`get_operation_run_service`) holding
+    the in-process task store. The store keeps a strong reference to each
+    background task so it survives the request that created it; a
+    done-callback evicts finished runs so a long-lived worker does not
+    accumulate them. The durable ``operation_run`` row is the source of
+    truth -- :meth:`poll` reads it, so it works after the in-memory task is
+    gone (a different pod, a restarted process).
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[uuid.UUID, _RunState] = {}
+
+    # -- submit -----------------------------------------------------------
+
+    async def submit_call(self, operator: Operator, arguments: dict[str, Any]) -> uuid.UUID:
+        """Create a durable run for an async ``/operations/call`` and launch it.
+
+        Persists a ``pending`` row (origin ``direct``) with a lease claimed
+        by this worker, then launches the governed dispatch
+        (:func:`~meho_backplane.operations.meta_tools.call_operation`) as a
+        background task. Returns the run id (the 202 handle) immediately.
+
+        ``arguments`` is the ``call_operation`` shape: ``{"connector_id",
+        "op_id", "target"?, "params"?, "work_ref"?}``. Only a ``params_hash``
+        is persisted, never the raw params (the run never resumes, and a
+        params blob would be a new secret surface).
+        """
+        from meho_backplane.operations._validate import compute_params_hash
+        from meho_backplane.operations.meta_tools import call_operation
+
+        connector_id = str(arguments["connector_id"])
+        op_id = str(arguments["op_id"])
+        params: dict[str, Any] = arguments.get("params") or {}
+        params_hash = compute_params_hash(params) if params else None
+
+        owner = _lease_owner()
+        run_id = await self._create_and_claim(
+            operator,
+            owner=owner,
+            origin=OperationRunOrigin.DIRECT,
+            connector_id=connector_id,
+            op_id=op_id,
+            target_name=_target_name(arguments.get("target")),
+            params_hash=params_hash,
+            approval_request_id=None,
+        )
+        self._launch(
+            run_id,
+            op_id=op_id,
+            owner=owner,
+            coro_factory=lambda: call_operation(operator, arguments),
+        )
+        return run_id
+
+    async def submit_approval_resume(
+        self,
+        operator: Operator,
+        request: ApprovalRequest,
+        *,
+        params: dict[str, Any] | None,
+    ) -> uuid.UUID:
+        """Create a durable run for an async approval resume and launch it.
+
+        The approve route has already committed the decision; this hands the
+        re-dispatch to the background substrate so ``/approve`` returns
+        promptly with the handle instead of blocking for the resumed op's
+        full duration. The resumed dispatch runs through the shared
+        :func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`
+        (same policy bypass, same exactly-one-resumer claim, same audit) so
+        the async path preserves every guarantee the inline path has.
+
+        *request* is a (detached) row; ``expire_on_commit=False`` on the
+        process sessionmaker keeps its loaded columns readable in the
+        background task.
+        """
+        from meho_backplane.operations._validate import compute_params_hash
+        from meho_backplane.operations.approval_queue import resume_dispatch_after_approval
+
+        effective_params = params if params is not None else request.params
+        params_hash = (
+            compute_params_hash(effective_params)
+            if isinstance(effective_params, dict) and effective_params
+            else None
+        )
+        owner = _lease_owner()
+        run_id = await self._create_and_claim(
+            operator,
+            owner=owner,
+            origin=OperationRunOrigin.APPROVAL_RESUME,
+            connector_id=str(request.connector_id),
+            op_id=str(request.op_id),
+            target_name=None,
+            params_hash=params_hash,
+            approval_request_id=request.id,
+        )
+        self._launch(
+            run_id,
+            op_id=str(request.op_id),
+            owner=owner,
+            coro_factory=lambda: resume_dispatch_after_approval(
+                operator=operator, request=request, params=params
+            ),
+        )
+        return run_id
+
+    async def _create_and_claim(
+        self,
+        operator: Operator,
+        *,
+        owner: str,
+        origin: OperationRunOrigin,
+        connector_id: str,
+        op_id: str,
+        target_name: str | None,
+        params_hash: str | None,
+        approval_request_id: uuid.UUID | None,
+    ) -> uuid.UUID:
+        """Insert a ``pending`` row + claim this worker's lease; commit; return id."""
+        settings = get_settings()
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.create_run(
+                session,
+                tenant_id=operator.tenant_id,
+                identity_sub=operator.sub,
+                origin=origin,
+                connector_id=connector_id,
+                op_id=op_id,
+                target_name=target_name,
+                params_hash=params_hash,
+                approval_request_id=approval_request_id,
+            )
+            await run_lifecycle.claim_lease(
+                session,
+                row,
+                owner=owner,
+                ttl_seconds=settings.operation_run_lease_ttl_seconds,
+            )
+            await session.commit()
+            return row.id
+
+    # -- background execution --------------------------------------------
+
+    def _launch(
+        self,
+        run_id: uuid.UUID,
+        *,
+        op_id: str,
+        owner: str,
+        coro_factory: _DispatchCoro,
+    ) -> asyncio.Task[None]:
+        """Launch the dispatch task, anchored in the store; return its handle."""
+        task = asyncio.create_task(
+            self._run_to_completion(run_id, op_id=op_id, owner=owner, coro_factory=coro_factory),
+            name=f"operation-run-{run_id}",
+        )
+        self._store[run_id] = _RunState(task=task)
+
+        def _evict(_task: asyncio.Task[None], rid: uuid.UUID = run_id) -> None:
+            self._store.pop(rid, None)
+
+        task.add_done_callback(_evict)
+        return task
+
+    async def _run_to_completion(
+        self,
+        run_id: uuid.UUID,
+        *,
+        op_id: str,
+        owner: str,
+        coro_factory: _DispatchCoro,
+    ) -> None:
+        """Background coroutine: mark running, dispatch, persist terminal state.
+
+        Never re-raises (a failed run is a recorded ``failed`` row, not a
+        crashed task): an unhandled task exception would surface only as a
+        GC-time warning. A heartbeat sidecar keeps the lease fresh so the
+        reaper does not reclaim a healthy long-running worker; if *this* task
+        dies, the sidecar dies with it, the lease lapses, and the reaper
+        drives the row to ``failed``.
+        """
+        structlog.contextvars.bind_contextvars(audit_op_id=op_id, audit_op_class="write")
+        heartbeat = asyncio.create_task(
+            self._heartbeat_loop(run_id, owner),
+            name=f"operation-run-heartbeat-{run_id}",
+        )
+        try:
+            if not await self._mark_running(run_id):
+                # The run was cancelled before it started; do not dispatch.
+                return
+            try:
+                envelope = await coro_factory()
+            except asyncio.CancelledError:
+                # Cooperative cancellation (shutdown / GC); leave the row for
+                # the reaper to reclaim rather than writing a terminal state
+                # from a torn task.
+                raise
+            except Exception as exc:
+                _log.warning(
+                    "operation_run_dispatch_unexpected_failure",
+                    run_id=str(run_id),
+                    op_id=op_id,
+                    error=str(exc),
+                )
+                await self._finalize_failure(run_id, error=f"{type(exc).__name__}: {exc}")
+                return
+            await self._finalize_success(run_id, result=_normalize_envelope(envelope))
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+            structlog.contextvars.unbind_contextvars("audit_op_id", "audit_op_class")
+
+    async def _mark_running(self, run_id: uuid.UUID) -> bool:
+        """Transition ``pending`` -> ``running``. Return ``False`` if not pending.
+
+        A cancel that raced in before the task started leaves the row
+        terminal (``cancelled``); the transition would be illegal, so we
+        report ``False`` and the caller skips the dispatch entirely -- the op
+        is never sent for a run the operator already cancelled.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None:
+                return False
+            if row.status != OperationRunStatus.PENDING.value:
+                _log.info(
+                    "operation_run_not_started_non_pending",
+                    run_id=str(run_id),
+                    status=row.status,
+                )
+                return False
+            await run_lifecycle.mark_running(session, row)
+            await session.commit()
+            return True
+
+    async def _finalize_success(self, run_id: uuid.UUID, *, result: dict[str, Any]) -> None:
+        """Persist the result envelope + transition ``running`` -> ``succeeded``.
+
+        A cancel that landed while the dispatch was in flight leaves the row
+        ``cancelled`` (terminal); the transition is then illegal. That is the
+        best-effort cancel contract: the dispatch may have completed anyway,
+        but its own synchronous audit row is the durable record of what
+        executed, so discarding the envelope here loses nothing auditable.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None:
+                return
+            try:
+                await run_lifecycle.succeed_run(session, row, result=result)
+                await session.commit()
+            except run_lifecycle.IllegalOperationRunTransitionError:
+                # The row raced to a terminal state (operator cancel) between
+                # the get and the transition. ``succeed_run`` raises from its
+                # Python-side guard *before* any DB write, so there is nothing
+                # to undo -- the session's uncommitted changes (the in-memory
+                # ``result`` assignment) are discarded when the context
+                # manager closes the session.
+                _log.info(
+                    "operation_run_finalize_success_skipped_terminal",
+                    run_id=str(run_id),
+                    status=row.status,
+                )
+
+    async def _finalize_failure(self, run_id: uuid.UUID, *, error: str) -> None:
+        """Record a run-crash reason + transition ``running`` -> ``failed``."""
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None:
+                return
+            try:
+                await run_lifecycle.fail_run(session, row, error=error)
+                await session.commit()
+            except run_lifecycle.IllegalOperationRunTransitionError:
+                # Raced to terminal; the guard raised before any DB write, so
+                # the closing context manager discards the uncommitted change.
+                _log.info(
+                    "operation_run_finalize_failure_skipped_terminal",
+                    run_id=str(run_id),
+                    status=row.status,
+                )
+
+    async def _heartbeat_loop(self, run_id: uuid.UUID, owner: str) -> None:
+        """Extend *run_id*'s lease every ``ttl/2`` until cancelled or lost.
+
+        A :class:`OperationRunLeaseLostError` means the reaper reclaimed the
+        row (or an operator cancelled it): stop heartbeating -- the run is no
+        longer ours to keep alive. Each beat opens its own short-lived
+        committed transaction (the conditional ``UPDATE`` is atomic).
+        """
+        ttl_seconds = get_settings().operation_run_lease_ttl_seconds
+        interval = max(1.0, ttl_seconds / 2.0)
+        sessionmaker = get_sessionmaker()
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                async with sessionmaker() as session:
+                    await run_lifecycle.heartbeat(
+                        session,
+                        run_id=run_id,
+                        owner=owner,
+                        ttl_seconds=ttl_seconds,
+                    )
+                    await session.commit()
+            except run_lifecycle.OperationRunLeaseLostError:
+                _log.info("operation_run_lease_lost", run_id=str(run_id), owner=owner)
+                return
+
+    # -- read + cancel ----------------------------------------------------
+
+    async def poll(self, operator: Operator, run_id: uuid.UUID) -> OperationRun:
+        """Return the durable state of a run the operator's tenant owns.
+
+        Reads the ``operation_run`` row (the source of truth), so it works
+        after the creating request returned and even after the in-memory task
+        is gone. A cross-tenant / unknown id raises
+        :class:`~meho_backplane.operations.operation_run.OperationRunNotFoundError`
+        -- existence is not leaked across tenants.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None or row.tenant_id != operator.tenant_id:
+                raise run_lifecycle.OperationRunNotFoundError(run_id)
+            return row
+
+    async def list(
+        self,
+        operator: Operator,
+        *,
+        status: OperationRunStatus | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[OperationRun]:
+        """List the operator's tenant's runs, newest first (tenant-isolated)."""
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            return await run_lifecycle.list_runs(
+                session,
+                tenant_id=operator.tenant_id,
+                status=status,
+                limit=limit,
+                offset=offset,
+            )
+
+    async def cancel(self, operator: Operator, run_id: uuid.UUID) -> OperationRun:
+        """Cancel a non-terminal run the operator's tenant owns.
+
+        Records the durable cancel intent via the shared
+        :func:`~meho_backplane.operations.operation_run.cancel_run` service
+        path. Tenant isolation is enforced here first (a cross-tenant /
+        unknown handle raises ``OperationRunNotFoundError`` -> 404), matching
+        :meth:`poll`. The in-flight task is not torn down synchronously: it
+        loses its lease on the next heartbeat and its result is discarded
+        when it finalises against the now-terminal row (best-effort cancel).
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None or row.tenant_id != operator.tenant_id:
+                raise run_lifecycle.OperationRunNotFoundError(run_id)
+            cancelled = await run_lifecycle.cancel_run(session, run_id, operator=operator)
+            await session.commit()
+            return cancelled
+
+
+#: Process-wide singleton. The in-process task store must be shared across
+#: every request handler in the process, so the service is a module
+#: singleton (the same pattern the agent invoker uses).
+_service: OperationRunService | None = None
+
+
+def get_operation_run_service() -> OperationRunService:
+    """Return the process-wide :class:`OperationRunService` singleton."""
+    global _service
+    if _service is None:
+        _service = OperationRunService()
+    return _service

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1276,6 +1276,18 @@ class Settings(BaseModel):
     agent_run_reaper_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
     agent_run_reaper_max_per_tick: int = Field(default=50, ge=1, le=1000)
     agent_run_lease_ttl_seconds: int = Field(default=60, ge=10, le=3600)
+    # Async governed dispatch (#3079) -- the operation-run reaper reclaims
+    # a governed dispatch whose worker died mid-flight (pod restart, OOM,
+    # network partition). Same lease + tick shape as the agent-run reaper,
+    # but a single always-fail-into-audit policy: an orphaned governed op
+    # is never re-dispatched (it can wrap a non-idempotent vendor write),
+    # so it is driven to ``failed`` (an audited terminal state), never
+    # re-run. Gated on OPERATION_RUN_REAPER_ENABLED so operators running an
+    # external lease-reclaim mechanism can disable the in-tree reaper.
+    operation_run_reaper_enabled: bool = True
+    operation_run_reaper_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
+    operation_run_reaper_max_per_tick: int = Field(default=50, ge=1, le=1000)
+    operation_run_lease_ttl_seconds: int = Field(default=60, ge=10, le=3600)
     # Initiative #2415 (#2501) -- gateway runner dead-man switch. Same
     # opt-out shape as AGENT_RUN_REAPER_ENABLED, but default-on is what
     # "mandatory" means: a runner cannot opt out of heartbeating (the stamp
@@ -2012,6 +2024,19 @@ def get_settings() -> Settings:
         ),
         agent_run_lease_ttl_seconds=int(
             os.environ.get("AGENT_RUN_LEASE_TTL_SECONDS", "60"),
+        ),
+        # Async governed dispatch (#3079) -- operation-run reaper knobs.
+        operation_run_reaper_enabled=parse_bool_env(
+            os.environ.get("OPERATION_RUN_REAPER_ENABLED", "true"),
+        ),
+        operation_run_reaper_tick_interval_seconds=int(
+            os.environ.get("OPERATION_RUN_REAPER_TICK_INTERVAL_SECONDS", "30"),
+        ),
+        operation_run_reaper_max_per_tick=int(
+            os.environ.get("OPERATION_RUN_REAPER_MAX_PER_TICK", "50"),
+        ),
+        operation_run_lease_ttl_seconds=int(
+            os.environ.get("OPERATION_RUN_LEASE_TTL_SECONDS", "60"),
         ),
         gateway_deadman_enabled=parse_bool_env(
             os.environ.get("GATEWAY_DEADMAN_ENABLED", "true"),

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -249,7 +249,7 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     "identity_budget",
     "operation_group",
     # ``operation_run.tenant_id`` is a real ``REFERENCES tenant(id)`` FK from
-    # migration ``0079`` (#3079 async governed dispatch — durable run handle).
+    # migration ``0080`` (#3079 async governed dispatch — durable run handle).
     # PG rejects truncating ``tenant`` unless every referencing table is listed
     # in the same statement, so ``operation_run`` must appear here or every
     # PG-backed acceptance test errors at setup with ``cannot truncate a table

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -248,6 +248,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # table referenced in a foreign key constraint``.
     "identity_budget",
     "operation_group",
+    # ``operation_run.tenant_id`` is a real ``REFERENCES tenant(id)`` FK from
+    # migration ``0079`` (#3079 async governed dispatch — durable run handle).
+    # PG rejects truncating ``tenant`` unless every referencing table is listed
+    # in the same statement, so ``operation_run`` must appear here or every
+    # PG-backed acceptance test errors at setup with ``cannot truncate a table
+    # referenced in a foreign key constraint``.
+    "operation_run",
     # ``runner_assignments.tenant_id`` and ``runner_check_results.tenant_id``
     # are real ``REFERENCES tenant(id)`` FKs from migration ``0059``
     # (Initiative #2415 T3, #2499). Same rule as ``runner_principal`` below:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -445,6 +445,10 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   carries a real ``REFERENCES tenant(id)`` FK; must be listed here or
         #   PG rejects the per-test TRUNCATE of ``tenant`` with ``cannot
         #   truncate a table referenced in a foreign key constraint``.
+        # * ``operation_run`` — migration 0079 (#3079 async governed dispatch —
+        #   durable run handle) carries a real ``REFERENCES tenant(id)`` FK; must
+        #   be listed here or PG rejects the per-test TRUNCATE of ``tenant`` with
+        #   ``cannot truncate a table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -453,7 +457,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, "
+                "service_principal_grant, addon_pairing, operation_run, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -511,9 +515,10 @@ async def pg_engine_empty_tenant(
         # Same single non-cascading TRUNCATE as ``pg_engine`` (see that
         # fixture for why every real ``REFERENCES tenant(id)`` table —
         # including ``agent_run`` from migration 0017,
-        # ``agent_principal`` from migration 0018, and ``sensor_results``
-        # (FK to ``sensor``) from migration 0071 — must be listed
-        # here). Deliberately no follow-up INSERT —
+        # ``agent_principal`` from migration 0018, ``sensor_results``
+        # (FK to ``sensor``) from migration 0071, and ``operation_run``
+        # from migration 0079 (#3079 async governed dispatch) — must be
+        # listed here). Deliberately no follow-up INSERT —
         # ``tenant`` stays empty, reproducing the clean-room deploy.
         await conn.execute(
             text(
@@ -523,7 +528,7 @@ async def pg_engine_empty_tenant(
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, "
+                "service_principal_grant, addon_pairing, operation_run, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -445,7 +445,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   carries a real ``REFERENCES tenant(id)`` FK; must be listed here or
         #   PG rejects the per-test TRUNCATE of ``tenant`` with ``cannot
         #   truncate a table referenced in a foreign key constraint``.
-        # * ``operation_run`` — migration 0079 (#3079 async governed dispatch —
+        # * ``operation_run`` — migration 0080 (#3079 async governed dispatch —
         #   durable run handle) carries a real ``REFERENCES tenant(id)`` FK; must
         #   be listed here or PG rejects the per-test TRUNCATE of ``tenant`` with
         #   ``cannot truncate a table referenced in a foreign key constraint``.
@@ -517,7 +517,7 @@ async def pg_engine_empty_tenant(
         # including ``agent_run`` from migration 0017,
         # ``agent_principal`` from migration 0018, ``sensor_results``
         # (FK to ``sensor``) from migration 0071, and ``operation_run``
-        # from migration 0079 (#3079 async governed dispatch) — must be
+        # from migration 0080 (#3079 async governed dispatch) — must be
         # listed here). Deliberately no follow-up INSERT —
         # ``tenant`` stays empty, reproducing the clean-room deploy.
         await conn.execute(

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -47,9 +47,11 @@ from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 import respx
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 
 import meho_backplane.audit as _audit_module
 from meho_backplane.auth.jwt import clear_jwks_cache
@@ -360,3 +362,91 @@ def test_self_approval_forbidden_detail_carries_break_glass_hint(
     detail = response.json()["detail"]
     assert detail.startswith("self_approval_forbidden"), detail
     assert "APPROVAL_ALLOW_SELF_APPROVAL" in detail, detail
+
+
+# ---------------------------------------------------------------------------
+# #3079 — async governed dispatch: approve with `async: true` returns 202 +
+# the durable run handle instead of blocking for the resumed op.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunService:
+    """Records approval-resume submits, returns a fixed handle (no task launch)."""
+
+    def __init__(self, run_id: uuid.UUID) -> None:
+        self.run_id = run_id
+        self.resumed: list[uuid.UUID] = []
+
+    async def submit_approval_resume(
+        self, operator: Any, request: Any, *, params: Any
+    ) -> uuid.UUID:
+        self.resumed.append(request.id)
+        return self.run_id
+
+
+@pytest.mark.asyncio
+async def test_approve_async_returns_202_and_run_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`POST /approve` with `async: true` records the decision, returns 202 + handle.
+
+    Driven over an httpx ``ASGITransport`` so the seed + request share one
+    event loop. The background substrate is faked (the value under test is
+    the route wiring: decision committed synchronously, resume handed off,
+    202 + `{run_id, status: pending, async: true}` returned) — mirrors the
+    async `/call` route test for the same contract.
+    """
+    from meho_backplane.api.v1 import approvals as approvals_module
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.operations._validate import compute_params_hash
+    from meho_backplane.operations.approval_queue import create_pending_request
+
+    params = {"disk_gb": 40}
+    requester = Operator(
+        sub="op-requester",
+        name="Requester",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+    async with get_sessionmaker()() as session:
+        request = await create_pending_request(
+            session,
+            operator=requester,
+            connector_id="vmware-rest-9.0",
+            op_id="vm.create",
+            target=None,
+            params=params,
+            params_hash=compute_params_hash(params),
+        )
+        await session.commit()
+        request_id = request.id
+
+    fixed = uuid.uuid4()
+    fake = _FakeRunService(fixed)
+    monkeypatch.setattr(approvals_module, "get_operation_run_service", lambda: fake)
+
+    key = make_rsa_keypair("kid-approve-async")
+    # A different principal approves (self-approval is forbidden by default).
+    headers = {
+        "Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR, sub='op-approver')}"
+    }
+
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="https://testserver",
+        ) as ac:
+            response = await ac.post(
+                f"/api/v1/approvals/{request_id}/approve",
+                json={"params": params, "async": True},
+                headers=headers,
+            )
+
+    assert response.status_code == 202, response.text
+    assert response.json() == {"run_id": str(fixed), "status": "pending", "async": True}
+    # The decision was handed to the background substrate for this request.
+    assert fake.resumed == [request_id]

--- a/backend/tests/test_api_v1_operation_runs.py
+++ b/backend/tests/test_api_v1_operation_runs.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Route tests for async governed dispatch (#3079).
+
+Covers the HTTP surface: the ``async: true`` branch on
+``POST /api/v1/operations/call`` (202 + handle) and the
+``/api/v1/operations/runs*`` poll / list / cancel routes, plus the
+byte-identical sync path (criterion 4). The runs router is mounted
+**before** the operations router so the literal ``/runs`` list route wins
+over the operations router's ``/{descriptor_id}`` catch-all -- the same
+ordering :mod:`meho_backplane.main` uses.
+
+Tokens are minted through the real ``verify_jwt_and_bind`` chain via the
+shared OIDC helpers, mirroring :mod:`tests.test_api_v1_operations`. The DB
+rows are inserted directly (SQLite does not enforce the ``tenant_id`` FK in
+the test path, so the pinned ``DEFAULT_TENANT_ID`` needs no tenant row).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import meho_backplane.api.v1.operations as operations_module
+from meho_backplane.api.v1.operation_runs import router as operation_runs_router
+from meho_backplane.api.v1.operations import router as operations_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import OperationRun, OperationRunOrigin, OperationRunStatus
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    # Runs router first -- mirrors main.py so /runs is not shadowed by the
+    # operations router's /{descriptor_id} catch-all.
+    app.include_router(operation_runs_router)
+    app.include_router(operations_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _token(key: Any, *, role: TenantRole = TenantRole.OPERATOR) -> str:
+    return mint_token(key, sub="op-1", tenant_role=role.value, tenant_id=DEFAULT_TENANT_ID)
+
+
+async def _insert_run(
+    *,
+    status: OperationRunStatus = OperationRunStatus.PENDING,
+    result: dict[str, Any] | None = None,
+    tenant_id: str = DEFAULT_TENANT_ID,
+    op_id: str = "vm.list",
+) -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = OperationRun(
+            id=uuid.uuid4(),
+            tenant_id=uuid.UUID(tenant_id),
+            identity_sub="op-1",
+            origin=OperationRunOrigin.DIRECT.value,
+            connector_id="vmware-rest-9.0",
+            op_id=op_id,
+            status=status.value,
+            result=result,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+class _FakeService:
+    """Stand-in for the run service: records submits, returns a fixed handle."""
+
+    def __init__(self, run_id: uuid.UUID) -> None:
+        self.run_id = run_id
+        self.submitted: list[dict[str, Any]] = []
+
+    async def submit_call(self, operator: Any, arguments: dict[str, Any]) -> uuid.UUID:
+        self.submitted.append(arguments)
+        return self.run_id
+
+
+# ---------------------------------------------------------------------------
+# POST /call async branch + sync unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_call_async_returns_202_and_run_handle(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``async: true`` returns 202 + the durable run handle (does not dispatch inline)."""
+    fixed = uuid.uuid4()
+    fake = _FakeService(fixed)
+    monkeypatch.setattr(operations_module, "get_operation_run_service", lambda: fake)
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/call",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+            json={
+                "connector_id": "vmware-rest-9.0",
+                "op_id": "vm.list",
+                "target": "dc-vcenter",
+                "params": {"folder": "prod"},
+                "async": True,
+            },
+        )
+    assert response.status_code == 202
+    body = response.json()
+    assert body == {"run_id": str(fixed), "status": "pending", "async": True}
+    # The async control is stripped before the dispatch arguments.
+    assert fake.submitted and "async_" not in fake.submitted[0]
+    assert fake.submitted[0]["op_id"] == "vm.list"
+
+
+def test_call_sync_is_unchanged_and_does_not_submit_a_run(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``async`` the route dispatches inline (200) and creates no run."""
+    fixed = uuid.uuid4()
+    fake = _FakeService(fixed)
+    monkeypatch.setattr(operations_module, "get_operation_run_service", lambda: fake)
+
+    envelope = {"status": "ok", "op_id": "vm.list", "result": {"vms": []}, "duration_ms": 5.0}
+
+    async def fake_call(operator: Any, arguments: dict[str, Any]) -> dict[str, Any]:
+        return envelope
+
+    monkeypatch.setattr(operations_module, "call_operation", fake_call)
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/call",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+            json={"connector_id": "vmware-rest-9.0", "op_id": "vm.list", "target": "dc-vcenter"},
+        )
+    assert response.status_code == 200
+    assert response.json() == envelope
+    assert fake.submitted == []  # sync path never touches the run substrate
+
+
+# ---------------------------------------------------------------------------
+# GET /runs/{handle} poll
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_persisted_result_envelope() -> None:
+    """A completed run's full envelope is retrievable via the handle (#3079 core)."""
+    envelope = {"status": "ok", "op_id": "vm.list", "result": {"vms": ["a"]}, "duration_ms": 8.0}
+    run_id = await _insert_run(status=OperationRunStatus.SUCCEEDED, result=envelope)
+
+    key = make_rsa_keypair("kid-A")
+    client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            f"/api/v1/operations/runs/{run_id}",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == str(run_id)
+    assert body["status"] == "succeeded"
+    assert body["result"] == envelope
+    assert body["connector_id"] == "vmware-rest-9.0"
+
+
+def test_poll_unknown_handle_is_404(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            f"/api/v1/operations/runs/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "operation_run_not_found"
+
+
+# ---------------------------------------------------------------------------
+# GET /runs list  +  POST /runs/{handle}/cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_runs_is_tenant_scoped_and_not_shadowed_by_descriptor_route() -> None:
+    """``GET /runs`` lists this tenant's runs (and is not caught by /{descriptor_id})."""
+    await _insert_run(op_id="vm.list")
+    await _insert_run(op_id="vm.power")
+    # A different tenant's run must not appear.
+    await _insert_run(tenant_id="00000000-0000-0000-0000-0000000000ff", op_id="other")
+
+    key = make_rsa_keypair("kid-A")
+    client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/runs",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 2
+    assert {r["op_id"] for r in rows} == {"vm.list", "vm.power"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_run_returns_cancelled() -> None:
+    run_id = await _insert_run(status=OperationRunStatus.PENDING)
+
+    key = make_rsa_keypair("kid-A")
+    client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            f"/api/v1/operations/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_terminal_run_is_409() -> None:
+    run_id = await _insert_run(status=OperationRunStatus.SUCCEEDED, result={"status": "ok"})
+
+    key = make_rsa_keypair("kid-A")
+    client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            f"/api/v1/operations/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 409
+    assert response.json()["detail"] == "operation_run_not_cancellable"
+
+
+def test_cancel_unknown_run_is_404(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            f"/api/v1/operations/runs/{uuid.uuid4()}/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "operation_run_not_found"

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -362,6 +362,16 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                     # hits the real get_settings() -> KeyError on
                     # KEYCLOAK_ISSUER_URL, since this test pins no env).
                     gateway_deadman_enabled=False,
+                    # #3079 async governed dispatch added an operation_run
+                    # reaper to the lifespan, gated on
+                    # OPERATION_RUN_REAPER_ENABLED (default on). Pin it off — a
+                    # bare MagicMock attribute is truthy, so without this the
+                    # gate reads True and the real start_operation_run_reaper is
+                    # called, whose task-creation yield lets the unconditionally
+                    # started topology refresh scheduler run one loop iteration,
+                    # which hits the real get_settings() -> KeyError on
+                    # KEYCLOAK_ISSUER_URL (this test pins no env).
+                    operation_run_reaper_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -418,6 +428,12 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 # #2501 gateway dead-man sweeper — same defensive patch.
                 start_gateway_deadman_sweeper=MagicMock(),
                 stop_gateway_deadman_sweeper=AsyncMock(),
+                # #3079 async governed dispatch operation_run reaper — same
+                # defensive patch (the gate above is pinned off) so a future
+                # default flip can't smuggle the real reaper (and the topology
+                # scheduler yield it triggers) back into this env-free test.
+                start_operation_run_reaper=MagicMock(),
+                stop_operation_run_reaper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),
@@ -494,6 +510,12 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                     # real sweeper and KeyError on KEYCLOAK_ISSUER_URL (this
                     # env-free test pins no env). Same shape as the sibling.
                     gateway_deadman_enabled=False,
+                    # #3079 async governed dispatch operation_run reaper — pin
+                    # off; a bare MagicMock attribute is truthy, which would
+                    # start the real reaper whose task-creation yield lets the
+                    # unconditional topology refresh scheduler run one loop and
+                    # KeyError on KEYCLOAK_ISSUER_URL. Same shape as the sibling.
+                    operation_run_reaper_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -546,6 +568,12 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 # #2501 gateway dead-man sweeper — same defensive patch.
                 start_gateway_deadman_sweeper=MagicMock(),
                 stop_gateway_deadman_sweeper=AsyncMock(),
+                # #3079 async governed dispatch operation_run reaper — same
+                # defensive patch (the gate above is pinned off) so a future
+                # default flip can't smuggle the real reaper (and the topology
+                # scheduler yield it triggers) back into this env-free test.
+                start_operation_run_reaper=MagicMock(),
+                stop_operation_run_reaper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),

--- a/backend/tests/test_operation_run_lifecycle.py
+++ b/backend/tests/test_operation_run_lifecycle.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the operation-run lifecycle service (#3079).
+
+Covers :mod:`meho_backplane.operations.operation_run` -- the create /
+inspect / transition / lease / cancel surface and its **enforced** state
+machine, plus the closed-enum ``CHECK`` drift guards against
+:class:`~meho_backplane.db.models.OperationRunStatus` /
+:class:`~meho_backplane.db.models.OperationRunOrigin`.
+
+Runs synchronously against the ``sqlite+aiosqlite`` engine the autouse
+``_default_database_url`` fixture pre-migrates to head.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    _OPERATION_RUN_ORIGINS,
+    _OPERATION_RUN_STATUSES,
+    OperationRun,
+    OperationRunOrigin,
+    OperationRunStatus,
+    Tenant,
+)
+from meho_backplane.operations.operation_run import (
+    ALLOWED_TRANSITIONS,
+    TERMINAL_STATUSES,
+    IllegalOperationRunTransitionError,
+    OperationRunLeaseLostError,
+    OperationRunNotFoundError,
+    UnauthorizedOperationRunCancellationError,
+    cancel_run,
+    claim_lease,
+    create_run,
+    fail_run,
+    get_run,
+    heartbeat,
+    list_runs,
+    mark_running,
+    release_lease,
+    succeed_run,
+    transition,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
+    """Return the tenant row's id, inserting it on the first call (FK parent)."""
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+def _operator(*, tenant_id: uuid.UUID, role: TenantRole, sub: str = "op-1") -> Operator:
+    return Operator(
+        sub=sub,
+        raw_jwt="fake.jwt.value",
+        tenant_id=tenant_id,
+        tenant_role=role,
+    )
+
+
+async def _fresh_pending(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    origin: OperationRunOrigin = OperationRunOrigin.DIRECT,
+) -> OperationRun:
+    return await create_run(
+        session,
+        tenant_id=tenant_id,
+        identity_sub="op-1",
+        origin=origin,
+        connector_id="vault-1.x",
+        op_id="secret.read",
+        target_name="the-vault",
+        params_hash="abc123",
+    )
+
+
+# ---------------------------------------------------------------------------
+# create / get / list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_run_inserts_pending_row_with_coordinates() -> None:
+    """``create_run`` inserts a ``pending`` row carrying the dispatch coordinates."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="user-7",
+            origin=OperationRunOrigin.DIRECT,
+            connector_id="vmware-rest-9.0",
+            op_id="vm.list",
+            target_name="dc-vcenter",
+            params_hash="deadbeef",
+        )
+        await session.commit()
+        run_id = run.id
+
+    assert isinstance(run_id, uuid.UUID)
+    assert run.status == OperationRunStatus.PENDING.value
+    assert run.origin == OperationRunOrigin.DIRECT.value
+    assert run.connector_id == "vmware-rest-9.0"
+    assert run.op_id == "vm.list"
+    assert run.target_name == "dc-vcenter"
+    assert run.params_hash == "deadbeef"
+    assert run.result is None
+    assert run.started_at is None and run.ended_at is None
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+    assert loaded is not None
+    assert loaded.id == run_id
+
+
+@pytest.mark.asyncio
+async def test_get_run_returns_none_for_absent_id() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        assert await get_run(session, uuid.uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_list_runs_tenant_isolated_status_filtered_newest_first() -> None:
+    """``list_runs`` is tenant-scoped, status-filterable, newest-first, bounded."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_a = await _seed_tenant(session, slug="rdc-internal")
+        tenant_b = await _seed_tenant(session, slug="other-tenant")
+        older = await _fresh_pending(session, tenant_id=tenant_a)
+        older.created_at = datetime.now(UTC) - timedelta(hours=1)
+        newer = await _fresh_pending(session, tenant_id=tenant_a)
+        await mark_running(session, newer)
+        # A cross-tenant row must never surface in tenant_a's listing.
+        await _fresh_pending(session, tenant_id=tenant_b)
+        await session.commit()
+        a_id_older, a_id_newer = older.id, newer.id
+
+    async with sessionmaker() as session:
+        rows = await list_runs(session, tenant_id=tenant_a)
+        assert [r.id for r in rows] == [a_id_newer, a_id_older]  # newest first
+
+        running = await list_runs(session, tenant_id=tenant_a, status=OperationRunStatus.RUNNING)
+        assert [r.id for r in running] == [a_id_newer]
+
+        page = await list_runs(session, tenant_id=tenant_a, limit=1)
+        assert [r.id for r in page] == [a_id_newer]
+
+
+# ---------------------------------------------------------------------------
+# transitions + timestamps + lease clearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_running_stamps_started_at() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await mark_running(session, run)
+        await session.commit()
+    assert run.status == OperationRunStatus.RUNNING.value
+    assert run.started_at is not None
+
+
+@pytest.mark.asyncio
+async def test_terminal_transition_stamps_ended_at_and_clears_lease() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await claim_lease(session, run, owner="host:1", ttl_seconds=60)
+        await mark_running(session, run)
+        assert run.lease_owner == "host:1"
+        await succeed_run(session, run, result={"status": "ok", "op_id": "secret.read"})
+        await session.commit()
+    assert run.status == OperationRunStatus.SUCCEEDED.value
+    assert run.ended_at is not None
+    assert run.lease_owner is None and run.lease_expires_at is None
+    assert run.result == {"status": "ok", "op_id": "secret.read"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("from_status", "to_status"),
+    [
+        (OperationRunStatus.PENDING, OperationRunStatus.SUCCEEDED),
+        (OperationRunStatus.PENDING, OperationRunStatus.FAILED),
+        (OperationRunStatus.SUCCEEDED, OperationRunStatus.RUNNING),
+        (OperationRunStatus.FAILED, OperationRunStatus.SUCCEEDED),
+        (OperationRunStatus.CANCELLED, OperationRunStatus.RUNNING),
+    ],
+)
+async def test_illegal_transition_raises_before_write(
+    from_status: OperationRunStatus, to_status: OperationRunStatus
+) -> None:
+    """An edge not on :data:`ALLOWED_TRANSITIONS` raises and leaves status unchanged."""
+    assert to_status not in ALLOWED_TRANSITIONS[from_status]
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        # Drive to the source state via legal edges without extra payload.
+        run.status = from_status.value
+        await session.flush()
+        with pytest.raises(IllegalOperationRunTransitionError):
+            await transition(session, run, to_status)
+        assert run.status == from_status.value
+
+
+@pytest.mark.asyncio
+async def test_fail_run_records_error_distinct_from_result() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await mark_running(session, run)
+        await fail_run(session, run, error="worker died")
+        await session.commit()
+    assert run.status == OperationRunStatus.FAILED.value
+    assert run.error == "worker died"
+    assert run.result is None
+
+
+# ---------------------------------------------------------------------------
+# lease / heartbeat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_extends_when_owner_matches_and_running() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await claim_lease(session, run, owner="host:1", ttl_seconds=1)
+        await mark_running(session, run)
+        first_expiry = run.lease_expires_at
+        await session.commit()
+        run_id = run.id
+    assert first_expiry is not None
+
+    async with sessionmaker() as session:
+        refreshed = await heartbeat(session, run_id=run_id, owner="host:1", ttl_seconds=120)
+        await session.commit()
+    assert refreshed.lease_expires_at is not None
+    # SQLite drops tzinfo on read-back; normalise both sides to naive UTC to
+    # compare wall-clock. The production PG path preserves tz.
+    assert refreshed.lease_expires_at.replace(tzinfo=None) > first_expiry.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_raises_lease_lost_on_owner_mismatch() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await claim_lease(session, run, owner="host:1", ttl_seconds=60)
+        await mark_running(session, run)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        with pytest.raises(OperationRunLeaseLostError):
+            await heartbeat(session, run_id=run_id, owner="host:99", ttl_seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_raises_lease_lost_when_terminal() -> None:
+    """A cancelled (terminal) run is no longer heartbeatable (status guard)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await claim_lease(session, run, owner="host:1", ttl_seconds=60)
+        await mark_running(session, run)
+        await transition(session, run, OperationRunStatus.CANCELLED)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        with pytest.raises(OperationRunLeaseLostError):
+            await heartbeat(session, run_id=run_id, owner="host:1", ttl_seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_release_lease_is_idempotent() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await claim_lease(session, run, owner="host:1", ttl_seconds=60)
+        await release_lease(session, run)
+        await release_lease(session, run)  # no-op second time
+        await session.commit()
+    assert run.lease_owner is None and run.lease_expires_at is None
+
+
+# ---------------------------------------------------------------------------
+# cancel authorization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_cancels_for_operator() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await session.commit()
+        run_id = run.id
+        operator = _operator(tenant_id=tenant_id, role=TenantRole.OPERATOR)
+
+    async with sessionmaker() as session:
+        cancelled = await cancel_run(session, run_id, operator=operator)
+        await session.commit()
+    assert cancelled.status == OperationRunStatus.CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_rejects_read_only_operator() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await session.commit()
+        run_id = run.id
+        operator = _operator(tenant_id=tenant_id, role=TenantRole.READ_ONLY)
+
+    async with sessionmaker() as session:
+        with pytest.raises(UnauthorizedOperationRunCancellationError):
+            await cancel_run(session, run_id, operator=operator)
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_missing_id_raises_not_found() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        operator = _operator(tenant_id=tenant_id, role=TenantRole.OPERATOR)
+        with pytest.raises(OperationRunNotFoundError):
+            await cancel_run(session, uuid.uuid4(), operator=operator)
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_already_terminal_raises_illegal_transition() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = await _fresh_pending(session, tenant_id=tenant_id)
+        await mark_running(session, run)
+        await succeed_run(session, run, result={"status": "ok", "op_id": "secret.read"})
+        await session.commit()
+        run_id = run.id
+        operator = _operator(tenant_id=tenant_id, role=TenantRole.OPERATOR)
+
+    async with sessionmaker() as session:
+        with pytest.raises(IllegalOperationRunTransitionError):
+            await cancel_run(session, run_id, operator=operator)
+
+
+# ---------------------------------------------------------------------------
+# closed-enum CHECK constraints + drift guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_check_rejects_unknown() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            OperationRun(
+                tenant_id=tenant_id,
+                identity_sub="op-bad",
+                origin=OperationRunOrigin.DIRECT.value,
+                connector_id="vault-1.x",
+                op_id="secret.read",
+                status="not-a-real-status",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_origin_check_rejects_unknown() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            OperationRun(
+                tenant_id=tenant_id,
+                identity_sub="op-bad",
+                origin="not-a-real-origin",
+                connector_id="vault-1.x",
+                op_id="secret.read",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+def test_terminal_statuses_are_the_three_terminal_states() -> None:
+    assert {
+        OperationRunStatus.SUCCEEDED,
+        OperationRunStatus.FAILED,
+        OperationRunStatus.CANCELLED,
+    } == TERMINAL_STATUSES
+
+
+def test_status_literals_match_model_enum() -> None:
+    """``_OPERATION_RUN_STATUSES`` mirrors :class:`OperationRunStatus`."""
+    assert set(_OPERATION_RUN_STATUSES) == {s.value for s in OperationRunStatus}
+
+
+def test_origin_literals_match_model_enum() -> None:
+    """``_OPERATION_RUN_ORIGINS`` mirrors :class:`OperationRunOrigin`."""
+    assert set(_OPERATION_RUN_ORIGINS) == {o.value for o in OperationRunOrigin}
+
+
+def _load_migration_0079() -> object:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "0079_create_operation_run.py"
+    )
+    spec = importlib.util.spec_from_file_location("_migration_0079", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_literals_match_model_enum() -> None:
+    """Migration ``0079``'s frozen tuples match the model enums (drift guard)."""
+    module = _load_migration_0079()
+    assert set(module._OPERATION_RUN_STATUSES) == {s.value for s in OperationRunStatus}  # type: ignore[attr-defined]
+    assert set(module._OPERATION_RUN_ORIGINS) == {o.value for o in OperationRunOrigin}  # type: ignore[attr-defined]

--- a/backend/tests/test_operation_run_lifecycle.py
+++ b/backend/tests/test_operation_run_lifecycle.py
@@ -455,14 +455,14 @@ def test_origin_literals_match_model_enum() -> None:
     assert set(_OPERATION_RUN_ORIGINS) == {o.value for o in OperationRunOrigin}
 
 
-def _load_migration_0079() -> object:
+def _load_migration_0080() -> object:
     path = (
         Path(__file__).resolve().parent.parent
         / "alembic"
         / "versions"
-        / "0079_create_operation_run.py"
+        / "0080_create_operation_run.py"
     )
-    spec = importlib.util.spec_from_file_location("_migration_0079", path)
+    spec = importlib.util.spec_from_file_location("_migration_0080", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -470,7 +470,7 @@ def _load_migration_0079() -> object:
 
 
 def test_migration_literals_match_model_enum() -> None:
-    """Migration ``0079``'s frozen tuples match the model enums (drift guard)."""
-    module = _load_migration_0079()
+    """Migration ``0080``'s frozen tuples match the model enums (drift guard)."""
+    module = _load_migration_0080()
     assert set(module._OPERATION_RUN_STATUSES) == {s.value for s in OperationRunStatus}  # type: ignore[attr-defined]
     assert set(module._OPERATION_RUN_ORIGINS) == {o.value for o in OperationRunOrigin}  # type: ignore[attr-defined]

--- a/backend/tests/test_operation_run_reaper.py
+++ b/backend/tests/test_operation_run_reaper.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the operation-run reaper (#3079).
+
+Covers :mod:`meho_backplane.operations.operation_run_reaper` -- the sweep
+that reclaims a governed dispatch whose worker died mid-flight. The single
+policy is fail-into-audit: an orphaned run is driven to ``failed`` (an
+audited terminal state) and **never** re-dispatched (a governed op can wrap
+a non-idempotent vendor write). This is the "never silently lost" half of
+the #3079 lease/reaper acceptance criterion.
+
+These tests fixture a run directly into the DB (no runner) and back-date its
+``lease_expires_at`` to simulate a dead worker, then drive the reaper's tick
+directly. On SQLite the advisory lock is a no-op (single-replica test
+process). Runs against the ``sqlite+aiosqlite`` engine the autouse
+``_default_database_url`` fixture pre-migrates to head.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    OperationRun,
+    OperationRunOrigin,
+    OperationRunStatus,
+    Tenant,
+)
+from meho_backplane.operations.operation_run_reaper import (
+    OPERATION_RUN_REAPER_INTERRUPTION_REASON,
+    _run_one_tick,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+async def _seed_running_run(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    status: OperationRunStatus = OperationRunStatus.RUNNING,
+    lease_age_seconds: float | None = 120.0,
+) -> uuid.UUID:
+    """Insert a run in *status*; back-date the lease when *lease_age_seconds* is set."""
+    run = OperationRun(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        identity_sub="op-1",
+        origin=OperationRunOrigin.DIRECT.value,
+        connector_id="vmware-rest-9.0",
+        op_id="vm.create",
+        status=status.value,
+        lease_owner="dead-pod:42",
+        started_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+    if lease_age_seconds is not None:
+        run.lease_expires_at = datetime.now(UTC) - timedelta(seconds=lease_age_seconds)
+    session.add(run)
+    await session.commit()
+    return run.id
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_running_run_is_failed_and_audited() -> None:
+    """An expired-lease ``running`` run is driven to ``failed`` + audited."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run_id = await _seed_running_run(session, tenant_id=tenant_id)
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        run = await session.get(OperationRun, run_id)
+        assert run is not None
+        assert run.status == OperationRunStatus.FAILED.value
+        assert run.error == OPERATION_RUN_REAPER_INTERRUPTION_REASON
+        assert run.ended_at is not None
+        assert run.lease_owner is None and run.lease_expires_at is None
+        # Result is never populated -- the op is not re-dispatched.
+        assert run.result is None
+
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.run_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert len(audit_rows) == 1
+        assert audit_rows[0].operator_sub == "system:operation-run-reaper"
+        assert audit_rows[0].path == "internal/operation-run/reaper/fail-into-audit"
+
+
+@pytest.mark.asyncio
+async def test_reaper_ignores_running_run_with_fresh_lease() -> None:
+    """A healthy worker (lease in the future) is not reclaimed."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = OperationRun(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            identity_sub="op-1",
+            origin=OperationRunOrigin.DIRECT.value,
+            connector_id="vmware-rest-9.0",
+            op_id="vm.create",
+            status=OperationRunStatus.RUNNING.value,
+            lease_owner="live-pod:7",
+            lease_expires_at=datetime.now(UTC) + timedelta(seconds=120),
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        row = await session.get(OperationRun, run_id)
+        assert row is not None
+        assert row.status == OperationRunStatus.RUNNING.value
+        audit = (
+            (await session.execute(select(AuditLog).where(AuditLog.run_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert audit == []
+
+
+@pytest.mark.asyncio
+async def test_reaper_ignores_pending_run_even_with_stale_lease() -> None:
+    """A ``pending`` run is not reaped (the claim query filters on ``running``)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run_id = await _seed_running_run(
+            session, tenant_id=tenant_id, status=OperationRunStatus.PENDING
+        )
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        row = await session.get(OperationRun, run_id)
+        assert row is not None
+        assert row.status == OperationRunStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_reaper_handles_empty_table_cleanly() -> None:
+    """A tick with no expired rows does nothing and writes no audit row."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await _seed_tenant(session)
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        audit = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.operator_sub == "system:operation-run-reaper")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert audit == []

--- a/backend/tests/test_operation_run_service.py
+++ b/backend/tests/test_operation_run_service.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the async governed dispatch runner (#3079).
+
+Covers :class:`meho_backplane.operations.operation_run_service.OperationRunService`
+-- the submit / background-execute / persist / poll / cancel behaviour that
+turns a governed dispatch into a durable, pollable run.
+
+The background dispatch (``call_operation`` / the approval resume) is
+monkeypatched so these tests are deterministic and never touch a real
+connector: the value under test is the *run* machinery (does the envelope
+get persisted? does a crash become a ``failed`` run? does a cancel win the
+race?), not the dispatch itself. Each test uses a fresh
+:class:`OperationRunService` (not the process singleton) so the in-process
+task store never leaks across tests, and grabs the launched task from the
+store to ``await`` it to completion -- the task is created but has not run
+when ``submit_*`` returns, so the grab is race-free.
+
+Runs against the ``sqlite+aiosqlite`` engine the autouse
+``_default_database_url`` fixture pre-migrates to head.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations.approval_queue as approval_queue
+import meho_backplane.operations.meta_tools as meta_tools
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    OperationRun,
+    OperationRunOrigin,
+    OperationRunStatus,
+    Tenant,
+)
+from meho_backplane.operations import operation_run as run_lifecycle
+from meho_backplane.operations.operation_run import OperationRunNotFoundError
+from meho_backplane.operations.operation_run_service import OperationRunService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+def _operator(*, tenant_id: uuid.UUID, role: TenantRole = TenantRole.OPERATOR) -> Operator:
+    return Operator(sub="op-1", raw_jwt="fake.jwt", tenant_id=tenant_id, tenant_role=role)
+
+
+_ARGS = {
+    "connector_id": "vmware-rest-9.0",
+    "op_id": "vm.list",
+    "target": "dc-vcenter",
+    "params": {"folder": "prod"},
+}
+
+
+async def _drain(service: OperationRunService, run_id: uuid.UUID) -> None:
+    """Await the launched background task to completion.
+
+    The task is grabbed from the store synchronously (it is created but has
+    not run when ``submit_*`` returns) and awaited fully *before* any other
+    DB access, so the test never interleaves DB IO with the background task
+    on the single-connection SQLite test engine.
+    """
+    await service._store[run_id].task
+
+
+@pytest.mark.asyncio
+async def test_submit_call_persists_result_envelope_retrievable_via_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Async submit -> durable handle -> the completed envelope is persisted.
+
+    This is the dropped-response-class fix: after the background dispatch
+    completes, the full ``OperationResult`` envelope is retrievable via the
+    handle even though nothing was returned to the submitter.
+    """
+
+    async def fake_call(operator: Operator, arguments: dict[str, object]) -> dict[str, object]:
+        return {
+            "status": "ok",
+            "op_id": arguments["op_id"],
+            "result": {"vms": ["a", "b", "c"]},
+            "duration_ms": 42.0,
+        }
+
+    monkeypatch.setattr(meta_tools, "call_operation", fake_call)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    service = OperationRunService()
+
+    # The submit returns a durable handle immediately (a UUID), without
+    # blocking for the dispatch.
+    run_id = await service.submit_call(operator, dict(_ARGS))
+    assert isinstance(run_id, uuid.UUID)
+    task = service._store[run_id].task
+
+    await task  # drive the background dispatch to completion
+
+    post = await service.poll(operator, run_id)
+    assert post.status == OperationRunStatus.SUCCEEDED.value
+    assert post.origin == OperationRunOrigin.DIRECT.value
+    assert post.connector_id == "vmware-rest-9.0"
+    assert post.target_name == "dc-vcenter"
+    assert post.params_hash is not None  # secret-safe correlation, not raw params
+    assert post.result == {
+        "status": "ok",
+        "op_id": "vm.list",
+        "result": {"vms": ["a", "b", "c"]},
+        "duration_ms": 42.0,
+    }
+    assert post.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_submit_call_records_error_envelope_as_succeeded_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch that returns an *error envelope* is a ``succeeded`` run.
+
+    ``succeeded`` is the *run* completing; the persisted envelope carries the
+    dispatch's own ``status`` (here ``error``). The run is not ``failed`` --
+    that state is reserved for a run that never produced an envelope.
+    """
+
+    async def fake_call(operator: Operator, arguments: dict[str, object]) -> dict[str, object]:
+        return {
+            "status": "error",
+            "op_id": arguments["op_id"],
+            "error": "connector 500",
+            "duration_ms": 3.0,
+            "extras": {"error_code": "connector_http_error"},
+        }
+
+    monkeypatch.setattr(meta_tools, "call_operation", fake_call)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    service = OperationRunService()
+
+    run_id = await service.submit_call(operator, dict(_ARGS))
+    await _drain(service, run_id)
+
+    row = await service.poll(operator, run_id)
+    assert row.status == OperationRunStatus.SUCCEEDED.value
+    assert row.result is not None
+    assert row.result["status"] == "error"
+    assert row.error is None  # run-level error stays distinct from the envelope
+
+
+@pytest.mark.asyncio
+async def test_submit_call_unexpected_exception_marks_run_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch that *raises* (defence-in-depth) becomes a ``failed`` run."""
+
+    async def boom(operator: Operator, arguments: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(meta_tools, "call_operation", boom)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    service = OperationRunService()
+
+    run_id = await service.submit_call(operator, dict(_ARGS))
+    await _drain(service, run_id)
+
+    row = await service.poll(operator, run_id)
+    assert row.status == OperationRunStatus.FAILED.value
+    assert row.error is not None and "RuntimeError" in row.error
+    assert row.result is None
+
+
+async def _insert_run(
+    tenant_id: uuid.UUID,
+    *,
+    status: OperationRunStatus = OperationRunStatus.PENDING,
+) -> uuid.UUID:
+    """Insert a run row directly (no background task) for read/cancel tests."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = OperationRun(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            identity_sub="op-1",
+            origin=OperationRunOrigin.DIRECT.value,
+            connector_id="vmware-rest-9.0",
+            op_id="vm.list",
+            status=status.value,
+        )
+        session.add(run)
+        await session.commit()
+        return run.id
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_run_via_service_records_intent() -> None:
+    """``cancel`` records the durable cancel intent (best-effort cancel)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    run_id = await _insert_run(tenant_id)
+    service = OperationRunService()
+
+    cancelled = await service.cancel(operator, run_id)
+    assert cancelled.status == OperationRunStatus.CANCELLED.value
+    polled = await service.poll(operator, run_id)
+    assert polled.status == OperationRunStatus.CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_mark_running_returns_false_for_cancelled_run() -> None:
+    """The background task skips the dispatch when the run raced to terminal.
+
+    A cancel that landed before the task started leaves the row terminal;
+    ``_mark_running`` returns ``False`` so the op is never sent for a run the
+    operator already cancelled.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run_id = await _seed_and_cancel(session, tenant_id)
+    service = OperationRunService()
+    assert await service._mark_running(run_id) is False
+
+
+@pytest.mark.asyncio
+async def test_finalize_success_skips_when_run_cancelled() -> None:
+    """A cancel that landed mid-dispatch wins: the envelope is discarded.
+
+    When the dispatch completes but the row is already ``cancelled``, the
+    finalize transition is illegal and is skipped -- the run stays
+    ``cancelled`` and ``result`` stays ``None`` (the dispatch's own
+    synchronous audit row is the durable record of what executed).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = OperationRun(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            identity_sub="op-1",
+            origin=OperationRunOrigin.DIRECT.value,
+            connector_id="vmware-rest-9.0",
+            op_id="vm.list",
+            status=OperationRunStatus.RUNNING.value,
+            started_at=None,
+        )
+        session.add(run)
+        await run_lifecycle.transition(session, run, OperationRunStatus.CANCELLED)
+        await session.commit()
+        run_id = run.id
+
+    service = OperationRunService()
+    await service._finalize_success(run_id, result={"status": "ok", "op_id": "vm.list"})
+
+    operator = _operator(tenant_id=tenant_id)
+    row = await service.poll(operator, run_id)
+    assert row.status == OperationRunStatus.CANCELLED.value
+    assert row.result is None
+
+
+async def _seed_and_cancel(session: AsyncSession, tenant_id: uuid.UUID) -> uuid.UUID:
+    run = OperationRun(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        identity_sub="op-1",
+        origin=OperationRunOrigin.DIRECT.value,
+        connector_id="vmware-rest-9.0",
+        op_id="vm.list",
+        status=OperationRunStatus.PENDING.value,
+    )
+    session.add(run)
+    await run_lifecycle.transition(session, run, OperationRunStatus.CANCELLED)
+    await session.commit()
+    return run.id
+
+
+@pytest.mark.asyncio
+async def test_list_is_tenant_isolated() -> None:
+    """``list`` returns only the operator's tenant's runs."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_a = await _seed_tenant(session, slug="rdc-internal")
+        tenant_b = await _seed_tenant(session, slug="other-tenant")
+    a_run = await _insert_run(tenant_a)
+    await _insert_run(tenant_b)
+    service = OperationRunService()
+
+    rows = await service.list(_operator(tenant_id=tenant_a))
+    assert [r.id for r in rows] == [a_run]
+
+
+@pytest.mark.asyncio
+async def test_poll_cross_tenant_is_not_found() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_a = await _seed_tenant(session, slug="rdc-internal")
+        tenant_b = await _seed_tenant(session, slug="other-tenant")
+    run_id = await _insert_run(tenant_a)
+    service = OperationRunService()
+
+    with pytest.raises(OperationRunNotFoundError):
+        await service.poll(_operator(tenant_id=tenant_b), run_id)
+
+
+@pytest.mark.asyncio
+async def test_submit_approval_resume_persists_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An async approval resume runs on the substrate and persists its envelope."""
+    request = SimpleNamespace(
+        id=uuid.uuid4(),
+        params={"disk_gb": 40},
+        connector_id="vmware-rest-9.0",
+        op_id="vm.create",
+    )
+
+    async def fake_resume(*, operator: Operator, request: object, params: object) -> object:
+        return SimpleNamespace(
+            model_dump=lambda mode="json": {
+                "status": "ok",
+                "op_id": "vm.create",
+                "result": {"vm_id": "vm-99"},
+                "duration_ms": 7.0,
+            }
+        )
+
+    monkeypatch.setattr(approval_queue, "resume_dispatch_after_approval", fake_resume)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    service = OperationRunService()
+
+    run_id = await service.submit_approval_resume(operator, request, params=None)  # type: ignore[arg-type]
+    await _drain(service, run_id)
+
+    row = await service.poll(operator, run_id)
+    assert row.status == OperationRunStatus.SUCCEEDED.value
+    assert row.origin == OperationRunOrigin.APPROVAL_RESUME.value
+    assert row.approval_request_id == request.id
+    assert row.result == {
+        "status": "ok",
+        "op_id": "vm.create",
+        "result": {"vm_id": "vm-99"},
+        "duration_ms": 7.0,
+    }

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3151,6 +3151,201 @@
         }
       }
     },
+    "/api/v1/operations/runs": {
+      "get": {
+        "tags": [
+          "operations"
+        ],
+        "summary": "List Operation Runs",
+        "description": "List the operator's tenant's async operation runs, newest first.\n\nTenant-isolated server-side via the JWT \u2014 cross-tenant runs are\ninvisible. ``?status=running`` narrows to one lifecycle state. Returns\n``created_at DESC``.",
+        "operationId": "list_operation_runs_api_v1_operations_runs_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OperationRunStatus",
+              "nullable": true,
+              "description": "Filter by lifecycle status (pending / running / succeeded / failed / cancelled). Omit for every state.",
+              "title": "Status"
+            },
+            "description": "Filter by lifecycle status (pending / running / succeeded / failed / cancelled). Omit for every state."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Max runs per page (1..500).",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Max runs per page (1..500)."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Rows to skip for paging.",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Rows to skip for paging."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OperationRunSummaryResponse"
+                  },
+                  "title": "Response List Operation Runs Api V1 Operations Runs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/operations/runs/{handle}": {
+      "get": {
+        "tags": [
+          "operations"
+        ],
+        "summary": "Get Operation Run Status",
+        "description": "Poll an async operation run's durable state by handle (the run id).\n\nReads the durable ``operation_run`` row, so it works after the request\nthat submitted the run has returned \u2014 the dropped-response-class fix: the\nfull result envelope is retrievable here even if the submit response was\nlost in transit. An unknown / cross-tenant handle is 404.",
+        "operationId": "get_operation_run_status_api_v1_operations_runs__handle__get",
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationRunStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/operations/runs/{handle}/cancel": {
+      "post": {
+        "tags": [
+          "operations"
+        ],
+        "summary": "Cancel Operation Run",
+        "description": "Cancel a non-terminal async operation run by handle (the run id).\n\nRecords the durable cancel intent through the shared\n:func:`~meho_backplane.operations.operation_run.cancel_run` service path.\nThe in-flight task is not torn down synchronously: it loses its lease and\nits result is discarded when it finalises against the now-terminal row\n(best-effort cancel \u2014 a governed op already dispatched to the vendor may\ncomplete, but its own synchronous audit row is the durable record).\n\nAn unknown / cross-tenant handle is 404 (existence is not leaked across\ntenants). An already-terminal run is 409, not a 500. A ``read_only``\noperator is rejected by the route's role gate; the service's own role\ncheck is a defence-in-depth backstop mapped to 403.",
+        "operationId": "cancel_operation_run_api_v1_operations_runs__handle__cancel_post",
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationRunSummaryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/operations/groups": {
       "get": {
         "tags": [
@@ -3378,7 +3573,7 @@
           "operations"
         ],
         "summary": "Post Call",
-        "description": "Invoke :func:`~meho_backplane.operations.dispatch` for an op id.\n\nDelegates to :func:`call_operation`. The dispatcher contract is\n\"always return a structured result\"; errors land in the result\nenvelope (``status='error'`` + ``extras.error_code``) rather than\nHTTP 4xx. The route returns 200 on a structured-error envelope so\ncallers see the dispatcher's error_code in ``extras``.\n\nTarget-failure contract (#136, completed by #2110 Option A): **every**\ntarget-failure mode returns HTTP 200 + the dispatcher envelope \u2014 a\nmissing / empty / ``name``-less target is\n``extras.error_code=\"target_required\"``, a ``target`` of a wrong JSON\ntype (e.g. ``target: 12345``) is\n``extras.error_code=\"target_invalid_type\"`` (carrying\n``extras.received_type``), a supplied name that resolves to no live\ntarget is ``extras.error_code=\"no_target\"``, and a name matching more\nthan one target (alias collision) is\n``extras.error_code=\"ambiguous_target\"`` \u2014 the resolution codes carry\nthe candidate ``matches``. No target-failure mode returns a 4xx: a\nconsumer's error handling is a single switch on ``extras.error_code``.",
+        "description": "Invoke :func:`~meho_backplane.operations.dispatch` for an op id.\n\nDelegates to :func:`call_operation`. The dispatcher contract is\n\"always return a structured result\"; errors land in the result\nenvelope (``status='error'`` + ``extras.error_code``) rather than\nHTTP 4xx. The route returns 200 on a structured-error envelope so\ncallers see the dispatcher's error_code in ``extras``.\n\nAsync governed dispatch (#3079): when the body carries ``async: true``\nthe route does **not** dispatch inline. It creates a durable\n``operation_run`` row, launches the governed dispatch on a background\ntask, and returns HTTP 202 + the run handle immediately \u2014\n``{\"run_id\", \"status\": \"pending\", \"async\": true}``. The caller polls /\ncancels via ``/api/v1/operations/runs/{handle}``; the completed\n``OperationResult`` envelope is persisted on the run, so a dropped\nresponse never loses the outcome (the motivating incident: an 83s\nvendor call whose 200 was lost in transit). Default (``async`` absent /\nfalse) is byte-identical to the pre-#3079 synchronous path below.\n\nTarget-failure contract (#136, completed by #2110 Option A): **every**\ntarget-failure mode returns HTTP 200 + the dispatcher envelope \u2014 a\nmissing / empty / ``name``-less target is\n``extras.error_code=\"target_required\"``, a ``target`` of a wrong JSON\ntype (e.g. ``target: 12345``) is\n``extras.error_code=\"target_invalid_type\"`` (carrying\n``extras.received_type``), a supplied name that resolves to no live\ntarget is ``extras.error_code=\"no_target\"``, and a name matching more\nthan one target (alias collision) is\n``extras.error_code=\"ambiguous_target\"`` \u2014 the resolution codes carry\nthe candidate ``matches``. No target-failure mode returns a 4xx: a\nconsumer's error handling is a single switch on ``extras.error_code``.",
         "operationId": "post_call_api_v1_operations_call_post",
         "parameters": [
           {
@@ -9098,7 +9293,7 @@
           "approvals"
         ],
         "summary": "Approve Approval Request",
-        "description": "Approve a pending request and re-dispatch the original operation.\n\nThe ``params`` body must be the original params unchanged; the service\nre-hashes them and rejects with 422 on a mismatch. On a successful\napproval the original dispatch is re-executed and the result returned.\n\nHTTP status codes:\n\n* 200 \u2014 approved + re-dispatched successfully.\n* 403 \u2014 operator lacks ``operator`` role, **or** the approver is the\n  requester and self-approval break-glass is disabled (G11.7-T1 #1401).\n* 404 \u2014 request not found (or belongs to another tenant).\n* 409 \u2014 request is already decided.\n* 422 \u2014 params hash mismatch.",
+        "description": "Approve a pending request and re-dispatch the original operation.\n\nThe ``params`` body must be the original params unchanged; the service\nre-hashes them and rejects with 422 on a mismatch. On a successful\napproval the original dispatch is re-executed and the result returned.\n\nAsync governed dispatch (#3079): with ``async: true`` the decision is\nstill recorded + audited synchronously, but the resumed op is dispatched\non a background task and the route returns HTTP 202 + a durable run\nhandle (``{\"run_id\", \"status\": \"pending\", \"async\": true}``) instead of\nblocking for the resumed op's full duration. The resume runs through the\nsame exactly-one-resumer claim + policy bypass + audit path the inline\nresume uses. Default (``async`` absent / false) is byte-identical to the\npre-#3079 inline resume below.\n\nHTTP status codes:\n\n* 200 \u2014 approved + re-dispatched successfully (sync).\n* 202 \u2014 approved; resume launched in the background (``async: true``).\n* 403 \u2014 operator lacks ``operator`` role, **or** the approver is the\n  requester and self-approval break-glass is disabled (G11.7-T1 #1401).\n* 404 \u2014 request not found (or belongs to another tenant).\n* 409 \u2014 request is already decided.\n* 422 \u2014 params hash mismatch.",
         "operationId": "approve_approval_request_api_v1_approvals__request_id__approve_post",
         "parameters": [
           {
@@ -21300,6 +21495,12 @@
             "title": "Reason",
             "description": "Optional human-readable approval reason (recorded in the audit row).",
             "default": ""
+          },
+          "async": {
+            "type": "boolean",
+            "title": "Async",
+            "description": "Async governed dispatch (#3079). When true, the decision is still recorded synchronously, but the resumed op is dispatched on a background task and the route returns HTTP 202 + a durable run handle immediately instead of blocking for the resumed op's full duration. Poll / cancel via ``/api/v1/operations/runs/{handle}``. Default false \u2014 the response is byte-identical to the pre-#3079 inline resume.",
+            "default": false
           }
         },
         "additionalProperties": false,
@@ -23883,6 +24084,12 @@
             "minLength": 1,
             "nullable": true,
             "title": "Work Ref"
+          },
+          "async": {
+            "type": "boolean",
+            "title": "Async",
+            "description": "Async governed dispatch (#3079). When true, ``/call`` returns a durable run handle (HTTP 202) immediately instead of holding the connection for the op's full duration; execution proceeds server-side and the caller polls / cancels via ``/api/v1/operations/runs/{handle}``. The completed ``OperationResult`` envelope is persisted on the run, so a dropped response never loses the outcome. Default false \u2014 sync mode is byte-identical to the pre-#3079 behaviour.",
+            "default": false
           }
         },
         "additionalProperties": false,
@@ -27639,6 +27846,165 @@
         ],
         "title": "OperationDescriptor",
         "description": "Full :class:`~meho_backplane.db.models.EndpointDescriptor` read shape.\n\nReturned by :func:`describe_descriptor` (and the\n``GET /api/v1/operations/{descriptor_id}`` route). ``embedding`` is\ndeliberately omitted \u2014 it's a 384-dim float vector that adds wire\nbulk with no operator value at the descriptor-inspection layer.\n``llm_instructions`` IS included; the route is gated on\n``tenant_admin`` so the per-op agent prompt stays out of read-only\noperators' hands."
+      },
+      "OperationRunStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed",
+          "cancelled"
+        ],
+        "title": "OperationRunStatus",
+        "description": "Closed lifecycle status of an :class:`OperationRun`.\n\nAsync governed dispatch (#3079). A ``POST /api/v1/operations/call``\n(or ``/approvals/{id}/approve``) submitted in async mode creates one\ndurable ``operation_run`` row whose ``status`` walks an explicit,\nenforced state machine. The legal transitions live in\n:data:`meho_backplane.operations.operation_run.ALLOWED_TRANSITIONS`;\nthe service rejects any edge not on that map so an illegal jump cannot\nland in the DB.\n\nMembers:\n\n* :attr:`PENDING` -- the row was created but the background task has\n  not started executing the dispatch yet (initial state on insert).\n* :attr:`RUNNING` -- the background task is executing the governed\n  dispatch (target resolve + policy + connector call + audit).\n* :attr:`SUCCEEDED` -- the dispatch **completed** and its full\n  :class:`~meho_backplane.connectors.schemas.OperationResult` envelope\n  is persisted on ``result`` (terminal). Note this is the *run*\n  completing, not the op succeeding: a dispatch that returned\n  ``status='error'`` / ``'denied'`` / ``'needs-approval'`` is a\n  ``succeeded`` **run** whose persisted envelope carries that\n  dispatch status. The dropped-response class the feature eliminates\n  is exactly this: the envelope is durable regardless of the caller's\n  connection.\n* :attr:`FAILED` -- the background task itself did not complete: the\n  worker died mid-flight (lease lapsed, reaped by the operation-run\n  reaper) or the dispatch raised unexpectedly (terminal). Distinct\n  from a persisted error envelope on a ``succeeded`` run.\n* :attr:`CANCELLED` -- an authorized operator cancelled a non-terminal\n  run (terminal).\n\nThere is deliberately no ``awaiting_approval`` state (unlike\n:class:`AgentRunStatus`): a governed dispatch runs to a terminal\nenvelope in one shot. A ``needs-approval`` dispatch parks its own\n:class:`ApprovalRequest` and is recorded as a ``succeeded`` run whose\nenvelope names the parked request."
+      },
+      "OperationRunStatusResponse": {
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationRunStatus"
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "target_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Name"
+          },
+          "approval_request_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Approval Request Id"
+          },
+          "result": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Result"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "title": "Error"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Started At"
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ended At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run_id",
+          "status",
+          "origin",
+          "connector_id",
+          "op_id",
+          "target_name",
+          "approval_request_id",
+          "result",
+          "error",
+          "created_at",
+          "started_at",
+          "ended_at"
+        ],
+        "title": "OperationRunStatusResponse",
+        "description": "Poll response for ``GET /operations/runs/{handle}``.\n\n``result`` carries the full persisted ``OperationResult`` envelope once\nthe run reaches ``succeeded`` (the dropped-response-class fix); ``error``\ncarries the run-crash / reaper reason on a ``failed`` run. Both are\n``None`` while the run is still ``pending`` / ``running``."
+      },
+      "OperationRunSummaryResponse": {
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationRunStatus"
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "target_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Name"
+          },
+          "approval_request_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Approval Request Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Started At"
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ended At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run_id",
+          "status",
+          "origin",
+          "connector_id",
+          "op_id",
+          "target_name",
+          "approval_request_id",
+          "created_at",
+          "started_at",
+          "ended_at"
+        ],
+        "title": "OperationRunSummaryResponse",
+        "description": "One row of the operation-run list (``GET /operations/runs``).\n\nA scannable index row: identity, lifecycle state, dispatch coordinates,\ntimestamps. The full ``result`` envelope is omitted \u2014 a caller wanting a\nrun's result polls ``GET /operations/runs/{handle}``."
       },
       "OperatorIdentity": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -318,6 +318,15 @@ const (
 	MemoryScopeUserTenant MemoryScope = "user-tenant"
 )
 
+// Defines values for OperationRunStatus.
+const (
+	OperationRunStatusCancelled OperationRunStatus = "cancelled"
+	OperationRunStatusFailed    OperationRunStatus = "failed"
+	OperationRunStatusPending   OperationRunStatus = "pending"
+	OperationRunStatusRunning   OperationRunStatus = "running"
+	OperationRunStatusSucceeded OperationRunStatus = "succeeded"
+)
+
 // Defines values for PermissionVerdict.
 const (
 	PermissionVerdictAutoExecute   PermissionVerdict = "auto-execute"
@@ -1220,6 +1229,9 @@ type ApprovalRequestView struct {
 
 // ApproveRequestBody POST body for “…/approve“.
 type ApproveRequestBody struct {
+	// Async Async governed dispatch (#3079). When true, the decision is still recorded synchronously, but the resumed op is dispatched on a background task and the route returns HTTP 202 + a durable run handle immediately instead of blocking for the resumed op's full duration. Poll / cancel via ``/api/v1/operations/runs/{handle}``. Default false — the response is byte-identical to the pre-#3079 inline resume.
+	Async *bool `json:"async,omitempty"`
+
 	// Params The original dispatch params, unchanged. The hash must match the stored params_hash on the approval request.
 	Params *map[string]interface{} `json:"params,omitempty"`
 
@@ -2759,6 +2771,8 @@ type BudgetStatus struct {
 // untouched. The field stores an opaque string -- no validation, no
 // tracker API call (Goal #1651 ships the field only).
 type CallOperationBody struct {
+	// Async Async governed dispatch (#3079). When true, ``/call`` returns a durable run handle (HTTP 202) immediately instead of holding the connection for the op's full duration; execution proceeds server-side and the caller polls / cancels via ``/api/v1/operations/runs/{handle}``. The completed ``OperationResult`` envelope is persisted on the run, so a dropped response never loses the outcome. Default false — sync mode is byte-identical to the pre-#3079 behaviour.
+	Async       *bool                     `json:"async,omitempty"`
 	ConnectorId string                    `json:"connector_id"`
 	OpId        string                    `json:"op_id"`
 	Params      *map[string]interface{}   `json:"params,omitempty"`
@@ -5330,6 +5344,160 @@ type OperationDescriptor struct {
 	Tags              []string                `json:"tags"`
 	TenantId          *openapi_types.UUID     `json:"tenant_id"`
 	Version           string                  `json:"version"`
+}
+
+// OperationRunStatus Closed lifecycle status of an :class:`OperationRun`.
+//
+// Async governed dispatch (#3079). A “POST /api/v1/operations/call“
+// (or “/approvals/{id}/approve“) submitted in async mode creates one
+// durable “operation_run“ row whose “status“ walks an explicit,
+// enforced state machine. The legal transitions live in
+// :data:`meho_backplane.operations.operation_run.ALLOWED_TRANSITIONS`;
+// the service rejects any edge not on that map so an illegal jump cannot
+// land in the DB.
+//
+// Members:
+//
+//   - :attr:`PENDING` -- the row was created but the background task has
+//     not started executing the dispatch yet (initial state on insert).
+//   - :attr:`RUNNING` -- the background task is executing the governed
+//     dispatch (target resolve + policy + connector call + audit).
+//   - :attr:`SUCCEEDED` -- the dispatch **completed** and its full
+//     :class:`~meho_backplane.connectors.schemas.OperationResult` envelope
+//     is persisted on “result“ (terminal). Note this is the *run*
+//     completing, not the op succeeding: a dispatch that returned
+//     “status='error'“ / “'denied'“ / “'needs-approval'“ is a
+//     “succeeded“ **run** whose persisted envelope carries that
+//     dispatch status. The dropped-response class the feature eliminates
+//     is exactly this: the envelope is durable regardless of the caller's
+//     connection.
+//   - :attr:`FAILED` -- the background task itself did not complete: the
+//     worker died mid-flight (lease lapsed, reaped by the operation-run
+//     reaper) or the dispatch raised unexpectedly (terminal). Distinct
+//     from a persisted error envelope on a “succeeded“ run.
+//   - :attr:`CANCELLED` -- an authorized operator cancelled a non-terminal
+//     run (terminal).
+//
+// There is deliberately no “awaiting_approval“ state (unlike
+// :class:`AgentRunStatus`): a governed dispatch runs to a terminal
+// envelope in one shot. A “needs-approval“ dispatch parks its own
+// :class:`ApprovalRequest` and is recorded as a “succeeded“ run whose
+// envelope names the parked request.
+type OperationRunStatus string
+
+// OperationRunStatusResponse Poll response for “GET /operations/runs/{handle}“.
+//
+// “result“ carries the full persisted “OperationResult“ envelope once
+// the run reaches “succeeded“ (the dropped-response-class fix); “error“
+// carries the run-crash / reaper reason on a “failed“ run. Both are
+// “None“ while the run is still “pending“ / “running“.
+type OperationRunStatusResponse struct {
+	ApprovalRequestId *openapi_types.UUID     `json:"approval_request_id"`
+	ConnectorId       string                  `json:"connector_id"`
+	CreatedAt         time.Time               `json:"created_at"`
+	EndedAt           *time.Time              `json:"ended_at"`
+	Error             *string                 `json:"error"`
+	OpId              string                  `json:"op_id"`
+	Origin            string                  `json:"origin"`
+	Result            *map[string]interface{} `json:"result"`
+	RunId             openapi_types.UUID      `json:"run_id"`
+	StartedAt         *time.Time              `json:"started_at"`
+
+	// Status Closed lifecycle status of an :class:`OperationRun`.
+	//
+	// Async governed dispatch (#3079). A ``POST /api/v1/operations/call``
+	// (or ``/approvals/{id}/approve``) submitted in async mode creates one
+	// durable ``operation_run`` row whose ``status`` walks an explicit,
+	// enforced state machine. The legal transitions live in
+	// :data:`meho_backplane.operations.operation_run.ALLOWED_TRANSITIONS`;
+	// the service rejects any edge not on that map so an illegal jump cannot
+	// land in the DB.
+	//
+	// Members:
+	//
+	// * :attr:`PENDING` -- the row was created but the background task has
+	//   not started executing the dispatch yet (initial state on insert).
+	// * :attr:`RUNNING` -- the background task is executing the governed
+	//   dispatch (target resolve + policy + connector call + audit).
+	// * :attr:`SUCCEEDED` -- the dispatch **completed** and its full
+	//   :class:`~meho_backplane.connectors.schemas.OperationResult` envelope
+	//   is persisted on ``result`` (terminal). Note this is the *run*
+	//   completing, not the op succeeding: a dispatch that returned
+	//   ``status='error'`` / ``'denied'`` / ``'needs-approval'`` is a
+	//   ``succeeded`` **run** whose persisted envelope carries that
+	//   dispatch status. The dropped-response class the feature eliminates
+	//   is exactly this: the envelope is durable regardless of the caller's
+	//   connection.
+	// * :attr:`FAILED` -- the background task itself did not complete: the
+	//   worker died mid-flight (lease lapsed, reaped by the operation-run
+	//   reaper) or the dispatch raised unexpectedly (terminal). Distinct
+	//   from a persisted error envelope on a ``succeeded`` run.
+	// * :attr:`CANCELLED` -- an authorized operator cancelled a non-terminal
+	//   run (terminal).
+	//
+	// There is deliberately no ``awaiting_approval`` state (unlike
+	// :class:`AgentRunStatus`): a governed dispatch runs to a terminal
+	// envelope in one shot. A ``needs-approval`` dispatch parks its own
+	// :class:`ApprovalRequest` and is recorded as a ``succeeded`` run whose
+	// envelope names the parked request.
+	Status     OperationRunStatus `json:"status"`
+	TargetName *string            `json:"target_name"`
+}
+
+// OperationRunSummaryResponse One row of the operation-run list (“GET /operations/runs“).
+//
+// A scannable index row: identity, lifecycle state, dispatch coordinates,
+// timestamps. The full “result“ envelope is omitted — a caller wanting a
+// run's result polls “GET /operations/runs/{handle}“.
+type OperationRunSummaryResponse struct {
+	ApprovalRequestId *openapi_types.UUID `json:"approval_request_id"`
+	ConnectorId       string              `json:"connector_id"`
+	CreatedAt         time.Time           `json:"created_at"`
+	EndedAt           *time.Time          `json:"ended_at"`
+	OpId              string              `json:"op_id"`
+	Origin            string              `json:"origin"`
+	RunId             openapi_types.UUID  `json:"run_id"`
+	StartedAt         *time.Time          `json:"started_at"`
+
+	// Status Closed lifecycle status of an :class:`OperationRun`.
+	//
+	// Async governed dispatch (#3079). A ``POST /api/v1/operations/call``
+	// (or ``/approvals/{id}/approve``) submitted in async mode creates one
+	// durable ``operation_run`` row whose ``status`` walks an explicit,
+	// enforced state machine. The legal transitions live in
+	// :data:`meho_backplane.operations.operation_run.ALLOWED_TRANSITIONS`;
+	// the service rejects any edge not on that map so an illegal jump cannot
+	// land in the DB.
+	//
+	// Members:
+	//
+	// * :attr:`PENDING` -- the row was created but the background task has
+	//   not started executing the dispatch yet (initial state on insert).
+	// * :attr:`RUNNING` -- the background task is executing the governed
+	//   dispatch (target resolve + policy + connector call + audit).
+	// * :attr:`SUCCEEDED` -- the dispatch **completed** and its full
+	//   :class:`~meho_backplane.connectors.schemas.OperationResult` envelope
+	//   is persisted on ``result`` (terminal). Note this is the *run*
+	//   completing, not the op succeeding: a dispatch that returned
+	//   ``status='error'`` / ``'denied'`` / ``'needs-approval'`` is a
+	//   ``succeeded`` **run** whose persisted envelope carries that
+	//   dispatch status. The dropped-response class the feature eliminates
+	//   is exactly this: the envelope is durable regardless of the caller's
+	//   connection.
+	// * :attr:`FAILED` -- the background task itself did not complete: the
+	//   worker died mid-flight (lease lapsed, reaped by the operation-run
+	//   reaper) or the dispatch raised unexpectedly (terminal). Distinct
+	//   from a persisted error envelope on a ``succeeded`` run.
+	// * :attr:`CANCELLED` -- an authorized operator cancelled a non-terminal
+	//   run (terminal).
+	//
+	// There is deliberately no ``awaiting_approval`` state (unlike
+	// :class:`AgentRunStatus`): a governed dispatch runs to a terminal
+	// envelope in one shot. A ``needs-approval`` dispatch parks its own
+	// :class:`ApprovalRequest` and is recorded as a ``succeeded`` run whose
+	// envelope names the parked request.
+	Status     OperationRunStatus `json:"status"`
+	TargetName *string            `json:"target_name"`
 }
 
 // OperatorIdentity Operator identity surface exposed to the CLI and MCP “meho_status“.
@@ -8875,6 +9043,29 @@ type PostResultQueryApiV1OperationsResultQueryPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListOperationRunsApiV1OperationsRunsGetParams defines parameters for ListOperationRunsApiV1OperationsRunsGet.
+type ListOperationRunsApiV1OperationsRunsGetParams struct {
+	// Status Filter by lifecycle status (pending / running / succeeded / failed / cancelled). Omit for every state.
+	Status *OperationRunStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// Limit Max runs per page (1..500).
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Rows to skip for paging.
+	Offset        *int    `form:"offset,omitempty" json:"offset,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// GetOperationRunStatusApiV1OperationsRunsHandleGetParams defines parameters for GetOperationRunStatusApiV1OperationsRunsHandleGet.
+type GetOperationRunStatusApiV1OperationsRunsHandleGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// CancelOperationRunApiV1OperationsRunsHandleCancelPostParams defines parameters for CancelOperationRunApiV1OperationsRunsHandleCancelPost.
+type CancelOperationRunApiV1OperationsRunsHandleCancelPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // GetSearchApiV1OperationsSearchGetParams defines parameters for GetSearchApiV1OperationsSearchGet.
 type GetSearchApiV1OperationsSearchGetParams struct {
 	// ConnectorId Connector implementation id in `<impl_id>-<version>` form — e.g. `vmware-rest-9.0`, `vault-1.x`, `k8s-1.x`. NOT the bare product name (`vault`, `vmware`): a bare product slug names no connector and returns 404. Discover valid ids via `GET /api/v1/connectors`.
@@ -11762,6 +11953,15 @@ type ClientInterface interface {
 
 	PostResultQueryApiV1OperationsResultQueryPost(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListOperationRunsApiV1OperationsRunsGet request
+	ListOperationRunsApiV1OperationsRunsGet(ctx context.Context, params *ListOperationRunsApiV1OperationsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetOperationRunStatusApiV1OperationsRunsHandleGet request
+	GetOperationRunStatusApiV1OperationsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, params *GetOperationRunStatusApiV1OperationsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CancelOperationRunApiV1OperationsRunsHandleCancelPost request
+	CancelOperationRunApiV1OperationsRunsHandleCancelPost(ctx context.Context, handle openapi_types.UUID, params *CancelOperationRunApiV1OperationsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetSearchApiV1OperationsSearchGet request
 	GetSearchApiV1OperationsSearchGet(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -14409,6 +14609,42 @@ func (c *Client) PostResultQueryApiV1OperationsResultQueryPostWithBody(ctx conte
 
 func (c *Client) PostResultQueryApiV1OperationsResultQueryPost(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostResultQueryApiV1OperationsResultQueryPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListOperationRunsApiV1OperationsRunsGet(ctx context.Context, params *ListOperationRunsApiV1OperationsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListOperationRunsApiV1OperationsRunsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetOperationRunStatusApiV1OperationsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, params *GetOperationRunStatusApiV1OperationsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetOperationRunStatusApiV1OperationsRunsHandleGetRequest(c.Server, handle, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CancelOperationRunApiV1OperationsRunsHandleCancelPost(ctx context.Context, handle openapi_types.UUID, params *CancelOperationRunApiV1OperationsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCancelOperationRunApiV1OperationsRunsHandleCancelPostRequest(c.Server, handle, params)
 	if err != nil {
 		return nil, err
 	}
@@ -25395,6 +25631,200 @@ func NewPostResultQueryApiV1OperationsResultQueryPostRequestWithBody(server stri
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListOperationRunsApiV1OperationsRunsGetRequest generates requests for ListOperationRunsApiV1OperationsRunsGet
+func NewListOperationRunsApiV1OperationsRunsGetRequest(server string, params *ListOperationRunsApiV1OperationsRunsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/operations/runs")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGetOperationRunStatusApiV1OperationsRunsHandleGetRequest generates requests for GetOperationRunStatusApiV1OperationsRunsHandleGet
+func NewGetOperationRunStatusApiV1OperationsRunsHandleGetRequest(server string, handle openapi_types.UUID, params *GetOperationRunStatusApiV1OperationsRunsHandleGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "handle", runtime.ParamLocationPath, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/operations/runs/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewCancelOperationRunApiV1OperationsRunsHandleCancelPostRequest generates requests for CancelOperationRunApiV1OperationsRunsHandleCancelPost
+func NewCancelOperationRunApiV1OperationsRunsHandleCancelPostRequest(server string, handle openapi_types.UUID, params *CancelOperationRunApiV1OperationsRunsHandleCancelPostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "handle", runtime.ParamLocationPath, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/operations/runs/%s/cancel", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -40409,6 +40839,15 @@ type ClientWithResponsesInterface interface {
 
 	PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx context.Context, params *PostResultQueryApiV1OperationsResultQueryPostParams, body PostResultQueryApiV1OperationsResultQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostResultQueryApiV1OperationsResultQueryPostResponse, error)
 
+	// ListOperationRunsApiV1OperationsRunsGetWithResponse request
+	ListOperationRunsApiV1OperationsRunsGetWithResponse(ctx context.Context, params *ListOperationRunsApiV1OperationsRunsGetParams, reqEditors ...RequestEditorFn) (*ListOperationRunsApiV1OperationsRunsGetResponse, error)
+
+	// GetOperationRunStatusApiV1OperationsRunsHandleGetWithResponse request
+	GetOperationRunStatusApiV1OperationsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, params *GetOperationRunStatusApiV1OperationsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*GetOperationRunStatusApiV1OperationsRunsHandleGetResponse, error)
+
+	// CancelOperationRunApiV1OperationsRunsHandleCancelPostWithResponse request
+	CancelOperationRunApiV1OperationsRunsHandleCancelPostWithResponse(ctx context.Context, handle openapi_types.UUID, params *CancelOperationRunApiV1OperationsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse, error)
+
 	// GetSearchApiV1OperationsSearchGetWithResponse request
 	GetSearchApiV1OperationsSearchGetWithResponse(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*GetSearchApiV1OperationsSearchGetResponse, error)
 
@@ -43726,6 +44165,75 @@ func (r PostResultQueryApiV1OperationsResultQueryPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostResultQueryApiV1OperationsResultQueryPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListOperationRunsApiV1OperationsRunsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]OperationRunSummaryResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListOperationRunsApiV1OperationsRunsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListOperationRunsApiV1OperationsRunsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetOperationRunStatusApiV1OperationsRunsHandleGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *OperationRunStatusResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetOperationRunStatusApiV1OperationsRunsHandleGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetOperationRunStatusApiV1OperationsRunsHandleGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *OperationRunSummaryResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -50821,6 +51329,33 @@ func (c *ClientWithResponses) PostResultQueryApiV1OperationsResultQueryPostWithR
 	return ParsePostResultQueryApiV1OperationsResultQueryPostResponse(rsp)
 }
 
+// ListOperationRunsApiV1OperationsRunsGetWithResponse request returning *ListOperationRunsApiV1OperationsRunsGetResponse
+func (c *ClientWithResponses) ListOperationRunsApiV1OperationsRunsGetWithResponse(ctx context.Context, params *ListOperationRunsApiV1OperationsRunsGetParams, reqEditors ...RequestEditorFn) (*ListOperationRunsApiV1OperationsRunsGetResponse, error) {
+	rsp, err := c.ListOperationRunsApiV1OperationsRunsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListOperationRunsApiV1OperationsRunsGetResponse(rsp)
+}
+
+// GetOperationRunStatusApiV1OperationsRunsHandleGetWithResponse request returning *GetOperationRunStatusApiV1OperationsRunsHandleGetResponse
+func (c *ClientWithResponses) GetOperationRunStatusApiV1OperationsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, params *GetOperationRunStatusApiV1OperationsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*GetOperationRunStatusApiV1OperationsRunsHandleGetResponse, error) {
+	rsp, err := c.GetOperationRunStatusApiV1OperationsRunsHandleGet(ctx, handle, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetOperationRunStatusApiV1OperationsRunsHandleGetResponse(rsp)
+}
+
+// CancelOperationRunApiV1OperationsRunsHandleCancelPostWithResponse request returning *CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse
+func (c *ClientWithResponses) CancelOperationRunApiV1OperationsRunsHandleCancelPostWithResponse(ctx context.Context, handle openapi_types.UUID, params *CancelOperationRunApiV1OperationsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse, error) {
+	rsp, err := c.CancelOperationRunApiV1OperationsRunsHandleCancelPost(ctx, handle, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCancelOperationRunApiV1OperationsRunsHandleCancelPostResponse(rsp)
+}
+
 // GetSearchApiV1OperationsSearchGetWithResponse request returning *GetSearchApiV1OperationsSearchGetResponse
 func (c *ClientWithResponses) GetSearchApiV1OperationsSearchGetWithResponse(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*GetSearchApiV1OperationsSearchGetResponse, error) {
 	rsp, err := c.GetSearchApiV1OperationsSearchGet(ctx, params, reqEditors...)
@@ -57458,6 +57993,105 @@ func ParsePostResultQueryApiV1OperationsResultQueryPostResponse(rsp *http.Respon
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListOperationRunsApiV1OperationsRunsGetResponse parses an HTTP response from a ListOperationRunsApiV1OperationsRunsGetWithResponse call
+func ParseListOperationRunsApiV1OperationsRunsGetResponse(rsp *http.Response) (*ListOperationRunsApiV1OperationsRunsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListOperationRunsApiV1OperationsRunsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []OperationRunSummaryResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetOperationRunStatusApiV1OperationsRunsHandleGetResponse parses an HTTP response from a GetOperationRunStatusApiV1OperationsRunsHandleGetWithResponse call
+func ParseGetOperationRunStatusApiV1OperationsRunsHandleGetResponse(rsp *http.Response) (*GetOperationRunStatusApiV1OperationsRunsHandleGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetOperationRunStatusApiV1OperationsRunsHandleGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest OperationRunStatusResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCancelOperationRunApiV1OperationsRunsHandleCancelPostResponse parses an HTTP response from a CancelOperationRunApiV1OperationsRunsHandleCancelPostWithResponse call
+func ParseCancelOperationRunApiV1OperationsRunsHandleCancelPostResponse(rsp *http.Response) (*CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CancelOperationRunApiV1OperationsRunsHandleCancelPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest OperationRunSummaryResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/async-governed-dispatch.md
+++ b/docs/codebase/async-governed-dispatch.md
@@ -49,7 +49,7 @@ load-bearing:
   resume runs), `status`, `result` (the persisted envelope JSON), `error`
   (run-crash / reaper reason), `lease_owner` / `lease_expires_at`, and the
   `created_at` / `started_at` / `ended_at` timestamps. Table created by
-  migration `0079`.
+  migration `0080`.
 - `OperationRunStatus` / `OperationRunOrigin` — closed enums backed by DB
   `CHECK` constraints; drift-guarded against the migration's frozen tuples in
   `tests/test_operation_run_lifecycle.py`.
@@ -155,4 +155,4 @@ the `main.py` lifespan alongside the other background sweeps.
   per-operation: a run is `succeeded` only after the dispatch's audit row
   commits).
 - [`agent-run.md`](agent-run.md) — the substrate this mirrors.
-- Migration `0079` — the `operation_run` table.
+- Migration `0080` — the `operation_run` table.

--- a/docs/codebase/async-governed-dispatch.md
+++ b/docs/codebase/async-governed-dispatch.md
@@ -1,0 +1,158 @@
+# async-governed-dispatch — durable run handle (202 + poll) for long operations
+
+## Overview
+
+Async governed dispatch (#3079) lets a caller submit a governed operation
+without holding the HTTP connection for the operation's full duration.
+`POST /api/v1/operations/call` with `async: true` (and
+`POST /api/v1/approvals/{id}/approve` with `async: true`) creates a durable
+`operation_run` row, launches the governed dispatch on a background
+`asyncio` task, and returns **HTTP 202 + a run handle** immediately. The
+caller polls / cancels via the handle; the completed
+`OperationResult` envelope is persisted on the row, so it survives a dropped
+response.
+
+Motivating incident: an 83s vendor call (OVF library-item deploy) held the
+dispatch connection open; the client's network path dropped the 200
+response, and the successful result envelope was lost — the audit log
+records lifecycle events but not the full composite result envelope, so a
+dropped response meant a lost result. Async mode eliminates that class: the
+envelope is durable and re-readable via the handle.
+
+Sync mode remains the default and is byte-identical to the pre-#3079 path —
+async is strictly opt-in per request.
+
+This reuses the *shape* of the `agent_run` durable-execution substrate
+(durable row + lease/heartbeat + reaper — see
+[`agent-run.md`](agent-run.md)) applied to a single governed dispatch
+instead of an LLM tool-use loop. Two differences from `agent_run` are
+load-bearing:
+
+- **No `resume` in-flight policy.** A governed op can wrap a non-idempotent
+  vendor write. Re-dispatching a half-executed write on pod death would
+  double-execute it, so an orphaned run is **never** re-dispatched — the
+  reaper drives it to `failed` (an audited terminal state). This is the safe
+  half of the acceptance criterion "survives pod restart via lease/reaper
+  semantics **or** terminates into an audited terminal state — never
+  silently lost."
+- **Raw params are not persisted — only a `params_hash`.** A persisted
+  params blob would be a new secret surface (the same posture `audit_log`
+  takes), and because the run never resumes, nothing needs them
+  re-hydrated. The running task holds params in memory for the one dispatch.
+
+## Key types
+
+- `OperationRun` (`db/models.py`) — one durable row per async governed
+  dispatch. Columns: `id` (the handle), `tenant_id` (FK), `identity_sub` /
+  `identity_act`, `origin` (`direct` | `approval_resume`), `connector_id`,
+  `op_id`, `target_name`, `params_hash`, `approval_request_id` (soft-FK for
+  resume runs), `status`, `result` (the persisted envelope JSON), `error`
+  (run-crash / reaper reason), `lease_owner` / `lease_expires_at`, and the
+  `created_at` / `started_at` / `ended_at` timestamps. Table created by
+  migration `0079`.
+- `OperationRunStatus` / `OperationRunOrigin` — closed enums backed by DB
+  `CHECK` constraints; drift-guarded against the migration's frozen tuples in
+  `tests/test_operation_run_lifecycle.py`.
+- `operations/operation_run.py` — the lifecycle service (a trim of
+  `operations/agent_run.py`): create / get / list, the enforced state
+  machine (`transition`, `ALLOWED_TRANSITIONS`), lease (`claim_lease`,
+  `heartbeat`, `release_lease`), and the terminal helpers `succeed_run`
+  (persists the envelope) / `fail_run` (records the crash reason) /
+  `cancel_run` (operator-authorized). Every mutator flushes; the caller owns
+  the commit.
+- `operations/operation_run_service.py` — `OperationRunService`, a
+  process-wide singleton holding the in-process task store. `submit_call` /
+  `submit_approval_resume` create the row + claim a lease + launch the
+  background task; `poll` / `list` / `cancel` are the read/cancel surface.
+- `api/v1/operation_runs.py` — the `GET /runs`, `GET /runs/{handle}`,
+  `POST /runs/{handle}/cancel` routes. Registered **before** the operations
+  router in `main.py` so the literal `/runs` list route is not shadowed by
+  the operations router's `/{descriptor_id}` catch-all.
+- `operations/operation_run_reaper.py` — the expired-lease reclaim sweep
+  (single fail-into-audit policy).
+
+## Control flow
+
+Async submit (`POST /operations/call`, `async: true`):
+
+1. `post_call` strips the transport-only `async_` control and calls
+   `OperationRunService.submit_call(operator, arguments)`.
+2. `submit_call` computes a `params_hash`, inserts a `pending` row, and
+   claims a lease under this worker's `"<hostname>:<pid>"` owner (one
+   committed transaction), then launches a background task and returns the
+   run id. The route answers `202` + `{run_id, status: "pending", async: true}`.
+3. The background task (`_run_to_completion`) starts a heartbeat sidecar,
+   transitions the row `pending → running`, then awaits `call_operation` —
+   the **same** governed-dispatch path a sync request runs (identical policy
+   gate, identical synchronous audit write). On return it persists the
+   envelope and transitions `running → succeeded` (`succeed_run`). An
+   unexpected raise (defence-in-depth) transitions `running → failed`.
+4. The caller reads the durable outcome via `GET /operations/runs/{handle}`.
+
+Async approve (`POST /approvals/{id}/approve`, `async: true`): the decision
+is recorded + audited synchronously (unchanged), then
+`submit_approval_resume` launches `resume_dispatch_after_approval` on the
+background substrate and the route returns 202 + the handle. The
+exactly-one-resumer claim (#2293) still guards the single execution, now won
+inside the background task.
+
+State machine (`pending → running → succeeded | failed`, plus
+`→ cancelled` from any non-terminal state):
+
+- `succeeded` means the **run** completed and its envelope is durable —
+  even when the envelope's own `status` is `error` / `denied` /
+  `needs-approval`. The dispatch outcome lives in the persisted envelope,
+  not the run status.
+- `failed` is reserved for a run that never produced an envelope (worker
+  died / reaped, or the dispatch raised).
+- `cancelled` is best-effort: the durable intent is recorded; an in-flight
+  task loses its lease on the next heartbeat and its result is discarded
+  when it finalises against the now-terminal row (the dispatch's own
+  synchronous audit row remains the record of what executed).
+
+## Reaper
+
+`operation_run_reaper` scans `status='running' AND lease_expires_at < now()`
+on a fixed cadence (advisory-lock leader election per tick, `FOR UPDATE SKIP
+LOCKED` claim, per-row savepoint isolation, one commit per tick — the same
+discipline as the agent-run reaper) and drives each orphaned run to `failed`
+with a stable interruption reason, writing an internal audit row
+(`operator_sub='system:operation-run-reaper'`, `run_id` = the operation-run
+id, migration-`0034` audit correlation) in the same transaction. It never
+re-dispatches. Gated on `OPERATION_RUN_REAPER_ENABLED`; started/stopped in
+the `main.py` lifespan alongside the other background sweeps.
+
+## Dependencies
+
+- `operations/meta_tools.call_operation` — the governed dispatch the direct
+  async path runs in the background.
+- `operations/approval_queue.resume_dispatch_after_approval` — the resume the
+  async approve path runs in the background.
+- `operations/agent_run.py` + `agent/reaper.py` — the pattern reference (the
+  durable-row / lease / reaper shape this substrate mirrors).
+- `db/advisory.advisory_lock`, `db/engine.get_sessionmaker`,
+  `settings` (`operation_run_*` knobs), `main.py` lifespan wiring.
+
+## Known issues / notes
+
+- **No CLI verbs yet.** The generated Go client (`cli/api/openapi.json` /
+  `client.gen.go`) carries the new paths after `make snapshot-openapi &&
+  make generate`, but no `meho operation runs …` CLI command is wired.
+  Adding operator CLI verbs is a follow-up.
+- **Pending rows are not reaped.** The reaper only reclaims `running` rows
+  (a `pending` row has no lease window that matters). The task transitions
+  `pending → running` within milliseconds of the row insert, so the window
+  is negligible; mirrors the agent-run reaper's posture.
+- **In-process task store is per-replica.** The durable row is the source of
+  truth, so `poll` works from any replica, but the launching replica holds
+  the live task. If that replica dies, the reaper (any replica) reclaims the
+  row into `failed`.
+
+## References
+
+- Issue #3079 (async governed dispatch).
+- v0.1-spec §6 (audit is synchronous + append-only — preserved
+  per-operation: a run is `succeeded` only after the dispatch's audit row
+  commits).
+- [`agent-run.md`](agent-run.md) — the substrate this mirrors.
+- Migration `0079` — the `operation_run` table.


### PR DESCRIPTION
## Summary

- Adds an **opt-in async mode** to governed dispatch (#3079): `POST /api/v1/operations/call` with `async: true` creates a durable `operation_run` row, launches the governed dispatch on a background task, and returns **HTTP 202 + a run handle** immediately — instead of holding the request connection for the operation's full duration.
- New handle surface: `GET /api/v1/operations/runs` (list), `GET /api/v1/operations/runs/{handle}` (poll), `POST /api/v1/operations/runs/{handle}/cancel` (cancel). A completed run **persists its full `OperationResult` envelope** on the row, so a dropped response is retrievable via the handle — eliminating the dropped-response class (the motivating incident: an 83s vendor call whose 200 was lost in transit).
- `POST /api/v1/approvals/{id}/approve` gains the same opt-in `async: true`: the decision is recorded + audited synchronously, then the resumed op runs on the background substrate and the route returns 202 + the handle.
- **Sync mode is the default and byte-identical** to the pre-#3079 path. Audit stays per-operation + append-only (v0.1-spec §6): a run is marked `succeeded` only after the dispatch's synchronous audit row commits.

## Design (builds ON the existing seams; does not rebuild)

Reuses the `agent_run` durable-execution shape (durable row + lease/heartbeat + reaper — `operations/agent_run.py`, `agent/reaper.py`, `agent/invocation.py`) applied to a single governed dispatch. Two deliberate differences from `agent_run`:

- **No `resume` policy.** A governed op can wrap a non-idempotent vendor write, so an orphaned run (worker died mid-flight) is **never** re-dispatched — the `operation_run` reaper drives it to `failed` (an audited terminal state). This is the safe half of the acceptance criterion "survives pod restart via lease/reaper **or** terminates into an audited terminal state — never silently lost."
- **Raw params are not persisted — only a `params_hash`** (the same posture `audit_log` takes); the run never resumes, so nothing needs them re-hydrated.

The direct async path runs through the same `call_operation`; the async approve path through the same `resume_dispatch_after_approval` (same policy gate, same exactly-one-resumer claim #2293, same synchronous audit).

## Files

- `db/models.py` + migration `0079` — `operation_run` table + `OperationRunStatus`/`OperationRunOrigin` enums (closed `CHECK`s).
- `operations/operation_run.py` — lifecycle service (state machine + lease + cancel).
- `operations/operation_run_service.py` — submit / background-execute / poll / cancel runner.
- `operations/operation_run_reaper.py` — expired-lease reclaim (single fail-into-audit policy).
- `api/v1/operation_runs.py` — poll/list/cancel routes (registered before the operations router so `/runs` is not shadowed by `/{descriptor_id}`).
- `api/v1/operations.py` + `operations/meta_tools.py` — the `async` flag + 202 branch on `/call`.
- `api/v1/approvals.py` — the `async` flag + 202 branch on `/approve`.
- `settings.py`, `main.py` — reaper knobs + lifespan wiring.
- `cli/api/openapi.json` + `cli/internal/api/client.gen.go` — regenerated (`make snapshot-openapi && make generate`).
- `docs/codebase/async-governed-dispatch.md` — the subsystem doc.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean across the changeset.
- [x] `mypy` — clean on all changed modules.
- [x] `code-quality.py --diff` — 0 blockers.
- [x] `pytest tests/test_operation_run_lifecycle.py tests/test_operation_run_service.py tests/test_operation_run_reaper.py tests/test_api_v1_operation_runs.py` — 46 passed (lifecycle state machine + lease/heartbeat + cancel auth + CHECK/drift guards; submit→persist→poll, error-envelope-as-succeeded, unexpected-raise→failed, best-effort cancel, approval-resume; reaper reclaim→failed+audit; route 202 + poll returns persisted envelope + list/cancel 200/404/409 + **sync path unchanged**).
- [x] Adjacent regressions green: `test_api_v1_operations`, `test_api_v1_approvals`, `test_agent_approval_resume`, `test_db_agent_run`, `test_db_models`, `test_mcp_surface_conformance`.
- [x] Migration `0079` up/down/up roundtrip clean; alembic single head `0079`.
- [x] App boots (no circular imports); Go client builds (`go build ./...`).

## Acceptance criteria (#3079)

- [x] Async submit returns a durable handle; execution survives pod restart (lease/reaper) **or** terminates into an audited terminal state — never silently lost (reaper → `failed` + audit row).
- [x] Completed results persisted + retrievable via the handle (dropped-response class eliminated).
- [x] Approve on an async-mode op returns promptly; the resumed execution runs in the background under the same policy/audit guarantees.
- [x] Sync mode remains the default and byte-identical for existing callers.

## Out of scope / follow-ups

- No `meho operation runs …` CLI verbs yet (the generated client carries the paths; operator verbs are a follow-up).
- DBOS substrate swap remains deferred repo-wide (rows kept substrate-neutral).

Closes #3079

🤖 Generated with [Claude Code](https://claude.com/claude-code)
