### PR TITLE
feat(pairing): out-of-process audit parent-linkage for paired add-on runs (#3028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,24 @@ connector-related release-notes line.
   Supersedes the label-humanization pass (internal#230) by folding it
   into both drawers.
 
+### Added — out-of-process audit parent-linkage for paired add-on orchestrations (#3028)
+
+- A paired add-on orchestrating from outside the backplane can now group all
+  the `call_operation` dispatches of one run into a **single audit-replay
+  subtree**, extending #2086's in-process lineage to out-of-process parents.
+  The first dispatch a paired service principal issues under a given `work_ref`
+  opens an orchestration run (a synthesized replay `session_id` + an
+  `addon.orchestration` anchor audit row); every later dispatch for that
+  work_ref resolves the same run and back-links to the anchor, so
+  `GET /api/v1/audit/sessions/{id}/replay` reconstructs the orchestration and
+  its resulting dispatches as one tree. Linkage is accepted **only** from a
+  paired principal for its **own** work_refs — keyed by the caller's
+  `keycloak_client_id`, so a different add-on presenting the same work_ref
+  string gets its own isolated subtree, and non-paired principals (users,
+  agents, unpaired service accounts) are unaffected. Audit stays synchronous
+  append-only: the anchor is an ordinary audit row carrying only its own
+  columns (new migration `0082`, `addon_orchestration_run`).
+
 ### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975 / PR #3184)
 
 - `vmware.composite.datastore.usage` enriched every datastore row with the

--- a/backend/alembic/versions/0080_create_addon_orchestration_run.py
+++ b/backend/alembic/versions/0080_create_addon_orchestration_run.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``addon_orchestration_run`` table (#3028).
+
+The out-of-process parent-linkage anchor for a paired add-on's orchestration
+run (Initiative #2900, scope item 4). #2086 gave *in-process* dispatches a
+replay subtree by re-binding ``parent_audit_id`` / ``agent_session_id`` before
+a resumed dispatch. An external orchestrator (a paired add-on) has no
+in-process parent audit row to hang its per-step dispatches off, so this table
+holds one **synthesized** anchor per ``(keycloak_client_id, work_ref)``: a
+stable ``session_id`` (the replay anchor) plus the ``anchor_audit_id`` of the
+orchestration-root ``audit_log`` row written when the run is first opened. Each
+subsequent dispatch for that work_ref binds those two values, so its DISPATCH
+audit row groups under the one subtree.
+
+Keyed by ``(keycloak_client_id, work_ref)`` — the isolation boundary that makes
+linkage acceptable "only from the paired principal for its own work_refs": a
+different principal presenting the same work_ref string resolves its own row
+(keyed by its own clientId), never another add-on's subtree.
+
+Additive-only (migration-compat contract): a fresh table plus one unique
+index, no ALTER of an existing object.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0080"
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "addon_orchestration_run",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), sa.ForeignKey("tenant.id"), nullable=False),
+        # The paired principal's OAuth clientId (== addon_pairing.keycloak_client_id).
+        sa.Column("keycloak_client_id", sa.Text(), nullable=False),
+        # The external change-ticket ref the orchestration groups under.
+        sa.Column("work_ref", sa.Text(), nullable=False),
+        # Synthesized replay anchor: the agent_session_id every row of the run
+        # carries, so /audit/sessions/{id}/replay reconstructs the subtree.
+        sa.Column("session_id", sa.Uuid(), nullable=False),
+        # The id of the orchestration-root audit_log row (parent_audit_id target).
+        sa.Column("anchor_audit_id", sa.Uuid(), nullable=False),
+        # The service-account sub that first opened the run (audit provenance).
+        sa.Column("opened_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "opened_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+
+    # Race-safe resolve-or-open + the per-principal isolation boundary: one
+    # anchor per (clientId, work_ref). Globally unique — a Keycloak clientId is
+    # global, so it is never namespaced by tenant.
+    op.create_index(
+        "addon_orchestration_run_client_work_ref_idx",
+        "addon_orchestration_run",
+        ["keycloak_client_id", "work_ref"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "addon_orchestration_run_client_work_ref_idx",
+        table_name="addon_orchestration_run",
+    )
+    op.drop_table("addon_orchestration_run")

--- a/backend/alembic/versions/0082_create_addon_orchestration_run.py
+++ b/backend/alembic/versions/0082_create_addon_orchestration_run.py
@@ -29,7 +29,9 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0080"
+# Merge-order ledger: final slot 0082 in the chain 0079→0080→0081→0082→0083;
+# down_revision re-points from "0079" to "0081" (#3204) at merge time (orchestrator ledger).
+revision: str = "0082"
 down_revision: str | None = "0079"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/backend/alembic/versions/0082_create_addon_orchestration_run.py
+++ b/backend/alembic/versions/0082_create_addon_orchestration_run.py
@@ -32,7 +32,7 @@ from alembic import op
 # Merge-order ledger: final slot 0082 in the chain 0079→0080→0081→0082→0083;
 # down_revision re-points from "0079" to "0081" (#3204) at merge time (orchestrator ledger).
 revision: str = "0082"
-down_revision: str | None = "0079"
+down_revision: str | None = "0081"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -693,6 +693,31 @@ def _is_service_account_token(claims: Any, settings: Settings) -> bool:
     return isinstance(username, str) and username.startswith(prefix)
 
 
+def _extract_client_id(claims: Any, settings: Settings) -> str | None:
+    """Recover the OAuth ``clientId`` of a service-account (client-credentials) token.
+
+    Keycloak names a client's service-account user
+    ``service-account-<clientId>`` and stamps it on the username claim (the
+    same #3178 marker :func:`_is_service_account_token` keys on). Stripping the
+    configured prefix recovers the ``clientId``, which for a paired add-on
+    equals ``addon_pairing.keycloak_client_id`` — the seam the #3028 add-on
+    parent-linkage matches a dispatch's principal against.
+
+    Returns ``None`` for any token that is not a prefix-marked service account
+    (interactive users, agent / runner clients whose username lacks the marker,
+    or a realm with the marker disabled by an empty prefix). Reuses the exact
+    settings :func:`_is_service_account_token` uses so the derived value stays
+    consistent with the ``service`` classification.
+    """
+    prefix = settings.jwt_service_account_username_prefix
+    if not prefix:
+        return None
+    username = claims.get(settings.jwt_service_account_username_claim)
+    if isinstance(username, str) and username.startswith(prefix):
+        return username[len(prefix) :] or None
+    return None
+
+
 def _extract_principal_kind(claims: Any, settings: Settings) -> PrincipalKind:
     """Extract ``principal_kind`` from *claims*.
 
@@ -995,6 +1020,7 @@ def _operator_from_claims(claims: Any, raw_jwt: str, settings: Settings) -> Oper
     tenant_id = _extract_tenant_id(claims, settings)
     tenant_role = _extract_tenant_role(claims, settings)
     principal_kind = _extract_principal_kind(claims, settings)
+    client_id = _extract_client_id(claims, settings)
     capabilities = _extract_capabilities(claims, settings)
     scopes = _extract_scopes(claims, settings)
     platform_admin = _extract_platform_admin(claims, settings)
@@ -1018,6 +1044,7 @@ def _operator_from_claims(claims: Any, raw_jwt: str, settings: Settings) -> Oper
             tenant_id=tenant_id,
             tenant_role=tenant_role,
             principal_kind=principal_kind,
+            client_id=client_id,
             capabilities=capabilities,
             scopes=scopes,
             platform_admin=platform_admin,

--- a/backend/src/meho_backplane/auth/operator.py
+++ b/backend/src/meho_backplane/auth/operator.py
@@ -197,6 +197,14 @@ class Operator(BaseModel):
     tenant_id: UUID
     tenant_role: TenantRole
     principal_kind: PrincipalKind = PrincipalKind.USER
+    #: The OAuth ``clientId`` of a client-credentials (service-account) token,
+    #: recovered from the ``service-account-<clientId>`` username marker
+    #: (#3178). Populated for :attr:`PrincipalKind.SERVICE` principals; ``None``
+    #: for interactive users and any token without the marker. Used by the
+    #: add-on parent-linkage seam (#3028) to match a paired add-on's dispatch
+    #: to its ``addon_pairing.keycloak_client_id`` — linkage is accepted only
+    #: from a paired principal for its own work_refs.
+    client_id: str | None = None
     capabilities: frozenset[str] = frozenset()
     scopes: frozenset[str] = frozenset()
     platform_admin: bool = False

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4298,6 +4298,90 @@ class AddonPairing(Base):
     )
 
 
+class AddonOrchestrationRun(Base):
+    """One out-of-process orchestration run's audit-linkage anchor (#3028).
+
+    Initiative #2900 scope item 4. #2086 gave *in-process* dispatches a single
+    replay subtree by re-binding ``parent_audit_id`` / ``agent_session_id``
+    before a resumed dispatch. A paired add-on orchestrating from *outside* the
+    backplane has no in-process parent audit row to hang its per-step
+    dispatches off, so this row synthesises one: a stable ``session_id`` (the
+    replay anchor every dispatch of the run carries) and the ``anchor_audit_id``
+    of the orchestration-root ``audit_log`` row written when the run is first
+    opened. Each subsequent ``call_operation`` for the same ``work_ref`` binds
+    those two values, so its DISPATCH row nests under the one subtree that
+    ``/audit/sessions/{session_id}/replay`` reconstructs.
+
+    The row is the out-of-process analogue of ``ApprovalRequest``'s
+    ``{request_audit_id, agent_session_id}`` durable-linkage copies: resolve
+    once (open + write the anchor), then re-bind on every later dispatch.
+
+    Schema decisions
+    ----------------
+
+    * ``keycloak_client_id`` -- Text NOT NULL. The paired principal's OAuth
+      clientId, equal to :attr:`AddonPairing.keycloak_client_id`. The linkage
+      key: a run belongs to exactly one paired principal.
+    * ``work_ref`` -- Text NOT NULL. The external change-ticket ref the run
+      groups under. Together with ``keycloak_client_id`` it uniquely names a
+      run (``addon_orchestration_run_client_work_ref_idx``), which is both the
+      race-safe resolve-or-open key and the isolation boundary: a *different*
+      paired principal presenting the same work_ref string resolves its own
+      row, never another add-on's subtree.
+    * ``session_id`` -- UUID NOT NULL. Synthesised replay anchor; the
+      ``agent_session_id`` stamped on the anchor row and every dispatch of the
+      run.
+    * ``anchor_audit_id`` -- UUID NOT NULL. Id of the orchestration-root
+      ``audit_log`` row; the ``parent_audit_id`` each dispatch back-links to.
+    * ``opened_by_sub`` -- Text NOT NULL. The service-account ``sub`` that
+      first opened the run (audit provenance; distinct from the pairing's
+      human ``owner_sub``).
+    * ``tenant_id`` -- UUID NOT NULL, FK to ``tenant.id`` (the ``NO ACTION``
+      soft-FK discipline used across the chassis).
+
+    Indexes
+    -------
+
+    * ``addon_orchestration_run_client_work_ref_idx`` -- unique on
+      ``(keycloak_client_id, work_ref)``. Globally unique (a Keycloak clientId
+      is not namespaced by tenant), so it is not a composite with
+      ``tenant_id``.
+    """
+
+    __tablename__ = "addon_orchestration_run"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    keycloak_client_id: Mapped[str] = mapped_column(Text, nullable=False)
+    work_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    session_id: Mapped[uuid.UUID] = mapped_column(Uuid(), nullable=False)
+    anchor_audit_id: Mapped[uuid.UUID] = mapped_column(Uuid(), nullable=False)
+    opened_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    opened_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "addon_orchestration_run_client_work_ref_idx",
+            "keycloak_client_id",
+            "work_ref",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
 #: The capability-surface kinds a paired add-on may advertise under the v1
 #: integration contract (#3026). Mirrors
 #: :class:`meho_backplane.operations.addon_capability_schemas.CapabilityKind`

--- a/backend/src/meho_backplane/operations/addon_orchestration.py
+++ b/backend/src/meho_backplane/operations/addon_orchestration.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Out-of-process audit parent-linkage for paired add-on orchestrations (#3028).
+
+Initiative #2900 scope item 4. #2086 gave *in-process* dispatches a single
+audit-replay subtree: the approval-resume path re-binds ``parent_audit_id`` /
+``agent_session_id`` before a resumed dispatch, so the executed op's audit row
+nests under the parking call instead of orphaning as a second root. A paired
+add-on orchestrating from *outside* the backplane has no in-process parent
+audit row to hang its per-step dispatches off — each ``call_operation`` it
+issues would otherwise land as an independent replay root.
+
+This module synthesises the missing parent. The first ``call_operation`` a
+paired principal issues under a given ``work_ref`` **opens** an orchestration
+run: one :class:`~meho_backplane.db.models.AddonOrchestrationRun` row keyed by
+``(keycloak_client_id, work_ref)`` carrying a fresh ``session_id`` (the replay
+anchor) and ``anchor_audit_id``, plus one ``audit_log`` "orchestration-root"
+row written under those ids. Every subsequent dispatch for the same work_ref
+**resolves** that run and binds the two ids around the dispatch (via
+:func:`bound_parent_linkage`), so its DISPATCH audit row carries the shared
+``agent_session_id`` and back-links to the anchor. ``/audit/sessions/{id}/
+replay`` — which anchors on ``agent_session_id`` and descends by
+``parent_audit_id`` — then reconstructs one subtree spanning the orchestration
+and all resulting dispatches.
+
+Authorization (the "only from the paired principal for its own work_refs"
+contract):
+
+* Linkage is offered **only** to a ``PrincipalKind.SERVICE`` principal whose
+  recovered ``client_id`` resolves to a live :class:`AddonPairing` in the same
+  tenant. A non-paired principal (or a user / agent token) gets ``None`` — no
+  linkage, dispatches stay independent exactly as before.
+* A run is keyed by the **caller's own** ``keycloak_client_id``, so a different
+  paired principal presenting the same work_ref string opens (or resolves) its
+  own run and can never attach to — or even observe — another add-on's subtree.
+
+The row is the out-of-process analogue of ``ApprovalRequest``'s
+``{request_audit_id, agent_session_id}`` durable copies (#2086): resolve once,
+re-bind on every later dispatch. Audit stays synchronous append-only — the
+anchor is an ordinary ``audit_log`` row (its own columns only; no
+back-references), consistent with the v0.1-spec §6 discipline.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.auth.operator import Operator, PrincipalKind
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonOrchestrationRun, AuditLog
+from meho_backplane.operations._audit import (
+    agent_session_id_var,
+    parent_audit_id_var,
+)
+
+# NB: ``addon_pairing`` is imported lazily inside
+# :func:`resolve_or_open_orchestration_run`, not at module scope. It pulls in
+# the ``addon_pairing_schemas -> runner_principals -> scheduler -> agent``
+# chain, and the agent layer imports this package's ``meta_tools`` (which in
+# turn imports *this* module) — an eager import here would close that cycle.
+# The pairing lookup is only needed at dispatch time, so the deferral is free.
+
+__all__ = [
+    "ORCHESTRATION_METHOD",
+    "ORCHESTRATION_PATH",
+    "OrchestrationRun",
+    "bound_parent_linkage",
+    "resolve_or_open_orchestration_run",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: ``audit_log.method`` for the synthesised orchestration-root row. A new verb
+#: alongside ``DISPATCH`` / ``APPROVAL``; ``method`` is free-form text (no CHECK
+#: constraint), and audit queries surface the row by it.
+ORCHESTRATION_METHOD = "ORCHESTRATION"
+
+#: ``audit_log.path`` for the orchestration-root row — a stable op-shaped label.
+ORCHESTRATION_PATH = "addon.orchestration"
+
+
+@dataclass(frozen=True)
+class OrchestrationRun:
+    """The resolved parent-linkage anchor for one ``(client_id, work_ref)`` run."""
+
+    session_id: uuid.UUID
+    anchor_audit_id: uuid.UUID
+    work_ref: str
+    keycloak_client_id: str
+
+
+def _to_run(row: AddonOrchestrationRun) -> OrchestrationRun:
+    return OrchestrationRun(
+        session_id=row.session_id,
+        anchor_audit_id=row.anchor_audit_id,
+        work_ref=row.work_ref,
+        keycloak_client_id=row.keycloak_client_id,
+    )
+
+
+async def _select_run(keycloak_client_id: str, work_ref: str) -> OrchestrationRun | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(AddonOrchestrationRun).where(
+                    AddonOrchestrationRun.keycloak_client_id == keycloak_client_id,
+                    AddonOrchestrationRun.work_ref == work_ref,
+                )
+            )
+        ).scalar_one_or_none()
+    return _to_run(row) if row is not None else None
+
+
+async def _open_run(
+    *,
+    operator: Operator,
+    keycloak_client_id: str,
+    work_ref: str,
+) -> OrchestrationRun:
+    """Insert the run row + its orchestration-root audit row in one transaction.
+
+    Both land atomically so a run can never point at an anchor id that has no
+    ``audit_log`` row (which would re-scatter replay into per-dispatch roots).
+    On a lost resolve-or-open race the unique index raises ``IntegrityError``;
+    the caller falls back to :func:`_select_run`.
+    """
+    session_id = uuid.uuid4()
+    anchor_audit_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AddonOrchestrationRun(
+                tenant_id=operator.tenant_id,
+                keycloak_client_id=keycloak_client_id,
+                work_ref=work_ref,
+                session_id=session_id,
+                anchor_audit_id=anchor_audit_id,
+                opened_by_sub=operator.sub,
+                opened_at=now,
+            )
+        )
+        # Flush the run first so its unique constraint fires before the anchor
+        # audit row is added — a lost race leaves nothing to roll back.
+        await session.flush()
+        session.add(
+            AuditLog(
+                id=anchor_audit_id,
+                occurred_at=now,
+                operator_sub=operator.sub,
+                tenant_id=operator.tenant_id,
+                # Root of the run: no parent, carries the anchor session id so
+                # replay seeds on it and every dispatch of the run descends here.
+                parent_audit_id=None,
+                agent_session_id=session_id,
+                method=ORCHESTRATION_METHOD,
+                path=ORCHESTRATION_PATH,
+                status_code=200,
+                request_id=None,
+                duration_ms=Decimal("0.00"),
+                payload={
+                    "keycloak_client_id": keycloak_client_id,
+                    "work_ref": work_ref,
+                    "result_status": "opened",
+                },
+                work_ref=work_ref,
+            )
+        )
+        await session.commit()
+    _log.info(
+        "addon_orchestration_run_opened",
+        keycloak_client_id=keycloak_client_id,
+        work_ref=work_ref,
+        session_id=str(session_id),
+    )
+    return OrchestrationRun(
+        session_id=session_id,
+        anchor_audit_id=anchor_audit_id,
+        work_ref=work_ref,
+        keycloak_client_id=keycloak_client_id,
+    )
+
+
+async def resolve_or_open_orchestration_run(
+    operator: Operator,
+    work_ref: str,
+) -> OrchestrationRun | None:
+    """Resolve (or open) the parent-linkage anchor for *operator*'s *work_ref*.
+
+    Returns ``None`` when the caller is not eligible for out-of-process linkage
+    — i.e. it is not a paired add-on service principal for this tenant. In that
+    case the dispatch keeps its pre-#3028 behaviour (an independent audit row).
+    Only a ``PrincipalKind.SERVICE`` principal whose ``client_id`` matches a
+    live :class:`AddonPairing` in the operator's own tenant is linked, and the
+    run is keyed by that client_id so it is scoped to the caller's own
+    work_refs.
+    """
+    client_id = operator.client_id
+    if operator.principal_kind is not PrincipalKind.SERVICE or not client_id:
+        return None
+
+    # Deferred import — see the module-level note on the import cycle.
+    from meho_backplane.operations.addon_pairing import AddonPairingService
+
+    pairing = await AddonPairingService().get_by_client_id(client_id)
+    if pairing is None or pairing.tenant_id != operator.tenant_id:
+        # Not a paired principal (or a cross-tenant clientId collision that must
+        # never link) — decline linkage rather than fabricating a subtree.
+        return None
+
+    existing = await _select_run(client_id, work_ref)
+    if existing is not None:
+        return existing
+    try:
+        return await _open_run(
+            operator=operator,
+            keycloak_client_id=client_id,
+            work_ref=work_ref,
+        )
+    except IntegrityError as exc:
+        from meho_backplane.operations.addon_pairing import _is_unique_violation
+
+        if not _is_unique_violation(exc):
+            raise
+        # Lost the resolve-or-open race: a concurrent dispatch for the same
+        # (client_id, work_ref) opened the run first. Its row now exists.
+        raced = await _select_run(client_id, work_ref)
+        if raced is None:  # pragma: no cover - unique violation implies a row
+            raise
+        return raced
+
+
+@asynccontextmanager
+async def bound_parent_linkage(run: OrchestrationRun) -> AsyncIterator[None]:
+    """Bind the run's ``agent_session_id`` + ``parent_audit_id`` for a dispatch.
+
+    Mirrors the approval-resume re-bind
+    (:func:`~meho_backplane.operations.approval_queue._dispatch_resume_with_bound_context`):
+    token-set both lineage contextvars, yield, then ``reset`` in a ``finally``
+    so the binding never leaks past the dispatch.
+    :func:`~meho_backplane.operations._audit.write_audit_row` reads exactly
+    these vars into the DISPATCH row's columns, so no audit-writer change is
+    needed — the row nests under the orchestration anchor automatically.
+    """
+    session_token = agent_session_id_var.set(run.session_id)
+    parent_token = parent_audit_id_var.set(run.anchor_audit_id)
+    try:
+        yield
+    finally:
+        parent_audit_id_var.reset(parent_token)
+        agent_session_id_var.reset(session_token)

--- a/backend/src/meho_backplane/operations/addon_pairing.py
+++ b/backend/src/meho_backplane/operations/addon_pairing.py
@@ -435,6 +435,31 @@ class AddonPairingService:
             return None
         return PairedAddonRead.model_validate(row)
 
+    async def get_by_client_id(
+        self,
+        keycloak_client_id: str,
+    ) -> PairedAddonRead | None:
+        """Fetch one live pairing by its Keycloak ``clientId``; ``None`` if absent.
+
+        The clientId is globally unique (Keycloak has no per-tenant clientId
+        namespace; ``addon_pairing_keycloak_client_id_idx``), so this needs no
+        tenant scope — the returned row *carries* its ``tenant_id`` for the
+        caller to cross-check against the request's tenant. This is the lookup
+        the #3028 add-on parent-linkage seam uses to answer "is this dispatch's
+        service principal a paired add-on, and which pairing?".
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonPairing).where(
+                    AddonPairing.keycloak_client_id == keycloak_client_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return PairedAddonRead.model_validate(row)
+
     async def heartbeat(
         self,
         tenant_id: uuid.UUID,

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -79,6 +79,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from contextlib import AsyncExitStack
 from typing import Annotated, Any, Final
 
 import structlog
@@ -102,6 +103,10 @@ from meho_backplane.operations._lookup import (
 )
 from meho_backplane.operations._request_preview import preview_dispatch
 from meho_backplane.operations._search import hybrid_search, resolve_group_id
+from meho_backplane.operations.addon_orchestration import (
+    bound_parent_linkage,
+    resolve_or_open_orchestration_run,
+)
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.operations.ingest.list_connectors import next_step_for_registered_connector
 from meho_backplane.targets.resolver import (
@@ -1065,14 +1070,29 @@ async def _call_operation_impl(
     if isinstance(work_ref_arg, str) and work_ref_arg:
         work_ref_token = work_ref_var.set(work_ref_arg)
     try:
-        result = await dispatch(
-            operator=operator,
-            connector_id=connector_id,
-            op_id=op_id,
-            target=resolved_target,
-            params=params,
-            _approved=approved,
-        )
+        async with AsyncExitStack() as linkage_stack:
+            # #3028 out-of-process parent-linkage: when a paired add-on service
+            # principal dispatches under a ``work_ref``, group its per-step
+            # dispatches into one audit-replay subtree by binding the
+            # orchestration run's synthesized ``session_id`` + anchor
+            # ``parent_audit_id`` around the dispatch. Resolution reads the
+            # *effective* work_ref (the arg above or an ambient ``Meho-Work-Ref``
+            # header) and returns ``None`` for any non-paired caller, so the
+            # pre-#3028 behaviour (an independent audit row) is untouched for
+            # users, agents, and unpaired service principals.
+            effective_work_ref = work_ref_var.get()
+            if effective_work_ref:
+                linkage_run = await resolve_or_open_orchestration_run(operator, effective_work_ref)
+                if linkage_run is not None:
+                    await linkage_stack.enter_async_context(bound_parent_linkage(linkage_run))
+            result = await dispatch(
+                operator=operator,
+                connector_id=connector_id,
+                op_id=op_id,
+                target=resolved_target,
+                params=params,
+                _approved=approved,
+            )
     finally:
         if work_ref_token is not None:
             work_ref_var.reset(work_ref_token)

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -318,6 +318,10 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # ``tenant`` FK, so the tenant-FK drift guard does not cover it — listed
     # by hand.
     "addon_capability",
+    # ``addon_orchestration_run`` (#3028) carries ``tenant`` + ``addon_pairing``
+    # FKs from migration ``0082``; listed so the per-test TRUNCATE of both
+    # parents does not error.
+    "addon_orchestration_run",
     "targets",
     "tenant",
 )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -455,7 +455,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   same statement (``cannot truncate a table referenced in a foreign
         #   key constraint``). No direct ``tenant`` FK — the tenant-FK drift
         #   guard does not cover it, so it is listed by hand here.
-        # * ``addon_orchestration_run`` — migration 0080 (#3028 out-of-process
+        # * ``addon_orchestration_run`` — migration 0082 (#3028 out-of-process
         #   audit parent-linkage) carries a real ``REFERENCES tenant(id)`` FK;
         #   same rule — list it here or the per-test TRUNCATE of ``tenant``
         #   fails with ``cannot truncate a table referenced in a foreign key

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -455,6 +455,11 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   same statement (``cannot truncate a table referenced in a foreign
         #   key constraint``). No direct ``tenant`` FK — the tenant-FK drift
         #   guard does not cover it, so it is listed by hand here.
+        # * ``addon_orchestration_run`` — migration 0080 (#3028 out-of-process
+        #   audit parent-linkage) carries a real ``REFERENCES tenant(id)`` FK;
+        #   same rule — list it here or the per-test TRUNCATE of ``tenant``
+        #   fails with ``cannot truncate a table referenced in a foreign key
+        #   constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -463,7 +468,8 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, operation_run, addon_capability, "
+                "service_principal_grant, addon_pairing, operation_run, "
+                "addon_capability, addon_orchestration_run, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -534,7 +540,8 @@ async def pg_engine_empty_tenant(
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
                 "event_outbox, event_source, gateway_command, "
-                "service_principal_grant, addon_pairing, operation_run, addon_capability, "
+                "service_principal_grant, addon_pairing, operation_run, "
+                "addon_capability, addon_orchestration_run, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/test_addon_orchestration_linkage.py
+++ b/backend/tests/test_addon_orchestration_linkage.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for out-of-process audit parent-linkage (#3028).
+
+Covers the two acceptance criteria of the task directly:
+
+1. *A multi-dispatch external run replays as one audit subtree spanning
+   orchestration + resulting dispatches* — :func:`test_run_replays_as_one_subtree`.
+2. *Linkage only accepted from the paired principal for its own work_refs* —
+   :func:`test_non_service_principal_gets_no_linkage`,
+   :func:`test_unpaired_service_principal_gets_no_linkage`, and
+   :func:`test_distinct_principals_same_work_ref_are_isolated`.
+
+Plus the resolve-or-open idempotency the multi-dispatch grouping relies on and
+the contextvar-binding contract :func:`write_audit_row` reads.
+
+No Keycloak is touched: the pairing row is seeded straight into the DB (the
+linkage seam only *reads* ``addon_pairing`` by clientId).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, select
+
+from meho_backplane.audit_query.replay import replay_session
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AddonOrchestrationRun,
+    AddonPairing,
+    AuditLog,
+    Tenant,
+)
+from meho_backplane.operations._audit import agent_session_id_var, parent_audit_id_var
+from meho_backplane.operations.addon_orchestration import (
+    ORCHESTRATION_METHOD,
+    ORCHESTRATION_PATH,
+    bound_parent_linkage,
+    resolve_or_open_orchestration_run,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_OTHER_TENANT = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+async def _seed_tenant(tenant_id: uuid.UUID = _TENANT, slug: str = "tenant-a") -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=tenant_id, slug=slug, name=slug.title()))
+            await session.commit()
+
+
+async def _seed_pairing(
+    *,
+    tenant_id: uuid.UUID = _TENANT,
+    name: str = "automation",
+    client_id: str = "addon:automation",
+) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AddonPairing(
+                tenant_id=tenant_id,
+                name=name,
+                keycloak_client_id=client_id,
+                keycloak_internal_id=str(uuid.uuid4()),
+                owner_sub="human-owner",
+                contract_version=1,
+                addon_contract_version=1,
+                addon_min_backplane_version=1,
+                created_by_sub="human-operator",
+            )
+        )
+        await session.commit()
+
+
+def _service_operator(
+    *,
+    client_id: str | None = "addon:automation",
+    tenant_id: uuid.UUID = _TENANT,
+    sub: str = "svc-automation",
+) -> Operator:
+    return Operator(
+        sub=sub,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.READ_ONLY,
+        principal_kind=PrincipalKind.SERVICE,
+        client_id=client_id,
+    )
+
+
+async def _count(model: type, **filters: object) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(func.count()).select_from(model)
+        for col, val in filters.items():
+            stmt = stmt.where(getattr(model, col) == val)
+        return int((await session.execute(stmt)).scalar_one())
+
+
+async def _insert_dispatch_row(op_id: str) -> None:
+    """Insert one DISPATCH audit row exactly as ``write_audit_row`` would build it.
+
+    Reads the lineage contextvars — so the test proves that a dispatch running
+    *inside* :func:`bound_parent_linkage` inherits the run's session + parent.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AuditLog(
+                id=uuid.uuid4(),
+                occurred_at=datetime.now(UTC),
+                operator_sub="svc-automation",
+                tenant_id=_TENANT,
+                parent_audit_id=parent_audit_id_var.get(),
+                agent_session_id=agent_session_id_var.get(),
+                method="DISPATCH",
+                path=op_id,
+                status_code=200,
+                duration_ms=Decimal("1.00"),
+                payload={"op_id": op_id},
+            )
+        )
+        await session.commit()
+
+
+# --------------------------------------------------------------------------- #
+# Authorization: linkage only from a paired principal (criterion 2)
+# --------------------------------------------------------------------------- #
+
+
+async def test_non_service_principal_gets_no_linkage() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    user = Operator(
+        sub="human",
+        raw_jwt="",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+        client_id=None,
+    )
+    assert await resolve_or_open_orchestration_run(user, "jira:OPS-1") is None
+    assert await _count(AddonOrchestrationRun) == 0
+
+
+async def test_unpaired_service_principal_gets_no_linkage() -> None:
+    await _seed_tenant()
+    # No pairing row seeded for this clientId.
+    op = _service_operator(client_id="addon:not-paired")
+    assert await resolve_or_open_orchestration_run(op, "jira:OPS-1") is None
+    assert await _count(AddonOrchestrationRun) == 0
+
+
+async def test_service_principal_without_client_id_gets_no_linkage() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    op = _service_operator(client_id=None)
+    assert await resolve_or_open_orchestration_run(op, "jira:OPS-1") is None
+    assert await _count(AddonOrchestrationRun) == 0
+
+
+async def test_cross_tenant_pairing_is_declined() -> None:
+    # A clientId whose pairing belongs to another tenant must never link.
+    await _seed_tenant(tenant_id=_OTHER_TENANT, slug="tenant-b")
+    await _seed_pairing(tenant_id=_OTHER_TENANT, client_id="addon:automation")
+    await _seed_tenant()
+    op = _service_operator(tenant_id=_TENANT, client_id="addon:automation")
+    assert await resolve_or_open_orchestration_run(op, "jira:OPS-1") is None
+    assert await _count(AddonOrchestrationRun) == 0
+
+
+async def test_distinct_principals_same_work_ref_are_isolated() -> None:
+    await _seed_tenant()
+    await _seed_pairing(name="automation", client_id="addon:automation")
+    await _seed_pairing(name="ssp", client_id="addon:ssp")
+    op_a = _service_operator(client_id="addon:automation", sub="svc-a")
+    op_b = _service_operator(client_id="addon:ssp", sub="svc-b")
+
+    run_a = await resolve_or_open_orchestration_run(op_a, "jira:OPS-42")
+    run_b = await resolve_or_open_orchestration_run(op_b, "jira:OPS-42")
+
+    assert run_a is not None and run_b is not None
+    # Same work_ref string, different principals → separate subtrees.
+    assert run_a.session_id != run_b.session_id
+    assert run_a.anchor_audit_id != run_b.anchor_audit_id
+    assert await _count(AddonOrchestrationRun) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Resolve-or-open idempotency (the multi-dispatch grouping foundation)
+# --------------------------------------------------------------------------- #
+
+
+async def test_open_writes_a_single_anchor_row() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    op = _service_operator()
+
+    run = await resolve_or_open_orchestration_run(op, "jira:OPS-7")
+    assert run is not None
+
+    # Exactly one run row and one ORCHESTRATION-root audit row.
+    assert await _count(AddonOrchestrationRun) == 1
+    assert await _count(AuditLog, method=ORCHESTRATION_METHOD) == 1
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        anchor = (
+            await session.execute(select(AuditLog).where(AuditLog.id == run.anchor_audit_id))
+        ).scalar_one()
+    assert anchor.method == ORCHESTRATION_METHOD
+    assert anchor.path == ORCHESTRATION_PATH
+    assert anchor.parent_audit_id is None
+    assert anchor.agent_session_id == run.session_id
+    assert anchor.work_ref == "jira:OPS-7"
+
+
+async def test_resolve_is_idempotent_across_dispatches() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    op = _service_operator()
+
+    first = await resolve_or_open_orchestration_run(op, "jira:OPS-7")
+    second = await resolve_or_open_orchestration_run(op, "jira:OPS-7")
+
+    assert first is not None and second is not None
+    assert first.session_id == second.session_id
+    assert first.anchor_audit_id == second.anchor_audit_id
+    # Resolving the second time opens nothing new.
+    assert await _count(AddonOrchestrationRun) == 1
+    assert await _count(AuditLog, method=ORCHESTRATION_METHOD) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Contextvar binding contract
+# --------------------------------------------------------------------------- #
+
+
+async def test_bound_parent_linkage_sets_and_resets_vars() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    op = _service_operator()
+    run = await resolve_or_open_orchestration_run(op, "jira:OPS-7")
+    assert run is not None
+
+    assert agent_session_id_var.get() is None
+    assert parent_audit_id_var.get() is None
+    async with bound_parent_linkage(run):
+        assert agent_session_id_var.get() == run.session_id
+        assert parent_audit_id_var.get() == run.anchor_audit_id
+    # Cleanly reset — the binding never leaks past the dispatch.
+    assert agent_session_id_var.get() is None
+    assert parent_audit_id_var.get() is None
+
+
+# --------------------------------------------------------------------------- #
+# Criterion 1: multi-dispatch run replays as ONE subtree
+# --------------------------------------------------------------------------- #
+
+
+async def test_run_replays_as_one_subtree() -> None:
+    await _seed_tenant()
+    await _seed_pairing()
+    op = _service_operator()
+
+    # First dispatch opens the run; two dispatches execute under its linkage.
+    run = await resolve_or_open_orchestration_run(op, "jira:OPS-99")
+    assert run is not None
+    async with bound_parent_linkage(run):
+        await _insert_dispatch_row("vmware-rest-9.0:vm.list")
+    # A later dispatch resolves the SAME run (out-of-process, fresh context).
+    run2 = await resolve_or_open_orchestration_run(op, "jira:OPS-99")
+    assert run2 is not None
+    async with bound_parent_linkage(run2):
+        await _insert_dispatch_row("vmware-rest-9.0:vm.power_on")
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        roots = await replay_session(run.session_id, tenant_id=_TENANT, session=session)
+
+    # One subtree: the orchestration anchor is the sole root; both dispatches
+    # nest under it.
+    assert len(roots) == 1
+    anchor = roots[0]
+    assert anchor.method == ORCHESTRATION_METHOD
+    assert anchor.path == ORCHESTRATION_PATH
+    assert len(anchor.children) == 2
+    child_paths = {child.path for child in anchor.children}
+    assert child_paths == {"vmware-rest-9.0:vm.list", "vmware-rest-9.0:vm.power_on"}
+    for child in anchor.children:
+        assert child.method == "DISPATCH"
+        assert child.agent_session_id == run.session_id

--- a/backend/tests/test_auth_principal_kind.py
+++ b/backend/tests/test_auth_principal_kind.py
@@ -114,6 +114,7 @@ def _make_app() -> FastAPI:
         return {
             "sub": operator.sub,
             "principal_kind": operator.principal_kind.value,
+            "client_id": operator.client_id or "",
         }
 
     return mini
@@ -391,3 +392,78 @@ def test_custom_claim_name(monkeypatch: pytest.MonkeyPatch) -> None:
             resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200, resp.text
     assert resp.json()["principal_kind"] == "agent"
+
+
+# ---------------------------------------------------------------------------
+# clientId recovery for the add-on parent-linkage seam (#3028)
+# ---------------------------------------------------------------------------
+#
+# A paired add-on's Keycloak service-account username is
+# ``service-account-<clientId>``; stripping the reserved prefix recovers the
+# ``clientId`` (== ``addon_pairing.keycloak_client_id``), which the #3028
+# out-of-process parent-linkage matches a dispatch's principal against.
+
+
+def _client_id(token: str, key: Any) -> str:
+    """Drive a token through ``verify_jwt`` and return the resolved client_id."""
+    app = _make_app()
+    with respx.mock as r:
+        r.get(_DISCOVERY_URL).mock(
+            return_value=httpx.Response(200, json={"issuer": _ISSUER, "jwks_uri": _JWKS_URL})
+        )
+        r.get(_JWKS_URL).mock(return_value=httpx.Response(200, json=_public_jwks(key)))
+        with TestClient(app) as client:
+            resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["client_id"]
+
+
+def test_client_id_recovered_from_service_account_username() -> None:
+    """A ``service-account-addon:<name>`` username → client_id ``addon:<name>``."""
+    key = _make_key("kid-cid-svc")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "service-account-addon:automation"},
+    )
+    assert _client_id(token, key) == "addon:automation"
+
+
+def test_client_id_absent_for_ordinary_user() -> None:
+    """An interactive user's username has no service-account marker → empty client_id."""
+    key = _make_key("kid-cid-user")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "alice"},
+    )
+    assert _client_id(token, key) == ""
+
+
+def test_client_id_uses_custom_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The clientId derivation strips the configured (custom) prefix."""
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "svc:")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    key = _make_key("kid-cid-prefix")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"preferred_username": "svc:addon:ssp"},
+    )
+    assert _client_id(token, key) == "addon:ssp"
+
+
+def test_extract_client_id_unit() -> None:
+    """``_extract_client_id`` reads the marker directly off a claims mapping."""
+    from meho_backplane.auth.jwt import _extract_client_id
+
+    settings = get_settings()
+    assert (
+        _extract_client_id({"preferred_username": "service-account-addon:automation"}, settings)
+        == "addon:automation"
+    )
+    assert _extract_client_id({"preferred_username": "alice"}, settings) is None
+    assert _extract_client_id({}, settings) is None
+    # A bare prefix with no clientId body resolves to None, not "".
+    assert _extract_client_id({"preferred_username": "service-account-"}, settings) is None

--- a/docs/codebase/addon-parent-linkage.md
+++ b/docs/codebase/addon-parent-linkage.md
@@ -59,7 +59,7 @@ audit row carrying only its own columns. No back-reference column is added to
   `{request_audit_id, agent_session_id}`. Unique index
   `addon_orchestration_run_client_work_ref_idx` on `(keycloak_client_id,
   work_ref)` is both the race-safe resolve-or-open key and the isolation
-  boundary. Migration `0080`.
+  boundary. Migration `0082`.
 - `operations/addon_orchestration.py` — the linkage service:
   - `resolve_or_open_orchestration_run(operator, work_ref)` → `OrchestrationRun
     | None`. Runs the pairing check, then a SELECT-first resolve-or-open

--- a/docs/codebase/addon-parent-linkage.md
+++ b/docs/codebase/addon-parent-linkage.md
@@ -1,0 +1,150 @@
+# Add-on out-of-process audit parent-linkage (#3028)
+
+How a paired add-on's multi-step orchestration, driven from *outside* the
+backplane, collapses into a single audit-replay subtree — the out-of-process
+counterpart to the in-process lineage #2086 gave approval-gated and composite
+dispatches.
+
+## Overview
+
+`#2086` established the in-process rule: an operation that resumes after an
+approval re-binds `parent_audit_id` and `agent_session_id` before it
+dispatches, so the executed op's audit row nests under the call that parked it
+instead of orphaning as a second replay root. `/audit/sessions/{id}/replay`
+anchors on `agent_session_id` and descends by `parent_audit_id`, so that
+re-bind is all it takes to make the chain one tree.
+
+A paired add-on (the first consumers are meho-automation and meho-ssp)
+orchestrates from outside the backplane. It calls `call_operation` several
+times for one unit of work, but there is no in-process parent audit row to hang
+those dispatches off — each would land as an independent replay root. This
+subsystem synthesises the missing parent.
+
+The first `call_operation` a paired service principal issues under a given
+`work_ref` **opens an orchestration run**:
+
+- one `addon_orchestration_run` row, keyed by `(keycloak_client_id, work_ref)`,
+  carrying a freshly minted `session_id` (the replay anchor) and
+  `anchor_audit_id`;
+- one `audit_log` "orchestration-root" row (`method=ORCHESTRATION`,
+  `path=addon.orchestration`) written under those ids, with no parent.
+
+Every later dispatch for the same `work_ref` **resolves** that run and binds
+its `session_id` + `anchor_audit_id` around the dispatch, so the DISPATCH row
+`write_audit_row` writes carries the shared session id and back-links to the
+anchor. Replay then reconstructs the orchestration and all its resulting
+dispatches as one subtree.
+
+**Authorization — linkage only from the paired principal for its own
+work_refs.** Linkage is offered only to a `PrincipalKind.SERVICE` principal
+whose recovered `client_id` resolves to a live `addon_pairing` in the same
+tenant. A run is keyed by the caller's *own* `keycloak_client_id`, so:
+
+- a non-paired caller (a user, an agent, an unpaired service account) gets no
+  linkage — dispatches keep their pre-#3028 independent-row behaviour;
+- a *different* paired principal presenting the same `work_ref` string opens or
+  resolves its own run and can never attach to — or observe — another add-on's
+  subtree.
+
+Audit stays synchronous append-only (v0.1-spec §6): the anchor is an ordinary
+audit row carrying only its own columns. No back-reference column is added to
+`audit_log`; the parent linkage rides the existing `parent_audit_id` /
+`agent_session_id` / `work_ref` columns.
+
+## Key types
+
+- `AddonOrchestrationRun` (`db/models.py`) — the per-`(client_id, work_ref)`
+  anchor row. `session_id` + `anchor_audit_id` are the durable copies re-bound
+  on every later dispatch, the out-of-process analogue of `ApprovalRequest`'s
+  `{request_audit_id, agent_session_id}`. Unique index
+  `addon_orchestration_run_client_work_ref_idx` on `(keycloak_client_id,
+  work_ref)` is both the race-safe resolve-or-open key and the isolation
+  boundary. Migration `0080`.
+- `operations/addon_orchestration.py` — the linkage service:
+  - `resolve_or_open_orchestration_run(operator, work_ref)` → `OrchestrationRun
+    | None`. Runs the pairing check, then a SELECT-first resolve-or-open
+    (a lost race raises the unique-index `IntegrityError`, caught and retried
+    as a SELECT). Returns `None` for any caller not eligible for linkage.
+  - `bound_parent_linkage(run)` — async context manager that token-sets
+    `agent_session_id_var` + `parent_audit_id_var` and resets them in a
+    `finally`. Mirrors `approval_queue._dispatch_resume_with_bound_context`.
+  - `ORCHESTRATION_METHOD` / `ORCHESTRATION_PATH` — the anchor row's
+    `method` / `path`.
+- `Operator.client_id` (`auth/operator.py`) — the caller's OAuth `clientId`,
+  recovered at JWT verification by `_extract_client_id` (`auth/jwt.py`) from the
+  `service-account-<clientId>` username marker (the same #3178 marker the
+  `service` classification keys on). `None` for interactive users and any token
+  without the marker. For a paired add-on it equals
+  `addon_pairing.keycloak_client_id`.
+- `AddonPairingService.get_by_client_id(client_id)` (`operations/addon_pairing.py`)
+  — the pairing lookup by the globally-unique clientId; returns the row
+  (carrying its `tenant_id` for the caller to cross-check).
+
+## Control flow
+
+`_call_operation_impl` (`operations/meta_tools.py`), shared by the MCP tool and
+the REST route, is the single hook:
+
+1. bind the per-op `work_ref` arg onto `work_ref_var` (unchanged, #1657);
+2. read the *effective* work_ref (the arg or an ambient `Meho-Work-Ref`
+   header) off `work_ref_var`;
+3. if non-empty, `resolve_or_open_orchestration_run(operator, work_ref)`:
+   - not a `SERVICE` principal, or no `client_id` → `None`;
+   - `client_id` has no live pairing, or the pairing is another tenant's →
+     `None`;
+   - otherwise SELECT the existing run, or open one (insert the run row + write
+     the anchor audit row in one transaction);
+4. if a run came back, enter `bound_parent_linkage(run)` on an `AsyncExitStack`
+   so `agent_session_id_var` + `parent_audit_id_var` are set for the dispatch;
+5. `dispatch(...)` runs; `write_audit_row` reads those vars into the DISPATCH
+   row's columns; the exit stack resets them.
+
+Opening a run writes the run row and the anchor audit row in the same session
+so a run can never reference an anchor id that has no `audit_log` row (which
+would re-scatter replay into per-dispatch roots).
+
+## Dependencies
+
+- `operations/_audit.py` — the `agent_session_id_var` / `parent_audit_id_var` /
+  `work_ref_var` contextvars and the `write_audit_row` reader. Unchanged by
+  this task; the linkage only binds vars it already reads.
+- `audit_query/replay.py` — `replay_session` (recursive CTE) is unchanged: it
+  already descends `parent_audit_id`, so a correctly-parented dispatch row
+  surfaces under the anchor with no query change.
+- `operations/addon_pairing.py` — `get_by_client_id` + the `_is_unique_violation`
+  dialect-portable helper.
+- `auth/jwt.py` / `auth/operator.py` — the `client_id` recovery seam.
+
+## Known issues / follow-ups
+
+- **No dedicated REST read surface** for orchestration runs. Operators reach a
+  run's subtree the existing way: `GET /api/v1/audit?work_ref=<ref>` surfaces
+  the rows (all carrying the synthesized `session_id`), then
+  `GET /api/v1/audit/sessions/{session_id}/replay` renders the tree. A
+  first-class "list my orchestration runs" endpoint is a possible follow-up,
+  not required by the task.
+- **clientId recovery is username-derived.** `client_id` is stripped from the
+  `service-account-<clientId>` marker, not read from a dedicated `azp` claim.
+  That keeps it consistent with the #3178 service classification and needs no
+  new Keycloak mapper, but a realm that stops emitting the marker would drop
+  the linkage (the dispatch would simply fall back to an independent audit
+  row — fail-open into the pre-#3028 behaviour, never a wrong subtree).
+- **Run rows are not reaped.** An orchestration run row is small and durable;
+  a retention sweep (mirroring approval-request TTLs) is a later concern.
+- This generalises the "verify the caller's client id against the pairing's
+  `keycloak_client_id`" hardening item named in
+  [`addon-pairing.md`](addon-pairing.md) §Known issues — the same clientId ↔
+  pairing binding, applied to audit parent-linkage.
+
+## References
+
+- Initiative #2900 (add-on pairing contract, scope item 4), Task #3028.
+- #2086 — the in-process replay-as-tree lineage this extends
+  (`operations/approval_queue.py` `_dispatch_resume_with_bound_context` is the
+  re-bind precedent).
+- #3025 / [`addon-pairing.md`](addon-pairing.md) — the pairing identity plane
+  this linkage authorizes against.
+- #3178 — service-account (`principal_kind=service`) classification, the
+  `client_id` recovery seam's basis.
+- v0.1-spec §6 (synchronous append-only audit), §4 (JSONFlux); CLAUDE.md
+  postulate 7 (audit lineage).


### PR DESCRIPTION
## Summary

- Extends #2086's in-process replay-as-tree lineage to **out-of-process** orchestrators (Initiative #2900, scope item 4). A paired add-on driving a multi-step run from outside the backplane has no in-process parent audit row to hang its per-step `call_operation` dispatches off, so each would land as an independent replay root. This synthesises the missing parent.
- The first dispatch a paired **service** principal issues under a given `work_ref` opens an orchestration run: one `addon_orchestration_run` row (migration `0080`) keyed by `(keycloak_client_id, work_ref)` carrying a fresh `session_id` + `anchor_audit_id`, plus one `addon.orchestration` anchor audit row. Every later dispatch for that work_ref resolves the same run and binds the two lineage contextvars around the dispatch, so its DISPATCH row nests under the anchor and `/audit/sessions/{id}/replay` reconstructs **one subtree**.
- **Linkage only from the paired principal for its own work_refs**: offered only to a `PrincipalKind.SERVICE` principal whose recovered `client_id` resolves to a live pairing in its own tenant, and the run is keyed by the caller's own `keycloak_client_id`, so a different add-on presenting the same work_ref string gets its own isolated subtree; non-paired principals (users, agents, unpaired service accounts) are untouched. The caller's `client_id` is recovered at JWT verification from the `service-account-<clientId>` username marker (#3178) and surfaced on `Operator`.
- Audit stays synchronous append-only (v0.1-spec §6): the anchor is an ordinary audit row carrying only its own columns; **no** back-reference is added to `audit_log`. Replay's recursive CTE is unchanged — it already descends `parent_audit_id`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean on changed modules (the one error is a pre-existing darwin-only `socket.MSG_ERRQUEUE` in `connectors/net/icmp.py`, resolves on Linux CI)
- [x] `code-quality.py --diff` — 0 blockers (warnings are pre-existing / warn-level)
- [x] Acceptance criterion 1 — *multi-dispatch external run replays as one subtree*: `test_run_replays_as_one_subtree`
- [x] Acceptance criterion 2 — *linkage only from the paired principal for its own work_refs*: `test_non_service_principal_gets_no_linkage`, `test_unpaired_service_principal_gets_no_linkage`, `test_service_principal_without_client_id_gets_no_linkage`, `test_cross_tenant_pairing_is_declined`, `test_distinct_principals_same_work_ref_are_isolated`
- [x] Resolve-or-open idempotency + single-anchor write + contextvar bind/reset — `test_addon_orchestration_linkage.py` (12 tests)
- [x] `client_id` recovery seam — `test_auth_principal_kind.py` (`_extract_client_id` + end-to-end via `verify_jwt`)
- [x] Impacted suites green: `test_addon_pairing_service`, `test_addon_pairing_conformance`, `test_mcp_surface_conformance` (no new MCP tool — internal dispatch behaviour, not a meta-tool), `test_mcp_human_only_surface`, `test_mcp_audit`, `tests/migrations/*` (alembic probe + uuid consistency), plus a direct `alembic upgrade head` (single head `0080`) + `downgrade -1`
- [x] Both per-test TRUNCATE lists updated for the new tenant-FK table (integration conftest ×2 + acceptance `_TRUNCATE_TABLES`)

## Out of scope (recorded, deferred)

- No dedicated REST read surface for orchestration runs — operators reach a subtree via `GET /api/v1/audit?work_ref=<ref>` → `.../sessions/{session_id}/replay` (no new route, so no OpenAPI/Go-client regen needed).
- Run-row retention sweep (mirroring approval-request TTLs).
- Sibling #2900 tasks land in parallel: #3026 capability advertisement (PR #3204), #3027 step-event push.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3028
