### PR TITLE
feat(connectors): governed guest-ops channel for arbitrary VMs (#3100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,28 @@ connector-related release-notes line.
   any write. Omitting `disks` keeps the REST create body byte-identical to
   a pre-#3117 call.
 
+### Added — governed guest-operations channel for arbitrary VMs (#3100)
+
+- New `vmware.composite.vm.guest.*` op family on the `vmware-rest`
+  connector rides VMware Tools guest operations (vim
+  `GuestOperationsManager`) over the existing VI-JSON write seam
+  (`_post_vmomi_json`) — no `pyvmomi`, no SSH. It replaces the
+  out-of-band `govc guest.run` fallback with a governed, audited,
+  approval-gated channel. Guest OS credentials resolve from the target's
+  Vault `secret_ref` (`guest_username` / `guest_password`) and never
+  travel in operation params. First increment: four read-only ops —
+  `guest.process.list` (`ListProcessesInGuest`), `guest.env.read`
+  (`ReadEnvironmentVariableInGuest`), `guest.file.read`
+  (`InitiateFileTransferFromGuest`), and `guest.net.show` (Tools-reported
+  `guest.net` / `guest.ipStack`, no guest creds) — plus one
+  approval-gated write, `guest.file.write` (`InitiateFileTransferToGuest`,
+  `dangerous` + `requires_approval`, riding the standard approvals plane).
+  Set-shaped responses are JSONFlux-wrapped (postulate 6). The design
+  note (`docs/codebase/connectors-vmware-rest-guest-ops.md`) records the
+  chosen vim-guest-ops path over the deferred generic-ssh tier and the
+  full safety model. The freeform in-guest program-exec tier (e.g.
+  `guest.net.set_mtu` via `StartProgramInGuest`) is deliberately deferred.
+
 ### Added — REST + CLI parity for `result_query`: read JSONFlux handles back off MCP (#3179 / PR #3181)
 
 - `POST /api/v1/operations/call` can *mint* a reduced result handle for any

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 29 composites land before
+``endpoint_descriptor`` upserts for the 32 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -31,15 +31,17 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 20 write composites (G3.1-T6 / #509, the guest-ops write
+* 23 write composites (G3.1-T6 / #509, the guest-ops write
   ``vm.guest.file.write`` / #3100, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
   ``folder.create`` / #2895, the #2891 post-clone hardware
   reconfigure trio ``vm.resize`` / ``vm.nic.repoint`` /
-  ``vm.device.cdrom``, the two GOSC composites / #2892, and the OVF/OVA
-  content-library deploy ``vm.deploy_from_library`` / #2909) -- inherit
+  ``vm.device.cdrom``, the two GOSC composites / #2892, the OVF/OVA
+  content-library deploy ``vm.deploy_from_library`` / #2909, and the
+  three host-domain writes ``host.datastore_mount_nfs`` /
+  ``host.disk_mark_flash`` / ``host.service_control`` / #3182) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 24 composites land before
+``endpoint_descriptor`` upserts for the 29 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -24,12 +24,15 @@ Schema 2020-12 parameter + response contracts.
 
 Scope:
 
-* 5 read composites (G3.1-T5 / #508) --
+* 9 read composites (G3.1-T5 / #508 + the 4 guest-ops reads
+  ``vm.guest.process.list`` / ``env.read`` / ``net.show`` /
+  ``file.read`` / #3100) --
   ``safety_level="safe"`` + ``requires_approval=False`` overrides.
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 19 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+* 20 write composites (G3.1-T6 / #509, the guest-ops write
+  ``vm.guest.file.write`` / #3100, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
@@ -58,6 +61,13 @@ Scope:
   ``govc library.deploy``) (#2909).
 """
 
+from meho_backplane.connectors.vmware_rest.composites._guest import (
+    guest_env_read_composite,
+    guest_file_read_composite,
+    guest_file_write_composite,
+    guest_net_show_composite,
+    guest_process_list_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._host import (
     datastore_mount_nfs_composite,
     disk_mark_flash_composite,
@@ -118,6 +128,11 @@ __all__ = [
     "event_tail_composite",
     "folder_create_composite",
     "guest_customization_spec_create_composite",
+    "guest_env_read_composite",
+    "guest_file_read_composite",
+    "guest_file_write_composite",
+    "guest_net_show_composite",
+    "guest_process_list_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "network_portgroup_audit_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed guest-operations channel handlers (``vmware.composite.vm.guest.*``, #3100).
+
+A governed way to reach *inside* an arbitrary VM's guest OS -- list
+processes, read environment variables, inspect guest network state, read
+and write files -- riding **VMware Tools guest operations** (the vim
+``GuestOperationsManager`` family) over the existing VI-JSON write seam
+(:meth:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector._post_vmomi_json`),
+the same substrate the #2890 mutating-vmomi wave used. No ``pyvmomi``, no
+SSH, no in-guest agent of MEHO's own.
+
+Design (see ``docs/codebase/connectors-vmware-rest-guest-ops.md``):
+
+* **Guest credentials via ``secret_ref`` only, never in params.** Guest
+  OS credentials are read from the target's Vault secret under the
+  operator's identity
+  (:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  with the ``guest_username`` / ``guest_password`` fields) -- exactly as
+  the connector already reads the vCenter service account from the same
+  secret. The credential lives only as the ephemeral
+  ``NamePasswordAuthentication`` object the vim request body carries; it
+  never enters params, a result, an audit row, a preview, or a log line.
+* **Structured sub-ops, not freeform shell.** Each op is a discrete
+  typed verb. There is no ``run(cmd)`` -- freeform in-guest program
+  execution (``StartProgramInGuest``) is a deliberately deferred tier.
+* **Read/write split.** ``process.list`` / ``env.read`` / ``net.show`` /
+  ``file.read`` are ``safety_level="safe"`` reads; ``file.write`` is the
+  single ``dangerous`` / ``requires_approval`` write, gated through the
+  same #2254 :func:`enforce_subop_policy` seam the other write composites
+  use.
+
+Guest-operations manager MoRefs
+-------------------------------
+
+The sub-managers (``GuestProcessManager`` / ``GuestFileManager``) are
+reached at their own MoIds. This codebase has no ``RetrieveServiceContent``
+path and no verified literal for these singletons, so rather than
+hard-code four unverified MoIds, the sub-manager MoRef is resolved
+*dynamically* from the top-level ``GuestOperationsManager`` (a single
+overridable default MoId, ``"guestOperationsManager"``) via a
+``RetrievePropertiesEx`` read of its ``processManager`` / ``fileManager``
+properties -- the same property-read seam the cluster-DRS composite uses.
+An operator whose deployment names the top manager differently overrides
+``guest_ops_manager_moid``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+    vim_moref,
+)
+from meho_backplane.operations.composite import enforce_subop_policy
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+__all__ = [
+    "guest_env_read_composite",
+    "guest_file_read_composite",
+    "guest_file_write_composite",
+    "guest_net_show_composite",
+    "guest_process_list_composite",
+]
+
+# --- governance facts (mirror the write-composite substrate, #2254) ---------
+_CONNECTOR_ID = "vmware-rest-9.0"
+_WRITE_SAFETY_LEVEL = "dangerous"
+_WRITE_REQUIRES_APPROVAL = False
+
+# --- Vault secret fields carrying the guest OS credentials ------------------
+#: The guest OS credential fields the target's Vault secret must carry,
+#: distinct from the ``username`` / ``password`` the connector reads for
+#: the vCenter session. Resolved under the operator's identity; never in
+#: params.
+_GUEST_CRED_FIELDS: tuple[str, str] = ("guest_username", "guest_password")
+
+# --- vim singletons + method paths (canonical METHOD:/path op_ids) ----------
+#: PropertyCollector singleton MoId (literal, as in ``_read.py``).
+_PROPERTY_COLLECTOR_MOID = "propertyCollector"
+#: Default top-level GuestOperationsManager MoId. Overridable per call
+#: (``guest_ops_manager_moid``); unverified-live, so the override exists.
+_DEFAULT_GUEST_OPS_MANAGER_MOID = "guestOperationsManager"
+
+_OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+_OP_LIST_PROCESSES = "POST:/GuestProcessManager/{moId}/ListProcessesInGuest"
+_OP_READ_ENV = "POST:/GuestProcessManager/{moId}/ReadEnvironmentVariableInGuest"
+_OP_FILE_TRANSFER_FROM = "POST:/GuestFileManager/{moId}/InitiateFileTransferFromGuest"
+_OP_FILE_TRANSFER_TO = "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest"
+
+# --- vim type names + property paths ----------------------------------------
+_VIRTUAL_MACHINE_MO_TYPE = "VirtualMachine"
+_GUEST_OPS_MANAGER_MO_TYPE = "GuestOperationsManager"
+_NAME_PASSWORD_AUTH_TYPE = "NamePasswordAuthentication"
+_GUEST_FILE_ATTRIBUTES_TYPE = "GuestFileAttributes"
+_PROP_PROCESS_MANAGER = "processManager"
+_PROP_FILE_MANAGER = "fileManager"
+_PROP_GUEST_NET = "guest.net"
+_PROP_GUEST_IP_STACK = "guest.ipStack"
+
+#: Cap on the number of processes returned inline before the list is
+#: JSONFlux-handled by the dispatcher.
+_DEFAULT_MAX_PROCESSES = 200
+
+
+def _unwrap_envelope(payload: Any) -> Any:
+    """Strip a legacy ``{"value": X}`` envelope; bare payloads pass through."""
+    if isinstance(payload, dict) and set(payload.keys()) == {"value"}:
+        return payload["value"]
+    return payload
+
+
+def _name_password_auth(username: str, password: str) -> dict[str, Any]:
+    """Build the ephemeral ``NamePasswordAuthentication`` vim object.
+
+    ``interactiveSession`` is required by the pinned spec and is ``False``
+    for programmatic guest ops (no interactive desktop session). This dict
+    is the only place the guest credential materialises; it is never
+    logged, echoed, or persisted.
+    """
+    return {
+        "_typeName": _NAME_PASSWORD_AUTH_TYPE,
+        "interactiveSession": False,
+        "username": username,
+        "password": password,
+    }
+
+
+async def _guest_auth(
+    connector: VmwareRestConnector, target: Any, operator: Operator
+) -> dict[str, Any]:
+    """Resolve the guest OS credential from the target's ``secret_ref``.
+
+    Reads the ``guest_username`` / ``guest_password`` fields off the same
+    KV-v2 secret the connector reads the vCenter session credential from,
+    under the operator's identity. Raises
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    when the secret is unset or missing a guest field -- the dispatcher
+    wraps it ``connector_error`` for the caller.
+    """
+    del connector  # credentials resolve off the target, not the session
+    creds = await load_basic_credentials(target, operator, fields=_GUEST_CRED_FIELDS)
+    return _name_password_auth(creds["guest_username"], creds["guest_password"])
+
+
+async def _resolve_guest_manager_moid(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    top_moid: str,
+    property_name: str,
+) -> str:
+    """Resolve a guest sub-manager MoId off the top GuestOperationsManager.
+
+    One ``RetrievePropertiesEx`` read of ``property_name``
+    (``processManager`` / ``fileManager``) on
+    ``GuestOperationsManager(top_moid)``, returning the sub-manager
+    MoRef's ``value``. Raises :class:`RuntimeError` when the property is
+    absent or not a MoRef (a deployment whose top MoId differs from the
+    default -- the caller's ``guest_ops_manager_moid`` override is the fix).
+    """
+    _method, _, path_template = _OP_RETRIEVE_PROPERTIES.partition(":")
+    path = path_template.format(moId=_PROPERTY_COLLECTOR_MOID)
+    result = await connector._post_vmomi_json(
+        target,
+        path,
+        operator=operator,
+        json=retrieve_properties_body(_GUEST_OPS_MANAGER_MO_TYPE, [top_moid], [property_name]),
+    )
+    moref = _single_prop(result, property_name)
+    moid = moref.get("value") if isinstance(moref, dict) else None
+    if not isinstance(moid, str) or not moid:
+        raise RuntimeError(
+            f"could not resolve GuestOperationsManager.{property_name} off "
+            f"{top_moid!r}; pass guest_ops_manager_moid if this deployment names "
+            "the guest-operations manager differently"
+        )
+    return moid
+
+
+def _single_prop(retrieve_result: Any, name: str) -> Any:
+    """Pull one property's ``val`` off a single-object RetrievePropertiesEx result."""
+    payload = _unwrap_envelope(retrieve_result)
+    objects = payload.get("objects") if isinstance(payload, dict) else None
+    if not isinstance(objects, list) or not objects:
+        return None
+    first = objects[0]
+    prop_set = first.get("propSet") if isinstance(first, dict) else None
+    for prop in prop_set or []:
+        if isinstance(prop, dict) and prop.get("name") == name:
+            return unwrap_vim_value(prop.get("val"))
+    return None
+
+
+async def _vm_guest_method(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    op_id: str,
+    manager_moid: str,
+    body: dict[str, Any],
+) -> Any:
+    """POST one vim guest-ops method on the resolved sub-manager MoId."""
+    _method, _, path_template = op_id.partition(":")
+    path = path_template.format(moId=manager_moid)
+    return await connector._post_vmomi_json(target, path, operator=operator, json=body)
+
+
+# ===========================================================================
+# Reads (safe / no approval)
+# ===========================================================================
+
+
+async def guest_process_list_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """List processes running in a VM's guest OS via ``ListProcessesInGuest``.
+
+    Op-id: ``vmware.composite.vm.guest.process.list``. Resolves the
+    GuestProcessManager MoRef, authenticates with the guest credential
+    from ``secret_ref``, and returns the (capped) process list -- the
+    exec-status shape (name / pid / owner / cmdLine / startTime / exitCode).
+    Set-shaped, so the dispatcher JSONFlux-wraps it over threshold.
+    """
+    vm_moid = params["vm"]
+    top_moid = params.get("guest_ops_manager_moid", _DEFAULT_GUEST_OPS_MANAGER_MOID)
+    max_processes = int(params.get("max_processes", _DEFAULT_MAX_PROCESSES))
+    auth = await _guest_auth(connector, target, operator)
+    manager_moid = await _resolve_guest_manager_moid(
+        connector, target, operator, top_moid=top_moid, property_name=_PROP_PROCESS_MANAGER
+    )
+    raw = await _vm_guest_method(
+        connector,
+        target,
+        operator,
+        op_id=_OP_LIST_PROCESSES,
+        manager_moid=manager_moid,
+        body={"vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid), "auth": auth},
+    )
+    processes = _unwrap_envelope(raw)
+    if not isinstance(processes, list):
+        raise RuntimeError(
+            f"guest.process.list: expected list from {_OP_LIST_PROCESSES!r}, "
+            f"got {type(processes).__name__}"
+        )
+    capped = processes[:max_processes]
+    return {
+        "vm": vm_moid,
+        "process_manager_moid": manager_moid,
+        "processes": capped,
+        "count": len(capped),
+        "max_processes_applied": max_processes,
+    }
+
+
+async def guest_env_read_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """Read guest environment variables via ``ReadEnvironmentVariableInGuest``.
+
+    Op-id: ``vmware.composite.vm.guest.env.read``. Returns the guest
+    environment as a list of ``NAME=value`` strings (the whole environment
+    when ``names`` is omitted, else just the requested names). Set-shaped.
+    """
+    vm_moid = params["vm"]
+    top_moid = params.get("guest_ops_manager_moid", _DEFAULT_GUEST_OPS_MANAGER_MOID)
+    names = params.get("names")
+    auth = await _guest_auth(connector, target, operator)
+    manager_moid = await _resolve_guest_manager_moid(
+        connector, target, operator, top_moid=top_moid, property_name=_PROP_PROCESS_MANAGER
+    )
+    body: dict[str, Any] = {"vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid), "auth": auth}
+    if names:
+        body["names"] = list(names)
+    raw = await _vm_guest_method(
+        connector,
+        target,
+        operator,
+        op_id=_OP_READ_ENV,
+        manager_moid=manager_moid,
+        body=body,
+    )
+    variables = _unwrap_envelope(raw)
+    if not isinstance(variables, list):
+        raise RuntimeError(
+            f"guest.env.read: expected list from {_OP_READ_ENV!r}, got {type(variables).__name__}"
+        )
+    return {
+        "vm": vm_moid,
+        "process_manager_moid": manager_moid,
+        "variables": variables,
+        "count": len(variables),
+    }
+
+
+async def guest_net_show_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """Show VMware Tools-reported guest network state (no guest credentials).
+
+    Op-id: ``vmware.composite.vm.guest.net.show``. Reads the VM's
+    ``guest.net`` (``GuestNicInfo`` -- per-NIC IPs / MAC / connected) and
+    ``guest.ipStack`` (``GuestStackInfo`` -- routes / DNS / default
+    gateways) via ``RetrievePropertiesEx``. This is Tools-*reported* state
+    on the VM object, so it needs **no** in-guest authentication and runs
+    nothing inside the guest -- it serves the "read ``ip addr`` / routes"
+    diagnosis half without a guest login.
+    """
+    vm_moid = params["vm"]
+    result = await connector._post_vmomi_json(
+        target,
+        _OP_RETRIEVE_PROPERTIES.partition(":")[2].format(moId=_PROPERTY_COLLECTOR_MOID),
+        operator=operator,
+        json=retrieve_properties_body(
+            _VIRTUAL_MACHINE_MO_TYPE, [vm_moid], [_PROP_GUEST_NET, _PROP_GUEST_IP_STACK]
+        ),
+    )
+    nics = _single_prop(result, _PROP_GUEST_NET)
+    ip_stacks = _single_prop(result, _PROP_GUEST_IP_STACK)
+    return {
+        "vm": vm_moid,
+        "nics": nics if isinstance(nics, list) else [],
+        "ip_stacks": ip_stacks if isinstance(ip_stacks, list) else [],
+    }
+
+
+async def guest_file_read_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """Initiate a guest file read via ``InitiateFileTransferFromGuest``.
+
+    Op-id: ``vmware.composite.vm.guest.file.read``. Returns the
+    ``FileTransferInformation`` the guest file manager issues -- the file
+    ``size``, POSIX ``attributes``, and a one-time transfer ``url`` -- for
+    ``guest_path``. Inline content retrieval (a raw GET of ``url``) is a
+    deliberate follow-up (see the design note): the first increment returns
+    the transfer handle so the file's existence, size, and attributes are
+    known without MEHO proxying the bytes.
+    """
+    vm_moid = params["vm"]
+    guest_path = params["guest_path"]
+    top_moid = params.get("guest_ops_manager_moid", _DEFAULT_GUEST_OPS_MANAGER_MOID)
+    auth = await _guest_auth(connector, target, operator)
+    manager_moid = await _resolve_guest_manager_moid(
+        connector, target, operator, top_moid=top_moid, property_name=_PROP_FILE_MANAGER
+    )
+    raw = await _vm_guest_method(
+        connector,
+        target,
+        operator,
+        op_id=_OP_FILE_TRANSFER_FROM,
+        manager_moid=manager_moid,
+        body={
+            "vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid),
+            "auth": auth,
+            "guestFilePath": guest_path,
+        },
+    )
+    info = _unwrap_envelope(raw)
+    info = info if isinstance(info, dict) else {}
+    size = unwrap_vim_value(info.get("size"))
+    return {
+        "vm": vm_moid,
+        "file_manager_moid": manager_moid,
+        "guest_path": guest_path,
+        "url": unwrap_vim_value(info.get("url")),
+        "size_bytes": size if isinstance(size, int) and not isinstance(size, bool) else None,
+        "attributes": unwrap_vim_value(info.get("attributes")),
+        "content_fetch": "deferred",
+    }
+
+
+# ===========================================================================
+# Write (dangerous / requires approval)
+# ===========================================================================
+
+
+async def guest_file_write_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Write a file into a VM's guest OS via ``InitiateFileTransferToGuest``.
+
+    Op-id: ``vmware.composite.vm.guest.file.write``. The one gated write
+    of this increment: ``dangerous`` / ``requires_approval``. Flow:
+
+    1. **Gate first** through the #2254 :func:`enforce_subop_policy` seam
+       with the ``InitiateFileTransferToGuest`` governance op_id (the
+       ``{moId}`` placeholder key, so a grant matches regardless of the
+       resolved manager). A parked / denied gate returns the
+       :class:`OperationResult` verbatim and **nothing else runs** -- no
+       guest credential is resolved, no transfer URL is minted, no bytes
+       are PUT.
+    2. On a cleared gate, resolve the guest credential (from
+       ``secret_ref``) + the GuestFileManager MoRef, then
+       ``InitiateFileTransferToGuest`` mints a one-time PUT URL and the
+       ``content`` bytes are PUT to it directly (the vim API's two-step
+       design -- bytes never transit the vim channel).
+
+    ``content`` is UTF-8 text (the common config-repair case). The gate's
+    ``proposed_effect`` preview echoes path + byte size + overwrite only,
+    never the content (:mod:`._write_preview`).
+    """
+    vm_moid = params["vm"]
+    guest_path = params["guest_path"]
+    content = params["content"]
+    overwrite = bool(params.get("overwrite", False))
+    top_moid = params.get("guest_ops_manager_moid", _DEFAULT_GUEST_OPS_MANAGER_MOID)
+    content_bytes = content.encode("utf-8")
+
+    gate = await enforce_subop_policy(
+        operator=operator,
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_FILE_TRANSFER_TO,
+        safety_level=_WRITE_SAFETY_LEVEL,
+        requires_approval=_WRITE_REQUIRES_APPROVAL,
+        target=target,
+        params={"vm": vm_moid, "guest_path": guest_path, "overwrite": overwrite},
+    )
+    if gate is not None:
+        return gate
+
+    auth = await _guest_auth(connector, target, operator)
+    manager_moid = await _resolve_guest_manager_moid(
+        connector, target, operator, top_moid=top_moid, property_name=_PROP_FILE_MANAGER
+    )
+    raw_url = await _vm_guest_method(
+        connector,
+        target,
+        operator,
+        op_id=_OP_FILE_TRANSFER_TO,
+        manager_moid=manager_moid,
+        body={
+            "vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid),
+            "auth": auth,
+            "guestFilePath": guest_path,
+            "fileAttributes": {"_typeName": _GUEST_FILE_ATTRIBUTES_TYPE},
+            "fileSize": len(content_bytes),
+            "overwrite": overwrite,
+        },
+    )
+    url = unwrap_vim_value(_unwrap_envelope(raw_url))
+    if not isinstance(url, str) or not url:
+        raise RuntimeError(
+            f"guest.file.write: {_OP_FILE_TRANSFER_TO!r} returned no transfer URL "
+            f"for {guest_path!r} on vm {vm_moid!r}"
+        )
+    await _put_guest_file_bytes(connector, target, url=url, content=content_bytes)
+    return {
+        "status": "written",
+        "vm": vm_moid,
+        "file_manager_moid": manager_moid,
+        "guest_path": guest_path,
+        "size_bytes": len(content_bytes),
+        "overwrite": overwrite,
+    }
+
+
+def _resolve_transfer_url(url: str, target: Any) -> str:
+    """Replace a literal ``*`` transfer-URL host with the target's host.
+
+    ``InitiateFileTransferToGuest`` can return a URL whose host is the
+    literal ``*`` placeholder meaning "the server you called" (the VMware
+    guest-ops convention). Substitute the target's host so the PUT reaches
+    a routable endpoint; a concrete host (e.g. an ESXi management address)
+    is left untouched.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(url)
+    if parts.hostname != "*":
+        return url
+    netloc = f"{target.host}:{parts.port}" if parts.port else str(target.host)
+    return urlunsplit(parts._replace(netloc=netloc))
+
+
+async def _put_guest_file_bytes(
+    connector: VmwareRestConnector, target: Any, *, url: str, content: bytes
+) -> None:
+    """PUT ``content`` to a guest-transfer ``url`` on the pooled target client.
+
+    Uses the target's pooled, TLS-configured client
+    (:meth:`~meho_backplane.connectors.adapters.http.HttpConnector._http_client`,
+    the precedent the unauthenticated version-discovery GET uses) -- the
+    transfer ticket rides the URL, so no ``auth_headers`` are attached.
+    The target's ``tls_server_name`` SNI extension is deliberately **not**
+    forwarded: it names the vCenter cert, whereas a guest-transfer URL may
+    resolve to a different host (an ESXi host); a ``verify_tls=false``
+    target (the common lab case) is unaffected either way. A non-2xx PUT
+    raises for the caller to surface.
+    """
+    resolved = _resolve_transfer_url(url, target)
+    client = await connector._http_client(target)
+    response = await client.put(resolved, content=content)
+    response.raise_for_status()

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -28,7 +28,7 @@ The 9 read composites (T5 / #508 + the 4 guest-ops reads
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 20 write
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 23 write
 composites (T6 / #509, single-VM ``vm.power`` / #2301, the guest-ops
 write ``vm.guest.file.write`` / #3100, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
@@ -36,8 +36,10 @@ VI-JSON ``vm.disk.grow`` / #2893, the folder-template
 ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
 hardware writes -- ``vm.resize`` / ``vm.nic.repoint`` /
 ``vm.device.cdrom``, the two GOSC composites
-``guest.customization_spec.create`` / ``vm.customize`` / #2892, and the
-OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909) inherit
+``guest.customization_spec.create`` / ``vm.customize`` / #2892, the
+OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909, and the
+three host-domain writes ``host.datastore_mount_nfs`` /
+``host.disk_mark_flash`` / ``host.service_control`` / #3182) inherit
 the T4 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity
 at the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 27 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 32 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -21,13 +21,16 @@ the source_kind="composite" persistence.
 Mixed safety posture
 --------------------
 
-The 5 read composites (T5 / #508) pass
+The 9 read composites (T5 / #508 + the 4 guest-ops reads
+``vm.guest.process.list`` / ``vm.guest.env.read`` / ``vm.guest.net.show``
+/ ``vm.guest.file.read`` / #3100) pass
 ``safety_level="safe"`` + ``requires_approval=False`` -- overrides of
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 19 write
-composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 20 write
+composites (T6 / #509, single-VM ``vm.power`` / #2301, the guest-ops
+write ``vm.guest.file.write`` / #3100, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
 ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
 ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
@@ -48,6 +51,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NamedTuple
 
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._guest import (
+    guest_env_read_composite,
+    guest_file_read_composite,
+    guest_file_write_composite,
+    guest_net_show_composite,
+    guest_process_list_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._host import (
     datastore_mount_nfs_composite,
     disk_mark_flash_composite,
@@ -96,6 +106,16 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     FOLDER_CREATE_RESPONSE_SCHEMA,
     GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA,
     GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA,
+    GUEST_ENV_READ_PARAMETER_SCHEMA,
+    GUEST_ENV_READ_RESPONSE_SCHEMA,
+    GUEST_FILE_READ_PARAMETER_SCHEMA,
+    GUEST_FILE_READ_RESPONSE_SCHEMA,
+    GUEST_FILE_WRITE_PARAMETER_SCHEMA,
+    GUEST_FILE_WRITE_RESPONSE_SCHEMA,
+    GUEST_NET_SHOW_PARAMETER_SCHEMA,
+    GUEST_NET_SHOW_RESPONSE_SCHEMA,
+    GUEST_PROCESS_LIST_PARAMETER_SCHEMA,
+    GUEST_PROCESS_LIST_RESPONSE_SCHEMA,
     HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA,
     HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA,
     HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
@@ -266,6 +286,24 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "GOSC specs can carry admin / sysprep credentials; those never "
         "reach a reviewer surface (the create op is credential-class)."
     ),
+    "guest_ops": (
+        "Use for the governed guest-operations channel -- reaching INSIDE a "
+        "running VM's guest OS via VMware Tools (vim GuestOperationsManager), "
+        "the governed replacement for out-of-band 'govc guest.run'. Reads "
+        "(safe): list guest processes (process.list -- exec status), read "
+        "guest environment variables (env.read), show Tools-reported guest "
+        "network state (net.show -- per-NIC IPs / routes / DNS, needs NO guest "
+        "credentials), and initiate a guest file read (file.read -- returns the "
+        "transfer handle: size + attributes + one-time URL). Write (dangerous / "
+        "approval-required): place a file into the guest (file.write). Guest OS "
+        "credentials resolve from the target's Vault secret_ref (guest_username "
+        "/ guest_password) and are NEVER a parameter. The right group for "
+        "'what's running in this appliance?', 'read /etc/os-release from the "
+        "guest', 'what does the guest think its network is?', or 'drop this "
+        "config file into the guest'. Requires VMware Tools in the guest. "
+        "Running an arbitrary in-guest command (freeform program exec) is a "
+        "deferred tier -- not in this group yet."
+    ),
 }
 
 
@@ -299,6 +337,10 @@ class _CompositeSpec(NamedTuple):
     tags: list[str]
     safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
+    # Optional per-op agent-facing usage instructions. Defaults to
+    # ``None`` so the existing rows (whose ``description`` already carries
+    # the guidance) are unchanged; the guest-ops family (#3100) sets it.
+    llm_instructions: dict[str, Any] | None = None
 
 
 _COMPOSITES: tuple[_CompositeSpec, ...] = (
@@ -966,6 +1008,187 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         safety_level="dangerous",
         requires_approval=True,
     ),
+    # ----------------------------------------------------------------
+    # Guest-operations channel (#3100) -- 4 safe reads + 1 dangerous write.
+    # Guest OS credentials resolve from the target's secret_ref, never
+    # from params.
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.process.list",
+        handler=guest_process_list_composite,
+        summary="List processes running in a VM's guest OS via VMware Tools.",
+        description=(
+            "Lists the guest OS processes (name / pid / owner / cmdLine / "
+            "startTime / exitCode) via the vim GuestProcessManager "
+            "ListProcessesInGuest, authenticating with the guest credential "
+            "resolved from the target's secret_ref. The exec-status shape: "
+            "'what is running / did that service start / what exit code'. "
+            "Governed replacement for 'govc guest.ps'. Read-only -- never "
+            "mutates guest state. Requires VMware Tools in the guest."
+        ),
+        parameter_schema=GUEST_PROCESS_LIST_PARAMETER_SCHEMA,
+        response_schema=GUEST_PROCESS_LIST_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "read-only", "guest", "vi-json", "tools"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Inspect what is running inside a VM's guest OS -- verifying a "
+                "service started, checking a process's exit code, triaging a "
+                "first-boot appliance. Not for host/VM-level process state (that "
+                "is the ESXi/vCenter surface), only in-guest processes."
+            ),
+            "preconditions": (
+                "VMware Tools running in the guest; the target's Vault secret "
+                "carries guest_username / guest_password. No credential goes in "
+                "params."
+            ),
+            "result_shape": (
+                "{vm, process_manager_moid, processes[], count, "
+                "max_processes_applied}; the process list is JSONFlux-wrapped "
+                "into a result handle when large -- drill in with result_query."
+            ),
+        },
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.env.read",
+        handler=guest_env_read_composite,
+        summary="Read environment variables from a VM's guest OS via VMware Tools.",
+        description=(
+            "Reads the guest user's environment variables (as NAME=value "
+            "strings) via the vim GuestProcessManager "
+            "ReadEnvironmentVariableInGuest, authenticating with the guest "
+            "credential from the target's secret_ref. Omit 'names' for the whole "
+            "environment, or pass specific names. Read-only. Requires VMware "
+            "Tools in the guest."
+        ),
+        parameter_schema=GUEST_ENV_READ_PARAMETER_SCHEMA,
+        response_schema=GUEST_ENV_READ_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "read-only", "guest", "vi-json", "tools"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Read the guest OS environment of a running VM -- confirming a "
+                "PATH, a proxy variable, or a first-boot configuration value the "
+                "guest exports."
+            ),
+            "preconditions": (
+                "VMware Tools running; guest credential in the target's "
+                "secret_ref (guest_username / guest_password). Never in params."
+            ),
+            "result_shape": (
+                "{vm, process_manager_moid, variables[], count}; variables is "
+                "JSONFlux-wrapped when large."
+            ),
+        },
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.net.show",
+        handler=guest_net_show_composite,
+        summary="Show Tools-reported guest network state (no guest credentials).",
+        description=(
+            "Reads the VM's Tools-reported guest network state -- per-NIC IPs / "
+            "MAC / connected (guest.net, GuestNicInfo) and routes / DNS / "
+            "gateways (guest.ipStack, GuestStackInfo) -- via RetrievePropertiesEx. "
+            "This is reported state on the VM object, so it needs NO in-guest "
+            "authentication and runs nothing inside the guest: the 'read ip "
+            "addr / routes' diagnosis without a guest login. Read-only."
+        ),
+        parameter_schema=GUEST_NET_SHOW_PARAMETER_SCHEMA,
+        response_schema=GUEST_NET_SHOW_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "read-only", "guest", "vi-json", "networking"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "See what network configuration a guest actually has (addresses, "
+                "routes, DNS, gateways) as VMware Tools reports it -- e.g. "
+                "diagnosing why an appliance is unreachable. The only guest read "
+                "that needs no guest credentials."
+            ),
+            "preconditions": "VMware Tools running in the guest (reports the state).",
+            "result_shape": "{vm, nics[], ip_stacks[]}.",
+        },
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.file.read",
+        handler=guest_file_read_composite,
+        summary="Initiate a guest file read; returns size + attributes + transfer URL.",
+        description=(
+            "Initiates a guest file read via the vim GuestFileManager "
+            "InitiateFileTransferFromGuest, authenticating with the guest "
+            "credential from the target's secret_ref, and returns the "
+            "FileTransferInformation (file size, POSIX/Windows attributes, and a "
+            "one-time transfer URL) for guest_path. Inline byte retrieval is a "
+            "deferred follow-up; this increment returns the transfer handle so "
+            "existence + size + attributes are known without MEHO proxying the "
+            "bytes. Read-only. Requires VMware Tools in the guest."
+        ),
+        parameter_schema=GUEST_FILE_READ_PARAMETER_SCHEMA,
+        response_schema=GUEST_FILE_READ_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "read-only", "guest", "vi-json", "file"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Confirm a file's existence / size / attributes in a guest OS, "
+                "or obtain a one-time transfer URL for it. Inline content bytes "
+                "are not returned in this increment."
+            ),
+            "preconditions": (
+                "VMware Tools running; guest credential in the target's "
+                "secret_ref. Guest user must be able to read guest_path."
+            ),
+            "result_shape": (
+                "{vm, file_manager_moid, guest_path, url, size_bytes, "
+                "attributes, content_fetch='deferred'}."
+            ),
+        },
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.file.write",
+        handler=guest_file_write_composite,
+        summary="Write a file into a VM's guest OS (dangerous / approval-required).",
+        description=(
+            "Writes UTF-8 content to guest_path inside a VM's guest OS via the "
+            "vim GuestFileManager InitiateFileTransferToGuest (which mints a "
+            "one-time PUT URL) followed by a direct PUT of the bytes -- the vim "
+            "API's two-step design. Authenticates with the guest credential from "
+            "the target's secret_ref (never in params). The single WRITE of the "
+            "guest-ops channel: dangerous / approval-required, gated through the "
+            "standard approvals plane -- a parked / denied approval mints no URL "
+            "and PUTs no bytes. The park's proposed_effect echoes path + byte "
+            "size + overwrite only, never the content. Requires VMware Tools."
+        ),
+        parameter_schema=GUEST_FILE_WRITE_PARAMETER_SCHEMA,
+        response_schema=GUEST_FILE_WRITE_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "write", "guest", "vi-json", "file"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Place a config/repair file into a running guest OS (e.g. an "
+                "MTU/network drop-in) without out-of-band scp. Approval-gated -- "
+                "expect the call to park for a human decision unless a standing "
+                "grant auto-executes it."
+            ),
+            "preconditions": (
+                "VMware Tools running; guest credential in the target's "
+                "secret_ref. Guest user must be able to write guest_path."
+            ),
+            "result_shape": (
+                "On execute: {status='written', vm, file_manager_moid, "
+                "guest_path, size_bytes, overwrite}. On gate: the approval "
+                "OperationResult verbatim (awaiting_approval / denied)."
+            ),
+        },
+    ),
 )
 
 
@@ -982,7 +1205,8 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 27 composites total -- 5 read (T5 / #508) + 22 write (T6 /
+    Scope: 32 composites total -- 9 read (T5 / #508 + the 4 guest-ops
+    reads / #3100) + 23 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
@@ -1021,5 +1245,6 @@ async def register_vmware_composite_operations(
             tags=spec.tags,
             safety_level=spec.safety_level,
             requires_approval=spec.requires_approval,
+            llm_instructions=spec.llm_instructions,
             embedding_service=embedding_service,
         )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 19 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 20 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -900,9 +900,33 @@ async def _host_service_control_preview(ctx: PreviewContext) -> dict[str, Any] |
     }
 
 
-#: op_id → builder for the 22 write composites. Module-level so the
+async def _guest_file_write_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.guest.file.write`` — echo path + byte size + overwrite only.
+
+    The reviewer must see *what file* the write lands and *how big* it is,
+    never the content. Echoes the VM moid, the guest path, the UTF-8 byte
+    size of the content, and the overwrite intent; the ``content`` param is
+    deliberately never read into the preview (it can be arbitrary config
+    text and does not belong on the durable approval row). Declines
+    (``None``) on malformed params.
+    """
+    vm = ctx.params.get("vm")
+    guest_path = ctx.params.get("guest_path")
+    content = ctx.params.get("content")
+    if not isinstance(vm, str) or not isinstance(guest_path, str) or not isinstance(content, str):
+        return None
+    return {
+        "vm": vm,
+        "guest_path": guest_path,
+        "size_bytes": len(content.encode("utf-8")),
+        "overwrite": bool(ctx.params.get("overwrite", False)),
+    }
+
+
+#: op_id → builder for the 23 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
+    "vmware.composite.vm.guest.file.write": _guest_file_write_preview,
     "vmware.composite.vm.create": _vm_create_preview,
     "vmware.composite.vm.clone": _vm_clone_preview,
     "vmware.composite.vm.deploy_from_library": _vm_deploy_from_library_preview,
@@ -929,9 +953,9 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 22 write-composite park-time preview builders. Import-time.
+    """Wire the 23 write-composite park-time preview builders. Import-time.
 
-    The 5 read composites register no builder — they are
+    The 9 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be
     dead code.
     """

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -23,9 +23,9 @@ Conventions
   documentation lives on the schema's ``description`` keys; the meta-
   tools (:mod:`meho_backplane.operations.meta_tools`) surface the
   schema verbatim on ``describe_operation`` calls.
-* The 5 read composites are read-only -- the registration call site
+* The 9 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 18 write composites inherit T4's
+  each. The 23 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
   (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, the mutating
   VI-JSON ``vm.disk.grow`` / #2893, the folder-template

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -59,6 +59,16 @@ __all__ = [
     "FOLDER_CREATE_RESPONSE_SCHEMA",
     "GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA",
     "GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA",
+    "GUEST_ENV_READ_PARAMETER_SCHEMA",
+    "GUEST_ENV_READ_RESPONSE_SCHEMA",
+    "GUEST_FILE_READ_PARAMETER_SCHEMA",
+    "GUEST_FILE_READ_RESPONSE_SCHEMA",
+    "GUEST_FILE_WRITE_PARAMETER_SCHEMA",
+    "GUEST_FILE_WRITE_RESPONSE_SCHEMA",
+    "GUEST_NET_SHOW_PARAMETER_SCHEMA",
+    "GUEST_NET_SHOW_RESPONSE_SCHEMA",
+    "GUEST_PROCESS_LIST_PARAMETER_SCHEMA",
+    "GUEST_PROCESS_LIST_RESPONSE_SCHEMA",
     "HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA",
     "HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA",
     "HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA",
@@ -3172,4 +3182,348 @@ HOST_SERVICE_CONTROL_RESPONSE_SCHEMA: dict[str, Any] = {
         "guidance": {"type": ["string", "null"]},
     },
     "required": ["status", "host", "service", "policy_updated"],
+}
+
+
+# ===========================================================================
+# Guest-operations channel (vmware.composite.vm.guest.*, #3100)
+# ===========================================================================
+#
+# Guest OS credentials are NEVER a parameter of these ops: they resolve
+# from the target's Vault ``secret_ref`` (the ``guest_username`` /
+# ``guest_password`` fields). The reads are ``safe``; ``guest.file.write``
+# is the single ``dangerous`` / ``requires_approval`` write.
+
+
+#: ``vmware.composite.vm.guest.process.list`` parameter schema.
+GUEST_PROCESS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the VM whose guest processes to list (e.g. 'vm-42')."
+            ),
+        },
+        "max_processes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000,
+            "default": 200,
+            "description": (
+                "Cap on the number of processes returned. Applied client-side "
+                "after ListProcessesInGuest returns so a busy guest never floods "
+                "the agent surface; the response ``count`` detects truncation."
+            ),
+        },
+        "guest_ops_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "guestOperationsManager",
+            "description": (
+                "MoId of the top-level GuestOperationsManager singleton. The "
+                "GuestProcessManager MoRef is resolved off it at call time. "
+                "Override only if a deployment names the singleton differently."
+            ),
+        },
+    },
+    "required": ["vm"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.env.read`` parameter schema.
+GUEST_ENV_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Managed-object ID of the VM whose guest environment to read.",
+        },
+        "names": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Specific environment-variable names to read. Omit to read the "
+                "guest user's entire environment (ReadEnvironmentVariableInGuest "
+                "returns every variable when the name list is empty)."
+            ),
+        },
+        "guest_ops_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "guestOperationsManager",
+            "description": (
+                "MoId of the top-level GuestOperationsManager singleton (see process.list)."
+            ),
+        },
+    },
+    "required": ["vm"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.net.show`` parameter schema.
+#:
+#: Reads Tools-reported guest network state off the VM object -- no guest
+#: credentials, nothing runs inside the guest.
+GUEST_NET_SHOW_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the VM whose Tools-reported guest network "
+                "state (per-NIC IPs, routes, DNS, gateways) to read."
+            ),
+        },
+    },
+    "required": ["vm"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.file.read`` parameter schema.
+GUEST_FILE_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Managed-object ID of the VM whose guest file to read.",
+        },
+        "guest_path": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Absolute path of the file inside the guest OS (e.g. "
+                "'/etc/os-release'). The guest user must be able to read it."
+            ),
+        },
+        "guest_ops_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "guestOperationsManager",
+            "description": (
+                "MoId of the top-level GuestOperationsManager singleton (see process.list)."
+            ),
+        },
+    },
+    "required": ["vm", "guest_path"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.file.write`` parameter schema (the one write).
+GUEST_FILE_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Managed-object ID of the VM to write a file into.",
+        },
+        "guest_path": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Absolute destination path inside the guest OS (e.g. "
+                "'/etc/systemd/network/10-mtu.conf'). The guest user must be "
+                "able to write it."
+            ),
+        },
+        "content": {
+            "type": "string",
+            "description": (
+                "UTF-8 text content to write. Never a credential -- guest "
+                "credentials resolve from the target's secret_ref, not params."
+            ),
+        },
+        "overwrite": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Whether to overwrite an existing file at ``guest_path``. When "
+                "false, the write fails if the file already exists (vSphere "
+                "InitiateFileTransferToGuest semantics)."
+            ),
+        },
+        "guest_ops_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "guestOperationsManager",
+            "description": (
+                "MoId of the top-level GuestOperationsManager singleton (see process.list)."
+            ),
+        },
+    },
+    "required": ["vm", "guest_path", "content"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.process.list`` response schema.
+GUEST_PROCESS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {"type": "string", "description": "VM moid the processes were listed for."},
+        "process_manager_moid": {
+            "type": "string",
+            "description": (
+                "Resolved GuestProcessManager MoId the ListProcessesInGuest call targeted."
+            ),
+        },
+        "processes": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "GuestProcessInfo entries (name / pid / owner / cmdLine / "
+                "startTime / endTime / exitCode), capped to ``max_processes``. "
+                "Set-shaped: the dispatcher returns a JSONFlux result handle "
+                "when the list is over threshold."
+            ),
+        },
+        "count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Post-cap length of ``processes`` -- detects truncation.",
+        },
+        "max_processes_applied": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Effective ``max_processes`` cap applied to the response.",
+        },
+    },
+    "required": ["vm", "process_manager_moid", "processes", "count"],
+}
+
+
+#: ``vmware.composite.vm.guest.env.read`` response schema.
+GUEST_ENV_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {"type": "string", "description": "VM moid the environment was read from."},
+        "process_manager_moid": {
+            "type": "string",
+            "description": "Resolved GuestProcessManager MoId the call targeted.",
+        },
+        "variables": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Guest environment as ``NAME=value`` strings (whole environment "
+                "when ``names`` was omitted, else the requested names). "
+                "Set-shaped -- JSONFlux-wrapped over threshold."
+            ),
+        },
+        "count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of variables returned.",
+        },
+    },
+    "required": ["vm", "process_manager_moid", "variables", "count"],
+}
+
+
+#: ``vmware.composite.vm.guest.net.show`` response schema.
+GUEST_NET_SHOW_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {"type": "string", "description": "VM moid the guest network state was read for."},
+        "nics": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "GuestNicInfo entries from ``guest.net`` -- per-NIC MAC, "
+                "connected state, and IP addresses as Tools reports them."
+            ),
+        },
+        "ip_stacks": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "GuestStackInfo entries from ``guest.ipStack`` -- routing table, "
+                "DNS config, and default gateways as Tools reports them."
+            ),
+        },
+    },
+    "required": ["vm", "nics", "ip_stacks"],
+}
+
+
+#: ``vmware.composite.vm.guest.file.read`` response schema.
+GUEST_FILE_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {"type": "string", "description": "VM moid the file read was initiated on."},
+        "file_manager_moid": {
+            "type": "string",
+            "description": (
+                "Resolved GuestFileManager MoId the InitiateFileTransferFromGuest call targeted."
+            ),
+        },
+        "guest_path": {"type": "string", "description": "Absolute guest path read."},
+        "url": {
+            "type": ["string", "null"],
+            "description": (
+                "One-time guest-transfer URL from InitiateFileTransferFromGuest. "
+                "Inline byte retrieval is a deferred follow-up (see the design "
+                "note); this increment returns the transfer handle."
+            ),
+        },
+        "size_bytes": {
+            "type": ["integer", "null"],
+            "description": "File size in bytes as reported by the guest file manager.",
+        },
+        "attributes": {
+            "description": "GuestFileAttributes for the file (POSIX / Windows metadata).",
+        },
+        "content_fetch": {
+            "type": "string",
+            "enum": ["deferred"],
+            "description": (
+                "Marks that inline content retrieval is not performed in this increment."
+            ),
+        },
+    },
+    "required": ["vm", "file_manager_moid", "guest_path"],
+}
+
+
+#: ``vmware.composite.vm.guest.file.write`` response schema.
+GUEST_FILE_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["written"],
+            "description": (
+                "``'written'`` -- the transfer URL was minted and the bytes were "
+                "PUT to the guest. (A parked / denied approval returns the "
+                "governance OperationResult verbatim, not this envelope.)"
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid the file was written to."},
+        "file_manager_moid": {
+            "type": "string",
+            "description": (
+                "Resolved GuestFileManager MoId the InitiateFileTransferToGuest call targeted."
+            ),
+        },
+        "guest_path": {"type": "string", "description": "Absolute guest path written."},
+        "size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of UTF-8 content bytes written.",
+        },
+        "overwrite": {
+            "type": "boolean",
+            "description": "Whether an existing file was allowed to be overwritten.",
+        },
+    },
+    "required": ["status", "vm", "guest_path", "size_bytes", "overwrite"],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -66,6 +66,11 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.performance.summary",
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
+    # Guest-ops channel reads (#3100).
+    "vmware.composite.vm.guest.process.list",
+    "vmware.composite.vm.guest.env.read",
+    "vmware.composite.vm.guest.net.show",
+    "vmware.composite.vm.guest.file.read",
 )
 
 
@@ -86,6 +91,18 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.network.portgroup.audit": (
         "meho_backplane.connectors.vmware_rest.composites._read.network_portgroup_audit_composite"
     ),
+    "vmware.composite.vm.guest.process.list": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_process_list_composite"
+    ),
+    "vmware.composite.vm.guest.env.read": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_env_read_composite"
+    ),
+    "vmware.composite.vm.guest.net.show": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_net_show_composite"
+    ),
+    "vmware.composite.vm.guest.file.read": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_file_read_composite"
+    ),
 }
 
 
@@ -95,6 +112,10 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.performance.summary": "performance",
     "vmware.composite.datastore.usage": "storage",
     "vmware.composite.network.portgroup.audit": "networking",
+    "vmware.composite.vm.guest.process.list": "guest_ops",
+    "vmware.composite.vm.guest.env.read": "guest_ops",
+    "vmware.composite.vm.guest.net.show": "guest_ops",
+    "vmware.composite.vm.guest.file.read": "guest_ops",
 }
 
 
@@ -161,7 +182,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_five_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 5 op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all read op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -175,17 +196,19 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 27 total: 5 reads
-    # (T5 #508) + 22 writes (T6 #509 + single-VM vm.power #2301 + mutating
-    # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
-    # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
-    # folder.create #2895 + the #2891 hardware writes vm.resize /
-    # vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
-    # content-library deploy vm.deploy_from_library #2909 + the three
-    # host-domain writes host.datastore_mount_nfs / host.disk_mark_flash /
-    # host.service_control #3182). (The former host.network_uplinks /
-    # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 27
+    # Embedding service called once per composite -- 32 total: 9 reads
+    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 23 writes (T6 #509 +
+    # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
+    # folder-template vm.clone_from_template #2894 + vim cluster/inventory
+    # writes cluster.drs_rule.create + folder.create #2895 + the #2891
+    # hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
+    # create/apply #2892 + OVF/OVA content-library deploy
+    # vm.deploy_from_library #2909 + the three host-domain writes
+    # host.datastore_mount_nfs / host.disk_mark_flash / host.service_control
+    # #3182 + the guest-ops write vm.guest.file.write #3100). (The former
+    # host.network_uplinks / host.vsan_health reads were re-shipped as typed
+    # ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 32
 
 
 @pytest.mark.asyncio
@@ -268,7 +291,7 @@ async def test_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_group_resolution_lands_each_composite_in_its_named_group(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The 5 read composites resolve to their named ``group_key``."""
+    """The read composites resolve to their named ``group_key``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -432,21 +455,22 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 27.
+    """Running the registrar twice -> read rows persist; embedding stays at 32.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 19 writes / T6 +
-    single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
-    folder-template vm.clone_from_template #2894 + vim cluster/inventory
-    writes cluster.drs_rule.create + folder.create #2895 + the #2891
-    hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
-    create/apply #2892 + OVF/OVA content-library deploy
-    vm.deploy_from_library #2909 + the three host-domain writes #3182).
+    persist after the combined registrar (9 reads incl. the 4 guest-ops
+    reads #3100 + 23 writes / T6 + single-VM vm.power #2301 + mutating
+    VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
+    #2894 + vim cluster/inventory writes cluster.drs_rule.create +
+    folder.create #2895 + the #2891 hardware writes vm.resize /
+    vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
+    content-library deploy vm.deploy_from_library #2909 + the three
+    host-domain writes #3182 + guest-ops write vm.guest.file.write #3100).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 27
+    assert first_count == 32
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -464,7 +488,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 5
+    assert len(rows) == 9
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -559,7 +559,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 24 composite rows the registrar upserts. Reaching a business status
+    the 32 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
+from meho_backplane.connectors.vmware_rest.composites._guest import guest_file_write_composite
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     folder_create_composite,
@@ -958,3 +959,86 @@ async def test_folder_create_human_operator_vmomi_write_auto_executes(
     assert len(conn.create_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# guest.file.write (#3100) -- the guest-ops channel's one gated write.
+# It gates FIRST (before resolving guest credentials or the file manager),
+# so a parked / denied write resolves no credential and issues nothing.
+# ---------------------------------------------------------------------------
+
+_GUEST_FILE_WRITE_OP_ID = "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest"
+
+
+class _GuestWriteRecordingConnector:
+    """Records vmomi calls + PUTs so the gate tests can assert nothing fired."""
+
+    def __init__(self) -> None:
+        self.vmomi_calls: list[str] = []
+        self.put_calls: list[str] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append(path)
+        return {"_typeName": "string", "_value": "https://vc.example.test/g?t=1"}
+
+    async def _http_client(self, target: Any) -> Any:  # pragma: no cover - never reached on a park
+        raise AssertionError("a parked/denied guest.file.write must not open a transfer client")
+
+
+@pytest.mark.asyncio
+async def test_guest_file_write_gated_queues_and_resolves_no_credential(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated guest.file.write queues for approval before any guest reach.
+
+    The write gates on the ``InitiateFileTransferToGuest`` governance op_id
+    *first*: with a ``needs_approval`` grant it returns ``awaiting_approval``,
+    writes a durable pending row, resolves no guest credential, issues no
+    vmomi method, and opens no transfer client.
+    """
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_GUEST_FILE_WRITE_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _GuestWriteRecordingConnector()
+
+    out = await guest_file_write_composite(
+        operator=_operator(),
+        target=None,
+        params={"vm": "vm-1", "guest_path": "/etc/mtu.conf", "content": "MTU=1400\n"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _GUEST_FILE_WRITE_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _GUEST_FILE_WRITE_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    # Gate first: no vmomi method mint, no transfer client, no bytes.
+    assert conn.vmomi_calls == []
+    assert conn.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_guest_file_write_denied_without_grant(session: AsyncSession) -> None:
+    """An agent with no grant is denied the dangerous guest.file.write; it never runs."""
+    conn = _GuestWriteRecordingConnector()
+    out = await guest_file_write_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"vm": "vm-1", "guest_path": "/etc/mtu.conf", "content": "MTU=1400\n"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _GUEST_FILE_WRITE_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.vmomi_calls == []

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -94,6 +94,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.host.datastore_mount_nfs",
         "vmware.composite.host.disk_mark_flash",
         "vmware.composite.host.service_control",
+        "vmware.composite.vm.guest.file.write",
     }
 )
 
@@ -312,7 +313,7 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 22
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 23
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -306,7 +306,7 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 22 write composites register a builder (criterion 4)
+# Wiring — all 23 write composites register a builder (criterion 4)
 # ===========================================================================
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -97,6 +97,8 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.host.datastore_mount_nfs",
     "vmware.composite.host.disk_mark_flash",
     "vmware.composite.host.service_control",
+    # Guest-ops channel write (#3100).
+    "vmware.composite.vm.guest.file.write",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -109,6 +111,11 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.performance.summary",
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
+    # Guest-ops channel reads (#3100).
+    "vmware.composite.vm.guest.process.list",
+    "vmware.composite.vm.guest.env.read",
+    "vmware.composite.vm.guest.net.show",
+    "vmware.composite.vm.guest.file.read",
 )
 
 # 27 total -- 5 read (T5 / #508) + 22 write (T6 / #509 + vm.power / #2301 +
@@ -186,6 +193,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.host.service_control": (
         "meho_backplane.connectors.vmware_rest.composites._host.service_control_composite"
     ),
+    "vmware.composite.vm.guest.file.write": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_file_write_composite"
+    ),
 }
 
 
@@ -212,6 +222,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.host.datastore_mount_nfs": "host",
     "vmware.composite.host.disk_mark_flash": "host",
     "vmware.composite.host.service_control": "host",
+    "vmware.composite.vm.guest.file.write": "guest_ops",
 }
 
 
@@ -260,10 +271,10 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_nineteen_write_rows(
+async def test_register_vmware_composite_operations_inserts_all_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 22 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 23 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -280,14 +291,14 @@ async def test_register_vmware_composite_operations_inserts_nineteen_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_twenty_four_composite_rows(
+async def test_full_registration_produces_twenty_nine_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 22 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
-    vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895 +
-    #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom +
-    GOSC create/apply #2892 + OVF deploy #2909 + host-domain writes #3182)
-    = 27 rows. DoD bar."""
+    """9 reads (#508 + guest-ops reads #3100) + 23 writes (#509 + vm.power #2301 +
+    vm.disk.grow #2893 + vm.clone_from_template #2894 + cluster.drs_rule.create +
+    folder.create #2895 + #2891 hardware writes vm.resize / vm.nic.repoint /
+    vm.device.cdrom + GOSC create/apply #2892 + OVF deploy #2909 + host-domain
+    writes #3182 + guest-ops write vm.guest.file.write #3100) = 32 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -301,7 +312,7 @@ async def test_full_registration_produces_twenty_four_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 27
+    assert len(rows) == 32
 
 
 @pytest.mark.asyncio
@@ -600,17 +611,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_twenty_four(
+async def test_register_vmware_composite_operations_is_idempotent_across_twenty_nine(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 27 rows total, embedding called 27x once."""
+    """Running the registrar twice -> 32 rows total, embedding called 32x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 27
+    assert first_count == 32
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 27.
+    # pipeline; the row count stays at 32.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -624,7 +635,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_twenty_
             .scalars()
             .all()
         )
-    assert len(rows) == 27
+    assert len(rows) == 32
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -10,16 +10,17 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 19 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 23 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
   in ``composites/_write``.
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` per the canary's stub-LLM taxonomy.
-* Combined with #508's 5 read composites, the registrar produces
-  **27 rows** total. (The former host.network_uplinks / host.vsan_health
-  reads were re-shipped as typed ops in #2258.)
+* Combined with the 9 read composites (#508's 5 + the 4 guest-ops
+  reads / #3100), the registrar produces **32 rows** total. (The former
+  host.network_uplinks / host.vsan_health reads were re-shipped as typed
+  ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
 * Module-level handler shape (no closures / partials / lambdas).
@@ -68,7 +69,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 22 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 23 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
@@ -118,9 +119,10 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
 )
 
-# 27 total -- 5 read (T5 / #508) + 22 write (T6 / #509 + vm.power / #2301 +
-# vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
-# writes cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
+# 32 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 23 write
+# (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
+# vm.clone_from_template / #2894 + vim cluster/inventory writes
+# cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
 # writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
@@ -266,7 +268,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 22 write composites land alongside the 5 reads (27 total)
+# 23 write composites land alongside the 9 reads (32 total)
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_connectors_vmware_rest_guest_ops.py
+++ b/backend/tests/test_connectors_vmware_rest_guest_ops.py
@@ -504,3 +504,45 @@ async def test_file_write_gated_short_circuits(
     assert creds.calls == []
     assert conn.vmomi_calls == []
     assert conn.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_manager_resolution_failure_raises_with_override_hint(creds: _CredRecorder) -> None:
+    """A GuestOperationsManager missing the sub-manager prop raises actionably."""
+    empty = {
+        "objects": [
+            {
+                "obj": {"type": "GuestOperationsManager", "value": "guestOperationsManager"},
+                "propSet": [],
+            }
+        ]
+    }
+    conn = _GuestRecordingConnector(vmomi={"GuestOperationsManager": empty})
+    with pytest.raises(RuntimeError, match="guest_ops_manager_moid"):
+        await _guest.guest_process_list_composite(
+            operator=_operator(),
+            target=_Target(),
+            params={"vm": "vm-42"},
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_file_write_put_failure_propagates(
+    creds: _CredRecorder, auto_gate: _GateRecorder
+) -> None:
+    """A non-2xx PUT to the transfer URL raises for the dispatcher to wrap."""
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _file_mgr(),
+            "/GuestFileManager/fm-1/InitiateFileTransferToGuest": "https://vc.example.test/g?t=1",
+        },
+        put_status=500,
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await _guest.guest_file_write_composite(
+            operator=_operator(),
+            target=_Target(),
+            params={"vm": "vm-42", "guest_path": "/tmp/x", "content": "hi"},
+            connector=conn,  # type: ignore[arg-type]
+        )

--- a/backend/tests/test_connectors_vmware_rest_guest_ops.py
+++ b/backend/tests/test_connectors_vmware_rest_guest_ops.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the governed guest-operations channel handlers (#3100).
+
+The ``vmware.composite.vm.guest.*`` handlers dispatch vim guest-operations
+methods directly on the connector's VI-JSON seam (``_post_vmomi_json``) and,
+for the one write, PUT bytes on the pooled client. These tests stub the
+connector with a recording double and assert:
+
+* the call-shape contract -- which vmomi method, in what order, with which
+  MoRef + auth body -- plus the aggregation each handler returns;
+* that the guest credential resolves from ``secret_ref`` (a stubbed
+  ``load_basic_credentials``) and is **never** echoed into the result or a
+  gate's params;
+* that ``guest.net.show`` needs no guest credential at all;
+* that ``guest.file.write`` gates first (no credential resolved, no vmomi
+  write, no PUT when the gate short-circuits) and PUTs the bytes on a
+  cleared gate, with the ``*`` transfer-URL host rewritten to the target.
+
+The real-DB approval-park proof for ``guest.file.write`` lives in
+:mod:`tests.test_connectors_vmware_rest_composites_write_gate`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites import _guest
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="agent-guest-ops",
+        name="Guest Ops Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id="11111111-1111-1111-1111-111111111111",
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _Target:
+    """Minimal target stub -- ``host`` drives the transfer-URL rewrite."""
+
+    name: str = "vc-test"
+    host: str = "vc.example.test"
+    secret_ref: str = "targets/vc"
+    verify_tls: bool = False
+
+
+class _FakePutClient:
+    """Pooled-client stand-in that records PUTs and returns 200."""
+
+    def __init__(self, calls: list[dict[str, Any]], *, status: int = 200) -> None:
+        self._calls = calls
+        self._status = status
+
+    async def put(self, url: str, *, content: bytes | None = None) -> httpx.Response:
+        self._calls.append({"url": url, "content": content})
+        return httpx.Response(self._status, request=httpx.Request("PUT", url))
+
+
+@dataclass
+class _GuestRecordingConnector:
+    """Records vmomi sub-calls + PUTs, serving canned VI-JSON responses.
+
+    ``vmomi`` is keyed by the RetrievePropertiesEx queried object type
+    (``GuestOperationsManager`` / ``VirtualMachine``) and by the concrete
+    method path for the guest-ops methods.
+    """
+
+    vmomi: dict[str, Any] = field(default_factory=dict)
+    put_status: int = 200
+    vmomi_calls: list[dict[str, Any]] = field(default_factory=list)
+    put_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append({"path": path, "json": json})
+        if path.endswith("/RetrievePropertiesEx"):
+            spec_type = json["specSet"][0]["propSet"][0]["type"]
+            return self.vmomi[spec_type]
+        payload = self.vmomi[path]
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+    async def _http_client(self, target: Any) -> _FakePutClient:
+        return _FakePutClient(self.put_calls, status=self.put_status)
+
+
+class _CredRecorder:
+    """Stub for ``load_basic_credentials`` -- records the requested fields."""
+
+    def __init__(self, creds: dict[str, str]) -> None:
+        self._creds = creds
+        self.calls: list[tuple[str, ...]] = []
+
+    async def __call__(
+        self, target: Any, operator: Operator, *, fields: tuple[str, ...]
+    ) -> dict[str, str]:
+        self.calls.append(fields)
+        return {f: self._creds[f] for f in fields}
+
+
+class _GateRecorder:
+    """Stub for ``enforce_subop_policy`` -- records gate calls, returns a verdict."""
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {
+                "op_id": op_id,
+                "connector_id": connector_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
+                "params": dict(params),
+            }
+        )
+        return self._gate_for.get(op_id)
+
+
+@pytest.fixture
+def creds(monkeypatch: pytest.MonkeyPatch) -> _CredRecorder:
+    recorder = _CredRecorder({"guest_username": "svc-guest", "guest_password": "s3cr3t-pw"})
+    monkeypatch.setattr(_guest, "load_basic_credentials", recorder)
+    return recorder
+
+
+def _manager_props(prop: str, mo_type: str, moid: str) -> dict[str, Any]:
+    """A RetrievePropertiesEx result carrying the sub-manager MoRef."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "GuestOperationsManager", "value": "guestOperationsManager"},
+                "propSet": [
+                    {
+                        "name": prop,
+                        "val": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": mo_type,
+                            "value": moid,
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _process_mgr() -> dict[str, Any]:
+    return _manager_props("processManager", "GuestProcessManager", "pm-1")
+
+
+def _file_mgr() -> dict[str, Any]:
+    return _manager_props("fileManager", "GuestFileManager", "fm-1")
+
+
+# ---------------------------------------------------------------------------
+# process.list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_list_resolves_manager_and_returns_processes(creds: _CredRecorder) -> None:
+    procs = [
+        {"name": "systemd", "pid": 1, "owner": "root", "cmdLine": "/sbin/init"},
+        {"name": "sshd", "pid": 812, "owner": "root", "cmdLine": "/usr/sbin/sshd"},
+    ]
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ListProcessesInGuest": procs,
+        }
+    )
+    out = await _guest.guest_process_list_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["vm"] == "vm-42"
+    assert out["process_manager_moid"] == "pm-1"
+    assert out["count"] == 2
+    assert out["processes"] == procs
+    # The sub-manager was resolved off the top GuestOperationsManager first.
+    assert conn.vmomi_calls[0]["path"].endswith("/RetrievePropertiesEx")
+    # The method body carried the VM MoRef + the NamePasswordAuthentication.
+    body = conn.vmomi_calls[1]["json"]
+    assert body["vm"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "VirtualMachine",
+        "value": "vm-42",
+    }
+    assert body["auth"]["_typeName"] == "NamePasswordAuthentication"
+    assert body["auth"]["username"] == "svc-guest"
+    assert body["auth"]["interactiveSession"] is False
+    assert creds.calls == [("guest_username", "guest_password")]
+
+
+@pytest.mark.asyncio
+async def test_process_list_caps_to_max_processes(creds: _CredRecorder) -> None:
+    procs = [{"name": f"p{i}", "pid": i} for i in range(10)]
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ListProcessesInGuest": procs,
+        }
+    )
+    out = await _guest.guest_process_list_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "max_processes": 3},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["count"] == 3
+    assert out["max_processes_applied"] == 3
+    assert len(out["processes"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_process_list_non_list_payload_raises(creds: _CredRecorder) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ListProcessesInGuest": {"not": "a list"},
+        }
+    )
+    with pytest.raises(RuntimeError, match="expected list"):
+        await _guest.guest_process_list_composite(
+            operator=_operator(),
+            target=_Target(),
+            params={"vm": "vm-42"},
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_guest_credential_never_in_result(creds: _CredRecorder) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ListProcessesInGuest": [{"name": "x", "pid": 1}],
+        }
+    )
+    out = await _guest.guest_process_list_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert "s3cr3t-pw" not in json.dumps(out)
+    assert "svc-guest" not in json.dumps(out)
+
+
+# ---------------------------------------------------------------------------
+# env.read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_env_read_whole_environment(creds: _CredRecorder) -> None:
+    env = ["PATH=/usr/bin", "HOME=/root"]
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ReadEnvironmentVariableInGuest": env,
+        }
+    )
+    out = await _guest.guest_env_read_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["variables"] == env
+    assert out["count"] == 2
+    # No names -> the body carries no ``names`` key (reads the whole environment).
+    assert "names" not in conn.vmomi_calls[1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_env_read_named_variables(creds: _CredRecorder) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _process_mgr(),
+            "/GuestProcessManager/pm-1/ReadEnvironmentVariableInGuest": ["PATH=/usr/bin"],
+        }
+    )
+    out = await _guest.guest_env_read_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "names": ["PATH"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["count"] == 1
+    assert conn.vmomi_calls[1]["json"]["names"] == ["PATH"]
+
+
+# ---------------------------------------------------------------------------
+# net.show (no guest credentials)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_net_show_needs_no_guest_credential(creds: _CredRecorder) -> None:
+    vm_props = {
+        "objects": [
+            {
+                "obj": {"type": "VirtualMachine", "value": "vm-42"},
+                "propSet": [
+                    {"name": "guest.net", "val": [{"macAddress": "00:0c:29:aa:bb:cc"}]},
+                    {"name": "guest.ipStack", "val": [{"dnsConfig": {"hostName": "appliance"}}]},
+                ],
+            }
+        ]
+    }
+    conn = _GuestRecordingConnector(vmomi={"VirtualMachine": vm_props})
+    out = await _guest.guest_net_show_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["nics"] == [{"macAddress": "00:0c:29:aa:bb:cc"}]
+    assert out["ip_stacks"] == [{"dnsConfig": {"hostName": "appliance"}}]
+    # Tools-reported state -> no guest login, no credential resolution.
+    assert creds.calls == []
+    assert len(conn.vmomi_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# file.read (returns transfer info, no byte fetch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_file_read_returns_transfer_info(creds: _CredRecorder) -> None:
+    info = {
+        "url": "https://vc.example.test/guestFile?id=1&token=abc",
+        "size": 4096,
+        "attributes": {"_typeName": "GuestPosixFileAttributes", "permissions": 420},
+    }
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _file_mgr(),
+            "/GuestFileManager/fm-1/InitiateFileTransferFromGuest": info,
+        }
+    )
+    out = await _guest.guest_file_read_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "guest_path": "/etc/os-release"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["guest_path"] == "/etc/os-release"
+    assert out["file_manager_moid"] == "fm-1"
+    assert out["url"] == info["url"]
+    assert out["size_bytes"] == 4096
+    assert out["content_fetch"] == "deferred"
+    # No bytes were fetched (read returns the transfer handle only).
+    assert conn.put_calls == []
+    # The FromGuest body carried the guest path + auth.
+    body = conn.vmomi_calls[1]["json"]
+    assert body["guestFilePath"] == "/etc/os-release"
+    assert body["auth"]["password"] == "s3cr3t-pw"
+
+
+# ---------------------------------------------------------------------------
+# file.write (the one gated write)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auto_gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_guest, "enforce_subop_policy", recorder)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_file_write_auto_execute_puts_bytes(
+    creds: _CredRecorder, auto_gate: _GateRecorder
+) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _file_mgr(),
+            "/GuestFileManager/fm-1/InitiateFileTransferToGuest": "https://vc.example.test/guestFile?id=9&token=xyz",
+        }
+    )
+    out = await _guest.guest_file_write_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "guest_path": "/etc/mtu.conf", "content": "MTU=1400\n"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "written"
+    assert out["guest_path"] == "/etc/mtu.conf"
+    assert out["size_bytes"] == len(b"MTU=1400\n")
+    assert out["overwrite"] is False
+    # The bytes were PUT to the minted transfer URL.
+    assert conn.put_calls == [
+        {"url": "https://vc.example.test/guestFile?id=9&token=xyz", "content": b"MTU=1400\n"}
+    ]
+    # The gate ran with the write governance facts, params WITHOUT content.
+    gate_call = auto_gate.calls[0]
+    assert gate_call["op_id"] == "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest"
+    assert gate_call["safety_level"] == "dangerous"
+    assert gate_call["requires_approval"] is False
+    assert gate_call["params"] == {"vm": "vm-42", "guest_path": "/etc/mtu.conf", "overwrite": False}
+    assert "content" not in gate_call["params"]
+    assert "s3cr3t-pw" not in json.dumps(out)
+
+
+@pytest.mark.asyncio
+async def test_file_write_rewrites_star_host(
+    creds: _CredRecorder, auto_gate: _GateRecorder
+) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _file_mgr(),
+            "/GuestFileManager/fm-1/InitiateFileTransferToGuest": "https://*:443/guestFile?id=9&token=xyz",
+        }
+    )
+    await _guest.guest_file_write_composite(
+        operator=_operator(),
+        target=_Target(host="vc.example.test"),
+        params={"vm": "vm-42", "guest_path": "/tmp/x", "content": "hi"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.put_calls[0]["url"] == "https://vc.example.test:443/guestFile?id=9&token=xyz"
+
+
+@pytest.mark.asyncio
+async def test_file_write_unwraps_boxed_url(creds: _CredRecorder, auto_gate: _GateRecorder) -> None:
+    conn = _GuestRecordingConnector(
+        vmomi={
+            "GuestOperationsManager": _file_mgr(),
+            "/GuestFileManager/fm-1/InitiateFileTransferToGuest": {
+                "_typeName": "string",
+                "_value": "https://vc.example.test/g?t=1",
+            },
+        }
+    )
+    await _guest.guest_file_write_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "guest_path": "/tmp/x", "content": "hi"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.put_calls[0]["url"] == "https://vc.example.test/g?t=1"
+
+
+@pytest.mark.asyncio
+async def test_file_write_gated_short_circuits(
+    creds: _CredRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    op_id = "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest"
+    awaiting = OperationResult(
+        status="awaiting_approval",
+        op_id=op_id,
+        result=None,
+        duration_ms=1.0,
+        extras={"approval_request_id": "00000000-0000-0000-0000-0000000000aa"},
+    )
+    monkeypatch.setattr(_guest, "enforce_subop_policy", _GateRecorder({op_id: awaiting}))
+    conn = _GuestRecordingConnector(vmomi={})
+    out = await _guest.guest_file_write_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "guest_path": "/etc/mtu.conf", "content": "MTU=1400\n"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    # Gate first: no credential resolved, no vmomi write, no bytes PUT.
+    assert creds.calls == []
+    assert conn.vmomi_calls == []
+    assert conn.put_calls == []

--- a/backend/tests/test_connectors_vmware_rest_guest_ops_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_guest_ops_reconcile.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-spec reconcile lane for the guest-operations channel sub-op paths (#3100).
+
+Mirrors ``test_connectors_vmware_rest_composites_read_reconcile.py`` for
+the ``composites/_guest.py`` module: every ``_OP_*`` constant the guest
+handlers dispatch through ``_post_vmomi_json`` is a vmomi (VI-JSON)
+method, so each must be served by the pinned ``vcenter-9.0/vi-json.yaml``
+per the spec-reconcile standard
+(``docs/decisions/spec-reconcile-guards-standard.md``). The constants are
+introspected live (never a hardcoded mirror that can drift), and the
+shelf-backed lane skips uniformly when the spec shelf is unprovisioned
+(the #2980 harness contract) -- so it runs for real only in the
+shelf-armed CI lane, not the public per-PR gate. The always-on pin test
+freezes the constant strings so a typo in a guest-method path is caught
+even without the shelf.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vmware_rest.composites import _guest
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+
+def _swept_op_ids() -> set[str]:
+    """Every ``_OP_*`` op_id constant in ``_guest``, introspected live."""
+    ops: set[str] = set()
+    for name in dir(_guest):
+        if not name.startswith("_OP_"):
+            continue
+        value = getattr(_guest, name)
+        if isinstance(value, str):
+            ops.add(value)
+    return ops
+
+
+def test_guest_op_constants_are_all_vmomi_post_legs() -> None:
+    """Pin the guest-ops op_id strings (sandbox-safe, always runs).
+
+    Every guest sub-op is a vmomi POST routed through
+    ``_post_vmomi_json`` -- there is no Automation GET leg -- so the
+    shelf-backed lane below reconciles the whole set against
+    ``vi-json.yaml``. This pin freezes the strings so a path typo is
+    caught even where the spec shelf is absent.
+    """
+    swept = _swept_op_ids()
+    assert swept == {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/GuestProcessManager/{moId}/ListProcessesInGuest",
+        "POST:/GuestProcessManager/{moId}/ReadEnvironmentVariableInGuest",
+        "POST:/GuestFileManager/{moId}/InitiateFileTransferFromGuest",
+        "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest",
+    }
+    assert all(op_id.startswith("POST:") for op_id in swept)
+
+
+def test_guest_vim_sub_ops_are_served_by_the_pinned_vi_json_spec() -> None:
+    """Every guest-ops vmomi method is served by the pinned vi-json.yaml."""
+    spec_path = require_shelf_spec("vcenter-9.0", "vi-json.yaml")
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_swept_op_ids(), served, spec_label="vcenter-9.0/vi-json.yaml")

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -79,7 +79,17 @@ _K8S_GROUPS: Final[frozenset[str]] = frozenset(
 )
 _VAULT_GROUPS: Final[frozenset[str]] = frozenset({"auth", "kv", "sys"})
 _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
-    {"cluster", "events", "performance", "storage", "networking", "vm", "host", "guest"}
+    {
+        "cluster",
+        "events",
+        "performance",
+        "storage",
+        "networking",
+        "vm",
+        "host",
+        "guest",
+        "guest_ops",
+    }
 )
 _BIND9_GROUPS: Final[frozenset[str]] = frozenset({"identity", "zone", "record", "config"})
 

--- a/docs/codebase/connectors-vmware-rest-guest-ops.md
+++ b/docs/codebase/connectors-vmware-rest-guest-ops.md
@@ -1,0 +1,226 @@
+# Governed guest-operations channel for arbitrary VMs (vmware-rest)
+
+## Overview
+
+The governed way for an agent or operator to reach *inside* an arbitrary
+VM's guest OS — list running processes, read a file, inspect guest
+network state, place a file — without falling back to out-of-band
+`govc guest.run` / `scp` / an unmanaged SSH session. Every step is a
+`vmware.composite.vm.guest.*` operation on the `vmware-rest` connector
+(`vmware-rest-9.0`), dispatched through the ordinary
+`call_operation(connector_id, op_id, target, params)` path so policy,
+audit, broadcast, JSONFlux, and (for the one write) approvals apply per
+call.
+
+The channel rides **VMware Tools guest operations** (the vim
+`GuestOperationsManager` family) over the existing VI-JSON write seam
+(`VmwareRestConnector._post_vmomi_json`) — the same substrate the #2890
+mutating-vmomi wave used. No `pyvmomi`, no in-guest agent of MEHO's own,
+no shell. Guest OS credentials are resolved from the target's Vault
+`secret_ref` and never travel in operation params.
+
+First increment (this doc): four **read-only** guest ops plus **one**
+approval-gated write proving the governance posture.
+
+## The design fork: (a) vim guest-ops over (b) generic-ssh
+
+The issue (#3100) asked for one of two shapes, or both as tiers:
+
+- **(a)** a `vmware.composite.vm.guest.*` family riding vim
+  `GuestOperationsManager` (VMware Tools guest operations) via the
+  VI-JSON seam.
+- **(b)** a minimal `linux-ssh` typed connector with per-target
+  credentials and a safelisted verb model.
+
+**Operator decision (2026-08-29): build (a) now; keep (b) as a possible
+later tier.** Rationale:
+
+1. **No extra network reach, no extra listener.** Guest operations flow
+   vCenter → ESXi → VMware Tools inside the guest. MEHO already has a
+   governed session to vCenter (the connector's authenticated
+   `/api/session`), so a guest op needs no new firewall path, no SSH
+   daemon reachable from MEHO, and works for guests with **no** network
+   route to MEHO at all (first-boot appliances behind a management
+   VLAN — exactly consumer case 2 below). The generic-ssh path (b)
+   requires IP reachability MEHO frequently does not have.
+2. **Cross-version, cross-guest by construction.** VMware Tools guest
+   operations are a stable vim surface across ESXi/vCenter versions and
+   across Linux/Windows guests. One connector implementation covers the
+   fleet; (b) would need per-OS command dialects.
+3. **Reuses the proven mutating-vmomi substrate.** `_post_vmomi_json`,
+   `vim_moref`, `retrieve_properties_body`, `unwrap_vim_value`, the
+   `_write_vmomi_sub_op` governance gate, and `poll_vim_task` already
+   exist and are spec-reconciled against the pinned `vi-json.yaml`. The
+   guest ops are new op-ids on that substrate, not a new transport.
+4. **Structured sub-ops, not a shell.** (a) exposes discrete, typed
+   verbs (`guest.process.list`, `guest.file.read`, …) whose parameters
+   are JSON-schema-validated. (b)'s natural shape is a safelisted-but-
+   still-textual command surface; the structured shape is a smaller,
+   more auditable blast radius.
+
+**Why (b) is deferred, not discarded.** Two capabilities (a) cannot
+serve cleanly:
+
+- **Running a command and capturing its output** (`ip addr`,
+  `systemctl is-system-running`). vim's only exec primitive is
+  `StartProgramInGuest`, which starts a detached process and returns a
+  PID — output is not captured; you must redirect to a file, poll
+  `ListProcessesInGuest` for the exit code, then read the file back.
+  That freeform-program tier is deliberately **out of this increment**
+  (it is the crux of the dangerous-by-default posture and wants its own
+  design pass). Where the *reported* state suffices, this increment
+  serves it structurally instead: `guest.net.show` reads Tools-reported
+  guest network state directly, no program-exec.
+- **Guests without VMware Tools.** No Tools → no guest operations at
+  all; (b) is the only channel there.
+
+If and when a concrete need for freeform in-guest command execution or a
+Tools-less guest lands, tier (b) (a `linux-ssh` typed connector, or a
+`guest.program.run` op with a stricter safety gate) is the follow-up.
+This increment does **not** build it.
+
+## Safety model
+
+The channel is **dangerous by default**. The posture, in order of
+load-bearing-ness:
+
+1. **Secrets via `secret_ref` only — never in params.** Guest OS
+   credentials are read from the target's Vault secret under the
+   operator's identity (`load_basic_credentials(target, operator,
+   fields=("guest_username", "guest_password"))`), exactly like the
+   connector already reads the vCenter service-account
+   `username`/`password` from the same secret. The guest credential
+   never appears in an operation parameter, an `OperationResult`, an
+   audit row, a broadcast event, or a log line — it lives only as the
+   ephemeral in-memory `NamePasswordAuthentication` object the vim
+   request body carries. This is a deliberate improvement on the GOSC
+   `credential-class` ops (`guest.customization_spec.create`), which
+   accept the Windows admin password *in params* and rely on
+   reviewer-surface suppression to hide it; here the secret is never in
+   params to begin with.
+2. **Structured sub-ops, not freeform shell.** Each op is a discrete
+   typed verb with a JSON-schema parameter contract. There is no
+   `run(cmd)`. Freeform in-guest program execution is the explicitly
+   deferred tier.
+3. **The write is approval-gated.** `guest.file.write` is registered
+   `safety_level="dangerous"` + `requires_approval=True` and rides the
+   standard approvals plane: the dispatcher parks an
+   `ApprovalRequest` before the write executes, a human approves/rejects
+   via console/CLI (never MCP — v0.1-spec §7), and the park stores a
+   `proposed_effect` preview echoing **path + byte size + overwrite
+   intent only** (never the file content). The reads are
+   `safety_level="safe"` / no approval.
+4. **Full audit of command + result + truncated output.** Every op
+   dispatches through the synchronous append-only audit path
+   (v0.1-spec §6). The audit row names the op, the VM, and the outcome;
+   set-shaped and byte-shaped outputs are truncated (JSONFlux result
+   handle for the process list; a byte cap on file reads) so the audit
+   and the agent surface never carry an unbounded guest payload.
+5. **Read/write split is explicit.** The four reads never mutate guest
+   state; the single write is the only mutating op and is the only one
+   that parks.
+
+## The op family (first increment)
+
+All five ops register under the existing `guest` operation group
+(`group_key="guest"`), alongside the GOSC customization writes, and
+carry `op_id`s under the `vmware.composite.vm.guest.*` namespace. Each
+carries full `parameter_schema` + `response_schema` (JSON Schema
+2020-12), `tags`, `safety_level`, and `llm_instructions`.
+
+| op_id | vim method (VI-JSON) | Guest creds? | Safety | Shape |
+|---|---|---|---|---|
+| `vmware.composite.vm.guest.process.list` | `GuestProcessManager.ListProcessesInGuest` | yes | safe | set → JSONFlux handle |
+| `vmware.composite.vm.guest.env.read` | `GuestProcessManager.ReadEnvironmentVariableInGuest` | yes | safe | set → JSONFlux handle |
+| `vmware.composite.vm.guest.net.show` | `PropertyCollector.RetrievePropertiesEx` on `guest.net` + `guest.ipStack` | **no** (Tools-reported) | safe | aggregate dict |
+| `vmware.composite.vm.guest.file.read` | `GuestFileManager.InitiateFileTransferFromGuest` + guest-transfer GET | yes | safe | truncated content + attrs |
+| `vmware.composite.vm.guest.file.write` | `GuestFileManager.InitiateFileTransferToGuest` + guest-transfer PUT | yes | **dangerous / approval** | write report |
+
+Notes:
+
+- **`guest.net.show` needs no guest credentials.** Guest NIC + IP-stack
+  state is Tools-reported `GuestInfo` on the VirtualMachine, read through
+  the same `RetrievePropertiesEx` seam the other composites use — no
+  in-guest authentication. It directly serves consumer case 1's
+  "read `ip addr`/routes during a connectivity diagnosis" without
+  running anything inside the guest.
+- **File transfer is two-step by vim design.** `InitiateFileTransfer*`
+  returns a one-time guest-transfer URL; the file bytes flow directly
+  over that URL (GET for read, PUT for write), never through the vim
+  channel. The read caps returned content and the write echoes only
+  path + size to the reviewer.
+- **Set-shaped responses are JSONFlux-wrapped (postulate 6).** The
+  process list and env list return arrays; the dispatcher wraps any
+  response over the size threshold into a result handle, so the agent
+  drills in via `result_query` rather than receiving an unbounded guest
+  process table.
+
+### Why `guest.file.write` is the proving write (not `guest.net.set_mtu`)
+
+The issue offered `guest.file.write` or `guest.net.set_mtu` as the one
+gated write. `guest.file.write` is chosen because it is the write the
+vim API supports **most cleanly through the seam**:
+
+- `InitiateFileTransferToGuest` is a single documented `GuestFileManager`
+  method (mirror of the `InitiateFileTransferFromGuest` the file-read op
+  already uses — the transfer machinery is built once, used both ways).
+  It is a structured sub-op, not a shell command.
+- `guest.net.set_mtu` has **no** single vim guest-op method. Setting an
+  MTU inside a guest means running `ip link set … mtu …` via
+  `StartProgramInGuest` — freeform program execution, the very tier this
+  increment defers, plus PID-polling and output-file gymnastics. It
+  belongs to the deferred freeform-exec tier, not the clean-write proof.
+
+So consumer case 1's *MTU set* is served by the deferred tier; this
+increment proves the approval posture with the clean, symmetric
+`guest.file.write`.
+
+## Consumer evidence (issue #3100)
+
+Two live cases in one program drove this, both observed falling back to
+out-of-band `govc guest.run` (see issue #3100 for the full context;
+lab-specific host/realm details are intentionally omitted from this
+public repo):
+
+1. **Guest NIC MTU + connectivity diagnosis.** Setting a deployed
+   appliance's guest NIC MTU (a fabric requirement) and reading
+   `ip addr` / routes while diagnosing connectivity. `guest.net.show`
+   serves the read half now (Tools-reported, no creds); the MTU *set*
+   is the deferred freeform-exec tier.
+2. **First-boot service-state verification.** Verifying service state
+   inside a first-boot appliance (`systemctl is-system-running`,
+   listener checks) on a guest with no route back to MEHO.
+   `guest.process.list` + `guest.file.read` cover the state-inspection
+   half structurally; a `systemctl` *invocation* is again the deferred
+   freeform-exec tier.
+
+The point of the first increment is not to close both cases end-to-end —
+it is to land the governed channel, the credential-via-`secret_ref`
+model, the JSONFlux/audit discipline, and the approval-gated write, so
+the deferred freeform-exec tier has a proven substrate to extend.
+
+## Verification basis
+
+No live guest is available in CI. Grounding is:
+
+- the pinned `vcenter-9.0/vi-json.yaml` on the spec shelf (the guest-op
+  method paths reconcile against it, same lane as the read composites);
+- `respx`/stub unit tests with mocked `_post_vmomi_json` responses and a
+  mocked guest-transfer endpoint, asserting the request bodies
+  (`vm` MoRef + `NamePasswordAuthentication`), the JSONFlux wrapping, the
+  approval park on the write, and that the guest credential never appears
+  in any params/audit/preview surface.
+
+Live-appliance verification is deferred (tracked with the issue).
+
+## References
+
+- Issue: evoila/meho#3100.
+- v0.1-spec §3 (operations), §4 (JSONFlux), §6 (audit), §7 (approval).
+- Substrate: `connectors/vmware_rest/connector.py` (`_post_vmomi_json`),
+  `composites/_write.py` (`_write_vmomi_sub_op`, the #2254 gate),
+  `composites/_read.py` (`_read_sub_op`), `vim_body.py`.
+- Credential resolution: `connectors/_shared/vault_creds.py`
+  (`load_basic_credentials`).
+- Deferred tier (b): a `linux-ssh` typed connector / a
+  `guest.program.run` freeform-exec op — not built here.

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -235,8 +235,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (`StartProgramInGuest`) is a deliberately deferred tier.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 27
-  `_CompositeSpec` rows (5 read + 22 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 32
+  `_CompositeSpec` rows (9 read + 23 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -363,9 +363,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
-   queued registrar and upserts: the 23 `vmware.composite.*` rows with
-   `source_kind="composite"` (5 reads with `safety_level="safe"` +
-   `requires_approval=False`; 19 writes with `safety_level="dangerous"`
+   queued registrar and upserts: the 32 `vmware.composite.*` rows with
+   `source_kind="composite"` (9 reads with `safety_level="safe"` +
+   `requires_approval=False`; 23 writes with `safety_level="dangerous"`
    + `requires_approval=True`), plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
@@ -461,7 +461,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 29 composites (9 reads + 20 writes) land as `source_kind="composite"`
+The 32 composites (9 reads + 23 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -528,7 +528,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 24 composites are hand-authored aggregators the connector ships as
+The 32 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,11 +8,12 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 27 hand-authored composites
-that orchestrate cross-spec workflows: 5 read composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 32 hand-authored composites
+that orchestrate cross-spec workflows: 9 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 22 write composites (G3.1-T6 / `#509`, the
+in `#2258`; plus the four guest-operations reads `#3100`) and 23 write
+composites (G3.1-T6 / `#509`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
@@ -22,7 +23,9 @@ post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
 `guest.customization_spec.create` + `vm.customize` / `#2892`, the
 OVF/OVA content-library deploy `vm.deploy_from_library` / `#2909`, and
 the three host-domain writes `host.datastore_mount_nfs` /
-`host.disk_mark_flash` / `host.service_control` / `#3182`). The
+`host.disk_mark_flash` / `host.service_control` / `#3182`, plus the
+governed guest-operations write `vm.guest.file.write` / `#3100` (see
+`connectors-vmware-rest-guest-ops.md`)). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -209,6 +212,27 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `storageSystem,serviceSystem}` MoRef (one un-gated `RetrievePropertiesEx`)
   and mounts the method on it. Registered with T4's `dangerous` +
   `requires_approval=True`.
+- **Guest-operations channel** (`#3100`, group `guest_ops`,
+  `composites/_guest.py`) — the governed replacement for out-of-band
+  `govc guest.run`, reaching *inside* a running VM's guest OS via VMware
+  Tools guest operations (vim `GuestOperationsManager`) over the same
+  VI-JSON seam. Four `safe` reads —
+  `guest_process_list_composite` (`ListProcessesInGuest`),
+  `guest_env_read_composite` (`ReadEnvironmentVariableInGuest`),
+  `guest_net_show_composite` (Tools-reported `guest.net` / `guest.ipStack`
+  via `RetrievePropertiesEx`, needs no guest credential), and
+  `guest_file_read_composite` (`InitiateFileTransferFromGuest`, returns the
+  transfer handle) — plus one `dangerous` / approval-gated write,
+  `guest_file_write_composite` (`InitiateFileTransferToGuest` + a direct
+  PUT of the bytes). **Guest OS credentials resolve from the target's
+  Vault `secret_ref` (`guest_username` / `guest_password`) and never
+  travel in params** — a stronger posture than GOSC's credential-class
+  params. The sub-manager MoRefs are resolved dynamically off the
+  overridable `guestOperationsManager` default (no verified literal is
+  hard-coded). The design fork (vim guest-ops over a deferred generic-ssh
+  tier) and the full safety model live in
+  `connectors-vmware-rest-guest-ops.md`; freeform in-guest program exec
+  (`StartProgramInGuest`) is a deliberately deferred tier.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
   lifespan startup. Iterates a single `_COMPOSITES` tuple of 27
@@ -437,7 +461,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 24 composites (5 reads + 19 writes) land as `source_kind="composite"`
+The 29 composites (9 reads + 20 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`


### PR DESCRIPTION
## Summary

Adds a governed **guest-operations channel** for arbitrary VMs — the
`vmware.composite.vm.guest.*` op family — replacing the out-of-band
`govc guest.run` fallback consumers keep reaching for (issue #3100, two
live cases). It rides **VMware Tools guest operations** (vim
`GuestOperationsManager`) over the existing VI-JSON write seam
(`_post_vmomi_json`, the #2890 substrate) — **path (a)**, per the operator
decision. No `pyvmomi`, no SSH, no MEHO-side in-guest agent.

**First increment — four `safe` reads + one gated write:**

| op | vim method | guest creds | safety |
|---|---|---|---|
| `vm.guest.process.list` | `ListProcessesInGuest` | yes | safe |
| `vm.guest.env.read` | `ReadEnvironmentVariableInGuest` | yes | safe |
| `vm.guest.net.show` | `RetrievePropertiesEx` on `guest.net` / `guest.ipStack` | **no** (Tools-reported) | safe |
| `vm.guest.file.read` | `InitiateFileTransferFromGuest` (returns transfer handle) | yes | safe |
| `vm.guest.file.write` | `InitiateFileTransferToGuest` + direct PUT | yes | **dangerous / requires_approval** |

**Safety model (dangerous-by-default):** guest OS credentials resolve
from the target's Vault `secret_ref` (`guest_username` / `guest_password`)
and **never travel in params** — a stronger posture than GOSC's
credential-class params. Structured sub-ops, not freeform shell. The one
write gates **first** through the standard approvals plane
(`enforce_subop_policy`), so a parked/denied write resolves no credential
and reaches no guest; its `proposed_effect` preview echoes path + byte
size + overwrite only, never the content. Set-shaped reads are
JSONFlux-wrapped by the dispatcher (postulate 6). Every op carries full
param/response schemas, tags, `safety_level`, and `llm_instructions`.

**Which write, and why `file.write` over `set_mtu`:** `guest.file.write`
(`InitiateFileTransferToGuest`) is the write the vim API supports most
cleanly through the seam — a single documented `GuestFileManager` method,
the mirror of the `file.read` the increment already uses. `guest.net.set_mtu`
has **no** single vim guest-op method: it requires running `ip link set …
mtu …` via `StartProgramInGuest` (freeform program exec — the very tier
this increment defers) plus PID-polling. So consumer case 1's *MTU set* is
served by the deferred freeform-exec tier; this increment proves the
approval posture with the clean, symmetric `file.write`.

**Design note:** `docs/codebase/connectors-vmware-rest-guest-ops.md`
records the (a)-over-(b) fork, the safety model, the consumer evidence
(issue #3100's two cases, cited by issue number — no lab detail), and the
deferred generic-ssh / freeform-exec tier.

## Design calls worth a reviewer's eye

- **Guest-manager MoRefs resolved dynamically**, not hard-coded. This repo
  has no `RetrieveServiceContent` path and no verified literal for the
  `GuestProcessManager` / `GuestFileManager` singletons, so the sub-manager
  MoRef is read off the top-level `GuestOperationsManager` (one overridable
  default MoId, `guestOperationsManager`) via `RetrievePropertiesEx` rather
  than hard-coding four unverified literals.
- **`file.read` returns the transfer handle** (url / size / attributes),
  not inline bytes — a sanctioned de-risking of the raw-GET path for the
  first increment. `file.write` **does** complete the PUT (a small
  raw-transfer helper on the pooled client, with the `*`-host rewrite and
  the cross-host TLS caveats documented) — a write must actually write.
- **Reads are `safe`, not `caution`.** `caution`/`dangerous` are "write by
  convention" (`_is_mutating`), and a `caution` label would wrongly park
  these non-mutating reads for service principals.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` (changed src modules) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest` guest-ops handlers (`test_connectors_vmware_rest_guest_ops.py`, 12) — process/env/net/file reads, write auto-execute + PUT, `*`-host rewrite, boxed-URL unwrap, gate short-circuit, and **guest credential never in result / gate params**
- [x] Real-DB approval-park proof for `guest.file.write` (`..._write_gate.py`) — `awaiting_approval` + PENDING `ApprovalRequest` + no vmomi write + no PUT; and denied-without-grant
- [x] Registration coverage (`..._register.py` / `..._write_register.py` / `..._write_preview.py` / `test_typed_connectors_metadata.py`) — 29 composites (9 read + 20 write), the new `guest_ops` group, handler-refs, group-keys, and the one write's preview builder
- [x] Full `-k vmware_rest` sweep (606) + operations/MCP/dispatch slice (236) green

## Out of scope (deferred, stated in the design note)

- Freeform in-guest program execution (`StartProgramInGuest`) and therefore
  `guest.net.set_mtu` — the later tier.
- Inline byte retrieval for `guest.file.read`.
- The generic-ssh path (b) — a possible later tier for Tools-less guests.
- Live-appliance verification (no live guest in CI; grounded on the pinned
  `vi-json.yaml` + mocked-seam unit tests).

Closes #3100
