### PR TITLE
feat(pairing): durable step-event push contract scoped to the paired add-on's lineage (#3027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ connector-related release-notes line.
   its own events and one add-on can never read another's — even when their
   events share a `work_ref`. Pairing now captures the add-on's
   service-account `sub` at pair time (`AddonPairing.service_account_sub`)
-  as the identity join key. New migration `0082` (`addon_step_event` +
+  as the identity join key. New migration `0083` (`addon_step_event` +
   `service_account_sub`). See `docs/codebase/addon-step-events.md`.
 
 ### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975 / PR #3184)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,24 @@ connector-related release-notes line.
   append-only: the anchor is an ordinary audit row carrying only its own
   columns (new migration `0082`, `addon_orchestration_run`).
 
+### Added — step-event push contract: durable, resumable subscription scoped to the paired add-on's lineage (#3027)
+
+- A paired add-on gains a **durable, resumable** outbound subscription to
+  the step events that belong to its own work — approval outcomes and
+  dispatch completions — replacing the at-most-once, count-trimmed Valkey
+  SSE feed a restart silently loses events across. The add-on reads
+  `GET /api/v1/addons/pairings/{name}/events?after=<seq>` as its own
+  service principal; each event carries a monotonic `seq`, so the add-on
+  persists the last `seq` it saw and reads strictly forward on reconnect —
+  no missed events across its own restarts. Scoping is structural: a step
+  event is attributed to a pairing at **write** time by the responsible
+  principal's Keycloak `sub`, so a pairing's durable log only ever holds
+  its own events and one add-on can never read another's — even when their
+  events share a `work_ref`. Pairing now captures the add-on's
+  service-account `sub` at pair time (`AddonPairing.service_account_sub`)
+  as the identity join key. New migration `0082` (`addon_step_event` +
+  `service_account_sub`). See `docs/codebase/addon-step-events.md`.
+
 ### Fixed — `datastore.usage` scopes VM placement per datastore off vim, not an ignorable filter (#2975 / PR #3184)
 
 - `vmware.composite.datastore.usage` enriched every datastore row with the

--- a/backend/alembic/versions/0082_create_addon_step_event.py
+++ b/backend/alembic/versions/0082_create_addon_step_event.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Step-event push contract: ``service_account_sub`` + ``addon_step_event`` (#3027).
+
+The durable substrate of the add-on step-event push contract (Initiative
+#2900, Task #3027): a paired add-on subscribes to a durable, resumable
+stream of the step events (approval outcomes, dispatch completions) that
+belong to **its own** work — replacing the at-most-once, count-trimmed
+Valkey SSE feed a restart would silently lose events across.
+
+Two additive changes, no ALTER of an existing object beyond the single new
+column (migration-compat contract):
+
+1. ``addon_pairing.service_account_sub`` — the Keycloak service-account
+   user id (the OIDC ``sub`` the add-on's ``client_credentials`` tokens
+   carry). NULL for pairings created before this migration. It is the join
+   key that binds a produced row (``approval_request.principal_sub`` /
+   ``agent_run.identity_sub`` — both the add-on's ``sub``) to its pairing,
+   and binds a subscription request to its pairing (``service_account_sub
+   == operator.sub``). Captured at pair time from Keycloak; a NULL row
+   simply never matches (fail-closed) until it re-pairs.
+
+2. ``addon_step_event`` — one durable row per step event delivered to a
+   paired add-on. ``seq`` is a ``BIGSERIAL`` monotonic cursor (the same
+   portable-serial shape ``event_outbox.event_id`` uses) so an add-on
+   resumes with ``WHERE pairing_id = :p AND seq > :after ORDER BY seq``
+   and never misses a committed event across its own restarts. The
+   ``pairing_id`` FK is ``ON DELETE CASCADE`` so unpair (which hard-deletes
+   the pairing row) takes the step-event log with it — an unpaired
+   backplane stays byte-identical to a never-paired one.
+
+Revision numbering: this branch was cut from head ``0079``, so
+``down_revision`` points at ``0079`` and the chain is linear here.
+Sibling wave-2 PRs claimed ``0080`` and ``0081``; this migration is filed
+as ``0082`` so it does not collide on the filename. When those siblings
+land first, ``down_revision`` must be re-pointed to the then-current head
+(``0081``) at merge time — an additive re-point, no DDL change.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0082"
+# Cut from head 0079 (siblings claimed 0080/0081); re-point to the current
+# head at merge time if those land first.
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # (1) The pairing -> service-account-subject join key. Nullable: rows
+    # written by the #3025 pair path predate the fetch; a NULL never
+    # matches a produced ``sub`` (fail-closed).
+    op.add_column(
+        "addon_pairing",
+        sa.Column("service_account_sub", sa.Text(), nullable=True),
+    )
+    # Drives both the produce-time attribution lookup
+    # (``service_account_sub == owner_principal_sub``) and the
+    # subscription bind (``service_account_sub == operator.sub``). Plain
+    # b-tree, not unique: Keycloak client uniqueness already makes the
+    # service-account subject one-per-pairing, and a plain index sidesteps
+    # cross-dialect partial-unique-with-NULL grammar.
+    op.create_index(
+        "addon_pairing_service_account_sub_idx",
+        "addon_pairing",
+        ["service_account_sub"],
+        postgresql_using="btree",
+    )
+
+    # (2) The durable step-event log.
+    payload_type = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+    # Portable BIGSERIAL: BigInteger + primary_key + autoincrement compiles
+    # to BIGSERIAL on PG; Integer on SQLite is the only rowid-aliasing
+    # autoincrement shape. Same pattern as event_outbox.event_id (0027).
+    seq_type = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
+
+    op.create_table(
+        "addon_step_event",
+        sa.Column(
+            "seq",
+            seq_type,
+            primary_key=True,
+            autoincrement=True,
+            nullable=False,
+        ),
+        # Stable, client-facing event id (distinct from the seq cursor):
+        # lets an add-on dedupe on reconnect without depending on the
+        # dialect-specific seq value.
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "pairing_id",
+            sa.Uuid(),
+            sa.ForeignKey("addon_pairing.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_kind", sa.Text(), nullable=False),
+        sa.Column("work_ref", sa.Text(), nullable=True),
+        # Convention-only reference to ``audit_log.id`` (no enforced FK,
+        # mirroring BroadcastEvent.audit_id): the audit row is the
+        # canonical record, this is the downstream durable delivery view.
+        sa.Column("audit_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "payload",
+            payload_type,
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+
+    # Resume read: ``WHERE pairing_id = :p AND seq > :after ORDER BY seq``.
+    op.create_index(
+        "addon_step_event_pairing_seq_idx",
+        "addon_step_event",
+        ["pairing_id", "seq"],
+        postgresql_using="btree",
+    )
+    # Stable event-id uniqueness (per-tenant would also do; global is
+    # simplest and matches the UUID's global namespace).
+    op.create_index(
+        "addon_step_event_id_idx",
+        "addon_step_event",
+        ["id"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("addon_step_event_id_idx", table_name="addon_step_event")
+    op.drop_index("addon_step_event_pairing_seq_idx", table_name="addon_step_event")
+    op.drop_table("addon_step_event")
+    op.drop_index(
+        "addon_pairing_service_account_sub_idx",
+        table_name="addon_pairing",
+    )
+    op.drop_column("addon_pairing", "service_account_sub")

--- a/backend/alembic/versions/0083_create_addon_step_event.py
+++ b/backend/alembic/versions/0083_create_addon_step_event.py
@@ -33,7 +33,7 @@ column (migration-compat contract):
 Revision numbering: this branch was cut from head ``0079``, so
 ``down_revision`` points at ``0079`` and the chain is linear here.
 Sibling wave-2 PRs claimed ``0080`` and ``0081``; this migration is filed
-as ``0082`` so it does not collide on the filename. When those siblings
+as ``0083`` so it does not collide on the filename. When those siblings
 land first, ``down_revision`` must be re-pointed to the then-current head
 (``0081``) at merge time — an additive re-point, no DDL change.
 """
@@ -45,10 +45,10 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = "0082"
+revision: str = "0083"
 # Cut from head 0079 (siblings claimed 0080/0081); re-point to the current
 # head at merge time if those land first.
-down_revision: str | None = "0079"
+down_revision: str | None = "0082"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/api/v1/addon_pairing.py
+++ b/backend/src/meho_backplane/api/v1/addon_pairing.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 from typing import Annotated, Final
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi import status as http_status
 from fastapi.responses import Response
 
@@ -63,6 +63,10 @@ from meho_backplane.operations.addon_pairing_schemas import (
     PairedAddonListResponse,
     PairedAddonRead,
 )
+from meho_backplane.operations.addon_step_events import (
+    AddonStepEventService,
+    StepEventListResponse,
+)
 
 __all__ = ["router"]
 
@@ -82,7 +86,12 @@ _OP_IDS: Final[dict[str, str]] = {
     "pair": "addon.pair",
     "unpair": "addon.unpair",
     "heartbeat": "addon.heartbeat",
+    "events": "addon.events",
 }
+
+#: Default / maximum step-event page size for the subscription read.
+_EVENTS_DEFAULT_LIMIT: Final[int] = 100
+_EVENTS_MAX_LIMIT: Final[int] = 500
 
 
 def _handle_admin_error(exc: KeycloakAdminError) -> HTTPException:
@@ -231,3 +240,56 @@ async def heartbeat_pairing(
             status_code=http_status.HTTP_404_NOT_FOUND,
             detail="addon_not_paired",
         ) from exc
+
+
+@router.get("/{name}/events", response_model=StepEventListResponse)
+async def list_step_events(
+    name: Annotated[str, Path()],
+    after: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=_EVENTS_MAX_LIMIT)] = _EVENTS_DEFAULT_LIMIT,
+    operator: Operator = _require_jwt,
+) -> StepEventListResponse:
+    """Durable, resumable step-event subscription for the paired add-on (#3027).
+
+    The add-on authenticates as its own **service** principal (a non-service
+    principal is 403) and reads the step events (approval outcomes, dispatch
+    completions) that belong to **its own** work. Scoping is cryptographic:
+    the caller is bound to a pairing by its token ``sub`` (which is the
+    pairing's ``service_account_sub``), and ``{name}`` must be that same
+    pairing — a service principal can never read another add-on's log. A
+    caller whose ``sub`` binds to no pairing, or whose bound pairing is not
+    ``{name}``, gets 404 (indistinguishable from a missing pairing).
+
+    Resume: ``after`` is the last ``seq`` the add-on saw (``0`` reads from
+    the start of the retained log); the response's ``next_cursor`` is the
+    ``seq`` to pass as ``after`` on the next poll, so an add-on never misses
+    a committed event across its own restarts.
+    """
+    if operator.principal_kind is not PrincipalKind.SERVICE:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="events_require_service_principal",
+        )
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["events"],
+        audit_op_class="read",
+        audit_addon_name=name,
+    )
+    service = AddonStepEventService()
+    pairing = await service.resolve_pairing_for_sub(
+        tenant_id=operator.tenant_id,
+        service_account_sub=operator.sub,
+    )
+    # A 404 whether the caller binds to no pairing or to a different one:
+    # never reveal another add-on's pairing name, and never leak whether a
+    # name exists to a principal that does not own it.
+    if pairing is None or pairing.name != name:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="addon_not_paired",
+        )
+    return await service.list_for_pairing(
+        pairing_id=pairing.id,
+        after_seq=after,
+        limit=limit,
+    )

--- a/backend/src/meho_backplane/auth/keycloak_admin.py
+++ b/backend/src/meho_backplane/auth/keycloak_admin.py
@@ -523,6 +523,57 @@ class KeycloakAdminClient:
             )
         return secret
 
+    async def get_service_account_user_id(self, keycloak_internal_id: str) -> str:
+        """Return the Keycloak service-account user id for a confidential client.
+
+        Calls ``GET /clients/{id}/service-account-user`` (#3027). A
+        confidential ``serviceAccountsEnabled`` client owns a hidden
+        service-account **user**; the OIDC ``sub`` its ``client_credentials``
+        tokens carry is that user's id, not the client's ``clientId`` or
+        internal id. The add-on pairing path persists this as
+        ``AddonPairing.service_account_sub`` so a produced row
+        (``approval_request.principal_sub`` / ``agent_run.identity_sub``)
+        and a subscription request (``operator.sub``) both join back to the
+        pairing.
+
+        Raises
+        ------
+        KeycloakClientNotFoundError
+            The internal id is unknown (Keycloak 404).
+        KeycloakAdminError
+            A non-404 failure, or a 200 whose body carries no ``id`` (a
+            client without service accounts enabled).
+        """
+        assert self._http is not None
+        assert self._token
+        log = structlog.get_logger(__name__)
+        url = f"{self._admin_url}/clients/{keycloak_internal_id}/service-account-user"
+        try:
+            resp = await self._http.get(url, headers=self._auth_headers())
+        except httpx.HTTPError as exc:
+            raise KeycloakAdminError(
+                f"Keycloak get_service_account_user_id network error: {type(exc).__name__}"
+            ) from exc
+        if resp.status_code == 404:
+            raise KeycloakClientNotFoundError(f"Keycloak client {keycloak_internal_id!r} not found")
+        if resp.status_code != 200:
+            log.warning(
+                "keycloak_get_service_account_user_failed",
+                keycloak_internal_id=keycloak_internal_id,
+                status=resp.status_code,
+            )
+            raise KeycloakAdminError(
+                f"Keycloak get_service_account_user_id failed: HTTP {resp.status_code}"
+            )
+        representation: dict[str, Any] = resp.json()
+        service_account_sub = str(representation.get("id", "")).strip()
+        if not service_account_sub:
+            raise KeycloakAdminError(
+                f"Keycloak get_service_account_user_id returned no user id for "
+                f"client {keycloak_internal_id!r} (service accounts not enabled?)"
+            )
+        return service_account_sub
+
     async def disable_client(self, keycloak_internal_id: str) -> None:
         """Disable the Keycloak client identified by *keycloak_internal_id*.
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4345,8 +4345,13 @@ class AddonStepEvent(Base):
     * ``seq`` -- ``BIGSERIAL`` primary key. The monotonic resume cursor:
       an add-on resumes with ``WHERE pairing_id = :p AND seq > :after
       ORDER BY seq`` and never misses a committed event across its own
-      restarts. ``BIGSERIAL`` on PG; ``Integer`` autoincrement on SQLite
-      via :data:`_PORTABLE_BIG_SERIAL` (same shape as
+      restarts. That "never misses" property needs commit order to equal
+      ``seq`` order per pairing (``seq`` is drawn at INSERT but visible only
+      at COMMIT); the recorder guarantees it with a per-pairing advisory
+      lock across the assign→commit window
+      (:meth:`~meho_backplane.operations.addon_step_events.AddonStepEventService._serialize_pairing_seq`).
+      ``BIGSERIAL`` on PG; ``Integer`` autoincrement on SQLite via
+      :data:`_PORTABLE_BIG_SERIAL` (same shape as
       :attr:`EventOutbox.event_id`).
     * ``id`` -- UUID. Stable, client-facing event id (distinct from the
       dialect-specific ``seq``) so an add-on can dedupe on reconnect.

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4261,6 +4261,18 @@ class AddonPairing(Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     keycloak_client_id: Mapped[str] = mapped_column(Text, nullable=False)
     keycloak_internal_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # The Keycloak service-account user id (the OIDC ``sub`` the add-on's
+    # ``client_credentials`` tokens carry). The join key that binds a
+    # produced row (``approval_request.principal_sub`` /
+    # ``agent_run.identity_sub``) and a subscription request
+    # (``operator.sub``) back to this pairing (#3027 step-event push).
+    # NULL for pairings created before migration 0082 -- a NULL never
+    # matches a produced ``sub`` (fail-closed) until the add-on re-pairs.
+    service_account_sub: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
     owner_sub: Mapped[str] = mapped_column(Text, nullable=False)
     contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
     addon_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -4292,6 +4304,120 @@ class AddonPairing(Base):
         Index(
             "addon_pairing_keycloak_client_id_idx",
             "keycloak_client_id",
+            unique=True,
+            postgresql_using="btree",
+        ),
+        # Drives the #3027 produce-time attribution lookup
+        # (``service_account_sub == owner_principal_sub``) and the
+        # subscription bind (``service_account_sub == operator.sub``).
+        Index(
+            "addon_pairing_service_account_sub_idx",
+            "service_account_sub",
+            postgresql_using="btree",
+        ),
+    )
+
+
+class AddonStepEvent(Base):
+    """One durable step event delivered to a paired add-on (#3027).
+
+    The step-event push contract's durable substrate (Initiative #2900,
+    Task #3027): a paired add-on subscribes to a resumable stream of the
+    step events that belong to **its own** work — approval outcomes
+    (``approval.approved`` / ``approval.rejected`` / ``approval.expired``)
+    and dispatch completions (``agent_run.completed``) — replacing the
+    at-most-once, count-trimmed Valkey SSE feed a restart would silently
+    lose events across.
+
+    Attribution is by identity, enforced at write time: a step event is
+    recorded only when the producing row's responsible principal
+    (``approval_request.principal_sub`` / ``agent_run.identity_sub``, both
+    the add-on's Keycloak service-account ``sub``) matches a pairing's
+    :attr:`AddonPairing.service_account_sub`. The row is therefore stamped
+    with that ``pairing_id``, and a subscription — bound to the caller's
+    own pairing by its token ``sub`` — only ever reads its own rows. An
+    event outside the paired principal's lineage is never written into
+    another pairing's log, so it can never be delivered.
+
+    Columns
+    -------
+
+    * ``seq`` -- ``BIGSERIAL`` primary key. The monotonic resume cursor:
+      an add-on resumes with ``WHERE pairing_id = :p AND seq > :after
+      ORDER BY seq`` and never misses a committed event across its own
+      restarts. ``BIGSERIAL`` on PG; ``Integer`` autoincrement on SQLite
+      via :data:`_PORTABLE_BIG_SERIAL` (same shape as
+      :attr:`EventOutbox.event_id`).
+    * ``id`` -- UUID. Stable, client-facing event id (distinct from the
+      dialect-specific ``seq``) so an add-on can dedupe on reconnect.
+    * ``tenant_id`` -- UUID NOT NULL, real ``REFERENCES tenant(id)`` FK.
+    * ``pairing_id`` -- UUID NOT NULL, ``REFERENCES addon_pairing(id) ON
+      DELETE CASCADE``. Unpair hard-deletes the pairing row, cascading the
+      step-event log away so an unpaired backplane is byte-identical to a
+      never-paired one.
+    * ``event_kind`` -- Text NOT NULL. The step-event discriminator
+      (``approval.<decision>``, ``agent_run.completed``). Free-text, same
+      discipline as :attr:`EventOutbox.event_kind`.
+    * ``work_ref`` -- Text nullable. The external change-ticket reference
+      the add-on filters its own work on; ``None`` when the producing row
+      carried none.
+    * ``audit_id`` -- UUID nullable. Convention-only reference to
+      ``audit_log.id`` (no enforced FK, mirroring
+      :attr:`~meho_backplane.broadcast.events.BroadcastEvent.audit_id`):
+      audit is the canonical record, this is the durable delivery view.
+    * ``payload`` -- portable JSON -> JSONB NOT NULL default ``{}``. The
+      event-specific body the add-on consumes.
+    * ``created_at`` -- ``timestamptz`` NOT NULL DEFAULT ``now()``.
+
+    Migration ``0082``.
+    """
+
+    __tablename__ = "addon_step_event"
+
+    seq: Mapped[int] = mapped_column(
+        _PORTABLE_BIG_SERIAL,
+        primary_key=True,
+        autoincrement=True,
+    )
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        nullable=False,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    pairing_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("addon_pairing.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    event_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    work_ref: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    audit_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(), nullable=True, default=None)
+    payload: Mapped[dict[str, object]] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "addon_step_event_pairing_seq_idx",
+            "pairing_id",
+            "seq",
+            postgresql_using="btree",
+        ),
+        Index(
+            "addon_step_event_id_idx",
+            "id",
             unique=True,
             postgresql_using="btree",
         ),

--- a/backend/src/meho_backplane/operations/addon_pairing.py
+++ b/backend/src/meho_backplane/operations/addon_pairing.py
@@ -174,7 +174,7 @@ class AddonPairingService:
         client_id = _keycloak_client_id(payload.name)
         audience = get_settings().keycloak_audience
 
-        internal_id, client_secret = await self._provision_keycloak_client(
+        internal_id, client_secret, service_account_sub = await self._provision_keycloak_client(
             name=payload.name,
             tenant_id=tenant_id,
             owner_sub=owner,
@@ -186,6 +186,7 @@ class AddonPairingService:
             name=payload.name,
             keycloak_client_id=client_id,
             keycloak_internal_id=internal_id,
+            service_account_sub=service_account_sub,
             owner_sub=owner,
             contract_version=negotiated.negotiated_version,
             addon_contract_version=payload.addon_contract_version,
@@ -216,17 +217,22 @@ class AddonPairingService:
         tenant_id: uuid.UUID,
         owner_sub: str,
         audience: str,
-    ) -> tuple[str, str]:
-        """Create the add-on's ``kind=service`` client and read back its secret.
+    ) -> tuple[str, str, str]:
+        """Create the add-on's ``kind=service`` client and read back its identity.
 
         Isolated so its rollback contract is one unit: if anything after
-        ``create_client`` raises — most importantly ``get_client_secret`` —
-        the just-created live client is deleted before the error propagates.
-        A 409 conflict surfaces as :class:`AddonAlreadyPairedError` (the
-        conflicting client belongs to a prior pairing and is not ours to
-        delete).
+        ``create_client`` raises — ``get_client_secret`` or
+        ``get_service_account_user_id`` — the just-created live client is
+        deleted before the error propagates. A 409 conflict surfaces as
+        :class:`AddonAlreadyPairedError` (the conflicting client belongs to
+        a prior pairing and is not ours to delete).
 
-        Returns the ``(keycloak_internal_id, client_secret)`` pair.
+        Returns the ``(keycloak_internal_id, client_secret,
+        service_account_sub)`` triple. ``service_account_sub`` is the OIDC
+        ``sub`` the add-on's tokens carry (#3027) — the join key for the
+        step-event subscription; captured here, at the one point the
+        backplane provisions the identity, so it is never inferred from an
+        unverified token later.
         """
         client_id = _keycloak_client_id(name)
         internal_id: str | None = None
@@ -244,6 +250,7 @@ class AddonPairingService:
                     kind_attribute="service",
                 )
                 client_secret = await kc_client.get_client_secret(internal_id)
+                service_account_sub = await kc_client.get_service_account_user_id(internal_id)
         except KeycloakClientConflictError as exc:
             raise AddonAlreadyPairedError(name) from exc
         except BaseException as exc:
@@ -252,7 +259,7 @@ class AddonPairingService:
                     internal_id, tenant_id=tenant_id, name=name, cause=exc
                 )
             raise
-        return internal_id, client_secret
+        return internal_id, client_secret, service_account_sub
 
     async def _insert_row(
         self,

--- a/backend/src/meho_backplane/operations/addon_step_events.py
+++ b/backend/src/meho_backplane/operations/addon_step_events.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add-on step-event push contract — durable recorder + resumable read (#3027).
+
+The step-event push contract (Initiative #2900, Task #3027) gives a paired
+add-on a **durable, resumable** outbound subscription to the step events
+that belong to its own work — approval outcomes and dispatch completions —
+replacing the at-most-once, count-trimmed Valkey SSE feed a restart would
+silently lose events across.
+
+Two responsibilities, one cohesive service:
+
+* **Record** (:meth:`AddonStepEventService.record_if_owned` /
+  :meth:`record_if_owned_committed`) — called at the producer sites
+  (approval-lifecycle notifications, agent-run terminal transition) with
+  the responsible principal's Keycloak ``sub``. A step event is written
+  **only** when that ``sub`` matches a pairing's
+  :attr:`~meho_backplane.db.models.AddonPairing.service_account_sub`; the
+  row is stamped with that ``pairing_id``. A produced event whose principal
+  is not a paired add-on is a cheap no-op (one indexed lookup, no write),
+  so the overwhelmingly common non-add-on producer path costs almost
+  nothing.
+
+* **Read** (:meth:`AddonStepEventService.list_for_pairing`) — the
+  subscription surface. Bound (by the caller's token ``sub`` →
+  :meth:`resolve_pairing_for_sub`) to the caller's **own** pairing, it
+  returns that pairing's events with ``seq > after`` in ``seq`` order.
+  ``seq`` is a monotonic ``BIGSERIAL`` cursor, so an add-on persists the
+  last ``seq`` it saw, reconnects, and reads strictly forward — no missed
+  events across its own restarts (durable delivery with resume).
+
+Scoping is structural: attribution happens at write time by identity, so a
+pairing's log only ever contains that pairing's events. An event outside
+the paired principal's lineage is never written into another pairing's log
+and therefore can never be delivered — the property the acceptance test
+pins.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, AddonStepEvent
+
+__all__ = [
+    "AddonStepEventService",
+    "StepEventListResponse",
+    "StepEventRead",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class StepEventRead(BaseModel):
+    """One step event as delivered to a subscribed add-on."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    seq: int
+    id: uuid.UUID
+    event_kind: str
+    work_ref: str | None
+    audit_id: uuid.UUID | None
+    payload: dict[str, object]
+    created_at: datetime
+
+
+class StepEventListResponse(BaseModel):
+    """A page of step events plus the cursor to resume past it.
+
+    ``next_cursor`` is the ``seq`` of the last returned event (as a string
+    so the wire cursor is opaque and dialect-agnostic); ``None`` when the
+    page is empty. The add-on passes it back as ``after`` to read strictly
+    forward on the next poll / reconnect.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[StepEventRead]
+    next_cursor: str | None = None
+
+
+class AddonStepEventService:
+    """Record + read durable step events for paired add-ons (#3027).
+
+    Stateless; instantiate per request and call freely.
+    """
+
+    def __init__(self) -> None:
+        self._log = _log
+
+    async def _resolve_pairing_id(
+        self,
+        session: AsyncSession,
+        *,
+        tenant_id: uuid.UUID,
+        service_account_sub: str,
+    ) -> uuid.UUID | None:
+        """Return the pairing id whose service-account ``sub`` matches, else ``None``.
+
+        The ``addon_pairing_service_account_sub_idx`` makes this a cheap
+        indexed lookup. A ``NULL`` ``service_account_sub`` (a pre-#3027
+        pairing) never matches a real ``sub``, so an un-backfilled pairing
+        fails closed until it re-pairs.
+        """
+        result = await session.execute(
+            select(AddonPairing.id).where(
+                AddonPairing.tenant_id == tenant_id,
+                AddonPairing.service_account_sub == service_account_sub,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def record_if_owned(
+        self,
+        session: AsyncSession,
+        *,
+        tenant_id: uuid.UUID,
+        owner_principal_sub: str | None,
+        event_kind: str,
+        work_ref: str | None,
+        audit_id: uuid.UUID | None,
+        payload: dict[str, object],
+    ) -> AddonStepEvent | None:
+        """Append a step event in *session* iff its owner is a paired add-on.
+
+        Same-transaction discipline: the row is added and flushed (so
+        ``seq`` is populated) but **not** committed — the caller's
+        transaction owns the commit, so a producer rollback discards the
+        step event alongside the state change that produced it.
+
+        Returns the inserted :class:`AddonStepEvent`, or ``None`` when
+        *owner_principal_sub* is absent or not a paired add-on's
+        service-account ``sub`` (the cheap no-op common path).
+        """
+        if not owner_principal_sub:
+            return None
+        pairing_id = await self._resolve_pairing_id(
+            session,
+            tenant_id=tenant_id,
+            service_account_sub=owner_principal_sub,
+        )
+        if pairing_id is None:
+            return None
+        row = AddonStepEvent(
+            tenant_id=tenant_id,
+            pairing_id=pairing_id,
+            event_kind=event_kind,
+            work_ref=work_ref,
+            audit_id=audit_id,
+            payload=payload,
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    async def record_if_owned_committed(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        owner_principal_sub: str | None,
+        event_kind: str,
+        work_ref: str | None,
+        audit_id: uuid.UUID | None,
+        payload: dict[str, object],
+    ) -> None:
+        """Fail-open variant that owns its own committed transaction.
+
+        For producer sites without an ambient session in the producing
+        transaction — the post-commit approval-lifecycle notification. It
+        opens its own session, records, and commits. A failure is logged
+        and swallowed (fail-open), matching the surrounding approval
+        broadcast posture: a step-event write must never block the durable
+        approval decision, and the add-on re-reads forward by ``seq`` on
+        its next poll.
+        """
+        try:
+            sessionmaker = get_sessionmaker()
+            async with sessionmaker() as session:
+                row = await self.record_if_owned(
+                    session,
+                    tenant_id=tenant_id,
+                    owner_principal_sub=owner_principal_sub,
+                    event_kind=event_kind,
+                    work_ref=work_ref,
+                    audit_id=audit_id,
+                    payload=payload,
+                )
+                if row is None:
+                    return
+                await session.commit()
+        except Exception:
+            self._log.exception(
+                "addon_step_event_record_failed",
+                event_kind=event_kind,
+                tenant_id=str(tenant_id),
+            )
+
+    async def resolve_pairing_for_sub(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        service_account_sub: str,
+    ) -> AddonPairing | None:
+        """Return the pairing the caller's token ``sub`` binds to, else ``None``.
+
+        The subscription bind: a paired add-on authenticates as its
+        service principal, whose ``sub`` is exactly the
+        ``service_account_sub`` captured at pair time. A caller whose
+        ``sub`` matches no pairing (a non-add-on service principal, or a
+        pre-#3027 pairing with a ``NULL`` ``service_account_sub``) resolves
+        to ``None`` and is refused.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonPairing).where(
+                    AddonPairing.tenant_id == tenant_id,
+                    AddonPairing.service_account_sub == service_account_sub,
+                )
+            )
+            return result.scalar_one_or_none()
+
+    async def list_for_pairing(
+        self,
+        *,
+        pairing_id: uuid.UUID,
+        after_seq: int = 0,
+        limit: int = 100,
+    ) -> StepEventListResponse:
+        """Return this pairing's step events with ``seq > after_seq``, ``seq``-ordered.
+
+        The durable resume read: ``after_seq`` is the last ``seq`` the
+        add-on saw (``0`` on a cold start reads from the beginning of the
+        retained log). Rows are ordered by the monotonic ``seq`` and
+        capped at *limit*; ``next_cursor`` is the last returned ``seq`` so
+        the add-on reads strictly forward on its next call.
+        """
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1; got {limit}")
+        if after_seq < 0:
+            raise ValueError(f"after_seq must be >= 0; got {after_seq}")
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AddonStepEvent)
+                .where(
+                    AddonStepEvent.pairing_id == pairing_id,
+                    AddonStepEvent.seq > after_seq,
+                )
+                .order_by(AddonStepEvent.seq)
+                .limit(limit)
+            )
+            rows = result.scalars().all()
+        items = [StepEventRead.model_validate(row) for row in rows]
+        next_cursor = str(items[-1].seq) if items else None
+        return StepEventListResponse(items=items, next_cursor=next_cursor)

--- a/backend/src/meho_backplane/operations/addon_step_events.py
+++ b/backend/src/meho_backplane/operations/addon_step_events.py
@@ -30,6 +30,19 @@ Two responsibilities, one cohesive service:
   last ``seq`` it saw, reconnects, and reads strictly forward — no missed
   events across its own restarts (durable delivery with resume).
 
+The ``seq > after`` high-watermark cursor is only exact if, for a given
+pairing, ``seq`` order equals **commit** order. It does not on its own:
+``seq`` is drawn at INSERT (flush) but a row only becomes visible at
+COMMIT, so two concurrent writes to the same pairing can commit out of
+``seq`` order — a lower ``seq`` still uncommitted while a higher ``seq``
+is already visible. A reader that advances its cursor past the higher
+``seq`` would then permanently skip the lower one. The recorder closes
+that gap by holding a **transaction-scoped per-pairing advisory lock**
+(:func:`_pairing_seq_lock_key`) across the ``seq``-assign→commit window,
+so the two windows cannot interleave and commit order equals ``seq``
+order per pairing. The "no missed events" property is therefore
+structural, not best-effort.
+
 Scoping is structural: attribution happens at write time by identity, so a
 pairing's log only ever contains that pairing's events. An event outside
 the paired principal's lineage is never written into another pairing's log
@@ -39,12 +52,13 @@ pins.
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from datetime import datetime
 
 import structlog
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
@@ -57,6 +71,28 @@ __all__ = [
 ]
 
 _log = structlog.get_logger(__name__)
+
+#: Domain-separation prefix for the per-pairing seq-serialization advisory
+#: key, so this key space never collides with another subsystem that hashes
+#: a bare UUID into ``pg_advisory_xact_lock`` (the topology scheduler, the
+#: checks dashboard-transition claim). A collision would only cost a
+#: spurious wait, never a correctness bug, but the prefix keeps the key
+#: spaces disjoint by construction.
+_SEQ_LOCK_KEY_DOMAIN = b"addon_step_event_seq:"
+
+
+def _pairing_seq_lock_key(pairing_id: uuid.UUID) -> int:
+    """Map a pairing id to a stable signed-63-bit advisory-lock key.
+
+    ``pg_advisory_xact_lock`` takes a ``bigint`` (signed 64-bit). A blake2b
+    digest of the pairing UUID under a domain-separation prefix is
+    deterministic and well-distributed; masking to 63 bits keeps it
+    non-negative so it round-trips through asyncpg's ``bigint`` binding
+    without tripping the sign bit. Mirrors
+    :func:`meho_backplane.checks.investigate._dashboard_transition_lock_key`.
+    """
+    digest = hashlib.blake2b(_SEQ_LOCK_KEY_DOMAIN + pairing_id.bytes, digest_size=8).digest()
+    return int.from_bytes(digest, "big") & 0x7FFF_FFFF_FFFF_FFFF
 
 
 class StepEventRead(BaseModel):
@@ -119,6 +155,41 @@ class AddonStepEventService:
         )
         return result.scalar_one_or_none()
 
+    async def _serialize_pairing_seq(self, session: AsyncSession, pairing_id: uuid.UUID) -> None:
+        """Serialize the ``seq``-assign→commit window for *pairing_id* on PG.
+
+        The durable-resume guarantee (AC1) is that a reader resuming from
+        ``seq > after`` never skips a **committed** lower ``seq``. ``seq``
+        is a ``BIGSERIAL`` drawn at INSERT (flush) but only made visible at
+        COMMIT, so without serialization two writes to the same pairing can
+        commit out of ``seq`` order: writer A draws ``seq=N`` and commits
+        slowly while writer B draws ``seq=N+1`` and commits first. A reader
+        that advances its cursor to ``N+1`` before A commits then never
+        returns ``N`` — a permanently skipped event.
+
+        A transaction-scoped per-pairing advisory lock, taken **before** the
+        INSERT and held to the caller's commit (``pg_advisory_xact_lock``
+        releases only at COMMIT / ROLLBACK), forces one writer's whole
+        [draw ``seq`` … commit] window to complete before the next writer to
+        the same pairing can draw its ``seq``. For a given pairing, ``seq``
+        order therefore equals commit order, so when a committed row with
+        ``seq=M`` is visible every ``seq < M`` for that pairing has already
+        committed — the high-watermark cursor is exact.
+
+        Scope is per pairing, so the lock never contends across pairings, and
+        the per-pairing write rate (one add-on's own approval outcomes +
+        dispatch completions) is low, so the serialization cost is
+        negligible. A no-op on non-PostgreSQL dialects: the SQLite unit-test
+        path is single-writer, so ``seq`` order already equals commit order
+        there. Mirrors
+        :func:`meho_backplane.checks.investigate._lock_dashboard_transition`.
+        """
+        conn = await session.connection()
+        if conn.dialect.name != "postgresql":
+            return
+        key = _pairing_seq_lock_key(pairing_id)
+        await session.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": key})
+
     async def record_if_owned(
         self,
         session: AsyncSession,
@@ -137,6 +208,13 @@ class AddonStepEventService:
         transaction owns the commit, so a producer rollback discards the
         step event alongside the state change that produced it.
 
+        Before the INSERT draws ``seq``, the caller's transaction takes the
+        per-pairing advisory lock (:meth:`_serialize_pairing_seq`) held to
+        commit, so concurrent writes to the same pairing commit in ``seq``
+        order and the resume cursor can never skip a committed lower ``seq``.
+        The lock is taken only once the owner is known to be a paired add-on,
+        so the common non-add-on producer path never touches it.
+
         Returns the inserted :class:`AddonStepEvent`, or ``None`` when
         *owner_principal_sub* is absent or not a paired add-on's
         service-account ``sub`` (the cheap no-op common path).
@@ -150,6 +228,7 @@ class AddonStepEventService:
         )
         if pairing_id is None:
             return None
+        await self._serialize_pairing_seq(session, pairing_id)
         row = AddonStepEvent(
             tenant_id=tenant_id,
             pairing_id=pairing_id,

--- a/backend/src/meho_backplane/operations/agent_run.py
+++ b/backend/src/meho_backplane/operations/agent_run.py
@@ -80,6 +80,7 @@ from meho_backplane.db.models import (
     ScheduledTriggerInFlightPolicy,
 )
 from meho_backplane.events.outbox import publish as publish_event
+from meho_backplane.operations.addon_step_events import AddonStepEventService
 
 #: Event kind the agent-run terminal-transition emits onto the outbox.
 #: The event drain's subscription matcher (:mod:`meho_backplane.events.matcher`)
@@ -559,6 +560,27 @@ async def transition(
                 # under, so a subscriber's JSONB filter can route the
                 # follow-up against runs of a specific change record.
                 # NULL when the run carried no ticket.
+                "work_ref": row.work_ref,
+            },
+        )
+        # #3027 step-event push: durably record the dispatch completion
+        # for the paired add-on that owns this run (matched by the run's
+        # responsible principal ``identity_sub``). In the producer's
+        # transaction — a run-transition rollback discards it too. A no-op
+        # when the run's principal is not a paired add-on.
+        await AddonStepEventService().record_if_owned(
+            session,
+            tenant_id=row.tenant_id,
+            owner_principal_sub=row.identity_sub,
+            event_kind=AGENT_RUN_COMPLETED_EVENT_KIND,
+            work_ref=row.work_ref,
+            audit_id=None,
+            payload={
+                "run_id": str(row.id),
+                "status": to_status.value,
+                "agent_definition_id": (
+                    str(row.agent_definition_id) if row.agent_definition_id is not None else None
+                ),
                 "work_ref": row.work_ref,
             },
         )

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -1239,7 +1239,31 @@ async def publish_approval_event(
     ``"rejected"``, or ``"expired"`` (sweeper-driven). The broadcast
     ``op_id`` is ``approval.<decision>`` so operator watchers can match
     the family with a simple glob (``approval.*``).
+
+    #3027 step-event push: alongside the fail-open Valkey broadcast, the
+    outcome is durably recorded for the paired add-on that **requested**
+    the approval (matched by ``request.principal_sub`` — the requester's
+    ``sub``, constant across the request's lifecycle, so every decision
+    routes to the same add-on regardless of who decided it). The record is
+    a self-contained fail-open commit; a no-op when the requester is not a
+    paired add-on.
     """
+    from meho_backplane.operations.addon_step_events import AddonStepEventService
+
+    await AddonStepEventService().record_if_owned_committed(
+        tenant_id=tenant_id,
+        owner_principal_sub=request.principal_sub,
+        event_kind=f"approval.{decision}",
+        work_ref=request.work_ref,
+        audit_id=audit_id,
+        payload={
+            "approval_request_id": str(request.id),
+            "decision": decision,
+            "connector_id": request.connector_id,
+            "approval_op_id": request.op_id,
+            "work_ref": request.work_ref,
+        },
+    )
     try:
         from meho_backplane.broadcast.events import BroadcastEvent, classify_op
         from meho_backplane.broadcast.publisher import publish_event

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -322,6 +322,14 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # FKs from migration ``0082``; listed so the per-test TRUNCATE of both
     # parents does not error.
     "addon_orchestration_run",
+    # ``addon_step_event`` carries real ``REFERENCES tenant(id)`` and
+    # ``REFERENCES addon_pairing(id)`` FKs from migration ``0082`` (#3027
+    # step-event push). PG rejects truncating ``tenant`` / ``addon_pairing``
+    # unless every referencing table is listed in the same statement, so
+    # this must appear here or every PG-backed acceptance test errors at
+    # setup with ``cannot truncate a table referenced in a foreign key
+    # constraint``.
+    "addon_step_event",
     "targets",
     "tenant",
 )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -460,6 +460,11 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   same rule — list it here or the per-test TRUNCATE of ``tenant``
         #   fails with ``cannot truncate a table referenced in a foreign key
         #   constraint``.
+        # * ``addon_step_event`` — migration 0082 (#3027 step-event push) carries
+        #   real ``REFERENCES tenant(id)`` and ``REFERENCES addon_pairing(id)``
+        #   FKs; must be listed alongside ``tenant`` and ``addon_pairing`` or PG
+        #   rejects the per-test TRUNCATE with ``cannot truncate a table
+        #   referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -470,6 +475,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "event_outbox, event_source, gateway_command, "
                 "service_principal_grant, addon_pairing, operation_run, "
                 "addon_capability, addon_orchestration_run, "
+                "service_principal_grant, addon_pairing, addon_step_event, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -542,6 +548,7 @@ async def pg_engine_empty_tenant(
                 "event_outbox, event_source, gateway_command, "
                 "service_principal_grant, addon_pairing, operation_run, "
                 "addon_capability, addon_orchestration_run, "
+                "service_principal_grant, addon_pairing, addon_step_event, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/integration/test_addon_step_events_concurrency.py
+++ b/backend/tests/integration/test_addon_step_events_concurrency.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Concurrency coverage for the add-on step-event recorder (#3027, B1).
+
+The unit suite (`tests/test_addon_step_events.py`) proves durable resume
+for **serial** writes on SQLite, but SQLite is single-writer and cannot
+stage the failure mode the resume cursor is actually exposed to: two
+writes to the same pairing that commit out of `seq` order. `seq` is a
+`BIGSERIAL` drawn at INSERT (flush) but only visible at COMMIT, so writer A
+can draw the lower `seq`, hold it uncommitted, while writer B draws the
+higher `seq` and commits first. A reader between the two commits would
+advance its high-watermark cursor past B and then `seq > cursor`
+permanently skips the committed A — a lost event.
+
+`AddonStepEventService._serialize_pairing_seq` closes the gap with a
+transaction-scoped per-pairing advisory lock across the assign→commit
+window. These tests exercise it against the real `pgvector/pgvector:pg16`
+container:
+
+* **serialization** — writer A holds the lock with an uncommitted lower
+  `seq`; writer B is forced to block at the lock (proven with an explicit
+  "no committed event is visible yet" read), so no higher committed `seq`
+  can exist ahead of the uncommitted lower one. After A commits, a cursor
+  walk misses nothing.
+* **scope** — the lock is *per pairing*: a concurrent write to a different
+  pairing does not block behind A's lock, so the serialization never
+  degrades into a global write bottleneck.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import func, select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, AddonStepEvent
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_step_events import AddonStepEventService
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Matches the tenant row the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+async def _seed_pairing(*, name: str, service_account_sub: str) -> uuid.UUID:
+    """Insert one paired add-on under tenant A and return its id."""
+    pairing_id = uuid.uuid4()
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        session.add(
+            AddonPairing(
+                id=pairing_id,
+                tenant_id=TENANT_A_ID,
+                name=name,
+                keycloak_client_id=f"addon:{name}",
+                keycloak_internal_id=f"kc-{name}",
+                service_account_sub=service_account_sub,
+                owner_sub="op-admin",
+                contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+                created_by_sub="op-admin",
+            )
+        )
+    return pairing_id
+
+
+@pytest.fixture
+async def paired_addon(pg_engine: None) -> AsyncIterator[tuple[uuid.UUID, str]]:
+    """A single paired add-on: yields ``(pairing_id, service_account_sub)``."""
+    sub = f"svc-{uuid.uuid4().hex[:8]}"
+    pairing_id = await _seed_pairing(name="automation", service_account_sub=sub)
+    yield pairing_id, sub
+
+
+@_skip_no_docker
+async def test_resume_misses_nothing_under_out_of_order_commit(
+    paired_addon: tuple[uuid.UUID, str],
+) -> None:
+    """The per-pairing lock forbids a committed higher ``seq`` ahead of an
+    uncommitted lower one, so a resume cursor walk misses nothing.
+
+    Stages the exact interleaving the raw ``seq > after`` cursor was unsafe
+    under: writer A draws the lower ``seq`` and holds it uncommitted while
+    writer B tries to write the same pairing. Without serialization B would
+    draw a higher ``seq`` and commit first, letting a reader skip A. With
+    the lock B is blocked until A commits, proven by the empty read while A
+    still holds its uncommitted row.
+    """
+    pairing_id, sub = paired_addon
+    svc = AddonStepEventService()
+    sm = get_sessionmaker()
+
+    # Writer A: acquire the per-pairing lock + draw the lower seq, but do
+    # NOT commit yet. The session stays open holding the xact lock.
+    session_a = sm()
+    try:
+        row_a = await svc.record_if_owned(
+            session_a,
+            tenant_id=TENANT_A_ID,
+            owner_principal_sub=sub,
+            event_kind="event.a",
+            work_ref=None,
+            audit_id=None,
+            payload={"which": "a"},
+        )
+        assert row_a is not None
+        seq_a = row_a.seq
+
+        # Writer B: a concurrent committed write to the SAME pairing. It
+        # must block at the advisory lock A holds — it cannot draw its seq.
+        task_b = asyncio.create_task(
+            svc.record_if_owned_committed(
+                tenant_id=TENANT_A_ID,
+                owner_principal_sub=sub,
+                event_kind="event.b",
+                work_ref=None,
+                audit_id=None,
+                payload={"which": "b"},
+            )
+        )
+        # Give B time to reach the lock and block on it.
+        await asyncio.sleep(0.5)
+        assert not task_b.done(), "writer B was not serialized behind A's lock"
+
+        # The anti-bug assertion: with A's lower seq still uncommitted and B
+        # blocked, the durable log holds NO event. Without the lock B would
+        # have committed its higher seq here, and a reader advancing its
+        # cursor to it would permanently skip A.
+        pre = await svc.list_for_pairing(pairing_id=pairing_id, after_seq=0, limit=100)
+        assert pre.items == []
+
+        await session_a.commit()  # release the lock; A's seq becomes visible
+    finally:
+        await session_a.close()
+
+    # B now unblocks, draws a seq strictly above A's, and commits.
+    await asyncio.wait_for(task_b, timeout=10)
+
+    # Commit order == seq order per pairing: A (committed first) has the
+    # lower seq; B the higher.
+    async with sm() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(AddonStepEvent)
+                    .where(AddonStepEvent.pairing_id == pairing_id)
+                    .order_by(AddonStepEvent.seq)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert [r.event_kind for r in rows] == ["event.a", "event.b"]
+    assert rows[0].seq == seq_a
+    assert rows[1].seq > seq_a
+
+    # Full durable-resume walk, one event per page: stepping the cursor
+    # forward yields both events in seq order with no gap and no repeat.
+    seen: list[str] = []
+    cursor = 0
+    while True:
+        page = await svc.list_for_pairing(pairing_id=pairing_id, after_seq=cursor, limit=1)
+        if not page.items:
+            break
+        seen.append(page.items[0].event_kind)
+        assert page.next_cursor is not None
+        cursor = int(page.next_cursor)
+    assert seen == ["event.a", "event.b"]
+
+
+@_skip_no_docker
+async def test_lock_is_per_pairing_and_does_not_block_a_sibling(
+    paired_addon: tuple[uuid.UUID, str],
+) -> None:
+    """The seq lock is scoped per pairing — a write to a different pairing
+    does not block behind it, so serialization is not a global bottleneck.
+    """
+    pairing_a, sub_a = paired_addon
+    sub_b = f"svc-{uuid.uuid4().hex[:8]}"
+    pairing_b = await _seed_pairing(name="ssp", service_account_sub=sub_b)
+    svc = AddonStepEventService()
+    sm = get_sessionmaker()
+
+    session_a = sm()
+    try:
+        row_a = await svc.record_if_owned(
+            session_a,
+            tenant_id=TENANT_A_ID,
+            owner_principal_sub=sub_a,
+            event_kind="pairing.a",
+            work_ref=None,
+            audit_id=None,
+            payload={},
+        )
+        assert row_a is not None
+
+        # A different pairing's committed write must complete while A still
+        # holds pairing_a's lock (different lock key -> no contention).
+        await asyncio.wait_for(
+            svc.record_if_owned_committed(
+                tenant_id=TENANT_A_ID,
+                owner_principal_sub=sub_b,
+                event_kind="pairing.b",
+                work_ref=None,
+                audit_id=None,
+                payload={},
+            ),
+            timeout=5,
+        )
+
+        async with sm() as session:
+            b_count = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(AddonStepEvent)
+                    .where(AddonStepEvent.pairing_id == pairing_b)
+                )
+            ).scalar_one()
+        assert b_count == 1
+
+        await session_a.commit()
+    finally:
+        await session_a.close()
+
+    async with sm() as session:
+        a_count = (
+            await session.execute(
+                select(func.count())
+                .select_from(AddonStepEvent)
+                .where(AddonStepEvent.pairing_id == pairing_a)
+            )
+        ).scalar_one()
+    assert a_count == 1

--- a/backend/tests/migrations/test_migration_0082_addon_step_event.py
+++ b/backend/tests/migrations/test_migration_0082_addon_step_event.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0082_create_addon_step_event``.
+
+#3027 step-event push contract. Two additive changes: the
+``addon_pairing.service_account_sub`` column (the identity join key) and the
+``addon_step_event`` durable log table (BIGSERIAL cursor + tenant/pairing
+FKs + resume and stable-id indexes).
+
+Idempotency pinning: every forward / round-trip step targets this
+migration's own revision (``0082``) and its ``down_revision`` (``0079``),
+never ``head`` — so a future head migration cannot make ``upgrade("head")``
+re-run this DDL on a schema that already has it. SQLite is the test driver;
+the migration uses only generic DDL so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0082"
+_DOWN_REVISION = "0079"
+_TABLE = "addon_step_event"
+_EXPECTED_COLUMNS = {
+    "seq",
+    "id",
+    "tenant_id",
+    "pairing_id",
+    "event_kind",
+    "work_ref",
+    "audit_id",
+    "payload",
+    "created_at",
+}
+_EXPECTED_INDEXES = {
+    "addon_step_event_pairing_seq_idx",
+    "addon_step_event_id_idx",
+}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0082.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _index_names(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def test_upgrade_adds_service_account_sub_column(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0082`` adds the pairing identity join column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert "service_account_sub" in _columns(sync_url, "addon_pairing")
+
+
+def test_upgrade_creates_step_event_table(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0082`` creates the durable step-event log with its full shape."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _columns(sync_url, _TABLE) == _EXPECTED_COLUMNS
+    assert _index_names(sync_url, _TABLE) >= _EXPECTED_INDEXES
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0079`` drops the table + column; ``upgrade 0082`` restores them."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)
+    assert "service_account_sub" in _columns(sync_url, "addon_pairing")
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _TABLE not in _table_names(sync_url)
+    assert "service_account_sub" not in _columns(sync_url, "addon_pairing")
+
+    command.upgrade(cfg, _REVISION)
+    assert _columns(sync_url, _TABLE) == _EXPECTED_COLUMNS
+    assert _index_names(sync_url, _TABLE) >= _EXPECTED_INDEXES

--- a/backend/tests/migrations/test_migration_0083_addon_step_event.py
+++ b/backend/tests/migrations/test_migration_0083_addon_step_event.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Behavioural tests for Alembic migration ``0082_create_addon_step_event``.
+"""Behavioural tests for Alembic migration ``0083_create_addon_step_event``.
 
 #3027 step-event push contract. Two additive changes: the
 ``addon_pairing.service_account_sub`` column (the identity join key) and the
@@ -9,7 +9,7 @@
 FKs + resume and stable-id indexes).
 
 Idempotency pinning: every forward / round-trip step targets this
-migration's own revision (``0082``) and its ``down_revision`` (``0079``),
+migration's own revision (``0083``) and its ``down_revision`` (``0082``),
 never ``head`` — so a future head migration cannot make ``upgrade("head")``
 re-run this DDL on a schema that already has it. SQLite is the test driver;
 the migration uses only generic DDL so PG parity holds.
@@ -30,8 +30,8 @@ from meho_backplane.db.engine import reset_engine_for_testing
 from meho_backplane.db.migrations import alembic_config
 from meho_backplane.settings import get_settings
 
-_REVISION = "0082"
-_DOWN_REVISION = "0079"
+_REVISION = "0083"
+_DOWN_REVISION = "0082"
 _TABLE = "addon_step_event"
 _EXPECTED_COLUMNS = {
     "seq",
@@ -56,7 +56,7 @@ def alembic_cfg(
     tmp_path: Path,
 ) -> Iterator[tuple[Config, str]]:
     """Pin env, reset caches, return an Alembic config + sync URL."""
-    db_path = tmp_path / "migration_0082.db"
+    db_path = tmp_path / "migration_0083.db"
     async_url = f"sqlite+aiosqlite:///{db_path}"
     sync_url = f"sqlite:///{db_path}"
     monkeypatch.setenv("DATABASE_URL", async_url)
@@ -106,14 +106,14 @@ def _table_names(sync_url: str) -> set[str]:
 
 
 def test_upgrade_adds_service_account_sub_column(alembic_cfg: tuple[Config, str]) -> None:
-    """``upgrade 0082`` adds the pairing identity join column."""
+    """``upgrade 0083`` adds the pairing identity join column."""
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _REVISION)
     assert "service_account_sub" in _columns(sync_url, "addon_pairing")
 
 
 def test_upgrade_creates_step_event_table(alembic_cfg: tuple[Config, str]) -> None:
-    """``upgrade 0082`` creates the durable step-event log with its full shape."""
+    """``upgrade 0083`` creates the durable step-event log with its full shape."""
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _REVISION)
 
@@ -122,7 +122,7 @@ def test_upgrade_creates_step_event_table(alembic_cfg: tuple[Config, str]) -> No
 
 
 def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
-    """``downgrade 0079`` drops the table + column; ``upgrade 0082`` restores them."""
+    """``downgrade 0082`` drops the table + column; ``upgrade 0083`` restores them."""
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _REVISION)
     assert _TABLE in _table_names(sync_url)

--- a/backend/tests/test_addon_capability_service.py
+++ b/backend/tests/test_addon_capability_service.py
@@ -88,6 +88,7 @@ def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     mock_client.create_client = AsyncMock(return_value=internal_id)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
     return MagicMock(return_value=mock_client)

--- a/backend/tests/test_addon_pairing_service.py
+++ b/backend/tests/test_addon_pairing_service.py
@@ -73,6 +73,7 @@ def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=internal_id)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
     mock_client.delete_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
@@ -219,6 +220,34 @@ async def test_secret_readback_failure_rolls_back_keycloak_client() -> None:
     factory = _mock_kc_ok()
     mock_client = factory.return_value
     mock_client.get_client_secret = AsyncMock(side_effect=RuntimeError("kc flap"))
+    with patch(_PATCH_TARGET, factory), pytest.raises(RuntimeError):
+        await AddonPairingService().pair(_TENANT, "op-admin", _request())
+    mock_client.create_client.assert_awaited_once()
+    mock_client.delete_client.assert_awaited_once_with(_KC_INTERNAL_ID)
+    assert await _fetch(_TENANT) == []
+
+
+@pytest.mark.asyncio
+async def test_pair_persists_service_account_sub() -> None:
+    """The Keycloak service-account subject is captured on the pairing (#3027)."""
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    with patch(_PATCH_TARGET, factory):
+        await AddonPairingService().pair(_TENANT, "op-admin", _request())
+    mock_client.get_service_account_user_id.assert_awaited_once_with(_KC_INTERNAL_ID)
+    rows = await _fetch(_TENANT)
+    assert len(rows) == 1
+    assert rows[0].service_account_sub == "svc-account-uuid"
+
+
+@pytest.mark.asyncio
+async def test_service_account_fetch_failure_rolls_back_keycloak_client() -> None:
+    """A ``get_service_account_user_id`` failure rolls the just-created client back."""
+    await _seed_tenant()
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+    mock_client.get_service_account_user_id = AsyncMock(side_effect=RuntimeError("kc flap"))
     with patch(_PATCH_TARGET, factory), pytest.raises(RuntimeError):
         await AddonPairingService().pair(_TENANT, "op-admin", _request())
     mock_client.create_client.assert_awaited_once()

--- a/backend/tests/test_addon_step_events.py
+++ b/backend/tests/test_addon_step_events.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the add-on step-event push contract (#3027).
+
+Covers the two acceptance criteria directly:
+
+* **Durable delivery with resume** — :meth:`AddonStepEventService.record_if_owned`
+  appends monotonic ``seq`` rows; :meth:`list_for_pairing` reads strictly
+  forward from an ``after`` cursor, so an add-on that persists its last
+  ``seq`` resumes without gaps or repeats across a restart.
+* **Scoping enforced** — a step event is written only when its owner
+  principal matches a pairing's ``service_account_sub``; one pairing's
+  subscription never returns another pairing's events, even when both
+  carry the same ``work_ref``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import func, select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, AddonStepEvent, Tenant
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_step_events import AddonStepEventService
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_OTHER_TENANT = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+_SUB_A = "svc-account-A"
+_SUB_B = "svc-account-B"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+async def _seed_tenant(tenant_id: uuid.UUID = _TENANT, slug: str = "tenant-a") -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=tenant_id, slug=slug, name=slug))
+            await session.commit()
+
+
+async def _seed_pairing(
+    *,
+    tenant_id: uuid.UUID = _TENANT,
+    name: str,
+    service_account_sub: str | None,
+) -> uuid.UUID:
+    """Insert a pairing row directly (no Keycloak) and return its id."""
+    pairing_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AddonPairing(
+                id=pairing_id,
+                tenant_id=tenant_id,
+                name=name,
+                keycloak_client_id=f"addon:{name}",
+                keycloak_internal_id=f"kc-{name}",
+                service_account_sub=service_account_sub,
+                owner_sub="op-admin",
+                contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+    return pairing_id
+
+
+async def _record(
+    service: AddonStepEventService,
+    *,
+    tenant_id: uuid.UUID = _TENANT,
+    owner_principal_sub: str | None,
+    event_kind: str = "approval.approved",
+    work_ref: str | None = "gh:evoila/meho#1",
+    payload: dict[str, object] | None = None,
+) -> AddonStepEvent | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await service.record_if_owned(
+            session,
+            tenant_id=tenant_id,
+            owner_principal_sub=owner_principal_sub,
+            event_kind=event_kind,
+            work_ref=work_ref,
+            audit_id=None,
+            payload=payload or {"decision": "approved"},
+        )
+        await session.commit()
+        return row
+
+
+@pytest.mark.asyncio
+async def test_record_if_owned_appends_for_a_paired_principal() -> None:
+    """A produced event whose owner matches a pairing's sub is recorded."""
+    await _seed_tenant()
+    pairing_id = await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    row = await _record(service, owner_principal_sub=_SUB_A)
+
+    assert row is not None
+    assert row.pairing_id == pairing_id
+    assert row.event_kind == "approval.approved"
+    assert row.seq >= 1
+
+
+@pytest.mark.asyncio
+async def test_record_if_owned_noop_when_owner_absent_or_unpaired() -> None:
+    """No pairing match (or no owner) -> no row written, cheap no-op."""
+    await _seed_tenant()
+    await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    assert await _record(service, owner_principal_sub=None) is None
+    assert await _record(service, owner_principal_sub="some-human-sub") is None
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        count = (
+            await session.execute(select(func.count()).select_from(AddonStepEvent))
+        ).scalar_one()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_for_pairing_resumes_forward_from_cursor() -> None:
+    """Durable resume: reading with after=<last seq> yields only newer events."""
+    await _seed_tenant()
+    pairing_id = await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    for i in range(3):
+        await _record(service, owner_principal_sub=_SUB_A, event_kind=f"approval.step{i}")
+
+    first_page = await service.list_for_pairing(pairing_id=pairing_id, after_seq=0, limit=2)
+    assert [e.event_kind for e in first_page.items] == ["approval.step0", "approval.step1"]
+    assert first_page.next_cursor is not None
+
+    # Resume strictly past the cursor — no repeats, the third event only.
+    resumed = await service.list_for_pairing(
+        pairing_id=pairing_id,
+        after_seq=int(first_page.next_cursor),
+        limit=100,
+    )
+    assert [e.event_kind for e in resumed.items] == ["approval.step2"]
+
+    # A cursor at the head returns an empty page (nothing missed, nothing new).
+    tail = await service.list_for_pairing(
+        pairing_id=pairing_id,
+        after_seq=int(resumed.next_cursor),
+        limit=100,
+    )
+    assert tail.items == []
+    assert tail.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_scoping_never_delivers_another_pairings_events() -> None:
+    """Acceptance: events outside the principal's lineage are never delivered.
+
+    Two paired add-ons in the same tenant, each with an event carrying the
+    **same** work_ref. Each pairing's subscription returns only its own
+    event — the other's is never visible.
+    """
+    await _seed_tenant()
+    pairing_a = await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    pairing_b = await _seed_pairing(name="ssp", service_account_sub=_SUB_B)
+    service = AddonStepEventService()
+
+    shared_work_ref = "gh:evoila/meho#42"
+    await _record(
+        service,
+        owner_principal_sub=_SUB_A,
+        event_kind="approval.approved",
+        work_ref=shared_work_ref,
+    )
+    await _record(
+        service,
+        owner_principal_sub=_SUB_B,
+        event_kind="approval.rejected",
+        work_ref=shared_work_ref,
+    )
+
+    a_events = await service.list_for_pairing(pairing_id=pairing_a, after_seq=0, limit=100)
+    b_events = await service.list_for_pairing(pairing_id=pairing_b, after_seq=0, limit=100)
+
+    assert [e.event_kind for e in a_events.items] == ["approval.approved"]
+    assert [e.event_kind for e in b_events.items] == ["approval.rejected"]
+    # Cross-pairing isolation is total, work_ref collision notwithstanding.
+    assert all(e.work_ref == shared_work_ref for e in a_events.items + b_events.items)
+
+
+@pytest.mark.asyncio
+async def test_resolve_pairing_for_sub_binds_by_token_sub() -> None:
+    """The subscription bind: a caller's token sub maps to its own pairing."""
+    await _seed_tenant()
+    pairing_id = await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    bound = await service.resolve_pairing_for_sub(tenant_id=_TENANT, service_account_sub=_SUB_A)
+    assert bound is not None
+    assert bound.id == pairing_id
+    assert bound.name == "automation"
+
+    # An unknown sub binds to nothing (a non-add-on service principal).
+    assert (
+        await service.resolve_pairing_for_sub(tenant_id=_TENANT, service_account_sub="nobody")
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_scoped_to_tenant() -> None:
+    """A sub that matches a pairing in another tenant is not attributed here."""
+    await _seed_tenant()
+    await _seed_tenant(tenant_id=_OTHER_TENANT, slug="tenant-b")
+    await _seed_pairing(tenant_id=_OTHER_TENANT, name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    # Same sub, but recorded under _TENANT where no pairing owns it.
+    row = await _record(service, tenant_id=_TENANT, owner_principal_sub=_SUB_A)
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_record_if_owned_committed_persists_and_is_fail_open() -> None:
+    """The committed variant writes a durable row and swallows failures."""
+    await _seed_tenant()
+    pairing_id = await _seed_pairing(name="automation", service_account_sub=_SUB_A)
+    service = AddonStepEventService()
+
+    await service.record_if_owned_committed(
+        tenant_id=_TENANT,
+        owner_principal_sub=_SUB_A,
+        event_kind="approval.approved",
+        work_ref="gh:evoila/meho#7",
+        audit_id=uuid.uuid4(),
+        payload={"decision": "approved"},
+    )
+
+    page = await service.list_for_pairing(pairing_id=pairing_id, after_seq=0, limit=100)
+    assert [e.event_kind for e in page.items] == ["approval.approved"]
+
+    # Fail-open: an unpaired owner is a silent no-op (no raise, no row).
+    await service.record_if_owned_committed(
+        tenant_id=_TENANT,
+        owner_principal_sub="not-an-addon",
+        event_kind="approval.approved",
+        work_ref=None,
+        audit_id=None,
+        payload={},
+    )
+    page2 = await service.list_for_pairing(pairing_id=pairing_id, after_seq=0, limit=100)
+    assert len(page2.items) == 1

--- a/backend/tests/test_api_v1_addon_capability.py
+++ b/backend/tests/test_api_v1_addon_capability.py
@@ -105,6 +105,7 @@ def _service_token(key: Any) -> str:
 def _mock_kc_ok() -> MagicMock:
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.delete_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/backend/tests/test_api_v1_addon_pairing.py
+++ b/backend/tests/test_api_v1_addon_pairing.py
@@ -36,6 +36,7 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, Tenant
 from meho_backplane.main import app
 from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_step_events import AddonStepEventService
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -103,6 +104,10 @@ def _mock_kc_ok() -> MagicMock:
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    # The service token below authenticates with sub="addon-svc"; the pair
+    # flow captures the same value as service_account_sub so the paired
+    # add-on's subscription binds to its own pairing (#3027).
+    mock_client.get_service_account_user_id = AsyncMock(return_value="addon-svc")
     mock_client.delete_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
@@ -251,3 +256,65 @@ async def test_heartbeat_unpaired_is_404(client: TestClient) -> None:
         mock_discovery_and_jwks(r, public_jwks(key))
         resp = client.post("/api/v1/addons/pairings/ghost/heartbeat", headers=headers)
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_events_service_principal_only_and_scoped(client: TestClient) -> None:
+    """The subscription is service-principal-only and bound to the caller's own pairing."""
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-ev")
+    admin_headers = {"Authorization": f"Bearer {_token(key)}"}
+    service_headers = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin_headers)
+
+        # A human principal cannot subscribe.
+        human = client.get("/api/v1/addons/pairings/automation/events", headers=admin_headers)
+        assert human.status_code == 403, human.text
+
+        # The paired service principal reads its own (initially empty) log.
+        mine = client.get("/api/v1/addons/pairings/automation/events", headers=service_headers)
+        assert mine.status_code == 200, mine.text
+        assert mine.json() == {"items": [], "next_cursor": None}
+
+        # A different pairing name -> 404: never another add-on's log.
+        other = client.get("/api/v1/addons/pairings/ssp/events", headers=service_headers)
+        assert other.status_code == 404, other.text
+
+
+@pytest.mark.asyncio
+async def test_events_durable_resume(client: TestClient) -> None:
+    """Durable delivery with resume: read once, resume past the cursor gap-free."""
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-evr")
+    admin_headers = {"Authorization": f"Bearer {_token(key)}"}
+    service_headers = {"Authorization": f"Bearer {_service_token(key)}"}
+    with patch(_PATCH_TARGET, _mock_kc_ok()), respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin_headers)
+
+        # A step event lands for the paired add-on (owner sub == its token sub).
+        await AddonStepEventService().record_if_owned_committed(
+            tenant_id=_TENANT,
+            owner_principal_sub="addon-svc",
+            event_kind="approval.approved",
+            work_ref="gh:evoila/meho#5",
+            audit_id=None,
+            payload={"decision": "approved"},
+        )
+
+        first = client.get("/api/v1/addons/pairings/automation/events", headers=service_headers)
+        assert first.status_code == 200, first.text
+        body = first.json()
+        assert [e["event_kind"] for e in body["items"]] == ["approval.approved"]
+        cursor = body["next_cursor"]
+        assert cursor is not None
+
+        # Resume strictly past the cursor -> nothing missed, nothing repeated.
+        resumed = client.get(
+            f"/api/v1/addons/pairings/automation/events?after={cursor}",
+            headers=service_headers,
+        )
+        assert resumed.status_code == 200, resumed.text
+        assert resumed.json() == {"items": [], "next_cursor": None}

--- a/backend/tests/test_api_v1_agent_principals.py
+++ b/backend/tests/test_api_v1_agent_principals.py
@@ -141,6 +141,7 @@ def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     """Return a mock KeycloakAdminClient that succeeds on create/secret/disable."""
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.disable_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/backend/tests/test_api_v1_runner_principals.py
+++ b/backend/tests/test_api_v1_runner_principals.py
@@ -161,6 +161,7 @@ def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     """A mock KeycloakAdminClient that succeeds on create/secret/disable."""
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.disable_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/backend/tests/test_keycloak_admin.py
+++ b/backend/tests/test_keycloak_admin.py
@@ -266,3 +266,43 @@ async def test_get_client_secret_unexpected_status_raises() -> None:
         async with _client() as kc:
             with pytest.raises(KeycloakAdminError):
                 await kc.get_client_secret(_INTERNAL_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_service_account_user_id_returns_id() -> None:
+    """The service-account user's id is the ``sub`` the add-on's tokens carry (#3027)."""
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/service-account-user").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "sa-user-uuid", "username": "service-account-addon:automation"},
+            )
+        )
+        async with _client() as kc:
+            sub = await kc.get_service_account_user_id(_INTERNAL_ID)
+    assert sub == "sa-user-uuid"
+
+
+@pytest.mark.asyncio
+async def test_get_service_account_user_id_not_found_raises() -> None:
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/service-account-user").mock(
+            return_value=httpx.Response(404)
+        )
+        async with _client() as kc:
+            with pytest.raises(KeycloakClientNotFoundError):
+                await kc.get_service_account_user_id(_INTERNAL_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_service_account_user_id_empty_id_raises() -> None:
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/service-account-user").mock(
+            return_value=httpx.Response(200, json={"id": ""})
+        )
+        async with _client() as kc:
+            with pytest.raises(KeycloakAdminError):
+                await kc.get_service_account_user_id(_INTERNAL_ID)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9963,6 +9963,82 @@
         }
       }
     },
+    "/api/v1/addons/pairings/{name}/events": {
+      "get": {
+        "tags": [
+          "addon-pairing"
+        ],
+        "summary": "List Step Events",
+        "description": "Durable, resumable step-event subscription for the paired add-on (#3027).\n\nThe add-on authenticates as its own **service** principal (a non-service\nprincipal is 403) and reads the step events (approval outcomes, dispatch\ncompletions) that belong to **its own** work. Scoping is cryptographic:\nthe caller is bound to a pairing by its token ``sub`` (which is the\npairing's ``service_account_sub``), and ``{name}`` must be that same\npairing \u2014 a service principal can never read another add-on's log. A\ncaller whose ``sub`` binds to no pairing, or whose bound pairing is not\n``{name}``, gets 404 (indistinguishable from a missing pairing).\n\nResume: ``after`` is the last ``seq`` the add-on saw (``0`` reads from\nthe start of the retained log); the response's ``next_cursor`` is the\n``seq`` to pass as ``after`` on the next poll, so an add-on never misses\na committed event across its own restarts.",
+        "operationId": "list_step_events_api_v1_addons_pairings__name__events_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "After"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StepEventListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/addons/pairings/{name}/capabilities": {
       "put": {
         "tags": [
@@ -31207,6 +31283,78 @@
         ],
         "title": "StepBodyVerify",
         "description": "The verify surface as exposed at *run* time -- substituted-and-frozen.\n\nSame discriminator (``type``) as the template-side\n:class:`~meho_backplane.runbooks.schemas.Verify` union, but every\n``${run.target}`` / ``${run.params.X}`` substitution in\n:attr:`op_id` / :attr:`params` / :attr:`expect` has already been\nresolved by the engine (#1301). This shape is what the operator /\nagent reads to know *what they will be asked* once the step's\naction is performed -- the prompt text (for ``confirm``) or the\nop-call shape and expected result (for ``operation_call``).\n\nFields are nullable by ``type`` (``prompt`` populated only on\n``confirm``; ``op_id`` / ``params`` / ``expect`` populated only on\n``operation_call``). A flat shape with optional fields is used\nrather than a discriminated sub-union because :class:`StepBody`\nalready discriminates at the parent level on ``StepBody.type``;\nnesting a second discriminated union here would force two parse\npaths for one logical decision and complicates JSON-Schema\ngeneration."
+      },
+      "StepEventListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/StepEventRead"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "StepEventListResponse",
+        "description": "A page of step events plus the cursor to resume past it.\n\n``next_cursor`` is the ``seq`` of the last returned event (as a string\nso the wire cursor is opaque and dialect-agnostic); ``None`` when the\npage is empty. The add-on passes it back as ``after`` to read strictly\nforward on the next poll / reconnect."
+      },
+      "StepEventRead": {
+        "properties": {
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "event_kind": {
+            "type": "string",
+            "title": "Event Kind"
+          },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
+          },
+          "audit_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Audit Id"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "seq",
+          "id",
+          "event_kind",
+          "work_ref",
+          "audit_id",
+          "payload",
+          "created_at"
+        ],
+        "title": "StepEventRead",
+        "description": "One step event as delivered to a subscribed add-on."
       },
       "StepPosition": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -7518,6 +7518,28 @@ type StepBodyVerify struct {
 // StepBodyVerifyType defines model for StepBodyVerify.Type.
 type StepBodyVerifyType string
 
+// StepEventListResponse A page of step events plus the cursor to resume past it.
+//
+// “next_cursor“ is the “seq“ of the last returned event (as a string
+// so the wire cursor is opaque and dialect-agnostic); “None“ when the
+// page is empty. The add-on passes it back as “after“ to read strictly
+// forward on the next poll / reconnect.
+type StepEventListResponse struct {
+	Items      []StepEventRead `json:"items"`
+	NextCursor *string         `json:"next_cursor"`
+}
+
+// StepEventRead One step event as delivered to a subscribed add-on.
+type StepEventRead struct {
+	AuditId   *openapi_types.UUID    `json:"audit_id"`
+	CreatedAt time.Time              `json:"created_at"`
+	EventKind string                 `json:"event_kind"`
+	Id        openapi_types.UUID     `json:"id"`
+	Payload   map[string]interface{} `json:"payload"`
+	Seq       int                    `json:"seq"`
+	WorkRef   *string                `json:"work_ref"`
+}
+
 // StepPosition 1-indexed position of the current step within the template.
 //
 // :attr:`n` is the 1-indexed step number; :attr:`total` is the
@@ -8573,6 +8595,13 @@ type ShowCapabilitiesApiV1AddonsPairingsNameCapabilitiesGetParams struct {
 
 // DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams defines parameters for DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut.
 type DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ListStepEventsApiV1AddonsPairingsNameEventsGetParams defines parameters for ListStepEventsApiV1AddonsPairingsNameEventsGet.
+type ListStepEventsApiV1AddonsPairingsNameEventsGetParams struct {
+	After         *int    `form:"after,omitempty" json:"after,omitempty"`
+	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -11717,6 +11746,9 @@ type ClientInterface interface {
 
 	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListStepEventsApiV1AddonsPairingsNameEventsGet request
+	ListStepEventsApiV1AddonsPairingsNameEventsGet(ctx context.Context, name string, params *ListStepEventsApiV1AddonsPairingsNameEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost request
 	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13261,6 +13293,18 @@ func (c *Client) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithBo
 
 func (c *Client) DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPut(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequest(c.Server, name, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListStepEventsApiV1AddonsPairingsNameEventsGet(ctx context.Context, name string, params *ListStepEventsApiV1AddonsPairingsNameEventsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListStepEventsApiV1AddonsPairingsNameEventsGetRequest(c.Server, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -20056,6 +20100,93 @@ func NewDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutRequestWithBody
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListStepEventsApiV1AddonsPairingsNameEventsGetRequest generates requests for ListStepEventsApiV1AddonsPairingsNameEventsGet
+func NewListStepEventsApiV1AddonsPairingsNameEventsGetRequest(server string, name string, params *ListStepEventsApiV1AddonsPairingsNameEventsGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/addons/pairings/%s/events", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -40758,6 +40889,9 @@ type ClientWithResponsesInterface interface {
 
 	DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutWithResponse(ctx context.Context, name string, params *DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutParams, body DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutJSONRequestBody, reqEditors ...RequestEditorFn) (*DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse, error)
 
+	// ListStepEventsApiV1AddonsPairingsNameEventsGetWithResponse request
+	ListStepEventsApiV1AddonsPairingsNameEventsGetWithResponse(ctx context.Context, name string, params *ListStepEventsApiV1AddonsPairingsNameEventsGetParams, reqEditors ...RequestEditorFn) (*ListStepEventsApiV1AddonsPairingsNameEventsGetResponse, error)
+
 	// HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request
 	HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error)
 
@@ -42367,6 +42501,29 @@ func (r DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse) Statu
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r DeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListStepEventsApiV1AddonsPairingsNameEventsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StepEventListResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListStepEventsApiV1AddonsPairingsNameEventsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListStepEventsApiV1AddonsPairingsNameEventsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -50576,6 +50733,15 @@ func (c *ClientWithResponses) DeclareCapabilitiesApiV1AddonsPairingsNameCapabili
 	return ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse(rsp)
 }
 
+// ListStepEventsApiV1AddonsPairingsNameEventsGetWithResponse request returning *ListStepEventsApiV1AddonsPairingsNameEventsGetResponse
+func (c *ClientWithResponses) ListStepEventsApiV1AddonsPairingsNameEventsGetWithResponse(ctx context.Context, name string, params *ListStepEventsApiV1AddonsPairingsNameEventsGetParams, reqEditors ...RequestEditorFn) (*ListStepEventsApiV1AddonsPairingsNameEventsGetResponse, error) {
+	rsp, err := c.ListStepEventsApiV1AddonsPairingsNameEventsGet(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListStepEventsApiV1AddonsPairingsNameEventsGetResponse(rsp)
+}
+
 // HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse request returning *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse
 func (c *ClientWithResponses) HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostWithResponse(ctx context.Context, name string, params *HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostParams, reqEditors ...RequestEditorFn) (*HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPostResponse, error) {
 	rsp, err := c.HeartbeatPairingApiV1AddonsPairingsNameHeartbeatPost(ctx, name, params, reqEditors...)
@@ -55457,6 +55623,39 @@ func ParseDeclareCapabilitiesApiV1AddonsPairingsNameCapabilitiesPutResponse(rsp 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CapabilityDeclarationResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListStepEventsApiV1AddonsPairingsNameEventsGetResponse parses an HTTP response from a ListStepEventsApiV1AddonsPairingsNameEventsGetWithResponse call
+func ParseListStepEventsApiV1AddonsPairingsNameEventsGetResponse(rsp *http.Response) (*ListStepEventsApiV1AddonsPairingsNameEventsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListStepEventsApiV1AddonsPairingsNameEventsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StepEventListResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -194,7 +194,11 @@ lists active pairings and maps each to a `PairingHealth`
   principal in the pairing's tenant, matched by add-on name. A finer binding
   (verifying the caller's client id against the pairing's
   `keycloak_client_id`) is a hardening follow-up for the initiative's
-  security-review DoD item.
+  security-review DoD item. Task #3027 added
+  `AddonPairing.service_account_sub` (the add-on's token `sub`, captured at
+  pair time), which enables exactly this check — heartbeat could verify
+  `operator.sub == service_account_sub` — though it is not yet wired here.
+  See `addon-step-events.md` for the step-event push contract that uses it.
 - **Console is read-only**: pair / unpair are REST-only. Console write
   actions (a pair/unpair button behind CSRF) are a follow-up.
 - **Capabilities are not yet rendered in the console** or exposed as a

--- a/docs/codebase/addon-step-events.md
+++ b/docs/codebase/addon-step-events.md
@@ -1,0 +1,170 @@
+# Add-on step-event push contract
+
+The durable outbound event subscription a paired add-on rides for its own
+orchestration needs (Initiative #2900, Task #3027). It gives a paired
+add-on a **durable, resumable** stream of the step events that belong to
+its own work — approval outcomes and dispatch completions — replacing the
+at-most-once, count-trimmed Valkey SSE feed (`api/v1/feed.py`) that a
+restart silently loses events across.
+
+Two acceptance properties define it, and both are structural rather than
+best-effort:
+
+- **Durable delivery with resume.** Every recorded event carries a
+  monotonic `seq`. An add-on persists the last `seq` it consumed,
+  reconnects, and reads strictly forward. Nothing recorded is lost across
+  the add-on's own restarts.
+- **Scoping to the paired principal's lineage.** A step event is attributed
+  to a pairing at **write** time by identity, so a pairing's log only ever
+  holds that pairing's events. An event outside the paired principal's
+  lineage is never written into another pairing's log and therefore can
+  never be delivered — even when two add-ons' events share a `work_ref`.
+
+## Why a dedicated durable log, not the broadcast feed
+
+Two substrates already carry these events, and neither is a durable
+per-add-on subscription:
+
+- **Broadcast** (`BroadcastEvent` on a Valkey stream, `api/v1/feed.py`) is
+  at-most-once and count-trimmed. It is the operator-awareness feed; a
+  subscriber that reconnects after the trim window has passed silently
+  misses events. Resume is `Last-Event-Id` against the live stream, not a
+  durable log.
+- **`event_outbox`** (`events/outbox.py`) is durable but single-consumer:
+  the drain claims rows and stamps `processed_at`. It carries
+  `agent_run.completed`, not approval outcomes, and its cursor is the
+  drain's, not a per-subscriber one.
+
+Approval outcomes and dispatch completions are the events the add-on needs,
+they carry the principal and `work_ref` in their lineage, and the durable
+gap is exactly that they are at-most-once on the wire. So the contract adds
+a small, cohesive **durable projection**: one append-only row per step
+event attributed to a paired add-on, with its own `BIGSERIAL` cursor. This
+is the transactional-outbox discipline (`docs/codebase/events.md`) applied
+to outbound add-on delivery.
+
+## The identity join
+
+The load-bearing problem is attribution: a produced row (an
+`approval_request`, an `agent_run`) carries the responsible principal's
+Keycloak service-account **`sub`** (a UUID), while the pairing row stores
+the OAuth `clientId` (`addon:<name>`). They do not join.
+
+`AddonPairing.service_account_sub` (migration `0082`) closes the gap. At
+pair time the backplane already provisions the add-on's confidential
+Keycloak client; it now also fetches that client's service-account **user
+id** (`KeycloakAdminClient.get_service_account_user_id` →
+`GET /clients/{id}/service-account-user`) and persists it. That value is
+exactly the `sub` the add-on's `client_credentials` tokens carry, so:
+
+- a **produced row** joins to its pairing by
+  `service_account_sub == approval_request.principal_sub` /
+  `== agent_run.identity_sub`;
+- a **subscription request** binds to its pairing by
+  `service_account_sub == operator.sub` (the caller's own token subject).
+
+Capturing it at provisioning time — the one point the backplane controls
+the identity — means attribution is never inferred from an unverified
+token. A pairing created before `0082` has `service_account_sub = NULL`; a
+`NULL` never matches a real `sub`, so it fails closed until the add-on
+re-pairs.
+
+## Key types
+
+- `meho_backplane.db.models.AddonStepEvent` — table `addon_step_event`
+  (migration `0082`). `seq` (`BIGSERIAL` cursor), `id` (stable UUID event
+  id), `tenant_id` FK, `pairing_id` FK (`ON DELETE CASCADE`), `event_kind`,
+  `work_ref`, `audit_id` (convention-only reference to `audit_log.id`, same
+  as `BroadcastEvent.audit_id`), `payload`, `created_at`. Index
+  `(pairing_id, seq)` drives the resume read.
+- `meho_backplane.operations.addon_step_events.AddonStepEventService` — the
+  cohesive record + read service:
+  - `record_if_owned(session, ...)` — append in the caller's transaction
+    (flush, no commit) iff the owner `sub` matches a pairing. A cheap no-op
+    (one indexed lookup, no write) when the producer is not a paired
+    add-on, so the overwhelmingly common producer path costs almost
+    nothing.
+  - `record_if_owned_committed(...)` — the same, owning its own committed,
+    fail-open transaction, for producer sites without an ambient
+    transaction (the post-commit approval notification).
+  - `resolve_pairing_for_sub(...)` — the subscription bind (token `sub` →
+    pairing).
+  - `list_for_pairing(pairing_id, after_seq, limit)` — the durable resume
+    read; returns `StepEventListResponse` (`{items, next_cursor}`).
+- `meho_backplane.api.v1.addon_pairing.list_step_events` —
+  `GET /api/v1/addons/pairings/{name}/events?after=<seq>&limit=N`.
+
+## Control flow
+
+**Record (producer side).** Two producers call the recorder:
+
+1. **Dispatch completions** — `operations/agent_run.py`'s terminal
+   transition, in the **same transaction** as the run's status write (a
+   run-transition rollback discards the step event too). Owner =
+   `agent_run.identity_sub`; kind `agent_run.completed`.
+2. **Approval outcomes** — `operations/approval_queue.publish_approval_event`,
+   the single choke point for `pending` / `approved` / `rejected` /
+   `expired`. Owner = `approval_request.principal_sub` (the requester —
+   constant across the request's lifecycle, so every decision routes to the
+   same add-on regardless of who decided it); kind `approval.<decision>`.
+   Recorded via the fail-open committed variant, matching the surrounding
+   approval-broadcast posture: a step-event write never blocks the durable
+   decision, and the add-on re-reads forward by `seq`.
+
+**Read (subscription side).** `GET /api/v1/addons/pairings/{name}/events`:
+
+1. Require a **service** principal (a non-service principal is 403).
+2. Bind the caller to its pairing by `operator.sub` → `service_account_sub`.
+3. A caller whose `sub` binds to no pairing, or whose bound pairing is not
+   `{name}`, gets a uniform 404 — never another add-on's log, never a
+   name-existence oracle to a principal that does not own it.
+4. Return the pairing's events with `seq > after`, `seq`-ordered, capped at
+   `limit`; `next_cursor` is the last `seq` for the next poll.
+
+## Scoping proof
+
+The acceptance test (`tests/test_addon_step_events.py`) records events for
+two paired add-ons in the same tenant that carry the **same** `work_ref`,
+then asserts each pairing's subscription returns only its own event. The
+isolation is total because attribution happened at write time by identity:
+the cross-pairing containment is not a read-time filter that could be
+bypassed but a property of which rows exist in which pairing's log.
+
+## Durability posture
+
+- The **dispatch-completion** record is in the producer's transaction —
+  fully durable with the state change (transactional outbox).
+- The **approval-outcome** record is a self-contained committed write at
+  the fail-open notification choke point. A backplane crash in the narrow
+  window between the decision commit and the step-event commit is the same
+  window the existing approval broadcast already accepts; the acceptance
+  criterion — no missed events across the **add-on's** restarts — holds for
+  every committed row, which is what the `seq` cursor resumes over.
+
+## Known issues / follow-ups
+
+- **SSE / long-poll transport.** The durable substrate + resumable cursor
+  read is the load-bearing contract. A push transport (SSE or long-poll
+  over the durable table, cursor = `seq`) is a thin layer on top and a
+  natural follow-up; the durability and resume live in the table, not the
+  transport.
+- **Direct `call_operation` completions.** Dispatch-completion recording is
+  wired to the `agent_run` terminal transition (and is a reusable seam for
+  the async governed-dispatch run handle, #3079). A direct, non-agent-run
+  governed dispatch that completes synchronously is audited but not yet
+  projected into the step-event log; adding that seam is additive.
+- **Heartbeat binding.** `service_account_sub` also enables the finer
+  heartbeat principal binding flagged in `addon-pairing.md` (verify
+  `operator.sub == pairing.service_account_sub`); that hardening is not
+  changed here.
+- **Retention.** The log grows append-only; a retention sweep (mirroring
+  the announcement-retention job) is a future operational refinement.
+
+## References
+
+- Initiative #2900 (add-on pairing contract), Task #3027 (this contract),
+  Task #3025 (the pairing foundation, `addon-pairing.md`).
+- `docs/codebase/events.md` — the transactional-outbox substrate this
+  discipline mirrors; `docs/codebase/broadcast.md` — the at-most-once feed
+  it complements; `docs/codebase/approvals.md` — the approval lifecycle
+  producer.

--- a/docs/codebase/addon-step-events.md
+++ b/docs/codebase/addon-step-events.md
@@ -50,7 +50,7 @@ The load-bearing problem is attribution: a produced row (an
 Keycloak service-account **`sub`** (a UUID), while the pairing row stores
 the OAuth `clientId` (`addon:<name>`). They do not join.
 
-`AddonPairing.service_account_sub` (migration `0082`) closes the gap. At
+`AddonPairing.service_account_sub` (migration `0083`) closes the gap. At
 pair time the backplane already provisions the add-on's confidential
 Keycloak client; it now also fetches that client's service-account **user
 id** (`KeycloakAdminClient.get_service_account_user_id` →
@@ -65,14 +65,14 @@ exactly the `sub` the add-on's `client_credentials` tokens carry, so:
 
 Capturing it at provisioning time — the one point the backplane controls
 the identity — means attribution is never inferred from an unverified
-token. A pairing created before `0082` has `service_account_sub = NULL`; a
+token. A pairing created before `0083` has `service_account_sub = NULL`; a
 `NULL` never matches a real `sub`, so it fails closed until the add-on
 re-pairs.
 
 ## Key types
 
 - `meho_backplane.db.models.AddonStepEvent` — table `addon_step_event`
-  (migration `0082`). `seq` (`BIGSERIAL` cursor), `id` (stable UUID event
+  (migration `0083`). `seq` (`BIGSERIAL` cursor), `id` (stable UUID event
   id), `tenant_id` FK, `pairing_id` FK (`ON DELETE CASCADE`), `event_kind`,
   `work_ref`, `audit_id` (convention-only reference to `audit_log.id`, same
   as `BroadcastEvent.audit_id`), `payload`, `created_at`. Index

--- a/docs/codebase/addon-step-events.md
+++ b/docs/codebase/addon-step-events.md
@@ -130,6 +130,45 @@ isolation is total because attribution happened at write time by identity:
 the cross-pairing containment is not a read-time filter that could be
 bypassed but a property of which rows exist in which pairing's log.
 
+## Ordering under concurrent writers
+
+The `seq > after` resume cursor is a **high-watermark**: once an add-on
+advances its stored cursor past `seq = N`, it never re-reads anything at or
+below `N`. That is only safe if, for a given pairing, `seq` order equals
+**commit** order — because `seq` is a `BIGSERIAL` drawn at INSERT (flush)
+while the row becomes visible only at COMMIT. Those two moments are not the
+same, so two concurrent writes to the same pairing can commit out of `seq`
+order: writer A draws `seq = N` and commits slowly, writer B draws
+`seq = N+1` and commits first. A reader between the two commits sees only
+`N+1`, advances its cursor to `N+1`, and then `seq > N+1` **permanently
+skips** the committed `N`. That is a lost event, which the durable-resume
+acceptance criterion forbids.
+
+The recorder closes the gap by holding a **transaction-scoped per-pairing
+advisory lock** (`pg_advisory_xact_lock`, keyed by
+`_pairing_seq_lock_key(pairing_id)`) taken **before** the INSERT draws
+`seq` and released only at the caller's COMMIT / ROLLBACK. One writer's
+whole `[draw seq … commit]` window therefore completes before the next
+writer to the same pairing can draw its `seq`, so commit order equals `seq`
+order per pairing. When a committed row with `seq = M` is visible, every
+`seq < M` for that pairing has already committed — the high-watermark
+cursor is exact and the "no missed events" property is **structural, not
+best-effort**.
+
+Cost is negligible: the lock is per pairing (no cross-pairing contention),
+it is taken only once the producer is known to be a paired add-on (the
+overwhelmingly common non-add-on path never touches it), and a single
+pairing's write rate — its own approval outcomes plus dispatch completions
+— is low. On SQLite (the unit-test dialect) the lock is a no-op: that path
+is single-writer, so `seq` order already equals commit order. The
+serialization is proven on real PostgreSQL by
+`tests/integration/test_addon_step_events_concurrency.py`, which stages the
+out-of-order-commit interleaving explicitly (writer A holds an uncommitted
+lower `seq` while writer B is blocked at the lock, then asserts a cursor
+walk misses nothing). This is the same `pg_advisory_xact_lock` discipline
+the checks dashboard-transition claim uses
+(`checks/investigate.py::_lock_dashboard_transition`).
+
 ## Durability posture
 
 - The **dispatch-completion** record is in the producer's transaction —


### PR DESCRIPTION
## Summary

- **Step-event push contract (Initiative #2900, Task #3027).** A paired add-on gains a **durable, resumable** outbound subscription to the step events that belong to its own work — approval outcomes and dispatch completions — replacing the at-most-once, count-trimmed Valkey SSE feed (`api/v1/feed.py`) a restart silently loses events across.
- **Durable delivery with resume.** Each event carries a monotonic `BIGSERIAL` `seq`. The add-on reads `GET /api/v1/addons/pairings/{name}/events?after=<seq>` as its own service principal, persists the last `seq` it saw, and resumes strictly forward on reconnect — no missed events across its own restarts.
- **Scoping is structural, enforced at write time.** A step event is attributed to a pairing by the producing row's responsible principal (`approval_request.principal_sub` / `agent_run.identity_sub` — the add-on's Keycloak service-account `sub`) matching the pairing's new `service_account_sub` column, captured at pair time from Keycloak. A pairing's durable log only ever holds its own events; the subscription binds to the caller's own pairing by its token `sub`. An event outside the paired principal's lineage is never written into another pairing's log and can never be delivered — even when two add-ons' events carry the same `work_ref`.
- **Riding the existing substrate.** The recorder is the transactional-outbox discipline (`docs/codebase/events.md`) applied to outbound add-on delivery: the dispatch-completion record lands in the producer's transaction; the approval-outcome record is a fail-open committed write at the single `publish_approval_event` choke point, matching the existing approval-broadcast posture. `BroadcastEvent.audit_id → audit_log` linkage direction is preserved (`audit_id` is a convention-only reference, no reverse column).

## What's included

- Migration `0082`: `addon_step_event` table (`seq` cursor, tenant + `ON DELETE CASCADE` pairing FKs, `event_kind`, `work_ref`, `audit_id`, `payload`) + `addon_pairing.service_account_sub`.
- `operations/addon_step_events.py`: `AddonStepEventService` — `record_if_owned` (in-transaction), `record_if_owned_committed` (fail-open), `resolve_pairing_for_sub` (bind), `list_for_pairing` (resumable read, `{items, next_cursor}`).
- `KeycloakAdminClient.get_service_account_user_id` + pair-time capture (rollback-safe).
- Recorder wired into the agent-run terminal transition and `publish_approval_event`.
- `GET /api/v1/addons/pairings/{name}/events` — service-principal-only, cryptographically bound + name-matched (uniform 404 otherwise).
- OpenAPI snapshot + Go client regenerated (`cli/api/openapi.json`, `cli/internal/api/client.gen.go`).
- Both per-test TRUNCATE lists updated (tenant + `addon_pairing` FKs); drift guard green.
- `docs/codebase/addon-step-events.md`; `addon-pairing.md` cross-reference.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed modules) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC1 durable resume** — `list_for_pairing` reads strictly forward from an `after` cursor; endpoint round-trip proves gap-free resume (`test_addon_step_events.py`, `test_api_v1_addon_pairing.py::test_events_durable_resume`)
- [x] **AC2 scoping** — two paired add-ons, same `work_ref`, each subscription returns only its own event (`test_addon_step_events.py::test_scoping_never_delivers_another_pairings_events`); endpoint 403 non-service, uniform 404 for another pairing (`test_events_service_principal_only_and_scoped`)
- [x] Recorder no-op for non-add-on / cross-tenant principals; committed fail-open variant
- [x] `get_service_account_user_id` happy/404/empty; pair persists `service_account_sub`; SA-fetch failure rolls the Keycloak client back
- [x] Migration `0082` round-trip (column + table + indexes)
- [x] No regressions: `test_event_outbox`, `test_event_matcher`, `test_agent_run`, `test_agent_run_lifecycle`, `test_api_v1_approvals`, `test_approval_queue`, `test_approval_expiry`, `test_agent_approval_resume`, `test_db_models`, `test_features`, `test_mcp_surface_conformance`, `test_addon_pairing_conformance`, `test_api_v1_health`, list-envelope contract, truncate-list drift guard — all green

## Out of scope (deferred follow-ups; not required by the acceptance criteria)

- SSE / long-poll **transport** over the durable table (the durability + resume live in the table + `seq` cursor; the transport is a thin layer).
- Direct (non-agent-run) `call_operation` completion projection — the recorder is a reusable seam the async governed-dispatch run handle (#3079) can call.
- Wiring the finer heartbeat principal binding now that `service_account_sub` exists (a security-review hardening item).
- Step-event log retention sweep.

## Note for the orchestrator

Sibling wave-2 PRs claimed migrations `0080`/`0081`; this migration is filed as **`0082`** off head `0079`, so its chain is linear in this branch. If `0080`/`0081` land first, re-point `down_revision` to the then-current head at merge (additive, no DDL change). Sibling `register`/`CHANGELOG` rebases expected.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3027


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-29)

Addressed review finding **B1** (blocker) from the iteration-1
REQUEST_CHANGES review — `c5b7efe7`.

### B1 — resume cursor could skip a committed lower `seq` under concurrent same-pairing writes

**Fix chosen: per-pairing advisory-lock serialization of the seq-assign→commit window** (reviewer option **a**).

`AddonStepEventService.record_if_owned` now takes a transaction-scoped
`pg_advisory_xact_lock`, keyed by `_pairing_seq_lock_key(pairing_id)`,
**before** the INSERT draws `seq` and held to the caller's COMMIT. One
writer's whole `[draw seq … commit]` window therefore completes before
the next writer to the same pairing can draw its `seq`, so **commit order
equals `seq` order per pairing** and the `seq > after` high-watermark
cursor can never advance past an uncommitted lower `seq`. The
"no missed events" guarantee is now structural.

**Why this over the alternatives:**

- It is the **smallest** change that makes the durable-resume guarantee
  actually hold: no schema change, no new column, no migration edit, and
  the client-holds-cursor wire contract (endpoint, OpenAPI, Go client)
  is unchanged. Options (b) set-membership / low-watermark and (c) a
  server-side safe-watermark gate both require a per-subscriber delivery
  marker or a watermark column — the `event_outbox` `processed_at` model
  fits a single server-side drain, not a client that persists its own
  cursor and resumes with `after=<seq>`. Option (d) weakens the contract
  to at-least-once-with-lookback, which the AC's "no missed events"
  wording does not want.
- It is **consistent with existing repo patterns**: the identical
  `pg_advisory_xact_lock` discipline already guards the checks
  dashboard-transition claim (`checks/investigate.py::_lock_dashboard_transition`),
  including the blake2b→signed-63-bit key helper shape.
- The cost is negligible: the lock is **per pairing** (no cross-pairing
  contention — proven by a companion test), is taken only once the
  producer is a known paired add-on (the overwhelmingly common non-add-on
  path never touches it), and a single pairing's write rate is low. On
  SQLite it is a no-op (single-writer; `seq` order already equals commit
  order).

**Regression test** —
`backend/tests/integration/test_addon_step_events_concurrency.py`, on the
real `pgvector:pg16` container:

- `test_resume_misses_nothing_under_out_of_order_commit` stages the exact
  interleaving: writer A holds an uncommitted lower `seq` while writer B
  is blocked at the lock; an explicit read proves no committed higher
  `seq` exists ahead of the uncommitted lower one; after A commits, a
  one-event-per-page cursor walk misses nothing. Verified to **fail** with
  the lock removed (mutation check) and pass with it in place.
- `test_lock_is_per_pairing_and_does_not_block_a_sibling` proves the lock
  does not globally serialize writes.

Docs/claims reconciled to match: `addon-step-events.md` gains an
"Ordering under concurrent writers" section, and the module + model
docstrings state the serialization behind the "no missed events" claim.

**Local verification:** `ruff` / `ruff format --check` / `mypy` clean;
`code-quality.py --diff` 0 blockers; `pytest` 104 passed
(concurrency + step-events + agent_run + approval_queue + api_v1_approvals).

<!-- auto-implement-issue: continue, iteration 1 -->
