### PR TITLE
feat(policy): add destructive safety tier + default gate exclusions (#3196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,29 @@ connector-related release-notes line.
   write-path (#2901 / #3187) and governed-delete (#3183 / #3195) decisions;
   implementation seams are filed as sibling Tasks under #3207.
 
+### Added — `destructive` safety tier + default policy/filter exclusions (evoila-bosnia/meho-internal#3183 / #3196)
+
+- Added a fourth, most-restrictive `safety_level` value —
+  `safe < caution < dangerous < destructive` — the foundation of the
+  governed delete-shaped-operations path
+  (`docs/decisions/governed-delete-operations.md`, requirement 4). A
+  new Alembic migration widens the `ck_endpoint_descriptor_safety_level`
+  CHECK constraint; the `SafetyLevel` alias, both `VALID_SAFETY_LEVELS`
+  frozensets, every `Literal["safe", "caution", "dangerous"]` union, and
+  the MCP/console enums are widened in lockstep. The tier is **excluded
+  by default at every gate**: the agent policy gate maps it to `deny`
+  with a `deny` ceiling that no `AgentPermission` grant can lift
+  (non-grantable for agents); the service-principal gate parks it always
+  and a standing `ServicePrincipalGrant` can never satisfy it (refused at
+  both grant-creation and dispatch-time consult, single-sourced through
+  the delete-shaped classifier); and the satellite mint wall's existing
+  safe-only rule refuses it with `MintRefusalCode.OP_NOT_SAFE`, so
+  **deletes are never minted to a satellite** (agreeing with the
+  satellite write-path decision, #2901 / #3187). No connector adopts the
+  tier yet — this ships the tier and its exclusions only; the
+  preview-hash binding (#3197) and the first governed delete op family
+  (#3198) build on it.
+
 ### Changed — Audit + Broadcast console drawers resolve reference GUIDs to human-investigable substance (evoila-bosnia/meho-internal#236)
 
 - The operator console's **Audit row** and **Broadcast event** detail

--- a/backend/alembic/versions/0084_widen_safety_level_destructive.py
+++ b/backend/alembic/versions/0084_widen_safety_level_destructive.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Widen ``endpoint_descriptor.safety_level`` with the ``destructive`` tier.
+
+Revision ID: 0084
+Revises: 0079
+Create Date: 2026-08-30
+
+Initiative #3183 (governed delete-shaped operations), Task #3196 — the
+foundation task. The ratified decision
+(:file:`docs/decisions/governed-delete-operations.md`, requirement 4)
+adds a fourth, most-restrictive ``safety_level`` value above
+``dangerous``:
+
+    safe < caution < dangerous < destructive
+
+``safety_level`` is a closed enum pinned by the DB CHECK constraint
+``ck_endpoint_descriptor_safety_level`` (migration ``0005``:
+``safety_level IN ('safe', 'caution', 'dangerous')``). Adding the value
+is therefore a migration that widens that CHECK, in lockstep with the
+Python mirrors (``SafetyLevel`` alias, ``_VALID_SAFETY_LEVELS`` /
+``VALID_SAFETY_LEVELS`` frozensets, and the CHECK literal on the ORM
+model) updated in the same PR.
+
+Migration-number note (orchestrator-owned)
+------------------------------------------
+This revision is numbered ``0084`` with ``down_revision = "0079"`` —
+``0079`` is the current head on ``origin/main`` at branch time, so the
+chain resolves in isolation and the migration suite stays green. The
+numbers ``0080``-``0083`` are reserved for queued PRs (#3201 / #3204 /
+#3205 / #3206). If those land first the orchestrator re-points
+``down_revision`` to the then-current head (``0083``) at merge; if the
+queue shifts it re-points to whatever the real head is. Either way the
+final linear chain ends at this migration — pinning to ``0079`` keeps
+this branch's ``alembic upgrade head`` correct until that re-point.
+
+Why the closed enum (and the migration shape) matter
+----------------------------------------------------
+The same reasoning as migration ``0010`` (``graph_edge.kind``): a
+portable ``CHECK ... IN (...)`` recreated under
+:func:`op.batch_alter_table` drives both PostgreSQL (native
+``ALTER TABLE`` DDL) and SQLite (table rebuild — SQLite has no
+``ALTER TABLE ... DROP CONSTRAINT``). PostgreSQL ``ENUM`` types would
+force an ``ALTER TYPE ADD VALUE`` ceremony SQLite cannot mirror,
+breaking the dev/test path. Closed-with-migration-widening is the
+chassis pattern.
+
+Reversibility contract
+----------------------
+``upgrade()`` drops the existing constraint and recreates it over the
+wider four-value tuple. Backward compatibility is automatic: every
+pre-migration row's ``safety_level`` is in the three-value subset,
+which is a strict subset of the new set, so no row violates the widened
+constraint and no backfill is needed.
+
+``downgrade()`` narrows the constraint back to the three-value subset.
+Narrowing a CHECK is not backward-compatible by itself — any row
+written with ``safety_level='destructive'`` between the upgrade and the
+downgrade would violate the narrowed constraint. Following ``0010``'s
+precedent, ``downgrade()`` explicitly counts ``destructive`` rows and
+raises :class:`RuntimeError` with the count before attempting the DDL,
+turning an opaque mid-``ALTER TABLE`` failure into a clear
+operator-facing message.
+
+Migrations must be **self-contained** — the value tuples are inlined
+verbatim rather than imported from :mod:`meho_backplane.db.models`, so
+Alembic runs against any historical revision's model graph.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0084"
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINT: str = "ck_endpoint_descriptor_safety_level"
+_TABLE: str = "endpoint_descriptor"
+
+#: The four-value v0.2.next vocabulary — the three pre-#3183 values plus
+#: the ``destructive`` tier. Mirrors the ``SafetyLevel`` alias and the
+#: CHECK literal on the ORM model; inlined because migrations must be
+#: self-contained.
+_SAFETY_LEVELS_V4: tuple[str, ...] = ("safe", "caution", "dangerous", "destructive")
+
+#: The pre-#3183 three-value subset — what ``downgrade()`` narrows back to.
+_SAFETY_LEVELS_V3: tuple[str, ...] = ("safe", "caution", "dangerous")
+
+#: The value added by this migration — the set ``downgrade()`` must refuse
+#: to orphan.
+_ADDED_ONLY: tuple[str, ...] = ("destructive",)
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a ``column IN ('a', 'b', ...)`` clause for a CHECK constraint.
+
+    Mirrors the helper in ``0010_widen_graph_edge_kind`` — migrations must
+    be self-contained, so the helper is inlined rather than imported.
+    """
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Widen ``ck_endpoint_descriptor_safety_level`` to include ``destructive``.
+
+    Drop the existing constraint and recreate it over the wider tuple.
+    Every pre-migration row's ``safety_level`` is in the three-value
+    subset, a strict subset of the new set, so no row violates the widened
+    constraint — backward compatibility is automatic.
+
+    Wrapped in :func:`op.batch_alter_table` for SQLite portability.
+    """
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_constraint(_CONSTRAINT, type_="check")
+        batch_op.create_check_constraint(
+            _CONSTRAINT,
+            _check_in("safety_level", _SAFETY_LEVELS_V4),
+        )
+
+
+def downgrade() -> None:
+    """Narrow ``ck_endpoint_descriptor_safety_level`` back to three values.
+
+    Refuses (with :class:`RuntimeError`) if any row carries the
+    ``destructive`` value added by this migration — narrowing the
+    constraint while those rows exist would orphan them on next write and
+    surface as an opaque DDL failure. The pre-check turns that into a clear
+    "you have N destructive-tier ops; re-classify them first" message
+    before any DDL runs.
+    """
+    endpoint_descriptor = sa.table(
+        _TABLE,
+        sa.column("safety_level", sa.Text()),
+    )
+    count_col = sa.func.count().label("n")
+    blocking_stmt = (
+        sa.select(endpoint_descriptor.c.safety_level, count_col)
+        .where(endpoint_descriptor.c.safety_level.in_(_ADDED_ONLY))
+        .group_by(endpoint_descriptor.c.safety_level)
+    )
+
+    bind = op.get_bind()
+    blocking_rows = bind.execute(blocking_stmt).all()
+
+    if blocking_rows:
+        total = sum(row.n for row in blocking_rows)
+        details = ", ".join(f"{row.safety_level}={row.n}" for row in blocking_rows)
+        raise RuntimeError(
+            "Cannot downgrade migration 0084: endpoint_descriptor contains "
+            f"{total} row(s) with the destructive-tier safety_level ({details}) "
+            "that would be orphaned by the narrowed CHECK constraint. "
+            "Re-classify them (safety_level -> 'dangerous') before running "
+            "`alembic downgrade`."
+        )
+
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_constraint(_CONSTRAINT, type_="check")
+        batch_op.create_check_constraint(
+            _CONSTRAINT,
+            _check_in("safety_level", _SAFETY_LEVELS_V3),
+        )

--- a/backend/alembic/versions/0084_widen_safety_level_destructive.py
+++ b/backend/alembic/versions/0084_widen_safety_level_destructive.py
@@ -4,7 +4,7 @@
 """Widen ``endpoint_descriptor.safety_level`` with the ``destructive`` tier.
 
 Revision ID: 0084
-Revises: 0079
+Revises: 0083
 Create Date: 2026-08-30
 
 Initiative #3183 (governed delete-shaped operations), Task #3196 — the
@@ -75,7 +75,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0084"
-down_revision: str | None = "0079"
+down_revision: str | None = "0083"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/auth/permissions.py
+++ b/backend/src/meho_backplane/auth/permissions.py
@@ -125,12 +125,13 @@ _log = structlog.get_logger(__name__)
 
 #: Default verdict when no AgentPermission row matches, keyed by
 #: safety_level value. ``safe`` → auto-execute, ``caution`` →
-#: needs-approval, ``dangerous`` → deny. Unknown safety_level falls
-#: back to deny (fail-closed).
+#: needs-approval, ``dangerous`` → deny, ``destructive`` → deny.
+#: Unknown safety_level falls back to deny (fail-closed).
 _SAFETY_DEFAULT: dict[str, PermissionVerdict] = {
     "safe": PermissionVerdict.AUTO_EXECUTE,
     "caution": PermissionVerdict.NEEDS_APPROVAL,
     "dangerous": PermissionVerdict.DENY,
+    "destructive": PermissionVerdict.DENY,
 }
 
 #: Hard upper-bound ceiling for each safety_level.  A permission row
@@ -139,13 +140,21 @@ _SAFETY_DEFAULT: dict[str, PermissionVerdict] = {
 #: valid -- the ``None`` sentinel is handled in ``_apply_ceiling``).
 #: ``dangerous`` is capped at ``needs-approval`` (not ``deny``) so an
 #: explicit grant *is* honoured -- "deny **unless granted**" (#820) --
-#: while a granted destructive op still lands on human approval rather
+#: while a granted dangerous op still lands on human approval rather
 #: than auto-executing. The *default* (no grant) for ``dangerous``
 #: stays ``deny`` via ``_SAFETY_DEFAULT``.
+#:
+#: ``destructive`` (#3183) is the exception to "deny unless granted":
+#: its ceiling is ``deny``, so *no* AgentPermission grant can lift an
+#: agent principal off ``deny`` — the tier is non-grantable for agents
+#: by construction (default deny + deny ceiling). Governed execution of
+#: a destructive op is a human decision on the non-agent approval path
+#: (#3197 / #3198), never an agent verdict.
 _SAFETY_CEILING: dict[str, PermissionVerdict | None] = {
     "safe": None,
     "caution": PermissionVerdict.NEEDS_APPROVAL,
     "dangerous": PermissionVerdict.NEEDS_APPROVAL,
+    "destructive": PermissionVerdict.DENY,
 }
 
 # Verdict ordering: lower index = more permissive. Used to compare
@@ -292,7 +301,8 @@ async def resolve_verdict(
         ``"vault.kv.read"``).
     safety_level:
         The op's :attr:`~meho_backplane.db.models.EndpointDescriptor.safety_level`
-        column value: one of ``"safe"``, ``"caution"``, ``"dangerous"``.
+        column value: one of ``"safe"``, ``"caution"``, ``"dangerous"``,
+        ``"destructive"``.
     target_id:
         The dispatch target's identifier (UUID or any object with a
         ``.id`` attribute), or ``None`` when the op is target-agnostic.

--- a/backend/src/meho_backplane/broadcast/announce_gate.py
+++ b/backend/src/meho_backplane/broadcast/announce_gate.py
@@ -70,7 +70,12 @@ _log = structlog.get_logger(__name__)
 #: so this map is the single place the ``>= caution`` threshold is encoded.
 #: An unknown level (never expected -- the column is CHECK-constrained)
 #: ranks ``0`` so the gate stays permissive (fail-open) on it.
-_SAFETY_RANK: Final[dict[str, int]] = {"safe": 0, "caution": 1, "dangerous": 2}
+_SAFETY_RANK: Final[dict[str, int]] = {
+    "safe": 0,
+    "caution": 1,
+    "dangerous": 2,
+    "destructive": 3,
+}
 _SAFETY_GATE_THRESHOLD: Final[int] = _SAFETY_RANK["caution"]
 
 #: Per-tenant enablement cache, mirroring ``overrides._TENANT_CACHE``.

--- a/backend/src/meho_backplane/connectors/argocd/ops.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops.py
@@ -82,7 +82,7 @@ class ArgoCdOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/bind9/ops.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops.py
@@ -67,7 +67,7 @@ class Bind9Op:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/typed_ops.py
@@ -86,7 +86,7 @@ class FleetLcmTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/gcloud/ops.py
+++ b/backend/src/meho_backplane/connectors/gcloud/ops.py
@@ -75,7 +75,7 @@ class GcloudOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -153,7 +153,7 @@ class _CompositeSpec(NamedTuple):
     response_schema: dict[str, Any]
     group_key: str
     tags: list[str]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
 
 

--- a/backend/src/meho_backplane/connectors/harbor/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/typed_ops.py
@@ -82,7 +82,7 @@ class HarborTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -66,7 +66,7 @@ class HolodeckOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/keycloak/ops_read.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_read.py
@@ -137,7 +137,7 @@ class KeycloakOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -96,7 +96,7 @@ class KubernetesOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/loki/ops.py
+++ b/backend/src/meho_backplane/connectors/loki/ops.py
@@ -65,7 +65,7 @@ class LokiOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/mongodb/ops.py
+++ b/backend/src/meho_backplane/connectors/mongodb/ops.py
@@ -55,7 +55,7 @@ class MongoOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/nsx/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_ops.py
@@ -78,7 +78,7 @@ class NsxTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/pfsense/ops.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops.py
@@ -51,7 +51,7 @@ class PfSenseOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/postgres/ops.py
+++ b/backend/src/meho_backplane/connectors/postgres/ops.py
@@ -56,7 +56,7 @@ class PostgresOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/prometheus/ops.py
+++ b/backend/src/meho_backplane/connectors/prometheus/ops.py
@@ -58,7 +58,7 @@ class PrometheusOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/proxmox/ops.py
+++ b/backend/src/meho_backplane/connectors/proxmox/ops.py
@@ -193,7 +193,7 @@ class ProxmoxOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/rabbitmq/ops.py
+++ b/backend/src/meho_backplane/connectors/rabbitmq/ops.py
@@ -78,7 +78,7 @@ class RabbitMqOp:
     group_key: str
     tags: tuple[str, ...]
     llm_instructions: dict[str, Any]
-    safety_level: Literal["safe", "caution", "dangerous"] = "safe"
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"] = "safe"
     requires_approval: bool = False
 
 

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -72,7 +72,7 @@ class Rke2Op:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -115,7 +115,7 @@ class SddcTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/sddc_vcf5/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_vcf5/typed_ops.py
@@ -77,7 +77,7 @@ class SddcVcf5TypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/tempo/ops.py
+++ b/backend/src/meho_backplane/connectors/tempo/ops.py
@@ -67,7 +67,7 @@ class TempoOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcd/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcd/typed_ops.py
@@ -75,7 +75,7 @@ class VcloudDirectorTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
@@ -142,7 +142,7 @@ class VcfaTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcf_fleet/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/typed_ops.py
@@ -86,7 +86,7 @@ class FleetTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_installer/typed_ops.py
@@ -95,7 +95,7 @@ class InstallerTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
@@ -127,7 +127,7 @@ class VrliTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
@@ -139,7 +139,7 @@ class VropsTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -278,7 +278,7 @@ class _CompositeSpec(NamedTuple):
     response_schema: dict[str, Any]
     group_key: str
     tags: list[str]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -134,7 +134,7 @@ class VmwareTypedOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/vra8/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vra8/typed_ops.py
@@ -83,7 +83,7 @@ class Vra8TypedOp:
     response_schema: dict[str, Any] | None
     group_key: str
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/connectors/windows_dns/ops.py
+++ b/backend/src/meho_backplane/connectors/windows_dns/ops.py
@@ -80,7 +80,7 @@ class WindowsDnsOp:
     response_schema: dict[str, Any] | None
     group_key: str | None
     tags: tuple[str, ...]
-    safety_level: Literal["safe", "caution", "dangerous"]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
     requires_approval: bool
     llm_instructions: dict[str, Any] | None
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1410,6 +1410,10 @@ class EndpointDescriptor(Base):
     hooks. ``safety_level='safe'`` operations execute under the
     default-allow policy (v0.2); ``'caution'`` and ``'dangerous'``
     flow through G7 / G10 policy logic once those Goals land.
+    ``'destructive'`` is the fourth, most-restrictive tier (#3183):
+    an operator-assigned floor for delete-shaped ops that is
+    denied for agent principals, parked for service principals, and
+    never minted to a satellite — excluded by default at every gate.
     ``requires_approval=true`` (independent of ``safety_level``)
     forces the dispatcher to write an audit row in
     ``status='pending'`` and wait for an operator decision before
@@ -1628,7 +1632,7 @@ class EndpointDescriptor(Base):
             name="ck_endpoint_descriptor_source_kind",
         ),
         sa.CheckConstraint(
-            "safety_level IN ('safe', 'caution', 'dangerous')",
+            "safety_level IN ('safe', 'caution', 'dangerous', 'destructive')",
             name="ck_endpoint_descriptor_safety_level",
         ),
     )

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -582,7 +582,7 @@ register_mcp_tool(
                 "custom_description": {"type": ["string", "null"]},
                 "safety_level": {
                     "type": ["string", "null"],
-                    "enum": ["safe", "caution", "dangerous", None],
+                    "enum": ["safe", "caution", "dangerous", "destructive", None],
                 },
                 "requires_approval": {"type": ["boolean", "null"]},
                 "is_enabled": {"type": ["boolean", "null"]},

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -369,7 +369,7 @@ register_mcp_tool(
                             "group_key": {"type": ["string", "null"]},
                             "safety_level": {
                                 "type": "string",
-                                "enum": ["safe", "caution", "dangerous"],
+                                "enum": ["safe", "caution", "dangerous", "destructive"],
                             },
                             "requires_approval": {"type": "boolean"},
                             "fused_score": {"type": "number"},

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -166,12 +166,22 @@ def _service_safety_gate_reason(descriptor: EndpointDescriptor) -> str | None:
 
     Resolution of #3152 as its option 1: the non-agent gate now consults
     ``safety_level`` for a service principal on a ``requires_approval=False``
-    op. A ``dangerous`` op parks always; a mutating ``caution`` op parks;
-    ``safe`` (and any non-mutating) op is unchanged (auto-executes). A
-    standing grant is the sanctioned path to run either unattended.
+    op. A ``destructive`` op parks always and is never grant-satisfiable
+    (#3183); a ``dangerous`` op parks always; a mutating ``caution`` op
+    parks; ``safe`` (and any non-mutating) op is unchanged (auto-executes).
+    A standing grant is the sanctioned path to run a ``dangerous`` /
+    ``caution`` op unattended — but never a ``destructive`` one (the grant
+    lookup in :func:`~meho_backplane.operations.service_grants.consult_and_record_grant`
+    refuses the tier before matching a row).
 
     Returns the park reason, or ``None`` when the op stays auto-execute.
     """
+    if descriptor.safety_level == "destructive":
+        return (
+            "safety_level=destructive; service-principal deletes park always "
+            "(routed to the approval queue) and are never satisfiable by a "
+            "standing grant — mandatory human approval (#3183)"
+        )
     if descriptor.safety_level == "dangerous":
         return (
             "safety_level=dangerous; service-principal mutations park "

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -111,7 +111,7 @@ READ_HTTP_METHODS: Final[frozenset[str]] = frozenset({"GET", "HEAD"})
 #: same set is enforced by the DB CHECK constraint; the Python-side
 #: validator catches bad input before the round-trip.
 VALID_SAFETY_LEVELS: Final[frozenset[str]] = frozenset(
-    {"safe", "caution", "dangerous"},
+    {"safe", "caution", "dangerous", "destructive"},
 )
 
 

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -937,7 +937,7 @@ class EditOpBody(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     custom_description: str | None = Field(default=None, min_length=1, max_length=4096)
-    safety_level: Literal["safe", "caution", "dangerous"] | None = None
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"] | None = None
     requires_approval: bool | None = None
     is_enabled: bool | None = None
 

--- a/backend/src/meho_backplane/operations/ingest/schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/schemas.py
@@ -21,7 +21,7 @@ __all__ = [
     "SafetyLevel",
 ]
 
-SafetyLevel = Literal["safe", "caution", "dangerous"]
+SafetyLevel = Literal["safe", "caution", "dangerous", "destructive"]
 
 
 class EndpointDescriptorProto(BaseModel):
@@ -92,7 +92,9 @@ class EndpointDescriptorProto(BaseModel):
     """Heuristic from the HTTP verb. ``GET`` / ``HEAD`` / ``OPTIONS``
     → ``safe``; ``POST`` / ``PUT`` / ``PATCH`` → ``caution``;
     ``DELETE`` → ``dangerous``. Operator can override at review
-    (T4 state machine)."""
+    (T4 state machine), including to the most-restrictive
+    ``destructive`` tier (#3183) — the parser never assigns
+    ``destructive`` itself; it is an operator/typed-op decision."""
 
     requires_approval: bool = False
     """Always ``False`` at parse time. Operators flip per-op during

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -623,7 +623,7 @@ class ReviewService:
         *,
         tenant_id: UUID | None,
         custom_description: str | _UnsetType | None = _UNSET,
-        safety_level: Literal["safe", "caution", "dangerous"] | None = None,
+        safety_level: Literal["safe", "caution", "dangerous", "destructive"] | None = None,
         requires_approval: bool | None = None,
         is_enabled: bool | None = None,
         llm_instructions: dict[str, object] | None = None,

--- a/backend/src/meho_backplane/operations/service_grants.py
+++ b/backend/src/meho_backplane/operations/service_grants.py
@@ -155,9 +155,20 @@ def _delete_shaped_reason_by_pattern(op_id: str, patterns: tuple[str, ...]) -> s
 def _delete_shaped_reason_by_descriptor(descriptor: EndpointDescriptor) -> str | None:
     """Return a refusal reason if the resolved descriptor marks destruction.
 
-    Best-effort second check (only when a descriptor resolves): the HTTP
-    ``DELETE`` verb, or a hand-authored ``destructive`` tag on a typed op.
+    Best-effort second check (only when a descriptor resolves): the
+    ``destructive`` safety tier (#3183), the HTTP ``DELETE`` verb, or a
+    hand-authored ``destructive`` tag on a typed op. The three inputs
+    single-source the delete-shaped classification — ``DELETE:`` verbs and
+    ``destructive``-tagged typed ops are the shapes an operator resolves
+    into the ``destructive`` tier, so once the tier is set it is itself the
+    authoritative signal.
     """
+    if descriptor.safety_level == "destructive":
+        return (
+            f"op {descriptor.op_id!r} is safety_level=destructive; delete-shaped "
+            "operations are never grantable — a standing grant is the floor of "
+            "what runs unattended, not a bypass of a destructive gate"
+        )
     method = (descriptor.method or "").upper()
     if method == "DELETE":
         return (
@@ -483,7 +494,28 @@ async def consult_and_record_grant(
     grant-use audit row (``approval.decision`` shape) in its own committed
     transaction and publishes a fail-open broadcast — same visibility as a
     human approval decision — before returning.
+
+    A ``destructive``-tier op (#3183) is refused here **before** any grant
+    lookup: the tier is non-grantable, so even a stale grant row that
+    predates the op's promotion into the tier can never auto-approve it.
+    This is the dispatch-time twin of the create-time refusal in
+    :func:`_delete_shaped_reason_by_descriptor`; together they make
+    "a standing grant can never satisfy a destructive op" hold whether the
+    grant is being created or consulted.
     """
+    destructive_reason = _delete_shaped_reason_by_descriptor(descriptor)
+    if destructive_reason is not None:
+        _log.info(
+            "service_grant_refused_delete_shaped",
+            op_id=descriptor.op_id,
+            connector_id=connector_id,
+            safety_level=descriptor.safety_level,
+            principal_sub=operator.sub,
+            tenant_id=str(operator.tenant_id),
+            reason=destructive_reason,
+        )
+        return None
+
     target_id = _target_uuid(target)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -493,7 +493,7 @@ type CompositeOpHandler = Callable[..., Awaitable[dict[str, Any] | OperationResu
 # invalid values at the Python boundary rather than at commit time
 # (where the IntegrityError message names the constraint, not the
 # field that produced it).
-_VALID_SAFETY_LEVELS: frozenset[str] = frozenset({"safe", "caution", "dangerous"})
+_VALID_SAFETY_LEVELS: frozenset[str] = frozenset({"safe", "caution", "dangerous", "destructive"})
 
 
 class HandlerRefError(ValueError):
@@ -942,7 +942,7 @@ async def register_typed_operation(
     response_schema: dict[str, Any] | None = None,
     group_key: str | None = None,
     tags: list[str] | None = None,
-    safety_level: Literal["safe", "caution", "dangerous"] = "safe",
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"] = "safe",
     requires_approval: bool = False,
     llm_instructions: dict[str, Any] | None = None,
     custom_description: str | None = None,
@@ -1179,7 +1179,7 @@ async def register_composite_operation(
     response_schema: dict[str, Any] | None = None,
     group_key: str | None = None,
     tags: list[str] | None = None,
-    safety_level: Literal["safe", "caution", "dangerous"] = "dangerous",
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"] = "dangerous",
     requires_approval: bool = True,
     llm_instructions: dict[str, Any] | None = None,
     custom_description: str | None = None,

--- a/backend/src/meho_backplane/ui/templates/connectors/_review_op_row.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_review_op_row.html
@@ -99,7 +99,7 @@
           data-control="safety_level"
           onchange="this.form.requestSubmit()"
         >
-          {% for level in ["safe", "caution", "dangerous"] %}
+          {% for level in ["safe", "caution", "dangerous", "destructive"] %}
             <option value="{{ level }}" {{ "selected" if op.safety_level == level else "" }}>
               {{ level }}
             </option>

--- a/backend/tests/migrations/test_migration_0084_destructive_safety_level.py
+++ b/backend/tests/migrations/test_migration_0084_destructive_safety_level.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0084_widen_safety_level_destructive``.
+
+#3183 / #3196. Widens the ``ck_endpoint_descriptor_safety_level`` CHECK
+constraint from three values to four by adding the ``destructive`` tier
+(``safe < caution < dangerous < destructive``).
+
+Idempotency pinning: every forward / round-trip step targets this
+migration's own revision (``0084``) and its ``down_revision`` (``0079``),
+never ``head`` — so a future head migration cannot make ``upgrade("head")``
+re-run this constraint recreate on a schema that already has it. SQLite is
+the test driver and the migration uses only generic ``CHECK ... IN (...)``
+DDL under ``batch_alter_table``, so PostgreSQL parity holds.
+
+The ``down_revision`` is pinned to ``0079`` (the head at branch time);
+the orchestrator re-points it to the then-current head at merge if the
+0080-0083 queue lands first (see the migration docstring). This test
+targets the literal revision ids so it stays correct under that re-point
+only if the ids move in lockstep — which the orchestrator's re-point does.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0084"
+_DOWN_REVISION = "0079"
+_TABLE = "endpoint_descriptor"
+_CONSTRAINT = "ck_endpoint_descriptor_safety_level"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0084.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor(sync_url: str, safety_level: str, op_id: str) -> None:
+    """Insert a minimal ``endpoint_descriptor`` row at *safety_level*.
+
+    Raises :class:`~sqlalchemy.exc.IntegrityError` when the CHECK
+    constraint rejects the value — the failure surface the tests assert on.
+    """
+    now = datetime.now(UTC).isoformat()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO endpoint_descriptor "
+                    "(id, product, version, impl_id, op_id, source_kind, safety_level, "
+                    " requires_approval, is_enabled, needs_reingest, created_at, updated_at) "
+                    "VALUES (:id, :product, :version, :impl_id, :op_id, :source_kind, "
+                    " :safety_level, 0, 1, 0, :created_at, :updated_at)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "product": "vault",
+                    "version": "1.x",
+                    "impl_id": "vault",
+                    "op_id": op_id,
+                    "source_kind": "typed",
+                    "safety_level": safety_level,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_upgrade_check_accepts_destructive(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0084`` widens the CHECK so a ``destructive`` row inserts."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    # The three pre-existing values still insert...
+    for level in ("safe", "caution", "dangerous"):
+        _insert_descriptor(sync_url, level, f"op.{level}")
+    # ...and the new tier now inserts too.
+    _insert_descriptor(sync_url, "destructive", "op.destroy")
+
+
+def test_upgrade_check_still_rejects_unknown_value(alembic_cfg: tuple[Config, str]) -> None:
+    """A value outside the widened four-set is still rejected by the CHECK."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    with pytest.raises(IntegrityError):
+        _insert_descriptor(sync_url, "catastrophic", "op.bogus")
+
+
+def test_downgrade_refuses_when_destructive_rows_exist(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0079`` raises (not a silent DDL failure) when a
+    ``destructive`` row would be orphaned by the narrowed CHECK."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    _insert_descriptor(sync_url, "destructive", "op.destroy")
+
+    with pytest.raises(RuntimeError, match="destructive-tier"):
+        command.downgrade(cfg, _DOWN_REVISION)
+
+
+def test_downgrade_narrows_check_when_no_destructive_rows(alembic_cfg: tuple[Config, str]) -> None:
+    """With no ``destructive`` rows, ``downgrade 0079`` narrows the CHECK
+    back to three values — a subsequent ``destructive`` insert is rejected."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    _insert_descriptor(sync_url, "dangerous", "op.dangerous")
+
+    command.downgrade(cfg, _DOWN_REVISION)
+
+    with pytest.raises(IntegrityError):
+        _insert_descriptor(sync_url, "destructive", "op.destroy")
+
+
+def test_upgrade_round_trips_after_clean_downgrade(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0084`` → clean ``downgrade 0079`` → ``upgrade 0084`` again
+    leaves the widened CHECK in place (idempotent constraint recreate)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    command.downgrade(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _REVISION)
+
+    _insert_descriptor(sync_url, "destructive", "op.destroy")

--- a/backend/tests/test_announce_gate.py
+++ b/backend/tests/test_announce_gate.py
@@ -194,6 +194,26 @@ async def test_gate_blocks_enabled_write_caution_no_claim() -> None:
     assert "meho_broadcast_announce" in block
 
 
+async def test_gate_blocks_enabled_write_destructive_no_claim() -> None:
+    """enabled + destructive tier + no claim -> remediation string.
+
+    The ``destructive`` tier (#3183) ranks above ``caution`` in
+    ``_SAFETY_RANK`` (rank 3), so it is at-or-above the gate threshold and
+    is *not* mistaken for a fail-open unknown level (which would rank 0 and
+    slip the gate).
+    """
+    await _seed_tenant(enabled=True)
+    with patch(
+        "meho_backplane.broadcast.announce_gate.caller_has_active_announce_claim",
+        new=AsyncMock(return_value=False),
+    ):
+        block = await announce_gate_blocks(
+            _operator(), op_id="vault.kv.delete", safety_level="destructive", target_name="vault-1"
+        )
+    assert block is not None
+    assert "meho_broadcast_announce" in block
+
+
 async def test_gate_passes_when_claim_covers_op() -> None:
     """An active covering claim lets the op through."""
     await _seed_tenant(enabled=True)

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -155,9 +155,14 @@ async def _claim() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("level", ["caution", "dangerous"])
+@pytest.mark.parametrize("level", ["caution", "dangerous", "destructive"])
 async def test_mint_refuses_non_safe_op(monkeypatch: pytest.MonkeyPatch, level: str) -> None:
-    """A non-'safe' op is refused before the policy gate — no rows written."""
+    """A non-'safe' op is refused before the policy gate — no rows written.
+
+    The ``destructive`` tier (#3183) is transitively excluded from every
+    satellite by this same safe-only wall: a delete is never minted to a
+    runner, agreeing with the satellite write-path decision (#2901 / #3187).
+    """
     await _seed_tenant()
     _patch_lookup(monkeypatch, _descriptor(safety_level=level))
 

--- a/backend/tests/test_permission_resolver.py
+++ b/backend/tests/test_permission_resolver.py
@@ -264,6 +264,46 @@ async def test_dangerous_op_with_no_grant_denies() -> None:
     assert "dangerous" in reason
 
 
+# ---------------------------------------------------------------------------
+# Destructive tier (#3183) — deny by default, non-grantable for agents
+# ---------------------------------------------------------------------------
+
+
+async def test_destructive_op_denied_by_default() -> None:
+    """``safety_level='destructive'`` with no rows → ``deny``."""
+    verdict, reason = await _resolve(safety_level="destructive")
+    assert verdict == PermissionVerdict.DENY
+    assert "safety_level default" in reason
+
+
+async def test_auto_execute_grant_cannot_lift_destructive_off_deny() -> None:
+    """An ``auto-execute`` grant on a ``destructive`` op stays ``deny``.
+
+    The ``destructive`` tier (#3183) has a ``deny`` ceiling — unlike
+    ``dangerous`` (ceiling ``needs-approval``), *no* ``AgentPermission``
+    grant lifts an agent principal off ``deny``. This is the "no grant can
+    lift it" contract: even the most permissive grant is clamped back to
+    ``deny`` by the ceiling.
+    """
+    await _seed_tenant(_TENANT_ID, "t-destructive-autoexec")
+    await _insert_permission(op_pattern="*", verdict="auto-execute")
+    verdict, reason = await _resolve(safety_level="destructive")
+    assert verdict == PermissionVerdict.DENY
+    assert "ceiling" in reason
+
+
+async def test_needs_approval_grant_cannot_lift_destructive_off_deny() -> None:
+    """A ``needs-approval`` grant on a ``destructive`` op stays ``deny``.
+
+    Even a grant sitting at what would be a human-approval verdict cannot
+    park a destructive op for an agent — the ``deny`` ceiling pins it.
+    """
+    await _seed_tenant(_TENANT_ID, "t-destructive-needs")
+    await _insert_permission(op_pattern="*", verdict="needs-approval")
+    verdict, _reason = await _resolve(safety_level="destructive")
+    assert verdict == PermissionVerdict.DENY
+
+
 async def test_expired_grant_ignored_by_resolver() -> None:
     """A grant past its ``expires_at`` no longer counts (G11.2-T6 #819).
 

--- a/backend/tests/test_service_grants.py
+++ b/backend/tests/test_service_grants.py
@@ -158,6 +158,36 @@ async def test_create_refuses_destructive_tagged_descriptor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_refuses_destructive_tier_descriptor() -> None:
+    """An op whose descriptor is in the ``destructive`` safety tier (#3183) is
+    refused at grant creation, even without a delete-shaped name or the
+    ``destructive`` tag — the tier itself is the authoritative signal.
+    """
+    async with get_sessionmaker()() as s:
+        s.add(
+            EndpointDescriptor(
+                tenant_id=_TENANT_ID,
+                product="vault",
+                version="1.x",
+                impl_id="vault",
+                op_id="vault.sys.rekey",
+                source_kind="typed",
+                method="POST",
+                safety_level="destructive",
+                tags=["write"],
+                is_enabled=True,
+            )
+        )
+        await s.commit()
+
+    svc = ServicePrincipalGrantService()
+    payload = _payload(op_id="vault.sys.rekey", connector_id="vault-1.x")
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, payload)
+    assert "destructive" in str(exc.value)
+
+
+@pytest.mark.asyncio
 async def test_create_refuses_past_and_naive_expiry() -> None:
     """A past or timezone-naive ``expires_at`` is refused."""
     svc = ServicePrincipalGrantService()

--- a/backend/tests/test_service_principal_grant_gate.py
+++ b/backend/tests/test_service_principal_grant_gate.py
@@ -458,3 +458,37 @@ def test_is_mutating(method: str | None, safety_level: str, expected: bool) -> N
 def test_service_safety_gate_reason(method: str, safety_level: str, gated: bool) -> None:
     reason = _service_safety_gate_reason(_descriptor(method=method, safety_level=safety_level))
     assert (reason is not None) is gated
+
+
+@pytest.mark.parametrize("method", ["DELETE", "POST", None])
+def test_service_safety_gate_reason_destructive_parks_always(method: str | None) -> None:
+    """The ``destructive`` tier (#3183) parks a service principal always,
+    regardless of HTTP method, and names the mandatory-human-approval
+    contract in its reason string."""
+    reason = _service_safety_gate_reason(_descriptor(method=method, safety_level="destructive"))
+    assert reason is not None
+    assert "destructive" in reason
+    assert "never satisfiable by a standing grant" in reason
+
+
+@pytest.mark.asyncio
+async def test_service_principal_destructive_parks_and_grant_never_satisfies() -> None:
+    """A ``destructive`` op parks for a service principal **even with a live
+    matching grant** — the tier is non-grantable (#3183), so
+    ``consult_and_record_grant`` refuses it before any lookup and no
+    grant-use audit row is written.
+    """
+    grant_id = await _seed_grant()
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.SERVICE),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="destructive",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    # The live grant did NOT clear the gate — no auto-approval was recorded.
+    assert not await _grant_use_rows(grant_id)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -26303,7 +26303,8 @@
             "enum": [
               "safe",
               "caution",
-              "dangerous"
+              "dangerous",
+              "destructive"
             ],
             "nullable": true,
             "title": "Safety Level"

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -223,9 +223,10 @@ const (
 
 // Defines values for EditOpBodySafetyLevel.
 const (
-	EditOpBodySafetyLevelCaution   EditOpBodySafetyLevel = "caution"
-	EditOpBodySafetyLevelDangerous EditOpBodySafetyLevel = "dangerous"
-	EditOpBodySafetyLevelSafe      EditOpBodySafetyLevel = "safe"
+	EditOpBodySafetyLevelCaution     EditOpBodySafetyLevel = "caution"
+	EditOpBodySafetyLevelDangerous   EditOpBodySafetyLevel = "dangerous"
+	EditOpBodySafetyLevelDestructive EditOpBodySafetyLevel = "destructive"
+	EditOpBodySafetyLevelSafe        EditOpBodySafetyLevel = "safe"
 )
 
 // Defines values for EditOpWarningCode.

--- a/docs/codebase/agent-permission-model.md
+++ b/docs/codebase/agent-permission-model.md
@@ -111,6 +111,7 @@ error naming the `principal_kind=agent` enforcement scope.
    | `safe` | `auto-execute` |
    | `caution` | `needs-approval` |
    | `dangerous` | `deny` |
+   | `destructive` | `deny` |
    | unknown | `deny` (fail-closed) |
 
 4. **Apply safety-level ceiling.** A row's verdict can only tighten to the
@@ -120,11 +121,16 @@ error naming the `principal_kind=agent` enforcement scope.
    |---|---|---|
    | `safe` | none | Any row verdict is valid |
    | `caution` | `needs-approval` | `auto-execute` row → `needs-approval` |
-   | `dangerous` | `needs-approval` | `auto-execute` row → `needs-approval`; a destructive op is grantable up to human approval, never auto-executed. The *default* (no grant) stays `deny`. |
+   | `dangerous` | `needs-approval` | `auto-execute` row → `needs-approval`; a dangerous op is grantable up to human approval, never auto-executed. The *default* (no grant) stays `deny`. |
+   | `destructive` | `deny` | `auto-execute` / `needs-approval` row → `deny`; the tier is **non-grantable for agents** — no `AgentPermission` grant lifts an agent principal off `deny` (#3183). |
 
-   This is the "destructive = deny **unless granted**" rule (#820): the
-   no-grant default is `deny`, but an explicit grant *is* honoured up to the
-   `needs-approval` ceiling.
+   For `caution` / `dangerous` this is the "deny **unless granted**" rule
+   (#820): the no-grant default is `deny`, but an explicit grant *is*
+   honoured up to the `needs-approval` ceiling. The `destructive` tier
+   (#3183) is the exception — its ceiling is `deny`, so it is denied for
+   agent principals regardless of any grant. Governed execution of a
+   destructive op is a human decision on the non-agent approval path
+   (#3197 / #3198), never an agent verdict.
 
 5. **Apply role ceiling.** `READ_ONLY` principals are capped at `needs-approval`;
    `OPERATOR` and `TENANT_ADMIN` are uncapped.

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -229,7 +229,12 @@ default), `GATEWAY_DEADMAN_TICK_INTERVAL_SECONDS` (default 30),
   (`GET /gateway/{runner}/next` / `POST /gateway/{runner}/result`) — #2498.
 - Single-use capability-command minting + request-id dedup — #2500. The
   runner's `safe`-only executor guard is defence in depth, not the mint
-  rule.
+  rule. The central mint wall (`mint_gateway_command`) refuses any
+  `safety_level != "safe"` op with `MintRefusalCode.OP_NOT_SAFE` *before*
+  the policy gate, so the `destructive` tier (#3183) is transitively
+  excluded from every satellite the day it exists — **deletes are never
+  minted to a satellite**, agreeing with the satellite write-path decision
+  (#2901 / #3187).
 - Heartbeat + central stale/unknown flipping — #2501.
 - The scoped per-runner service principal + credential scoping — #2502.
   `MEHO_RUNNER_TOKEN` is the seam it fills; this chassis treats it as an

--- a/docs/codebase/service-principal-grants.md
+++ b/docs/codebase/service-principal-grants.md
@@ -66,14 +66,18 @@ non-service principal still holds ≥1 live grant.
 `_is_mutating`): an ingested op is read-class iff its HTTP `method` ∈
 `{GET, HEAD}` (the `READ_HTTP_METHODS` set); a typed / composite op
 carries no `method`, so its curated `safety_level` stands in (`safe` =
-read, `caution` / `dangerous` = write). `dangerous` parks always; a
-`caution` op parks only when mutating.
+read, `caution` / `dangerous` / `destructive` = write). `destructive`
+parks always **and is never grant-satisfiable** (#3183); `dangerous`
+parks always; a `caution` op parks only when mutating.
 
 When a `SERVICE` op would park, the gate consults a live standing grant
 (`connector_id` must be supplied so the grant's connector scope can be
 matched — the dispatcher and the composite sub-op gate both pass it; the
 gateway path is safe-only and never needs it). A match auto-approves the
 op and records the use; absent a match, the op parks for a human decision.
+The one exception is the `destructive` tier: `consult_and_record_grant`
+refuses it **before** any grant lookup, so even a stale grant row cannot
+auto-approve a destructive op — the tier always parks for a human.
 
 ### The grant (`db/models.py::ServicePrincipalGrant`, `operations/service_grants.py`)
 
@@ -113,8 +117,15 @@ delete-shaped ops:
   env `SERVICE_GRANT_DELETE_SHAPED_PATTERNS`, `fnmatchcase` over the op id;
   default `DELETE:*`, `*.delete`, `*.destroy`, `*.remove`, `*.purge`), and
 - **by descriptor** (best-effort when a descriptor resolves via
-  `lookup_descriptor`): the HTTP `DELETE` verb, or a hand-authored
-  `destructive` tag on a typed op.
+  `lookup_descriptor`): the `destructive` safety tier (#3183), the HTTP
+  `DELETE` verb, or a hand-authored `destructive` tag on a typed op.
+
+`_delete_shaped_reason_by_descriptor` single-sources that descriptor-level
+classification and is consulted at **both** ends: create-time (above) and
+dispatch-time (`consult_and_record_grant`, so a stale grant predating an
+op's promotion into the `destructive` tier can never satisfy it). That is
+what makes "a standing grant can never satisfy a destructive op" hold
+whether the grant is being created or consulted.
 
 Ops the workflow models as its human gate (e.g. a bring-up start) are
 expected to stay ungranted — the grant list is the floor, not a bypass.


### PR DESCRIPTION
## Summary

- Adds a fourth, most-restrictive `safety_level` value —
  `safe < caution < dangerous < destructive` — the foundation of the
  governed delete-shaped-operations path ratified in
  `docs/decisions/governed-delete-operations.md` (requirement 4, #3183).
- Ships the **tier + its default exclusions only**. No connector adopts the
  tier; the preview-hash binding (#3197) and the first governed delete op
  family (#3198) build on this.
- Excluded by default at **every** gate: agent policy gate → `deny`
  (non-grantable), service-principal gate → parks always + never
  grant-satisfiable, satellite mint wall → `OP_NOT_SAFE` (never minted to a
  runner, per #2901/#3187).

## The value surface (widened in lockstep)

- **Migration `0084`** widens the `ck_endpoint_descriptor_safety_level` CHECK
  (batch `drop`+`create_check_constraint`, the `0010_widen_graph_edge_kind`
  chassis pattern; `downgrade` refuses when `destructive` rows exist).
- `SafetyLevel` alias, both `VALID_SAFETY_LEVELS` frozensets, **every**
  `Literal["safe","caution","dangerous"]` union (35 sites incl. all connector
  op contracts), the model CHECK, and the MCP `search`/`connector_admin` +
  console enums all gain `destructive`.

## The gate exclusions

| Gate | Behaviour for `destructive` |
|---|---|
| Agent (`auth/permissions.py`) | `_SAFETY_DEFAULT` → `DENY`; `_SAFETY_CEILING` → `DENY` — **no `AgentPermission` grant lifts it** off deny |
| Service principal (`operations/_validate.py`) | `_service_safety_gate_reason` parks always; never satisfiable by a standing grant — refused at **create-time** (`_delete_shaped_reason_by_descriptor`) **and** dispatch-time (`consult_and_record_grant`), single-sourcing the delete-shaped classification |
| Satellite (`operations/gateway_commands.py`) | existing safe-only wall refuses any non-`safe` op with `OP_NOT_SAFE` — transitively excluded, pinned by a new test case |
| Broadcast announce (`broadcast/announce_gate.py`) | `_SAFETY_RANK` gains `destructive=3` so it ranks **above** `dangerous` rather than fail-opening to rank 0 |

The verdict `_more_restrictive` needs no edit — `destructive` maps to `DENY`
and `DENY` is already the top-ranked verdict, so it orders as the ceiling.

## Design note — the agent ceiling (`DENY` vs `needs-approval`)

The ratified decision doc's requirement-4 bullet phrases the agent ceiling as
`needs-approval`, but the issue's acceptance criteria require "`_SAFETY_CEILING`
pins it, and no `AgentPermission` grant can lift it" — a `needs-approval`
ceiling would let a grant lift `deny → needs-approval` (parking the op), which
the AC forbids. This PR follows the AC (ceiling `DENY`, non-grantable for
agents), which also matches the decision's own comparison text ("the new tier
is stricter still: **DENY for agent principals, non-grantable**, human-approval-
always"). Governed execution of a destructive op is a human decision on the
non-agent approval path (#3197 / #3198), never an agent verdict.

## Migration numbering

`0084` with `down_revision="0079"` (the head at branch time) so the alembic
chain resolves in isolation and the migration suite stays green. Slots
`0080-0083` are reserved for queued PRs (#3201 / #3204 / #3205 / #3206); the
orchestrator re-points `down_revision` at merge if that queue lands first (noted
in the migration docstring). A `down_revision="0083"` was rejected because 0083
does not exist in this branch — it breaks `get_current_head()` (`KeyError`),
turning every `alembic upgrade head` test red.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean on the diff (sole error is `connectors/net/icmp.py`'s `MSG_ERRQUEUE`, a pre-existing darwin-only socket constant, untouched here)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0 (the `resolve_verdict` block is pre-existing: 125 lines on origin/main, +1 docstring line here)
- [x] Migration `0084` smoke: `upgrade head` (0079→0084), CHECK accepts `destructive` / rejects unknown, `downgrade` refuses with a live `destructive` row
- [x] `tests/test_permission_resolver.py` — deny by default + grant cannot lift off deny
- [x] `tests/test_service_principal_grant_gate.py` / `test_service_grants.py` — parks always; grant never satisfies (create + consult)
- [x] `tests/test_gateway_commands.py` — `destructive` → `OP_NOT_SAFE`
- [x] `tests/test_announce_gate.py` — ranks above `caution`
- [x] `tests/migrations/test_migration_0084_*.py` — CHECK widen + downgrade refusal + round-trip

Broad slice: 1815 passed. The one failure — `test_chart_mcp_resource_uri.py::test_no_mcp_env_keys_when_ingress_disabled_and_nothing_set` — is a pre-existing local-helm `values.schema.json` validation quirk (reproduces on the clean `main` chart, references `safety` zero times, chart untouched here).

## Out of scope

- Preview-hash binding + blast-radius payload — #3197.
- First governed delete op family + conformance tests — #3198.
- Connector op contracts remain type-only widened; none adopts `destructive` yet.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3196
