### PR TITLE
feat(pairing): paired-surface activation — automation meta-tool family, CLI verbs, console panel (#3029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,30 @@ connector-related release-notes line.
     (`flight_recorder.record_trace`) is best-effort (F7 — never raises into a
     dispatch). Under #3207.
 
+### Added — paired-surface activation: the automation meta-tool family, CLI verbs, and console panel (#3029)
+
+- The first backplane surface gated on live **add-on pairing state** rather
+  than a static tenant capability (Initiative #2900). When a paired,
+  contract-healthy add-on advertises the `automation` `meta_tool_family`
+  capability, a small first-party surface activates across all three fronts —
+  the `meho_automation_list` MCP meta-tool, the `meho automation list` CLI
+  verb, and the `/ui/automation` console panel — and disappears cleanly on
+  unpair. A new fourth gating axis (`required_addon_family` on
+  `ToolDefinition`, resolved from
+  `AddonCapabilityService.active_meta_tool_families`) is AND-composed with the
+  role / capability / surface gates and enforced at both `tools/list` and
+  `tools/call`, so an **unpaired** backplane's tool listing stays
+  byte-identical to a build that never carried the family. CLI verbs and REST
+  routes follow the static-surface discipline (#2109): always registered, gated
+  server-side inside the handler (`GET /api/v1/automation` answers 403
+  `automation_addon_not_active` while inactive), so the OpenAPI snapshot stays
+  deterministic. Narrow-waist discipline (CLAUDE.md postulate 5) holds — a
+  paired add-on's blueprint / workflow identifiers are data in results, never
+  tool names, and there is no per-blueprint / per-workflow tool anywhere. Docs:
+  `docs/codebase/addon-pairing.md` (paired-surface activation) +
+  `docs/codebase/mcp.md` (the four-gate scoping + the pairing-gated inventory
+  row).
+
 ### Added — dispatch flight recorder: security-review-first design decision (#3207)
 
 - Records the operator-ratified (2026-08-30/31) design for a per-dispatch

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -60,6 +60,9 @@ __all__ = [
 #: the deliberately-unmapped set.
 TAG_FEATURE: Final[dict[str, str]] = {
     "addon-pairing": "addon_pairing",
+    # Paired-surface activation (#3029): the automation surface is part of the
+    # add-on pairing contract (Initiative #2900) and shares its maturity.
+    "automation": "addon_pairing",
     "agent-grants": "agent_runtime",
     "agent-principals": "agent_runtime",
     "agents": "agent_runtime",

--- a/backend/src/meho_backplane/api/v1/automation.py
+++ b/backend/src/meho_backplane/api/v1/automation.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /api/v1/automation`` — the paired automation surface (Task #3029).
+
+The REST twin of the ``meho_automation_list`` MCP meta-tool and the
+``meho automation list`` CLI verb — three fronts on one dispatch answer
+(Initiative #2900's paired-surface activation). All three read the shared
+:func:`~meho_backplane.operations.addon_automation.active_automation_surface`
+projection, so REST / CLI / MCP give the same verdict for the same tenant.
+
+Gating follows the established static-surface / server-side-gate discipline
+(#2109): the route is always registered (so the CLI's generated client and the
+OpenAPI snapshot are deterministic regardless of pairing state), and activation
+is enforced *inside* the handler. When no paired, contract-healthy add-on
+advertises the ``automation`` meta-tool family, the surface is inactive and the
+route answers ``403`` — the same "not available while unpaired" verdict the MCP
+call-time gate returns — rather than leaking an empty page that reads as "paired
+but empty". Tenant scope comes from the JWT-validated operator, never the query
+string.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi import status as http_status
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.operations.addon_automation import (
+    AutomationSurfaceResponse,
+    active_automation_surface,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/automation", tags=["automation"])
+
+#: Module-level Depends closure — avoid ruff B008. Read-only floor: discovering
+#: whether governed automation is available is benign, mirroring the
+#: ``meho_automation_list`` tool's ``read_only`` role.
+_require_read = Depends(require_role(TenantRole.READ_ONLY))
+
+#: Canonical audit op_id — the ``meho.automation.*`` family the MCP tool and CLI
+#: verb bind too, so a ``query_audit`` filter catches the read transport-independently.
+_LIST_OP_ID: Final[str] = "meho.automation.list"
+
+
+@router.get("", response_model=AutomationSurfaceResponse)
+async def list_automation_surface(
+    operator: Operator = _require_read,
+) -> AutomationSurfaceResponse:
+    """Return the paired automation add-on(s) and their advertised surface.
+
+    ``403`` (``automation_addon_not_active``) when the automation family is
+    inactive — nothing paired, or every candidate pairing is
+    contract-incompatible — so an unpaired backplane has no live automation
+    surface here, matching the MCP tool's true-absence gate. Otherwise returns
+    the non-empty provider list.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_LIST_OP_ID,
+        audit_op_class="read",
+    )
+    surface = await active_automation_surface(operator.tenant_id)
+    if not surface.providers:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="automation_addon_not_active",
+        )
+    return surface

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -77,6 +77,7 @@ from meho_backplane.api.v1.ask_docs import router as api_v1_ask_docs_router
 from meho_backplane.api.v1.audit import router as api_v1_audit_router
 from meho_backplane.api.v1.audit_reflex import router as api_v1_audit_reflex_router
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
+from meho_backplane.api.v1.automation import router as api_v1_automation_router
 from meho_backplane.api.v1.broadcast_overrides import (
     router as api_v1_broadcast_overrides_router,
 )
@@ -1103,6 +1104,12 @@ app.include_router(api_v1_addon_pairing_router)
 # against the negotiated contract; the backplane persists the declaration and
 # activates surfaces only while paired and contract-healthy (Initiative #2900).
 app.include_router(api_v1_addon_capability_router)
+# #3029 -- paired-surface activation (automation): the REST twin of the
+# ``meho_automation_list`` meta-tool and ``meho automation list`` CLI verb.
+# Always registered (static surface, #2109); activation is gated inside the
+# handler (403 while the automation add-on is unpaired / contract-unhealthy),
+# so the OpenAPI snapshot stays deterministic (Initiative #2900).
+app.include_router(api_v1_automation_router)
 # G7.1-T2 (#314) -- tenant-conventions CRUD + history (list / show /
 # create / update / delete / history). Reads gated to operator+;
 # writes gated to tenant_admin. Tenant-scoped via the JWT's

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -99,12 +99,14 @@ from meho_backplane.mcp.human_only import human_only_remediation
 from meho_backplane.mcp.registry import (
     ResourceTemplateDefinition,
     ToolDefinition,
+    addon_family_active,
     all_listed_resources_for,
     all_resource_templates_for,
     all_tools_for,
     capability_satisfied,
     get_resource_for_uri,
     get_tool,
+    has_addon_gated_tools,
     redacted_audit_uri,
     role_at_least,
     surface_visible,
@@ -185,6 +187,28 @@ def _read_mcp_broadcast_detail(raw_params: dict[str, Any]) -> Literal["full"] | 
 # ---------------------------------------------------------------------------
 
 
+async def _active_addon_families(operator: Operator) -> frozenset[str]:
+    """Resolve the meta-tool families a paired, healthy add-on activates.
+
+    The per-request bridge from the add-on capability plane
+    (:class:`~meho_backplane.operations.addon_capability.AddonCapabilityService`)
+    into the ``required_addon_family`` gate (Initiative #2900, Task #3029). A
+    single indexed read scoped to the caller's tenant; empty (fail-closed)
+    when nothing is paired. Callers guard on
+    :func:`~meho_backplane.mcp.registry.has_addon_gated_tools` (list path) or
+    the tool's own ``required_addon_family`` (call path) so the DB round-trip
+    only happens when an add-on-gated tool is actually in play.
+
+    The :class:`~meho_backplane.operations.addon_capability.AddonCapabilityService`
+    import is function-local: the capability plane transitively pulls in the
+    agent / scheduler chain, which re-enters this module at package-import time,
+    so a top-level import would be a cycle.
+    """
+    from meho_backplane.operations.addon_capability import AddonCapabilityService
+
+    return await AddonCapabilityService().active_meta_tool_families(operator.tenant_id)
+
+
 async def handle_tools_list(
     operator: Operator,
     _params: dict[str, Any] | None,
@@ -195,8 +219,18 @@ async def handle_tools_list(
     through G0.5-T4, growing into tens through G3+). The MCP spec allows
     a server to return all tools in one response and omit the
     ``nextCursor`` field, which is what this handler does.
+
+    Resolves the tenant's active add-on meta-tool families only when the
+    registry actually carries an add-on-gated tool (Task #3029), so the
+    common listing stays a pure in-memory registry filter and never pays for
+    a DB round-trip it can't use.
     """
-    visible = [defn.to_wire() for defn in all_tools_for(operator)]
+    active_families = (
+        await _active_addon_families(operator) if has_addon_gated_tools() else frozenset()
+    )
+    visible = [
+        defn.to_wire() for defn in all_tools_for(operator, active_addon_families=active_families)
+    ]
     return {"tools": visible}
 
 
@@ -359,6 +393,32 @@ async def handle_tools_call(
                 f"forbidden: {name!r} is on the operator surface and requires "
                 "an elevated (mcp:admin) MCP session",
             )
+
+        # Add-on family gate (Initiative #2900, Task #3029): a tool bound to a
+        # paired add-on's meta-tool family gates invocation too, not just
+        # listing. all_tools_for already hides it while the add-on is
+        # unpaired / contract-unhealthy, but a client that learned the name
+        # out-of-band could still try to call it. Re-check here — resolving the
+        # active family set only for a tool that actually declares the gate, so
+        # a non-add-on call never pays the DB round-trip — same 403-projected
+        # path as the gates above.
+        if defn.required_addon_family is not None:
+            active_families = await _active_addon_families(operator)
+            if not addon_family_active(active_families, defn.required_addon_family):
+                _log.warning(
+                    "mcp_tool_call_addon_family_forbidden",
+                    tool=name,
+                    required_addon_family=defn.required_addon_family,
+                )
+                status_code = 403
+                raise McpInvalidParamsError(
+                    f"forbidden: {name!r} requires the {defn.required_addon_family!r} "
+                    "add-on to be paired and contract-healthy",
+                    data={
+                        "reason": "addon_family_inactive",
+                        "required_addon_family": defn.required_addon_family,
+                    },
+                )
 
         # Validate arguments against the tool's inputSchema. ``cls`` is
         # pinned to :class:`jsonschema.Draft202012Validator` to make the

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -85,6 +85,7 @@ __all__ = [
     "ToolDefinition",
     "ToolHandler",
     "ToolSurface",
+    "addon_family_active",
     "all_listed_resources_for",
     "all_resource_templates_for",
     "all_tools_for",
@@ -93,6 +94,7 @@ __all__ = [
     "eager_import_mcp_modules",
     "get_resource_for_uri",
     "get_tool",
+    "has_addon_gated_tools",
     "register_mcp_resource",
     "register_mcp_tool",
     "role_at_least",
@@ -256,6 +258,38 @@ def surface_visible(operator: Operator, surface: ToolSurface) -> bool:
     return MCP_ADMIN_SCOPE in operator.scopes
 
 
+def addon_family_active(
+    active_addon_families: frozenset[str],
+    required_addon_family: str | None,
+) -> bool:
+    """Return True when *required_addon_family* is currently activated.
+
+    The **paired-surface** gate (Initiative #2900, Task #3029) — a fourth
+    axis AND-ed with role / capability / surface. A tool with
+    ``required_addon_family=None`` has no add-on gate and is always admitted.
+    When a family *is* required, the tool is admitted iff that family name is
+    in *active_addon_families* — the set of meta-tool families a **paired,
+    contract-healthy** add-on advertises for the caller's tenant
+    (:meth:`~meho_backplane.operations.addon_capability.AddonCapabilityService.active_meta_tool_families`).
+    The caller resolves that set once (an async DB read against the add-on
+    pairing / capability plane) and passes it in, keeping this gate a pure
+    membership test — the same shape as :func:`capability_satisfied` and
+    :func:`surface_visible`.
+
+    Fail-closed: the set is empty when nothing is paired, so an **unpaired**
+    backplane never admits an add-on-gated tool — its ``tools/list`` stays
+    byte-identical to a build that never had the paired family. Unlike the
+    ``required_capability`` axis (a static tenant JWT claim resolved in
+    :func:`capability_satisfied`), this axis reflects **live pairing health**:
+    the tool drops out the moment its add-on unpairs or drifts
+    contract-incompatible, and reappears when health recovers, without any
+    tool being re-registered.
+    """
+    if required_addon_family is None:
+        return True
+    return required_addon_family in active_addon_families
+
+
 #: JSON-Schema combinator keywords the Anthropic Messages API rejects at
 #: the *top level* of a tool's ``input_schema``. A request carrying one
 #: 400s with ``input_schema does not support oneOf, allOf, or anyOf at
@@ -291,8 +325,8 @@ class ToolDefinition(BaseModel):
 
     The wire shape exposed via ``tools/list`` is derived through
     :meth:`to_wire`, which drops the MEHO-internal fields (``required_role``,
-    ``op_class``, ``required_capability``, ``surface``) — clients don't
-    need them and they'd leak server-side policy detail.
+    ``op_class``, ``required_capability``, ``surface``, ``required_addon_family``)
+    — clients don't need them and they'd leak server-side policy detail.
 
     ``inputSchema`` is a JSON Schema 2020-12 object the handler validates
     incoming ``tools/call.arguments`` against. ``outputSchema`` is
@@ -327,6 +361,22 @@ class ToolDefinition(BaseModel):
     with the role + capability gates by :func:`surface_visible`;
     MEHO-internal — dropped from the wire shape like the RBAC fields.
 
+    ``required_addon_family`` (Initiative #2900, Task #3029) is an optional
+    fourth gating axis, *orthogonal* to the other three, that binds a tool to
+    a **paired add-on's** advertised meta-tool family. When set, the tool is
+    filtered out of ``tools/list`` and rejected at ``tools/call`` unless a
+    **paired, contract-healthy** add-on advertises a ``meta_tool_family``
+    capability of that name for the caller's tenant — true absence for an
+    unpaired backplane, so the surface appears only while the add-on is paired
+    and healthy and disappears cleanly on unpair. Distinct from
+    ``required_capability`` (a static tenant JWT claim): this axis reflects
+    live pairing health resolved from the add-on capability plane, so the gate
+    is applied by :func:`addon_family_active` against a per-request-resolved
+    active-family set rather than a pure operator-claim membership test.
+    ``None`` (the default) means "no add-on gate", so every existing tool
+    keeps its behaviour. MEHO-internal — dropped from the wire shape like the
+    RBAC fields.
+
     ``feature`` (#2675) names the tool's owning entry in
     :data:`~meho_backplane.features.FEATURE_MATURITY` so
     :func:`register_mcp_tool` can resolve the tool's maturity tier and
@@ -356,6 +406,7 @@ class ToolDefinition(BaseModel):
     required_role: TenantRole = TenantRole.OPERATOR
     op_class: str = "read"
     required_capability: str | None = None
+    required_addon_family: str | None = None
 
     @field_validator("feature")
     @classmethod
@@ -382,9 +433,9 @@ class ToolDefinition(BaseModel):
         Spec fields kept: ``name``, ``description``, ``inputSchema``,
         optional ``title`` / ``outputSchema``. MEHO fields dropped:
         ``required_role``, ``op_class``, ``required_capability``,
-        ``surface``. The drop is deliberate — clients don't need
-        server-side RBAC / capability / surface details and shouldn't
-        see them.
+        ``surface``, ``required_addon_family``. The drop is deliberate —
+        clients don't need server-side RBAC / capability / surface /
+        pairing details and shouldn't see them.
 
         ``inputSchema`` is additionally passed through
         :func:`_wire_safe_input_schema`, which strips top-level
@@ -633,10 +684,14 @@ def get_resource_for_uri(
     return None
 
 
-def all_tools_for(operator: Operator) -> list[ToolDefinition]:
+def all_tools_for(
+    operator: Operator,
+    *,
+    active_addon_families: frozenset[str] = frozenset(),
+) -> list[ToolDefinition]:
     """Return tools the operator may see, in registration order.
 
-    Three orthogonal gates, all AND-ed:
+    Four orthogonal gates, all AND-ed:
 
     * **role** — the operator's :class:`TenantRole` must meet
       ``required_role``.
@@ -649,8 +704,14 @@ def all_tools_for(operator: Operator) -> list[ToolDefinition]:
       session lists only :attr:`ToolSurface.WORKING`; the
       :attr:`ToolSurface.OPERATOR` planes are absent unless the session
       is :data:`MCP_ADMIN_SCOPE`-elevated (Initiative #3153, #3154).
+    * **add-on family** — when the tool declares a ``required_addon_family``,
+      that family must be in *active_addon_families* (the meta-tool families a
+      paired, contract-healthy add-on advertises for the tenant, per
+      :func:`addon_family_active`). Callers that can resolve the active set
+      (the listing handler) pass it; callers that cannot leave it empty, which
+      fail-closed hides every add-on-gated tool (Initiative #2900, #3029).
 
-    All three are *absence* gates (true absence, not a greyed-out entry),
+    All four are *absence* gates (true absence, not a greyed-out entry),
     so a tool a session may not use never appears in its ``tools/list``.
     """
     return [
@@ -659,7 +720,20 @@ def all_tools_for(operator: Operator) -> list[ToolDefinition]:
         if role_at_least(operator.tenant_role, defn.required_role)
         and capability_satisfied(operator, defn.required_capability)
         and surface_visible(operator, defn.surface)
+        and addon_family_active(active_addon_families, defn.required_addon_family)
     ]
+
+
+def has_addon_gated_tools() -> bool:
+    """Return True when any registered tool declares a ``required_addon_family``.
+
+    The listing handler consults this before doing the (async, DB-backed)
+    active-family resolution: with no add-on-gated tool registered the
+    resolution can only ever remove nothing, so it is skipped and
+    ``tools/list`` stays a pure in-memory registry filter — the common case.
+    A single-pass registry scan, cheap relative to the DB round-trip it guards.
+    """
+    return any(defn.required_addon_family is not None for defn, _ in _TOOLS.values())
 
 
 def all_resource_templates_for(

--- a/backend/src/meho_backplane/mcp/tools/automation.py
+++ b/backend/src/meho_backplane/mcp/tools/automation.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho_automation_list`` — the paired-surface automation family (Task #3029).
+
+The first tool of the ``automation`` meta-tool family, and the first surface
+gated on **add-on pairing state** rather than a static tenant capability. It is
+the automation analogue of ``meho_connector_list`` (``mcp/tools/connector_admin``
+neighbour): where ``meho_connector_list`` answers "what managed systems can I
+act on?", this answers "is the paired automation add-on live, and what surface
+does it advertise?".
+
+Narrow-waist discipline (CLAUDE.md postulate 5)
+===============================================
+
+The family is **small, stable, first-party** — the knowledge / docs precedent.
+A paired add-on's own entity identifiers (blueprint names, workflow names) are
+**data** carried in this tool's *results*, never tool names on the agent waist.
+There is no per-blueprint / per-workflow tool anywhere; the whole automation
+surface is this one meta-tool (and its CLI / console twins), which is exactly
+what activates and deactivates with pairing.
+
+The pairing gate (Initiative #2900, Task #3029)
+===============================================
+
+The tool declares ``required_addon_family="automation"``. The registry +
+dispatcher filter it out of ``tools/list`` (true absence) and reject a direct
+``tools/call`` (403-class, handler never runs) unless a **paired,
+contract-healthy** add-on advertises a ``meta_tool_family`` capability named
+``automation`` for the caller's tenant
+(:func:`~meho_backplane.mcp.registry.addon_family_active`, resolved from
+:meth:`~meho_backplane.operations.addon_capability.AddonCapabilityService.active_meta_tool_families`).
+Unlike ``required_capability`` (a static tenant JWT claim), the gate tracks
+**live pairing health**: the family disappears the moment the add-on unpairs or
+drifts contract-incompatible, and reappears when health recovers, with no tool
+re-registration. An unpaired backplane never lists it — its ``tools/list`` stays
+byte-identical to a build that never carried the family.
+
+Because the gate has already proven the automation add-on active by the time the
+handler runs, the handler reports what that add-on advertises: its pairing health
+and its declared surfaces (meta-tool families, CLI verb families, console panels,
+event kinds), read from the same activation plane the gate consulted.
+
+Audit
+=====
+
+The dispatcher writes one ``audit_log`` row per ``tools/call``; the handler binds
+``audit_op_id="meho.automation.list"`` (``op_class="read"``) so a ``query_audit``
+filter on ``op_id="meho.automation.*"`` catches the read across REST + CLI + MCP,
+the canonical-op_id discipline every meta-tool family follows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import structlog
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, ToolSurface, register_mcp_tool
+from meho_backplane.operations.addon_automation import AUTOMATION_FAMILY, active_automation_surface
+
+__all__: list[str] = []
+
+
+#: Read op-class — surfacing the advertised automation surface never mutates.
+_OP_CLASS_READ: Final[str] = "read"
+
+#: Canonical audit op_id — the ``meho.automation.*`` family the REST route and
+#: CLI verb bind too, so a ``query_audit`` filter catches the read
+#: transport-independently.
+_LIST_OP_ID: Final[str] = "meho.automation.list"
+
+
+_LIST_DESCRIPTION: Final[str] = (
+    "List the surface a paired automation add-on advertises — the automation "
+    "analogue of `meho_connector_list`. Only present while an automation "
+    "add-on is paired AND contract-healthy; it disappears cleanly when the "
+    "add-on unpairs. Returns, per providing add-on, its `contract_version`, "
+    "whether that version is still `contract_compatible` with this backplane, "
+    "its `paired_at` / `last_seen_at` liveness, and its declared `surfaces` "
+    "(each a `{kind, name, display_label}` where `kind` is one of "
+    "`meta_tool_family` / `cli_verb_family` / `console_panel` / `event_kind`).\n\n"
+    "WHEN TO CALL: to discover whether governed automation is available in this "
+    "tenant and what it exposes, before reaching for automation workflows. "
+    "Blueprint and workflow identifiers are the add-on's own data (driven "
+    "through the add-on, not the backplane waist) — this tool reports the "
+    "advertised surface, never a per-workflow tool."
+)
+
+
+_LIST_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+_SURFACE_ITEM_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "kind": {"type": "string"},
+        "name": {"type": "string"},
+        "display_label": {"type": ["string", "null"]},
+    },
+    "required": ["kind", "name", "display_label"],
+}
+
+_PROVIDER_ITEM_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "addon": {"type": "string"},
+        "contract_version": {"type": "integer"},
+        "contract_compatible": {"type": "boolean"},
+        "paired_at": {"type": ["string", "null"]},
+        "last_seen_at": {"type": ["string", "null"]},
+        "surfaces": {"type": "array", "items": _SURFACE_ITEM_SCHEMA},
+    },
+    "required": [
+        "addon",
+        "contract_version",
+        "contract_compatible",
+        "paired_at",
+        "last_seen_at",
+        "surfaces",
+    ],
+}
+
+_LIST_OUTPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "providers": {"type": "array", "items": _PROVIDER_ITEM_SCHEMA},
+    },
+    "required": ["providers"],
+}
+
+
+async def _automation_list_handler(
+    operator: Operator,
+    _arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the paired automation add-on(s) and their advertised surface.
+
+    The dispatcher's call-time ``required_addon_family`` gate has already
+    proven at least one paired, contract-healthy add-on advertises the
+    ``automation`` meta-tool family, so ``providers`` is non-empty on the happy
+    path. Delegates to the shared
+    :func:`~meho_backplane.operations.addon_automation.active_automation_surface`
+    read so the meta-tool, the REST route, and the console panel render one
+    identical answer, then serialises to the JSON-RPC wire dict
+    (``model_dump(mode="json")`` renders the ``CapabilityKind`` enum as its
+    value and the timestamps as ISO-8601 strings, matching ``outputSchema``).
+    """
+    structlog.contextvars.bind_contextvars(audit_op_id=_LIST_OP_ID)
+    surface = await active_automation_surface(operator.tenant_id)
+    return surface.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        feature="addon_pairing",
+        name="meho_automation_list",
+        surface=ToolSurface.WORKING,
+        description=_LIST_DESCRIPTION,
+        inputSchema=_LIST_INPUT_SCHEMA,
+        outputSchema=_LIST_OUTPUT_SCHEMA,
+        required_role=TenantRole.READ_ONLY,
+        op_class=_OP_CLASS_READ,
+        required_addon_family=AUTOMATION_FAMILY,
+    ),
+    handler=_automation_list_handler,
+)

--- a/backend/src/meho_backplane/operations/addon_automation.py
+++ b/backend/src/meho_backplane/operations/addon_automation.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Paired automation surface — the read the MCP / CLI / console twins share (#3029).
+
+Initiative #2900's paired-surface activation (Task #3029) exposes a paired
+automation add-on across three fronts — the ``meho_automation_list`` meta-tool,
+the ``meho automation list`` CLI verb, and the ``/ui/automation`` console panel.
+All three answer the same question ("is an automation add-on paired and healthy,
+and what surface does it advertise?") and must give the same answer, so the read
+lives here once rather than three times.
+
+It is a thin projection over the two planes #3025 / #3026 built: the pairing
+lifecycle (:class:`~meho_backplane.operations.addon_pairing.AddonPairingService`)
+for health / liveness, and the capability activation view
+(:class:`~meho_backplane.operations.addon_capability.AddonCapabilityService`) for
+the declared surfaces. A capability is included only while its pairing is
+contract-healthy (the same ``is_contract_compatible`` gate every other activation
+read applies), so an unpaired or contract-skewed add-on contributes nothing —
+the surface deactivates without any row being deleted.
+
+Narrow-waist note (CLAUDE.md postulate 5): the projected data is *advertised
+surface* — capability ``(kind, name)`` rows — never a paired add-on's own entity
+identifiers (blueprint names, workflow names), which stay data driven through the
+add-on itself, never names on any MEHO surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict
+
+from meho_backplane.operations.addon_capability import AddonCapabilityService
+from meho_backplane.operations.addon_capability_schemas import CapabilityKind
+from meho_backplane.operations.addon_pairing import AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import is_contract_compatible
+
+__all__ = [
+    "AUTOMATION_FAMILY",
+    "AutomationProvider",
+    "AutomationSurfaceEntry",
+    "AutomationSurfaceResponse",
+    "active_automation_surface",
+]
+
+#: The meta-tool family name a paired add-on advertises (a ``meta_tool_family``
+#: capability) to activate the automation surface. Single source of truth for
+#: the MCP gate (``required_addon_family``), the REST route, the CLI verb, and
+#: the console panel. "automation" is the pairing / family name the
+#: capability-plane tests already exercise as the exemplar add-on.
+AUTOMATION_FAMILY: Final[str] = "automation"
+
+
+class AutomationSurfaceEntry(BaseModel):
+    """One advertised surface of a paired automation add-on."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: CapabilityKind
+    name: str
+    display_label: str | None
+
+
+class AutomationProvider(BaseModel):
+    """A paired add-on advertising the automation family, with its live health.
+
+    ``paired_at`` / ``last_seen_at`` are :class:`~datetime.datetime` so the
+    console panel can render them relatively; the MCP wire (``model_dump(
+    mode="json")``) and the REST response serialise them to ISO-8601 strings,
+    matching the meta-tool's ``outputSchema``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    addon: str
+    contract_version: int
+    contract_compatible: bool
+    paired_at: datetime
+    last_seen_at: datetime | None
+    surfaces: list[AutomationSurfaceEntry]
+
+
+class AutomationSurfaceResponse(BaseModel):
+    """The tenant's active automation surface — zero or more providers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    providers: list[AutomationProvider]
+
+
+async def active_automation_surface(
+    tenant_id: uuid.UUID,
+    *,
+    family: str = AUTOMATION_FAMILY,
+) -> AutomationSurfaceResponse:
+    """Return the paired add-on(s) advertising *family* and their advertised surface.
+
+    Reads the tenant's active capabilities once, keeps only add-ons that
+    advertise a ``meta_tool_family`` capability named *family* (the set the MCP
+    surface gate keys on), and stamps each with its pairing health
+    (``contract_compatible`` recomputed live against this backplane, mirroring
+    the ``/ui/pairing`` panel) and its full declared surface. ``providers`` is
+    empty when nothing is paired or every candidate pairing is
+    contract-incompatible — the fail-closed, unpaired baseline every twin
+    renders identically.
+    """
+    capability_service = AddonCapabilityService()
+    active = await capability_service.active_capabilities(tenant_id)
+
+    provider_addons = sorted(
+        {
+            cap.addon
+            for cap in active
+            if cap.kind is CapabilityKind.META_TOOL_FAMILY and cap.name == family
+        }
+    )
+    surfaces_by_addon: dict[str, list[AutomationSurfaceEntry]] = {
+        addon: [] for addon in provider_addons
+    }
+    for cap in active:
+        if cap.addon in surfaces_by_addon:
+            surfaces_by_addon[cap.addon].append(
+                AutomationSurfaceEntry(
+                    kind=cap.kind,
+                    name=cap.name,
+                    display_label=cap.display_label,
+                )
+            )
+
+    pairing_service = AddonPairingService()
+    providers: list[AutomationProvider] = []
+    for addon in provider_addons:
+        pairing = await pairing_service.get(tenant_id, addon)
+        if pairing is None:
+            # Raced with an unpair between the capability read and this lookup;
+            # the add-on is no longer paired, so it drops off the surface.
+            continue
+        providers.append(
+            AutomationProvider(
+                addon=addon,
+                contract_version=pairing.contract_version,
+                contract_compatible=is_contract_compatible(
+                    addon_contract_version=pairing.addon_contract_version,
+                    addon_min_backplane_version=pairing.addon_min_backplane_version,
+                ),
+                paired_at=pairing.paired_at,
+                last_seen_at=pairing.last_seen_at,
+                surfaces=surfaces_by_addon[addon],
+            )
+        )
+
+    return AutomationSurfaceResponse(providers=providers)

--- a/backend/src/meho_backplane/operations/addon_capability.py
+++ b/backend/src/meho_backplane/operations/addon_capability.py
@@ -214,6 +214,22 @@ class AddonCapabilityService:
         active.sort(key=lambda c: (c.addon, c.kind.value, c.name))
         return active
 
+    async def active_meta_tool_families(self, tenant_id: uuid.UUID) -> frozenset[str]:
+        """Return the names of the tenant's active meta-tool families.
+
+        The paired-surface activation view the MCP / CLI / console surfaces
+        gate on (Initiative #2900, Task #3029): a meta-tool family name is
+        present iff a **paired, contract-healthy** add-on advertises it (a
+        ``meta_tool_family`` capability, via :meth:`active_capabilities`). The
+        single source of truth for the gate — a frozenset so the caller can
+        pass it straight into :func:`~meho_backplane.mcp.registry.addon_family_active`.
+        Empty (fail-closed) when nothing is paired or every pairing is
+        contract-incompatible, so an unpaired backplane activates no add-on
+        surface.
+        """
+        active = await self.active_capabilities(tenant_id, kind=CapabilityKind.META_TOOL_FAMILY)
+        return frozenset(cap.name for cap in active)
+
     @staticmethod
     async def _pairing_capabilities(
         session: AsyncSession, pairing_id: uuid.UUID

--- a/backend/src/meho_backplane/ui/maturity.py
+++ b/backend/src/meho_backplane/ui/maturity.py
@@ -67,6 +67,9 @@ MATURITY_INDEX_URL = "https://evoila.github.io/meho/latest/reference/maturity/"
 #: two cannot drift silently.
 SURFACE_FEATURE: dict[str, str] = {
     "pairing": "addon_pairing",
+    # Paired-surface activation (#3029): the automation panel is part of the
+    # add-on pairing contract (Initiative #2900) and shares its maturity.
+    "automation": "addon_pairing",
     "broadcast": "broadcast",
     "knowledge": "memory_knowledge",
     "corpus": "doc_collections",

--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -93,6 +93,7 @@ from meho_backplane.ui.routes.agents.grants import build_agent_grants_router
 from meho_backplane.ui.routes.agents.runs import build_runs_router
 from meho_backplane.ui.routes.approvals import build_approvals_router
 from meho_backplane.ui.routes.audit import build_audit_router
+from meho_backplane.ui.routes.automation import build_automation_router
 from meho_backplane.ui.routes.broadcast import build_router as build_broadcast_router
 from meho_backplane.ui.routes.checks import build_checks_router
 from meho_backplane.ui.routes.connectors import build_router as build_connectors_router
@@ -124,6 +125,7 @@ __all__ = [
     "build_agents_router",
     "build_approvals_router",
     "build_audit_router",
+    "build_automation_router",
     "build_broadcast_router",
     "build_checks_router",
     "build_connectors_router",
@@ -285,6 +287,15 @@ def build_router() -> APIRouter:
     # so its concrete path wins against ``/ui/{slug}``. Pair / unpair are REST
     # (``/api/v1/addons/pairings``); the console is read-only.
     router.include_router(build_pairing_router())
+    # Paired-automation panel (#3029, Initiative #2900): read-only
+    # ``/ui/automation`` — the console twin of the ``meho_automation_list``
+    # meta-tool / ``meho automation list`` CLI verb. Gated on activation (not
+    # registration): renders the advertised surface of a paired,
+    # contract-healthy automation add-on and the inactive empty state
+    # otherwise. One literal route, no ``{param}`` sub-path, so no
+    # first-match-wins shadowing concern; included before the stubs aggregate
+    # so its concrete path wins against ``/ui/{slug}``.
+    router.include_router(build_automation_router())
     # Audit-query forensic console (G10.15-T1 #1944): ``/ui/audit`` (filter
     # form + first result page) + ``/ui/audit/results`` (filter-submit +
     # forward-cursor "Load more" fragment). Reads dispatch the

--- a/backend/src/meho_backplane/ui/routes/automation.py
+++ b/backend/src/meho_backplane/ui/routes/automation.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/automation`` — the paired-automation console panel (Task #3029).
+
+The operator-console face of Initiative #2900's paired-surface activation, and
+the console twin of the ``meho_automation_list`` meta-tool / ``meho automation
+list`` CLI verb. One glance answers "is a governed automation add-on live in
+this tenant, and what surface does it advertise?": each provider row shows the
+add-on's negotiated contract version, whether that version is still compatible
+with this backplane (both-direction skew re-evaluated live), its last liveness
+heartbeat, when it was paired, and the surfaces it declares (meta-tool families,
+CLI verb families, console panels, event kinds).
+
+The panel is **gated on activation, not registration** (the console analogue of
+the meta-tool's true-absence gate): it renders only the surfaces of a paired,
+contract-healthy add-on advertising the ``automation`` meta-tool family — read
+through the shared
+:func:`~meho_backplane.operations.addon_automation.active_automation_surface`
+projection every twin uses, so the console never diverges from what the agent
+and CLI see. When nothing is active the panel shows the inactive empty state —
+the surface "disappears cleanly on unpair".
+
+Serves two response shapes from one handler (the pairing / sensors mould): the
+full ``automation/list.html`` page on a browser navigation, and the
+``automation/_table_rows.html`` fragment on an ``HX-Request`` (the 30s
+auto-refresh poll). Read-only; tenant scoping is non-overrideable (the session's
+``tenant_id``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.operations.addon_automation import active_automation_surface
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.checks.views import coerce_utc_aware
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_automation_router"]
+
+#: Module-level ``Depends`` closure — ruff B008 idiom, matching the pairing /
+#: sensors / runners routes.
+_require_session_dep = Depends(require_ui_session)
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when HTMX issued the request (``HX-Request: true``)."""
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def build_automation_router() -> APIRouter:
+    """Construct the paired-automation panel :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can build
+    parallel routers without sharing route state — the chassis convention.
+    Registers the single ``GET /ui/automation`` route serving both the full
+    page and the HTMX fragment from one handler.
+    """
+    router = APIRouter(tags=["ui-automation"])
+
+    async def _handler(
+        request: Request,
+        session_ctx: UISessionContext = _require_session_dep,
+    ) -> HTMLResponse:
+        """Serve ``GET /ui/automation``. See module docstring."""
+        surface = await active_automation_surface(session_ctx.tenant_id)
+        rows = [
+            {
+                "addon": provider.addon,
+                "contract_version": provider.contract_version,
+                "contract_compatible": provider.contract_compatible,
+                "compat_badge": (
+                    "badge-success" if provider.contract_compatible else "badge-error"
+                ),
+                "compat_label": ("compatible" if provider.contract_compatible else "incompatible"),
+                "paired_at": coerce_utc_aware(provider.paired_at),
+                "last_seen": coerce_utc_aware(provider.last_seen_at),
+                "surfaces": [
+                    {
+                        "kind": entry.kind.value,
+                        "name": entry.name,
+                        "display_label": entry.display_label,
+                    }
+                    for entry in provider.surfaces
+                ],
+            }
+            for provider in surface.providers
+        ]
+        context: dict[str, object] = {
+            "page_title": "Automation",
+            "active_surface": "automation",
+            "rows": rows,
+            "now_utc": datetime.now(UTC),
+        }
+        template_name = (
+            "automation/_table_rows.html" if _is_htmx_request(request) else "automation/list.html"
+        )
+        return get_templates().TemplateResponse(request, template_name, context)
+
+    router.add_api_route(
+        "/ui/automation",
+        _handler,
+        methods=["GET"],
+        name="ui_automation_list",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/templates/automation/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/automation/_table_rows.html
@@ -1,0 +1,71 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Paired-automation panel table-rows fragment (#3029).
+
+  Rendered in two contexts:
+    * As a partial ``{% include %}``d by ``list.html`` on the initial
+      full-page render.
+    * As the standalone fragment ``GET /ui/automation`` returns when the
+      ``HX-Request`` header is set (the 30s auto-refresh poll). HTMX
+      outerHTML-swaps it into the existing ``#automation-table-body`` element.
+
+  Each provider row lists the add-on's advertised surface as ``kind:name``
+  chips. The ``Last seen`` / ``Paired`` columns render a relative string
+  ("3 h ago") with a tooltip carrying the full ISO timestamp — pure
+  server-side via the ``_rel`` macro, no JS. An add-on that has never sent a
+  heartbeat has ``last_seen == None`` and renders the em-dash placeholder.
+  The empty state is the inactive surface — no paired, contract-healthy
+  automation add-on.
+-#}
+{% macro _rel(ts) -%}
+  {%- set ago = (now_utc - ts).total_seconds() | int -%}
+  {%- if ago < 60 -%}just now
+  {%- elif ago < 3600 -%}{{ (ago // 60) }} min ago
+  {%- elif ago < 86400 -%}{{ (ago // 3600) }} h ago
+  {%- elif ago < 604800 -%}{{ (ago // 86400) }} d ago
+  {%- else -%}{{ ts.strftime("%Y-%m-%d") }}
+  {%- endif -%}
+{%- endmacro %}
+<tbody id="automation-table-body">
+  {% if rows %}
+    {% for row in rows %}
+      <tr data-addon-name="{{ row.addon }}">
+        <td class="font-medium">{{ row.addon }}</td>
+        <td class="text-xs"><span class="font-mono">v{{ row.contract_version }}</span></td>
+        <td>
+          <span class="badge {{ row.compat_badge }} badge-sm">{{ row.compat_label }}</span>
+        </td>
+        <td>
+          {% if row.last_seen %}
+            <span class="text-xs" title="{{ row.last_seen.isoformat() }}">{{ _rel(row.last_seen) }}</span>
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <span class="text-xs" title="{{ row.paired_at.isoformat() }}">{{ _rel(row.paired_at) }}</span>
+        </td>
+        <td>
+          {% if row.surfaces %}
+            <div class="flex flex-wrap gap-1">
+              {% for surface in row.surfaces %}
+                <span class="badge badge-ghost badge-sm font-mono" title="{{ surface.display_label or surface.name }}">{{ surface.kind }}:{{ surface.name }}</span>
+              {% endfor %}
+            </div>
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+  {% else %}
+    <tr>
+      <td colspan="6" class="text-center text-sm opacity-60 py-6">
+        No automation add-on is paired and contract-healthy — the automation
+        surface is inactive.
+      </td>
+    </tr>
+  {% endif %}
+</tbody>

--- a/backend/src/meho_backplane/ui/templates/automation/list.html
+++ b/backend/src/meho_backplane/ui/templates/automation/list.html
@@ -1,0 +1,61 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the paired-automation panel (#3029, Initiative #2900).
+  Extends ``base.html`` so the chrome matches the rest of the console. One
+  glance answers "is a governed automation add-on live in this tenant, and
+  what surface does it advertise?": each provider row shows the add-on name,
+  its negotiated contract version, a compatibility badge (both-direction skew
+  re-evaluated live against the current backplane contract), its last liveness
+  heartbeat, when it was paired, and the surfaces it declares.
+
+  Gated on activation: rows appear only while a paired, contract-healthy
+  add-on advertises the ``automation`` meta-tool family; the surface
+  disappears cleanly on unpair. Auto-refresh: the table arms an
+  ``hx-trigger="every 30s"`` poll so the projection stays live. Read-only —
+  pairing / unpairing stay on the REST surface (``/api/v1/addons/pairings``).
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Automation &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="flex items-center gap-2 text-2xl font-semibold">Automation{% include "_maturity_badge.html" %}</h1>
+      <p class="text-sm opacity-70">
+        The paired automation add-on surface — activated only while an
+        automation add-on is paired and contract-healthy, and gone when it
+        unpairs. Blueprint and workflow identifiers stay the add-on's own
+        data; this panel shows the advertised surface, never per-workflow
+        controls. Read-only.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Table ---------- #}
+  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+    <table
+      class="table table-sm"
+      hx-get="/ui/automation"
+      hx-trigger="every 30s"
+      hx-target="#automation-table-body"
+      hx-swap="outerHTML"
+    >
+      <thead>
+        <tr>
+          <th>Add-on</th>
+          <th>Contract</th>
+          <th>Compatibility</th>
+          <th>Last seen</th>
+          <th>Paired</th>
+          <th>Advertised surface</th>
+        </tr>
+      </thead>
+      {% include "automation/_table_rows.html" %}
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -53,6 +53,7 @@
   ("operations", "/ui/operations", "terminal", "Operations"),
   ("keycloak", "/ui/keycloak", "key-round", "Keycloak"),
   ("pairing", "/ui/pairing", "plug", "Pairing"),
+  ("automation", "/ui/automation", "share-2", "Automation"),
   ("vault", "/ui/vault", "lock", "Vault"),
   ("approvals", "/ui/approvals", "bell", "Approvals"),
   ("audit", "/ui/audit", "scroll-text", "Audit"),

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -230,6 +230,7 @@ def isolated_registry() -> Iterator[None]:
         topology_create_node,
         topology_delete_node,
     )
+    from meho_backplane.mcp.tools import automation as automation_tools
     from meho_backplane.mcp.tools import broadcast as broadcast_tools
     from meho_backplane.mcp.tools import (
         doc_collections as doc_collections_tools,
@@ -345,6 +346,13 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(sensors)
     importlib.reload(memory_tools)
     importlib.reload(memory_promote_tool)
+    # #3029: the pairing-gated ``meho_automation_list`` meta-tool joins the
+    # reload list for the same reason every other tool module does -- the
+    # autouse ``clear_registries()`` above would otherwise leave it
+    # unregistered in any test file that imports this fixture after the first
+    # one runs in the process, so the surface-partition + activation-gate pins
+    # would see a registry missing the automation family.
+    importlib.reload(automation_tools)
     # G11.1-T2 (#809): the agent-definition MCP tools join the reload
     # list for the same reason every other tool module does -- the
     # autouse clear_registries() above would otherwise leave them

--- a/backend/tests/test_mcp_automation_activation.py
+++ b/backend/tests/test_mcp_automation_activation.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Paired-surface activation gate for the automation family (Task #3029).
+
+The first surface gated on live **add-on pairing state** rather than a static
+tenant capability. This file pins the acceptance contract end to end:
+
+* the ``meho_automation_list`` meta-tool is **absent** from ``tools/list`` and
+  **rejected** at ``tools/call`` while no paired, contract-healthy add-on
+  advertises the ``automation`` meta-tool family — an unpaired backplane's
+  listing is byte-identical to a build that never carried the family;
+* it **appears** the moment such a pairing exists and its capability is
+  declared, and its ``tools/call`` succeeds;
+* it **disappears cleanly** when the add-on unpairs or drifts
+  contract-incompatible, without any tool being re-registered.
+
+The gate is the ``required_addon_family`` axis on ``ToolDefinition``, resolved
+per request from :meth:`AddonCapabilityService.active_meta_tool_families`. The
+Keycloak admin client is monkey-patched so tests need no live Keycloak (the
+capability-service test's pattern).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select, update
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AddonPairing, Tenant
+from meho_backplane.mcp.handlers import handle_tools_call, handle_tools_list
+from meho_backplane.mcp.registry import (
+    ToolSurface,
+    addon_family_active,
+    get_tool,
+    has_addon_gated_tools,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.operations.addon_capability import AddonCapabilityService
+from meho_backplane.operations.addon_capability_schemas import (
+    CapabilityDeclaration,
+    CapabilityKind,
+    DeclareCapabilitiesRequest,
+)
+from meho_backplane.operations.addon_pairing import AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_pairing_schemas import PairAddonRequest
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_AUTOMATION_TOOL = "meho_automation_list"
+_AUTOMATION_FAMILY = "automation"
+_PATCH_TARGET = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+
+
+@pytest.fixture(autouse=True)
+def _keycloak_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Keycloak admin knobs the pairing service reads at settings time."""
+    monkeypatch.setenv("KEYCLOAK_ADMIN_URL", "https://keycloak.test/admin/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_ID", "meho-admin")
+    monkeypatch.setenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "s3cr3t")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _mock_kc_ok(internal_id: str) -> MagicMock:
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def _seed_operator_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        exists = (
+            await session.execute(select(Tenant).where(Tenant.id == OPERATOR_TENANT_ID))
+        ).scalar_one_or_none()
+        if exists is None:
+            session.add(Tenant(id=OPERATOR_TENANT_ID, slug="op-tenant", name="Operator Tenant"))
+            await session.commit()
+
+
+async def _pair(name: str = _AUTOMATION_FAMILY) -> None:
+    """Pair *name* under the operator tenant (Keycloak mocked)."""
+    request = PairAddonRequest(
+        name=name,
+        addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+        addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+    )
+    with patch(_PATCH_TARGET, _mock_kc_ok(f"kc-{name}")):
+        await AddonPairingService().pair(OPERATOR_TENANT_ID, "op-admin", request)
+
+
+async def _declare_meta_tool_family(addon: str = _AUTOMATION_FAMILY) -> None:
+    """Declare a ``meta_tool_family`` capability named after the automation family."""
+    request = DeclareCapabilitiesRequest(
+        capabilities=[
+            CapabilityDeclaration(kind=CapabilityKind.META_TOOL_FAMILY, name=_AUTOMATION_FAMILY),
+        ],
+    )
+    await AddonCapabilityService().declare(OPERATOR_TENANT_ID, addon, request)
+
+
+async def _drive_contract_incompatible(name: str = _AUTOMATION_FAMILY) -> None:
+    """Skew the pairing so its add-on floor exceeds this backplane's contract."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(AddonPairing)
+            .where(AddonPairing.tenant_id == OPERATOR_TENANT_ID, AddonPairing.name == name)
+            .values(addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION + 1)
+        )
+        await session.commit()
+
+
+async def _unpair(name: str = _AUTOMATION_FAMILY) -> None:
+    with patch(_PATCH_TARGET, _mock_kc_ok(f"kc-{name}")):
+        await AddonPairingService().unpair(OPERATOR_TENANT_ID, name)
+
+
+async def _activate_automation() -> None:
+    """Seed the happy path: tenant + paired, contract-healthy add-on + declaration."""
+    await _seed_operator_tenant()
+    await _pair()
+    await _declare_meta_tool_family()
+
+
+async def _listed_names(*, scopes: frozenset[str] = frozenset()) -> list[str]:
+    op = build_operator(scopes=scopes)
+    result = await handle_tools_list(op, None)
+    return [tool["name"] for tool in result["tools"]]
+
+
+# ---------------------------------------------------------------------------
+# Unit: the gate predicate + registry plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_addon_family_active_predicate() -> None:
+    """``addon_family_active`` is a pure membership test, fail-closed on empty."""
+    assert addon_family_active(frozenset(), None) is True  # ungated tool
+    assert addon_family_active(frozenset({_AUTOMATION_FAMILY}), _AUTOMATION_FAMILY) is True
+    assert addon_family_active(frozenset(), _AUTOMATION_FAMILY) is False
+    assert addon_family_active(frozenset({"other"}), _AUTOMATION_FAMILY) is False
+
+
+def test_automation_tool_declares_the_addon_family_gate() -> None:
+    """The registered tool carries ``required_addon_family`` and stays working-surface."""
+    entry = get_tool(_AUTOMATION_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    assert defn.required_addon_family == _AUTOMATION_FAMILY
+    assert defn.surface is ToolSurface.WORKING
+    assert has_addon_gated_tools() is True
+
+
+def test_addon_family_dropped_from_wire_shape() -> None:
+    """``to_wire`` never leaks the MEHO-internal ``required_addon_family`` field."""
+    entry = get_tool(_AUTOMATION_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    assert "required_addon_family" not in defn.to_wire()
+
+
+# ---------------------------------------------------------------------------
+# tools/list — appear on pair, absent otherwise
+# ---------------------------------------------------------------------------
+
+
+async def test_automation_absent_when_unpaired() -> None:
+    """No pairing → the family is absent (byte-identical unpaired listing)."""
+    names = await _listed_names()
+    assert _AUTOMATION_TOOL not in names
+
+
+async def test_automation_present_when_paired_and_healthy() -> None:
+    """A paired, contract-healthy add-on advertising the family lists the tool."""
+    await _activate_automation()
+    names = await _listed_names()
+    assert _AUTOMATION_TOOL in names
+
+
+async def test_automation_absent_when_paired_but_contract_incompatible() -> None:
+    """A paired but contract-skewed add-on deactivates the surface."""
+    await _activate_automation()
+    await _drive_contract_incompatible()
+    names = await _listed_names()
+    assert _AUTOMATION_TOOL not in names
+
+
+async def test_automation_absent_when_family_not_declared() -> None:
+    """Paired + healthy but advertising no ``automation`` family → still absent.
+
+    Pairing alone does not activate the surface; the add-on must declare the
+    ``meta_tool_family`` capability. Proves the gate keys on the advertised
+    family name, not merely on the pairing's existence.
+    """
+    await _seed_operator_tenant()
+    await _pair()
+    names = await _listed_names()
+    assert _AUTOMATION_TOOL not in names
+
+
+async def test_automation_disappears_on_unpair() -> None:
+    """Activate, confirm present, unpair, confirm the surface is gone."""
+    await _activate_automation()
+    assert _AUTOMATION_TOOL in await _listed_names()
+    await _unpair()
+    assert _AUTOMATION_TOOL not in await _listed_names()
+
+
+# ---------------------------------------------------------------------------
+# tools/call — the gate is enforced at invocation too
+# ---------------------------------------------------------------------------
+
+
+async def test_call_rejected_when_inactive() -> None:
+    """Naming the tool directly is 403-class while the family is inactive.
+
+    The handler must never run — knowing the name out-of-band cannot bypass the
+    pairing gate. The rejection names the add-on family.
+    """
+    op = build_operator()
+    with pytest.raises(McpInvalidParamsError) as exc:
+        await handle_tools_call(op, {"name": _AUTOMATION_TOOL, "arguments": {}})
+    message = str(exc.value).lower()
+    assert "automation" in message
+    assert exc.value.data == {
+        "reason": "addon_family_inactive",
+        "required_addon_family": _AUTOMATION_FAMILY,
+    }
+
+
+async def test_call_succeeds_when_active() -> None:
+    """With the family active the call passes the gate and returns the surface."""
+    await _activate_automation()
+    op = build_operator()
+    result: dict[str, Any] = await handle_tools_call(
+        op, {"name": _AUTOMATION_TOOL, "arguments": {}}
+    )
+    providers = result["structuredContent"]["providers"]
+    assert [p["addon"] for p in providers] == [_AUTOMATION_FAMILY]
+    kinds = {surface["kind"] for surface in providers[0]["surfaces"]}
+    assert CapabilityKind.META_TOOL_FAMILY.value in kinds

--- a/backend/tests/test_mcp_output_schema_conformance.py
+++ b/backend/tests/test_mcp_output_schema_conformance.py
@@ -34,7 +34,7 @@ import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import jsonschema
 import pytest
@@ -49,6 +49,15 @@ from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.main import app
 from meho_backplane.mcp import registry as mcp_registry
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.operations.addon_capability import AddonCapabilityService
+from meho_backplane.operations.addon_capability_schemas import (
+    CapabilityDeclaration,
+    CapabilityKind,
+    DeclareCapabilitiesRequest,
+)
+from meho_backplane.operations.addon_pairing import AddonPairingService
+from meho_backplane.operations.addon_pairing_contract import BACKPLANE_CONTRACT_VERSION
+from meho_backplane.operations.addon_pairing_schemas import PairAddonRequest
 from meho_backplane.topology.schemas import TopologyEdge, TopologyEdgeEndpoint
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
@@ -73,6 +82,7 @@ _PUBLISH_DELETE = "meho_backplane.topology.node_delete.publish_event"
 _COVERED_TOOLS: frozenset[str] = frozenset(
     {
         "call_operation",
+        "meho_automation_list",
         "create_doc_collections",
         "delete_doc_collections",
         "list_doc_collections",
@@ -617,6 +627,60 @@ async def test_list_targets_conforms(
     payload = _assert_conforms("list_targets", _call(client, "list_targets", {}))
     assert [t["name"] for t in payload["targets"]] == ["rdc-vault", "rdc-vcenter"]
     assert payload["next_cursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# Automation family (paired-surface activation, #3029)
+# ---------------------------------------------------------------------------
+
+
+_ADDON_KC_PATCH = "meho_backplane.operations.addon_pairing.KeycloakAdminClient.from_settings"
+
+
+def _mock_addon_kc() -> Any:
+    """A mocked Keycloak admin client so pairing needs no live Keycloak."""
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value="kc-automation-internal")
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=mock_client)
+
+
+async def test_meho_automation_list_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The pairing-gated automation surface payload conforms to its outputSchema.
+
+    Seeds a paired, contract-healthy automation add-on advertising the
+    ``automation`` meta-tool family so the gate admits the call, then validates
+    the emitted ``structuredContent`` against the declared schema.
+    """
+    client, _op = client_with_operator
+    await _seed_tenant()
+    with patch(_ADDON_KC_PATCH, _mock_addon_kc()):
+        await AddonPairingService().pair(
+            OPERATOR_TENANT_ID,
+            "op-admin",
+            PairAddonRequest(
+                name="automation",
+                addon_contract_version=BACKPLANE_CONTRACT_VERSION,
+                addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
+            ),
+        )
+    await AddonCapabilityService().declare(
+        OPERATOR_TENANT_ID,
+        "automation",
+        DeclareCapabilitiesRequest(
+            capabilities=[
+                CapabilityDeclaration(kind=CapabilityKind.META_TOOL_FAMILY, name="automation"),
+            ],
+        ),
+    )
+    payload = _assert_conforms("meho_automation_list", _call(client, "meho_automation_list", {}))
+    assert [p["addon"] for p in payload["providers"]] == ["automation"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_structured_content.py
+++ b/backend/tests/test_mcp_structured_content.py
@@ -57,6 +57,7 @@ from tests.mcp_test_fixtures import (
 EXPECTED_DECLARING_TOOLS: frozenset[str] = frozenset(
     {
         "call_operation",
+        "meho_automation_list",
         "create_doc_collections",
         "delete_doc_collections",
         "list_doc_collections",

--- a/backend/tests/test_mcp_surface_conformance.py
+++ b/backend/tests/test_mcp_surface_conformance.py
@@ -39,7 +39,7 @@ The pinned snapshots are tied to the live registry by
 never drift from reality (a reclassification breaks the per-claim-shape
 pins; an unclassified addition breaks the partition guard). The
 authoritative human-readable enumeration of the same split — name +
-one-liner + surface + gating claim for all 78 tools — lives in
+one-liner + surface + gating claim for all 79 tools — lives in
 ``docs/codebase/mcp.md`` (the dual-surface inventory).
 """
 
@@ -78,6 +78,18 @@ _DOCS_CAP_GATED: frozenset[str] = _DOCS_WORKING_TOOLS | {
     "create_doc_collections",
     "delete_doc_collections",
 }
+
+#: The **pairing-gated** automation family (Task #3029). Unlike the docs
+#: capability (a static tenant JWT claim), these tools are gated on live add-on
+#: pairing state — absent from every session's listing until a paired,
+#: contract-healthy add-on advertises the ``automation`` meta-tool family, so
+#: they sit on neither the pinned working nor operator surface (both of which
+#: represent a provisioned-but-unpaired session). Their appear-on-pair /
+#: disappear-on-unpair behaviour is pinned by ``test_mcp_automation_activation``;
+#: here they only complete the registry partition. Kept a separate set so the
+#: unpaired working/operator listings stay byte-identical to a build that never
+#: carried the family.
+_AUTOMATION_GATED_TOOLS: frozenset[str] = frozenset({"meho_automation_list"})
 
 #: The default working surface, as the exact sorted listing a ``tools/list``
 #: response carries for a session that clears role + capability but is NOT
@@ -233,24 +245,49 @@ def test_pinned_surfaces_are_sorted_and_unique() -> None:
 
 
 def test_pinned_surfaces_partition_the_live_registry() -> None:
-    """The two pinned listings partition the whole registry (exhaustive + disjoint).
+    """The pinned listings partition the whole registry (exhaustive + disjoint).
 
     This is the tie that keeps the snapshots honest: an unclassified new
     tool (once it clears #3154's construction-time surface requirement)
-    lands in the registry but neither pinned listing, breaking the
+    lands in the registry but no pinned listing, breaking the
     exhaustiveness check; a reclassified tool breaks the per-claim-shape
     listing pins below. Either way CI fails visibly.
+
+    Three disjoint sets now partition the registry: the working surface, the
+    operator surface, and the pairing-gated automation family (#3029) — which
+    is on neither default surface because it is absent until an add-on pairs,
+    so it is carried separately here rather than folded into the working
+    listing (which would break the byte-identical-unpaired pins below).
     """
     working = set(WORKING_SURFACE_SORTED)
     operator = set(OPERATOR_SURFACE_SORTED)
+    automation = set(_AUTOMATION_GATED_TOOLS)
     assert working.isdisjoint(operator)
-    assert working | operator == set(mcp_registry._TOOLS)
+    assert working.isdisjoint(automation)
+    assert operator.isdisjoint(automation)
+    assert working | operator | automation == set(mcp_registry._TOOLS)
 
 
 def test_full_surface_is_working_plus_operator() -> None:
     """The elevated listing is exactly the union of the two surfaces."""
     assert set(FULL_SURFACE_SORTED) == set(WORKING_SURFACE_SORTED) | set(OPERATOR_SURFACE_SORTED)
     assert len(FULL_SURFACE_SORTED) == len(WORKING_SURFACE_SORTED) + len(OPERATOR_SURFACE_SORTED)
+
+
+def test_automation_family_absent_from_default_surfaces() -> None:
+    """The pairing-gated automation family is on neither pinned default surface (#3029).
+
+    The pinned working / operator listings represent a provisioned-but-unpaired
+    session, so the automation family — absent until an add-on pairs — must not
+    appear in either. This is the static half of the byte-identical-unpaired
+    guarantee; the live-DB half (the wire listing with and without a paired
+    add-on) is pinned by ``test_mcp_automation_activation``.
+    """
+    automation = set(_AUTOMATION_GATED_TOOLS)
+    assert automation.isdisjoint(set(WORKING_SURFACE_SORTED))
+    assert automation.isdisjoint(set(OPERATOR_SURFACE_SORTED))
+    # The family is nonetheless registered — it is a real, gated tool.
+    assert automation <= set(mcp_registry._TOOLS)
 
 
 def test_human_only_verbs_absent_from_both_surfaces() -> None:

--- a/backend/tests/test_mcp_surface_filter.py
+++ b/backend/tests/test_mcp_surface_filter.py
@@ -74,6 +74,19 @@ _DOCS_CAP_GATED: frozenset[str] = _DOCS_WORKING_TOOLS | {
     "delete_doc_collections",
 }
 
+#: The pairing-gated automation family (Task #3029) — gated on live add-on
+#: pairing state via ``required_addon_family`` rather than a static tenant
+#: capability. Absent from every session's default listing (working or
+#: operator) until a paired, contract-healthy add-on advertises the
+#: ``automation`` meta-tool family, so it is carried separately from the two
+#: default-surface sets and completes the registry partition.
+_AUTOMATION_GATED: frozenset[str] = frozenset({"meho_automation_list"})
+
+#: The automation family's advertised meta-tool family name — the value the
+#: ``required_addon_family`` gate matches against ``all_tools_for``'s
+#: ``active_addon_families`` argument.
+_AUTOMATION_FAMILY = "automation"
+
 #: The default working surface: the full, exact set every session lists
 #: (do-work + coordinate). Pinned so any drift — a new tool that forgets
 #: to classify, or a reclassification — fails here loudly (Initiative
@@ -223,11 +236,54 @@ def test_every_registered_tool_carries_a_surface() -> None:
 
 
 def test_surface_partition_is_exhaustive_and_disjoint() -> None:
-    """The pinned working / operator sets partition the whole registry."""
+    """The pinned working / operator / automation sets partition the whole registry.
+
+    The pairing-gated automation family (#3029) is on neither default surface —
+    it is absent until an add-on pairs — so it completes the partition as a
+    third disjoint set rather than joining the working listing.
+    """
     from meho_backplane.mcp import registry as mcp_registry
 
     assert _WORKING_SURFACE.isdisjoint(_OPERATOR_SURFACE)
-    assert set(mcp_registry._TOOLS) == _WORKING_SURFACE | _OPERATOR_SURFACE
+    assert _WORKING_SURFACE.isdisjoint(_AUTOMATION_GATED)
+    assert _OPERATOR_SURFACE.isdisjoint(_AUTOMATION_GATED)
+    assert set(mcp_registry._TOOLS) == _WORKING_SURFACE | _OPERATOR_SURFACE | _AUTOMATION_GATED
+
+
+def test_addon_family_gate_hides_automation_without_active_pairing() -> None:
+    """``all_tools_for`` omits the automation family unless its family is active.
+
+    The default call (no ``active_addon_families``) fails closed: the
+    pairing-gated tool is absent, so an elevated session with every capability
+    still does not see it — the byte-identical-unpaired guarantee at the filter
+    level.
+    """
+    op = _operator(
+        role=TenantRole.TENANT_ADMIN,
+        capabilities=frozenset({_DOCS_CAPABILITY}),
+        scopes=frozenset({MCP_ADMIN_SCOPE}),
+    )
+    names = {defn.name for defn in all_tools_for(op)}
+    assert names.isdisjoint(_AUTOMATION_GATED)
+
+
+def test_addon_family_gate_admits_automation_when_family_active() -> None:
+    """``all_tools_for`` includes the automation family when its family is active.
+
+    Passing the active family set (what the listing handler resolves from the
+    add-on capability plane) admits the pairing-gated tool, AND-composed with
+    the role / capability / surface gates like every other axis.
+    """
+    op = _operator(
+        role=TenantRole.TENANT_ADMIN,
+        capabilities=frozenset({_DOCS_CAPABILITY}),
+        scopes=frozenset({MCP_ADMIN_SCOPE}),
+    )
+    names = {
+        defn.name
+        for defn in all_tools_for(op, active_addon_families=frozenset({_AUTOMATION_FAMILY}))
+    }
+    assert names >= _AUTOMATION_GATED
 
 
 def test_surface_dropped_from_wire_shape() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10153,6 +10153,50 @@
         }
       }
     },
+    "/api/v1/automation": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "List Automation Surface",
+        "description": "Return the paired automation add-on(s) and their advertised surface.\n\n``403`` (``automation_addon_not_active``) when the automation family is\ninactive \u2014 nothing paired, or every candidate pairing is\ncontract-incompatible \u2014 so an unpaired backplane has no live automation\nsurface here, matching the MCP tool's true-absence gate. Otherwise returns\nthe non-empty provider list.",
+        "operationId": "list_automation_surface_api_v1_automation_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationSurfaceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/conventions": {
       "get": {
         "tags": [
@@ -19728,6 +19772,28 @@
         }
       }
     },
+    "/ui/automation": {
+      "get": {
+        "tags": [
+          "ui-automation"
+        ],
+        "summary": "Ui Automation List",
+        "description": "Serve ``GET /ui/automation``. See module docstring.",
+        "operationId": "ui_automation_list_ui_automation_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/audit/results": {
       "get": {
         "tags": [
@@ -22250,6 +22316,92 @@
         ],
         "title": "AuthoredCheckItem",
         "description": "One operator-authored check in a runner's assignment document.\n\nThe runner-facing ``GET`` materialises each of these into a wire\n:class:`~meho_backplane.runner.wire.RunnerWorkItem` at request time:\n``target_name`` is resolved to a live target descriptor, ``op`` to the\nresolved connector's enabled descriptor (yielding ``handler_ref`` +\n``safety_level`` + the ``(product, version, impl_id)`` key). ``op`` is\nthe connector-side op id (e.g. ``\"vsphere.host.list\"``); the connector\ntriple is derived from the resolved target, not authored here."
+      },
+      "AutomationProvider": {
+        "properties": {
+          "addon": {
+            "type": "string",
+            "title": "Addon"
+          },
+          "contract_version": {
+            "type": "integer",
+            "title": "Contract Version"
+          },
+          "contract_compatible": {
+            "type": "boolean",
+            "title": "Contract Compatible"
+          },
+          "paired_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Paired At"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Seen At"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/AutomationSurfaceEntry"
+            },
+            "type": "array",
+            "title": "Surfaces"
+          }
+        },
+        "type": "object",
+        "required": [
+          "addon",
+          "contract_version",
+          "contract_compatible",
+          "paired_at",
+          "last_seen_at",
+          "surfaces"
+        ],
+        "title": "AutomationProvider",
+        "description": "A paired add-on advertising the automation family, with its live health.\n\n``paired_at`` / ``last_seen_at`` are :class:`~datetime.datetime` so the\nconsole panel can render them relatively; the MCP wire (``model_dump(\nmode=\"json\")``) and the REST response serialise them to ISO-8601 strings,\nmatching the meta-tool's ``outputSchema``."
+      },
+      "AutomationSurfaceEntry": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/CapabilityKind"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "display_label": {
+            "type": "string",
+            "nullable": true,
+            "title": "Display Label"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "name",
+          "display_label"
+        ],
+        "title": "AutomationSurfaceEntry",
+        "description": "One advertised surface of a paired automation add-on."
+      },
+      "AutomationSurfaceResponse": {
+        "properties": {
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/AutomationProvider"
+            },
+            "type": "array",
+            "title": "Providers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "providers"
+        ],
+        "title": "AutomationSurfaceResponse",
+        "description": "The tenant's active automation surface \u2014 zero or more providers."
       },
       "BackendReadiness": {
         "properties": {
@@ -33108,6 +33260,10 @@
     {
       "name": "auth",
       "x-maturity": "ga"
+    },
+    {
+      "name": "automation",
+      "x-maturity": "experimental"
     },
     {
       "name": "broadcast",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1519,6 +1519,42 @@ type AuthoredCheckItem struct {
 	TargetName     string                  `json:"target_name"`
 }
 
+// AutomationProvider A paired add-on advertising the automation family, with its live health.
+//
+// “paired_at“ / “last_seen_at“ are :class:`~datetime.datetime` so the
+// console panel can render them relatively; the MCP wire (“model_dump(
+// mode="json")“) and the REST response serialise them to ISO-8601 strings,
+// matching the meta-tool's “outputSchema“.
+type AutomationProvider struct {
+	Addon              string                   `json:"addon"`
+	ContractCompatible bool                     `json:"contract_compatible"`
+	ContractVersion    int                      `json:"contract_version"`
+	LastSeenAt         *time.Time               `json:"last_seen_at"`
+	PairedAt           time.Time                `json:"paired_at"`
+	Surfaces           []AutomationSurfaceEntry `json:"surfaces"`
+}
+
+// AutomationSurfaceEntry One advertised surface of a paired automation add-on.
+type AutomationSurfaceEntry struct {
+	DisplayLabel *string `json:"display_label"`
+
+	// Kind The surface kinds a paired add-on may advertise under contract v1.
+	//
+	// A ``str`` enum so it serialises as its wire value and an unknown kind on
+	// the request path fails Pydantic validation with a 422 that names the
+	// offending value — the "rejected loudly" contract. The vocabulary is
+	// versioned with the integration contract: adding a kind is a coordinated
+	// change across this enum, the ``addon_capability.kind`` CHECK constraint,
+	// and :data:`meho_backplane.db.models.ADDON_CAPABILITY_KINDS`.
+	Kind CapabilityKind `json:"kind"`
+	Name string         `json:"name"`
+}
+
+// AutomationSurfaceResponse The tenant's active automation surface — zero or more providers.
+type AutomationSurfaceResponse struct {
+	Providers []AutomationProvider `json:"providers"`
+}
+
 // BackendReadiness Typed result of a :meth:`SearchBackend.probe` call (T6 #1555).
 //
 // The liveness snapshot a probe reads back from a collection's backend.
@@ -8813,6 +8849,11 @@ type WhoTouchedApiV1AuditWhoTouchedTargetGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListAutomationSurfaceApiV1AutomationGetParams defines parameters for ListAutomationSurfaceApiV1AutomationGet.
+type ListAutomationSurfaceApiV1AutomationGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ListOverridesApiV1BroadcastOverridesGetParams defines parameters for ListOverridesApiV1BroadcastOverridesGet.
 type ListOverridesApiV1BroadcastOverridesGetParams struct {
 	// OpIdPattern Exact-match filter on op_id_pattern (not a glob match).
@@ -11879,6 +11920,9 @@ type ClientInterface interface {
 	// AuthConfigApiV1AuthConfigGet request
 	AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListAutomationSurfaceApiV1AutomationGet request
+	ListAutomationSurfaceApiV1AutomationGet(ctx context.Context, params *ListAutomationSurfaceApiV1AutomationGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListOverridesApiV1BroadcastOverridesGet request
 	ListOverridesApiV1BroadcastOverridesGet(ctx context.Context, params *ListOverridesApiV1BroadcastOverridesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -12508,6 +12552,9 @@ type ClientInterface interface {
 
 	// UiAuthLogoutUiAuthLogoutGet request
 	UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAutomationListUiAutomationGet request
+	UiAutomationListUiAutomationGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiBroadcastFeedUiBroadcastGet request
 	UiBroadcastFeedUiBroadcastGet(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13861,6 +13908,18 @@ func (c *Client) WhoTouchedApiV1AuditWhoTouchedTargetGet(ctx context.Context, ta
 
 func (c *Client) AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAuthConfigApiV1AuthConfigGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAutomationSurfaceApiV1AutomationGet(ctx context.Context, params *ListAutomationSurfaceApiV1AutomationGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAutomationSurfaceApiV1AutomationGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -16657,6 +16716,18 @@ func (c *Client) UiAuthLoginUiAuthLoginGet(ctx context.Context, params *UiAuthLo
 
 func (c *Client) UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiAuthLogoutUiAuthLogoutGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAutomationListUiAutomationGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAutomationListUiAutomationGetRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -22390,6 +22461,48 @@ func NewAuthConfigApiV1AuthConfigGetRequest(server string) (*http.Request, error
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListAutomationSurfaceApiV1AutomationGetRequest generates requests for ListAutomationSurfaceApiV1AutomationGet
+func NewListAutomationSurfaceApiV1AutomationGetRequest(server string, params *ListAutomationSurfaceApiV1AutomationGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/automation")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -32975,6 +33088,33 @@ func NewUiAuthLogoutUiAuthLogoutGetRequest(server string) (*http.Request, error)
 	return req, nil
 }
 
+// NewUiAutomationListUiAutomationGetRequest generates requests for UiAutomationListUiAutomationGet
+func NewUiAutomationListUiAutomationGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/automation")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewUiBroadcastFeedUiBroadcastGetRequest generates requests for UiBroadcastFeedUiBroadcastGet
 func NewUiBroadcastFeedUiBroadcastGetRequest(server string, params *UiBroadcastFeedUiBroadcastGetParams) (*http.Request, error) {
 	var err error
@@ -41022,6 +41162,9 @@ type ClientWithResponsesInterface interface {
 	// AuthConfigApiV1AuthConfigGetWithResponse request
 	AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error)
 
+	// ListAutomationSurfaceApiV1AutomationGetWithResponse request
+	ListAutomationSurfaceApiV1AutomationGetWithResponse(ctx context.Context, params *ListAutomationSurfaceApiV1AutomationGetParams, reqEditors ...RequestEditorFn) (*ListAutomationSurfaceApiV1AutomationGetResponse, error)
+
 	// ListOverridesApiV1BroadcastOverridesGetWithResponse request
 	ListOverridesApiV1BroadcastOverridesGetWithResponse(ctx context.Context, params *ListOverridesApiV1BroadcastOverridesGetParams, reqEditors ...RequestEditorFn) (*ListOverridesApiV1BroadcastOverridesGetResponse, error)
 
@@ -41651,6 +41794,9 @@ type ClientWithResponsesInterface interface {
 
 	// UiAuthLogoutUiAuthLogoutGetWithResponse request
 	UiAuthLogoutUiAuthLogoutGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLogoutUiAuthLogoutGetResponse, error)
+
+	// UiAutomationListUiAutomationGetWithResponse request
+	UiAutomationListUiAutomationGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAutomationListUiAutomationGetResponse, error)
 
 	// UiBroadcastFeedUiBroadcastGetWithResponse request
 	UiBroadcastFeedUiBroadcastGetWithResponse(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedUiBroadcastGetResponse, error)
@@ -43306,6 +43452,29 @@ func (r AuthConfigApiV1AuthConfigGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r AuthConfigApiV1AuthConfigGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListAutomationSurfaceApiV1AutomationGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AutomationSurfaceResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAutomationSurfaceApiV1AutomationGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAutomationSurfaceApiV1AutomationGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -47116,6 +47285,27 @@ func (r UiAuthLogoutUiAuthLogoutGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UiAuthLogoutUiAuthLogoutGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiAutomationListUiAutomationGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAutomationListUiAutomationGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAutomationListUiAutomationGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -51148,6 +51338,15 @@ func (c *ClientWithResponses) AuthConfigApiV1AuthConfigGetWithResponse(ctx conte
 	return ParseAuthConfigApiV1AuthConfigGetResponse(rsp)
 }
 
+// ListAutomationSurfaceApiV1AutomationGetWithResponse request returning *ListAutomationSurfaceApiV1AutomationGetResponse
+func (c *ClientWithResponses) ListAutomationSurfaceApiV1AutomationGetWithResponse(ctx context.Context, params *ListAutomationSurfaceApiV1AutomationGetParams, reqEditors ...RequestEditorFn) (*ListAutomationSurfaceApiV1AutomationGetResponse, error) {
+	rsp, err := c.ListAutomationSurfaceApiV1AutomationGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAutomationSurfaceApiV1AutomationGetResponse(rsp)
+}
+
 // ListOverridesApiV1BroadcastOverridesGetWithResponse request returning *ListOverridesApiV1BroadcastOverridesGetResponse
 func (c *ClientWithResponses) ListOverridesApiV1BroadcastOverridesGetWithResponse(ctx context.Context, params *ListOverridesApiV1BroadcastOverridesGetParams, reqEditors ...RequestEditorFn) (*ListOverridesApiV1BroadcastOverridesGetResponse, error) {
 	rsp, err := c.ListOverridesApiV1BroadcastOverridesGet(ctx, params, reqEditors...)
@@ -53174,6 +53373,15 @@ func (c *ClientWithResponses) UiAuthLogoutUiAuthLogoutGetWithResponse(ctx contex
 		return nil, err
 	}
 	return ParseUiAuthLogoutUiAuthLogoutGetResponse(rsp)
+}
+
+// UiAutomationListUiAutomationGetWithResponse request returning *UiAutomationListUiAutomationGetResponse
+func (c *ClientWithResponses) UiAutomationListUiAutomationGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAutomationListUiAutomationGetResponse, error) {
+	rsp, err := c.UiAutomationListUiAutomationGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAutomationListUiAutomationGetResponse(rsp)
 }
 
 // UiBroadcastFeedUiBroadcastGetWithResponse request returning *UiBroadcastFeedUiBroadcastGetResponse
@@ -56765,6 +56973,39 @@ func ParseAuthConfigApiV1AuthConfigGetResponse(rsp *http.Response) (*AuthConfigA
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAutomationSurfaceApiV1AutomationGetResponse parses an HTTP response from a ListAutomationSurfaceApiV1AutomationGetWithResponse call
+func ParseListAutomationSurfaceApiV1AutomationGetResponse(rsp *http.Response) (*ListAutomationSurfaceApiV1AutomationGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAutomationSurfaceApiV1AutomationGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AutomationSurfaceResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 
@@ -61809,6 +62050,22 @@ func ParseUiAuthLogoutUiAuthLogoutGetResponse(rsp *http.Response) (*UiAuthLogout
 	}
 
 	response := &UiAuthLogoutUiAuthLogoutGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiAutomationListUiAutomationGetResponse parses an HTTP response from a UiAutomationListUiAutomationGetWithResponse call
+func ParseUiAutomationListUiAutomationGetResponse(rsp *http.Response) (*UiAutomationListUiAutomationGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAutomationListUiAutomationGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/cli/internal/cmd/automation/automation.go
+++ b/cli/internal/cmd/automation/automation.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package automation hosts the cobra commands under `meho automation ...`
+// for Task #3029 of Initiative #2900 (the add-on pairing contract). It ships
+// one operator-facing verb that mirrors the `meho_automation_list` MCP
+// meta-tool and the `GET /api/v1/automation` REST route:
+//
+//   - `meho automation list [--json]` — the paired-automation surface: the
+//     add-on(s) advertising the `automation` meta-tool family, each with its
+//     negotiated contract version, live contract-compatibility, liveness, and
+//     declared surfaces (meta-tool / CLI verb families, console panels, event
+//     kinds). Role: read_only.
+//
+// Gating — server-side only, CLI ↔ REST ↔ MCP parity (#2109 / #3029). The
+// `meho automation` tree compiles into every CLI binary and is always visible;
+// it carries no client-side pairing pre-check. Activation is decided by the
+// backplane exactly as it is for `GET /api/v1/automation`: while no paired,
+// contract-healthy add-on advertises the `automation` family the route answers
+// 403 `automation_addon_not_active`, which the CLI renders as a clear
+// "not active" message. The verb is a thin shell over the same route the REST
+// surface exposes and the same activation view the meta-tool gate reads, so all
+// three fronts give one verdict for one tenant.
+//
+// Like the sibling docs / kb verb trees, every call drives the generated
+// `api.ClientWithResponses` surface directly: `api.NewAuthedClient` wires the
+// bearer + lazy 401-refresh editor, and the verb consumes the generated
+// `api.AutomationSurfaceResponse` / `api.AutomationProvider` types — no
+// consumer-side copies of the backend pydantic models.
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho automation` parent command. The command tree
+// compiles into every CLI binary and is always visible: there is no
+// client-side pairing gate (#2109). Activation is decided server-side by the
+// backplane, identically to `GET /api/v1/automation`.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "automation",
+		Short: "Inspect the paired automation add-on surface",
+		Long: "Operate the automation paired-add-on surface — the governed " +
+			"automation product paired with this backplane (Initiative #2900). " +
+			"The surface is active only while an automation add-on is paired " +
+			"and contract-healthy; while it is not, every verb returns a typed " +
+			"\"not active\" response rather than a silent or divergent " +
+			"client-side refusal, mirroring the `meho_automation_list` meta-tool " +
+			"and `GET /api/v1/automation`. Blueprint and workflow identifiers " +
+			"are the add-on's own data, driven through the add-on, never CLI " +
+			"verbs here.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newListCmd())
+	return cmd
+}
+
+// errMissingAccessToken mirrors the docs / kb verb trees' sentinel: the stored
+// token row exists but its access_token field is empty. A credential-state
+// failure (auth_expired, exit 2) rather than a transport failure.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// responseBodyCap bounds the bytes the automation transport reads off any
+// backplane response before surfacing `*http.MaxBytesError`. 1 MiB is generous:
+// the automation surface is a small provider list (one row per paired add-on,
+// each with a handful of advertised surfaces).
+const responseBodyCap int64 = 1 << 20
+
+// newAuthedClient builds an api.AuthedClient for the supplied backplane URL and
+// verifies a non-empty bearer is loaded. Mirrors the docs verb tree's helper.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		ResponseBodyLimit: responseBodyCap,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once and, on a 401, runs a one-shot bearer refresh
+// and re-issues call. Identical contract to the docs verb tree's helper.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a transport-layer request error into the right
+// output.StructuredError category — the same mapping the docs verb tree uses.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPStatus classifies a non-2xx automation response carried in the
+// typed envelope. The status set `GET /api/v1/automation` can return:
+//
+//   - 401 → auth_expired (token rejected / refresh impossible).
+//   - 403 → the surface is inactive (no paired, contract-healthy automation
+//     add-on) when the detail marker is `automation_addon_not_active`;
+//     otherwise a genuine role rejection rendered as insufficient_role.
+//   - Other non-2xx → unexpected with the raw body.
+func renderHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
+	body []byte,
+	jsonOut bool,
+) error {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		if decodeDetailString(bodyStr) == "automation_addon_not_active" {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(
+					"no automation add-on is paired and contract-healthy; the "+
+						"automation surface is inactive",
+				),
+				jsonOut,
+			)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, statusCode, bodyStr)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error body when
+// it's a plain string, falling back to the trimmed raw body when the JSON shape
+// doesn't match. Mirrors the docs verb tree's helper.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when truncation
+// happened. Rune-aware so multi-byte UTF-8 survives the cut.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/automation/list.go
+++ b/cli/internal/cmd/automation/list.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package automation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newListCmd returns the `meho automation list` command.
+//
+// Task #3029. The paired-surface discovery verb: it lists the add-on(s)
+// advertising the `automation` meta-tool family and the surface each declares,
+// mirroring the `meho_automation_list` MCP tool and `GET /api/v1/automation`.
+// A read every operator may run; there is no client-side pairing gate (#2109) —
+// the backplane returns 403 `automation_addon_not_active` while nothing is
+// paired, which the CLI renders as a clear "not active" message.
+//
+// CLI shape:
+//
+//	meho automation list \
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Exit codes mirror the sibling docs verbs:
+//   - 0   surface listed cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. the inactive-surface 403)
+//   - 5   insufficient_role
+func newListCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the paired automation add-on surface",
+		Long: "list calls GET /api/v1/automation and renders the automation " +
+			"add-on(s) currently paired and contract-healthy, each with its " +
+			"negotiated contract version, whether that version is still " +
+			"compatible with this backplane, its last liveness heartbeat, and " +
+			"the surfaces it advertises (meta-tool / CLI verb families, console " +
+			"panels, event kinds). When no automation add-on is paired the " +
+			"surface is inactive and the command reports that (exit 4). --json " +
+			"emits the raw API response so operators can pipe into jq.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// listOptions is the flag set for the automation list verb.
+type listOptions struct {
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := listSurface(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without an automation-surface payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), *resp.JSON200)
+	}
+	printSurfaceTable(cmd.OutOrStdout(), *resp.JSON200)
+	return nil
+}
+
+func listSurface(
+	ctx context.Context,
+	backplaneURL string,
+) (*api.ListAutomationSurfaceApiV1AutomationGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	// No query parameters — the surface is tenant-scoped from the bearer; the
+	// generated Authorization param is injected by the authed client's editor.
+	params := &api.ListAutomationSurfaceApiV1AutomationGetParams{}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListAutomationSurfaceApiV1AutomationGetResponse, error) {
+			return authed.ListAutomationSurfaceApiV1AutomationGetWithResponse(ctx, params)
+		},
+		func(r *api.ListAutomationSurfaceApiV1AutomationGetResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+// printSurfaceTable renders the automation surface as a compact table. Columns:
+// ADD-ON, CONTRACT, COMPATIBLE, SURFACES — the fields an operator reads to see
+// whether governed automation is live and what it exposes. Timestamps are
+// omitted from the human view; --json surfaces the full response.
+func printSurfaceTable(w io.Writer, surface api.AutomationSurfaceResponse) {
+	if len(surface.Providers) == 0 {
+		fmt.Fprintln(w, "no automation add-on is paired and contract-healthy")
+		return
+	}
+	fmt.Fprintf(w, "%-20s %-10s %-11s %s\n", "ADD-ON", "CONTRACT", "COMPATIBLE", "SURFACES")
+	for _, p := range surface.Providers {
+		fmt.Fprintf(w, "%-20s %-10s %-11s %s\n",
+			truncate(p.Addon, 20),
+			fmt.Sprintf("v%d", p.ContractVersion),
+			formatBool(p.ContractCompatible),
+			truncate(formatSurfaces(p.Surfaces), 60),
+		)
+	}
+}
+
+// formatSurfaces renders a provider's advertised surfaces as a comma-separated
+// `kind:name` list, "-" when it advertises none.
+func formatSurfaces(surfaces []api.AutomationSurfaceEntry) string {
+	if len(surfaces) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(surfaces))
+	for _, s := range surfaces {
+		parts = append(parts, fmt.Sprintf("%s:%s", string(s.Kind), s.Name))
+	}
+	return strings.Join(parts, ",")
+}
+
+// formatBool renders a compatibility flag as yes/no for the human table.
+func formatBool(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/approvals"
 	"github.com/evoila/meho/cli/internal/cmd/argocd"
 	"github.com/evoila/meho/cli/internal/cmd/audit"
+	"github.com/evoila/meho/cli/internal/cmd/automation"
 	"github.com/evoila/meho/cli/internal/cmd/bind9"
 	"github.com/evoila/meho/cli/internal/cmd/broadcast"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
@@ -152,6 +153,17 @@ func newRootCmd() *cobra.Command {
 	// before registerDynamicSubcommands so the backplane manifest
 	// cannot shadow the built-in `audit` parent.
 	root.AddCommand(audit.NewRootCmd())
+
+	// #3029 -- the `meho automation` tree for Initiative #2900's
+	// paired-surface activation. One verb: `automation list` wraps the
+	// GET /api/v1/automation route, the CLI twin of the
+	// `meho_automation_list` meta-tool. The tree compiles into every binary
+	// and carries no client-side pairing gate (#2109): activation is decided
+	// server-side (403 `automation_addon_not_active` while nothing is paired),
+	// so CLI / REST / MCP give one verdict for one tenant. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot shadow the
+	// built-in `automation` parent.
+	root.AddCommand(automation.NewRootCmd())
 
 	// G6.3-T4 (#381) -- broadcast-detail override management verbs
 	// (overrides list / set / remove) for Initiative #376. Wraps the

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -112,6 +112,45 @@ Routes (both under the `addon-pairing` tag):
 - `GET /api/v1/addons/pairings/{name}/capabilities` — an operator reads the
   declared surfaces + live activation state. 404 when absent / cross-tenant.
 
+## Paired-surface activation (#3029)
+
+Capability advertisement declares *what* an add-on contributes; **activation**
+is where the backplane turns a declared, healthy `meta_tool_family` into a live
+operator/agent surface. The `automation` family is the first: a paired add-on
+advertising a `meta_tool_family` capability named `automation` activates a
+small, first-party surface across all three fronts, gated on pairing health.
+
+- **Agent waist (MCP).** `ToolDefinition` gains a fourth gating axis,
+  `required_addon_family`, orthogonal to role / capability / surface
+  (`mcp/registry.py`; the full four-gate story is in `mcp.md`). A tool declaring
+  it is filtered out of `tools/list` and rejected 403-class at `tools/call`
+  unless the family is active. The listing handler resolves the tenant's active
+  families once per request via `AddonCapabilityService.active_meta_tool_families`
+  and passes them to `all_tools_for`; the check is guarded by
+  `has_addon_gated_tools()` (list path) and the tool's own gate (call path) so
+  the DB round-trip only happens when an add-on-gated tool is in play. The one
+  tool today is `meho_automation_list`.
+- **CLI + REST.** `meho automation list` → `GET /api/v1/automation`. Following
+  the static-surface discipline (#2109), the route is always registered and the
+  CLI verb always compiled in; activation is enforced **inside** the handler
+  (403 `automation_addon_not_active` while inactive), keeping the OpenAPI
+  snapshot deterministic. All three fronts read one projection
+  (`operations/addon_automation.active_automation_surface`) so they never
+  diverge.
+- **Console.** `/ui/automation` renders the advertised surface of the paired,
+  healthy add-on and an inactive empty state otherwise — the console analogue of
+  the meta-tool's true-absence gate.
+
+Postulate-5 discipline holds throughout: the family name and the add-on's
+declared surfaces are **data** (capability rows, result fields); a paired
+add-on's own entity identifiers — blueprint names, workflow names — are never
+tool names, and there is no per-blueprint / per-workflow tool anywhere. The
+surface is the single `automation` family, which activates and deactivates as a
+unit with pairing health. Key types:
+`operations/addon_automation` (the shared read + value types),
+`mcp/tools/automation` (the meta-tool), `api/v1/automation` (the REST twin),
+`ui/routes/automation` (the console panel).
+
 ## Key types
 
 - `meho_backplane.operations.addon_pairing_contract` — pure negotiation:
@@ -201,10 +240,12 @@ lists active pairings and maps each to a `PairingHealth`
   See `addon-step-events.md` for the step-event push contract that uses it.
 - **Console is read-only**: pair / unpair are REST-only. Console write
   actions (a pair/unpair button behind CSRF) are a follow-up.
-- **Capabilities are not yet rendered in the console** or exposed as a
-  tenant-wide REST read. `active_capabilities()` is the in-process activation
-  plumbing the sibling event-push task (#3027) consumes; a console panel and a
-  `GET /api/v1/addons/capabilities` list surface are follow-ups.
+- **Paired-surface activation (#3029) is the first real consumer of the
+  capability-activation plumbing.** The `automation` meta-tool family (MCP), the
+  `meho automation` CLI verbs, and the `/ui/automation` console panel are all
+  gated on activation state — see "Paired-surface activation" below. A generic
+  tenant-wide `GET /api/v1/addons/capabilities` list surface (beyond the
+  automation-scoped `GET /api/v1/automation`) is still a follow-up.
 - Keycloak client provisioning is now duplicated three ways (agent, runner,
   add-on); a shared helper is an extraction candidate once the pattern
   stabilises (rule of three), but is out of scope for this task.
@@ -212,7 +253,10 @@ lists active pairings and maps each to a `PairingHealth`
 ## References
 
 - Initiative #2900 (add-on pairing contract), Task #3025 (the pairing
-  foundation), Task #3026 (capability advertisement + activation, this plane).
+  foundation), Task #3026 (capability advertisement + activation, this plane),
+  Task #3029 (paired-surface activation — the automation family across MCP / CLI
+  / console). `mcp.md` (the four-gate agent-surface scoping + the pairing-gated
+  inventory row).
 - `service-principal-grants.md` — the scoping mechanism the paired principal
   relies on.
 - `connectors-keycloak.md` — the Keycloak admin client lifecycle.

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -319,7 +319,7 @@ rather than publish a schema its payloads violate.
 
 ## Agent-surface scoping (working vs. operator, #3154)
 
-`tools/list` is filtered by **three orthogonal gates**, all AND-composed
+`tools/list` is filtered by **four orthogonal gates**, all AND-composed
 in `all_tools_for` (`mcp/registry.py`) and re-checked at `tools/call` in
 `handle_tools_call` (`mcp/handlers.py`):
 
@@ -332,8 +332,22 @@ in `all_tools_for` (`mcp/registry.py`) and re-checked at `tools/call` in
    `ToolSurface` (`working` | `operator`); `surface_visible` admits the
    working surface to everyone and the operator surface only to an
    **elevated** session (Initiative #3153).
+4. **add-on family** — a tool declaring `required_addon_family` (only
+   the `automation` family today, Task #3029) is absent unless a
+   **paired, contract-healthy** add-on advertises a `meta_tool_family`
+   capability of that name for the tenant (`addon_family_active`). Unlike
+   the static `required_capability` claim, this axis tracks **live
+   pairing state**: the listing handler resolves the tenant's active
+   families once per request from
+   `AddonCapabilityService.active_meta_tool_families` (the add-on
+   capability plane, `addon-pairing.md`) and passes them to
+   `all_tools_for`; the tool appears only while the add-on is paired and
+   healthy and disappears cleanly on unpair. The resolution is guarded by
+   `has_addon_gated_tools()` so a registry with no add-on-gated tool pays
+   no DB round-trip, and at `tools/call` it runs only for a tool that
+   actually declares the gate — the hot path stays DB-free.
 
-All three are *true-absence* gates: a tool a session may not use never
+All four are *true-absence* gates: a tool a session may not use never
 appears in its `tools/list`, and naming it directly at `tools/call` is
 rejected 403-class (INVALID_PARAMS, handler never runs) — the listing
 filter is enforced, not cosmetic.
@@ -376,9 +390,15 @@ table can never silently drift from the code:
   reclassification or an un-pinned addition fails CI at the listing path
   a client actually observes.
 
-Counts: **25 working + 53 operator = 78 registered tools**, plus the
-**3 human-only verbs** (below) that carry no MCP registration under any
-claim set.
+Counts: **25 working + 53 operator + 1 pairing-gated automation =
+79 registered tools**, plus the **3 human-only verbs** (below) that
+carry no MCP registration under any claim set. The 25 working and 53
+operator counts are the **unpaired baseline** — a session with every
+capability provisioned but no add-on paired — so they stay byte-identical
+to a build that never carried the automation family; the single
+pairing-gated tool (`meho_automation_list`, #3029) is absent from that
+baseline and joins the working surface only while its add-on is paired
+and contract-healthy.
 
 **Name authority ↔ consumer docs (#3150).** The tool *names* in this
 inventory are the authority the consumer-facing docs/skills
@@ -396,9 +416,12 @@ is exposed*; #3150 owns *how consumer docs spell it*.
 Gating recap — a tool appears in a session's `tools/list` iff **role**
 `≥` its minimum **AND** the tenant holds any required **capability**
 **AND** the session clears the **surface** gate (working = always;
-operator = `mcp:admin`-elevated). The "Role" and "Extra gate" columns
-below are the per-tool half; the surface's scope requirement is stated
-in each table heading.
+operator = `mcp:admin`-elevated) **AND** any required **add-on family**
+is active (a paired, contract-healthy add-on advertises it). The "Role"
+and "Extra gate" columns below are the per-tool half; the surface's scope
+requirement is stated in each table heading. The "Extra gate" column
+carries both the `meho-docs` capability keys and the `automation (paired)`
+add-on-family gate.
 
 ### Working surface (default — every session, no elevation)
 
@@ -490,6 +513,24 @@ session (on top of the Role + Extra-gate columns).
 | `meho_topology_delete_node` | tenant_admin | — | Hard-delete a manually-seeded graph node. |
 | `meho_topology_unannotate` | tenant_admin | — | Delete a curated graph edge (re-promotes any superseded auto edge). |
 | `query_audit` | operator | — | Query the audit log for forensic reconstruction. |
+
+### Pairing-gated — automation family (paired add-on required, #3029)
+
+The first surface gated on **add-on pairing state** rather than a static
+tenant capability (Initiative #2900). The family is on the working
+surface (no `mcp:admin` elevation) but absent from every session's
+listing until a paired, contract-healthy add-on advertises the
+`automation` `meta_tool_family` capability; it disappears cleanly on
+unpair. The `automation` identifier is a **family** name — a paired
+add-on's own entity identifiers (blueprint names, workflow names) stay
+data in results, never tool names (CLAUDE.md postulate 5). The family is
+seeded with one discovery tool and grows behind the same gate. CLI twin:
+`meho automation list`; REST twin: `GET /api/v1/automation`; console:
+`/ui/automation`.
+
+| Tool | Role | Extra gate | What it does |
+|---|---|---|---|
+| `meho_automation_list` | read_only | `automation` (paired) | List the paired automation add-on(s) and the surface each advertises (families, panels, event kinds) with live health. |
 
 ### Human-only (no MCP path under any claim set)
 


### PR DESCRIPTION
## Summary

- **Paired-surface activation for the `automation` add-on family** (Initiative #2900, Task #3029): the first backplane surface gated on live **add-on pairing state** rather than a static tenant capability. When a paired, contract-healthy add-on advertises the `automation` `meta_tool_family` capability, a small first-party surface activates across all three fronts and disappears cleanly on unpair.
- **New fourth MCP gating axis** `required_addon_family` on `ToolDefinition`, AND-composed with role / capability / surface and enforced at both `tools/list` and `tools/call`. It resolves the tenant's active families from `AddonCapabilityService.active_meta_tool_families` (the #3026 activation plumbing — this is its first production consumer), guarded by `has_addon_gated_tools()` (list) and the tool's own gate (call) so the hot path stays DB-free.
- **Three twins, one dispatch answer**: the `meho_automation_list` MCP meta-tool, the `meho automation list` CLI verb, and the `/ui/automation` console panel, all reading one shared projection (`operations/addon_automation.active_automation_surface`). CLI verb + REST route follow the static-surface discipline (#2109): always registered, gated server-side inside the handler (`GET /api/v1/automation` → 403 `automation_addon_not_active` while inactive), so the OpenAPI snapshot stays deterministic.
- **Postulate 5 intact**: the `automation` identifier is a *family* name; a paired add-on's own blueprint / workflow identifiers stay data in results, never tool names. There is no per-blueprint / per-workflow tool anywhere; the whole surface is one gated family that grows behind the same gate.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (only the pre-existing macOS-only `icmp.py MSG_ERRQUEUE` error, unrelated)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] New `test_mcp_automation_activation.py` — the acceptance contract: absent unpaired (byte-identical), present when paired+healthy, absent when contract-incompatible, absent when family undeclared, disappears on unpair; call-time 403 when inactive; success when active
- [x] `test_mcp_surface_conformance.py` / `test_mcp_surface_filter.py` — updated: automation is a third disjoint gated set completing the registry partition; the 25/53 unpaired working/operator baselines stay byte-identical
- [x] `test_mcp_output_schema_conformance.py` / `test_mcp_structured_content.py` — new payload scenario + declaring-set pin
- [x] `test_maturity_surface_drift.py` / `test_ui_maturity_badge.py` — new `automation` REST tag + UI surface mapped to `addon_pairing`
- [x] CLI: `go build ./...`, `go vet`, `go test ./internal/cmd/...` — green; `meho automation list` verb wired
- [x] CLI API snapshot regenerated (`make -C cli snapshot-openapi generate`) — `cli/api/openapi.json` + `cli/internal/api/client.gen.go` committed
- [x] `docs/codebase/mcp.md` (four-gate scoping + pairing-gated inventory row + counts) + `docs/codebase/addon-pairing.md` (paired-surface activation section) + CHANGELOG `[Unreleased]`

## Out of scope

- The #3030 reference-double conformance harness (sibling task) — this PR ships the gate + conformance tests it will build on, not the double.
- A generic tenant-wide `GET /api/v1/addons/capabilities` list surface (beyond the automation-scoped read) — recorded as a follow-up in `addon-pairing.md`.
- Backplane→add-on dispatch (no add-on base URL in the pairing model) — the automation family surfaces the *advertised* surface; the add-on drives its own orchestration and calls back into the backplane.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3029
