### PR TITLE
feat(addons): capability advertisement schema + paired/healthy activation (#3026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,26 @@ connector-related release-notes line.
   identical-sets guard stays as belt-and-braces; authoritative placement makes
   its firing condition impossible in practice.
 
+### Added — add-on capability advertisement: declare surfaces against the contract, activated only while paired and healthy (#3026)
+
+- A paired add-on can now **declare the surfaces it contributes** — meta-tool
+  families, CLI verb families, console panels, event kinds — against the
+  integration-contract version it negotiated (#3025). The declaration is
+  replace-all and persisted stamped with its `declared_contract_version`; an
+  unknown capability kind is rejected loudly (a 422, backed at rest by the
+  `addon_capability.kind` CHECK). **Activation is derived, never stored:** a
+  capability is active only while its pairing is present *and*
+  contract-healthy, so a pairing driven contract-incompatible reads
+  `active=false` and drops out of the tenant-wide activation view without any
+  surface being rewritten. Unpair cascade-deletes the capability rows
+  (`pairing_id ON DELETE CASCADE`), so deactivation leaves no dead surface. The
+  add-on declares as its **service** principal over
+  `PUT /api/v1/addons/pairings/{name}/capabilities` (a human principal is 403);
+  operators read the declaration + activation state over the matching `GET`.
+  Capability advertisement is data, never an MCP tool name — the agent
+  meta-tool surface is unchanged. New migration `0080` (`addon_capability`).
+  See `docs/codebase/addon-pairing.md`.
+
 ### Added — add-on pairing handshake + identity: pair once as a scoped service principal over a versioned contract (#3025)
 
 - The backplane gains the foundation of the add-on pairing contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ connector-related release-notes line.
   `PUT /api/v1/addons/pairings/{name}/capabilities` (a human principal is 403);
   operators read the declaration + activation state over the matching `GET`.
   Capability advertisement is data, never an MCP tool name — the agent
-  meta-tool surface is unchanged. New migration `0080` (`addon_capability`).
+  meta-tool surface is unchanged. New migration `0081` (`addon_capability`).
   See `docs/codebase/addon-pairing.md`.
 
 ### Added — add-on pairing handshake + identity: pair once as a scoped service principal over a versioned contract (#3025)

--- a/backend/alembic/versions/0080_create_addon_capability.py
+++ b/backend/alembic/versions/0080_create_addon_capability.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``addon_capability`` table (#3026).
+
+The capability-advertisement plane on top of the #3025 pairing (Initiative
+#2900). One row is one surface a paired add-on advertises — a meta-tool
+family, CLI verb family, console panel, or event kind — owned by an
+``addon_pairing`` row and declared against that pairing's negotiated
+integration-contract version.
+
+``pairing_id`` carries ``ON DELETE CASCADE`` so unpair (which hard-deletes
+the pairing row) removes its capability rows in the same operation — no dead
+surfaces. The ``kind`` CHECK pins the versioned capability vocabulary at
+rest; the API rejects unknown kinds earlier with a 422.
+
+Additive-only (migration-compat contract): a fresh table plus its CHECK and
+one unique index, no ALTER of an existing object.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0080"
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "addon_capability",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column(
+            "pairing_id",
+            sa.Uuid(),
+            sa.ForeignKey("addon_pairing.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("display_label", sa.Text(), nullable=True),
+        sa.Column("declared_contract_version", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.CheckConstraint(
+            "kind IN ('meta_tool_family', 'cli_verb_family', 'console_panel', 'event_kind')",
+            name="ck_addon_capability_kind",
+        ),
+    )
+
+    # One row per advertised surface per pairing; also the per-pairing lookup.
+    op.create_index(
+        "addon_capability_pairing_kind_name_idx",
+        "addon_capability",
+        ["pairing_id", "kind", "name"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "addon_capability_pairing_kind_name_idx",
+        table_name="addon_capability",
+    )
+    op.drop_table("addon_capability")

--- a/backend/alembic/versions/0081_create_addon_capability.py
+++ b/backend/alembic/versions/0081_create_addon_capability.py
@@ -27,7 +27,7 @@ from alembic import op
 # Merge-order ledger: final slot 0081 in the chain 0079→0080→0081→0082→0083;
 # down_revision re-points from "0079" to "0080" (#3201) at merge time (orchestrator ledger).
 revision: str = "0081"
-down_revision: str | None = "0079"
+down_revision: str | None = "0080"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/alembic/versions/0081_create_addon_capability.py
+++ b/backend/alembic/versions/0081_create_addon_capability.py
@@ -24,7 +24,9 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0080"
+# Merge-order ledger: final slot 0081 in the chain 0079→0080→0081→0082→0083;
+# down_revision re-points from "0079" to "0080" (#3201) at merge time (orchestrator ledger).
+revision: str = "0081"
 down_revision: str | None = "0079"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/backend/src/meho_backplane/api/v1/addon_capability.py
+++ b/backend/src/meho_backplane/api/v1/addon_capability.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/addons/pairings/{name}/capabilities`` — capability advertisement (#3026).
+
+The REST surface over
+:class:`~meho_backplane.operations.addon_capability.AddonCapabilityService`,
+the capability-advertisement plane of Initiative #2900 built on the #3025
+pairing. A paired add-on declares the surfaces it contributes (meta-tool
+families, CLI verb families, console panels, event kinds) against its
+negotiated integration-contract version; the backplane persists the
+declaration and reports which surfaces are *active* (paired and
+contract-healthy).
+
+Route inventory
+---------------
+
+* ``PUT /api/v1/addons/pairings/{name}/capabilities`` — the paired add-on
+  declares its complete surface set (replace-all). Requires a **service**
+  principal (403 otherwise, as for heartbeat); 404 when the add-on is not
+  paired; 422 on an unknown capability kind or a malformed / duplicate
+  declaration. Audited (``op_id=addon.capabilities.declare``).
+* ``GET /api/v1/addons/pairings/{name}/capabilities`` — an operator reads the
+  add-on's declared surfaces plus their live activation state. 404 when
+  absent / cross-tenant. Role: ``operator``.
+
+Tenant scoping mirrors the pairing router: ``tenant_id`` comes from the
+JWT-validated :class:`~meho_backplane.auth.operator.Operator`, never the body
+or query string.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import status as http_status
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.middleware import verify_jwt_and_bind
+from meho_backplane.operations.addon_capability import AddonCapabilityService
+from meho_backplane.operations.addon_capability_schemas import (
+    CapabilityDeclarationResponse,
+    DeclareCapabilitiesRequest,
+)
+from meho_backplane.operations.addon_pairing import AddonNotPairedError
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/addons/pairings", tags=["addon-pairing"])
+
+#: Module-level Depends closures — avoid ruff B008. Declaring is the add-on's
+#: own action (it authenticates as its service principal); reading the
+#: declaration is operator-visible.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_jwt = Depends(verify_jwt_and_bind)
+
+_OP_IDS: Final[dict[str, str]] = {
+    "declare": "addon.capabilities.declare",
+    "show": "addon.capabilities.show",
+}
+
+
+@router.put("/{name}/capabilities", response_model=CapabilityDeclarationResponse)
+async def declare_capabilities(
+    name: Annotated[str, Path()],
+    payload: DeclareCapabilitiesRequest,
+    operator: Operator = _require_jwt,
+) -> CapabilityDeclarationResponse:
+    """Declare an add-on's advertised surfaces (paired service principal only).
+
+    The paired add-on authenticates as its own **service** principal and
+    replaces its declaration wholesale. A non-service principal is 403; an
+    unpaired add-on is 404; an unknown capability kind or a malformed /
+    duplicate declaration is 422 (rejected by the request schema before this
+    handler runs). Audited via the audit middleware.
+    """
+    if operator.principal_kind is not PrincipalKind.SERVICE:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="capabilities_declare_requires_service_principal",
+        )
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["declare"],
+        audit_op_class="write",
+        audit_addon_name=name,
+    )
+    service = AddonCapabilityService()
+    try:
+        return await service.declare(operator.tenant_id, name, payload)
+    except AddonNotPairedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        ) from exc
+
+
+@router.get("/{name}/capabilities", response_model=CapabilityDeclarationResponse)
+async def show_capabilities(
+    name: Annotated[str, Path()],
+    operator: Operator = _require_operator,
+) -> CapabilityDeclarationResponse:
+    """Return one add-on's declared surfaces + activation state (operator-gated).
+
+    Cross-tenant probes and unpaired add-ons return 404.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["show"],
+        audit_op_class="read",
+    )
+    service = AddonCapabilityService()
+    declaration = await service.list_declared(operator.tenant_id, name)
+    if declaration is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        )
+    return declaration

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4298,6 +4298,107 @@ class AddonPairing(Base):
     )
 
 
+#: The capability-surface kinds a paired add-on may advertise under the v1
+#: integration contract (#3026). Mirrors
+#: :class:`meho_backplane.operations.addon_capability_schemas.CapabilityKind`
+#: (the API-facing enum) and the ``addon_capability.kind`` CHECK below — the
+#: three are a coordinated change, guarded by ``test_addon_capability_service``
+#: so they cannot drift silently. ``models`` owns the tuple (not the enum) to
+#: avoid importing the operations layer into the DB layer.
+ADDON_CAPABILITY_KINDS: tuple[str, ...] = (
+    "meta_tool_family",
+    "cli_verb_family",
+    "console_panel",
+    "event_kind",
+)
+
+
+class AddonCapability(Base):
+    """One surface a paired add-on advertises — its capability declaration (#3026).
+
+    Foundation of Initiative #2900's capability-advertisement plane, built on
+    the #3025 pairing. Each row is one declared surface (``kind`` + ``name``)
+    owned by an :class:`AddonPairing`. The add-on declares its *complete*
+    surface set at once (replace-all — a re-declaration deletes the pairing's
+    prior rows and inserts the new set), so a dropped capability leaves no
+    residue.
+
+    Activation is **not** a column: a capability is *active* only while its
+    pairing is present and contract-healthy, re-evaluated live from the
+    pairing's negotiated-vs-current contract versions
+    (:func:`~meho_backplane.operations.addon_pairing_contract.is_contract_compatible`).
+    That keeps "activates surfaces only while paired and healthy" structural
+    rather than a stored flag that can drift out of sync with the pairing.
+
+    Schema decisions
+    ----------------
+
+    * ``pairing_id`` -- UUID NOT NULL, FK to ``addon_pairing.id`` with
+      ``ON DELETE CASCADE``. Unpair hard-deletes the pairing row (#3025); the
+      cascade removes the pairing's capability rows in the same operation, so
+      deactivation leaves no dead surface. No separate ``tenant_id`` column —
+      the tenant is the pairing's, reached through this FK.
+    * ``kind`` -- Text NOT NULL, constrained by the ``ck_addon_capability_kind``
+      CHECK to :data:`ADDON_CAPABILITY_KINDS`. The versioned capability
+      vocabulary at rest; the API rejects unknown kinds earlier (422) via the
+      Pydantic enum, so the CHECK is the at-rest guard against a direct insert.
+    * ``name`` -- Text NOT NULL. The surface identifier within its kind (a
+      meta-tool family, a CLI verb family, a console panel id, an event kind).
+    * ``display_label`` -- Text NULL. Optional human label for the surface.
+    * ``declared_contract_version`` -- Integer NOT NULL. The pairing's
+      negotiated contract version this declaration was advertised against, so
+      a declaration stays attributable to its contract after the backplane's
+      version advances.
+    * ``created_at`` -- ``timestamptz`` NOT NULL. Rows are immutable between
+      replace-all declarations (deleted + reinserted, never updated), so one
+      creation stamp is sufficient — no ``updated_at``.
+
+    Indexes
+    -------
+
+    * ``addon_capability_pairing_kind_name_idx`` -- unique composite on
+      ``(pairing_id, kind, name)``. Enforces one row per advertised surface
+      per pairing and drives the per-pairing capability lookup.
+    """
+
+    __tablename__ = "addon_capability"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    pairing_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("addon_pairing.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    display_label: Mapped[str | None] = mapped_column(Text, nullable=True)
+    declared_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        sa.CheckConstraint(
+            "kind IN ('meta_tool_family', 'cli_verb_family', 'console_panel', 'event_kind')",
+            name="ck_addon_capability_kind",
+        ),
+        Index(
+            "addon_capability_pairing_kind_name_idx",
+            "pairing_id",
+            "kind",
+            "name",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Initiative #2415 (#2499) — gateway assignment + result-ingest storage
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -61,6 +61,7 @@ from meho_backplane.agents import (
     stop_grant_expiry_sweeper,
 )
 from meho_backplane.api.openapi_maturity import inject_maturity_extensions
+from meho_backplane.api.v1.addon_capability import router as api_v1_addon_capability_router
 from meho_backplane.api.v1.addon_pairing import router as api_v1_addon_pairing_router
 from meho_backplane.api.v1.agent_grants import router as api_v1_agent_grants_router
 from meho_backplane.api.v1.agent_principals import (
@@ -1079,6 +1080,11 @@ app.include_router(api_v1_service_grants_router)
 # sibling add-on product paired as a scoped Keycloak service principal over a
 # versioned integration contract (Initiative #2900 foundation).
 app.include_router(api_v1_addon_pairing_router)
+# #3026 -- add-on capability advertisement: a paired add-on declares its
+# surfaces (meta-tool / CLI verb families, console panels, event kinds)
+# against the negotiated contract; the backplane persists the declaration and
+# activates surfaces only while paired and contract-healthy (Initiative #2900).
+app.include_router(api_v1_addon_capability_router)
 # G7.1-T2 (#314) -- tenant-conventions CRUD + history (list / show /
 # create / update / delete / history). Reads gated to operator+;
 # writes gated to tenant_admin. Tenant-scoped via the JWT's

--- a/backend/src/meho_backplane/operations/addon_capability.py
+++ b/backend/src/meho_backplane/operations/addon_capability.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add-on capability advertisement service — declare / read / activate (#3026).
+
+The single code path the REST routes
+(:mod:`meho_backplane.api.v1.addon_capability`) call through to persist an
+add-on's advertised surfaces and to read back what is *active*. Built on the
+#3025 pairing (Initiative #2900): a paired add-on declares the surfaces it
+contributes — meta-tool families, CLI verb families, console panels, event
+kinds — against the integration-contract version it negotiated, and the
+backplane activates them only while the pairing is present **and**
+contract-healthy.
+
+Design
+------
+
+* **Stateless and method-scoped** — each method opens its own DB session,
+  commits, and closes, mirroring
+  :class:`~meho_backplane.operations.addon_pairing.AddonPairingService`.
+* **Replace-all declaration** — :meth:`declare` deletes the pairing's prior
+  capability rows and inserts the new set in one transaction, so a dropped
+  capability leaves no residue. The whole operation runs in a single session
+  bound to the pairing row it resolved, so an unpair racing the declare
+  surfaces as a clean failure rather than a half-written set.
+* **Activation is derived, never stored** — a capability is active only while
+  its pairing satisfies
+  :func:`~meho_backplane.operations.addon_pairing_contract.is_contract_compatible`.
+  :meth:`active_capabilities` is the tenant-wide activation view downstream
+  surfaces (event push, console) read; per-add-on reads carry an ``active``
+  flag computed the same way. No surface is written twice as health flips.
+* **Cleanup is the pairing's cascade** — this service never deletes on
+  unpair; the ``addon_capability.pairing_id`` ``ON DELETE CASCADE`` FK does
+  (unpair hard-deletes the pairing row), so the foundation carries no
+  dependency on this feature.
+
+Error contract
+--------------
+
+* :class:`~meho_backplane.operations.addon_pairing.AddonNotPairedError` —
+  declare / read targeted an add-on with no active pairing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonCapability, AddonPairing
+from meho_backplane.operations.addon_capability_schemas import (
+    ActiveCapabilityRead,
+    CapabilityDeclarationResponse,
+    CapabilityKind,
+    CapabilityRead,
+    DeclareCapabilitiesRequest,
+)
+from meho_backplane.operations.addon_pairing import AddonNotPairedError
+from meho_backplane.operations.addon_pairing_contract import is_contract_compatible
+
+__all__ = ["AddonCapabilityService"]
+
+
+def _is_healthy(pairing: AddonPairing) -> bool:
+    """Return whether *pairing* is contract-healthy against the current build."""
+    return is_contract_compatible(
+        addon_contract_version=pairing.addon_contract_version,
+        addon_min_backplane_version=pairing.addon_min_backplane_version,
+    )
+
+
+class AddonCapabilityService:
+    """Declare / read / activate an add-on's advertised surfaces.
+
+    Stateless; instantiate once per request and call freely.
+    """
+
+    def __init__(self) -> None:
+        self._log = structlog.get_logger()
+
+    async def declare(
+        self,
+        tenant_id: uuid.UUID,
+        addon_name: str,
+        request: DeclareCapabilitiesRequest,
+    ) -> CapabilityDeclarationResponse:
+        """Persist an add-on's complete surface set (replace-all).
+
+        Resolves the pairing, deletes its prior capability rows, and inserts
+        the declared set stamped with the pairing's negotiated contract
+        version — all in one transaction. Returns the persisted declaration
+        with its live ``active`` state.
+
+        Raises
+        ------
+        AddonNotPairedError
+            When no pairing matches ``(tenant_id, addon_name)``.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            pairing = (
+                await session.execute(
+                    select(AddonPairing).where(
+                        AddonPairing.tenant_id == tenant_id,
+                        AddonPairing.name == addon_name,
+                    )
+                )
+            ).scalar_one_or_none()
+            if pairing is None:
+                raise AddonNotPairedError(addon_name)
+
+            await session.execute(
+                delete(AddonCapability).where(AddonCapability.pairing_id == pairing.id)
+            )
+            for cap in request.capabilities:
+                session.add(
+                    AddonCapability(
+                        pairing_id=pairing.id,
+                        kind=cap.kind.value,
+                        name=cap.name,
+                        display_label=cap.display_label,
+                        declared_contract_version=pairing.contract_version,
+                    )
+                )
+            await session.flush()
+            rows = await self._pairing_capabilities(session, pairing.id)
+            response = self._build_declaration(pairing, rows)
+            await session.commit()
+
+        self._log.info(
+            "addon_capabilities_declared",
+            tenant_id=str(tenant_id),
+            addon=addon_name,
+            count=len(response.capabilities),
+            declared_contract_version=response.declared_contract_version,
+            active=response.active,
+        )
+        return response
+
+    async def list_declared(
+        self,
+        tenant_id: uuid.UUID,
+        addon_name: str,
+    ) -> CapabilityDeclarationResponse | None:
+        """Return the add-on's declared surfaces + live activation state.
+
+        ``None`` when no pairing matches ``(tenant_id, addon_name)`` (the
+        route maps that to 404). A paired add-on that has declared nothing
+        yet returns an empty ``capabilities`` list — paired, no surfaces.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            pairing = (
+                await session.execute(
+                    select(AddonPairing).where(
+                        AddonPairing.tenant_id == tenant_id,
+                        AddonPairing.name == addon_name,
+                    )
+                )
+            ).scalar_one_or_none()
+            if pairing is None:
+                return None
+            rows = await self._pairing_capabilities(session, pairing.id)
+            return self._build_declaration(pairing, rows)
+
+    async def active_capabilities(
+        self,
+        tenant_id: uuid.UUID,
+        *,
+        kind: CapabilityKind | None = None,
+    ) -> list[ActiveCapabilityRead]:
+        """Return the tenant's *active* capabilities — paired and healthy only.
+
+        A capability is active only while its pairing is contract-healthy; an
+        unhealthy (contract-skewed) pairing contributes nothing here, so the
+        activation view flips with health without any surface being deleted.
+        Optionally scoped to one :class:`CapabilityKind` (the shape downstream
+        surfaces use — e.g. "which add-ons want ``event_kind`` X").
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            pairings = (
+                (
+                    await session.execute(
+                        select(AddonPairing).where(AddonPairing.tenant_id == tenant_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            healthy: dict[uuid.UUID, str] = {
+                pairing.id: pairing.name for pairing in pairings if _is_healthy(pairing)
+            }
+            if not healthy:
+                return []
+
+            query = select(AddonCapability).where(AddonCapability.pairing_id.in_(healthy.keys()))
+            if kind is not None:
+                query = query.where(AddonCapability.kind == kind.value)
+            rows = (await session.execute(query)).scalars().all()
+
+        active = [
+            ActiveCapabilityRead(
+                addon=healthy[row.pairing_id],
+                kind=CapabilityKind(row.kind),
+                name=row.name,
+                display_label=row.display_label,
+            )
+            for row in rows
+        ]
+        active.sort(key=lambda c: (c.addon, c.kind.value, c.name))
+        return active
+
+    @staticmethod
+    async def _pairing_capabilities(
+        session: AsyncSession, pairing_id: uuid.UUID
+    ) -> list[AddonCapability]:
+        """Return a pairing's capability rows, kind- then name-sorted."""
+        result = await session.execute(
+            select(AddonCapability)
+            .where(AddonCapability.pairing_id == pairing_id)
+            .order_by(AddonCapability.kind, AddonCapability.name)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    def _build_declaration(
+        pairing: AddonPairing,
+        rows: list[AddonCapability],
+    ) -> CapabilityDeclarationResponse:
+        """Assemble the per-add-on declaration response from persisted rows."""
+        declared_version = rows[0].declared_contract_version if rows else pairing.contract_version
+        return CapabilityDeclarationResponse(
+            addon=pairing.name,
+            declared_contract_version=declared_version,
+            active=_is_healthy(pairing),
+            capabilities=[CapabilityRead.model_validate(row) for row in rows],
+        )

--- a/backend/src/meho_backplane/operations/addon_capability_schemas.py
+++ b/backend/src/meho_backplane/operations/addon_capability_schemas.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic v2 value types for add-on capability advertisement (#3026).
+
+A paired add-on *declares* the surfaces it contributes to the backplane —
+meta-tool families, CLI verb families, console panels, event kinds — against
+the integration-contract version it negotiated at pairing time (#3025). The
+backplane persists the declaration and activates those surfaces only while
+the pairing is present **and** contract-healthy.
+
+Two things are versioned with the contract here:
+
+* **The capability vocabulary** — :class:`CapabilityKind` is the set of
+  surface kinds the *current* contract understands. A declaration naming a
+  kind outside it is rejected loudly (a 422 at the REST boundary), never a
+  silently-dropped surface. Growing the vocabulary is a coordinated
+  code + migration change (the kind list is mirrored by the
+  ``addon_capability.kind`` CHECK constraint and
+  :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`).
+* **The declaration itself** — every persisted capability records the
+  ``declared_contract_version`` it was advertised against (the pairing's
+  negotiated version), so a declaration made against an older contract stays
+  distinguishable after the backplane's contract advances.
+
+Intake models forbid unknown fields (``extra="forbid"``) so a typo in the
+handshake body is a 422, not a silently-ignored key.
+"""
+
+from __future__ import annotations
+
+import uuid
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = [
+    "CAPABILITY_NAME_MAX_LENGTH",
+    "ActiveCapabilityRead",
+    "CapabilityDeclaration",
+    "CapabilityDeclarationResponse",
+    "CapabilityKind",
+    "CapabilityRead",
+    "DeclareCapabilitiesRequest",
+]
+
+#: Upper bound on a capability ``name`` / ``display_label``. Generous enough
+#: for a dotted event kind (``run.step.completed``) or a hyphenated panel id,
+#: bounded so a declaration can't smuggle an unbounded blob into a Text column.
+CAPABILITY_NAME_MAX_LENGTH: int = 128
+
+#: Identifier alphabet for a capability ``name``: letters, digits, and the
+#: punctuation real surface identifiers use (dot for event kinds, colon /
+#: slash / hyphen / underscore for namespaced families and panel ids). No
+#: whitespace — a name with a space is a malformed declaration, rejected loud.
+_NAME_PATTERN: str = r"^[A-Za-z0-9._:/-]+$"
+
+
+class CapabilityKind(StrEnum):
+    """The surface kinds a paired add-on may advertise under contract v1.
+
+    A ``str`` enum so it serialises as its wire value and an unknown kind on
+    the request path fails Pydantic validation with a 422 that names the
+    offending value — the "rejected loudly" contract. The vocabulary is
+    versioned with the integration contract: adding a kind is a coordinated
+    change across this enum, the ``addon_capability.kind`` CHECK constraint,
+    and :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`.
+    """
+
+    META_TOOL_FAMILY = "meta_tool_family"
+    CLI_VERB_FAMILY = "cli_verb_family"
+    CONSOLE_PANEL = "console_panel"
+    EVENT_KIND = "event_kind"
+
+
+class CapabilityDeclaration(BaseModel):
+    """One advertised surface — a ``(kind, name)`` pair plus an optional label.
+
+    ``name`` is the surface identifier within its kind (a meta-tool family
+    name, a CLI verb family, a console panel id, an event kind). ``kind``
+    outside :class:`CapabilityKind` is a 422; a malformed ``name`` (spaces,
+    control chars) is likewise rejected.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: CapabilityKind
+    name: str = Field(min_length=1, max_length=CAPABILITY_NAME_MAX_LENGTH, pattern=_NAME_PATTERN)
+    display_label: str | None = Field(default=None, max_length=CAPABILITY_NAME_MAX_LENGTH)
+
+
+class DeclareCapabilitiesRequest(BaseModel):
+    """Replace-all intake for the capability declaration (the full surface set).
+
+    A declaration is the add-on's *complete* current surface set: persisting
+    it replaces any prior declaration wholesale, so a capability dropped from
+    the list is deactivated and leaves no dead surface. A ``(kind, name)``
+    listed twice is a malformed declaration and is rejected loudly rather
+    than silently de-duplicated.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    capabilities: list[CapabilityDeclaration]
+
+    @model_validator(mode="after")
+    def _reject_duplicate_capabilities(self) -> DeclareCapabilitiesRequest:
+        seen: set[tuple[str, str]] = set()
+        for cap in self.capabilities:
+            key = (cap.kind.value, cap.name)
+            if key in seen:
+                raise ValueError(
+                    f"duplicate capability declared: kind={cap.kind.value!r} name={cap.name!r}"
+                )
+            seen.add(key)
+        return self
+
+
+class CapabilityRead(BaseModel):
+    """One persisted capability row, built from the ORM via ``model_validate``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    kind: CapabilityKind
+    name: str
+    display_label: str | None
+    declared_contract_version: int
+
+
+class CapabilityDeclarationResponse(BaseModel):
+    """The declared surface set for one add-on plus its live activation state.
+
+    ``active`` is derived, never stored: it is ``True`` only while the owning
+    pairing is present **and** contract-healthy (re-evaluated live via
+    :func:`meho_backplane.operations.addon_pairing_contract.is_contract_compatible`),
+    so it flips with the pairing's health without any surface being written
+    twice. ``declared_contract_version`` is the pairing's negotiated version
+    the declaration was advertised against.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    addon: str
+    declared_contract_version: int
+    active: bool
+    capabilities: list[CapabilityRead]
+
+
+class ActiveCapabilityRead(BaseModel):
+    """One active capability, tagged with its owning add-on.
+
+    The unit of the tenant-wide *activation* view: a capability whose pairing
+    is paired and contract-healthy. This is the plumbing downstream surfaces
+    (event push, console) read to learn what is live for a tenant.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    addon: str
+    kind: CapabilityKind
+    name: str
+    display_label: str | None

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -312,7 +312,7 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # foreign key constraint``.
     "addon_pairing",
     # ``addon_capability.pairing_id`` is a ``REFERENCES addon_pairing(id)`` FK
-    # from migration ``0080`` (#3026 capability advertisement). PG rejects
+    # from migration ``0081`` (#3026 capability advertisement). PG rejects
     # truncating ``addon_pairing`` unless every referencing table is listed in
     # the same statement, so this must appear here. It carries no direct
     # ``tenant`` FK, so the tenant-FK drift guard does not cover it — listed

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -311,6 +311,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # test errors at setup with ``cannot truncate a table referenced in a
     # foreign key constraint``.
     "addon_pairing",
+    # ``addon_capability.pairing_id`` is a ``REFERENCES addon_pairing(id)`` FK
+    # from migration ``0080`` (#3026 capability advertisement). PG rejects
+    # truncating ``addon_pairing`` unless every referencing table is listed in
+    # the same statement, so this must appear here. It carries no direct
+    # ``tenant`` FK, so the tenant-FK drift guard does not cover it — listed
+    # by hand.
+    "addon_capability",
     "targets",
     "tenant",
 )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -449,6 +449,12 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   durable run handle) carries a real ``REFERENCES tenant(id)`` FK; must
         #   be listed here or PG rejects the per-test TRUNCATE of ``tenant`` with
         #   ``cannot truncate a table referenced in a foreign key constraint``.
+        # * ``addon_capability`` — migration 0080 (#3026 capability
+        #   advertisement) has a ``REFERENCES addon_pairing(id)`` FK, so PG
+        #   rejects truncating ``addon_pairing`` unless it is listed in the
+        #   same statement (``cannot truncate a table referenced in a foreign
+        #   key constraint``). No direct ``tenant`` FK — the tenant-FK drift
+        #   guard does not cover it, so it is listed by hand here.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -457,7 +463,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, operation_run, "
+                "service_principal_grant, addon_pairing, operation_run, addon_capability, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -528,7 +534,7 @@ async def pg_engine_empty_tenant(
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, operation_run, "
+                "service_principal_grant, addon_pairing, operation_run, addon_capability, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -449,7 +449,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   durable run handle) carries a real ``REFERENCES tenant(id)`` FK; must
         #   be listed here or PG rejects the per-test TRUNCATE of ``tenant`` with
         #   ``cannot truncate a table referenced in a foreign key constraint``.
-        # * ``addon_capability`` — migration 0080 (#3026 capability
+        # * ``addon_capability`` — migration 0081 (#3026 capability
         #   advertisement) has a ``REFERENCES addon_pairing(id)`` FK, so PG
         #   rejects truncating ``addon_pairing`` unless it is listed in the
         #   same statement (``cannot truncate a table referenced in a foreign

--- a/backend/tests/test_addon_capability_service.py
+++ b/backend/tests/test_addon_capability_service.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :class:`AddonCapabilityService` (#3026).
+
+Coverage:
+
+* declare persists the surface set, stamped with the pairing's negotiated
+  contract version (``declared_contract_version``).
+* re-declare is replace-all — a dropped capability leaves no residue.
+* declare on an unpaired add-on raises ``AddonNotPairedError``.
+* ``active_capabilities`` returns only capabilities of contract-healthy
+  pairings, and can scope to a single kind.
+* activation flips with pairing health: a pairing driven contract-incompatible
+  reads ``active=False`` and drops out of the tenant-wide activation view,
+  without any capability row being deleted.
+* unpair cascade-deletes the pairing's capability rows (no dead surfaces),
+  proven under ``PRAGMA foreign_keys=ON``.
+* the capability vocabulary is a single coordinated definition — the wire enum
+  matches the model's CHECK-constraint tuple.
+
+The Keycloak admin client is monkey-patched so tests need no live Keycloak.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import func, select, update
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import ADDON_CAPABILITY_KINDS, AddonCapability, AddonPairing, Tenant
+from meho_backplane.operations.addon_capability import AddonCapabilityService
+from meho_backplane.operations.addon_capability_schemas import (
+    CapabilityDeclaration,
+    CapabilityKind,
+    DeclareCapabilitiesRequest,
+)
+from meho_backplane.operations.addon_pairing import AddonNotPairedError, AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_pairing_schemas import PairAddonRequest
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_KC_INTERNAL_ID = "cc000000-0000-0000-0000-0000000cap00"
+_PATCH_TARGET = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_ADMIN_URL", "https://keycloak.test/admin/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_ID", "meho-admin")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "s3cr3t")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def _fk_enforced(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Enforce SQLite FKs so ``ON DELETE CASCADE`` fires in this test.
+
+    Mirrors the engine's opt-in gate: the per-test SQLite driver leaves FK
+    enforcement off by default (production PG always enforces it), so a
+    cascade-semantics test flips it on and rebuilds the engine.
+    """
+    monkeypatch.setenv("MEHO_SQLITE_FOREIGN_KEYS", "1")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+    yield
+    reset_engine_for_testing()
+    get_settings.cache_clear()
+
+
+def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _pair(name: str = "automation") -> None:
+    request = PairAddonRequest(
+        name=name,
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+    with patch(_PATCH_TARGET, _mock_kc_ok(f"{_KC_INTERNAL_ID[:-2]}{len(name):02d}")):
+        await AddonPairingService().pair(_TENANT, "op-admin", request)
+
+
+async def _capability_row_count(name: str) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        pairing_id = (
+            await session.execute(
+                select(AddonPairing.id).where(
+                    AddonPairing.tenant_id == _TENANT, AddonPairing.name == name
+                )
+            )
+        ).scalar_one()
+        return (
+            await session.execute(
+                select(func.count())
+                .select_from(AddonCapability)
+                .where(AddonCapability.pairing_id == pairing_id)
+            )
+        ).scalar_one()
+
+
+def _decl(*caps: tuple[CapabilityKind, str]) -> DeclareCapabilitiesRequest:
+    return DeclareCapabilitiesRequest(
+        capabilities=[CapabilityDeclaration(kind=k, name=n) for k, n in caps]
+    )
+
+
+def test_capability_vocabulary_is_a_single_coordinated_definition() -> None:
+    """The wire enum and the model's CHECK-constraint tuple cannot drift."""
+    assert tuple(kind.value for kind in CapabilityKind) == ADDON_CAPABILITY_KINDS
+
+
+@pytest.mark.asyncio
+async def test_declare_persists_and_stamps_contract_version() -> None:
+    await _seed_tenant()
+    await _pair()
+    result = await AddonCapabilityService().declare(
+        _TENANT,
+        "automation",
+        _decl(
+            (CapabilityKind.META_TOOL_FAMILY, "inventory"),
+            (CapabilityKind.EVENT_KIND, "run.step.completed"),
+        ),
+    )
+    assert result.addon == "automation"
+    assert result.active is True
+    assert result.declared_contract_version == BACKPLANE_CONTRACT_VERSION
+    assert {(c.kind, c.name) for c in result.capabilities} == {
+        (CapabilityKind.META_TOOL_FAMILY, "inventory"),
+        (CapabilityKind.EVENT_KIND, "run.step.completed"),
+    }
+    assert all(
+        c.declared_contract_version == BACKPLANE_CONTRACT_VERSION for c in result.capabilities
+    )
+    assert await _capability_row_count("automation") == 2
+
+
+@pytest.mark.asyncio
+async def test_redeclare_is_replace_all() -> None:
+    await _seed_tenant()
+    await _pair()
+    service = AddonCapabilityService()
+    await service.declare(
+        _TENANT,
+        "automation",
+        _decl(
+            (CapabilityKind.META_TOOL_FAMILY, "inventory"),
+            (CapabilityKind.CLI_VERB_FAMILY, "vm"),
+        ),
+    )
+    # A smaller re-declaration drops "vm" — no dead surface left behind.
+    result = await service.declare(
+        _TENANT, "automation", _decl((CapabilityKind.META_TOOL_FAMILY, "inventory"))
+    )
+    assert [(c.kind, c.name) for c in result.capabilities] == [
+        (CapabilityKind.META_TOOL_FAMILY, "inventory")
+    ]
+    assert await _capability_row_count("automation") == 1
+
+
+@pytest.mark.asyncio
+async def test_declare_on_unpaired_addon_raises() -> None:
+    await _seed_tenant()
+    with pytest.raises(AddonNotPairedError):
+        await AddonCapabilityService().declare(
+            _TENANT, "ghost", _decl((CapabilityKind.CONSOLE_PANEL, "pairing"))
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_declared_absent_is_none() -> None:
+    await _seed_tenant()
+    assert await AddonCapabilityService().list_declared(_TENANT, "ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_active_capabilities_filters_by_health_and_kind() -> None:
+    await _seed_tenant()
+    await _pair("automation")
+    await _pair("ssp")
+    service = AddonCapabilityService()
+    await service.declare(
+        _TENANT,
+        "automation",
+        _decl(
+            (CapabilityKind.META_TOOL_FAMILY, "inventory"),
+            (CapabilityKind.EVENT_KIND, "run.step.completed"),
+        ),
+    )
+    await service.declare(
+        _TENANT, "ssp", _decl((CapabilityKind.EVENT_KIND, "portal.request.raised"))
+    )
+
+    everything = await service.active_capabilities(_TENANT)
+    assert {(c.addon, c.kind, c.name) for c in everything} == {
+        ("automation", CapabilityKind.META_TOOL_FAMILY, "inventory"),
+        ("automation", CapabilityKind.EVENT_KIND, "run.step.completed"),
+        ("ssp", CapabilityKind.EVENT_KIND, "portal.request.raised"),
+    }
+
+    event_kinds = await service.active_capabilities(_TENANT, kind=CapabilityKind.EVENT_KIND)
+    assert {(c.addon, c.name) for c in event_kinds} == {
+        ("automation", "run.step.completed"),
+        ("ssp", "portal.request.raised"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_activation_flips_when_pairing_goes_contract_incompatible() -> None:
+    await _seed_tenant()
+    await _pair("automation")
+    service = AddonCapabilityService()
+    await service.declare(
+        _TENANT, "automation", _decl((CapabilityKind.META_TOOL_FAMILY, "inventory"))
+    )
+    assert (await service.list_declared(_TENANT, "automation")).active is True
+    assert len(await service.active_capabilities(_TENANT)) == 1
+
+    # Simulate the add-on now requiring a newer backplane than we run (the
+    # is_contract_compatible "backplane too old" drift direction).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(AddonPairing)
+            .where(AddonPairing.tenant_id == _TENANT, AddonPairing.name == "automation")
+            .values(addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1)
+        )
+        await session.commit()
+
+    declaration = await service.list_declared(_TENANT, "automation")
+    assert declaration.active is False
+    # The declaration persists (health can recover) but contributes nothing
+    # to the tenant-wide activation view while unhealthy.
+    assert len(declaration.capabilities) == 1
+    assert await service.active_capabilities(_TENANT) == []
+
+
+@pytest.mark.asyncio
+async def test_unpair_cascade_deletes_capabilities(_fk_enforced: None) -> None:
+    await _seed_tenant()
+    await _pair("automation")
+    await AddonCapabilityService().declare(
+        _TENANT,
+        "automation",
+        _decl(
+            (CapabilityKind.META_TOOL_FAMILY, "inventory"),
+            (CapabilityKind.CLI_VERB_FAMILY, "vm"),
+        ),
+    )
+    assert await _capability_row_count("automation") == 2
+
+    with patch(_PATCH_TARGET, _mock_kc_ok()):
+        assert await AddonPairingService().unpair(_TENANT, "automation") is True
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        remaining = (
+            await session.execute(select(func.count()).select_from(AddonCapability))
+        ).scalar_one()
+    assert remaining == 0

--- a/backend/tests/test_api_v1_addon_capability.py
+++ b/backend/tests/test_api_v1_addon_capability.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.addon_capability` (#3026).
+
+Coverage matrix:
+
+* declare (PUT): a paired **service** principal declares its surfaces (200); a
+  human principal is 403; an unpaired add-on is 404.
+* unknown capability kind -> 422 (rejected loudly); duplicate declaration ->
+  422.
+* show (GET): an operator reads the declaration + activation state; an
+  unpaired add-on is 404.
+* activation flips with pairing health: a pairing driven contract-incompatible
+  reads ``active=False`` on the read surface.
+* declare / show are audited (``addon.capabilities.declare`` /
+  ``addon.capabilities.show``).
+
+Keycloak admin is monkey-patched so tests need no live Keycloak.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import select, update
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, AuditLog, Tenant
+from meho_backplane.main import app
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+from ._vault_fakes import install_fake_vault
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_KC_INTERNAL_ID = "cc000000-0000-0000-0000-0000000cafe0"
+_PATCH_TARGET = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+_CAPS_URL = "/api/v1/addons/pairings/automation/capabilities"
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_URL", "https://keycloak.test/admin/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_ID", "meho-admin")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "s3cr3t")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    install_fake_vault(monkeypatch)
+    yield TestClient(app)
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-admin",
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    principal_kind: str | None = None,
+) -> str:
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=role.value,
+        tenant_id=str(_TENANT),
+        **({"principal_kind": principal_kind} if principal_kind else {}),
+    )
+
+
+def _service_token(key: Any) -> str:
+    """A paired add-on's ``principal_kind=service`` / ``read_only`` token."""
+    return _token(key, sub="addon-svc", role=TenantRole.READ_ONLY, principal_kind="service")
+
+
+def _mock_kc_ok() -> MagicMock:
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _audit_op_ids() -> list[str]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+    return [r.payload.get("op_id") for r in rows if isinstance(r.payload, dict)]
+
+
+def _pair_body() -> dict[str, object]:
+    return {
+        "name": "automation",
+        "addon_contract_version": BACKPLANE_CONTRACT_VERSION,
+        "addon_min_backplane_version": BACKPLANE_CONTRACT_VERSION,
+    }
+
+
+def _decl_body() -> dict[str, object]:
+    return {
+        "capabilities": [
+            {"kind": "meta_tool_family", "name": "inventory", "display_label": "Inventory"},
+            {"kind": "event_kind", "name": "run.step.completed"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_declare_service_principal_ok_and_audited(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin)
+        resp = client.put(_CAPS_URL, json=_decl_body(), headers=service)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["addon"] == "automation"
+    assert body["active"] is True
+    assert body["declared_contract_version"] == BACKPLANE_CONTRACT_VERSION
+    assert {(c["kind"], c["name"]) for c in body["capabilities"]} == {
+        ("meta_tool_family", "inventory"),
+        ("event_kind", "run.step.completed"),
+    }
+    assert "addon.capabilities.declare" in await _audit_op_ids()
+
+
+@pytest.mark.asyncio
+async def test_declare_human_principal_is_403(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl-human")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin)
+        resp = client.put(_CAPS_URL, json=_decl_body(), headers=admin)
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == "capabilities_declare_requires_service_principal"
+
+
+@pytest.mark.asyncio
+async def test_declare_unknown_kind_is_422(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl-bad")
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post(
+            "/api/v1/addons/pairings",
+            json=_pair_body(),
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+        resp = client.put(
+            _CAPS_URL,
+            json={"capabilities": [{"kind": "wormhole", "name": "x"}]},
+            headers=service,
+        )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_declare_duplicate_capability_is_422(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl-dup")
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post(
+            "/api/v1/addons/pairings",
+            json=_pair_body(),
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+        resp = client.put(
+            _CAPS_URL,
+            json={
+                "capabilities": [
+                    {"kind": "event_kind", "name": "dup"},
+                    {"kind": "event_kind", "name": "dup"},
+                ]
+            },
+            headers=service,
+        )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_declare_unpaired_is_404(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl-404")
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.put(
+            "/api/v1/addons/pairings/ghost/capabilities",
+            json=_decl_body(),
+            headers=service,
+        )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "addon_not_paired"
+
+
+@pytest.mark.asyncio
+async def test_show_reflects_declaration_and_is_audited(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-show")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin)
+        client.put(_CAPS_URL, json=_decl_body(), headers=service)
+        resp = client.get(
+            _CAPS_URL, headers={"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["active"] is True
+    assert len(body["capabilities"]) == 2
+    assert "addon.capabilities.show" in await _audit_op_ids()
+
+
+@pytest.mark.asyncio
+async def test_show_unpaired_is_404(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-show-404")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get("/api/v1/addons/pairings/ghost/capabilities", headers=headers)
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_show_activation_flips_with_pairing_health(client: TestClient) -> None:
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-flip")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    service = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin)
+        client.put(_CAPS_URL, json=_decl_body(), headers=service)
+
+        healthy = client.get(_CAPS_URL, headers=admin)
+        assert healthy.json()["active"] is True
+
+        # Drive the pairing contract-incompatible (backplane now too old for
+        # the add-on's declared floor); the declaration persists but deactivates.
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            await session.execute(
+                update(AddonPairing)
+                .where(AddonPairing.tenant_id == _TENANT, AddonPairing.name == "automation")
+                .values(addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1)
+            )
+            await session.commit()
+
+        unhealthy = client.get(_CAPS_URL, headers=admin)
+    assert unhealthy.status_code == 200, unhealthy.text
+    body = unhealthy.json()
+    assert body["active"] is False
+    assert len(body["capabilities"]) == 2

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9963,6 +9963,120 @@
         }
       }
     },
+    "/api/v1/addons/pairings/{name}/capabilities": {
+      "put": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Declare Capabilities",
+        "description": "Declare an add-on's advertised surfaces (paired service principal only).\n\nThe paired add-on authenticates as its own **service** principal and\nreplaces its declaration wholesale. A non-service principal is 403; an\nunpaired add-on is 404; an unknown capability kind or a malformed /\nduplicate declaration is 422 (rejected by the request schema before this\nhandler runs). Audited via the audit middleware.",
+        "operationId": "declare_capabilities_api_v1_addons_pairings__name__capabilities_put",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeclareCapabilitiesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilityDeclarationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "Show Capabilities",
+        "description": "Return one add-on's declared surfaces + activation state (operator-gated).\n\nCross-tenant probes and unpaired add-ons return 404.",
+        "operationId": "show_capabilities_api_v1_addons_pairings__name__capabilities_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilityDeclarationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/conventions": {
       "get": {
         "tags": [
@@ -24141,6 +24255,112 @@
         "title": "CandidateHint",
         "description": "One candidate target a connector's :meth:`Connector.list_candidates` returns.\n\nCandidates are potentially-reachable targets the connector inferred\nfrom an existing seed (e.g. a vCenter exposing its managed ESXi\nhosts; a kubeconfig listing peer cluster contexts). The\nG9.1-T6 ``meho targets discover`` CLI verb surfaces these to the\noperator; auto-registration is intentionally out of scope per\nInitiative #363 (operator runs ``meho targets import`` after review).\n\n``evidence`` is the debugging payload \u2014 whatever made the connector\nthink this candidate exists (e.g. ``{\"source\": \"kubeconfig\",\n\"context_name\": \"cluster-2\"}``); ``confidence`` is the connector's\nself-assessment of probe-vs-curation reliability."
       },
+      "CapabilityDeclaration": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/CapabilityKind"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._:/-]+$",
+            "title": "Name"
+          },
+          "display_label": {
+            "type": "string",
+            "maxLength": 128,
+            "nullable": true,
+            "title": "Display Label"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind",
+          "name"
+        ],
+        "title": "CapabilityDeclaration",
+        "description": "One advertised surface \u2014 a ``(kind, name)`` pair plus an optional label.\n\n``name`` is the surface identifier within its kind (a meta-tool family\nname, a CLI verb family, a console panel id, an event kind). ``kind``\noutside :class:`CapabilityKind` is a 422; a malformed ``name`` (spaces,\ncontrol chars) is likewise rejected."
+      },
+      "CapabilityDeclarationResponse": {
+        "properties": {
+          "addon": {
+            "type": "string",
+            "title": "Addon"
+          },
+          "declared_contract_version": {
+            "type": "integer",
+            "title": "Declared Contract Version"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/CapabilityRead"
+            },
+            "type": "array",
+            "title": "Capabilities"
+          }
+        },
+        "type": "object",
+        "required": [
+          "addon",
+          "declared_contract_version",
+          "active",
+          "capabilities"
+        ],
+        "title": "CapabilityDeclarationResponse",
+        "description": "The declared surface set for one add-on plus its live activation state.\n\n``active`` is derived, never stored: it is ``True`` only while the owning\npairing is present **and** contract-healthy (re-evaluated live via\n:func:`meho_backplane.operations.addon_pairing_contract.is_contract_compatible`),\nso it flips with the pairing's health without any surface being written\ntwice. ``declared_contract_version`` is the pairing's negotiated version\nthe declaration was advertised against."
+      },
+      "CapabilityKind": {
+        "type": "string",
+        "enum": [
+          "meta_tool_family",
+          "cli_verb_family",
+          "console_panel",
+          "event_kind"
+        ],
+        "title": "CapabilityKind",
+        "description": "The surface kinds a paired add-on may advertise under contract v1.\n\nA ``str`` enum so it serialises as its wire value and an unknown kind on\nthe request path fails Pydantic validation with a 422 that names the\noffending value \u2014 the \"rejected loudly\" contract. The vocabulary is\nversioned with the integration contract: adding a kind is a coordinated\nchange across this enum, the ``addon_capability.kind`` CHECK constraint,\nand :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`."
+      },
+      "CapabilityRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/CapabilityKind"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "display_label": {
+            "type": "string",
+            "nullable": true,
+            "title": "Display Label"
+          },
+          "declared_contract_version": {
+            "type": "integer",
+            "title": "Declared Contract Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "name",
+          "display_label",
+          "declared_contract_version"
+        ],
+        "title": "CapabilityRead",
+        "description": "One persisted capability row, built from the ORM via ``model_validate``."
+      },
       "CatalogListResponse": {
         "properties": {
           "catalog": {
@@ -25546,6 +25766,24 @@
         ],
         "title": "DecideResponseBody",
         "description": "Response for a successful operator decision.\n\nThe ``dispatch_*`` fields are populated whenever ``/decide`` attempted\nthe approved op's re-dispatch \u2014 for **every** approved request now, not\nonly direct operator ops (#2293). ``dispatch_status`` is ``\"ok\"`` when\n``/decide`` won the exactly-one-resumer claim and executed (the direct\nop, or the run-bound fallback when the in-process waiter was gone), or\n``\"already_resumed\"`` when the in-process agent waiter won the claim\nfirst (the run-bound waiter-alive case) \u2014 a benign \"executed elsewhere\"\nthat keeps the approver from double-dispatching. They stay ``None``\nonly on a rejection."
+      },
+      "DeclareCapabilitiesRequest": {
+        "properties": {
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/CapabilityDeclaration"
+            },
+            "type": "array",
+            "title": "Capabilities"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "capabilities"
+        ],
+        "title": "DeclareCapabilitiesRequest",
+        "description": "Replace-all intake for the capability declaration (the full surface set).\n\nA declaration is the add-on's *complete* current surface set: persisting\nit replaces any prior declaration wholesale, so a capability dropped from\nthe list is deactivated and leaves no dead surface. A ``(kind, name)``\nlisted twice is a malformed declaration and is rejected loudly rather\nthan silently de-duplicated."
       },
       "DeprecateTemplateResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -70,6 +70,14 @@ const (
 	CandidateHintConfidenceMedium CandidateHintConfidence = "medium"
 )
 
+// Defines values for CapabilityKind.
+const (
+	CapabilityKindCliVerbFamily  CapabilityKind = "cli_verb_family"
+	CapabilityKindConsolePanel   CapabilityKind = "console_panel"
+	CapabilityKindEventKind      CapabilityKind = "event_kind"
+	CapabilityKindMetaToolFamily CapabilityKind = "meta_tool_family"
+)
+
 // Defines values for ConfirmVerifyResponseAnswer.
 const (
 	ConfirmVerifyResponseAnswerEscalate ConfirmVerifyResponseAnswer = "escalate"
@@ -2815,6 +2823,70 @@ type CandidateHint struct {
 // CandidateHintConfidence defines model for CandidateHint.Confidence.
 type CandidateHintConfidence string
 
+// CapabilityDeclaration One advertised surface — a “(kind, name)“ pair plus an optional label.
+//
+// “name“ is the surface identifier within its kind (a meta-tool family
+// name, a CLI verb family, a console panel id, an event kind). “kind“
+// outside :class:`CapabilityKind` is a 422; a malformed “name“ (spaces,
+// control chars) is likewise rejected.
+type CapabilityDeclaration struct {
+	DisplayLabel *string `json:"display_label"`
+
+	// Kind The surface kinds a paired add-on may advertise under contract v1.
+	//
+	// A ``str`` enum so it serialises as its wire value and an unknown kind on
+	// the request path fails Pydantic validation with a 422 that names the
+	// offending value — the "rejected loudly" contract. The vocabulary is
+	// versioned with the integration contract: adding a kind is a coordinated
+	// change across this enum, the ``addon_capability.kind`` CHECK constraint,
+	// and :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`.
+	Kind CapabilityKind `json:"kind"`
+	Name string         `json:"name"`
+}
+
+// CapabilityDeclarationResponse The declared surface set for one add-on plus its live activation state.
+//
+// “active“ is derived, never stored: it is “True“ only while the owning
+// pairing is present **and** contract-healthy (re-evaluated live via
+// :func:`meho_backplane.operations.addon_pairing_contract.is_contract_compatible`),
+// so it flips with the pairing's health without any surface being written
+// twice. “declared_contract_version“ is the pairing's negotiated version
+// the declaration was advertised against.
+type CapabilityDeclarationResponse struct {
+	Active                  bool             `json:"active"`
+	Addon                   string           `json:"addon"`
+	Capabilities            []CapabilityRead `json:"capabilities"`
+	DeclaredContractVersion int              `json:"declared_contract_version"`
+}
+
+// CapabilityKind The surface kinds a paired add-on may advertise under contract v1.
+//
+// A “str“ enum so it serialises as its wire value and an unknown kind on
+// the request path fails Pydantic validation with a 422 that names the
+// offending value — the "rejected loudly" contract. The vocabulary is
+// versioned with the integration contract: adding a kind is a coordinated
+// change across this enum, the “addon_capability.kind“ CHECK constraint,
+// and :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`.
+type CapabilityKind string
+
+// CapabilityRead One persisted capability row, built from the ORM via “model_validate“.
+type CapabilityRead struct {
+	DeclaredContractVersion int                `json:"declared_contract_version"`
+	DisplayLabel            *string            `json:"display_label"`
+	Id                      openapi_types.UUID `json:"id"`
+
+	// Kind The surface kinds a paired add-on may advertise under contract v1.
+	//
+	// A ``str`` enum so it serialises as its wire value and an unknown kind on
+	// the request path fails Pydantic validation with a 422 that names the
+	// offending value — the "rejected loudly" contract. The vocabulary is
+	// versioned with the integration contract: adding a kind is a coordinated
+	// change across this enum, the ``addon_capability.kind`` CHECK constraint,
+	// and :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`.
+	Kind CapabilityKind `json:"kind"`
+	Name string         `json:"name"`
+}
+
 // CatalogListResponse Wire envelope for “GET /api/v1/connectors/catalog“.
 //
 // Wrapped in “catalog“ (not a bare list) so future paging fields can
@@ -3756,6 +3828,17 @@ type DecideResponseBodyDispatchResult1 = []interface{}
 // DecideResponseBody_DispatchResult defines model for DecideResponseBody.DispatchResult.
 type DecideResponseBody_DispatchResult struct {
 	union json.RawMessage
+}
+
+// DeclareCapabilitiesRequest Replace-all intake for the capability declaration (the full surface set).
+//
+// A declaration is the add-on's *complete* current surface set: persisting
+// it replaces any prior declaration wholesale, so a capability dropped from
+// the list is deactivated and leaves no dead surface. A “(kind, name)“
+// listed twice is a malformed declaration and is rejected loudly rather
+// than silently de-duplicated.
+type DeclareCapabilitiesRequest struct {
+	Capabilities []CapabilityDeclaration `json:"capabilities"`
 }
 
 // DeprecateTemplateResponse Response for “meho_runbook_deprecate_template“ -- the now-deprecated coordinates.
@@ -8483,6 +8566,16 @@ type ShowPairingApiV1AddonsPairingsNameGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams defines parameters for ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet.
+type ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams defines parameters for DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut.
+type DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams defines parameters for HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost.
 type HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -9808,6 +9901,9 @@ type VaultVersionsUiVaultVersionsGetParams struct {
 
 // PairAddonApiV1AddonsPairingsPostJSONRequestBody defines body for PairAddonApiV1AddonsPairingsPost for application/json ContentType.
 type PairAddonApiV1AddonsPairingsPostJSONRequestBody = PairAddonRequest
+
+// DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody defines body for DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut for application/json ContentType.
+type DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody = DeclareCapabilitiesRequest
 
 // RegisterAgentPrincipalApiV1AgentPrincipalsPostJSONRequestBody defines body for RegisterAgentPrincipalApiV1AgentPrincipalsPost for application/json ContentType.
 type RegisterAgentPrincipalApiV1AgentPrincipalsPostJSONRequestBody = AgentPrincipalCreate
@@ -11613,6 +11709,14 @@ type ClientInterface interface {
 	// ShowPairingApiV1AddonsPairingsNameGet request
 	ShowPairingApiV1AddonsPairingsNameGet(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet request
+	ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet(ctx context.Context, name string, params *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBody request with any body
+	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBody(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost request
 	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13121,6 +13225,42 @@ func (c *Client) UnpairAddonApiV1AddonsPairingsNameDelete(ctx context.Context, n
 
 func (c *Client) ShowPairingApiV1AddonsPairingsNameGet(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewShowPairingApiV1AddonsPairingsNameGetRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet(ctx context.Context, name string, params *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBody(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequestWithBody(c.Server, name, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequest(c.Server, name, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -19805,6 +19945,117 @@ func NewShowPairingApiV1AddonsPairingsNameGetRequest(server string, name string,
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetRequest generates requests for ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet
+func NewShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetRequest(server string, name string, params *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s/capabilities", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequest calls the generic DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut builder with application/json body
+func NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequest(server string, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequestWithBody(server, name, params, "application/json", bodyReader)
+}
+
+// NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequestWithBody generates requests for DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut with any type of body
+func NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequestWithBody(server string, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s/capabilities", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -40499,6 +40750,14 @@ type ClientWithResponsesInterface interface {
 	// ShowPairingApiV1AddonsPairingsNameGetWithResponse request
 	ShowPairingApiV1AddonsPairingsNameGetWithResponse(ctx context.Context, name string, params *ShowPairingApiV1AddonsPairingsNameGetParams, reqEditors ...RequestEditorFn) (*ShowPairingApiV1AddonsPairingsNameGetResponse, error)
 
+	// ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetWithResponse request
+	ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetWithResponse(ctx context.Context, name string, params *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams, reqEditors ...RequestEditorFn) (*ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse, error)
+
+	// DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBodyWithResponse request with any body
+	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBodyWithResponse(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error)
+
+	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithResponse(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error)
+
 	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request
 	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error)
 
@@ -42062,6 +42321,52 @@ func (r ShowPairingApiV1AddonsPairingsNameGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ShowPairingApiV1AddonsPairingsNameGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CapabilityDeclarationResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CapabilityDeclarationResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -50245,6 +50550,32 @@ func (c *ClientWithResponses) ShowPairingApiV1AddonsPairingsNameGetWithResponse(
 	return ParseShowPairingApiV1AddonsPairingsNameGetResponse(rsp)
 }
 
+// ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetWithResponse request returning *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse
+func (c *ClientWithResponses) ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetWithResponse(ctx context.Context, name string, params *ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams, reqEditors ...RequestEditorFn) (*ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse, error) {
+	rsp, err := c.ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGet(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse(rsp)
+}
+
+// DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBodyWithResponse request with arbitrary body returning *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse
+func (c *ClientWithResponses) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBodyWithResponse(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error) {
+	rsp, err := c.DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBody(ctx, name, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse(rsp)
+}
+
+func (c *ClientWithResponses) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithResponse(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error) {
+	rsp, err := c.DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut(ctx, name, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse(rsp)
+}
+
 // HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request returning *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse
 func (c *ClientWithResponses) HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error) {
 	rsp, err := c.HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx, name, params, reqEditors...)
@@ -55060,6 +55391,72 @@ func ParseShowPairingApiV1AddonsPairingsNameGetResponse(rsp *http.Response) (*Sh
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest PairedAddonRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse parses an HTTP response from a ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetWithResponse call
+func ParseShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse(rsp *http.Response) (*ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CapabilityDeclarationResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse parses an HTTP response from a DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithResponse call
+func ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse(rsp *http.Response) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CapabilityDeclarationResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -138,7 +138,7 @@ Routes (both under the `addon-pairing` tag):
   capability lifecycle path (`declare` / `list_declared` / `active_capabilities`).
 - `meho_backplane.db.models.AddonCapability` — table `addon_capability`;
   unique `(pairing_id, kind, name)`, `kind` CHECK, `pairing_id` FK with
-  `ON DELETE CASCADE`; migration `0080`.
+  `ON DELETE CASCADE`; migration `0081`.
 - `meho_backplane.api.v1.addon_capability` — the capability REST surface.
 - `meho_backplane.api.v1.health.PairingHealth` — the `/status` facet.
 - `meho_backplane.ui.routes.pairing` — the read-only `/ui/pairing` console

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -66,6 +66,52 @@ advertised version, or a downgrade that dropped the backplane version below
 the add-on's floor. Either way the pairing reads `contract_compatible=false`
 in `/status` and the console without a re-handshake.
 
+## Capability advertisement (#3026)
+
+On top of the pairing, an add-on **declares the surfaces it contributes** —
+meta-tool families, CLI verb families, console panels, event kinds — against
+the contract version it negotiated. The backplane persists the declaration and
+reports which surfaces are *active* (paired **and** contract-healthy).
+
+Capability advertisement is deliberately **not** MCP-tool registration
+(postulate 5): a declared surface is *data* (an `addon_capability` row), never
+a tool name on the agent waist. The `test_addon_pairing_conformance` seed still
+holds — an unpaired backplane grows no agent surface — and the capability
+plane is an operator/add-on-plane surface beside it.
+
+- **Vocabulary versioned with the contract.** `CapabilityKind` is the closed
+  set of surface kinds contract v1 understands (`meta_tool_family`,
+  `cli_verb_family`, `console_panel`, `event_kind`). A declaration naming an
+  unknown kind is rejected loudly — a 422 at the REST boundary, and the
+  `addon_capability.kind` CHECK constraint guards a direct insert at rest.
+  Growing the vocabulary is a coordinated change across the enum, the CHECK,
+  and `models.ADDON_CAPABILITY_KINDS` (drift-guarded in
+  `test_addon_capability_service`).
+- **Replace-all declaration.** `declare()` deletes the pairing's prior
+  capability rows and inserts the new set in one transaction, stamped with the
+  pairing's negotiated `declared_contract_version`. A capability dropped from
+  the list leaves no residue.
+- **Activation is derived, never stored.** A capability is active only while
+  its pairing satisfies `is_contract_compatible()`. `active` on the read
+  surface, and membership of the tenant-wide `active_capabilities()` view,
+  flip with pairing health without any row being written twice. A pairing
+  driven contract-incompatible reads `active=false` and drops out of the
+  activation view while its declaration persists (health can recover).
+- **Deactivation leaves no dead surfaces.** `addon_capability.pairing_id`
+  carries `ON DELETE CASCADE`; unpair (which hard-deletes the pairing row,
+  #3025) removes the capability rows in the same operation. The pairing
+  foundation carries no dependency on the capability plane — cleanup is the
+  cascade, not a reverse call.
+
+Routes (both under the `addon-pairing` tag):
+
+- `PUT /api/v1/addons/pairings/{name}/capabilities` — the paired add-on
+  (authenticating as its **service** principal; a human principal is 403)
+  declares its complete surface set. 404 when unpaired; 422 on an unknown kind
+  or a duplicate declaration. Audited (`op_id=addon.capabilities.declare`).
+- `GET /api/v1/addons/pairings/{name}/capabilities` — an operator reads the
+  declared surfaces + live activation state. 404 when absent / cross-tenant.
+
 ## Key types
 
 - `meho_backplane.operations.addon_pairing_contract` — pure negotiation:
@@ -84,6 +130,16 @@ in `/status` and the console without a re-handshake.
 - `meho_backplane.db.models.AddonPairing` — table `addon_pairing`; unique
   `(tenant_id, name)` and unique `keycloak_client_id`; migration `0079`.
 - `meho_backplane.api.v1.addon_pairing` — the REST surface.
+- `meho_backplane.operations.addon_capability_schemas` — `CapabilityKind`
+  (the versioned vocabulary), `DeclareCapabilitiesRequest` (replace-all
+  intake, `extra="forbid"`), `CapabilityDeclarationResponse` (declared set +
+  derived `active`), `ActiveCapabilityRead` (the tenant-wide activation unit).
+- `meho_backplane.operations.addon_capability.AddonCapabilityService` — the
+  capability lifecycle path (`declare` / `list_declared` / `active_capabilities`).
+- `meho_backplane.db.models.AddonCapability` — table `addon_capability`;
+  unique `(pairing_id, kind, name)`, `kind` CHECK, `pairing_id` FK with
+  `ON DELETE CASCADE`; migration `0080`.
+- `meho_backplane.api.v1.addon_capability` — the capability REST surface.
 - `meho_backplane.api.v1.health.PairingHealth` — the `/status` facet.
 - `meho_backplane.ui.routes.pairing` — the read-only `/ui/pairing` console
   panel.
@@ -141,13 +197,18 @@ lists active pairings and maps each to a `PairingHealth`
   security-review DoD item.
 - **Console is read-only**: pair / unpair are REST-only. Console write
   actions (a pair/unpair button behind CSRF) are a follow-up.
+- **Capabilities are not yet rendered in the console** or exposed as a
+  tenant-wide REST read. `active_capabilities()` is the in-process activation
+  plumbing the sibling event-push task (#3027) consumes; a console panel and a
+  `GET /api/v1/addons/capabilities` list surface are follow-ups.
 - Keycloak client provisioning is now duplicated three ways (agent, runner,
   add-on); a shared helper is an extraction candidate once the pattern
   stabilises (rule of three), but is out of scope for this task.
 
 ## References
 
-- Initiative #2900 (add-on pairing contract), Task #3025 (this foundation).
+- Initiative #2900 (add-on pairing contract), Task #3025 (the pairing
+  foundation), Task #3026 (capability advertisement + activation, this plane).
 - `service-principal-grants.md` — the scoping mechanism the paired principal
   relies on.
 - `connectors-keycloak.md` — the Keycloak admin client lifecycle.


### PR DESCRIPTION
## Summary

- A paired add-on (#3025) can now **declare the surfaces it contributes** — meta-tool families, CLI verb families, console panels, event kinds — against the integration-contract version it negotiated, and the backplane activates those surfaces **only while the pairing is present and contract-healthy** (Initiative #2900).
- **Versioned + loud rejection (AC1):** each declaration is stamped with the pairing's negotiated `declared_contract_version`; `CapabilityKind` is the versioned v1 vocabulary, mirrored by the `addon_capability.kind` CHECK and drift-guarded against `ADDON_CAPABILITY_KINDS`. An unknown kind is a 422.
- **Activation flips + no dead surfaces (AC2):** activation is derived, never stored — `active` and the tenant-wide `active_capabilities()` view recompute `is_contract_compatible()` live, so they flip with pairing health without rewriting a surface. Declaration is replace-all, and `addon_capability.pairing_id` carries `ON DELETE CASCADE` so unpair leaves no orphaned capability rows.
- Capability advertisement is **data, not an MCP tool** (postulate 5) — the agent meta-tool surface is unchanged (MCP surface conformance still green).

## Surface

- `PUT /api/v1/addons/pairings/{name}/capabilities` — the paired add-on declares its complete surface set as its **service** principal (a human principal is 403; unpaired 404; unknown/duplicate kind 422). Audited `addon.capabilities.declare`.
- `GET /api/v1/addons/pairings/{name}/capabilities` — operators read the declaration + live activation state. Audited `addon.capabilities.show`.
- New migration `0080` (`addon_capability`), added to both per-test TRUNCATE lists (it FKs `addon_pairing`, not `tenant`, so the tenant-FK drift guard doesn't cover it). CLI OpenAPI snapshot + Go client regenerated.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed files) — clean (pre-existing macOS-only `icmp.py` gap unrelated)
- [x] `.claude/hooks/code-quality.py --diff` — clean
- [x] `pytest tests/test_addon_capability_service.py tests/test_api_v1_addon_capability.py` — 16 passed (declare/persist/replace-all/active-filter/health-flip/cascade + REST RBAC/422/404/audit)
- [x] Guard/foundation lanes — `test_truncate_list_drift`, `test_addon_pairing_conformance`, `test_addon_pairing_service`, `test_api_v1_addon_pairing`, `test_api_v1_health`, `test_features` — 102 passed
- [x] `test_db_models`, `test_mcp_surface_conformance` (no MCP-tool change), `tests/migrations/` (replays 0079→0080) — 398 passed

## Out of scope

- Console rendering of capabilities and a tenant-wide `GET /api/v1/addons/capabilities` list surface (follow-ups; `active_capabilities()` is the in-process plumbing #3027 consumes).
- Go CLI verbs (`meho addon capabilities ...`) — consistent with #3025's deferral.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3026
