### PR TITLE
feat(approvals): destructive-tier preview-hash binding + mandatory blast-radius (#3197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,32 @@ connector-related release-notes line.
   preview-hash binding (#3197) and the first governed delete op family
   (#3198) build on it.
 
+### Added — governed deletes: preview-result-hash binding + mandatory blast-radius on the approvals plane (evoila-bosnia/meho-internal#3183 / #3197)
+
+- The `destructive` tier now enforces requirements 2 and 3 of
+  `docs/decisions/governed-delete-operations.md`, both fail-closed at the
+  dispatcher park seam. **Preview-result-hash binding:** `preview_operation`
+  emits a stable `preview_hash` over the canonicalised resolved request;
+  the caller presents it on the subsequent `call_operation`
+  (`preview_hash` arg on `CallOperationBody` and the MCP `call_operation`
+  schema — a dispatch control, kept out of `params_hash` and the op
+  schema). A destructive op that reaches `needs-approval` refuses to park
+  unless the dispatcher's server-recomputed preview hash **matches** the
+  presented one — a missing hash, a non-resolvable preview, or a mismatch
+  (params swapped between preview and call) is `denied` fail-closed. The
+  verified hash is persisted on a new nullable `approval_request.preview_hash`
+  column (Alembic migration `0086`, distinct from the existing
+  `params_hash` swap-defence) and re-verified when the request is approved
+  (a destructive row missing the binding is a 422 on every approve
+  surface). **Mandatory blast-radius:** a destructive op cannot park with
+  only the identifier-only default — its `proposed_effect` must carry a
+  `blast_radius` block (object identity, enumerated child objects,
+  irreversibility class), promoted to the envelope top level and rendered
+  as a "what this destroys" card in the console approval modal; a missing
+  block refuses the park. No connector adopts the tier yet — this ships the
+  binding + blast-radius mechanism; the first governed delete op family
+  (#3198) builds on it.
+
 ### Changed — Audit + Broadcast console drawers resolve reference GUIDs to human-investigable substance (evoila-bosnia/meho-internal#236)
 
 - The operator console's **Audit row** and **Broadcast event** detail

--- a/backend/alembic/versions/0086_add_approval_request_preview_hash.py
+++ b/backend/alembic/versions/0086_add_approval_request_preview_hash.py
@@ -4,7 +4,7 @@
 """Add ``approval_request.preview_hash`` for the destructive-tier preview binding.
 
 Revision ID: 0086
-Revises: 0084
+Revises: 0085
 Create Date: 2026-08-30
 
 Task #3197 under Initiative #3183 (governed deletes), decision
@@ -40,15 +40,12 @@ is nullable for the same "pre-existing rows have no value" reason.
 Migration-chain note (single linear head)
 ------------------------------------------
 
-Numbered ``0086`` with ``down_revision = "0084"`` — the head on
-``origin/main`` at branch time. A concurrent PR (#3219, flight-recorder
-trace store) holds ``0085``; this revision deliberately skips to ``0086``
-to avoid a duplicate-revision-id collision with it. If ``0085`` lands
-first, the orchestrator re-points this ``down_revision`` to the
-then-current head at merge so the chain stays a single linear head (the
-``Python (database migrations)`` CI gate). No data dependency on the
-skipped number — Alembic orders by the ``revision``/``down_revision``
-graph, not by filename.
+Numbered ``0086`` with ``down_revision = "0085"`` — the head on
+``origin/main`` (``0085_create_dispatch_trace_store``, the flight-recorder
+trace store that landed while this task was in flight). The chain is a
+single linear head ``0084 -> 0085 -> 0086``, which the ``Python (database
+migrations)`` CI gate requires. This column and the trace-store table are
+independent; the linear ordering is purely the head discipline.
 
 Reversibility contract
 ----------------------
@@ -65,7 +62,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0086"
-down_revision: str | None = "0084"
+down_revision: str | None = "0085"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/alembic/versions/0086_add_approval_request_preview_hash.py
+++ b/backend/alembic/versions/0086_add_approval_request_preview_hash.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``approval_request.preview_hash`` for the destructive-tier preview binding.
+
+Revision ID: 0086
+Revises: 0084
+Create Date: 2026-08-30
+
+Task #3197 under Initiative #3183 (governed deletes), decision
+``docs/decisions/governed-delete-operations.md`` requirement 2. The
+``destructive`` safety tier (shipped #3196, migration 0084) refuses to
+park a delete-shaped op unless a ``preview_operation`` of the identical
+``(connector_id, op_id, target, params)`` was executed and *its result
+hash* is presented with the request — so the approver sees precisely
+what will be destroyed. This migration ships the storage half: the
+column that records that bound hash on the parked row. The dispatch /
+approve code that produces + re-verifies it ships in the same task.
+
+What this migration adds
+------------------------
+
+* ``approval_request.preview_hash text NULL`` -- the SHA-256 hex over the
+  canonicalised resolved preview envelope, recorded at park time for a
+  ``destructive``-tier request and re-verified at approve time. Distinct
+  from the existing ``params_hash`` (which hashes the request *params*,
+  not the preview *result*).
+
+Why nullable (no ``server_default``)
+------------------------------------
+
+The binding is a **destructive-tier requirement only**: a ``safe`` /
+``caution`` / ``dangerous`` request carries no preview hash, so the
+column is ``NULL`` for every non-destructive row and for every pre-0086
+row. A nullable ``ADD COLUMN`` needs no backfill default — existing rows
+take ``NULL`` (the correct "no binding" state) with no table rewrite.
+Mirrors the ``approval_request.params`` add (migration ``0036``), which
+is nullable for the same "pre-existing rows have no value" reason.
+
+Migration-chain note (single linear head)
+------------------------------------------
+
+Numbered ``0086`` with ``down_revision = "0084"`` — the head on
+``origin/main`` at branch time. A concurrent PR (#3219, flight-recorder
+trace store) holds ``0085``; this revision deliberately skips to ``0086``
+to avoid a duplicate-revision-id collision with it. If ``0085`` lands
+first, the orchestrator re-points this ``down_revision`` to the
+then-current head at merge so the chain stays a single linear head (the
+``Python (database migrations)`` CI gate). No data dependency on the
+skipped number — Alembic orders by the ``revision``/``down_revision``
+graph, not by filename.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column. SQLite's ALTER TABLE drop-column has
+been supported since 3.35.0 (we're on 3.45+); Alembic's batch-mode
+fallback isn't required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0086"
+down_revision: str | None = "0084"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``preview_hash`` column to ``approval_request``."""
+    op.add_column(
+        "approval_request",
+        sa.Column("preview_hash", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``preview_hash`` column added in :func:`upgrade`."""
+    op.drop_column("approval_request", "preview_hash")

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -69,6 +69,7 @@ from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
     ParamsMismatchError,
+    PreviewBindingMissingError,
     SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
@@ -292,6 +293,13 @@ async def _capture_operator_decision(
             status_code=http_status.HTTP_409_CONFLICT,
             detail=f"approval_request_already_{exc.status}",
         ) from exc
+    except PreviewBindingMissingError as exc:
+        # #3197: a destructive row with no preview-hash binding cannot be
+        # approved (fail-closed re-verification of the mandatory binding).
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="preview_binding_missing",
+        ) from exc
     return request
 
 
@@ -447,6 +455,13 @@ async def _record_approval_decision(
         raise HTTPException(
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="params_hash_mismatch",
+        ) from exc
+    except PreviewBindingMissingError as exc:
+        # #3197: destructive-tier re-verification — no preview-hash binding
+        # on the row, so the approval is refused fail-closed.
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="preview_binding_missing",
         ) from exc
     return request
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5744,6 +5744,18 @@ class ApprovalRequest(Base):
       ``/approve`` path is re-hashed against this to detect substitution
       between request and approval.
 
+    * ``preview_hash`` -- Text nullable. The preview-result-hash binding
+      for the ``destructive`` tier (#3197, decision requirement 2). SHA-256
+      hex over the canonicalised *resolved preview envelope* of the
+      identical ``(connector_id, op_id, target, params)``
+      (:func:`~meho_backplane.operations._request_preview.compute_preview_hash`),
+      recorded at park time and re-verified when the request is approved.
+      Distinct from ``params_hash``: that hashes the request *params*; this
+      hashes the *preview result* the approver was shown ("exactly what
+      dies"). NULL for every non-``destructive`` request (the binding is a
+      destructive-tier requirement only) and for pre-0086 rows. Added by
+      migration ``0086``.
+
     * ``params`` -- JSON nullable (JSONB on PG). The original dispatch
       params, stored verbatim (#1503) so a parked **direct** operator op
       approved via ``/decide`` or MCP by-id — surfaces that hold only the
@@ -5860,6 +5872,13 @@ class ApprovalRequest(Base):
         nullable=True,
         default=None,
     )
+    # Preview-result-hash binding for the ``destructive`` tier (#3197).
+    # SHA-256 hex over the canonicalised resolved preview envelope of the
+    # identical (connector_id, op_id, target, params); stamped at park time
+    # and re-verified at approve time. Distinct from ``params_hash`` (which
+    # hashes params, not the preview result). NULL for every non-destructive
+    # request and for pre-0086 rows.
+    preview_hash: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     # Proposed effect -- human-readable summary for the reviewer.
     proposed_effect: Mapped[dict[str, object]] = mapped_column(
         _PORTABLE_JSON,

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -513,6 +513,22 @@ register_mcp_tool(
                         "never sent to the tracker."
                     ),
                 },
+                "preview_hash": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Preview-result-hash binding for a destructive-tier "
+                        "delete (#3197). REQUIRED when the op is "
+                        "`safety_level='destructive'`: first call "
+                        "`preview_operation` with the identical `connector_id` "
+                        "/ `op_id` / `target` / `params`, take the `preview_hash` "
+                        "it returns, and pass it here. The dispatcher recomputes "
+                        "the preview server-side and refuses to queue the "
+                        "approval (fail-closed) unless the hashes match — so "
+                        "the human approver sees exactly what will be destroyed. "
+                        "Ignored for every non-destructive op."
+                    ),
+                },
             },
             "required": ["connector_id", "op_id"],
             "additionalProperties": False,
@@ -687,6 +703,15 @@ register_mcp_tool(
                         "The would-be JSON request body after the "
                         "connector-boundary redaction pipeline; null when "
                         "the op declares no body (status=ok)."
+                    ),
+                },
+                "preview_hash": {
+                    "type": "string",
+                    "description": (
+                        "Preview-result-hash binding (#3197, status=ok): a "
+                        "stable SHA-256 over the resolved request. Present it "
+                        "as `call_operation`'s `preview_hash` arg to govern a "
+                        "destructive-tier delete."
                     ),
                 },
                 "error": {"type": ["string", "null"]},

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -489,6 +489,70 @@ def result_announce_required(op_id: str, remediation: str, duration_ms: float) -
     )
 
 
+def result_preview_binding_required(op_id: str, reason: str, duration_ms: float) -> OperationResult:
+    """Destructive-tier park refused: no bindable preview was presented (#3197).
+
+    Decision requirement 2. A ``destructive`` op refuses to park unless a
+    ``preview_operation`` of the identical ``(connector_id, op_id, target,
+    params)`` was executed and its ``preview_hash`` is presented on the
+    call. Returned when the caller presented no hash, or the op's preview
+    is not resolvable (so there is no literal effect to bind). Fail-closed:
+    the op is neither executed nor parked. ``status`` is ``"denied"`` with a
+    distinct ``error_code`` so an agent can tell this from a policy denial
+    and self-remediate by previewing first.
+    """
+    return OperationResult(
+        status="denied",
+        op_id=op_id,
+        error=f"denied: {reason}",
+        duration_ms=duration_ms,
+        extras={"error_code": "preview_binding_required", "reason": reason},
+    )
+
+
+def result_preview_hash_mismatch(op_id: str, duration_ms: float) -> OperationResult:
+    """Destructive-tier park refused: presented preview hash did not match (#3197).
+
+    Decision requirement 2, the tamper-evidence half. The dispatcher
+    recomputed the authoritative preview hash for the exact
+    ``(connector_id, op_id, target, params)`` being dispatched and it did
+    not equal the caller-presented ``preview_hash`` — the params were
+    swapped between preview and call, or a stale / forged hash was
+    supplied. Fail-closed: neither executed nor parked.
+    """
+    return OperationResult(
+        status="denied",
+        op_id=op_id,
+        error=(
+            "denied: preview_hash does not match the resolved request; the "
+            "previewed and dispatched (connector_id, op_id, target, params) "
+            "must be identical — re-run preview_operation and present its hash"
+        ),
+        duration_ms=duration_ms,
+        extras={"error_code": "preview_hash_mismatch"},
+    )
+
+
+def result_blast_radius_required(op_id: str, reason: str, duration_ms: float) -> OperationResult:
+    """Destructive-tier park refused: no blast-radius statement on the payload (#3197).
+
+    Decision requirement 3. A ``destructive`` op cannot park with only the
+    identifier-only default: its ``proposed_effect`` must carry a
+    blast-radius block (object identity, enumerated child objects,
+    irreversibility class) so the reviewer reads what dies *in the queue*.
+    Returned when that block is absent or malformed. Fail-closed: the op is
+    neither executed nor parked. ``reason`` names the missing field so the
+    connector author can populate the op's preview builder.
+    """
+    return OperationResult(
+        status="denied",
+        op_id=op_id,
+        error=f"denied: destructive op requires a blast-radius statement — {reason}",
+        duration_ms=duration_ms,
+        extras={"error_code": "blast_radius_required", "reason": reason},
+    )
+
+
 def result_awaiting_approval(
     op_id: str,
     approval_request_id: uuid.UUID,

--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -73,8 +73,9 @@ writes are the separate follow-up #1452).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol
 
 import structlog
 
@@ -87,9 +88,11 @@ if TYPE_CHECKING:
     from meho_backplane.db.models import EndpointDescriptor
 
 __all__ = [
+    "BLAST_RADIUS_KEY",
     "PREVIEW_REASON_CREDENTIAL_REDACTED",
     "PREVIEW_REASON_NOT_POPULATED",
     "PreviewContext",
+    "blast_radius_missing_reason",
     "build_permission_preflight",
     "build_proposed_effect",
     "describe_preview_provenance",
@@ -514,6 +517,50 @@ def describe_preview_provenance(
     if classify_op(op_id) in _SENSITIVE_CLASSES:
         return False, PREVIEW_REASON_CREDENTIAL_REDACTED
     return False, PREVIEW_REASON_NOT_POPULATED
+
+
+#: Top-level ``proposed_effect`` key carrying the mandatory blast-radius
+#: statement for the ``destructive`` tier (#3197, decision requirement 3).
+#: A destructive op's preview builder returns it inside its preview dict;
+#: :func:`~meho_backplane.operations.dispatcher._build_proposed_effect`
+#: promotes it to the top level (alongside ``safety_level`` / ``op_class``)
+#: so the reviewer surface and the mandatory-block gate read it without
+#: reaching into ``preview``.
+BLAST_RADIUS_KEY: Final[str] = "blast_radius"
+
+
+def blast_radius_missing_reason(proposed_effect: Mapping[str, Any] | None) -> str | None:
+    """Return ``None`` when a valid blast-radius block is present, else why not.
+
+    The mandatory-block gate for the ``destructive`` tier (#3197, decision
+    requirement 3). A destructive op cannot park with only the
+    identifier-only default: its ``proposed_effect`` must carry a
+    :data:`BLAST_RADIUS_KEY` block naming the three things the approver
+    reads before deciding —
+
+    * ``object`` -- the identity of what is destroyed (truthy);
+    * ``children`` -- the enumerated child objects that go with it (a list;
+      empty is valid — "no children", explicitly enumerated, is a
+      statement, not an omission);
+    * ``irreversibility`` -- the irreversibility class (a non-empty string).
+
+    Returns a human-readable reason naming the first missing / malformed
+    field so the dispatcher's refuse-to-park result is actionable; ``None``
+    means the block is well-formed and the park may proceed.
+    """
+    if not proposed_effect:
+        return "proposed_effect is empty (no blast-radius statement)"
+    block = proposed_effect.get(BLAST_RADIUS_KEY)
+    if not isinstance(block, Mapping):
+        return f"proposed_effect.{BLAST_RADIUS_KEY} block is absent"
+    if not block.get("object"):
+        return f"{BLAST_RADIUS_KEY}.object (object identity) is missing"
+    if not isinstance(block.get("children"), list):
+        return f"{BLAST_RADIUS_KEY}.children (enumerated child objects) must be a list"
+    irreversibility = block.get("irreversibility")
+    if not isinstance(irreversibility, str) or not irreversibility:
+        return f"{BLAST_RADIUS_KEY}.irreversibility (irreversibility class) is missing"
+    return None
 
 
 async def build_permission_preflight(ctx: PreviewContext) -> dict[str, Any] | None:

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -46,7 +46,10 @@ requestBody unwrap all run identically).
 
 from __future__ import annotations
 
-from typing import Any
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any, Final
 
 import structlog
 
@@ -63,9 +66,44 @@ from meho_backplane.operations._lookup import (
 from meho_backplane.operations._validate import InvalidOpSchemaError, validate_params
 from meho_backplane.redaction import apply_connector_boundary_redaction
 
-__all__ = ["preview_dispatch"]
+__all__ = ["compute_preview_hash", "preview_dispatch"]
 
 _log = structlog.get_logger(__name__)
+
+#: The envelope keys that define the *resolved request* — the deterministic
+#: projection of ``(connector_id, op_id, target, params)`` a preview binds.
+#: Volatile / advisory fields (``status``, ``source_kind``) are excluded so
+#: the hash is stable across preview and the subsequent governed dispatch.
+_PREVIEW_HASH_KEYS: Final[tuple[str, ...]] = (
+    "connector_id",
+    "op_id",
+    "method",
+    "resolved_path",
+    "query",
+    "redacted_body",
+)
+
+
+def compute_preview_hash(envelope: Mapping[str, Any]) -> str:
+    """Return a stable SHA-256 hex over a preview's canonicalised resolved envelope.
+
+    The preview-result-hash binding for the ``destructive`` tier (#3197,
+    decision requirement 2). Hashes only the :data:`_PREVIEW_HASH_KEYS`
+    projection of an ``status="ok"`` :func:`preview_dispatch` envelope — the
+    literal would-be request (``method`` / ``resolved_path`` / ``query`` /
+    ``redacted_body``) plus its ``connector_id`` / ``op_id`` identity — so two
+    previews of the identical ``(connector_id, op_id, target, params)`` yield
+    the identical hash, and the dispatcher can recompute it to detect a
+    param-swap between preview and the governed call.
+
+    Canonicalisation matches
+    :func:`~meho_backplane.operations._validate.compute_params_hash`
+    (``json.dumps(..., sort_keys=True, default=str, separators=(",", ":"))``)
+    so the hashing discipline is uniform across the two binding hashes.
+    """
+    source = {key: envelope.get(key) for key in _PREVIEW_HASH_KEYS}
+    canonical = json.dumps(source, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _invalid_op_schema_envelope(
@@ -320,10 +358,35 @@ async def _build_ingested_preview(
                 "exception_message": str(exc),
             },
         }
+    return _ok_ingested_envelope(
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        descriptor=descriptor,
+        request=request,
+    )
+
+
+def _ok_ingested_envelope(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    request: Any,
+) -> dict[str, Any]:
+    """Assemble the ``status="ok"`` preview envelope for a resolved request.
+
+    Redacts the body through the connector-boundary pipeline, logs the
+    resolution, and stamps the preview-result-hash binding (#3197) —
+    :func:`compute_preview_hash` over the resolved-request projection, so a
+    caller can present it on the subsequent governed ``call_operation`` of a
+    ``destructive``-tier op. Only ``status="ok"`` previews carry the hash: a
+    non-resolvable request has no literal effect to bind.
+    """
     redacted_body = _redact_request_body(
         request.body, connector_id=connector_id, operator=operator, op_id=op_id
     )
-
     _log.info(
         "preview_dispatch",
         connector_id=connector_id,
@@ -333,8 +396,7 @@ async def _build_ingested_preview(
         has_body=request.body is not None,
         tenant_id=str(operator.tenant_id),
     )
-
-    return {
+    envelope: dict[str, Any] = {
         "status": "ok",
         "op_id": op_id,
         "connector_id": connector_id,
@@ -344,6 +406,8 @@ async def _build_ingested_preview(
         "query": request.query,
         "redacted_body": redacted_body,
     }
+    envelope["preview_hash"] = compute_preview_hash(envelope)
+    return envelope
 
 
 async def preview_dispatch(
@@ -384,8 +448,11 @@ async def preview_dispatch(
     * ``source_kind`` -- the descriptor's source kind (present whenever a
       descriptor resolved).
     * On ``status == "ok"``: ``method``, ``resolved_path``, ``query``
-      (object or ``null``), and ``redacted_body`` (the raw body after the
-      redaction pipeline; ``null`` when the op declares no body).
+      (object or ``null``), ``redacted_body`` (the raw body after the
+      redaction pipeline; ``null`` when the op declares no body), and
+      ``preview_hash`` (#3197) -- the stable
+      :func:`compute_preview_hash` binding a caller presents on the
+      subsequent governed ``call_operation`` of a ``destructive``-tier op.
     * On a non-ok status: ``error`` (``"<code>: <human-readable>"``) and,
       for structured failures, an ``extras`` object carrying the
       machine-readable ``error_code`` and any per-code detail.

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -103,6 +103,7 @@ __all__ = [
     "ApprovalNotFoundError",
     "ApprovalRequestAlreadyDecidedError",
     "ParamsMismatchError",
+    "PreviewBindingMissingError",
     "SelfApprovalForbiddenError",
     "UnauthorizedApprovalError",
     "approve_request",
@@ -173,6 +174,31 @@ class ParamsMismatchError(ApprovalError):
         super().__init__(
             f"params hash mismatch on approval_request {request_id}; "
             "original params must be supplied unchanged"
+        )
+
+
+class PreviewBindingMissingError(ApprovalError):
+    """A ``destructive`` request is missing its preview-result-hash binding.
+
+    Raised by :func:`approve_request` (via :func:`_load_pending_for_approval`)
+    when a ``destructive``-tier request — identified by
+    ``proposed_effect.safety_level == "destructive"`` — carries no
+    ``preview_hash``. The dispatcher refuses to *park* a destructive op
+    without a verified binding (#3197, decision requirement 2), so a
+    well-formed pending row always has one; this is the fail-closed
+    re-verification at *approve* time, extending the existing
+    :class:`ParamsMismatchError` swap-defence to the preview binding. The
+    route layer maps it to 422. It fires only if a destructive row reached
+    the queue through some path that bypassed the dispatcher's park gate —
+    the approval is refused rather than clearing an unbound destructive op.
+    """
+
+    def __init__(self, request_id: uuid.UUID) -> None:
+        self.request_id = request_id
+        super().__init__(
+            f"approval_request {request_id} is destructive-tier but carries no "
+            "preview_hash binding; approval refused (the preview-result-hash "
+            "binding is mandatory for the destructive tier, #3197)"
         )
 
 
@@ -371,6 +397,7 @@ async def create_pending_request(
     run_id: uuid.UUID | None = None,
     proposed_effect: dict[str, Any] | None = None,
     expires_at: datetime | None = None,
+    preview_hash: str | None = None,
 ) -> ApprovalRequest:
     """Insert a pending :class:`ApprovalRequest` row + one audit row.
 
@@ -403,6 +430,12 @@ async def create_pending_request(
             ``created_at + APPROVAL_DEFAULT_TTL``; an explicit value is
             honoured but capped at that ceiling. The row is never parked
             with a null deadline — the TTL sweep depends on it.
+        preview_hash: The preview-result-hash binding for the
+            ``destructive`` tier (#3197). Stored verbatim on the row and
+            re-verified at approve time. ``None`` for every non-destructive
+            request (the binding is a destructive-tier requirement only);
+            the dispatcher supplies the value it already verified against
+            the recomputed preview.
 
     Returns:
         The flushed :class:`ApprovalRequest` row.
@@ -461,6 +494,7 @@ async def create_pending_request(
         connector_id=connector_id,
         target_id=target_id,
         params_hash=params_hash,
+        preview_hash=preview_hash,
         params=params,
         proposed_effect=proposed_effect,
         status=ApprovalRequestStatus.PENDING.value,
@@ -533,6 +567,10 @@ async def approve_request(
        request id alone and does not have the original params. The
        agent's REST path still supplies them so the swap defence applies
        on that branch.
+    6. If the row is ``destructive``-tier, it carries a ``preview_hash``
+       binding (else 422, :class:`PreviewBindingMissingError`). The
+       preview-result-hash re-verification (#3197, decision requirement 2)
+       — checked on every approve surface, independent of *params*.
 
     Then:
 
@@ -569,6 +607,8 @@ async def approve_request(
             break-glass is disabled (G11.7-T1 #1401).
         ParamsMismatchError: Hash of *params* != stored ``params_hash``
             (only raised when *params* is supplied).
+        PreviewBindingMissingError: The row is ``destructive``-tier but
+            carries no ``preview_hash`` binding (#3197).
     """
     request = await _load_pending_for_approval(
         session, request_id, operator=operator, params=params
@@ -1134,8 +1174,9 @@ async def _load_pending_for_approval(
     Runs the full approve precondition ladder in order so callers learn
     the most specific reason first: role gate → tenant-scoped load →
     pending guard → self-approval guard (G11.7-T1 #1401) → params-hash
-    check (only when *params* is supplied). Returns the validated
-    pending row; the caller flips status + writes the decision audit row.
+    check (only when *params* is supplied) → destructive preview-binding
+    re-verification (#3197). Returns the validated pending row; the caller
+    flips status + writes the decision audit row.
     """
     _check_reviewer_role(operator)
     request = await _load_for_tenant(session, request_id, operator.tenant_id)
@@ -1146,7 +1187,25 @@ async def _load_pending_for_approval(
         incoming_hash = compute_params_hash(params)
         if incoming_hash != request.params_hash:
             raise ParamsMismatchError(request_id)
+    _check_destructive_preview_binding(request)
     return request
+
+
+def _check_destructive_preview_binding(request: ApprovalRequest) -> None:
+    """Raise :class:`PreviewBindingMissingError` on an unbound destructive request.
+
+    The approve-time half of the preview-result-hash binding (#3197,
+    decision requirement 2). Extends the params-hash swap-defence: a
+    ``destructive``-tier request (``proposed_effect.safety_level ==
+    "destructive"``) must carry a ``preview_hash``. The dispatcher already
+    refuses to park one without a *verified* binding, so this is the
+    fail-closed re-verification at the decision point — an unbound
+    destructive row can never be approved into execution. Non-destructive
+    requests are unaffected (they legitimately carry no binding).
+    """
+    effect = request.proposed_effect or {}
+    if effect.get("safety_level") == "destructive" and not request.preview_hash:
+        raise PreviewBindingMissingError(request.id)
 
 
 async def _load_for_tenant(

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -281,6 +281,7 @@ from meho_backplane.operations._errors import (
     result_ambiguous_connector,
     result_announce_required,
     result_awaiting_approval,
+    result_blast_radius_required,
     result_connector_auth_failed,
     result_connector_error,
     result_connector_http_403,
@@ -295,6 +296,8 @@ from meho_backplane.operations._errors import (
     result_invalid_op_schema,
     result_invalid_params,
     result_no_connector,
+    result_preview_binding_required,
+    result_preview_hash_mismatch,
     result_target_required,
     result_unknown_op,
     wrap_ok_result,
@@ -312,10 +315,16 @@ from meho_backplane.operations._lookup import (
     parse_connector_id,
 )
 from meho_backplane.operations._preview import (
+    BLAST_RADIUS_KEY,
     PreviewContext,
+    blast_radius_missing_reason,
     build_permission_preflight,
     build_proposed_effect,
     describe_preview_provenance,
+)
+from meho_backplane.operations._request_preview import (
+    compute_preview_hash,
+    preview_dispatch,
 )
 from meho_backplane.operations._validate import (
     InvalidOpSchemaError,
@@ -1994,6 +2003,17 @@ async def _build_proposed_effect(
         # ``op_class`` / ``preview`` / fail-soft-marker envelope built by
         # :func:`build_proposed_effect` itself unchanged.
         base["safety_level"] = descriptor.safety_level
+        # #3197: promote a destructive op's blast-radius block (object
+        # identity, enumerated child objects, irreversibility class) from the
+        # builder's ``preview`` sub-dict to the top level of the envelope, so
+        # the mandatory-block gate in :func:`_handle_needs_approval` and the
+        # console modal read it without reaching into ``preview``. Mirrors the
+        # top-level stamping of ``safety_level`` / ``op_class`` above;
+        # ``setdefault`` never overrides a block a builder chose to place at
+        # the top level itself. A non-destructive op simply never populates it.
+        preview_body = base.get("preview")
+        if isinstance(preview_body, dict) and preview_body.get(BLAST_RADIUS_KEY) is not None:
+            base.setdefault(BLAST_RADIUS_KEY, preview_body[BLAST_RADIUS_KEY])
         return base
     except Exception:
         import structlog as _structlog
@@ -2007,6 +2027,73 @@ async def _build_proposed_effect(
         return None
 
 
+async def _destructive_binding_refusal(
+    *,
+    op_id: str,
+    connector_id: str,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    preview_hash: str | None,
+    proposed_effect: dict[str, Any] | None,
+    duration_ms: float,
+) -> OperationResult | None:
+    """Fail-closed gate for a ``destructive``-tier park (#3197, decision reqs 2 + 3).
+
+    Enforced only when the parking op is ``safety_level='destructive'``.
+    Returns a ``denied`` :class:`OperationResult` when the park must be
+    refused, or ``None`` when it may proceed:
+
+    * **Requirement 2 — preview-result-hash binding.** The caller must
+      present a ``preview_hash`` (from a prior ``preview_operation`` of the
+      identical ``(connector_id, op_id, target, params)``). The dispatcher
+      recomputes the authoritative hash by resolving the same preview
+      server-side and comparing: a missing hash, an op with no resolvable
+      preview, or a mismatch (params swapped between preview and call) all
+      refuse. This makes the binding tamper-evident rather than a
+      best-effort echo.
+    * **Requirement 3 — mandatory blast-radius statement.** The
+      ``proposed_effect`` must carry a well-formed blast-radius block
+      (:func:`~meho_backplane.operations._preview.blast_radius_missing_reason`);
+      a destructive op cannot park with only the identifier-only default.
+
+    Fail-closed throughout: the op is neither executed nor parked when any
+    check fails.
+    """
+    # Requirement 2: the preview-result-hash binding.
+    if not preview_hash:
+        return result_preview_binding_required(
+            op_id,
+            "safety_level=destructive requires a preview_hash from a prior "
+            "preview_operation of the identical (connector_id, op_id, target, "
+            "params) — none was presented",
+            duration_ms,
+        )
+    authoritative = await preview_dispatch(
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        target=target,
+        params=params,
+    )
+    if authoritative.get("status") != "ok":
+        return result_preview_binding_required(
+            op_id,
+            "safety_level=destructive requires a resolvable preview to bind, "
+            f"but preview_operation returned status={authoritative.get('status')!r} "
+            "for this (connector_id, op_id, target, params)",
+            duration_ms,
+        )
+    if compute_preview_hash(authoritative) != preview_hash:
+        return result_preview_hash_mismatch(op_id, duration_ms)
+
+    # Requirement 3: the mandatory blast-radius statement.
+    reason = blast_radius_missing_reason(proposed_effect)
+    if reason is not None:
+        return result_blast_radius_required(op_id, reason, duration_ms)
+    return None
+
+
 async def _handle_needs_approval(
     *,
     op_id: str,
@@ -2017,6 +2104,7 @@ async def _handle_needs_approval(
     params: dict[str, Any],
     params_hash: str,
     duration_ms: float,
+    preview_hash: str | None = None,
 ) -> OperationResult:
     """Create a durable pending approval row and return an awaiting_approval result.
 
@@ -2024,6 +2112,13 @@ async def _handle_needs_approval(
     ``"needs_approval"``. Opens its own DB session (same pattern as
     :func:`audit_and_broadcast_safe`) so the pending row + request audit
     row commit atomically without coupling to any outer transaction.
+
+    For a ``destructive``-tier op (#3197) the park is gated first by
+    :func:`_destructive_binding_refusal`: it refuses (fail-closed, no row
+    written) unless the caller presented a matching ``preview_hash`` and the
+    ``proposed_effect`` carries a blast-radius statement. The verified
+    ``preview_hash`` is then persisted on the row for approve-time
+    re-verification.
 
     On success returns :func:`~meho_backplane.operations._errors.result_awaiting_approval`
     with the pending row's id in ``extras["approval_request_id"]``.
@@ -2067,6 +2162,24 @@ async def _handle_needs_approval(
         params=params,
     )
 
+    # #3197: the destructive tier refuses to park (fail-closed, no durable
+    # row) unless the caller presented a matching preview_hash and the
+    # blast-radius statement is present. Non-destructive ops skip this
+    # entirely and park exactly as before.
+    if descriptor.safety_level == "destructive":
+        refusal = await _destructive_binding_refusal(
+            op_id=op_id,
+            connector_id=connector_id,
+            operator=operator,
+            target=target,
+            params=params,
+            preview_hash=preview_hash,
+            proposed_effect=proposed_effect,
+            duration_ms=duration_ms,
+        )
+        if refusal is not None:
+            return refusal
+
     try:
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
@@ -2080,6 +2193,7 @@ async def _handle_needs_approval(
                 params_hash=params_hash,
                 run_id=run_id,
                 proposed_effect=proposed_effect,
+                preview_hash=preview_hash,
             )
             await session.commit()
         # Publish AFTER commit so a phantom event cannot outlive a failed
@@ -2122,12 +2236,23 @@ async def dispatch(
     target: Any,
     params: dict[str, Any],
     _approved: bool = False,
+    preview_hash: str | None = None,
 ) -> OperationResult:
     """Single entry point for every MEHO operation.
 
     See the module docstring for the full algorithm + error contract.
     The function never raises; every operator-visible failure mode
     returns a structured :class:`OperationResult`.
+
+    ``preview_hash`` is the caller-presented preview-result-hash binding
+    for the ``destructive`` tier (#3197): the hash a prior
+    ``preview_operation`` of the identical ``(connector_id, op_id, target,
+    params)`` returned. It is consulted **only** when the op is
+    ``safety_level='destructive'`` and the policy gate routes the call to
+    ``needs-approval`` — the park is refused fail-closed unless it matches
+    the server-recomputed preview hash (see :func:`_destructive_binding_refusal`).
+    ``None`` (the default) for every non-destructive dispatch and on the
+    ``_approved`` resume path (the binding was verified at park + approve).
 
     ``_approved`` is an **internal** flag set only by the approval-queue
     resume path (:mod:`meho_backplane.api.v1.approvals`) after a human
@@ -2247,6 +2372,7 @@ async def dispatch(
                     params=params,
                     params_hash=params_hash,
                     duration_ms=duration_ms,
+                    preview_hash=preview_hash,
                 )
             if verdict is not PermissionVerdict.AUTO_EXECUTE:
                 # Defensive fail-closed: only an explicit AUTO_EXECUTE proceeds

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -423,6 +423,19 @@ class CallOperationBody(BaseModel):
     target: _TargetArg = None
     params: dict[str, Any] = Field(default_factory=dict)
     work_ref: str | None = Field(default=None, min_length=1)
+    preview_hash: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Preview-result-hash binding for the destructive tier (#3197). "
+            "The hash a prior preview_operation of the identical "
+            "(connector_id, op_id, target, params) returned. REQUIRED for a "
+            "safety_level='destructive' op — the dispatcher refuses to park "
+            "the approval fail-closed unless it matches the server-recomputed "
+            "preview hash. Ignored for every non-destructive op. None default "
+            "keeps a bare call_operation byte-identical to pre-#3197."
+        ),
+    )
     async_: bool = Field(
         default=False,
         alias="async",
@@ -1092,6 +1105,12 @@ async def _call_operation_impl(
                 target=resolved_target,
                 params=params,
                 _approved=approved,
+                # #3197: the destructive-tier preview-result-hash binding.
+                # A MEHO dispatch control (like ``work_ref`` above), not a
+                # connector op param — threaded top-level, never into
+                # ``params``, so it stays out of ``params_hash`` and the op's
+                # parameter_schema. ``None`` for a non-destructive call.
+                preview_hash=arguments.get("preview_hash"),
             )
     finally:
         if work_ref_token is not None:

--- a/backend/src/meho_backplane/ui/routes/approvals/routes.py
+++ b/backend/src/meho_backplane/ui/routes/approvals/routes.py
@@ -106,6 +106,7 @@ from meho_backplane.db.models import ApprovalRequest
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    PreviewBindingMissingError,
     SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
@@ -728,5 +729,16 @@ async def _commit_decision(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"This request was already {exc.status}.",
+        ) from exc
+    except PreviewBindingMissingError as exc:
+        # #3197: a destructive row missing its preview-hash binding cannot be
+        # approved (fail-closed re-verification of the mandatory binding).
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "This destructive request is missing its preview-result-hash "
+                "binding and cannot be approved. Re-file it via a fresh "
+                "preview + call."
+            ),
         ) from exc
     return request

--- a/backend/src/meho_backplane/ui/templates/approvals/_modal.html
+++ b/backend/src/meho_backplane/ui/templates/approvals/_modal.html
@@ -66,14 +66,17 @@
 -#}
 {% from "_icons.html" import icon %}
 {#- Mirror of the ops-launcher ``safety_badge`` mold (``operations/_results.html``):
-    ``safety_level`` is the closed ``safe`` / ``caution`` / ``dangerous`` enum
-    stamped on every parked envelope (#1855). Colour-by-severity so a reviewer
-    scanning the modal reads the policy gate before the label -- error for
-    dangerous, warning for caution, ghost for safe. Kept local (not imported)
-    so the modal stays self-contained and StrictUndefined-safe -- the launcher
-    partial references launcher-only context at its top level. -#}
+    ``safety_level`` is the closed ``safe`` / ``caution`` / ``dangerous`` /
+    ``destructive`` enum stamped on every parked envelope (#1855, +#3197 tier).
+    Colour-by-severity so a reviewer scanning the modal reads the policy gate
+    before the label -- error for destructive + dangerous, warning for caution,
+    ghost for safe. Kept local (not imported) so the modal stays self-contained
+    and StrictUndefined-safe -- the launcher partial references launcher-only
+    context at its top level. -#}
 {%- macro proposed_effect_safety_badge(level) -%}
-  {%- if level == "dangerous" -%}
+  {%- if level == "destructive" -%}
+    <span class="badge badge-error badge-sm font-semibold" title="Destructive — deletes objects; mandatory human approval, irreversible">{{ level }}</span>
+  {%- elif level == "dangerous" -%}
     <span class="badge badge-error badge-sm" title="Dangerous — irreversible or high-impact">{{ level }}</span>
   {%- elif level == "caution" -%}
     <span class="badge badge-warning badge-sm" title="Caution — state-changing">{{ level }}</span>
@@ -288,6 +291,63 @@
         {% endif %}
       {% endif %}
 
+      {#- Blast-radius statement (#3197) for the destructive tier. The
+          dispatcher refuses to park a destructive op unless its
+          ``proposed_effect`` carries this block (object identity, enumerated
+          child objects, irreversibility class), promoted to the top level by
+          ``_build_proposed_effect``. Render it prominently — this is what the
+          reviewer reads to see exactly what dies — as an error-tinted card
+          above the generic field table. All keys read via ``.get`` on the
+          real dict (StrictUndefined-safe). -#}
+      {% set blast = effect.get("blast_radius") %}
+      {% if blast is mapping and blast %}
+        <div class="mt-3 rounded-box border border-error/40 bg-error/5 p-3" aria-label="Blast radius">
+          <div class="flex items-center justify-between gap-3">
+            <h4 class="text-sm font-semibold text-error">Blast radius — what this destroys</h4>
+            {% if blast.get("irreversibility") %}
+              <span class="badge badge-error badge-sm font-mono" title="Irreversibility class">{{ blast.get("irreversibility") }}</span>
+            {% endif %}
+          </div>
+          {% if blast.get("object") %}
+            <dl class="mt-2 text-sm">
+              <div class="flex items-baseline justify-between gap-4">
+                <dt class="shrink-0 text-base-content/55">Object</dt>
+                <dd class="font-mono [overflow-wrap:anywhere]">
+                  {% set obj = blast.get("object") %}
+                  {% if obj is mapping or (obj is sequence and obj is not string) %}
+                    <pre class="whitespace-pre-wrap text-xs">{{ obj | tojson(indent=2) }}</pre>
+                  {% else %}
+                    {{ obj }}
+                  {% endif %}
+                </dd>
+              </div>
+            </dl>
+          {% endif %}
+          {% set children = blast.get("children") %}
+          <div class="mt-2 text-sm">
+            <p class="text-base-content/55">
+              Child objects also destroyed
+              {% if children is sequence and children is not string %}({{ children | length }}){% endif %}
+            </p>
+            {% if children is sequence and children is not string and children | length %}
+              <ul class="mt-1 list-disc space-y-0.5 pl-5 font-mono text-xs [overflow-wrap:anywhere]">
+                {% for child in children %}
+                  <li>
+                    {% if child is mapping or (child is sequence and child is not string) %}
+                      <pre class="whitespace-pre-wrap">{{ child | tojson(indent=2) }}</pre>
+                    {% else %}
+                      {{ child }}
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="mt-1 text-xs opacity-80">None — only the object above is destroyed.</p>
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+
       {#- The operation-specific fields: a bespoke ``preview`` when a builder
           computed one, else the generic redaction-safe ``params_echo``. Render
           the fields WITHIN that sub-dict as a table -- scalars inline, nested
@@ -340,15 +400,16 @@
         gated write actually executes, so surface what each decision does BEFORE
         the operator acts -- mirroring the ops Run modal's ``data-run-gate``
         alert (#1881) and the vault confirm gate (#1957). ``safety_level`` is the
-        closed ``safe``/``caution``/``dangerous`` enum already stamped on every
-        parked envelope (#1855) and rendered structurally above (#2447); reuse it
-        as the banner's severity source (error for dangerous, warning otherwise,
-        including when it is absent). No server change -- the value already rides
+        closed ``safe``/``caution``/``dangerous``/``destructive`` enum already
+        stamped on every parked envelope (#1855, +#3197 tier) and rendered
+        structurally above (#2447); reuse it as the banner's severity source
+        (error for destructive + dangerous, warning otherwise, including when it
+        is absent). No server change -- the value already rides
         ``proposed_effect``. -#}
     {% set safety = effect.get("safety_level") %}
     <div
       role="alert"
-      class="alert {{ 'alert-error' if safety == 'dangerous' else 'alert-warning' }} mt-5 items-start"
+      class="alert {{ 'alert-error' if safety in ('dangerous', 'destructive') else 'alert-warning' }} mt-5 items-start"
       data-approval-gate="confirm"
       data-safety-level="{{ safety if safety else '' }}"
     >

--- a/backend/tests/migrations/test_migration_0086_approval_request_preview_hash.py
+++ b/backend/tests/migrations/test_migration_0086_approval_request_preview_hash.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0086_add_approval_request_preview_hash``.
+
+#3197 / #3183 (governed deletes). Adds the nullable
+``approval_request.preview_hash`` column — the preview-result-hash binding
+recorded at park time for a ``destructive``-tier op and re-verified at
+approve time, distinct from the existing ``params_hash``.
+
+The migration is a plain nullable ``ADD COLUMN``, so the behaviour under
+test is schema shape: the column is present + nullable after ``upgrade``,
+absent after ``downgrade``, and the pair round-trips idempotently. SQLite
+is the test driver; the migration uses only generic ``ADD COLUMN`` /
+``DROP COLUMN`` DDL, so PostgreSQL parity holds.
+
+The ``down_revision`` is pinned to ``0084`` (the head on ``origin/main`` at
+branch time); the orchestrator re-points it to the then-current head at
+merge if a concurrent migration (e.g. ``0085``) lands first. This test
+targets the literal revision ids so it stays correct under that re-point
+only if the ids move in lockstep — which the orchestrator's re-point does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import inspect
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0086"
+_DOWN_REVISION = "0084"
+_TABLE = "approval_request"
+_COLUMN = "preview_hash"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0086.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _preview_hash_column(sync_url: str) -> dict[str, object] | None:
+    """Return the ``approval_request.preview_hash`` column spec, or ``None``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            columns = inspect(conn).get_columns(_TABLE)
+    finally:
+        sync_eng.dispose()
+    for column in columns:
+        if column["name"] == _COLUMN:
+            return column
+    return None
+
+
+def test_upgrade_adds_nullable_preview_hash(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0086`` adds ``preview_hash`` as a nullable column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    column = _preview_hash_column(sync_url)
+    assert column is not None, "preview_hash column must exist after upgrade"
+    # Nullable: a non-destructive / pre-0086 row legitimately carries no binding.
+    assert column["nullable"] is True
+
+
+def test_downgrade_drops_preview_hash(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0084`` drops the ``preview_hash`` column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _preview_hash_column(sync_url) is not None
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _preview_hash_column(sync_url) is None
+
+
+def test_upgrade_round_trips_after_clean_downgrade(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0086`` → ``downgrade 0084`` → ``upgrade 0086`` restores the column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    command.downgrade(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _REVISION)
+
+    assert _preview_hash_column(sync_url) is not None

--- a/backend/tests/migrations/test_migration_0086_approval_request_preview_hash.py
+++ b/backend/tests/migrations/test_migration_0086_approval_request_preview_hash.py
@@ -14,11 +14,9 @@ absent after ``downgrade``, and the pair round-trips idempotently. SQLite
 is the test driver; the migration uses only generic ``ADD COLUMN`` /
 ``DROP COLUMN`` DDL, so PostgreSQL parity holds.
 
-The ``down_revision`` is pinned to ``0084`` (the head on ``origin/main`` at
-branch time); the orchestrator re-points it to the then-current head at
-merge if a concurrent migration (e.g. ``0085``) lands first. This test
-targets the literal revision ids so it stays correct under that re-point
-only if the ids move in lockstep — which the orchestrator's re-point does.
+The ``down_revision`` is ``0085`` (``0085_create_dispatch_trace_store``,
+the head on ``origin/main``): the chain is the single linear head
+``0084 -> 0085 -> 0086``. This test targets the literal revision ids.
 """
 
 from __future__ import annotations
@@ -37,7 +35,7 @@ from meho_backplane.db.migrations import alembic_config
 from meho_backplane.settings import get_settings
 
 _REVISION = "0086"
-_DOWN_REVISION = "0084"
+_DOWN_REVISION = "0085"
 _TABLE = "approval_request"
 _COLUMN = "preview_hash"
 

--- a/backend/tests/test_destructive_preview_binding.py
+++ b/backend/tests/test_destructive_preview_binding.py
@@ -1,0 +1,604 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the destructive-tier preview binding + blast-radius (#3197).
+
+Task #3197 under Initiative #3183 (governed deletes), decision
+``docs/decisions/governed-delete-operations.md`` requirements 2 and 3:
+
+* **Requirement 2 — preview-result-hash binding.** ``preview_operation``
+  emits a stable ``preview_hash``; a ``destructive`` op refuses to park
+  unless the caller presents a hash that matches the dispatcher's
+  server-recomputed preview. Missing hash, non-resolvable preview, or a
+  mismatch all fail closed.
+* **Requirement 3 — mandatory blast-radius statement.** A ``destructive``
+  op cannot park with only the identifier-only default: its
+  ``proposed_effect`` must carry a ``blast_radius`` block (object identity,
+  enumerated child objects, irreversibility class), else the park is
+  refused.
+
+The keystone flow — a full park → human-approve → audited resume honouring
+the bound hash — is covered by
+``test_full_park_approve_resume_honours_bound_hash``. The approve-time
+re-verification (a destructive row missing its binding is refused) is
+covered by ``test_approve_refuses_destructive_row_without_binding``.
+
+Mirrors the sibling ingested-dispatch fixtures in
+``test_operations_request_preview.py`` (recording HTTP connector, in-memory
+SQLite via the autouse-migrated engine, deterministic embedding stub) and
+the park→approve→resume flow in ``test_connectors_argocd_write_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.adapters import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations._preview import (
+    _PREVIEW_BUILDERS,
+    PreviewContext,
+    blast_radius_missing_reason,
+    register_preview_builder,
+)
+from meho_backplane.operations._request_preview import preview_dispatch
+from meho_backplane.operations.approval_queue import (
+    PreviewBindingMissingError,
+    approve_request,
+    create_pending_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.settings import get_settings
+
+_TENANT: UUID = UUID("00000000-0000-0000-0000-000000003197")
+_OP_ID = "DELETE:/vms/{vm}"
+_CONNECTOR_ID = "gh-rest-3"
+_PARAMS = {"vm": "vm-42"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry, and isolate the preview registry."""
+    builders_snapshot = dict(_PREVIEW_BUILDERS)
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    _PREVIEW_BUILDERS.clear()
+    _PREVIEW_BUILDERS.update(builders_snapshot)
+
+
+@pytest.fixture
+def embedding() -> list[float]:
+    return [0.1] * 384
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _operator(
+    *, sub: str = "op-requester", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Destructive-Binding Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    """In-memory target shape the resolver / dispatcher / connectors read."""
+
+    def __init__(self, *, name: str = "gh-prod") -> None:
+        self.product = "gh"
+        self.fingerprint = _FakeFingerprint(version="3")
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = name
+        self.host = "api.github.com"
+        self.port = 443
+        self.auth_model: str | None = "shared_service_account"
+        self.secret_ref: str | None = None
+        self.fqdn: str | None = None
+
+
+class _RecordingHttpConnector(HttpConnector):
+    """Connector whose transport records calls instead of sending (no egress)."""
+
+    product = "gh"
+    version = "3"
+    impl_id = "gh-rest"
+    supported_version_range = ">=3,<4"
+    priority = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict[str, Any]] = []
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append({"verb": verb, "path": path})
+        return {"sent": True}
+
+    async def _request_json(
+        self,
+        target: Any,
+        method: str,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append({"verb": method, "path": path})
+        return {"sent": True}
+
+    async def fingerprint(  # type: ignore[override]
+        self, target: Any, operator: Operator | None = None
+    ) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+def _register_recording_connector() -> _RecordingHttpConnector:
+    register_connector_v2(product="gh", version="3", impl_id="gh-rest", cls=_RecordingHttpConnector)
+    connector = get_or_create_connector_instance(_RecordingHttpConnector)
+    assert isinstance(connector, _RecordingHttpConnector)
+    return connector
+
+
+async def _insert_destructive_descriptor(*, embedding: list[float]) -> None:
+    """Seed one enabled, ``destructive``, ``requires_approval`` ingested delete op.
+
+    ``requires_approval=True`` makes a ``USER`` dispatch park (reach the
+    approval queue) deterministically, so the destructive-tier gate in
+    ``_handle_needs_approval`` runs without depending on the #3196 USER-park
+    routing.
+    """
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="DELETE",
+        path="/vms/{vm}",
+        handler_ref=None,
+        summary="Destroy a VM.",
+        description="Ingested destructive delete test op.",
+        tags=[],
+        parameter_schema={
+            "type": "object",
+            "properties": {"vm": {"type": "string", "x-meho-param-loc": "path"}},
+        },
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="destructive",
+        requires_approval=True,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    async with get_sessionmaker()() as s:
+        s.add(descriptor)
+        await s.commit()
+
+
+async def _blast_radius_builder(ctx: PreviewContext) -> dict[str, Any]:
+    """A destructive-op preview builder that emits the mandatory blast-radius block."""
+    return {
+        "blast_radius": {
+            "object": {"kind": "vm", "id": ctx.params.get("vm")},
+            "children": [{"kind": "disk", "id": "disk-1"}],
+            "irreversibility": "permanent",
+        },
+        "note": "delete preview",
+    }
+
+
+async def _seed_target(*, name: str = "gh-prod") -> TargetORM:
+    async with get_sessionmaker()() as s:
+        target = TargetORM(
+            tenant_id=_TENANT,
+            name=name,
+            aliases=[],
+            product="gh",
+            host="api.github.com",
+            port=443,
+            fqdn=None,
+            secret_ref=None,
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "3"},
+            preferred_impl_id="gh-rest",
+            notes="seeded by test_destructive_preview_binding",
+        )
+        s.add(target)
+        await s.commit()
+        await s.refresh(target)
+        s.expunge(target)
+        return target
+
+
+async def _approval_row_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2 — preview_operation emits a stable, param-sensitive hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_emits_stable_param_sensitive_hash(embedding: list[float]) -> None:
+    """``preview_operation`` returns a 64-hex ``preview_hash`` that is stable for
+    identical args and differs when the resolved request differs."""
+    _register_recording_connector()
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    env1 = await preview_dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params={"vm": "vm-42"},
+    )
+    assert env1["status"] == "ok"
+    assert isinstance(env1["preview_hash"], str)
+    assert len(env1["preview_hash"]) == 64
+
+    env2 = await preview_dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params={"vm": "vm-42"},
+    )
+    assert env2["preview_hash"] == env1["preview_hash"]  # stable across identical args
+
+    env3 = await preview_dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params={"vm": "vm-99"},
+    )
+    assert env3["preview_hash"] != env1["preview_hash"]  # a different delete → different hash
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3 — blast-radius validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "effect, is_valid",
+    [
+        (None, False),
+        ({}, False),
+        ({"blast_radius": "not-a-dict"}, False),
+        ({"blast_radius": {"children": [], "irreversibility": "permanent"}}, False),  # no object
+        (
+            {"blast_radius": {"object": "vm-1", "irreversibility": "permanent"}},
+            False,
+        ),  # no children
+        ({"blast_radius": {"object": "vm-1", "children": "x", "irreversibility": "y"}}, False),
+        ({"blast_radius": {"object": "vm-1", "children": []}}, False),  # no irreversibility
+        (
+            {"blast_radius": {"object": "vm-1", "children": [], "irreversibility": "permanent"}},
+            True,
+        ),
+    ],
+)
+def test_blast_radius_missing_reason(effect: dict[str, Any] | None, is_valid: bool) -> None:
+    """The validator returns ``None`` only for a well-formed block; a reason otherwise."""
+    reason = blast_radius_missing_reason(effect)
+    assert (reason is None) is is_valid
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2 — the dispatcher refuses to park without a matching binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_park_without_preview_hash(embedding: list[float]) -> None:
+    """No ``preview_hash`` presented → ``preview_binding_required``, no row parked."""
+    connector = _register_recording_connector()
+    register_preview_builder(_OP_ID, _blast_radius_builder)
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    result = await dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params=_PARAMS,
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert connector.calls == []
+    assert await _approval_row_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_park_on_preview_hash_mismatch(embedding: list[float]) -> None:
+    """A stale / forged ``preview_hash`` → ``preview_hash_mismatch``, no row parked."""
+    connector = _register_recording_connector()
+    register_preview_builder(_OP_ID, _blast_radius_builder)
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    result = await dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params=_PARAMS,
+        preview_hash="deadbeef" * 8,  # not the server-recomputed hash
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_hash_mismatch"
+    assert connector.calls == []
+    assert await _approval_row_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_park_when_hash_binds_different_params(
+    embedding: list[float],
+) -> None:
+    """A hash previewed for other params (swap between preview and call) is refused."""
+    _register_recording_connector()
+    register_preview_builder(_OP_ID, _blast_radius_builder)
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    # Preview vm-99, then try to dispatch vm-42 with vm-99's hash.
+    other = await preview_dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params={"vm": "vm-99"},
+    )
+    result = await dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params={"vm": "vm-42"},
+        preview_hash=other["preview_hash"],
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_hash_mismatch"
+    assert await _approval_row_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3 — the dispatcher refuses to park without a blast-radius block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_park_without_blast_radius(embedding: list[float]) -> None:
+    """A correct hash but no blast-radius builder → ``blast_radius_required``.
+
+    No preview builder is registered, so ``proposed_effect`` carries only the
+    generic params-echo — no blast-radius block — and the park is refused even
+    though the preview-hash binding is satisfied.
+    """
+    connector = _register_recording_connector()
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    env = await preview_dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params=_PARAMS,
+    )
+    result = await dispatch(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeTarget(),
+        params=_PARAMS,
+        preview_hash=env["preview_hash"],
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "blast_radius_required"
+    assert connector.calls == []
+    assert await _approval_row_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# The keystone flow: park → human-approve → audited resume honouring the hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_park_approve_resume_honours_bound_hash(embedding: list[float]) -> None:
+    """A destructive op with a matching hash + blast-radius parks, is approved by a
+    second operator, and resumes to execution carrying the bound hash."""
+    connector = _register_recording_connector()
+    register_preview_builder(_OP_ID, _blast_radius_builder)
+    await _seed_target(name="gh-prod")
+    await _insert_destructive_descriptor(embedding=embedding)
+
+    requester = _operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "gh-prod",
+        "params": _PARAMS,
+    }
+
+    # 1) Preview → bind the hash.
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+    bound_hash = preview["preview_hash"]
+
+    # 2) Governed call presenting the bound hash → parks.
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert connector.calls == []  # nothing executed yet
+
+    # 3) The parked row carries the bound hash + the blast-radius statement.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    assert effect["blast_radius"]["object"] == {"kind": "vm", "id": "vm-42"}
+    assert effect["blast_radius"]["children"] == [{"kind": "disk", "id": "disk-1"}]
+    assert effect["blast_radius"]["irreversibility"] == "permanent"
+
+    # 4) A different operator approves (four-eyes) — the binding re-verifies.
+    approver = _operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    # 5) Audited resume → the bound delete executes exactly once.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume_result = await resume_dispatch_after_approval(
+            operator=approver, request=row, params=None
+        )
+    assert resume_result.status == "ok"
+    assert connector.calls == [{"verb": "DELETE", "path": "/vms/vm-42"}]
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2 — approve-time re-verification of the binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approve_refuses_destructive_row_without_binding(embedding: list[float]) -> None:
+    """A destructive row with no ``preview_hash`` cannot be approved (fail-closed).
+
+    Constructs a destructive pending row directly with ``preview_hash=None``
+    (the shape a park that bypassed the dispatcher gate would leave) and
+    proves ``approve_request`` refuses it — the approve-time half of the
+    binding, extending the ``params_hash`` swap-defence.
+    """
+    async with get_sessionmaker()() as s:
+        request = await create_pending_request(
+            s,
+            operator=_operator(sub="op-requester"),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=_PARAMS,
+            params_hash="abc123",
+            proposed_effect={"op_id": _OP_ID, "safety_level": "destructive"},
+            preview_hash=None,
+        )
+        await s.commit()
+        request_id = request.id
+
+    approver = _operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        with pytest.raises(PreviewBindingMissingError):
+            await approve_request(s, request_id, operator=approver, params=None)
+
+
+@pytest.mark.asyncio
+async def test_approve_allows_non_destructive_row_without_binding(embedding: list[float]) -> None:
+    """A non-destructive row legitimately carries no binding and approves normally."""
+    async with get_sessionmaker()() as s:
+        request = await create_pending_request(
+            s,
+            operator=_operator(sub="op-requester"),
+            connector_id=_CONNECTOR_ID,
+            op_id="POST:/vms",
+            target=None,
+            params=_PARAMS,
+            params_hash="abc123",
+            proposed_effect={"op_id": "POST:/vms", "safety_level": "dangerous"},
+            preview_hash=None,
+        )
+        await s.commit()
+        request_id = request.id
+
+    approver = _operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -24275,6 +24275,13 @@
             "nullable": true,
             "title": "Work Ref"
           },
+          "preview_hash": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Preview Hash",
+            "description": "Preview-result-hash binding for the destructive tier (#3197). The hash a prior preview_operation of the identical (connector_id, op_id, target, params) returned. REQUIRED for a safety_level='destructive' op \u2014 the dispatcher refuses to park the approval fail-closed unless it matches the server-recomputed preview hash. Ignored for every non-destructive op. None default keeps a bare call_operation byte-identical to pre-#3197."
+          },
           "async": {
             "type": "boolean",
             "title": "Async",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2781,10 +2781,13 @@ type BudgetStatus struct {
 // tracker API call (Goal #1651 ships the field only).
 type CallOperationBody struct {
 	// Async Async governed dispatch (#3079). When true, ``/call`` returns a durable run handle (HTTP 202) immediately instead of holding the connection for the op's full duration; execution proceeds server-side and the caller polls / cancels via ``/api/v1/operations/runs/{handle}``. The completed ``OperationResult`` envelope is persisted on the run, so a dropped response never loses the outcome. Default false — sync mode is byte-identical to the pre-#3079 behaviour.
-	Async       *bool                     `json:"async,omitempty"`
-	ConnectorId string                    `json:"connector_id"`
-	OpId        string                    `json:"op_id"`
-	Params      *map[string]interface{}   `json:"params,omitempty"`
+	Async       *bool                   `json:"async,omitempty"`
+	ConnectorId string                  `json:"connector_id"`
+	OpId        string                  `json:"op_id"`
+	Params      *map[string]interface{} `json:"params,omitempty"`
+
+	// PreviewHash Preview-result-hash binding for the destructive tier (#3197). The hash a prior preview_operation of the identical (connector_id, op_id, target, params) returned. REQUIRED for a safety_level='destructive' op — the dispatcher refuses to park the approval fail-closed unless it matches the server-recomputed preview hash. Ignored for every non-destructive op. None default keeps a bare call_operation byte-identical to pre-#3197.
+	PreviewHash *string                   `json:"preview_hash"`
 	Target      *CallOperationBody_Target `json:"target"`
 	WorkRef     *string                   `json:"work_ref"`
 }

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -543,6 +543,77 @@ top. The only path that does **not** carry it is the bare identifier
 default the caller stores when `_build_proposed_effect` returns `None`
 (connector-resolution / hook fault) — that degraded path is unchanged.
 
+## Destructive tier: preview-hash binding + mandatory blast-radius (#3197)
+
+The `destructive` safety tier (the fourth `safety_level`, #3196 —
+`safe < caution < dangerous < destructive`) adds two fail-closed
+requirements on top of the standard park, both landing at the dispatcher
+seam. They implement requirements 2 and 3 of
+[`docs/decisions/governed-delete-operations.md`](../decisions/governed-delete-operations.md).
+Neither applies to any lower tier; a `safe` / `caution` / `dangerous` op
+parks exactly as before.
+
+**Requirement 2 — preview-result-hash binding.** `preview_operation`
+(`operations/_request_preview.py::preview_dispatch`) now emits a
+`preview_hash` on its `status="ok"` envelope:
+`compute_preview_hash` takes a stable SHA-256 over the canonicalised
+*resolved request* projection (`connector_id` / `op_id` / `method` /
+`resolved_path` / `query` / `redacted_body`) — the literal would-be
+request, the same canonicalisation discipline as `compute_params_hash`.
+An agent/operator previews the destructive op, then presents that hash on
+the subsequent `call_operation` (top-level `preview_hash` arg on
+`CallOperationBody` / the MCP tool schema, a MEHO dispatch control like
+`work_ref` — never a connector op param, so it stays out of `params_hash`
+and the op's `parameter_schema`).
+
+When such an op reaches `needs-approval`, `_handle_needs_approval` calls
+`_destructive_binding_refusal` **before** it writes any row:
+
+- no `preview_hash` presented → `denied` / `preview_binding_required`;
+- the dispatcher **recomputes** the authoritative hash by resolving the
+  same preview server-side (`preview_dispatch` — read-only, no egress) and
+  comparing. A non-resolvable preview → `preview_binding_required`; a
+  mismatch (params swapped between preview and call, or a forged/stale
+  hash) → `preview_hash_mismatch`.
+
+The verified hash is persisted on `ApprovalRequest.preview_hash` (nullable
+`Text`, migration `0086`) — **distinct** from `params_hash` (that hashes
+the request *params*; this hashes the *preview result* the approver was
+shown). At approve time `_load_pending_for_approval` re-verifies it
+(`_check_destructive_preview_binding`): a `destructive` row
+(`proposed_effect.safety_level == "destructive"`) with no `preview_hash`
+raises `PreviewBindingMissingError` → HTTP 422 on every approve surface
+(REST `/approve`, `/decide`, the console). This extends the existing
+`params_hash` swap-defence to the preview binding. The resume path
+(`dispatch(..., _approved=True)`) skips the policy gate, so the binding is
+enforced once at park and once at approve, never re-checked on execution.
+
+**Requirement 3 — mandatory blast-radius statement.** A destructive op
+cannot park with only the identifier-only default: its `proposed_effect`
+must carry a top-level `blast_radius` block — `object` (object identity),
+`children` (the enumerated child objects, a list; empty is a valid
+explicit statement), and `irreversibility` (the irreversibility class).
+A destructive op's preview builder returns the block inside its `preview`
+dict; `dispatcher._build_proposed_effect` **promotes** it to the top level
+(mirroring the `safety_level` / `op_class` stamping) so the mandatory-block
+gate and the console modal read it without reaching into `preview`.
+`blast_radius_missing_reason` (`operations/_preview.py`) validates it; a
+missing/malformed block → `_handle_needs_approval` refuses the park with
+`denied` / `blast_radius_required` (naming the missing field) rather than
+falling back to the identifier-only default. So a `destructive` op that
+registers no blast-radius preview builder is un-parkable by construction —
+fail-closed. The console modal (`ui/templates/approvals/_modal.html`)
+renders the block as an error-tinted "what this destroys" card above the
+generic field table.
+
+**Scope note.** The gate lives on the top-level dispatch park path
+(`_handle_needs_approval`). The composite-subop park path
+(`operations/composite.py::enforce_subop_policy`) parks via its own
+`create_pending_request` call and is **not** gated here — a destructive op
+reached as a composite subop is a separate governance seam (a follow-up,
+not this task). In practice an agent cannot reach it: the destructive tier
+is `DENY` for agent principals at `resolve_verdict`.
+
 ## Uniform op-identity envelope (#2681)
 
 The preview base varies by outcome — a bespoke `{op_class, preview}`, the

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -104,7 +104,7 @@ preview_dispatch(operator, connector_id, op_id, target, params)
                      tenant, op).redacted   ◄── SAME pipeline the response path uses
         ▼
 {status: ok, op_id, connector_id, source_kind, method,
- resolved_path, query, redacted_body}
+ resolved_path, query, redacted_body, preview_hash}
 ```
 
 The HTTP transport (`HttpConnector._post_json` / `_request_json`) is
@@ -119,7 +119,7 @@ surfaces stay `OPERATOR`-gated at the route / tool layer.
 
 | `status` | meaning | extra fields |
 |---|---|---|
-| `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind` |
+| `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind`, `preview_hash` (#3197 — SHA-256 over the resolved-request projection; the caller presents it on a `destructive`-tier `call_operation` and the dispatcher recomputes + matches it before parking the approval) |
 | `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `invalid_op_schema` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail (`invalid_op_schema` carries `extras.missing_ref`, #3095) |
 | `unavailable` | not an HTTP-ingested op | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
 


### PR DESCRIPTION
## Summary

Implements requirements 2 and 3 of `docs/decisions/governed-delete-operations.md` for the `destructive` safety tier (shipped #3196), both fail-closed at the dispatcher park seam. Non-destructive ops are byte-identical to before.

- **Preview-result-hash binding (req 2).** `preview_operation` emits a stable `preview_hash` (`compute_preview_hash` over the canonicalised resolved request). The caller presents it on `call_operation` (new `preview_hash` arg on `CallOperationBody` + the MCP `call_operation` schema — a dispatch control, kept out of `params_hash` and the op schema). A destructive op reaching `needs-approval` refuses to park unless the dispatcher's **server-recomputed** preview hash matches the presented one — a missing hash, a non-resolvable preview, or a mismatch (param swap between preview and call) is `denied` fail-closed. The verified hash persists on a new nullable `approval_request.preview_hash` column (migration `0086`, distinct from the existing `params_hash`) and is **re-verified at approve time** (`approve_request` refuses a destructive row missing the binding → 422 on REST `/approve`, `/decide`, and the console).
- **Mandatory blast-radius (req 3).** A destructive op cannot park with only the identifier-only default — its `proposed_effect` must carry a `blast_radius` block (object identity, enumerated child objects, irreversibility class), promoted to the envelope top level and rendered as a "what this destroys" card in the console approval modal; a missing block refuses the park.

**Scope note.** The gate lives on the top-level dispatch park path (`_handle_needs_approval`). The composite-subop park path (`enforce_subop_policy`) is a separate governance seam and is intentionally not gated here — agents cannot reach the destructive tier (it is `DENY` at `resolve_verdict`). No connector adopts the tier yet; the first governed delete op family (#3198) builds on this mechanism.

## Migration-chain note

`0086_add_approval_request_preview_hash` has `down_revision="0085"` — the head on `origin/main` (`0085_create_dispatch_trace_store`, the flight-recorder trace store, #3212/#3219). The chain is a single linear head `0084 -> 0085 -> 0086` (CI gate `Python (database migrations)`). Verified locally: `alembic heads` → `['0086']`. The branch was rebased onto `origin/main` (`4fb7820e`) and the `down_revision` re-pointed directly, so no merge-time renumber is needed.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean (only unrelated pre-existing `icmp.py` `MSG_ERRQUEUE`, Linux-only; passes in CI)
- [x] code-quality diff gate — 0 blockers (extracted `_ok_ingested_envelope` to keep `_build_ingested_preview` under the limit)
- [x] New `tests/test_destructive_preview_binding.py` (16 tests): preview emits a stable, param-sensitive hash; **mismatch refuses dispatch**; missing hash refuses; **missing blast-radius refuses park**; blast-radius validator matrix; **full park → human-approve → audited resume honoring the bound hash**; approve-time re-verify refuses an unbound destructive row (and allows a non-destructive one).
- [x] New `tests/migrations/test_migration_0086_...py` — add/drop/round-trip of the nullable column.
- [x] Regression: `test_operations_request_preview`, `test_approval_queue`, `test_api_v1_approvals`, `test_ui_approvals`, `test_operations_dispatcher`, `test_announce_gate`, `test_service_principal_grant_gate`, `test_connectors_argocd_write_e2e`, `test_operations_preview` — 287 passed.
- [x] MCP conformance + UI: `test_mcp_surface_conformance`, `test_mcp_output_schema_conformance`, `test_mcp_structured_content`, `test_mcp_surface_filter`, `test_ui_operations`, `test_ui_conventions_write` — 96 passed.
- [x] `test_migration_compat` — 19 passed; single linear alembic head at `0086`.
- [x] CLI OpenAPI snapshot + generated Go client regenerated (`make snapshot-openapi && make generate`); `go build ./...` OK.

## Out of scope

- Composite-subop destructive park gating (separate seam; agents can't reach the tier).
- The `destructive` USER-principal auto-execute routing is a pre-existing #3196 concern, not this task.
- The first governed delete op family end-to-end is #3198.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3197

