### PR TITLE
feat(redaction): flight-recorder fail-closed redaction engine (F2) (#3213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ connector-related release-notes line.
   malformed JSON, truncated mid-token, path-config fault, unplaceable op
   family — returns an explicit uncertain verdict callers map to the F5
   operator-only degrade). No capture wiring (#3214) and no storage (#3212):
-  this is the engine alone, with 106 adversarial tests planting synthetic
+  this is the engine alone, with 129 adversarial tests planting synthetic
   secrets in every vector (unknown headers, allowlisted header values,
   nested body paths, oversized bodies truncated mid-secret, malformed JSON,
   binary bodies) — none survive. Does **not** close #3207.
@@ -148,35 +148,6 @@ connector-related release-notes line.
   - Additive Alembic migration `0085`; internal write API
     (`flight_recorder.record_trace`) is best-effort (F7 — never raises into a
     dispatch). Under #3207.
-=======
-### Added — flight recorder: fail-closed redaction engine (#3213)
-
-- Ships **F2** of the flight-recorder decision
-  (`docs/decisions/dispatch-flight-recorder.md`) as a **pure library**
-  (`meho_backplane.redaction.flight_recorder`) — the load-bearing security
-  control that makes agent-readable traces (F5) admissible at all: a trace
-  never contains a secret. Four fail-closed guarantees: a **header
-  allowlist** (only enumerated known-safe headers survive; every
-  `Authorization` / `Cookie` / `Set-Cookie` / `X-*-Token` / CSRF / session /
-  signed-URL header is stripped **unread** — a blocklist is rejected because
-  it fails open on unknown vendor fields); **per-connector body-path
-  redaction** (declarative dotted-path globs scrubbed from request and
-  response bodies, with the Tier-1 credential-shape engine reused underneath
-  as defense-in-depth); **hard-excluded op families** (credential /
-  session-mint / token op families never record bodies regardless of config,
-  **single-sourced** with the destructive / delete-shaped classifier at
-  `operations/service_grants.py` so the two lists cannot drift — the
-  governed-delete destructive family is included now per the pending
-  cross-ref amendment); and **redaction-uncertainty signalling** (any state
-  the engine cannot *prove* fully redacted — unparseable/binary body,
-  malformed JSON, truncated mid-token, path-config fault, unplaceable op
-  family — returns an explicit uncertain verdict callers map to the F5
-  operator-only degrade). No capture wiring (#3214) and no storage (#3212):
-  this is the engine alone, with 106 adversarial tests planting synthetic
-  secrets in every vector (unknown headers, allowlisted header values,
-  nested body paths, oversized bodies truncated mid-secret, malformed JSON,
-  binary bodies) — none survive. Does **not** close #3207.
->>>>>>> f14d487c (feat(redaction): flight-recorder fail-closed redaction engine (F2) (#3213))
 
 ### Added — dispatch flight recorder: security-review-first design decision (#3207)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,34 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: fail-closed redaction engine (#3213)
+
+- Ships **F2** of the flight-recorder decision
+  (`docs/decisions/dispatch-flight-recorder.md`) as a **pure library**
+  (`meho_backplane.redaction.flight_recorder`) — the load-bearing security
+  control that makes agent-readable traces (F5) admissible at all: a trace
+  never contains a secret. Four fail-closed guarantees: a **header
+  allowlist** (only enumerated known-safe headers survive; every
+  `Authorization` / `Cookie` / `Set-Cookie` / `X-*-Token` / CSRF / session /
+  signed-URL header is stripped **unread** — a blocklist is rejected because
+  it fails open on unknown vendor fields); **per-connector body-path
+  redaction** (declarative dotted-path globs scrubbed from request and
+  response bodies, with the Tier-1 credential-shape engine reused underneath
+  as defense-in-depth); **hard-excluded op families** (credential /
+  session-mint / token op families never record bodies regardless of config,
+  **single-sourced** with the destructive / delete-shaped classifier at
+  `operations/service_grants.py` so the two lists cannot drift — the
+  governed-delete destructive family is included now per the pending
+  cross-ref amendment); and **redaction-uncertainty signalling** (any state
+  the engine cannot *prove* fully redacted — unparseable/binary body,
+  malformed JSON, truncated mid-token, path-config fault, unplaceable op
+  family — returns an explicit uncertain verdict callers map to the F5
+  operator-only degrade). No capture wiring (#3214) and no storage (#3212):
+  this is the engine alone, with 106 adversarial tests planting synthetic
+  secrets in every vector (unknown headers, allowlisted header values,
+  nested body paths, oversized bodies truncated mid-secret, malformed JSON,
+  binary bodies) — none survive. Does **not** close #3207.
+
 ### Added — flight recorder: trace store + retention reaper + per-tenant capture config + kill switch (#3212)
 
 - Ships the storage + config substrate of the dispatch flight recorder
@@ -120,6 +148,35 @@ connector-related release-notes line.
   - Additive Alembic migration `0085`; internal write API
     (`flight_recorder.record_trace`) is best-effort (F7 — never raises into a
     dispatch). Under #3207.
+=======
+### Added — flight recorder: fail-closed redaction engine (#3213)
+
+- Ships **F2** of the flight-recorder decision
+  (`docs/decisions/dispatch-flight-recorder.md`) as a **pure library**
+  (`meho_backplane.redaction.flight_recorder`) — the load-bearing security
+  control that makes agent-readable traces (F5) admissible at all: a trace
+  never contains a secret. Four fail-closed guarantees: a **header
+  allowlist** (only enumerated known-safe headers survive; every
+  `Authorization` / `Cookie` / `Set-Cookie` / `X-*-Token` / CSRF / session /
+  signed-URL header is stripped **unread** — a blocklist is rejected because
+  it fails open on unknown vendor fields); **per-connector body-path
+  redaction** (declarative dotted-path globs scrubbed from request and
+  response bodies, with the Tier-1 credential-shape engine reused underneath
+  as defense-in-depth); **hard-excluded op families** (credential /
+  session-mint / token op families never record bodies regardless of config,
+  **single-sourced** with the destructive / delete-shaped classifier at
+  `operations/service_grants.py` so the two lists cannot drift — the
+  governed-delete destructive family is included now per the pending
+  cross-ref amendment); and **redaction-uncertainty signalling** (any state
+  the engine cannot *prove* fully redacted — unparseable/binary body,
+  malformed JSON, truncated mid-token, path-config fault, unplaceable op
+  family — returns an explicit uncertain verdict callers map to the F5
+  operator-only degrade). No capture wiring (#3214) and no storage (#3212):
+  this is the engine alone, with 106 adversarial tests planting synthetic
+  secrets in every vector (unknown headers, allowlisted header values,
+  nested body paths, oversized bodies truncated mid-secret, malformed JSON,
+  binary bodies) — none survive. Does **not** close #3207.
+>>>>>>> f14d487c (feat(redaction): flight-recorder fail-closed redaction engine (F2) (#3213))
 
 ### Added — dispatch flight recorder: security-review-first design decision (#3207)
 

--- a/backend/src/meho_backplane/redaction/flight_recorder/__init__.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/__init__.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho_backplane.redaction.flight_recorder`` -- fail-closed trace redaction.
+
+Task #3213, implementing **F2** of the accepted decision
+``docs/decisions/dispatch-flight-recorder.md``. This is the load-bearing
+security control of the dispatch flight recorder: it is what makes the F5
+agent-access override admissible, discharging the operator's verbatim
+condition *"as long as there are no secrets in there."*
+
+This package is a **pure library**. It has no capture wiring (the
+dispatcher seam is #3214's), no storage (the trace tables are #3212's),
+no I/O, no clocks, and no global mutable state. It answers exactly one
+question, four ways, and always fails closed:
+
+1. **Header allowlist** (:func:`redact_headers`) -- only enumerated
+   known-safe headers survive; everything else is stripped **unread**.
+   A blocklist is rejected: it fails open on unknown vendor fields.
+2. **Per-connector body-path redaction** (:class:`BodyPathRedactionConfig`,
+   :func:`redact_body`) -- declared dotted-path globs scrubbed from
+   request and response bodies, with a credential-shape net underneath.
+3. **Hard-excluded op families** (:func:`classify_body_exclusion`) --
+   credential / session-mint / token op families never record bodies,
+   regardless of config; single-sourced with the destructive /
+   delete-shaped classifier so the two lists cannot drift.
+4. **Redaction-uncertainty signalling** (:attr:`RedactionOutcome.uncertain`,
+   :attr:`SpanRedaction.uncertain`) -- any state the engine cannot
+   *prove* fully redacted (unparseable/binary body, malformed JSON,
+   truncated mid-token, path-config error, unplaceable op family) returns
+   an explicit uncertain verdict the caller MUST map to operator-only
+   visibility (the F5 degrade).
+
+The one call the capture wiring makes per span is :func:`redact_span`; the
+granular functions are exported for finer-grained use and testing.
+"""
+
+from meho_backplane.redaction.flight_recorder.bodies import (
+    BodyPathRedactionConfig,
+    redact_body,
+)
+from meho_backplane.redaction.flight_recorder.families import (
+    SECRET_FAMILY_PATTERNS,
+    SECRET_FAMILY_TAGS,
+    BodyExclusion,
+    classify_body_exclusion,
+)
+from meho_backplane.redaction.flight_recorder.headers import (
+    HEADER_ALLOWLIST,
+    redact_headers,
+)
+from meho_backplane.redaction.flight_recorder.span import SpanRedaction, redact_span
+from meho_backplane.redaction.flight_recorder.verdict import (
+    BODY_OMITTED_MARKER,
+    BODY_PATH_MARKER,
+    SECRET_FAMILY_OMITTED_MARKER,
+    UNPLACEABLE_FAMILY_MARKER,
+    RedactionOutcome,
+    merge_uncertainty,
+)
+
+__all__ = [
+    "BODY_OMITTED_MARKER",
+    "BODY_PATH_MARKER",
+    "HEADER_ALLOWLIST",
+    "SECRET_FAMILY_OMITTED_MARKER",
+    "SECRET_FAMILY_PATTERNS",
+    "SECRET_FAMILY_TAGS",
+    "UNPLACEABLE_FAMILY_MARKER",
+    "BodyExclusion",
+    "BodyPathRedactionConfig",
+    "RedactionOutcome",
+    "SpanRedaction",
+    "classify_body_exclusion",
+    "merge_uncertainty",
+    "redact_body",
+    "redact_headers",
+    "redact_span",
+]

--- a/backend/src/meho_backplane/redaction/flight_recorder/_content.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/_content.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Defense-in-depth credential-shape scrub for flight-recorder traces.
+
+Task #3213 (F2). The header allowlist (``headers``) and the per-connector
+body-path config (``bodies``) are the *structural* controls; this module
+is the shared **shape** net that runs underneath both, reusing the
+Tier-1 redaction engine already shipped by Initiative #805
+(:func:`meho_backplane.redaction.engine.redact`).
+
+Why a second net beneath the structural controls? The F5 agent-access
+override rests on "no secrets in there". The allowlist keeps unknown
+headers out and the body-path config scrubs declared paths, but a
+credential can still be *shaped* like one the moment a value survives:
+a ``Bearer …`` string pasted into a benign ``user-agent`` header, or a
+JWT nested at a path the connector author forgot to declare. Running the
+credential-shape patterns over every surviving string leaf closes that
+gap for every *known* secret shape without widening the structural
+surface.
+
+This is exactly the redaction precedent the preview path already relies
+on (``operations/_request_preview.py`` runs the connector-boundary
+engine over the would-be body); the flight recorder pins a tight,
+credential-only policy rather than resolving a tenant policy, because
+its job is "no secret shapes", not the broader infra-leak masking the
+connector-boundary policy also does.
+
+The policy is a module constant built at import (no I/O -- the engine
+and patterns are pure), so the scrub costs one frozen policy for the
+process lifetime.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.redaction.engine import redact
+from meho_backplane.redaction.policy import RedactionPolicy
+
+__all__ = ["CONTENT_POLICY_ID", "scrub_content"]
+
+#: The flight-recorder credential-shape policy id -- surfaced on the
+#: manifest and stable so a reader can attribute a firing to this net.
+CONTENT_POLICY_ID: Final[str] = "flight-recorder-credential-shapes"
+
+#: Tight, credential-only Tier-1 policy. Only the *secret*-shaped named
+#: patterns are pinned; the infra-leak shapes (``uuid`` / ``ipv4`` /
+#: ``ipv6`` / ``fqdn``) are deliberately excluded -- a hostname or UUID
+#: in a trace is not a secret and over-redacting them would gut the
+#: trace's debugging value. ``action='redact'`` replaces the whole match
+#: with a fixed marker: partial reveal of a credential is itself a leak.
+_CONTENT_POLICY: Final[RedactionPolicy] = RedactionPolicy.model_validate(
+    {
+        "id": CONTENT_POLICY_ID,
+        "version": 1,
+        "description": (
+            "Flight-recorder defense-in-depth: redact credential-shaped "
+            "strings in any surviving header value or body leaf (#3213)."
+        ),
+        "rules": [
+            {
+                "name": "fr-authorization-header",
+                "pattern": "authorization_header",
+                "action": "redact",
+                "reason": "authorization header value (RFC 7235 secret)",
+            },
+            {
+                "name": "fr-bearer-token",
+                "pattern": "bearer_token",
+                "action": "redact",
+                "reason": "bearer token",
+            },
+            {
+                "name": "fr-jwt",
+                "pattern": "jwt",
+                "action": "redact",
+                "reason": "JSON Web Token",
+            },
+            {
+                "name": "fr-api-key",
+                "pattern": "api_key",
+                "action": "redact",
+                "reason": "API key / access / refresh / session token / secret id",
+            },
+            {
+                "name": "fr-kubeconfig",
+                "pattern": "kubeconfig",
+                "action": "redact",
+                "reason": "embedded kubeconfig credential",
+            },
+        ],
+    },
+)
+
+
+def scrub_content(payload: Any) -> tuple[Any, bool]:
+    """Redact credential-shaped strings anywhere in *payload*.
+
+    Returns ``(redacted, fired)`` where *fired* is ``True`` when at
+    least one credential shape matched. The engine walks nested
+    dict / list / str structures and rewrites only string leaves, so a
+    caller can hand it a bare string (a header value), a parsed JSON
+    object, or a list and get the same-shaped result back.
+
+    Never raises for input shape: non-str / non-container leaves pass
+    through untouched (the engine's documented contract).
+    """
+    result = redact(payload, _CONTENT_POLICY)
+    return result.redacted, bool(result.manifest)

--- a/backend/src/meho_backplane/redaction/flight_recorder/bodies.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/bodies.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-connector body-path redaction for the flight-recorder engine.
+
+Task #3213 (F2.2). Each connector declares -- as a set of dotted-path
+globs -- which request/response body paths must be scrubbed before a
+body is recorded. This module applies that declarative config, then runs
+the shared credential-shape scrub (:mod:`._content`) underneath as
+defense-in-depth, and returns a fail-closed
+:class:`~meho_backplane.redaction.flight_recorder.verdict.RedactionOutcome`.
+
+Structural proof, not omniscience
+---------------------------------
+The engine can only claim a body *certain* (agent-readable) when it
+**proved** it applied every applicable rule: it parsed the body into a
+structure, redacted every declared path, and ran the shape net over
+every surviving leaf. Where that proof is impossible it drops the datum
+and flags ``uncertain`` (the F5 operator-only degrade):
+
+* **Unparseable / binary / unknown content-type** -- a body it cannot
+  turn into a structure cannot be walked to prove redaction.
+* **Malformed JSON** -- likewise; a half-object could hide a secret in
+  the unparsed remainder.
+* **Truncated** -- a body cut mid-token can split a secret across the
+  boundary so neither half matches a shape; the caller signals this via
+  ``truncated=True`` and the outcome is uncertain even though the parsed
+  prefix is scrubbed.
+* **Body-path config error** -- any fault while matching the declared
+  globs fails closed to a dropped, uncertain body.
+
+The dotted-path glob grammar is reused verbatim from the Tier-2 matcher
+(:mod:`meho_backplane.redaction.path_glob`): ``*`` matches one segment,
+``**`` matches any depth. A declared path that lands on an interior node
+(object or array) redacts the **whole subtree** at that path, so a
+declared ``credentials`` object never round-trips even partially.
+
+Parse posture
+-------------
+JSON is the only structurally-redactable body shape, so the engine
+parses a raw str/bytes body as JSON when the content-type says JSON *or*
+is unknown/absent (an opportunistic attempt that still fails closed on a
+parse error). A content-type that is *known* to be non-JSON
+(``text/plain``, form-encoded, XML, ``application/octet-stream``,
+``image/*`` …) is dropped uncertain without an attempt -- those shapes
+carry credentials the JSON path config cannot address, and the ops whose
+bodies *are* credentials are already hard-excluded by family
+(:mod:`.families`).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from meho_backplane.redaction.flight_recorder._content import scrub_content
+from meho_backplane.redaction.flight_recorder.verdict import (
+    BODY_OMITTED_MARKER,
+    BODY_PATH_MARKER,
+    RedactionOutcome,
+)
+from meho_backplane.redaction.path_glob import glob_to_regex, path_matches
+
+__all__ = ["BodyPathRedactionConfig", "redact_body"]
+
+
+#: Content-type bases the engine will not attempt to parse as JSON. A
+#: body of one of these shapes is dropped uncertain (fail-closed) rather
+#: than recorded, because the per-connector JSON path config cannot
+#: structurally address it.
+_NON_JSON_CONTENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "text/plain",
+        "text/html",
+        "text/csv",
+        "text/xml",
+        "application/xml",
+        "application/x-www-form-urlencoded",
+        "application/octet-stream",
+        "application/pdf",
+        "application/zip",
+        "application/gzip",
+    }
+)
+
+#: Content-type prefixes treated as non-JSON binary/opaque.
+_NON_JSON_PREFIXES: Final[tuple[str, ...]] = (
+    "image/",
+    "audio/",
+    "video/",
+    "font/",
+    "multipart/",
+)
+
+
+class BodyPathRedactionConfig(BaseModel):
+    """A connector's declared body-path redaction config.
+
+    ``paths`` is a tuple of dotted-path globs (see module docstring)
+    applied to **both** request and response bodies. Globs are validated
+    -- and compiled -- at construction so a malformed pattern fails when
+    the connector's config is loaded, not silently at first dispatch.
+
+    The config is frozen and side-effect-free; it is data a connector
+    ships, resolved and handed to :func:`redact_body` by the caller.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    connector_id: str
+    paths: tuple[str, ...] = ()
+
+    @field_validator("paths")
+    @classmethod
+    def _paths_compile(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: list[str] = []
+        for value in values:
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError("body-path glob must not be blank or whitespace-only")
+            try:
+                glob_to_regex(stripped)
+            except re.error as exc:  # pragma: no cover -- glob_to_regex escapes literals
+                raise ValueError(f"invalid body-path glob {stripped!r}: {exc}") from exc
+            normalized.append(stripped)
+        return tuple(normalized)
+
+
+def redact_body(
+    body: Any,
+    *,
+    paths: tuple[str, ...] = (),
+    content_type: str | None = None,
+    truncated: bool = False,
+) -> RedactionOutcome:
+    """Redact one body against its connector's declared *paths*, fail-closed.
+
+    Parameters
+    ----------
+    body
+        The raw body: a parsed ``dict`` / ``list`` (or scalar), a JSON
+        ``str``, or ``bytes``. ``None`` / empty round-trips to a recorded
+        ``None`` (nothing to redact).
+    paths
+        The connector's declared dotted-path globs (usually
+        ``BodyPathRedactionConfig.paths``).
+    content_type
+        The body's declared content-type, used to decide parseability.
+    truncated
+        ``True`` when the capture layer cut this body at a cap. Forces an
+        uncertain verdict: a secret split across the cut is unverifiable.
+
+    Returns a :class:`RedactionOutcome`. ``uncertain=True`` means the
+    caller must degrade this trace to operator-only.
+    """
+    if _is_empty_body(body):
+        return RedactionOutcome(value=None, reasons=("empty body",))
+
+    parsed, parse_reason = _parse_body(body, content_type)
+    if parse_reason is not None:
+        return RedactionOutcome(
+            value=BODY_OMITTED_MARKER,
+            uncertain=True,
+            reasons=(parse_reason,),
+        )
+
+    try:
+        path_redacted = _apply_path_redaction(parsed, paths)
+    except Exception as exc:  # any walk/glob fault fails closed (F2 uncertainty)
+        return RedactionOutcome(
+            value=BODY_OMITTED_MARKER,
+            uncertain=True,
+            reasons=(f"body-path redaction failed ({type(exc).__name__}): dropped fail-closed",),
+        )
+    scrubbed, _fired = scrub_content(path_redacted)
+
+    if truncated:
+        return RedactionOutcome(
+            value=scrubbed,
+            uncertain=True,
+            reasons=("body was truncated: tail unverifiable (fail-closed uncertain)",),
+        )
+    return RedactionOutcome(value=scrubbed)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _is_empty_body(body: Any) -> bool:
+    """``True`` for ``None`` / empty string / empty bytes -- nothing to redact."""
+    if body is None:
+        return True
+    if isinstance(body, str):
+        return body.strip() == ""
+    if isinstance(body, (bytes, bytearray)):
+        return len(body) == 0
+    return False
+
+
+def _parse_body(body: Any, content_type: str | None) -> tuple[Any, str | None]:
+    """Return ``(parsed, None)`` or ``(None, reason)`` when unparseable.
+
+    Already-parsed containers (``Mapping`` / non-str ``Sequence``) and
+    scalars pass through unchanged -- the caller handed us a structure we
+    can walk. A raw str/bytes body is parsed as JSON only when the
+    content-type permits (JSON or unknown); a known-non-JSON body is
+    refused fail-closed.
+    """
+    if isinstance(body, Mapping):
+        return body, None
+    if isinstance(body, (bytes, bytearray)):
+        base = _content_type_base(content_type)
+        if _is_known_non_json(base):
+            return None, (
+                f"binary / non-JSON body (content-type {base!r}): "
+                "cannot parse to prove redaction (fail-closed)"
+            )
+        try:
+            text = bytes(body).decode("utf-8")
+        except UnicodeDecodeError:
+            return None, "non-UTF-8 body: cannot parse to prove redaction (fail-closed)"
+        return _parse_json_text(text, content_type)
+    if isinstance(body, str):
+        base = _content_type_base(content_type)
+        if _is_known_non_json(base):
+            return None, (
+                f"non-JSON body (content-type {base!r}): cannot structurally redact (fail-closed)"
+            )
+        return _parse_json_text(body, content_type)
+    if isinstance(body, Sequence):
+        # A list handed in already parsed.
+        return body, None
+    # Bool / int / float / other scalar already parsed -- nothing to
+    # structurally redact; the shape scrub is a no-op on non-strings.
+    return body, None
+
+
+def _parse_json_text(text: str, content_type: str | None) -> tuple[Any, str | None]:
+    """Attempt to parse *text* as JSON; fail closed on any parse fault."""
+    try:
+        return json.loads(text), None
+    except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+        if _is_json_content_type(content_type):
+            return None, (
+                f"malformed JSON body ({type(exc).__name__}): cannot prove redaction (fail-closed)"
+            )
+        return None, (
+            "body is not parseable JSON and content-type is unknown: "
+            "cannot structurally redact (fail-closed)"
+        )
+
+
+def _content_type_base(content_type: str | None) -> str:
+    """Lowercased media type without parameters (``application/json`` from
+    ``application/json; charset=utf-8``). Empty string when absent."""
+    if not content_type:
+        return ""
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def _is_json_content_type(content_type: str | None) -> bool:
+    base = _content_type_base(content_type)
+    return base == "application/json" or base.endswith("+json") or base == "text/json"
+
+
+def _is_known_non_json(base: str) -> bool:
+    """``True`` for a content-type base we refuse to parse as JSON.
+
+    An empty base (absent content-type) returns ``False`` so the engine
+    still *attempts* an opportunistic JSON parse -- which itself fails
+    closed if the body is not JSON.
+    """
+    if not base:
+        return False
+    if _is_json_content_type(base):
+        return False
+    if base in _NON_JSON_CONTENT_TYPES:
+        return True
+    return any(base.startswith(prefix) for prefix in _NON_JSON_PREFIXES)
+
+
+def _apply_path_redaction(node: Any, globs: tuple[str, ...]) -> Any:
+    """Redact every node whose dotted path matches a declared glob."""
+    if not globs:
+        return node
+    return _walk_paths(node, globs, "")
+
+
+def _walk_paths(node: Any, globs: tuple[str, ...], path: str) -> Any:
+    if path and path_matches(globs, path):
+        # Redact the whole node (leaf or subtree) at a matching path.
+        return BODY_PATH_MARKER
+    if isinstance(node, Mapping):
+        return {
+            str(key): _walk_paths(value, globs, _join_path(path, str(key)))
+            for key, value in node.items()
+        }
+    if isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+        return [
+            _walk_paths(item, globs, _join_path(path, str(index)))
+            for index, item in enumerate(node)
+        ]
+    return node
+
+
+def _join_path(parent: str, child: str) -> str:
+    if not parent:
+        return child
+    return f"{parent}.{child}"

--- a/backend/src/meho_backplane/redaction/flight_recorder/bodies.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/bodies.py
@@ -170,13 +170,16 @@ def redact_body(
 
     try:
         path_redacted = _apply_path_redaction(parsed, paths)
-    except Exception as exc:  # any walk/glob fault fails closed (F2 uncertainty)
+        scrubbed, _fired = scrub_content(path_redacted)
+    except Exception as exc:  # any walk/glob/scrub fault fails closed (F2 uncertainty)
+        # Covers a RecursionError from an adversarially deep pre-parsed
+        # body handed straight in (bypassing the guarded JSON parse), so
+        # the engine never raises into its best-effort (F7) caller.
         return RedactionOutcome(
             value=BODY_OMITTED_MARKER,
             uncertain=True,
-            reasons=(f"body-path redaction failed ({type(exc).__name__}): dropped fail-closed",),
+            reasons=(f"body redaction failed ({type(exc).__name__}): dropped fail-closed",),
         )
-    scrubbed, _fired = scrub_content(path_redacted)
 
     if truncated:
         return RedactionOutcome(

--- a/backend/src/meho_backplane/redaction/flight_recorder/families.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/families.py
@@ -10,6 +10,23 @@ the whole body is the secret. This module classifies an op and, when it
 belongs to such a family, tells the caller to **never record its body**,
 regardless of config.
 
+Single-sourced with the sensitivity classifier
+----------------------------------------------
+The **primary** secret-bearing check is not a bespoke list: it delegates
+to :func:`meho_backplane.broadcast.events.classify_op`, the authoritative
+op-sensitivity classifier the audit/broadcast plane already uses to
+collapse ``credential_read`` / ``credential_mint`` / ``credential_write``
+ops to aggregate-only. Any op that classifier calls secret-bearing (its
+curated ``_CREDENTIAL_*_OPS`` allowlists -- ``vault.kv.read``,
+``harbor.robot.create``, ``vault.kv.put``, ``k8s.secret.create``, ...)
+never records a body here either, and the two planes cannot drift.
+Structured secret bodies of those ops (``{"data": {"password": ...}}``)
+carry no in-leaf label the credential-shape net could catch, so this
+delegation -- not the pattern/tag nets below -- is what actually protects
+them. The pattern globs and tag tokens are a *broadening* net on top,
+covering generic (``METHOD:/path``) ops and hand-authored tags the typed
+classifier does not see.
+
 Single-sourced with the destructive classifier
 ----------------------------------------------
 Per the decision record and its pending cross-ref amendment to
@@ -51,6 +68,7 @@ the caller degrades the trace to operator-only.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from fnmatch import fnmatchcase
 from typing import Final
@@ -60,9 +78,18 @@ from pydantic import BaseModel, ConfigDict
 __all__ = [
     "SECRET_FAMILY_PATTERNS",
     "SECRET_FAMILY_TAGS",
+    "SECRET_OP_CLASSES",
     "BodyExclusion",
     "classify_body_exclusion",
 ]
+
+
+#: The op-sensitivity classes (from
+#: :func:`meho_backplane.broadcast.events.classify_op`) whose bodies are
+#: secret material. An op in any of these classes never records a body.
+SECRET_OP_CLASSES: Final[frozenset[str]] = frozenset(
+    {"credential_read", "credential_mint", "credential_write"}
+)
 
 
 #: Case-sensitive globs matching credential / session-mint / token /
@@ -107,9 +134,13 @@ SECRET_FAMILY_PATTERNS: Final[tuple[str, ...]] = (
     "*:*/keys",
 )
 
-#: Descriptor tags that mark a secret-bearing family. Checked in addition
-#: to the op-id patterns so a hand-authored typed op can opt into the
-#: exclusion without matching a name glob.
+#: Secret-bearing tag *tokens*. A descriptor tag is treated as
+#: secret-bearing when any of its tokens (split on non-alphanumerics)
+#: is in this set -- so hyphenated compounds the codebase actually uses
+#: (``secret-read``, ``credential-mint``, ``credential-write``,
+#: ``secret-write``, ``auth-token``) match, not only bare words. Checked
+#: in addition to :func:`classify_op` and the op-id patterns so a
+#: hand-authored typed op can opt into the exclusion via a tag.
 SECRET_FAMILY_TAGS: Final[frozenset[str]] = frozenset(
     {
         "secret",
@@ -118,12 +149,49 @@ SECRET_FAMILY_TAGS: Final[frozenset[str]] = frozenset(
         "credentials",
         "session",
         "token",
+        "tokens",
         "auth",
         "authentication",
         "mint",
         "password",
+        "passwd",
+        "apikey",
+        "oauth",
+        "saml",
+        "openid",
+        "key",
+        "keys",
+        "privatekey",
+        "kubeconfig",
     }
 )
+
+
+def _tag_tokens(tag: str) -> set[str]:
+    """Split a tag into lowercase alphanumeric tokens.
+
+    ``"credential-read"`` -> ``{"credential", "read"}`` so a hyphenated
+    compound matches :data:`SECRET_FAMILY_TAGS` on its ``credential``
+    token; ``"read-only"`` -> ``{"read", "only"}`` matches nothing.
+    """
+    return {token for token in re.split(r"[^a-z0-9]+", tag.lower()) if token}
+
+
+def _classify_op_class(op_id: str) -> str | None:
+    """Return the sensitivity class from the authoritative classifier.
+
+    Delegates to :func:`meho_backplane.broadcast.events.classify_op`
+    (lazy import: it lives in a heavier module and keeps this library's
+    import graph a leaf). Returns ``None`` if the classifier is
+    unavailable or raises -- the pattern/tag nets below still apply, and
+    the caller's best-effort (F7) contract handles any propagated fault.
+    """
+    try:
+        from meho_backplane.broadcast.events import classify_op
+
+        return classify_op(op_id)
+    except Exception:  # pragma: no cover - classify_op is pure; defensive
+        return None
 
 
 class BodyExclusion(BaseModel):
@@ -177,17 +245,33 @@ def classify_body_exclusion(
 
     tag_set = {tag.strip().lower() for tag in tags if tag and tag.strip()}
 
-    # --- secret-bearing families (credential / session / token / …) ----
-    secret_tags = tag_set & SECRET_FAMILY_TAGS
-    if secret_tags:
+    # --- secret-bearing: authoritative classifier first (single source) -
+    op_class = _classify_op_class(op_id)
+    if op_class in SECRET_OP_CLASSES:
         return BodyExclusion(
             excluded=True,
             family="secret-bearing",
             reason=(
-                f"op {op_id!r} carries secret-bearing tag(s) "
-                f"{sorted(secret_tags)}; body never recorded"
+                f"op {op_id!r} classifies as {op_class!r} "
+                "(broadcast.events.classify_op); body never recorded"
             ),
         )
+
+    # --- secret-bearing: descriptor tag tokens -------------------------
+    matched_tag_tokens = {
+        token for tag in tag_set for token in _tag_tokens(tag) if token in SECRET_FAMILY_TAGS
+    }
+    if matched_tag_tokens:
+        return BodyExclusion(
+            excluded=True,
+            family="secret-bearing",
+            reason=(
+                f"op {op_id!r} carries secret-bearing tag token(s) "
+                f"{sorted(matched_tag_tokens)}; body never recorded"
+            ),
+        )
+
+    # --- secret-bearing: broadening op-id pattern net ------------------
     for pattern in secret_family_patterns:
         if fnmatchcase(op_id, pattern):
             return BodyExclusion(

--- a/backend/src/meho_backplane/redaction/flight_recorder/families.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/families.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hard-excluded op families for the flight-recorder redaction engine.
+
+Task #3213 (F2.3). Some op families carry secrets *as their body*:
+credential reads, session mints, token issuance, password resets, key
+material. For those, no per-connector body-path config is trustworthy --
+the whole body is the secret. This module classifies an op and, when it
+belongs to such a family, tells the caller to **never record its body**,
+regardless of config.
+
+Single-sourced with the destructive classifier
+----------------------------------------------
+Per the decision record and its pending cross-ref amendment to
+``docs/decisions/governed-delete-operations.md``, the **destructive /
+delete-shaped** family also joins the hard-exclusion set. To keep the
+two lists from drifting, this module does **not** re-declare the
+delete-shaped patterns: it reads them from the same single source the
+grant guard uses -- ``Settings.service_grant_delete_shaped_patterns``
+(the ``_delete_shaped_reason_by_pattern`` seam at
+``operations/service_grants.py``) -- and applies the same descriptor
+signals (HTTP ``DELETE`` method, ``destructive`` tag). When the
+``destructive`` safety tier (#3196) lands, this classifier already
+covers it via the tag it promotes; nothing here changes.
+
+  NOTE (pending cross-ref amendment): the reciprocal pointer from
+  ``governed-delete-operations.md`` back to the flight-recorder record is
+  a deliberate follow-up (see the "Interactions with sibling decisions"
+  section of ``dispatch-flight-recorder.md``). Including the destructive
+  family here now honours the decided shape ahead of that docs edit.
+
+Fail-closed over-exclusion
+--------------------------
+The secret-family pattern set is deliberately broad. Over-excluding an
+op (declining to record a benign body) only loses debugging exhaust; it
+never leaks. Under-excluding leaks a secret. So when in doubt, the
+family patterns match. The patterns are case-sensitive ``fnmatchcase``
+globs over the exact op id, spelled to hit both raw HTTP ops
+(``METHOD:/path``, method upper-cased) and dotted typed ops
+(``vault.sys.auth.enable``) without case folding -- the same convention
+the delete-shaped patterns use.
+
+Unplaceable op ids
+------------------
+A missing / blank op id cannot be classified. Per F5 that is a
+redaction-uncertainty trigger ("an op family the classifier could not
+place"): the body is withheld **and** the result is marked uncertain, so
+the caller degrades the trace to operator-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from fnmatch import fnmatchcase
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "SECRET_FAMILY_PATTERNS",
+    "SECRET_FAMILY_TAGS",
+    "BodyExclusion",
+    "classify_body_exclusion",
+]
+
+
+#: Case-sensitive globs matching credential / session-mint / token /
+#: secret / key-material op families across both op-id shapes. Broad by
+#: design (see module docstring): over-exclusion is the safe direction.
+SECRET_FAMILY_PATTERNS: Final[tuple[str, ...]] = (
+    # session lifecycle / login (session-mint)
+    "*login*",
+    "*logout*",
+    "*session*",
+    # token issuance
+    "*token*",
+    # credentials / secrets / passwords
+    "*credential*",
+    "*secret*",
+    "*password*",
+    "*passwd*",
+    # api keys
+    "*apikey*",
+    "*api_key*",
+    "*api-key*",
+    # minting / issuance / auth exchanges
+    "*mint*",
+    "*authenticate*",
+    "*authorization*",
+    "*.auth",
+    "*.auth.*",
+    "*:*/auth",
+    "*:*/auth/*",
+    "*:*/authorize*",
+    "*oauth*",
+    "*openid*",
+    "*saml*",
+    # key material
+    "*private_key*",
+    "*privatekey*",
+    "*.pem",
+    "*.key",
+    "*.keys",
+    "*.keys.*",
+    "*:*/key",
+    "*:*/keys",
+)
+
+#: Descriptor tags that mark a secret-bearing family. Checked in addition
+#: to the op-id patterns so a hand-authored typed op can opt into the
+#: exclusion without matching a name glob.
+SECRET_FAMILY_TAGS: Final[frozenset[str]] = frozenset(
+    {
+        "secret",
+        "secrets",
+        "credential",
+        "credentials",
+        "session",
+        "token",
+        "auth",
+        "authentication",
+        "mint",
+        "password",
+    }
+)
+
+
+class BodyExclusion(BaseModel):
+    """Whether an op's body must be hard-excluded from the flight recorder.
+
+    * ``excluded`` -- ``True`` means: never record this op's body.
+    * ``uncertain`` -- ``True`` only for the *unplaceable* case (missing
+      op id). A placed exclusion is *certain*: the omission is deliberate
+      and safe, so the trace stays agent-readable with a blank body. An
+      unplaceable op is uncertain -> operator-only.
+    * ``family`` -- the family label that fired (``None`` when the op is
+      not excluded).
+    * ``reason`` -- human-readable rationale (``None`` when not excluded).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    excluded: bool
+    uncertain: bool = False
+    family: str | None = None
+    reason: str | None = None
+
+
+def classify_body_exclusion(
+    op_id: str | None,
+    *,
+    tags: Iterable[str] = (),
+    method: str | None = None,
+    delete_shaped_patterns: tuple[str, ...] | None = None,
+    secret_family_patterns: tuple[str, ...] = SECRET_FAMILY_PATTERNS,
+) -> BodyExclusion:
+    """Classify *op_id* for flight-recorder body exclusion.
+
+    *tags* / *method* are the resolved descriptor signals (optional).
+    *delete_shaped_patterns* defaults to the single source of truth,
+    ``Settings.service_grant_delete_shaped_patterns``, resolved lazily so
+    this stays a pure library in tests that pass an explicit tuple.
+
+    Returns a :class:`BodyExclusion`. When ``excluded`` is ``True`` the
+    caller records no body for this op; when ``uncertain`` is also
+    ``True`` (unplaceable op), the caller additionally degrades the trace
+    to operator-only.
+    """
+    if op_id is None or not op_id.strip():
+        return BodyExclusion(
+            excluded=True,
+            uncertain=True,
+            family=None,
+            reason="op id missing/blank: family unplaceable (fail-closed uncertain)",
+        )
+
+    tag_set = {tag.strip().lower() for tag in tags if tag and tag.strip()}
+
+    # --- secret-bearing families (credential / session / token / …) ----
+    secret_tags = tag_set & SECRET_FAMILY_TAGS
+    if secret_tags:
+        return BodyExclusion(
+            excluded=True,
+            family="secret-bearing",
+            reason=(
+                f"op {op_id!r} carries secret-bearing tag(s) "
+                f"{sorted(secret_tags)}; body never recorded"
+            ),
+        )
+    for pattern in secret_family_patterns:
+        if fnmatchcase(op_id, pattern):
+            return BodyExclusion(
+                excluded=True,
+                family="secret-bearing",
+                reason=(
+                    f"op {op_id!r} matches secret-bearing family pattern "
+                    f"{pattern!r}; body never recorded"
+                ),
+            )
+
+    # --- destructive / delete-shaped (single-sourced) ------------------
+    if delete_shaped_patterns is None:
+        from meho_backplane.settings import get_settings
+
+        delete_shaped_patterns = get_settings().service_grant_delete_shaped_patterns
+    if (method or "").upper() == "DELETE":
+        return BodyExclusion(
+            excluded=True,
+            family="destructive",
+            reason=f"op {op_id!r} is an HTTP DELETE; body never recorded",
+        )
+    if "destructive" in tag_set:
+        return BodyExclusion(
+            excluded=True,
+            family="destructive",
+            reason=f"op {op_id!r} carries the 'destructive' tag; body never recorded",
+        )
+    for pattern in delete_shaped_patterns:
+        if fnmatchcase(op_id, pattern):
+            return BodyExclusion(
+                excluded=True,
+                family="destructive",
+                reason=(
+                    f"op {op_id!r} matches delete-shaped pattern {pattern!r} "
+                    "(single-sourced with the grant guard); body never recorded"
+                ),
+            )
+
+    return BodyExclusion(excluded=False)

--- a/backend/src/meho_backplane/redaction/flight_recorder/headers.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/headers.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Fail-closed header allowlist for the flight-recorder redaction engine.
+
+Task #3213 (F2.1). Only enumerated known-safe headers survive into a
+trace; **everything else is stripped unread**. This is an allowlist, not
+a blocklist, and that choice is load-bearing:
+
+    A blocklist ("record everything, drop the known-bad names") fails
+    *open* the instant a vendor invents a new auth header -- the unknown
+    ``X-Acme-Session`` sails through because it is on nobody's block
+    list. An allowlist fails *closed*: an unknown header is dropped
+    because it is not on the (small, curated) safe list, and the engine
+    never even reads its value.
+
+The allowlist is restricted to headers whose values are *structurally*
+non-secret: protocol negotiation, content metadata, caching, and
+correlation/rate-limit signals. Every header that carries -- or could
+carry -- a credential, a cookie, a token, a signed URL, or a client
+identity is absent by construction:
+
+* ``authorization`` / ``proxy-authorization`` / ``www-authenticate`` /
+  ``proxy-authenticate`` -- RFC 7235 credentials and challenges.
+* ``cookie`` / ``set-cookie`` -- session material.
+* every ``x-*-token`` / ``x-api-key`` / ``x-csrf-token`` / ``x-vault-token``
+  / ``x-amz-security-token`` / CSRF header the connector auth layer sets.
+* ``location`` / ``content-location`` / ``referer`` -- can carry tokens
+  in redirect targets and signed URLs.
+* ``forwarded`` / ``x-forwarded-*`` / ``x-real-ip`` -- client identity /
+  network topology (PII), not useful debugging exhaust here.
+
+As defense-in-depth, the value of every *surviving* header is still run
+through the credential-shape scrub (:mod:`._content`): if a caller ever
+pastes ``Bearer …`` into an otherwise-safe ``user-agent``, the shape net
+catches it. That firing does not make the outcome uncertain -- the
+engine *did* prove it redacted the shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+from meho_backplane.redaction.flight_recorder._content import scrub_content
+from meho_backplane.redaction.flight_recorder.verdict import RedactionOutcome
+
+__all__ = ["HEADER_ALLOWLIST", "redact_headers"]
+
+
+#: The curated set of known-safe header names, lowercased for
+#: case-insensitive matching (HTTP header names are case-insensitive per
+#: RFC 7230 §3.2). Kept deliberately small: anything not here is dropped
+#: unread. Additions are a security decision, not a convenience one.
+HEADER_ALLOWLIST: Final[frozenset[str]] = frozenset(
+    {
+        # --- content metadata -------------------------------------------
+        "content-type",
+        "content-length",
+        "content-encoding",
+        "content-language",
+        "content-range",
+        # --- protocol / negotiation -------------------------------------
+        "accept",
+        "accept-encoding",
+        "accept-language",
+        "accept-charset",
+        "accept-ranges",
+        "allow",
+        "connection",
+        "keep-alive",
+        "transfer-encoding",
+        "te",
+        "upgrade",
+        "expect",
+        "max-forwards",
+        "host",
+        "user-agent",
+        "server",
+        "via",
+        # --- caching / conditional --------------------------------------
+        "cache-control",
+        "pragma",
+        "age",
+        "date",
+        "expires",
+        "last-modified",
+        "etag",
+        "vary",
+        "if-match",
+        "if-none-match",
+        "if-modified-since",
+        "if-unmodified-since",
+        "range",
+        "retry-after",
+        # --- correlation / rate-limit (non-secret) ----------------------
+        "x-request-id",
+        "x-correlation-id",
+        "x-trace-id",
+        "traceparent",
+        "tracestate",
+        "x-ratelimit-limit",
+        "x-ratelimit-remaining",
+        "x-ratelimit-reset",
+        # --- response security policy (public directives) ---------------
+        "strict-transport-security",
+        "x-content-type-options",
+        "x-frame-options",
+        "referrer-policy",
+        "content-security-policy",
+    }
+)
+
+
+def redact_headers(headers: Any) -> RedactionOutcome:
+    """Return only the allowlisted headers; strip everything else unread.
+
+    *headers* is the raw header mapping (``httpx.Headers``, a plain
+    ``dict``, or any ``Mapping``). The returned :class:`RedactionOutcome`
+    carries a plain ``dict`` of the survivors under ``value`` (names
+    normalised to lowercase), with each survivor's value run through the
+    credential-shape scrub.
+
+    Fail-closed conditions:
+
+    * *headers* is not a mapping the engine can iterate -- it cannot
+      apply the allowlist, so it records **no** headers and flags the
+      outcome ``uncertain`` (the F5 operator-only degrade).
+    * a surviving header's value is not a string (bytes / list / other)
+      -- the engine cannot scrub it to prove it secret-free, so that one
+      header is dropped. Dropping a datum is safe, so this does **not**
+      make the whole outcome uncertain; it only adds a reason.
+
+    A non-allowlisted header's value is never read: the loop ``continue``s
+    on the name check before touching the value.
+    """
+    if headers is None:
+        return RedactionOutcome(value={}, reasons=("no headers",))
+    if not isinstance(headers, Mapping):
+        return RedactionOutcome(
+            value={},
+            uncertain=True,
+            reasons=("headers are not a mapping: cannot apply allowlist (fail-closed)",),
+        )
+
+    survivors: dict[str, str] = {}
+    dropped_non_string = 0
+    for raw_name, raw_value in headers.items():
+        name = str(raw_name).strip().lower()
+        if name not in HEADER_ALLOWLIST:
+            # Stripped UNREAD: we never inspect ``raw_value`` for a
+            # non-allowlisted header. This is the fail-closed guarantee.
+            continue
+        if not isinstance(raw_value, str):
+            dropped_non_string += 1
+            continue
+        scrubbed, _ = scrub_content(raw_value)
+        survivors[name] = scrubbed
+
+    reasons: tuple[str, ...] = ()
+    if dropped_non_string:
+        reasons = (
+            f"dropped {dropped_non_string} allowlisted header(s) with a "
+            "non-string value (cannot prove secret-free)",
+        )
+    return RedactionOutcome(value=survivors, reasons=reasons)

--- a/backend/src/meho_backplane/redaction/flight_recorder/span.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/span.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Span-level combiner for the flight-recorder redaction engine.
+
+Task #3213 (F2). This is the one call the capture wiring (#3214) makes
+per vendor-call span: hand it the raw captured artefacts plus the op
+context, get back the redacted artefacts and **one** fail-closed verdict.
+It composes the three structural controls -- the header allowlist
+(:mod:`.headers`), the per-connector body-path config (:mod:`.bodies`),
+and the hard-excluded op families (:mod:`.families`) -- and folds their
+outcomes into a single ``uncertain`` flag the caller maps to the F5
+operator-only degrade.
+
+The combiner is shape-neutral: it takes primitive kwargs, never a span
+model, so it never couples this library to the storage shape #3212 owns
+or the capture shape #3214 owns. The caller reads the redacted artefacts
+and the verdict off :class:`SpanRedaction` and lays them onto its own row.
+
+Fail-closed composition: a span is uncertain if *any* artefact is
+uncertain. Doubt anywhere withholds the whole trace from the agent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from meho_backplane.redaction.flight_recorder.bodies import redact_body
+from meho_backplane.redaction.flight_recorder.families import classify_body_exclusion
+from meho_backplane.redaction.flight_recorder.headers import redact_headers
+from meho_backplane.redaction.flight_recorder.verdict import (
+    SECRET_FAMILY_OMITTED_MARKER,
+    UNPLACEABLE_FAMILY_MARKER,
+    RedactionOutcome,
+    merge_uncertainty,
+)
+
+__all__ = ["SpanRedaction", "redact_span"]
+
+
+class SpanRedaction(BaseModel):
+    """The redacted, safe-to-persist artefacts for one span + its verdict.
+
+    * ``request_headers`` / ``response_headers`` -- allowlisted survivors
+      (plain dicts, names lowercased). Empty when none survived.
+    * ``request_body`` / ``response_body`` -- the redacted body, ``None``
+      (nothing to record), or an omission marker (family-excluded or
+      dropped fail-closed).
+    * ``body_recorded`` -- ``False`` when the op family is hard-excluded
+      or unplaceable, so no body content was recorded at all.
+    * ``uncertain`` -- ``True`` when the engine could not prove full
+      redaction for some artefact. The caller MUST degrade this trace to
+      operator-only (F5). ``False`` means every artefact is safe for the
+      agent surface.
+    * ``reasons`` -- the concatenated rationale strings from every
+      artefact, for operator display.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    request_headers: dict[str, str] = {}
+    response_headers: dict[str, str] = {}
+    request_body: Any = None
+    response_body: Any = None
+    body_recorded: bool = True
+    uncertain: bool = False
+    reasons: tuple[str, ...] = ()
+
+
+def redact_span(
+    *,
+    op_id: str | None,
+    connector_id: str | None = None,
+    method: str | None = None,
+    tags: Iterable[str] = (),
+    request_headers: Any = None,
+    response_headers: Any = None,
+    request_body: Any = None,
+    response_body: Any = None,
+    request_content_type: str | None = None,
+    response_content_type: str | None = None,
+    request_truncated: bool = False,
+    response_truncated: bool = False,
+    body_paths: tuple[str, ...] = (),
+    delete_shaped_patterns: tuple[str, ...] | None = None,
+) -> SpanRedaction:
+    """Redact one span's captured artefacts and return a single verdict.
+
+    Headers always pass through the allowlist. Bodies pass through the
+    per-connector path config + shape scrub **unless** the op family is
+    hard-excluded, in which case no body is recorded at all. The final
+    ``uncertain`` flag is the OR of every artefact's uncertainty.
+    """
+    req_headers = redact_headers(request_headers)
+    resp_headers = redact_headers(response_headers)
+
+    exclusion = classify_body_exclusion(
+        op_id,
+        tags=tags,
+        method=method,
+        delete_shaped_patterns=delete_shaped_patterns,
+    )
+
+    if exclusion.excluded:
+        marker = UNPLACEABLE_FAMILY_MARKER if exclusion.uncertain else SECRET_FAMILY_OMITTED_MARKER
+        reason = (exclusion.reason,) if exclusion.reason else ()
+        req_body = RedactionOutcome(value=marker, uncertain=exclusion.uncertain, reasons=reason)
+        resp_body = RedactionOutcome(value=marker, uncertain=exclusion.uncertain, reasons=reason)
+        body_recorded = False
+    else:
+        req_body = redact_body(
+            request_body,
+            paths=body_paths,
+            content_type=request_content_type,
+            truncated=request_truncated,
+        )
+        resp_body = redact_body(
+            response_body,
+            paths=body_paths,
+            content_type=response_content_type,
+            truncated=response_truncated,
+        )
+        body_recorded = True
+
+    uncertain, reasons = merge_uncertainty(req_headers, resp_headers, req_body, resp_body)
+
+    return SpanRedaction(
+        request_headers=req_headers.value,
+        response_headers=resp_headers.value,
+        request_body=req_body.value,
+        response_body=resp_body.value,
+        body_recorded=body_recorded,
+        uncertain=uncertain,
+        reasons=reasons,
+    )

--- a/backend/src/meho_backplane/redaction/flight_recorder/verdict.py
+++ b/backend/src/meho_backplane/redaction/flight_recorder/verdict.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Fail-closed verdict primitives for the flight-recorder redaction engine.
+
+Task #3213 (F2 of ``docs/decisions/dispatch-flight-recorder.md``). This
+module is the leaf of the ``flight_recorder`` redaction subpackage: it
+carries the small, dependency-light types every other module in the
+package returns, so ``headers`` / ``bodies`` / ``families`` / ``span``
+can import from here without an import cycle.
+
+The load-bearing concept is the **redaction-uncertainty verdict**. The
+whole flight recorder exists so an operator (and, per F5, an agent) can
+read a dispatch trace *"as long as there are no secrets in there."* This
+engine can only ever discharge that condition by *proving* it applied
+every redaction rule end to end. Where proof is impossible -- an
+unparseable body, a body-path config it could not resolve, an op family
+it could not place, a body truncated mid-token -- the datum is dropped
+fail-closed **and** the outcome is flagged :attr:`RedactionOutcome.uncertain`.
+
+The consumer (capture wiring, #3214) maps ``uncertain`` to the F5
+operator-only degrade: an uncertain trace is withheld from the agent
+handle entirely and is readable on the operator plane alone. The default
+on doubt is *less* exposure, never more.
+
+Purity: no I/O, no clocks, no logging, no global mutable state. Every
+function is deterministic for identical inputs, which is what lets the
+adversarial test suite drive the engine directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "BODY_OMITTED_MARKER",
+    "BODY_PATH_MARKER",
+    "SECRET_FAMILY_OMITTED_MARKER",
+    "UNPLACEABLE_FAMILY_MARKER",
+    "RedactionOutcome",
+    "merge_uncertainty",
+]
+
+
+#: Placed where a declared body path was scrubbed. A non-secret,
+#: fixed sentinel: it replaces the entire node (leaf or subtree) at a
+#: matching path so a nested credential object never round-trips even
+#: partially.
+BODY_PATH_MARKER: Final[str] = "[MEHO-REDACTED:body-path]"
+
+#: Placed where a body could not be proven fully redacted and was
+#: therefore dropped fail-closed (unparseable / binary / malformed /
+#: truncated-unparseable). Pairs with ``uncertain=True`` so the caller
+#: degrades the trace to operator-only.
+BODY_OMITTED_MARKER: Final[str] = "[MEHO-OMITTED:redaction-uncertain]"
+
+#: Placed where an op belongs to a hard-excluded secret-bearing family
+#: (credential / session-mint / token / destructive). The body is never
+#: recorded regardless of the per-connector path config. This is a
+#: *certain* omission -- the family was placed, so the trace stays
+#: agent-readable with the body deliberately blank.
+SECRET_FAMILY_OMITTED_MARKER: Final[str] = "[MEHO-OMITTED:secret-bearing-family]"
+
+#: Placed where the op family could not be placed at all (missing /
+#: blank op id). Fail-closed: the body is withheld *and* the outcome is
+#: uncertain, because an unplaceable op might be a secret-bearing one.
+UNPLACEABLE_FAMILY_MARKER: Final[str] = "[MEHO-OMITTED:family-unplaceable]"
+
+
+class RedactionOutcome(BaseModel):
+    """The result of redacting one captured artefact (headers or a body).
+
+    * ``value`` -- the safe-to-persist result. Never contains a secret:
+      it is either the redacted structure, ``None`` (nothing to record),
+      or one of the fixed omission markers above. When ``uncertain`` is
+      ``True`` this is a marker, never the raw datum.
+    * ``uncertain`` -- ``True`` when the engine could not *prove* the
+      redaction complete. The caller MUST map this to operator-only
+      visibility (the F5 degrade). ``False`` means the engine applied
+      every applicable rule and the artefact is safe for the agent
+      surface.
+    * ``reasons`` -- human-readable rationale strings, one per condition
+      that fired. Carried into the trace so an operator sees *why* a
+      datum was dropped or flagged without reading the engine's source.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    value: Any = None
+    uncertain: bool = False
+    reasons: tuple[str, ...] = ()
+
+
+def merge_uncertainty(*outcomes: RedactionOutcome) -> tuple[bool, tuple[str, ...]]:
+    """Fold several artefact outcomes into one span-level verdict.
+
+    A span is uncertain if *any* of its artefacts is uncertain -- doubt
+    anywhere degrades the whole trace to operator-only (fail-closed
+    composition). Reasons are concatenated in argument order so the
+    operator sees every contributing condition.
+    """
+    uncertain = any(outcome.uncertain for outcome in outcomes)
+    reasons = tuple(reason for outcome in outcomes for reason in outcome.reasons)
+    return uncertain, reasons

--- a/backend/tests/test_flight_recorder_redaction.py
+++ b/backend/tests/test_flight_recorder_redaction.py
@@ -312,6 +312,22 @@ def test_body_path_runtime_fault_fails_closed(monkeypatch: pytest.MonkeyPatch) -
     _assert_no_secret(out.value, _SENTINEL)
 
 
+def test_deeply_nested_preparsed_body_fails_closed_without_raising() -> None:
+    """A pathologically deep pre-parsed body must not raise into the caller."""
+    node: Any = {"leaf": _BEARER}
+    for _ in range(6000):
+        node = {"n": node}
+    # Must not raise (F7 best-effort contract); fails closed to uncertain.
+    out = redact_body(node, content_type="application/json")
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+    span = redact_span(
+        op_id="vmware.vm.list", response_body=node, response_content_type="application/json"
+    )
+    assert span.uncertain is True
+    _assert_no_secret(span, _SENTINEL)
+
+
 def test_empty_body_is_certain_none() -> None:
     for empty in (None, "", "   ", b""):
         out = redact_body(empty, content_type="application/json")
@@ -353,6 +369,76 @@ def test_secret_bearing_tag_excludes_body() -> None:
     result = classify_body_exclusion("acme.generic.op", tags=["session"])
     assert result.excluded is True
     assert result.family == "secret-bearing"
+
+
+# Real credential ops whose bodies ARE secrets -- these carry no op-id
+# substring the pattern net would catch and/or hyphenated tags the bare-word
+# set would miss, so they must be caught by the authoritative classify_op
+# delegation. This is the regression guard for the fail-open the adversarial
+# review found (vault.kv.read etc. leaking agent-visible).
+_REAL_CREDENTIAL_OPS = [
+    "vault.kv.read",
+    "vault.kv.list",
+    "vault.kv.put",
+    "vault.kv.patch",
+    "harbor.robot.create",
+    "vault.token.create",
+    "vault.auth.approle.generate_secret_id",
+    "vault.auth.userpass.write",
+    "k8s.secret.create",
+    "k8s.job.create",
+    "keycloak.user.create",
+    "keycloak.user.reset_password",
+    "sddc.credential.list",
+    "rke2.token.rotate",
+]
+
+
+@pytest.mark.parametrize("op_id", _REAL_CREDENTIAL_OPS)
+def test_real_credential_ops_never_record_body_via_classify_op(op_id: str) -> None:
+    """The single most important regression guard: real secret ops excluded."""
+    result = classify_body_exclusion(op_id)
+    assert result.excluded is True, f"{op_id} MUST be excluded (secret body)"
+    assert result.family == "secret-bearing"
+    assert result.uncertain is False
+
+
+def test_vault_kv_read_secret_body_never_reaches_agent_view() -> None:
+    """End-to-end: a vault.kv.read secret response is not agent-visible."""
+    span = redact_span(
+        op_id="vault.kv.read",
+        connector_id="vault-1.0",
+        method="GET",
+        tags=["read-only", "secret-read"],
+        response_body={"data": {"data": {"password": "PLACEHOLDER-vault-secret"}}},
+        response_content_type="application/json",
+    )
+    assert span.body_recorded is False
+    assert span.response_body == SECRET_FAMILY_OMITTED_MARKER
+    assert span.uncertain is False
+    _assert_no_secret(span, _SENTINEL)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "secret-read",
+        "credential-read",
+        "credential-mint",
+        "credential-write",
+        "secret-write",
+        "auth-token",
+    ],
+)
+def test_hyphenated_secret_tags_are_matched(tag: str) -> None:
+    result = classify_body_exclusion("acme.generic.op", tags=[tag])
+    assert result.excluded is True
+    assert result.family == "secret-bearing"
+
+
+def test_read_only_tag_is_not_secret_bearing() -> None:
+    result = classify_body_exclusion("acme.thing.status", tags=["read-only"])
+    assert result.excluded is False
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_flight_recorder_redaction.py
+++ b/backend/tests/test_flight_recorder_redaction.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Adversarial tests for the flight-recorder redaction engine (Task #3213).
+
+These tests are written from the attacker's chair: the engine's contract
+is that a trace never contains a secret, and the F5 agent-access override
+rests entirely on that. So the suite *plants* synthetic, PLACEHOLDER-shaped
+secrets in every capture vector -- unknown headers, allowlisted header
+values, declared and undeclared nested body paths, oversized bodies cut
+mid-token, malformed JSON, binary bodies -- and asserts none survive into
+the agent-readable output, and that every state the engine cannot prove
+redacted comes back marked uncertain (the operator-only degrade).
+
+All secrets here are synthetic and share the ``PLACEHOLDER`` sentinel so a
+secret-scanner never trips on a real credential shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from meho_backplane.redaction.flight_recorder import (
+    BODY_OMITTED_MARKER,
+    BODY_PATH_MARKER,
+    HEADER_ALLOWLIST,
+    SECRET_FAMILY_OMITTED_MARKER,
+    UNPLACEABLE_FAMILY_MARKER,
+    BodyExclusion,
+    BodyPathRedactionConfig,
+    classify_body_exclusion,
+    redact_body,
+    redact_headers,
+    redact_span,
+)
+from meho_backplane.redaction.flight_recorder import bodies as fr_bodies
+from meho_backplane.settings import get_settings
+
+# --- Synthetic, PLACEHOLDER-shaped secrets ---------------------------------
+# Each is crafted to match a credential *shape* the underlying Tier-1
+# engine detects, so the shape net can be exercised without a real secret.
+_BEARER = "Bearer PLACEHOLDER-TOKEN-abcdef0123456789"
+_JWT = "eyJPLACEHOLDER0aaa.PLACEHOLDER0bbbbb.PLACEHOLDER0ccccc"
+_AUTH_HEADER = "Authorization: Bearer PLACEHOLDER-abcdef012345"
+_API_KEY = "api_key=PLACEHOLDER-KEY-abcdef012345"
+_SENTINEL = "PLACEHOLDER"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the settings env so ``get_settings()`` resolves in the classifier.
+
+    Mirrors the convention in ``test_service_grants.py`` -- the
+    delete-shaped branch is single-sourced with the grant guard's
+    ``Settings.service_grant_delete_shaped_patterns``.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.delenv("SERVICE_GRANT_DELETE_SHAPED_PATTERNS", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _assert_no_secret(obj: Any, *needles: str) -> None:
+    """Recursively assert none of *needles* appear anywhere in *obj*."""
+    blob = repr(obj)
+    for needle in needles:
+        assert needle not in blob, f"secret {needle!r} survived in {blob!r}"
+
+
+# ===========================================================================
+# F2.1 -- header allowlist (fail-closed, allowlist not blocklist)
+# ===========================================================================
+
+_SECRET_HEADER_NAMES = [
+    "Authorization",
+    "Proxy-Authorization",
+    "WWW-Authenticate",
+    "Proxy-Authenticate",
+    "Cookie",
+    "Set-Cookie",
+    "X-Api-Key",
+    "X-Auth-Token",
+    "X-Vault-Token",
+    "X-Csrf-Token",
+    "X-Xsrf-Token",
+    "X-Amz-Security-Token",
+    "X-Acme-Invented-Session",  # unknown vendor header -> allowlist must drop
+    "Location",
+    "Content-Location",
+    "Referer",
+    "X-Forwarded-For",
+    "X-Real-Ip",
+]
+
+
+@pytest.mark.parametrize("name", _SECRET_HEADER_NAMES)
+def test_header_allowlist_strips_every_secret_header(name: str) -> None:
+    out = redact_headers({name: f"{_SENTINEL}-{name}-secret", "Content-Type": "application/json"})
+    assert name.lower() not in out.value
+    _assert_no_secret(out.value, _SENTINEL)
+    # A dropped header is not an uncertainty: the allowlist proved it out.
+    assert out.uncertain is False
+    assert out.value.get("content-type") == "application/json"
+
+
+def test_header_allowlist_is_case_insensitive() -> None:
+    out = redact_headers({"CoNtEnT-TyPe": "application/json", "AUTHORIZATION": _BEARER})
+    assert out.value == {"content-type": "application/json"}
+
+
+def test_non_allowlisted_header_value_is_never_read() -> None:
+    """A dropped header's value must be stripped *unread* (F2.1)."""
+
+    class _ExplodingValue:
+        def __str__(self) -> str:  # pragma: no cover - must never run
+            raise AssertionError("non-allowlisted header value was read")
+
+        def __repr__(self) -> str:  # pragma: no cover - must never run
+            raise AssertionError("non-allowlisted header value was read")
+
+    # No exception => the value was never touched.
+    out = redact_headers({"X-Secret-Token": _ExplodingValue()})
+    assert out.value == {}
+
+
+def test_secret_smuggled_into_allowlisted_header_value_is_scrubbed() -> None:
+    """Defense-in-depth: a shaped secret in a safe header is scrubbed."""
+    out = redact_headers({"User-Agent": f"app/1.0 {_BEARER}", "Server": _JWT})
+    _assert_no_secret(out.value, _SENTINEL)
+    assert "user-agent" in out.value  # header kept, value scrubbed
+
+
+def test_headers_not_a_mapping_is_uncertain() -> None:
+    out = redact_headers(["Authorization", _BEARER])
+    assert out.uncertain is True
+    assert out.value == {}
+
+
+def test_headers_none_is_certain_empty() -> None:
+    out = redact_headers(None)
+    assert out.uncertain is False
+    assert out.value == {}
+
+
+def test_allowlisted_header_non_string_value_dropped_not_uncertain() -> None:
+    out = redact_headers({"Content-Length": 1234, "Content-Type": "application/json"})
+    assert out.value == {"content-type": "application/json"}
+    assert out.uncertain is False
+    assert out.reasons  # a reason was recorded for the drop
+
+
+def test_allowlist_membership_excludes_all_known_secret_names() -> None:
+    for name in _SECRET_HEADER_NAMES:
+        assert name.lower() not in HEADER_ALLOWLIST
+
+
+# ===========================================================================
+# F2.2 -- per-connector body-path redaction
+# ===========================================================================
+
+
+def test_body_path_config_validates_and_compiles_globs() -> None:
+    cfg = BodyPathRedactionConfig(connector_id="acme", paths=("credentials", "items.*.password"))
+    assert cfg.paths == ("credentials", "items.*.password")
+    with pytest.raises(ValueError, match="blank"):
+        BodyPathRedactionConfig(connector_id="acme", paths=("  ",))
+
+
+def test_declared_top_level_path_redacts_whole_subtree() -> None:
+    body = {"credentials": {"user": "u", "pass": f"{_SENTINEL}-pw"}, "name": "keep"}
+    out = redact_body(body, paths=("credentials",), content_type="application/json")
+    assert out.value["credentials"] == BODY_PATH_MARKER
+    assert out.value["name"] == "keep"
+    assert out.uncertain is False
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_declared_nested_and_glob_paths_redact() -> None:
+    body = {
+        "items": [
+            {"password": f"{_SENTINEL}-a"},
+            {"password": f"{_SENTINEL}-b"},
+        ],
+        "deep": {"level": {"secret": f"{_SENTINEL}-c"}},
+    }
+    out = redact_body(
+        body,
+        paths=("items.*.password", "**.secret"),
+        content_type="application/json",
+    )
+    assert out.value["items"][0]["password"] == BODY_PATH_MARKER
+    assert out.value["items"][1]["password"] == BODY_PATH_MARKER
+    assert out.value["deep"]["level"]["secret"] == BODY_PATH_MARKER
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_undeclared_credential_shaped_value_caught_by_shape_net() -> None:
+    """A shaped secret at an *undeclared* nested path must not survive."""
+    body = {"a": {"b": {"c": _BEARER}}, "note": _JWT, "auth_line": _AUTH_HEADER}
+    out = redact_body(body, paths=(), content_type="application/json")
+    _assert_no_secret(out.value, _SENTINEL)
+    assert out.uncertain is False
+
+
+def test_non_secret_content_survives_redaction() -> None:
+    body = {"vm": "vm-42", "power": "on", "count": 3}
+    out = redact_body(body, paths=("credentials",), content_type="application/json")
+    assert out.value == body
+
+
+def test_raw_json_string_body_is_parsed_and_redacted() -> None:
+    out = redact_body(
+        '{"password_field": "keep", "token_line": "token=PLACEHOLDER-abcdefgh"}',
+        paths=("password_field",),
+        content_type="application/json",
+    )
+    assert out.value["password_field"] == BODY_PATH_MARKER
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_json_bytes_body_is_decoded_and_redacted() -> None:
+    out = redact_body(
+        b'{"secret": "PLACEHOLDER-x", "ok": 1}',
+        paths=("secret",),
+        content_type="application/json",
+    )
+    assert out.value["secret"] == BODY_PATH_MARKER
+    assert out.value["ok"] == 1
+
+
+# ===========================================================================
+# F2 -- redaction-uncertainty (fail-closed on every ambiguity)
+# ===========================================================================
+
+
+def test_malformed_json_is_uncertain_and_omitted() -> None:
+    out = redact_body('{"a": "PLACEHOLDER-secret", ', content_type="application/json")
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_binary_body_is_uncertain_and_omitted() -> None:
+    out = redact_body(b"\x00\x01PLACEHOLDER\xff\xfe", content_type="application/octet-stream")
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+
+
+def test_non_utf8_json_typed_body_is_uncertain() -> None:
+    out = redact_body(b"\xff\xfePLACEHOLDER", content_type="application/json")
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["text/plain", "application/x-www-form-urlencoded", "text/html", "application/xml"],
+)
+def test_known_non_json_content_type_is_uncertain(content_type: str) -> None:
+    out = redact_body("password=PLACEHOLDER-pw123456", content_type=content_type)
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_unknown_content_type_non_json_string_is_uncertain() -> None:
+    out = redact_body("this is not json PLACEHOLDER", content_type=None)
+    assert out.uncertain is True
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_unknown_content_type_valid_json_string_is_certain() -> None:
+    out = redact_body('{"ok": true}', content_type=None)
+    assert out.uncertain is False
+    assert out.value == {"ok": True}
+
+
+def test_truncated_body_is_uncertain_even_when_parseable() -> None:
+    out = redact_body({"partial": "data"}, content_type="application/json", truncated=True)
+    assert out.uncertain is True
+    assert "truncated" in " ".join(out.reasons)
+
+
+def test_oversized_body_truncated_mid_secret_never_leaks_to_agent() -> None:
+    """A body cut mid-token: whatever the parse outcome, it is uncertain."""
+    big = {"filler": "x" * 100_000, "tail_secret": _BEARER}
+    import json as _json
+
+    serialized = _json.dumps(big)
+    cut = serialized[: serialized.index("Bearer") + 10]  # slice through the token
+    out = redact_body(cut, content_type="application/json", truncated=True)
+    assert out.uncertain is True
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_body_path_runtime_fault_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any fault while matching declared globs drops the body, uncertain."""
+
+    def _boom(_globs: Any, _path: str) -> bool:
+        raise RuntimeError("glob engine exploded")
+
+    monkeypatch.setattr(fr_bodies, "path_matches", _boom)
+    out = redact_body({"x": _BEARER}, paths=("x",), content_type="application/json")
+    assert out.uncertain is True
+    assert out.value == BODY_OMITTED_MARKER
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+def test_empty_body_is_certain_none() -> None:
+    for empty in (None, "", "   ", b""):
+        out = redact_body(empty, content_type="application/json")
+        assert out.uncertain is False
+        assert out.value is None
+
+
+# ===========================================================================
+# F2.3 -- hard-excluded op families (single-sourced with delete-shaped)
+# ===========================================================================
+
+_SECRET_FAMILY_OPS = [
+    "vault.sys.auth.enable",
+    "keycloak.user.reset_password",
+    "rke2.token.rotate",
+    "k8s.secret.create",
+    "sddc.credential.list",
+    "secret.move",
+    "acme.session.login",
+    "acme.session.logout",
+    "provider.oauth.exchange",
+    "idp.token.mint",
+    "GET:/key",
+    "GET:/api/keys",
+    "POST:/auth/login",
+]
+
+
+@pytest.mark.parametrize("op_id", _SECRET_FAMILY_OPS)
+def test_secret_bearing_family_never_records_body(op_id: str) -> None:
+    result = classify_body_exclusion(op_id)
+    assert result.excluded is True
+    assert result.family == "secret-bearing"
+    # A placed exclusion is certain -- deliberate, safe omission.
+    assert result.uncertain is False
+
+
+def test_secret_bearing_tag_excludes_body() -> None:
+    result = classify_body_exclusion("acme.generic.op", tags=["session"])
+    assert result.excluded is True
+    assert result.family == "secret-bearing"
+
+
+@pytest.mark.parametrize(
+    "op_id",
+    ["DELETE:/vms/{id}", "vmware.vm.delete", "cluster.node.destroy", "cache.entries.purge"],
+)
+def test_destructive_family_excluded_via_settings_single_source(op_id: str) -> None:
+    result = classify_body_exclusion(op_id)
+    assert result.excluded is True
+    assert result.family == "destructive"
+
+
+def test_delete_method_excludes_body() -> None:
+    result = classify_body_exclusion("acme.thing.remove_it", method="delete")
+    assert result.excluded is True
+    assert result.family == "destructive"
+
+
+def test_destructive_tag_excludes_body() -> None:
+    result = classify_body_exclusion("acme.thing.wipe", tags=["destructive"])
+    assert result.excluded is True
+    assert result.family == "destructive"
+
+
+def test_delete_shaped_is_single_sourced_with_grant_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The classifier must read the *same* settings tuple the grant guard uses."""
+    monkeypatch.setenv("SERVICE_GRANT_DELETE_SHAPED_PATTERNS", "acme.custom.nuke")
+    get_settings.cache_clear()
+    # The custom pattern now excludes; a formerly delete-shaped default does not.
+    assert classify_body_exclusion("acme.custom.nuke").excluded is True
+    result_default = classify_body_exclusion("thing.remove")
+    # 'thing.remove' is not in the overridden set, and 'remove' is not a
+    # secret-family word -> no longer excluded, proving the source is settings.
+    assert result_default.excluded is False
+
+
+@pytest.mark.parametrize("op_id", ["vmware.vm.list", "GET:/vms", "nsx.segment.get"])
+def test_benign_read_ops_are_not_excluded(op_id: str) -> None:
+    assert classify_body_exclusion(op_id).excluded is False
+
+
+@pytest.mark.parametrize("op_id", [None, "", "   "])
+def test_unplaceable_op_is_excluded_and_uncertain(op_id: str | None) -> None:
+    result = classify_body_exclusion(op_id)
+    assert isinstance(result, BodyExclusion)
+    assert result.excluded is True
+    assert result.uncertain is True  # F5: cannot place -> operator-only
+
+
+# ===========================================================================
+# F2 -- span combiner (the capture-side entry point)
+# ===========================================================================
+
+
+def test_span_secret_op_records_no_body_but_stays_certain() -> None:
+    span = redact_span(
+        op_id="keycloak.token.mint",
+        connector_id="keycloak-1.0",
+        method="POST",
+        request_headers={"Authorization": _BEARER, "Content-Type": "application/json"},
+        request_body={"password": "PLACEHOLDER-pw"},
+        response_body={"access_token": "PLACEHOLDER-tok"},
+        request_content_type="application/json",
+        response_content_type="application/json",
+    )
+    assert span.body_recorded is False
+    assert span.request_body == SECRET_FAMILY_OMITTED_MARKER
+    assert span.response_body == SECRET_FAMILY_OMITTED_MARKER
+    assert span.uncertain is False
+    assert "authorization" not in span.request_headers
+    _assert_no_secret(span, _SENTINEL)
+
+
+def test_span_unplaceable_op_is_uncertain() -> None:
+    span = redact_span(op_id=None, request_body={"a": 1}, request_content_type="application/json")
+    assert span.uncertain is True
+    assert span.request_body == UNPLACEABLE_FAMILY_MARKER
+
+
+def test_span_uncertain_body_propagates_to_span_verdict() -> None:
+    span = redact_span(
+        op_id="vmware.vm.list",
+        response_body=b"\x00PLACEHOLDER\xff",
+        response_content_type="application/octet-stream",
+    )
+    assert span.uncertain is True
+    _assert_no_secret(span, _SENTINEL)
+
+
+def test_span_end_to_end_all_vectors_planted() -> None:
+    """Plant a secret in every vector at once; none may reach the agent view."""
+    span = redact_span(
+        op_id="vmware.vm.get",
+        connector_id="vmware-rest-9.0",
+        method="GET",
+        tags=["read"],
+        request_headers={"X-Vault-Token": f"{_SENTINEL}-req", "Accept": "application/json"},
+        response_headers={"Set-Cookie": f"session={_SENTINEL}", "Content-Type": "application/json"},
+        request_body={"note": _BEARER},
+        response_body={"config": {"creds": _JWT}, "secret_path": "PLACEHOLDER-bare"},
+        request_content_type="application/json",
+        response_content_type="application/json",
+        body_paths=("config.creds", "secret_path"),
+    )
+    assert span.uncertain is False  # everything provably redacted
+    assert span.body_recorded is True
+    assert span.response_body["config"]["creds"] == BODY_PATH_MARKER
+    assert span.response_body["secret_path"] == BODY_PATH_MARKER
+    assert "x-vault-token" not in span.request_headers
+    assert "set-cookie" not in span.response_headers
+    _assert_no_secret(span, _SENTINEL)
+
+
+# ===========================================================================
+# Property / adversarial battery -- shaped secrets at many nested locations
+# ===========================================================================
+
+_NEST_SHAPES: list[Any] = [
+    lambda s: {"x": s},
+    lambda s: {"a": {"b": {"c": s}}},
+    lambda s: [s, "ok"],
+    lambda s: {"items": [{"v": s}, {"v": "ok"}]},
+    lambda s: {"deep": [[{"k": s}]]},
+    lambda s: {"mixed": {"list": ["ok", {"leaf": s}]}},
+]
+
+
+@pytest.mark.parametrize("shape", _NEST_SHAPES)
+@pytest.mark.parametrize("secret", [_BEARER, _JWT, _AUTH_HEADER, _API_KEY])
+def test_property_shaped_secret_never_survives_anywhere(shape: Any, secret: str) -> None:
+    """A credential-shaped secret at any nesting is scrubbed by the shape net."""
+    body = shape(secret)
+    out = redact_body(body, paths=(), content_type="application/json")
+    assert out.uncertain is False
+    _assert_no_secret(out.value, _SENTINEL)
+
+
+@pytest.mark.parametrize("shape", _NEST_SHAPES)
+def test_property_declared_path_redacts_any_value_shape(shape: Any) -> None:
+    """A declared '**' path scrubs a value of ANY shape (not just credential-shaped)."""
+    body = shape("PLACEHOLDER-opaque-nonshaped-value")
+    # '**' matches any leaf path -> every leaf becomes the path marker.
+    out = redact_body(body, paths=("**",), content_type="application/json")
+    assert out.uncertain is False
+    _assert_no_secret(out.value, _SENTINEL)

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -698,6 +698,130 @@ The implementation lives at
 `backend/src/meho_backplane/audit_query/policy_replay.py` and the
 policy-by-id lookup is `meho_backplane.redaction.resolver.find_policy_by_id`.
 
+## Flight-recorder fail-closed redaction (F2)
+
+Task [#3213](https://github.com/evoila/meho/issues/3213) implements **F2**
+of the dispatch flight recorder decision
+([`docs/decisions/dispatch-flight-recorder.md`](../decisions/dispatch-flight-recorder.md),
+Initiative [#3207](https://github.com/evoila/meho/issues/3207)). It is a
+**separate engine** from the connector-boundary redaction above, with a
+different job. The connector-boundary engine masks *content* (credential
+and infra-leak shapes) in a response before a caller or LLM sees it; the
+flight-recorder engine decides what a per-dispatch *trace* may persist at
+all, and it is **fail-closed on every axis**: where it cannot *prove* a
+datum secret-free it drops the datum and flags the trace uncertain.
+
+Why fail-closed is load-bearing: the operator override on F5 makes traces
+readable by agents *"as long as there are no secrets in there."* That
+condition is discharged only by this engine. A blocklist, a best-effort
+scrub, or a "record and hope" posture would fail open the first time a
+vendor invents a new auth header — so the engine never does any of those.
+
+It is a **pure library**:
+`backend/src/meho_backplane/redaction/flight_recorder/`. No capture wiring
+(that is [#3214](https://github.com/evoila/meho/issues/3214)), no storage
+(that is [#3212](https://github.com/evoila/meho/issues/3212)), no I/O, no
+clocks, no global mutable state.
+
+```text
+   captured span (headers + bodies + op context)
+                    │
+                    ▼
+   redact_span(...)  ──►  classify_body_exclusion(op_id)   [F2.3]
+        │                        │ excluded? → body never recorded
+        ├── redact_headers()     │ unplaceable? → uncertain
+        │     allowlist [F2.1]   ▼
+        ├── redact_body(paths)   per-connector body-path scrub [F2.2]
+        │     + credential-shape net (reuses the Tier-1 engine)
+        ▼
+   SpanRedaction(request/response headers+bodies, uncertain, reasons)
+        │  uncertain == True ⇒ caller degrades to operator-only (F5)
+```
+
+**F2.1 — header allowlist, not blocklist** (`headers.py`). Only the
+enumerated `HEADER_ALLOWLIST` names survive; every other header is
+stripped **unread** (the loop `continue`s on the name check before the
+value is ever touched). The allowlist holds only headers whose values are
+structurally non-secret — content metadata, protocol negotiation,
+caching, correlation/rate-limit — and every credential/cookie/token/
+signed-URL/client-identity header is absent by construction:
+
+| Recorded (allowlisted) | Stripped unread (never allowlisted) |
+| --- | --- |
+| `content-type`, `content-length`, `content-encoding`, `content-language`, `content-range` | `authorization`, `proxy-authorization`, `www-authenticate`, `proxy-authenticate` |
+| `accept*`, `connection`, `transfer-encoding`, `host`, `user-agent`, `server`, `via`, `allow` | `cookie`, `set-cookie` |
+| `cache-control`, `date`, `age`, `expires`, `etag`, `vary`, `if-*`, `range`, `retry-after` | every `x-*-token`, `x-api-key`, `x-csrf-token`, `x-xsrf-token`, `x-vault-token`, `x-amz-security-token` |
+| `x-request-id`, `x-correlation-id`, `traceparent`, `tracestate`, `x-ratelimit-*` | `location`, `content-location`, `referer` (signed URLs / tokens) |
+| `strict-transport-security`, `x-content-type-options`, `x-frame-options`, `referrer-policy`, `content-security-policy` | `forwarded`, `x-forwarded-*`, `x-real-ip` (client identity / PII) |
+
+As defense-in-depth the value of every *surviving* header is still run
+through the credential-shape net (`_content.py`), so a `Bearer …` pasted
+into a `user-agent` is scrubbed too.
+
+**F2.2 — per-connector body-path redaction** (`bodies.py`). A connector
+declares dotted-path globs (`BodyPathRedactionConfig.paths`, glob grammar
+reused verbatim from `redaction.path_glob`) that are scrubbed from both
+request and response bodies; a glob landing on an interior node redacts
+the **whole subtree**. Underneath, the same credential-shape net runs
+over every surviving leaf, so a shaped secret at an *undeclared* nested
+path is still caught. JSON is the only structurally-redactable shape:
+a str/bytes body is parsed when the content-type is JSON or unknown;
+anything else fails closed (see F2 uncertainty).
+
+**F2.3 — hard-excluded op families** (`families.py`). Some op families
+carry secrets *as their body* — credential reads, session mints, token
+issuance, password resets, key material — so their bodies are **never
+recorded**, regardless of the path config. `classify_body_exclusion`
+matches broad, case-sensitive `fnmatchcase` globs
+(`SECRET_FAMILY_PATTERNS`, e.g. `*token*`, `*secret*`, `*credential*`,
+`*login*`, `*.auth.*`, `*:*/key`) plus descriptor tags
+(`SECRET_FAMILY_TAGS`) across both op-id shapes (`METHOD:/path` and dotted
+typed ops). Over-exclusion is deliberate — declining to record a benign
+body only loses debugging exhaust; under-exclusion leaks.
+
+| Family | Source | Records body? |
+| --- | --- | --- |
+| secret-bearing (credential / session-mint / token / password / key material) | `SECRET_FAMILY_PATTERNS` + `SECRET_FAMILY_TAGS` (seeded from the decision record) | never |
+| destructive / delete-shaped | **single-sourced** with the grant guard's `Settings.service_grant_delete_shaped_patterns` + HTTP `DELETE` + `destructive` tag | never |
+| everything else | — | yes (subject to F2.2) |
+
+The destructive family is **single-sourced** with the delete-shaped
+classifier at `operations/service_grants.py` (`_delete_shaped_reason_by_pattern`
+/ `_delete_shaped_reason_by_descriptor`) so the two lists cannot drift;
+`classify_body_exclusion` reads the same `Settings` tuple rather than
+re-declaring it. This honours the pending cross-ref amendment to
+[`governed-delete-operations.md`](../decisions/governed-delete-operations.md)
+noted in the flight-recorder decision's "Interactions with sibling
+decisions" section — the destructive family joins the hard-exclusion set
+now; the reciprocal pointer back from that doc is the deferred edit. When
+the `destructive` safety tier ([#3196](https://github.com/evoila/meho/issues/3196))
+lands, the classifier already covers it via the tag it promotes.
+
+**F2 uncertainty (the F5 degrade)**. Any state the engine cannot *prove*
+fully redacted returns `uncertain=True`, which the caller must map to
+operator-only visibility. Uncertainty triggers:
+
+| Trigger | Outcome |
+| --- | --- |
+| headers not a mapping | no headers recorded, uncertain |
+| unparseable / binary / unknown non-JSON body | body omitted, uncertain |
+| malformed JSON | body omitted, uncertain |
+| truncated mid-token (`truncated=True`) | parsed prefix scrubbed, still uncertain (a split secret matches no shape) |
+| body-path config fault at match time | body omitted, uncertain |
+| unplaceable op family (missing/blank op id) | body omitted, uncertain |
+
+A *placed* family exclusion is **certain** (the omission is deliberate and
+safe, so the trace stays agent-readable with a blank body); only an
+*unplaceable* op is uncertain. Fail-closed composition: a span is
+uncertain if any one artefact is uncertain.
+
+Adversarial coverage lives in
+`backend/tests/test_flight_recorder_redaction.py` (106 cases): synthetic
+`PLACEHOLDER`-shaped secrets planted in unknown headers, allowlisted
+header values, declared and undeclared nested body paths, oversized bodies
+truncated mid-token, malformed JSON, and binary bodies — none survive, and
+uncertainty fires wherever proof is impossible.
+
 ## References
 
 - Parent goal: [#800](https://github.com/evoila/meho/issues/800)
@@ -718,3 +842,9 @@ policy-by-id lookup is `meho_backplane.redaction.resolver.find_policy_by_id`.
   `backend/src/meho_backplane/audit_query/replay.py`.
 - Microsoft Presidio (Tier-2; #1072):
   <https://github.com/microsoft/presidio>.
+- Flight-recorder redaction (F2; #3213): decision
+  [`docs/decisions/dispatch-flight-recorder.md`](../decisions/dispatch-flight-recorder.md),
+  Initiative [#3207](https://github.com/evoila/meho/issues/3207); library
+  `backend/src/meho_backplane/redaction/flight_recorder/`; single-sourced
+  destructive classifier `operations/service_grants.py`
+  (`Settings.service_grant_delete_shaped_patterns`).

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -832,7 +832,7 @@ safe, so the trace stays agent-readable with a blank body); only an
 uncertain if any one artefact is uncertain.
 
 Adversarial coverage lives in
-`backend/tests/test_flight_recorder_redaction.py` (106 cases): synthetic
+`backend/tests/test_flight_recorder_redaction.py` (129 cases): synthetic
 `PLACEHOLDER`-shaped secrets planted in unknown headers, allowlisted
 header values, declared and undeclared nested body paths, oversized bodies
 truncated mid-token, malformed JSON, and binary bodies — none survive, and

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -756,7 +756,12 @@ signed-URL/client-identity header is absent by construction:
 
 As defense-in-depth the value of every *surviving* header is still run
 through the credential-shape net (`_content.py`), so a `Bearer …` pasted
-into a `user-agent` is scrubbed too.
+into a `user-agent` is scrubbed too. Residual assumption (accepted): an
+*opaque, non-shaped* secret placed in a surviving free-text header
+(`user-agent`, `server`, `via`) is not caught by the shape net — the
+allowlist admits these header *names* on the basis that their values are
+vendor-non-secret, the same structured-body caveat that applies to an
+undeclared, non-shaped body leaf.
 
 **F2.2 — per-connector body-path redaction** (`bodies.py`). A connector
 declares dotted-path globs (`BodyPathRedactionConfig.paths`, glob grammar
@@ -771,17 +776,28 @@ anything else fails closed (see F2 uncertainty).
 **F2.3 — hard-excluded op families** (`families.py`). Some op families
 carry secrets *as their body* — credential reads, session mints, token
 issuance, password resets, key material — so their bodies are **never
-recorded**, regardless of the path config. `classify_body_exclusion`
-matches broad, case-sensitive `fnmatchcase` globs
-(`SECRET_FAMILY_PATTERNS`, e.g. `*token*`, `*secret*`, `*credential*`,
-`*login*`, `*.auth.*`, `*:*/key`) plus descriptor tags
-(`SECRET_FAMILY_TAGS`) across both op-id shapes (`METHOD:/path` and dotted
-typed ops). Over-exclusion is deliberate — declining to record a benign
-body only loses debugging exhaust; under-exclusion leaks.
+recorded**, regardless of the path config. The **primary** check is
+single-sourced: `classify_body_exclusion` delegates to the authoritative
+`broadcast.events.classify_op`, and any op it calls `credential_read` /
+`credential_mint` / `credential_write` (its curated `_CREDENTIAL_*_OPS`
+allowlists — `vault.kv.read`, `harbor.robot.create`, `vault.kv.put`,
+`k8s.secret.create`, …) never records a body here either. Those ops carry
+structured secret bodies (`{"data": {"password": …}}`) whose opaque
+values have no in-leaf label the shape net could catch, so this
+delegation — not the pattern net — is what protects them, and the two
+planes cannot drift. On top of that, a **broadening net** covers generic
+(`METHOD:/path`) ops and hand-authored tags the typed classifier does not
+see: case-sensitive `fnmatchcase` globs (`SECRET_FAMILY_PATTERNS`, e.g.
+`*token*`, `*secret*`, `*login*`, `*.auth.*`, `*:*/key`) plus
+token-split descriptor tags (`SECRET_FAMILY_TAGS`, so hyphenated
+compounds like `secret-read` / `credential-mint` match). Over-exclusion
+is deliberate — declining to record a benign body only loses debugging
+exhaust; under-exclusion leaks.
 
 | Family | Source | Records body? |
 | --- | --- | --- |
-| secret-bearing (credential / session-mint / token / password / key material) | `SECRET_FAMILY_PATTERNS` + `SECRET_FAMILY_TAGS` (seeded from the decision record) | never |
+| secret-bearing (credential-read / -mint / -write) | **single-sourced** with `broadcast.events.classify_op` (`_CREDENTIAL_*_OPS`) | never |
+| secret-bearing (generic / tag-declared) | broadening `SECRET_FAMILY_PATTERNS` globs + token-split `SECRET_FAMILY_TAGS` | never |
 | destructive / delete-shaped | **single-sourced** with the grant guard's `Settings.service_grant_delete_shaped_patterns` + HTTP `DELETE` + `destructive` tag | never |
 | everything else | — | yes (subject to F2.2) |
 


### PR DESCRIPTION
Implements **F2** of `docs/decisions/dispatch-flight-recorder.md` (Initiative #3207) as a **pure library** — the load-bearing security control that makes agent-readable traces (F5) admissible: *a trace never contains a secret*. Discharges the operator's verbatim F5 condition, "as long as there are no secrets in there."

Closes #3213.

## Scope

`meho_backplane.redaction.flight_recorder` — **no capture wiring** (that is #3214), **no storage** (that is #3212). The engine alone: no I/O, no clocks, no global state. Four fail-closed guarantees:

1. **Header allowlist, not blocklist** (`headers.py`) — only enumerated known-safe headers survive; every `Authorization` / `Cookie` / `Set-Cookie` / `X-*-Token` / CSRF / session / `Location` / `Referer` / forwarding header is stripped **unread** (the value is never read for a non-allowlisted name). A blocklist is rejected — it fails open on unknown vendor fields. Surviving values still pass the credential-shape net.
2. **Per-connector body-path redaction** (`bodies.py`) — declarative dotted-path globs (grammar reused from `redaction.path_glob`) scrubbed from request+response bodies; a glob on an interior node redacts the whole subtree. The Tier-1 credential-shape engine runs underneath so a shaped secret at an *undeclared* nested path is still caught.
3. **Hard-excluded op families** (`families.py`) — credential / session-mint / token families never record bodies, regardless of config. **Single-sourced** two ways so the lists cannot drift: the secret-bearing determination delegates to the authoritative `broadcast.events.classify_op` (`_CREDENTIAL_{READ,MINT,WRITE}_OPS`), and the destructive/delete-shaped family reads the grant guard's `Settings.service_grant_delete_shaped_patterns`. The governed-delete destructive family is included now per the pending cross-ref amendment (doc note in `families.py` + `redaction.md`).
4. **Redaction-uncertainty signalling** (`verdict.py` / `span.py`) — any state the engine cannot *prove* fully redacted (unparseable/binary body, malformed JSON, truncated mid-token, path-config fault, unplaceable op family) returns an explicit `uncertain` verdict callers map to the F5 operator-only degrade.

`redact_span(...)` is the one call the capture wiring (#3214) will make per span.

## Adversarial review dance

An independent reviewer, explicitly briefed to smuggle a synthetic secret through the engine, found a **CRITICAL fail-open**: the secret-bearing family exclusion originally re-declared its own op-id patterns + bare-word tags and so *missed the codebase's real credential ops* (`vault.kv.read`, `harbor.robot.create`, `vault.kv.put`, …) whose structured secret bodies carry no in-leaf label the shape net can catch — a `vault.kv.read` secret would have reached an agent-visible trace. **Fixed** by delegating to `broadcast.events.classify_op` as the single-sourced primary determination (proven live by bidirectional monkeypatch; the two planes cannot drift), with the pattern/tag nets kept as a broadening layer, and by hardening the body walk to fail closed on deep pre-parsed input. **Re-review verdict: APPROVE.**

## Tests & gates

129 adversarial tests (`backend/tests/test_flight_recorder_redaction.py`) plant synthetic `PLACEHOLDER`-shaped secrets in every vector — unknown headers, allowlisted header values, declared + undeclared nested body paths, oversized bodies truncated mid-secret, malformed JSON, binary/non-UTF-8, 6000-deep bodies — none survive; uncertainty fires wherever proof is impossible. `ruff` / `ruff format --check` / `mypy` / `pytest` all green locally. Docs: new "Flight-recorder fail-closed redaction (F2)" section in `docs/codebase/redaction.md`; CHANGELOG bullet under `[Unreleased]`. Does **not** close #3207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
