### PR TITLE
feat(connectors): vmware host-domain write composites — NFS mount, disk flash-mark, bounded host service control (#3182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,34 @@ connector-related release-notes line.
   as the identity join key. New migration `0083` (`addon_step_event` +
   `service_account_sub`). See `docs/codebase/addon-step-events.md`.
 
+### Added — vmware host-domain write composites: NFS datastore mount, disk flash-marking, bounded host service control (#3182)
+
+- Three governed, vCenter-mediated **host-domain** write composites on the
+  typed `vmware-rest-9.0` surface, filling the `#2907` coverage register's
+  host-domain gap a governed nested-VCF factory bring-up hit (each write had
+  dropped to a documented out-of-band fallback). All three ride the existing
+  VI-JSON write seam the `#2893` disk-grow write established (`_post_vmomi_json`
+  through the `enforce_subop_policy` gate — no `pyvmomi`), select the host by
+  display name **or** moref, and register `dangerous` + `requires_approval`
+  with full param/response schemas, tags, `llm_instructions`, and a park-time
+  preview builder:
+  - `vmware.composite.host.datastore_mount_nfs` — mounts an NFS export as a
+    datastore via the synchronous `HostDatastoreSystem.CreateNasDatastore`
+    (returns the new datastore summary).
+  - `vmware.composite.host.disk_mark_flash` — marks host disks as flash (SSD)
+    or non-flash (HDD) via `HostStorageSystem.MarkAsSsd_Task` /
+    `MarkAsNonSsd_Task` (task-polled), keyed on a `mode` param; returns a
+    set-shaped per-disk `results` array (JSONFlux-reduced when large,
+    partial-failure tolerated).
+  - `vmware.composite.host.service_control` — start/stop/restart a host
+    service + optional `UpdateServicePolicy` via `HostServiceSystem`, **bounded
+    to a curated server-side allowlist** (`TSM-SSH` / `TSM` / `ntpd` / `ptpd`);
+    an out-of-list service name is refused with a structured
+    `service_not_allowed` before any resolution or write, never passed through.
+  - Grounding note: the real vim method for the HDD direction is
+    `MarkAsNonSsd_Task` (the issue's `MarkAsHdd_Task` was a mis-spelling); the
+    pinned-`vi-json.yaml` reconcile lane asserts every host vim path exists.
+
 ### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975 / PR #3184)
 
 - `vmware.composite.datastore.usage` enriched every datastore row with the

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -58,6 +58,11 @@ Scope:
   ``govc library.deploy``) (#2909).
 """
 
+from meho_backplane.connectors.vmware_rest.composites._host import (
+    datastore_mount_nfs_composite,
+    disk_mark_flash_composite,
+    service_control_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -107,7 +112,9 @@ __all__ = [
     "cluster_drs_recommendations_composite",
     "cluster_drs_rule_create_composite",
     "cluster_patch_composite",
+    "datastore_mount_nfs_composite",
     "datastore_usage_composite",
+    "disk_mark_flash_composite",
     "event_tail_composite",
     "folder_create_composite",
     "guest_customization_spec_create_composite",
@@ -116,6 +123,7 @@ __all__ = [
     "network_portgroup_audit_composite",
     "performance_summary_composite",
     "register_vmware_composite_operations",
+    "service_control_composite",
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_host.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_host.py
@@ -1,0 +1,569 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Host-domain write ``vmware.composite.host.*`` handlers (#3182).
+
+Three vCenter-mediated **host-domain** write composites that fill the
+coverage gap Initiative #2907's register named after a governed
+nested-VCF factory bring-up hit three host writes with no backplane op
+(each dropped to a documented out-of-band fallback):
+
+* ``vmware.composite.host.datastore_mount_nfs`` --
+  ``HostDatastoreSystem.CreateNasDatastore`` (mount an NFS export as a
+  datastore on a host);
+* ``vmware.composite.host.disk_mark_flash`` --
+  ``HostStorageSystem.MarkAsSsd_Task`` / ``MarkAsNonSsd_Task`` (present a
+  virtual disk as flash/HDD so vSAN-ready validation passes);
+* ``vmware.composite.host.service_control`` --
+  ``HostServiceSystem`` start/stop/restart + ``UpdateServicePolicy``,
+  bounded to a curated server-side service allowlist.
+
+All three ride the **same** governed VI-JSON write seam the #2893
+disk-grow write established: every mutating vim method flows through
+:func:`~meho_backplane.connectors.vmware_rest.composites._write._write_vmomi_sub_op`
+(the #2254 ``enforce_subop_policy`` gate → ``_post_vmomi_json`` on the
+documented ``/sdk/vim25/{release}`` base) -- no ``pyvmomi`` SDK
+dependency. Target is the vCenter; the host is selected by display name
+**or** moref (:func:`_resolve_host_moid`).
+
+Config-manager indirection
+--------------------------
+
+These vim methods are not on the ``HostSystem`` managed object -- they
+are on its per-host config sub-managers
+(``HostSystem.configManager.datastoreSystem`` /
+``.storageSystem`` / ``.serviceSystem``, each a
+``ManagedObjectReference``, spec-verified against ``HostConfigManager``
+in the pinned ``vi-json.yaml``). So every handler first resolves the
+host moid, then reads the one needed ``configManager.<sub>`` MoRef via a
+single un-gated ``RetrievePropertiesEx`` (a read), and mounts the method
+on that sub-manager's moid.
+
+Set-shaped reduction
+--------------------
+
+``disk_mark_flash`` fans out over N disks and returns a per-disk
+``results`` array (partial-failure tolerated), so its response is
+JSONFlux-reduced to a handle by the dispatcher when large -- the same
+auto-reduction ``vm.power.bulk`` relies on. The mount returns a single
+datastore summary and service_control a single applied envelope; both
+stay inline.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+import httpx
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    _OP_LIST_HOSTS,
+    _read_sub_op,
+    _unwrap_value,
+    _write_vmomi_sub_op,
+)
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    VIM_TYPE_NAME_KEY,
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
+from meho_backplane.connectors.vmware_rest.vim_task import TASK_STATE_ERROR, poll_vim_task
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+__all__ = [
+    "datastore_mount_nfs_composite",
+    "disk_mark_flash_composite",
+    "service_control_composite",
+]
+
+
+# vim (VI-JSON) governance op_ids -- the canonical ``METHOD:/path`` keys the
+# ingest parser emits from ``vi-json.yaml`` (the moId rides the path as
+# ``{moId}``). These are the op_ids fed to ``enforce_subop_policy`` via
+# ``_write_vmomi_sub_op``; the concrete path (moId substituted) is what
+# ``_post_vmomi_json`` POSTs. Kept out of any ``_SUB_OPS_*`` namespace so the
+# vCenter-REST ingest-reconcile sweep does not treat a vi-json path as a
+# ``vcenter.yaml`` row; the pinned ``vi-json.yaml`` reconcile asserts them.
+#
+# * ``CreateNasDatastore`` is **synchronous** -- its 200 body is the new
+#   Datastore MoRef directly, NOT a Task, so it is never polled
+#   (spec-verified: ``responses.200`` refers a ``Datastore`` instance).
+# * ``MarkAsSsd_Task`` / ``MarkAsNonSsd_Task`` return a ``*_Task`` MoRef
+#   polled to a terminal state. The pinned spec's method for the HDD
+#   direction is ``MarkAsNonSsd_Task`` (NOT ``MarkAsHdd_Task``, the #3182
+#   issue's mis-spelling) -- both are the same op keyed on the ``mode`` param.
+# * ``StartService`` / ``StopService`` / ``RestartService`` /
+#   ``UpdateServicePolicy`` are **synchronous** 204-No-Content methods (no
+#   Task, no result).
+_OP_CREATE_NAS_DATASTORE: Final = "POST:/HostDatastoreSystem/{moId}/CreateNasDatastore"
+_OP_MARK_AS_SSD_TASK: Final = "POST:/HostStorageSystem/{moId}/MarkAsSsd_Task"
+_OP_MARK_AS_NON_SSD_TASK: Final = "POST:/HostStorageSystem/{moId}/MarkAsNonSsd_Task"
+_OP_START_SERVICE: Final = "POST:/HostServiceSystem/{moId}/StartService"
+_OP_STOP_SERVICE: Final = "POST:/HostServiceSystem/{moId}/StopService"
+_OP_RESTART_SERVICE: Final = "POST:/HostServiceSystem/{moId}/RestartService"
+_OP_UPDATE_SERVICE_POLICY: Final = "POST:/HostServiceSystem/{moId}/UpdateServicePolicy"
+# Canonical vi-json.yaml key for the config-manager read (the singleton
+# PropertyCollector moId rides the path). The read is un-gated (a resolution
+# read, like disk-grow's device read), but the op_id is listed on the sub-op
+# manifests so the reconcile lane asserts the path exists in the pinned spec.
+_OP_RETRIEVE_PROPERTIES: Final = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+
+# Concrete runtime path for the config-manager read: the PropertyCollector is
+# a singleton whose moId is the literal ``propertyCollector`` (the same
+# concrete path the typed reads + read composites POST).
+_VMOMI_RETRIEVE_PROPERTIES_PATH: Final = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+#: vi-json sub-op manifests (parallel to ``_write._VIM_SUB_OPS_VM_DISK_GROW``;
+#: named out of the ``_SUB_OPS_*`` namespace so the vcenter.yaml sweep skips
+#: them). The pinned ``vi-json.yaml`` reconcile lane introspects these to
+#: assert every declared vim path exists in the spec.
+_VIM_SUB_OPS_HOST_DATASTORE_MOUNT_NFS: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_CREATE_NAS_DATASTORE,
+)
+_VIM_SUB_OPS_HOST_DISK_MARK_FLASH: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_MARK_AS_SSD_TASK,
+    _OP_MARK_AS_NON_SSD_TASK,
+)
+_VIM_SUB_OPS_HOST_SERVICE_CONTROL: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_START_SERVICE,
+    _OP_STOP_SERVICE,
+    _OP_RESTART_SERVICE,
+    _OP_UPDATE_SERVICE_POLICY,
+)
+
+# vim MO type + data-object ``_typeName`` discriminators (#3103: every
+# DataObject in a request body carries its tag). ``HostNasVolumeSpec`` is the
+# ``CreateNasDatastoreRequestType.spec`` data object.
+_HOST_SYSTEM_MO_TYPE: Final = "HostSystem"
+_HOST_NAS_VOLUME_SPEC_TYPE: Final = "HostNasVolumeSpec"
+
+# ``HostSystem.configManager`` sub-manager property paths (spec-verified
+# against ``HostConfigManager`` in the pinned ``vi-json.yaml``). Each read
+# returns the per-host sub-manager's ``ManagedObjectReference``.
+_PROP_CM_DATASTORE_SYSTEM: Final = "configManager.datastoreSystem"
+_PROP_CM_STORAGE_SYSTEM: Final = "configManager.storageSystem"
+_PROP_CM_SERVICE_SYSTEM: Final = "configManager.serviceSystem"
+
+# Curated server-side service allowlist for ``service_control`` (#3182). A
+# host service name NOT in this set is refused with a structured
+# ``service_not_allowed`` before any resolution or write -- never
+# passed through to the vim method (the standing no-arbitrary-exec posture,
+# #2901). The set is the small family of ESXi services a diagnostic /
+# upgrade arc legitimately toggles: SSH (``TSM-SSH``), the ESXi Shell
+# (``TSM``), and the two time daemons (``ntpd`` / ``ptpd``). Each key is a
+# real ``HostService.key`` (``HostServiceSystem.serviceInfo``).
+_SERVICE_ALLOWLIST: Final[frozenset[str]] = frozenset({"TSM-SSH", "TSM", "ntpd", "ptpd"})
+
+# operator-facing ``action`` -> synchronous HostServiceSystem method op_id.
+_SERVICE_ACTION_OP_IDS: Final[dict[str, str]] = {
+    "start": _OP_START_SERVICE,
+    "stop": _OP_STOP_SERVICE,
+    "restart": _OP_RESTART_SERVICE,
+}
+
+# operator-facing ``mode`` -> HostStorageSystem mark method op_id. ``flash``
+# presents the disk as SSD; ``non_flash`` is the inverse (``MarkAsNonSsd_Task``).
+_MARK_FLASH_MODE_OP_IDS: Final[dict[str, str]] = {
+    "flash": _OP_MARK_AS_SSD_TASK,
+    "non_flash": _OP_MARK_AS_NON_SSD_TASK,
+}
+
+# Default wall-clock bound for the MarkAs*_Task poll -- the 600s
+# ``vm.disk.grow`` convention; module-global so tests can zero it.
+_MARK_FLASH_TASK_TIMEOUT_SECONDS = 600.0
+
+
+def _extract_single_moref_value(retrieve_result: Any, prop: str) -> str | None:
+    """Pull the MoRef ``value`` for *prop* out of a RetrievePropertiesEx result.
+
+    The config-manager read queries one ``HostSystem`` for one
+    ``configManager.<sub>`` property whose ``val`` is a
+    ``ManagedObjectReference``. Funnels ``val`` through
+    :func:`unwrap_vim_value` (#3106) so a boxed MoRef normalises, then
+    returns its ``value`` moid. ``None`` when the property is absent or not
+    a MoRef -- the caller maps that to ``config_manager_unreadable``.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    if not isinstance(objects, list):
+        return None
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for entry in obj.get("propSet", []) or []:
+            if isinstance(entry, dict) and entry.get("name") == prop:
+                val = unwrap_vim_value(entry.get("val"))
+                value = val.get("value") if isinstance(val, dict) else None
+                return value if isinstance(value, str) and value else None
+    return None
+
+
+async def _resolve_host_moid(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    host: str,
+) -> tuple[str | None, str | None, list[str]]:
+    """Resolve a host selector (display name **or** moref) to its HostSystem moid.
+
+    Returns ``(moid, None, [])`` on a unique resolution, or
+    ``(None, status, candidates)`` on failure -- ``status`` one of
+    ``ambiguous_host`` / ``host_not_found`` and ``candidates`` the moids an
+    ambiguous display name matched. Resolution ladder (both filters are on
+    the read-only ``GET:/vcenter/host``):
+
+    1. ``filter.names=[host]`` -- a unique display-name match wins; multiple
+       matches refuse with the candidate moids (never the first row);
+    2. no name match -- treat *host* as a moref and verify it via
+       ``filter.hosts=[host]``; a single row confirms it, else
+       ``host_not_found``.
+    """
+    by_name = await _list_host_moids(connector, target, operator, {"filter.names": [host]})
+    if len(by_name) == 1:
+        return by_name[0], None, []
+    if len(by_name) > 1:
+        return None, "ambiguous_host", by_name
+    by_moref = await _list_host_moids(connector, target, operator, {"filter.hosts": [host]})
+    if len(by_moref) == 1:
+        return by_moref[0], None, []
+    return None, "host_not_found", []
+
+
+async def _list_host_moids(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    query: dict[str, Any],
+) -> list[str]:
+    """Return the ``host`` moids from one ``GET:/vcenter/host`` listing."""
+    listing = await _read_sub_op(connector, target, operator, _OP_LIST_HOSTS, query)
+    rows = _unwrap_value(listing)
+    if not isinstance(rows, list):
+        return []
+    return [
+        row["host"] for row in rows if isinstance(row, dict) and isinstance(row.get("host"), str)
+    ]
+
+
+async def _resolve_config_manager_moid(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    host_moid: str,
+    prop: str,
+) -> str | None:
+    """Resolve one ``HostSystem.configManager.<sub>`` sub-manager moid (un-gated read)."""
+    result = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], [prop]),
+    )
+    return _extract_single_moref_value(result, prop)
+
+
+async def _resolve_host_and_manager(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    host: str,
+    prop: str,
+) -> tuple[str | None, str | None, dict[str, Any] | None]:
+    """Resolve host moid + one config-manager sub-moid, or a refusal envelope.
+
+    Returns ``(host_moid, manager_moid, None)`` on success or
+    ``(None, None, envelope)`` when the host does not resolve uniquely or
+    the config manager is unreadable -- the shared pre-write resolution the
+    three handlers run before building their vim body. The envelope's
+    ``status`` is ``host_not_found`` / ``ambiguous_host`` /
+    ``config_manager_unreadable``; ``candidate_hosts`` is present on
+    ambiguity.
+    """
+    host_moid, failure, candidates = await _resolve_host_moid(
+        connector, target, operator, host=host
+    )
+    if host_moid is None:
+        envelope: dict[str, Any] = {"status": failure, "host": host}
+        if candidates:
+            envelope["candidate_hosts"] = candidates
+        return None, None, envelope
+    manager_moid = await _resolve_config_manager_moid(
+        connector, target, operator, host_moid=host_moid, prop=prop
+    )
+    if manager_moid is None:
+        return None, None, {"status": "config_manager_unreadable", "host": host_moid}
+    return host_moid, manager_moid, None
+
+
+# ===========================================================================
+# host.datastore_mount_nfs
+# ===========================================================================
+
+
+async def datastore_mount_nfs_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Mount an NFS export as a datastore on a host via ``CreateNasDatastore``.
+
+    Op-id: ``vmware.composite.host.datastore_mount_nfs``. Resolves the host
+    (name/moref) → its ``HostDatastoreSystem`` (config-manager read), builds
+    a ``HostNasVolumeSpec`` and issues the **synchronous**
+    ``HostDatastoreSystem.CreateNasDatastore`` through the governed vmomi
+    write seam. The 200 body is the new Datastore MoRef directly (no task
+    poll), so the composite returns ``status="mounted"`` with the datastore
+    moid + a summary of the mount. A parked/denied gate returns the
+    :class:`OperationResult` verbatim and no mount fires. A vim fault
+    (``DuplicateName`` for an existing datastore, ``HostConfigFault`` for an
+    unreachable export) propagates as a transport error the dispatcher wraps
+    ``connector_error``.
+    """
+    host_moid, ds_system_moid, refusal = await _resolve_host_and_manager(
+        connector, target, operator, host=params["host"], prop=_PROP_CM_DATASTORE_SYSTEM
+    )
+    if refusal is not None:
+        return {**refusal, "datastore": None}
+
+    nas_spec: dict[str, Any] = {
+        VIM_TYPE_NAME_KEY: _HOST_NAS_VOLUME_SPEC_TYPE,
+        "remoteHost": params["nfs_server"],
+        "remotePath": params["remote_path"],
+        "localPath": params["datastore_name"],
+        "accessMode": params.get("access_mode", "readWrite"),
+        "type": params.get("nfs_type", "NFS"),
+    }
+    gate, payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_CREATE_NAS_DATASTORE,
+        vmomi_path=f"/HostDatastoreSystem/{ds_system_moid}/CreateNasDatastore",
+        body={"spec": nas_spec},
+        params={
+            "host": host_moid,
+            "nfs_server": params["nfs_server"],
+            "remote_path": params["remote_path"],
+            "datastore_name": params["datastore_name"],
+        },
+    )
+    if gate is not None:
+        return gate
+
+    datastore = unwrap_vim_value(payload)
+    datastore_moid = datastore.get("value") if isinstance(datastore, dict) else None
+    return {
+        "status": "mounted",
+        "host": host_moid,
+        "datastore": datastore_moid,
+        "summary": {
+            "datastore": datastore_moid,
+            "name": params["datastore_name"],
+            "nfs_server": params["nfs_server"],
+            "remote_path": params["remote_path"],
+            "access_mode": nas_spec["accessMode"],
+            "type": nas_spec["type"],
+        },
+        "guidance": None,
+    }
+
+
+# ===========================================================================
+# host.disk_mark_flash
+# ===========================================================================
+
+
+async def disk_mark_flash_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Mark host disks as flash (SSD) or non-flash (HDD) via ``MarkAs*_Task``.
+
+    Op-id: ``vmware.composite.host.disk_mark_flash``. Resolves the host
+    (name/moref) → its ``HostStorageSystem`` (config-manager read), then per
+    ``scsiDiskUuid`` issues the mode's ``MarkAsSsd_Task`` (``mode="flash"``)
+    or ``MarkAsNonSsd_Task`` (``mode="non_flash"``) through the governed
+    vmomi write seam and polls the returned Task to a terminal state.
+    Set-shaped: one ``results`` row per disk (partial failure tolerated -- a
+    per-disk task fault / transport error / poll timeout is captured, not
+    aborted), aggregated into ``summary`` counts. A parked/denied gate on
+    the first disk returns the :class:`OperationResult` verbatim so no disk
+    is marked -- the gate decision is identical across disks (same op_id,
+    target, principal).
+    """
+    host_moid, storage_system_moid, refusal = await _resolve_host_and_manager(
+        connector, target, operator, host=params["host"], prop=_PROP_CM_STORAGE_SYSTEM
+    )
+    if refusal is not None:
+        return {**refusal, "mode": params.get("mode", "flash"), "results": [], "summary": None}
+
+    mode = params.get("mode", "flash")
+    op_id = _MARK_FLASH_MODE_OP_IDS[mode]
+    method_name = op_id.rsplit("/", 1)[-1]
+    results: list[dict[str, Any]] = []
+    for disk_uuid in params["disk_uuids"]:
+        gate, task_payload = await _write_vmomi_sub_op(
+            connector,
+            target,
+            operator,
+            op_id=op_id,
+            vmomi_path=f"/HostStorageSystem/{storage_system_moid}/{method_name}",
+            body={"scsiDiskUuid": disk_uuid},
+            params={"host": host_moid, "scsiDiskUuid": disk_uuid, "mode": mode},
+        )
+        if gate is not None:
+            # Deterministic across disks (same op_id/target/principal); on the
+            # first disk nothing has been marked yet, so park the whole op.
+            return gate
+        results.append(await _poll_mark_disk(connector, target, operator, disk_uuid, task_payload))
+
+    marked = sum(1 for row in results if row["status"] == "marked")
+    return {
+        "status": "marked" if marked == len(results) else "partial",
+        "host": host_moid,
+        "mode": mode,
+        "results": results,
+        "summary": {"marked": marked, "failed": len(results) - marked},
+        "guidance": None,
+    }
+
+
+async def _poll_mark_disk(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    disk_uuid: str,
+    task_payload: Any,
+) -> dict[str, Any]:
+    """Poll one MarkAs*_Task to terminal; return the per-disk ``results`` row.
+
+    Partial-failure tolerant: a task fault / poll timeout / transport error
+    on one disk is captured as a typed per-disk status (``faulted`` /
+    ``timeout`` / ``error``) rather than aborting the fan-out, mirroring
+    ``vm.power.bulk``'s per-entity capture.
+    """
+    try:
+        outcome = await poll_vim_task(
+            connector,
+            target,
+            operator,
+            task=unwrap_vim_value(task_payload),
+            timeout_seconds=_MARK_FLASH_TASK_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        return {"disk_uuid": disk_uuid, "status": "error", "task": None, "error": str(exc)}
+    if outcome.state == TASK_STATE_ERROR:
+        return {
+            "disk_uuid": disk_uuid,
+            "status": "faulted",
+            "task": outcome.task,
+            "error": outcome.error_message or "<no fault reported>",
+        }
+    if outcome.timed_out:
+        return {"disk_uuid": disk_uuid, "status": "timeout", "task": outcome.task, "error": None}
+    return {"disk_uuid": disk_uuid, "status": "marked", "task": outcome.task, "error": None}
+
+
+# ===========================================================================
+# host.service_control
+# ===========================================================================
+
+
+async def service_control_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Start/stop/restart a bounded host service + optionally set its policy.
+
+    Op-id: ``vmware.composite.host.service_control``. The service name is
+    checked against the curated :data:`_SERVICE_ALLOWLIST` **first** -- an
+    out-of-list name is refused with ``status="service_not_allowed"`` before
+    any host resolution or write, never passed through to the vim method
+    (the no-arbitrary-exec posture). Then resolves the host (name/moref) →
+    its ``HostServiceSystem`` (config-manager read), applies the requested
+    ``action`` (StartService/StopService/RestartService, synchronous
+    204-No-Content), and -- when ``policy`` is supplied -- also
+    ``UpdateServicePolicy``. Both writes flow through the governed vmomi
+    seam; a parked/denied gate returns the :class:`OperationResult`
+    verbatim. A vim fault (unknown service, config failure) propagates as a
+    transport error the dispatcher wraps ``connector_error``.
+    """
+    service = params["service"]
+    if service not in _SERVICE_ALLOWLIST:
+        return {
+            "status": "service_not_allowed",
+            "host": params["host"],
+            "service": service,
+            "action": params.get("action"),
+            "policy": params.get("policy"),
+            "policy_updated": False,
+            "allowed_services": sorted(_SERVICE_ALLOWLIST),
+            "guidance": (
+                f"service {service!r} is not in the curated host-service allowlist; "
+                f"service_control is bounded to {sorted(_SERVICE_ALLOWLIST)} and never "
+                "passes an arbitrary service name to the host"
+            ),
+        }
+
+    host_moid, service_system_moid, refusal = await _resolve_host_and_manager(
+        connector, target, operator, host=params["host"], prop=_PROP_CM_SERVICE_SYSTEM
+    )
+    if refusal is not None:
+        return {**refusal, "service": service, "action": params["action"], "policy_updated": False}
+
+    action = params["action"]
+    action_op_id = _SERVICE_ACTION_OP_IDS[action]
+    action_method = action_op_id.rsplit("/", 1)[-1]
+    gate, _ = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=action_op_id,
+        vmomi_path=f"/HostServiceSystem/{service_system_moid}/{action_method}",
+        body={"id": service},
+        params={"host": host_moid, "service": service, "action": action},
+    )
+    if gate is not None:
+        return gate
+
+    policy = params.get("policy")
+    if policy is not None:
+        gate, _ = await _write_vmomi_sub_op(
+            connector,
+            target,
+            operator,
+            op_id=_OP_UPDATE_SERVICE_POLICY,
+            vmomi_path=f"/HostServiceSystem/{service_system_moid}/UpdateServicePolicy",
+            body={"id": service, "policy": policy},
+            params={"host": host_moid, "service": service, "policy": policy},
+        )
+        if gate is not None:
+            return gate
+
+    return {
+        "status": "applied",
+        "host": host_moid,
+        "service": service,
+        "action": action,
+        "policy": policy,
+        "policy_updated": policy is not None,
+        "guidance": None,
+    }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 24 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 27 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -48,6 +48,11 @@ from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NamedTuple
 
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._host import (
+    datastore_mount_nfs_composite,
+    disk_mark_flash_composite,
+    service_control_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -91,10 +96,16 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     FOLDER_CREATE_RESPONSE_SCHEMA,
     GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA,
     GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA,
+    HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA,
+    HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA,
     HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
     HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
+    HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA,
+    HOST_DISK_MARK_FLASH_RESPONSE_SCHEMA,
     HOST_EVACUATE_PARAMETER_SCHEMA,
     HOST_EVACUATE_RESPONSE_SCHEMA,
+    HOST_SERVICE_CONTROL_PARAMETER_SCHEMA,
+    HOST_SERVICE_CONTROL_RESPONSE_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
@@ -221,15 +232,23 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "parameters."
     ),
     "host": (
-        "Use for host-lifecycle write "
+        "Use for host-lifecycle and host-domain write "
         "composites. Write (dangerous / "
         "approval-required): evacuate "
         "every VM off a host (recursive composite call into "
         "vm.migrate) then enter maintenance, or detach a host from a "
         "DVS after migrating its VM NICs off; the host_evacuate "
         "composite is the first production composite that calls "
-        "another composite. The right group for 'safely take this "
-        "host offline' workflows. Pair with 'networking' for the "
+        "another composite. Plus the host-domain writes (#3182), each "
+        "vCenter-mediated through the governed VI-JSON seam: mount an "
+        "NFS export as a datastore on a host "
+        "(datastore_mount_nfs), mark host disks as flash/HDD for "
+        "vSAN-ready validation (disk_mark_flash), or start/stop/restart "
+        "a bounded host service and set its policy (service_control, "
+        "allowlist-enforced — never an arbitrary service name). The "
+        "host is selected by display name or moref. The right group for "
+        "'safely take this host offline' and host bring-up / prep "
+        "workflows. Pair with 'networking' for the "
         "DVS-audit prerequisite to host_detach_from_vds, and with "
         "'cluster' / 'vm' for the pre-flight reads."
     ),
@@ -869,6 +888,84 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         safety_level="dangerous",
         requires_approval=True,
     ),
+    # ----------------------------------------------------------------
+    # Host-domain write composites (#3182) -- dangerous / requires approval
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.host.datastore_mount_nfs",
+        handler=datastore_mount_nfs_composite,
+        summary="Mount an NFS export as a datastore on a host via CreateNasDatastore.",
+        description=(
+            "Mounts an NFS v3/v4.1 export as a datastore on one host via the "
+            "synchronous vim HostDatastoreSystem.CreateNasDatastore — the pinned "
+            "vcenter.yaml serves no host NAS-mount REST path, so vim is the sole "
+            "governed path (#3182). Resolves the host by display name or moref "
+            "(GET:/vcenter/host), then reads the host's "
+            "HostSystem.configManager.datastoreSystem MoRef and mounts the method "
+            "on it, building a HostNasVolumeSpec from nfs_server / remote_path / "
+            "datastore_name / access_mode / nfs_type. The 200 body is the new "
+            "Datastore MoRef directly (no task poll), so the composite returns "
+            "status='mounted' with the datastore moid + a mount summary. A host "
+            "that does not resolve uniquely refuses before any write "
+            "(status='host_not_found' / 'ambiguous_host'). Nested-VCF hosts mount "
+            "a base-layer NFS export as principal storage this way."
+        ),
+        parameter_schema=HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA,
+        response_schema=HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "write", "host", "storage", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.disk_mark_flash",
+        handler=disk_mark_flash_composite,
+        summary="Mark host disks as flash (SSD) or non-flash (HDD) via MarkAs*_Task.",
+        description=(
+            "Marks one or more host disks as flash (SSD) or non-flash (HDD) via vim "
+            "HostStorageSystem.MarkAsSsd_Task (mode='flash') / MarkAsNonSsd_Task "
+            "(mode='non_flash') — the inverse is the same op keyed on the mode "
+            "param, not a second op (#3182). Nested labs present virtual disks as "
+            "HDD; vSAN-ready bring-up validation needs cache/capacity disks "
+            "flash-marked. Resolves the host by display name or moref, reads its "
+            "HostSystem.configManager.storageSystem MoRef, then per scsiDiskUuid "
+            "issues the mark task through the governed vmomi seam and polls it to a "
+            "terminal state. Set-shaped: one results row per disk (a per-disk fault "
+            "/ timeout / transport error is captured, not aborted), aggregated into "
+            "summary counts. Equivalent of 'govc host.storage.mark -ssd'."
+        ),
+        parameter_schema=HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA,
+        response_schema=HOST_DISK_MARK_FLASH_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "write", "host", "storage", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.service_control",
+        handler=service_control_composite,
+        summary="Start/stop/restart a bounded host service + optionally set its policy.",
+        description=(
+            "Starts / stops / restarts a host service and optionally sets its "
+            "startup policy via vim HostServiceSystem (synchronous StartService / "
+            "StopService / RestartService + UpdateServicePolicy) — e.g. enabling "
+            "host SSH (TSM-SSH) for a diagnostic / upgrade arc, then disabling it, "
+            "leaving an audit row each time (#3182). Bounded to a curated "
+            "server-side allowlist (TSM-SSH / TSM / ntpd / ptpd): an out-of-list "
+            "service is refused with status='service_not_allowed' before any host "
+            "resolution or write, never passed through (the no-arbitrary-exec "
+            "posture). Resolves the host by display name or moref, reads its "
+            "HostSystem.configManager.serviceSystem MoRef, applies the action "
+            "through the governed vmomi seam, then (when policy is supplied) "
+            "UpdateServicePolicy. Equivalent of 'govc host.service'."
+        ),
+        parameter_schema=HOST_SERVICE_CONTROL_PARAMETER_SCHEMA,
+        response_schema=HOST_SERVICE_CONTROL_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "write", "host", "service", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
 )
 
 
@@ -885,15 +982,17 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 24 composites total -- 5 read (T5 / #508) + 19 write (T6 /
+    Scope: 27 composites total -- 5 read (T5 / #508) + 22 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
     ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
     hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
     ``vm.device.cdrom``, the two GOSC composites
-    ``guest.customization_spec.create`` / ``vm.customize`` / #2892, and the
-    OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909). (The
+    ``guest.customization_spec.create`` / ``vm.customize`` / #2892, the
+    OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909, and
+    the three host-domain writes ``host.datastore_mount_nfs`` /
+    ``host.disk_mark_flash`` / ``host.service_control`` / #3182). (The
     former ``host.network_uplinks`` / ``host.vsan_health`` reads were
     re-shipped as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -821,7 +821,79 @@ async def _vm_customize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     return preview
 
 
-#: op_id → builder for the 19 write composites. Module-level so the
+async def _host_datastore_mount_nfs_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``host.datastore_mount_nfs`` — echo the mount coordinates (no I/O).
+
+    The params fully name the blast radius: which host, which NFS export,
+    the local datastore name, and the access mode. Host resolution
+    (name→moref) and the config-manager read stay the handler's job, so no
+    live read is issued and the preview cannot drift from the approved
+    dispatch. Declines on malformed params.
+    """
+    host = ctx.params.get("host")
+    nfs_server = ctx.params.get("nfs_server")
+    remote_path = ctx.params.get("remote_path")
+    datastore_name = ctx.params.get("datastore_name")
+    if not all(isinstance(v, str) for v in (host, nfs_server, remote_path, datastore_name)):
+        return None
+    return {
+        "host": host,
+        "nfs_server": nfs_server,
+        "remote_path": remote_path,
+        "datastore_name": datastore_name,
+        "access_mode": (
+            ctx.params.get("access_mode")
+            if isinstance(ctx.params.get("access_mode"), str)
+            else "readWrite"
+        ),
+        "nfs_type": (
+            ctx.params.get("nfs_type") if isinstance(ctx.params.get("nfs_type"), str) else "NFS"
+        ),
+    }
+
+
+async def _host_disk_mark_flash_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``host.disk_mark_flash`` — echo host + mode + the disk set (no I/O).
+
+    The disk UUID list is the blast radius; it is capped to
+    :data:`_PREVIEW_RESOLVED_CAP` with ``total_disks`` carrying the true
+    count so a large batch does not balloon the durable row. Declines when
+    ``disk_uuids`` is not a non-empty list.
+    """
+    host = ctx.params.get("host")
+    disk_uuids = ctx.params.get("disk_uuids")
+    if not isinstance(host, str) or not isinstance(disk_uuids, list) or not disk_uuids:
+        return None
+    uuids = [uuid for uuid in disk_uuids if isinstance(uuid, str)]
+    return {
+        "host": host,
+        "mode": ctx.params.get("mode") if isinstance(ctx.params.get("mode"), str) else "flash",
+        "disk_uuids": uuids[:_PREVIEW_RESOLVED_CAP],
+        "total_disks": len(uuids),
+    }
+
+
+async def _host_service_control_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``host.service_control`` — echo host + service + action + policy (no I/O).
+
+    The params fully name the change (which service, which transition,
+    optional startup policy); the allowlist check and host resolution stay
+    the handler's job. Declines on malformed params.
+    """
+    host = ctx.params.get("host")
+    service = ctx.params.get("service")
+    action = ctx.params.get("action")
+    if not all(isinstance(v, str) for v in (host, service, action)):
+        return None
+    return {
+        "host": host,
+        "service": service,
+        "action": action,
+        "policy": ctx.params.get("policy") if isinstance(ctx.params.get("policy"), str) else None,
+    }
+
+
+#: op_id → builder for the 22 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
@@ -843,11 +915,14 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.folder.create": _folder_create_preview,
     "vmware.composite.guest.customization_spec.create": _guest_customization_spec_create_preview,
     "vmware.composite.vm.customize": _vm_customize_preview,
+    "vmware.composite.host.datastore_mount_nfs": _host_datastore_mount_nfs_preview,
+    "vmware.composite.host.disk_mark_flash": _host_disk_mark_flash_preview,
+    "vmware.composite.host.service_control": _host_service_control_preview,
 }
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 19 write-composite park-time preview builders. Import-time.
+    """Wire the 22 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 23 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 27 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -59,10 +59,16 @@ __all__ = [
     "FOLDER_CREATE_RESPONSE_SCHEMA",
     "GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA",
     "GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA",
+    "HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA",
+    "HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA",
     "HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA",
     "HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA",
+    "HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA",
+    "HOST_DISK_MARK_FLASH_RESPONSE_SCHEMA",
     "HOST_EVACUATE_PARAMETER_SCHEMA",
     "HOST_EVACUATE_RESPONSE_SCHEMA",
+    "HOST_SERVICE_CONTROL_PARAMETER_SCHEMA",
+    "HOST_SERVICE_CONTROL_RESPONSE_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
@@ -2828,4 +2834,303 @@ VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm_id", "powered_on", "issues"],
+}
+
+
+# ===========================================================================
+# Host-domain write composites (#3182) -- dangerous / requires approval
+# ===========================================================================
+
+
+#: ``vmware.composite.host.datastore_mount_nfs`` parameter schema.
+#:
+#: Mount an NFS export as a datastore on a host via the **synchronous** vim
+#: ``HostDatastoreSystem.CreateNasDatastore`` (builds a ``HostNasVolumeSpec``).
+#: The host is selected by display name or moref; ``access_mode`` /
+#: ``nfs_type`` map to the pinned spec's ``HostMountMode_enum`` /
+#: ``HostNasVolumeSpec.type``.
+HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Host display name or moref (e.g. 'esxi-01.lab' or 'host-15'). "
+                "Resolved via ``GET:/vcenter/host`` — a display-name lookup first, "
+                "falling back to a moref match; an ambiguous name is refused with "
+                "``status='ambiguous_host'`` before any write."
+            ),
+        },
+        "nfs_server": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Hostname or IP of the NFS v3 server exporting the share "
+                "(``HostNasVolumeSpec.remoteHost``)."
+            ),
+        },
+        "remote_path": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exported remote path on the NFS server (``remotePath``).",
+        },
+        "datastore_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Local datastore name the mount is created under "
+                "(``HostNasVolumeSpec.localPath``). A name already in use on the "
+                "host faults vendor-side (``DuplicateName``)."
+            ),
+        },
+        "access_mode": {
+            "type": "string",
+            "enum": ["readWrite", "readOnly"],
+            "default": "readWrite",
+            "description": (
+                "Datastore access mode (``HostMountMode_enum``). ``readOnly`` is "
+                "for ISO / template stores a VM cannot power on from."
+            ),
+        },
+        "nfs_type": {
+            "type": "string",
+            "enum": ["NFS", "NFS41"],
+            "default": "NFS",
+            "description": (
+                "NAS volume type (``HostNasVolumeSpec.type``). ``NFS`` is v3; "
+                "``NFS41`` is v4.1. CIFS is deliberately out of scope (credential-"
+                "bearing)."
+            ),
+        },
+    },
+    "required": ["host", "nfs_server", "remote_path", "datastore_name"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.disk_mark_flash`` parameter schema.
+#:
+#: Present one or more host disks as flash (SSD) or non-flash (HDD) via vim
+#: ``HostStorageSystem.MarkAsSsd_Task`` / ``MarkAsNonSsd_Task`` (task-polled).
+#: Nested labs surface virtual disks as HDD; vSAN-ready bring-up validation
+#: needs them flash-marked. Disks are named by ``scsiDiskUuid``.
+HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Host display name or moref (see host.datastore_mount_nfs).",
+        },
+        "disk_uuids": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1,
+            "description": (
+                "SCSI disk UUIDs (``ScsiLun.uuid``) to mark. One "
+                "``MarkAs{Ssd,NonSsd}_Task`` is issued per disk and polled to a "
+                "terminal state; per-disk outcomes are captured independently "
+                "(a fault on one disk does not abort the rest)."
+            ),
+        },
+        "mode": {
+            "type": "string",
+            "enum": ["flash", "non_flash"],
+            "default": "flash",
+            "description": (
+                "``'flash'`` marks each disk as SSD (``MarkAsSsd_Task``); "
+                "``'non_flash'`` is the inverse (``MarkAsNonSsd_Task``) — the same "
+                "op keyed on this param, not a second op."
+            ),
+        },
+    },
+    "required": ["host", "disk_uuids"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.service_control`` parameter schema.
+#:
+#: Start / stop / restart a host service and optionally set its startup
+#: policy via vim ``HostServiceSystem`` (synchronous). **Bounded to a
+#: curated server-side allowlist**: an out-of-list ``service`` is refused
+#: (``status='service_not_allowed'``) before any write — never passed
+#: through to the host.
+HOST_SERVICE_CONTROL_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Host display name or moref (see host.datastore_mount_nfs).",
+        },
+        "service": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Host service key (``HostService.key``). Enforced server-side "
+                "against a curated allowlist (``TSM-SSH`` / ``TSM`` / ``ntpd`` / "
+                "``ptpd``); any other name is refused with "
+                "``status='service_not_allowed'`` before any resolution or write."
+            ),
+        },
+        "action": {
+            "type": "string",
+            "enum": ["start", "stop", "restart"],
+            "description": (
+                "Lifecycle transition: ``StartService`` / ``StopService`` / "
+                "``RestartService``. Applied before any policy update."
+            ),
+        },
+        "policy": {
+            "type": "string",
+            "enum": ["on", "automatic", "off"],
+            "description": (
+                "Optional startup policy (``HostServicePolicy_enum``): ``on`` "
+                "(start at host boot), ``automatic`` (start iff a firewall port is "
+                "open), ``off`` (do not start). When supplied, "
+                "``UpdateServicePolicy`` runs after the action."
+            ),
+        },
+    },
+    "required": ["host", "service", "action"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.datastore_mount_nfs`` response schema.
+HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["mounted", "host_not_found", "ambiguous_host", "config_manager_unreadable"],
+            "description": (
+                "``'mounted'`` — the datastore was created; the refusal statuses "
+                "are reached before any write (host name/moref did not resolve "
+                "uniquely, or the host's HostDatastoreSystem was unreadable)."
+            ),
+        },
+        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "datastore": {
+            "type": ["string", "null"],
+            "description": "New datastore moid; ``null`` on any non-``mounted`` status.",
+        },
+        "summary": {
+            "type": ["object", "null"],
+            "description": (
+                "Datastore summary on success — datastore moid, name, and the "
+                "resolved mount coordinates; ``null`` on refusal."
+            ),
+        },
+        "candidate_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Matched host moids on ``ambiguous_host``.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "host", "datastore"],
+}
+
+
+#: ``vmware.composite.host.disk_mark_flash`` response schema.
+HOST_DISK_MARK_FLASH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "marked",
+                "partial",
+                "host_not_found",
+                "ambiguous_host",
+                "config_manager_unreadable",
+            ],
+            "description": (
+                "``'marked'`` — every disk reached SSD/HDD state; ``'partial'`` — "
+                "at least one disk faulted / timed out / errored (see per-disk "
+                "``results``); the refusal statuses are reached before any write."
+            ),
+        },
+        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "mode": {"type": "string", "enum": ["flash", "non_flash"]},
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "disk_uuid": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["marked", "faulted", "timeout", "error"],
+                    },
+                    "task": {"type": ["string", "null"]},
+                    "error": {"type": ["string", "null"]},
+                },
+                "required": ["disk_uuid", "status"],
+            },
+            "description": "One row per disk in ``disk_uuids`` (empty on a pre-write refusal).",
+        },
+        "summary": {
+            "type": ["object", "null"],
+            "properties": {
+                "marked": {"type": "integer", "minimum": 0},
+                "failed": {"type": "integer", "minimum": 0},
+            },
+            "description": "Aggregate counts across ``results``; ``null`` on refusal.",
+        },
+        "candidate_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Matched host moids on ``ambiguous_host``.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "host", "mode", "results"],
+}
+
+
+#: ``vmware.composite.host.service_control`` response schema.
+HOST_SERVICE_CONTROL_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "applied",
+                "service_not_allowed",
+                "host_not_found",
+                "ambiguous_host",
+                "config_manager_unreadable",
+            ],
+            "description": (
+                "``'applied'`` — the action (and optional policy update) ran; "
+                "``'service_not_allowed'`` — the service is outside the curated "
+                "allowlist (refused before any resolution or write); the remaining "
+                "refusals are reached before any write."
+            ),
+        },
+        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "service": {"type": "string"},
+        "action": {"type": ["string", "null"], "enum": ["start", "stop", "restart", None]},
+        "policy": {"type": ["string", "null"], "enum": ["on", "automatic", "off", None]},
+        "policy_updated": {
+            "type": "boolean",
+            "description": "Whether ``UpdateServicePolicy`` ran (``policy`` was supplied).",
+        },
+        "allowed_services": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "The curated allowlist, echoed on ``service_not_allowed``.",
+        },
+        "candidate_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Matched host moids on ``ambiguous_host``.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "host", "service", "policy_updated"],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_host.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_host.py
@@ -1,0 +1,729 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Handler + governance tests for the host-domain write composites (#3182).
+
+Covers the three ``vmware.composite.host.*`` write composites shipped in
+:mod:`~meho_backplane.connectors.vmware_rest.composites._host`:
+``datastore_mount_nfs`` / ``disk_mark_flash`` / ``service_control``.
+
+Two tiers, mirroring the disk-grow write composite's proof
+(:mod:`tests.test_connectors_vmware_rest_composites_write` for handler
+behaviour +
+:mod:`tests.test_connectors_vmware_rest_composites_write_gate` for the
+real ``enforce_subop_policy`` gate):
+
+* **Handler behaviour** with a stubbed gate (``_GateRecorder``) and a
+  recording connector double -- the happy paths, the allowlist refusal,
+  the host-resolution refusals, and the per-disk partial-failure capture.
+* **Real-gate governance** against the autouse-migrated SQLite engine:
+  an agent-gated write **queues** (durable ``ApprovalRequest``, no wire
+  write), a dangerous write with no grant is **denied**, and a human
+  operator's already-approved composite **auto-executes** -- the #3182
+  proof that each host write rides the same governed VI-JSON seam the
+  #2893 disk-grow write established (the mutating vim method never
+  reaches the wire when the gate parks / denies).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
+from meho_backplane.connectors.vmware_rest.composites import _host, _write
+from meho_backplane.connectors.vmware_rest.composites._host import (
+    datastore_mount_nfs_composite,
+    disk_mark_flash_composite,
+    service_control_composite,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentPermission,
+    ApprovalRequest,
+    ApprovalRequestStatus,
+    PermissionVerdict,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000031a6")
+
+# Governance op_ids the host writes gate on (the vim ``METHOD:/path`` keys).
+_CREATE_NAS_OP_ID = "POST:/HostDatastoreSystem/{moId}/CreateNasDatastore"
+_MARK_SSD_OP_ID = "POST:/HostStorageSystem/{moId}/MarkAsSsd_Task"
+_START_SERVICE_OP_ID = "POST:/HostServiceSystem/{moId}/StartService"
+
+# Default config-manager sub-manager moids the double resolves per prop.
+_DEFAULT_CONFIG_MANAGERS: dict[str, tuple[str, str]] = {
+    "configManager.datastoreSystem": ("HostDatastoreSystem", "datastoreSystem-15"),
+    "configManager.storageSystem": ("HostStorageSystem", "storageSystem-15"),
+    "configManager.serviceSystem": ("HostServiceSystem", "serviceSystem-15"),
+}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Open a session against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _operator(
+    *,
+    principal_kind: PrincipalKind = PrincipalKind.AGENT,
+    sub: str = "agent-host-composite",
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Host Composite Governance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+async def _grant(*, principal_sub: str, op_pattern: str, verdict: PermissionVerdict) -> None:
+    """Seed one AgentPermission grant for *principal_sub* on *op_pattern*."""
+    async with get_sessionmaker()() as s:
+        s.add(
+            AgentPermission(
+                tenant_id=_TENANT_ID,
+                principal_sub=principal_sub,
+                op_pattern=op_pattern,
+                verdict=verdict.value,
+                target_scope="*",
+                created_by_sub="ops-admin",
+            )
+        )
+        await s.commit()
+
+
+class _GateRecorder:
+    """Recording stub for :func:`enforce_subop_policy` (auto-execute by default)."""
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {
+                "op_id": op_id,
+                "connector_id": connector_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
+                "params": dict(params),
+            }
+        )
+        return self._gate_for.get(op_id)
+
+    @property
+    def gated_op_ids(self) -> list[str]:
+        return [c["op_id"] for c in self.calls]
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    """Install a default (auto-execute) gate recorder on the ``_write`` module.
+
+    The host handlers route their mutating writes through
+    ``_write._write_vmomi_sub_op``, which resolves ``enforce_subop_policy`` in
+    the ``_write`` module namespace -- so patching it there gates the host
+    writes too.
+    """
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+class _HostRecordingConnector:
+    """Recording connector double for the host-domain composite tests.
+
+    Serves the ``GET:/vcenter/host`` resolution listing (keyed off the
+    ``names`` / ``hosts`` filter), the ``configManager.<sub>``
+    PropertyCollector read, and the ``Task.info`` poll, and records every
+    mutating vmomi write so the tests can assert what did / did not reach
+    the wire.
+    """
+
+    def __init__(
+        self,
+        *,
+        hosts: list[dict[str, str]] | None = None,
+        config_managers: dict[str, tuple[str, str]] | None = None,
+        fault_tasks: set[str] | None = None,
+    ) -> None:
+        self.hosts = hosts if hosts is not None else [{"host": "host-15", "name": "esxi-01"}]
+        # None → the default all-resolvable map; {} → nothing resolves (unreadable).
+        self.config_managers = (
+            _DEFAULT_CONFIG_MANAGERS if config_managers is None else config_managers
+        )
+        self._fault_tasks = fault_tasks or set()
+        self.writes: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params("/api", query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        params = params or {}
+        names = params.get("names") or params.get("filter.names")
+        if names:
+            return [h for h in self.hosts if h["name"] in names]
+        wanted = params.get("hosts") or params.get("filter.hosts")
+        if wanted:
+            return [h for h in self.hosts if h["host"] in wanted]
+        return list(self.hosts)
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        if path.endswith("/RetrievePropertiesEx"):
+            return self._serve_retrieve(json)
+        self.writes.append({"path": path, "json": json})
+        if path.endswith("/CreateNasDatastore"):
+            return {
+                "_typeName": "ManagedObjectReference",
+                "type": "Datastore",
+                "value": "datastore-99",
+            }
+        if path.endswith("_Task"):
+            task = f"task-{json['scsiDiskUuid']}"
+            return {"_typeName": "ManagedObjectReference", "type": "Task", "value": task}
+        return None  # 204-No-Content service methods
+
+    def _serve_retrieve(self, body: Any) -> dict[str, Any]:
+        spec = body["specSet"][0]
+        spec_type = spec["propSet"][0]["type"]
+        if spec_type == "HostSystem":
+            prop = spec["propSet"][0]["pathSet"][0]
+            resolved = self.config_managers.get(prop)
+            prop_set = (
+                []
+                if resolved is None
+                else [
+                    {
+                        "name": prop,
+                        "val": {
+                            "_typeName": "ManagedObjectReference",
+                            "type": resolved[0],
+                            "value": resolved[1],
+                        },
+                    }
+                ]
+            )
+            return {
+                "objects": [
+                    {"obj": {"type": "HostSystem", "value": "host-15"}, "propSet": prop_set}
+                ]
+            }
+        # Task.info poll.
+        task_moid = spec["objectSet"][0]["obj"]["value"]
+        info: dict[str, Any] = (
+            {"state": "error"} if task_moid in self._fault_tasks else {"state": "success"}
+        )
+        if task_moid in self._fault_tasks:
+            info["error"] = {"localizedMessage": "disk not found"}
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": task_moid},
+                    "propSet": [{"name": "info", "val": info}],
+                }
+            ]
+        }
+
+
+# ===========================================================================
+# datastore_mount_nfs — handler behaviour
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_mounts_and_returns_summary(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={
+            "host": "esxi-01",
+            "nfs_server": "10.0.0.5",
+            "remote_path": "/export/base",
+            "datastore_name": "base-nfs",
+            "access_mode": "readOnly",
+            "nfs_type": "NFS41",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "mounted"
+    assert out["host"] == "host-15"
+    assert out["datastore"] == "datastore-99"
+    assert out["summary"] == {
+        "datastore": "datastore-99",
+        "name": "base-nfs",
+        "nfs_server": "10.0.0.5",
+        "remote_path": "/export/base",
+        "access_mode": "readOnly",
+        "type": "NFS41",
+    }
+    # The mount landed on the host's HostDatastoreSystem sub-manager, with the
+    # HostNasVolumeSpec fully tagged and populated.
+    assert len(conn.writes) == 1
+    write = conn.writes[0]
+    assert write["path"] == "/HostDatastoreSystem/datastoreSystem-15/CreateNasDatastore"
+    spec = write["json"]["spec"]
+    assert spec["_typeName"] == "HostNasVolumeSpec"
+    assert spec["remoteHost"] == "10.0.0.5"
+    assert spec["localPath"] == "base-nfs"
+    assert spec["accessMode"] == "readOnly"
+    assert spec["type"] == "NFS41"
+    # The gate saw the create op with the entity in its params.
+    assert gate.gated_op_ids == [_CREATE_NAS_OP_ID]
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_defaults_access_mode_and_type(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={
+            "host": "host-15",
+            "nfs_server": "nfs.local",
+            "remote_path": "/vol/iso",
+            "datastore_name": "iso",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "mounted"  # type: ignore[index]
+    spec = conn.writes[0]["json"]["spec"]
+    assert spec["accessMode"] == "readWrite"
+    assert spec["type"] == "NFS"
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_refuses_ambiguous_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector(
+        hosts=[{"host": "host-1", "name": "dup"}, {"host": "host-2", "name": "dup"}]
+    )
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={
+            "host": "dup",
+            "nfs_server": "n",
+            "remote_path": "/p",
+            "datastore_name": "d",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "ambiguous_host"
+    assert sorted(out["candidate_hosts"]) == ["host-1", "host-2"]
+    assert out["datastore"] is None
+    assert conn.writes == []  # refused before any write
+    assert gate.calls == []  # never reached the gate
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_refuses_unknown_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector(hosts=[])
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "ghost", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "host_not_found"  # type: ignore[index]
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_refuses_when_config_manager_unreadable(
+    gate: _GateRecorder,
+) -> None:
+    conn = _HostRecordingConnector(config_managers={})
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "config_manager_unreadable"  # type: ignore[index]
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_resolves_host_by_moref(gate: _GateRecorder) -> None:
+    """A moref that is not a display name resolves via the filter.hosts fallback."""
+    conn = _HostRecordingConnector(hosts=[{"host": "host-42", "name": "esxi-nine"}])
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "host-42", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "mounted"  # type: ignore[index]
+    assert out["host"] == "host-42"  # type: ignore[index]
+
+
+# ===========================================================================
+# disk_mark_flash — handler behaviour
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_marks_every_disk(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a", "uuid-b"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "marked"
+    assert out["mode"] == "flash"
+    assert out["summary"] == {"marked": 2, "failed": 0}
+    assert [row["disk_uuid"] for row in out["results"]] == ["uuid-a", "uuid-b"]
+    assert all(row["status"] == "marked" for row in out["results"])
+    # One MarkAsSsd_Task per disk on the storage sub-manager.
+    mark_writes = [w for w in conn.writes if w["path"].endswith("MarkAsSsd_Task")]
+    assert len(mark_writes) == 2
+    assert mark_writes[0]["path"] == "/HostStorageSystem/storageSystem-15/MarkAsSsd_Task"
+    assert mark_writes[0]["json"] == {"scsiDiskUuid": "uuid-a"}
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_non_flash_uses_mark_as_non_ssd(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a"], "mode": "non_flash"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "marked"  # type: ignore[index]
+    assert out["mode"] == "non_flash"  # type: ignore[index]
+    assert conn.writes[0]["path"] == "/HostStorageSystem/storageSystem-15/MarkAsNonSsd_Task"
+    # The gate governs on the MarkAsNonSsd op_id (the inverse is the same op).
+    assert gate.gated_op_ids == ["POST:/HostStorageSystem/{moId}/MarkAsNonSsd_Task"]
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_partial_on_faulted_disk(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector(fault_tasks={"task-uuid-b"})
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a", "uuid-b"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "partial"  # type: ignore[index]
+    assert out["summary"] == {"marked": 1, "failed": 1}  # type: ignore[index]
+    rows = {row["disk_uuid"]: row for row in out["results"]}  # type: ignore[index]
+    assert rows["uuid-a"]["status"] == "marked"
+    assert rows["uuid-b"]["status"] == "faulted"
+    assert rows["uuid-b"]["error"] == "disk not found"
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_refuses_unknown_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector(hosts=[])
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "ghost", "disk_uuids": ["uuid-a"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "host_not_found"  # type: ignore[index]
+    assert out["results"] == []  # type: ignore[index]
+    assert conn.writes == []
+
+
+# ===========================================================================
+# service_control — handler behaviour + allowlist
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_service_control_applies_action_and_policy(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "service": "TSM-SSH", "action": "start", "policy": "on"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "applied"
+    assert out["policy_updated"] is True
+    paths = [w["path"] for w in conn.writes]
+    assert paths == [
+        "/HostServiceSystem/serviceSystem-15/StartService",
+        "/HostServiceSystem/serviceSystem-15/UpdateServicePolicy",
+    ]
+    assert conn.writes[0]["json"] == {"id": "TSM-SSH"}
+    assert conn.writes[1]["json"] == {"id": "TSM-SSH", "policy": "on"}
+
+
+@pytest.mark.asyncio
+async def test_service_control_without_policy_skips_policy_update(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "service": "ntpd", "action": "restart"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "applied"  # type: ignore[index]
+    assert out["policy_updated"] is False  # type: ignore[index]
+    assert [w["path"] for w in conn.writes] == [
+        "/HostServiceSystem/serviceSystem-15/RestartService"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_service_control_refuses_out_of_allowlist_service(gate: _GateRecorder) -> None:
+    """An out-of-list service is refused before any resolution or write."""
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "service": "vpxa", "action": "stop"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "service_not_allowed"
+    assert out["service"] == "vpxa"
+    assert out["allowed_services"] == ["TSM", "TSM-SSH", "ntpd", "ptpd"]
+    assert conn.writes == []
+    assert gate.calls == []  # never resolved a host, never gated
+
+
+@pytest.mark.asyncio
+async def test_service_control_refuses_unknown_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector(hosts=[])
+    out = await service_control_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "ghost", "service": "TSM-SSH", "action": "start"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "host_not_found"  # type: ignore[index]
+    assert conn.writes == []
+
+
+# ===========================================================================
+# Real-gate governance — the mutating vim write never reaches the wire when
+# the gate parks / denies (#3182, mirroring the disk-grow trio)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_gated_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    await _grant(
+        principal_sub="agent-host-composite",
+        op_pattern=_CREATE_NAS_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _CREATE_NAS_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    assert conn.writes == []  # CreateNasDatastore never reached the wire
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_denied_without_grant(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"host": "esxi-01", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _CREATE_NAS_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_human_operator_auto_executes(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params={"host": "esxi-01", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "mounted"
+    assert len(conn.writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_gated_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    await _grant(
+        principal_sub="agent-host-composite",
+        op_pattern=_MARK_SSD_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a", "uuid-b"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _MARK_SSD_OP_ID
+    # Parked on the first disk — no MarkAs*_Task reached the wire for any disk.
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_denied_without_grant(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _MARK_SSD_OP_ID
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_human_operator_auto_executes(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params={"host": "esxi-01", "disk_uuids": ["uuid-a"]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "marked"
+    assert len([w for w in conn.writes if w["path"].endswith("MarkAsSsd_Task")]) == 1
+
+
+@pytest.mark.asyncio
+async def test_service_control_gated_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    await _grant(
+        principal_sub="agent-host-composite",
+        op_pattern=_START_SERVICE_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(),
+        target=None,
+        params={"host": "esxi-01", "service": "TSM-SSH", "action": "start", "policy": "on"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _START_SERVICE_OP_ID
+    # Parked on the action — neither StartService nor UpdateServicePolicy fired.
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_service_control_denied_without_grant(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"host": "esxi-01", "service": "TSM-SSH", "action": "start"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _START_SERVICE_OP_ID
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_service_control_human_operator_auto_executes(session: AsyncSession) -> None:
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params={"host": "esxi-01", "service": "TSM-SSH", "action": "start"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "applied"
+    assert [w["path"] for w in conn.writes] == ["/HostServiceSystem/serviceSystem-15/StartService"]
+
+
+@pytest.mark.asyncio
+async def test_service_control_allowlist_is_the_expected_bounded_set() -> None:
+    """Pin the curated allowlist so an accidental widening is caught in review."""
+    assert frozenset({"TSM-SSH", "TSM", "ntpd", "ptpd"}) == _host._SERVICE_ALLOWLIST

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -83,7 +83,7 @@ import httpx
 import pytest
 import respx
 
-from meho_backplane.connectors.vmware_rest.composites import _write
+from meho_backplane.connectors.vmware_rest.composites import _host, _write
 from meho_backplane.operations.ingest import parse_openapi
 from tests.acceptance._vcenter_spec import (
     VCENTER_SPEC_REASON,
@@ -834,4 +834,97 @@ def test_vm_create_guest_id_map_is_grounded_in_both_pinned_specs() -> None:
             f"{vim_guest_id!r} is not a VirtualMachineGuestOsIdentifier enum "
             "value in the pinned vi-json.yaml — the #3099 guestId map targets "
             "a vim identifier the spec does not serve"
+        )
+
+
+# ---------------------------------------------------------------------------
+# host.datastore_mount_nfs / host.disk_mark_flash / host.service_control
+# VI-JSON sub-op reconciliation (#3182)
+# ---------------------------------------------------------------------------
+#
+# The three host-domain write composites' mutating paths are vi-json, not
+# vcenter REST: HostDatastoreSystem.CreateNasDatastore,
+# HostStorageSystem.MarkAsSsd_Task / MarkAsNonSsd_Task, and the four
+# HostServiceSystem methods (StartService / StopService / RestartService /
+# UpdateServicePolicy), each plus the shared configManager PropertyCollector
+# read. These are declared in ``_host._VIM_SUB_OPS_HOST_*`` (deliberately NOT
+# in any ``_SUB_OPS_*`` namespace, so the vcenter.yaml sweep skips them). Same
+# ``METHOD:/path`` keying as disk-grow — the moId rides the path as ``{moId}``
+# — so the same reconciliation proof applies, additionally checked against the
+# pinned ``vi-json.yaml`` when the spec-shelf is configured.
+
+
+def test_host_vi_json_sub_op_manifests_are_the_expected_sets() -> None:
+    """Pin the host-domain vi-json manifests so a drift can't shrink the reconcile."""
+    assert set(_host._VIM_SUB_OPS_HOST_DATASTORE_MOUNT_NFS) == {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HostDatastoreSystem/{moId}/CreateNasDatastore",
+    }
+    assert set(_host._VIM_SUB_OPS_HOST_DISK_MARK_FLASH) == {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HostStorageSystem/{moId}/MarkAsSsd_Task",
+        "POST:/HostStorageSystem/{moId}/MarkAsNonSsd_Task",
+    }
+    assert set(_host._VIM_SUB_OPS_HOST_SERVICE_CONTROL) == {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HostServiceSystem/{moId}/StartService",
+        "POST:/HostServiceSystem/{moId}/StopService",
+        "POST:/HostServiceSystem/{moId}/RestartService",
+        "POST:/HostServiceSystem/{moId}/UpdateServicePolicy",
+    }
+
+
+def test_host_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The host-domain vi-json op_ids are byte-for-byte what the parser emits.
+
+    Proves the ``METHOD:/path`` op_id strings the composites gate on match
+    what ``parse_openapi`` produces from a vi-json-shaped spec (the ``{moId}``
+    path template survives), so ``enforce_subop_policy``'s op_id / a grant's
+    op_pattern resolve against the ingested rows once the operator ingests
+    ``vi-json.yaml`` — the vi-json analogue of the vcenter reconcile above.
+    """
+    required = (
+        set(_host._VIM_SUB_OPS_HOST_DATASTORE_MOUNT_NFS)
+        | set(_host._VIM_SUB_OPS_HOST_DISK_MARK_FLASH)
+        | set(_host._VIM_SUB_OPS_HOST_SERVICE_CONTROL)
+    )
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_host_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each host-domain vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #3182 grounding: the host-domain write composites must
+    target paths that actually exist in the pinned spec (the issue's
+    ``MarkAsHdd_Task`` mis-spelling is exactly the drift this catches — the
+    real method is ``MarkAsNonSsd_Task``). Skips when the spec-shelf is not
+    configured, so CI — where the env vars are wired — is the operator-visible
+    signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    op_ids = (
+        set(_host._VIM_SUB_OPS_HOST_DATASTORE_MOUNT_NFS)
+        | set(_host._VIM_SUB_OPS_HOST_DISK_MARK_FLASH)
+        | set(_host._VIM_SUB_OPS_HOST_SERVICE_CONTROL)
+    )
+    for op_id in op_ids:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — a "
+            "host-domain vi-json sub-op targets a path the spec does not serve"
         )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,16 +175,17 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 24 total: 5 reads
-    # (T5 #508) + 19 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # Embedding service called once per composite -- 27 total: 5 reads
+    # (T5 #508) + 22 writes (T6 #509 + single-VM vm.power #2301 + mutating
     # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
     # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
     # folder.create #2895 + the #2891 hardware writes vm.resize /
     # vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
-    # content-library deploy vm.deploy_from_library #2909). (The former
-    # host.network_uplinks / host.vsan_health reads were re-shipped as
-    # typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 24
+    # content-library deploy vm.deploy_from_library #2909 + the three
+    # host-domain writes host.datastore_mount_nfs / host.disk_mark_flash /
+    # host.service_control #3182). (The former host.network_uplinks /
+    # host.vsan_health reads were re-shipped as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 27
 
 
 @pytest.mark.asyncio
@@ -431,7 +432,7 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 24.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 27.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
@@ -441,11 +442,11 @@ async def test_register_vmware_composite_operations_is_idempotent(
     writes cluster.drs_rule.create + folder.create #2895 + the #2891
     hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
     create/apply #2892 + OVF/OVA content-library deploy
-    vm.deploy_from_library #2909).
+    vm.deploy_from_library #2909 + the three host-domain writes #3182).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 24
+    assert first_count == 27
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -91,6 +91,9 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.folder.create",
         "vmware.composite.guest.customization_spec.create",
         "vmware.composite.vm.customize",
+        "vmware.composite.host.datastore_mount_nfs",
+        "vmware.composite.host.disk_mark_flash",
+        "vmware.composite.host.service_control",
     }
 )
 
@@ -302,14 +305,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 18 write composites register a builder (criterion 4)
+# Wiring — all 22 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
-def test_all_nineteen_write_composites_register_a_preview_builder() -> None:
+def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 19
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 22
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 19 vmware-rest write composites.
+"""Registration tests for the 22 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -18,7 +18,7 @@ and the GOSC composites ``guest.customization_spec.create`` /
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **23 rows** total. (The former host.network_uplinks / host.vsan_health
+  **27 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -68,7 +68,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 19 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 22 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
@@ -94,6 +94,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.folder.create",
     "vmware.composite.guest.customization_spec.create",
     "vmware.composite.vm.customize",
+    "vmware.composite.host.datastore_mount_nfs",
+    "vmware.composite.host.disk_mark_flash",
+    "vmware.composite.host.service_control",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -108,7 +111,7 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 24 total -- 5 read (T5 / #508) + 19 write (T6 / #509 + vm.power / #2301 +
+# 27 total -- 5 read (T5 / #508) + 22 write (T6 / #509 + vm.power / #2301 +
 # vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
 # writes cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
 # writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892).
@@ -174,6 +177,15 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.customize": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_customize_composite"
     ),
+    "vmware.composite.host.datastore_mount_nfs": (
+        "meho_backplane.connectors.vmware_rest.composites._host.datastore_mount_nfs_composite"
+    ),
+    "vmware.composite.host.disk_mark_flash": (
+        "meho_backplane.connectors.vmware_rest.composites._host.disk_mark_flash_composite"
+    ),
+    "vmware.composite.host.service_control": (
+        "meho_backplane.connectors.vmware_rest.composites._host.service_control_composite"
+    ),
 }
 
 
@@ -197,6 +209,9 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.folder.create": "vm",
     "vmware.composite.guest.customization_spec.create": "guest",
     "vmware.composite.vm.customize": "guest",
+    "vmware.composite.host.datastore_mount_nfs": "host",
+    "vmware.composite.host.disk_mark_flash": "host",
+    "vmware.composite.host.service_control": "host",
 }
 
 
@@ -240,7 +255,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 19 write composites land alongside the 5 reads (24 total)
+# 22 write composites land alongside the 5 reads (27 total)
 # ---------------------------------------------------------------------------
 
 
@@ -248,7 +263,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_nineteen_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 19 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 22 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -268,10 +283,11 @@ async def test_register_vmware_composite_operations_inserts_nineteen_write_rows(
 async def test_full_registration_produces_twenty_four_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 19 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    """5 reads (#508) + 22 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
     vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895 +
     #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom +
-    GOSC create/apply #2892 + OVF deploy #2909) = 24 rows. DoD bar."""
+    GOSC create/apply #2892 + OVF deploy #2909 + host-domain writes #3182)
+    = 27 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -285,7 +301,7 @@ async def test_full_registration_produces_twenty_four_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 24
+    assert len(rows) == 27
 
 
 @pytest.mark.asyncio
@@ -587,14 +603,14 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_twenty_four(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 24 rows total, embedding called 24x once."""
+    """Running the registrar twice -> 27 rows total, embedding called 27x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 24
+    assert first_count == 27
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 24.
+    # pipeline; the row count stays at 27.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -608,7 +624,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_twenty_
             .scalars()
             .all()
         )
-    assert len(rows) == 24
+    assert len(rows) == 27
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,19 +8,21 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 24 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 27 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 19 write composites (G3.1-T6 / `#509`, the
+in `#2258`) and 22 write composites (G3.1-T6 / `#509`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
 `cluster.drs_rule.create` + `folder.create` / `#2895`, the `#2891`
 post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
 `vm.device.cdrom`, the two guest-customization (GOSC) composites
-`guest.customization_spec.create` + `vm.customize` / `#2892`, and the
-OVF/OVA content-library deploy `vm.deploy_from_library` / `#2909`). The
+`guest.customization_spec.create` + `vm.customize` / `#2892`, the
+OVF/OVA content-library deploy `vm.deploy_from_library` / `#2909`, and
+the three host-domain writes `host.datastore_mount_nfs` /
+`host.disk_mark_flash` / `host.service_control` / `#3182`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -181,10 +183,36 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   The end-to-end proof across all three surfaces lives in
   `test_connectors_vmware_rest_composites_write_e2e`
   (`test_gosc_create_secret_hygiene_across_all_surfaces`).
+- **Host-domain write composites** (`composites/_host.py`, `#3182`,
+  group `host`) — three module-level `async def` handlers
+  (`datastore_mount_nfs_composite`, `disk_mark_flash_composite`,
+  `service_control_composite`) filling the `#2907` register's
+  host-domain coverage gap. All three are vCenter-mediated vim (VI-JSON)
+  writes riding the **same** governed `_write._write_vmomi_sub_op` seam
+  the `#2893` disk-grow write established (no `pyvmomi`): `datastore_`
+  `mount_nfs` issues the synchronous `HostDatastoreSystem.CreateNasDatastore`
+  (returns the new Datastore MoRef directly, no poll); `disk_mark_flash`
+  fans out `HostStorageSystem.MarkAsSsd_Task` / `MarkAsNonSsd_Task`
+  (the HDD direction is the same op keyed on the `mode` param — the real
+  vim method is `MarkAsNonSsd_Task`, not the issue's `MarkAsHdd_Task`
+  mis-spelling) per `scsiDiskUuid`, task-polled, with a set-shaped
+  per-disk `results` array (partial failure tolerated, JSONFlux-reduced
+  when large); `service_control` applies a `HostServiceSystem`
+  start/stop/restart + optional `UpdateServicePolicy` **bounded to a
+  curated server-side allowlist** (`TSM-SSH` / `TSM` / `ntpd` / `ptpd`)
+  — an out-of-list service name is refused (`status='service_not_allowed'`)
+  before any resolution or write, never passed through. The host is
+  selected by display name **or** moref (`GET:/vcenter/host` name lookup,
+  moref fallback, ambiguity refused). Because these vim methods live on
+  the per-host config sub-managers, not `HostSystem`, each handler first
+  reads the needed `HostSystem.configManager.{datastoreSystem,`
+  `storageSystem,serviceSystem}` MoRef (one un-gated `RetrievePropertiesEx`)
+  and mounts the method on it. Registered with T4's `dangerous` +
+  `requires_approval=True`.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 24
-  `_CompositeSpec` rows (5 read + 19 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 27
+  `_CompositeSpec` rows (5 read + 22 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.


### PR DESCRIPTION
## Summary

- Adds three governed, vCenter-mediated **host-domain** write composites on the typed `vmware-rest-9.0` surface, filling the [#2907](https://github.com/evoila/meho/issues/2907) coverage register's host-domain gap a governed nested-VCF factory bring-up hit (each write had dropped to a documented out-of-band fallback). All three ride the existing VI-JSON write seam the [#2893](https://github.com/evoila/meho/issues/2893) disk-grow write established (`_post_vmomi_json` through the `enforce_subop_policy` gate — **no pyvmomi**), select the host by **display name or moref**, and register `dangerous` + `requires_approval` with full param/response schemas, tags, `llm_instructions`, and a park-time preview builder:
  - **`vmware.composite.host.datastore_mount_nfs`** — synchronous `HostDatastoreSystem.CreateNasDatastore` (returns the new datastore summary).
  - **`vmware.composite.host.disk_mark_flash`** — `HostStorageSystem.MarkAsSsd_Task` / `MarkAsNonSsd_Task` (task-polled), keyed on a `mode` param; set-shaped **per-disk `results`** array (JSONFlux-reduced when large, partial-failure tolerated).
  - **`vmware.composite.host.service_control`** — `HostServiceSystem` start/stop/restart + optional `UpdateServicePolicy`, **bounded to a curated server-side allowlist** (`TSM-SSH` / `TSM` / `ntpd` / `ptpd`); an out-of-list service name is refused (`service_not_allowed`) before any resolution or write, never passed through.
- The three vim methods live on the per-host config sub-managers (`HostSystem.configManager.{datastoreSystem,storageSystem,serviceSystem}`), so each handler first reads the needed sub-manager MoRef (one un-gated `RetrievePropertiesEx`) and mounts the method on it. Placed in a **new cohesive module `composites/_host.py`** to keep the three registrations off the busy `_write.py`.
- Audit rows are the dispatcher's synchronous top-level composite audit (these dispatch through the audited path); JSONFlux reduction is the dispatcher's automatic handle-wrapping of the set-shaped `disk_mark_flash` results.

### Grounding note (deviation from the issue text)

The issue names `MarkAsHdd_Task` for the HDD direction; the **real** vim method in the pinned `vi-json.yaml` is **`MarkAsNonSsd_Task`** (there is no `MarkAsHdd_Task`). This PR uses the real method (same op keyed on the `mode` param, as the issue intended) and the extended reconcile lane asserts every host vim path exists in the pinned spec.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed modules) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] New `test_connectors_vmware_rest_composites_host.py` — handler happy-paths, allowlist refusal, host name/moref/ambiguous/not-found + config-manager-unreadable resolution, per-disk partial-failure capture, and the **real-gate governance trio** per composite (agent-gated write **queues** with a durable `ApprovalRequest` and never reaches the wire / dangerous write **denied** without a grant / human operator **auto-executes**) — mirroring the #2893 disk-grow proof.
- [x] Extended `..._l2_ingest_reconcile.py` — manifest pins + ingest round-trip + pinned-`vi-json.yaml` path-existence for all host vim sub-ops.
- [x] Shared registration/preview/count assertions bumped (27 composites total / 22 write); `register` + `write_register` + `write_preview` suites green.
- [x] 444 composite-family + mcp-surface tests and 220 preview/dispatch/acceptance tests pass locally.

## Out of scope / follow-up

- **Consumer follow-up (not this repo):** the automation add-on's blueprint steps that currently carry `coverage-gap` ManualSteps for these three host writes convert to governed `call_operation` dispatches. That is the consumer side (evoila-bosnia/meho-internal#223) — deliberately not touched here.
- Non-goals per the issue: hostd-direct targeting (needs a live vCenter target; satellite-runner territory, #2901) and arbitrary esxcli passthrough (stays needs-driven and bounded).

Closes #3182
