### PR TITLE
feat(flight-recorder): capture seam — vendor/composite/JSONFlux spans, caps, best-effort invariant (#3214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,37 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: capture seam + caps + best-effort invariant (#3214)
+
+- Ships the **capture seam** plus the **F3 caps** and **F7 failure invariant**
+  of the flight-recorder decision (`docs/decisions/dispatch-flight-recorder.md`),
+  composing the storage substrate (#3212) and the fail-closed redaction engine
+  (#3213) into span production on the **existing** single dispatch path — no
+  parallel execution path. Three span sources are instrumented:
+  **generic-connector vendor-call spans** (wrapped around the shared httpx seam
+  on `HttpConnector._request_json` / `_post_json`, capturing method, URL,
+  status, duration, and **redacted, capped** headers/bodies — the URL is
+  stripped to its request line so query/userinfo secrets never leak);
+  **composite sub-step spans** (a child dispatch re-enters `dispatch()` and
+  joins the **one** parent trace via a shared capture scope — no second trace,
+  no new machinery); and the **JSONFlux reduction span** (input rows → kept
+  fields → output size → handle id). Every header and body is **redacted at
+  capture** through the #3213 engine before a byte reaches a span, and the trace
+  inherits the OR of every span's redaction-uncertainty verdict (the F5
+  operator-only degrade). **F3 caps** are enforced at capture time — 64 KB per
+  span body (oversize truncates with a marker, which forces redaction
+  uncertainty), 1 MB per trace, ~50 spans per dispatch with the overflow
+  collapsing into counted per-kind span groups — and oversize **truncates,
+  never errors**. **F7** is a hard invariant: capture is best-effort and can
+  never fail, block, or materially slow a dispatch — every entry point swallows
+  its own errors, the disabled path is a single contextvar read, and the trace
+  is persisted after the audit row commits on the store's own best-effort path;
+  a test proves a forced recorder failure leaves the dispatch result
+  byte-identical and the audit row committed. Respects the F1 capture-enablement
+  config + global kill switch (captures nothing when disabled). Operator/agent
+  read surfaces (#3215/#3216) and typed-connector span instrumentation (#3217)
+  remain sibling tasks; does **not** close #3207.
+
 ### Added — first governed delete: `vmware.composite.vm.destroy` on the destructive tier + conformance (evoila-bosnia/meho-internal#3183 / #3198)
 
 - Models the **first real delete family** into the `destructive` safety
@@ -145,6 +176,7 @@ connector-related release-notes line.
   own lineage) in `docs/decisions/addon-contract-trust-model.md`: no
   code-change defects, two pre-tracked hardening follow-ups noted, no new
   issues filed. Tests and docs only — no backplane behavior change.
+
 
 ### Added — flight recorder: fail-closed redaction engine (#3213)
 

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -80,6 +80,7 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponen
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.base import Connector
+from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.targets.ssrf_guard import (
     TargetDestinationBlockedError,
     assert_public_destination_async,
@@ -225,6 +226,23 @@ def _retryable(exc: BaseException) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return 500 <= exc.response.status_code < 600
     return False
+
+
+def _post_body_content_type(
+    json_body: dict[str, Any] | None, data_body: dict[str, Any] | None
+) -> str | None:
+    """Content-type of the non-idempotent body actually sent (#3214).
+
+    ``json=`` serialises ``application/json``; ``data=`` serialises the
+    form-encoded shape OAuth2 token grants / session-login POSTs use. Returned
+    so the flight-recorder redaction engine can decide parseability (a
+    form-encoded body it cannot structurally redact fails closed).
+    """
+    if json_body is not None:
+        return "application/json"
+    if data_body is not None:
+        return "application/x-www-form-urlencoded"
+    return None
 
 
 def json_payload_or_empty(resp: httpx.Response) -> dict[str, Any]:
@@ -690,6 +708,13 @@ class HttpConnector(Connector):
         headers = await self.auth_headers(target, operator)
         if extra_headers:
             headers = {**headers, **extra_headers}
+        # Flight-recorder vendor-call span (#3214). ``span_start`` is a single
+        # contextvar read that returns ``None`` when capture is off, so an
+        # un-recorded dispatch pays nothing; ``record_vendor_call`` is
+        # best-effort (F7) and redacts headers/bodies at capture (#3213). The
+        # span is recorded before ``raise_for_status`` so a vendor 4xx/5xx is
+        # captured too.
+        _fr_start = flight_recorder_capture.span_start()
         resp = await client.request(
             method,
             path,
@@ -697,6 +722,14 @@ class HttpConnector(Connector):
             json=json,
             headers=headers,
             extensions=self._request_extensions(target),
+        )
+        flight_recorder_capture.record_vendor_call(
+            _fr_start,
+            method=method,
+            request_headers=headers,
+            response=resp,
+            request_body=json,
+            request_content_type="application/json" if json is not None else None,
         )
         resp.raise_for_status()
         return json_payload_or_empty(resp)
@@ -784,6 +817,11 @@ class HttpConnector(Connector):
         headers = await self.auth_headers(target, operator)
         if extra_headers:
             headers = {**headers, **extra_headers}
+        # Flight-recorder vendor-call span (#3214) -- see ``_request_json``.
+        # The request body is whichever of ``json`` / ``data`` was sent, with
+        # its matching content-type; a hard-excluded (login / token / DELETE)
+        # op has its body dropped by the redaction engine's family rules.
+        _fr_start = flight_recorder_capture.span_start()
         resp = await client.request(
             verb,
             path,
@@ -793,6 +831,14 @@ class HttpConnector(Connector):
             headers=headers,
             extensions=self._request_extensions(target),
             timeout=timeout,
+        )
+        flight_recorder_capture.record_vendor_call(
+            _fr_start,
+            method=verb,
+            request_headers=headers,
+            response=resp,
+            request_body=json if json is not None else data,
+            request_content_type=_post_body_content_type(json, data),
         )
         resp.raise_for_status()
         return json_payload_or_empty(resp)

--- a/backend/src/meho_backplane/flight_recorder/_capture_util.py
+++ b/backend/src/meho_backplane/flight_recorder/_capture_util.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pure helpers for the flight-recorder capture seam (#3214).
+
+Split out of :mod:`meho_backplane.flight_recorder.capture` so that module
+stays focused on the scope lifecycle + the three capture entry points. Every
+function here is side-effect-free (beyond reading structlog's ambient
+contextvars) and **never raises** -- the capture seam's F7 best-effort contract
+depends on it. F3's per-span body cap lives here (:func:`cap_body`); the
+per-trace and span-count caps live on the scope in :mod:`.capture`.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Final
+
+import msgspec
+import structlog
+
+from meho_backplane.flight_recorder.store import SpanInput
+
+__all__ = [
+    "MAX_SPAN_BODY_BYTES",
+    "approx_bytes",
+    "approx_span_bytes",
+    "as_mapping",
+    "cap_body",
+    "coerce_uuid",
+    "elapsed_ms",
+    "header_value",
+    "now_utc",
+    "request_id",
+    "response_content",
+    "safe_url",
+    "serialize",
+]
+
+#: Per-span body cap (F3). A request/response body larger than this truncates
+#: (marker + forced redaction-uncertainty); it never errors a dispatch.
+MAX_SPAN_BODY_BYTES: Final[int] = 64 * 1024
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def cap_body(body: Any) -> tuple[Any, bool]:
+    """Cap *body* at :data:`MAX_SPAN_BODY_BYTES`; return ``(body, truncated)``.
+
+    Oversize truncates (never errors, F3). A truncated body is handed to the
+    redaction engine as raw bytes with ``truncated=True`` so it fails closed to
+    a redaction-uncertain omission -- a secret split across the cut is
+    unverifiable.
+    """
+    if body is None:
+        return None, False
+    if isinstance(body, (bytes, bytearray)):
+        if len(body) > MAX_SPAN_BODY_BYTES:
+            return bytes(body[:MAX_SPAN_BODY_BYTES]), True
+        return bytes(body), False
+    if isinstance(body, str):
+        encoded = body.encode("utf-8", "replace")
+        if len(encoded) > MAX_SPAN_BODY_BYTES:
+            return encoded[:MAX_SPAN_BODY_BYTES], True
+        return body, False
+    encoded = serialize(body)
+    if len(encoded) > MAX_SPAN_BODY_BYTES:
+        return encoded[:MAX_SPAN_BODY_BYTES], True
+    return body, False
+
+
+def response_content(response: Any) -> bytes | None:
+    """Return the response body bytes, or ``None`` if unreadable."""
+    try:
+        content = response.content
+    except Exception:
+        return None
+    return bytes(content) if isinstance(content, (bytes, bytearray)) else None
+
+
+def header_value(response: Any, name: str) -> str | None:
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        value = headers.get(name)
+    except Exception:
+        return None
+    return value if isinstance(value, str) else None
+
+
+def as_mapping(headers: Any) -> Any:
+    """Coerce an ``httpx.Headers`` (or ``None``) into a plain dict.
+
+    The redactor fails closed on a non-mapping, so a plain ``dict`` is passed
+    when possible and the raw object otherwise (the redactor handles it).
+    """
+    if headers is None:
+        return None
+    try:
+        return dict(headers)
+    except Exception:
+        return headers
+
+
+def safe_url(url: Any) -> str:
+    """Return ``scheme://host[:port]/path`` -- no query, userinfo, or fragment.
+
+    Query strings and userinfo can carry tokens / signed-URL material, and the
+    redaction engine has no URL redactor, so the capture seam strips them here:
+    only the non-secret request line survives.
+    """
+    try:
+        scheme = getattr(url, "scheme", None)
+        host = getattr(url, "host", None)
+        path = getattr(url, "path", None)
+        if scheme and host:
+            port = getattr(url, "port", None)
+            netloc = host if port in (None, 80, 443) else f"{host}:{port}"
+            return f"{scheme}://{netloc}{path or ''}"
+        return str(url).split("?", 1)[0].split("#", 1)[0]
+    except Exception:
+        return "?"
+
+
+def coerce_uuid(value: Any) -> uuid.UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, TypeError):
+        return None
+
+
+def request_id() -> str | None:
+    """The ambient ``request_id`` correlation key, if bound (middleware)."""
+    try:
+        value = structlog.contextvars.get_contextvars().get("request_id")
+    except Exception:
+        return None
+    return value if isinstance(value, str) else None
+
+
+def elapsed_ms(monotonic_start: float) -> Decimal:
+    return Decimal(str(round((time.monotonic() - monotonic_start) * 1000, 2)))
+
+
+def serialize(payload: Any) -> bytes:
+    """Serialize *payload* to JSON bytes, never raising (mirrors the reducer)."""
+    try:
+        return msgspec.json.encode(payload)
+    except (TypeError, msgspec.EncodeError):
+        return str(payload).encode("utf-8", "replace")
+
+
+def approx_bytes(payload: Any) -> int:
+    return len(serialize(payload))
+
+
+def approx_span_bytes(span: SpanInput) -> int:
+    """Cheap upper-ish estimate of a span's persisted size for the trace cap."""
+    return len(span.name) + approx_bytes(span.attributes)

--- a/backend/src/meho_backplane/flight_recorder/capture.py
+++ b/backend/src/meho_backplane/flight_recorder/capture.py
@@ -1,0 +1,514 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder capture seam (#3214, capture seam + F3 caps + F7 invariant).
+
+The span-production layer of the dispatch flight recorder, per the decision
+of record ``docs/decisions/dispatch-flight-recorder.md`` (capture seam / F3 /
+F7). It rides the **existing** single dispatch path -- no parallel execution
+path -- and produces the ordered spans the store task (#3212) persists and the
+redaction engine (#3213) scrubs.
+
+What lives here
+---------------
+* A per-dispatch **capture scope** bound on a contextvar
+  (:data:`_active_capture_var`). Opened **once** at the root dispatch (when
+  :func:`meho_backplane.flight_recorder.should_capture` says so, F1) and
+  shared by every nested composite child dispatch, so a composite's sub-step
+  spans land under the **one** parent trace with no new machinery -- the child
+  re-enters :func:`dispatch` in the same task and sees the same scope.
+* A per-dispatch **op context** bound on a second contextvar
+  (:data:`_op_context_var`), rebound for every dispatch (root **and** each
+  child). A vendor-call span is redacted against the op context of the dispatch
+  that *made* the call -- so a composite child that mints a session has its
+  body hard-excluded by the child's op family, not the parent's.
+* The three capture entry points the seams call:
+  :func:`span_start` + :func:`record_vendor_call` (the shared httpx seam),
+  :func:`record_jsonflux_reduction` (the JSONFlux reducer), and the
+  ``composite_step`` marker emitted by :func:`begin_dispatch_capture` when a
+  nested child dispatch is detected.
+* The **F3 caps** enforced at capture time
+  (:data:`~meho_backplane.flight_recorder._capture_util.MAX_SPAN_BODY_BYTES`,
+  :data:`_MAX_TRACE_BYTES`, :data:`_MAX_SPANS`): oversize truncates, span
+  overflow collapses into counted per-kind groups, and nothing ever errors a
+  dispatch.
+
+The F7 invariant
+----------------
+Capture is strictly best-effort and can **never fail, block, or materially
+slow a dispatch**. Every public function swallows every exception (logging a
+warning), the span-assembly work is cheap, the disabled path is a single
+contextvar read, and persistence rides the store's own best-effort
+:func:`meho_backplane.flight_recorder.record_trace` (which opens its own
+session and never raises). This is the same fail-open discipline the
+result-handle spill proves
+(:mod:`meho_backplane.connectors.result_handle_store`).
+
+Capture-before-redaction is absolute: no raw vendor header or body byte is
+ever placed on a :class:`~meho_backplane.flight_recorder.store.SpanInput`.
+Every artefact passes through
+:func:`meho_backplane.redaction.flight_recorder.redact_span` first, and the
+trace inherits the OR of every span's redaction-uncertainty verdict (F5
+operator-only degrade).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Final
+
+import structlog
+
+from meho_backplane.flight_recorder._capture_util import (
+    approx_bytes,
+    approx_span_bytes,
+    as_mapping,
+    cap_body,
+    coerce_uuid,
+    elapsed_ms,
+    header_value,
+    now_utc,
+    request_id,
+    response_content,
+    safe_url,
+)
+from meho_backplane.flight_recorder.config import should_capture
+from meho_backplane.flight_recorder.store import SpanInput, record_trace
+from meho_backplane.redaction.flight_recorder import redact_span
+
+__all__ = [
+    "CaptureHandle",
+    "SpanStart",
+    "begin_dispatch_capture",
+    "end_dispatch_capture",
+    "record_jsonflux_reduction",
+    "record_vendor_call",
+    "span_start",
+]
+
+_log = structlog.get_logger(__name__)
+
+# --- F3 caps (fixed invariants, not tunable knobs) --------------------------
+#: Per-trace cap. Once a trace's accumulated span bytes would exceed this,
+#: further spans collapse into counted per-kind groups instead of persisting.
+_MAX_TRACE_BYTES: Final[int] = 1024 * 1024
+#: Soft per-dispatch span ceiling. Beyond it, spans collapse into counted
+#: per-kind groups -- the long-poll idiom the decision names (F3).
+_MAX_SPANS: Final[int] = 50
+#: Upper bound on the JSONFlux ``kept_fields`` list recorded on a reduction
+#: span, so a pathologically wide schema cannot blow the span byte budget.
+_MAX_JSONFLUX_KEPT_FIELDS: Final[int] = 200
+
+
+@dataclass(frozen=True, slots=True)
+class SpanStart:
+    """A cheap start marker for one vendor-call span.
+
+    Returned by :func:`span_start` **only** when capture is active for the
+    current dispatch, so the httpx seam pays for nothing (one contextvar read)
+    when the recorder is off. Carries the wall-clock start (for
+    :attr:`SpanInput.started_at`) and a monotonic reference (for the duration).
+    """
+
+    started_at: datetime
+    monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class _OpContext:
+    """The redaction-relevant context of one dispatch.
+
+    Rebound per dispatch so a vendor call is redacted against the op that made
+    it (a composite child's session mint is excluded by the child's family,
+    not the parent's).
+    """
+
+    op_id: str | None
+    connector_id: str | None
+    tags: tuple[str, ...]
+    body_paths: tuple[str, ...]
+    delete_shaped_patterns: tuple[str, ...] | None
+
+
+@dataclass(slots=True)
+class _CaptureScope:
+    """The mutable per-trace accumulator, bound once at the root dispatch."""
+
+    audit_id: uuid.UUID
+    tenant_id: uuid.UUID
+    target_id: uuid.UUID | None
+    spans: list[SpanInput] = field(default_factory=list)
+    total_bytes: int = 0
+    redaction_uncertain: bool = False
+    #: Per-kind count of spans dropped by the span-count / byte caps (F3).
+    overflow: dict[str, int] = field(default_factory=dict)
+
+    def add(self, span: SpanInput) -> None:
+        """Append *span* under the F3 caps; overflow collapses, never errors."""
+        if len(self.spans) >= _MAX_SPANS:
+            self._collapse(span.span_kind)
+            return
+        approx = approx_span_bytes(span)
+        # Always admit the first span (a single body is already <=64 KB, well
+        # under the 1 MB trace cap); collapse only once the trace is full.
+        if self.spans and self.total_bytes + approx > _MAX_TRACE_BYTES:
+            self._collapse(span.span_kind)
+            return
+        self.spans.append(span)
+        self.total_bytes += approx
+
+    def _collapse(self, kind: str) -> None:
+        self.overflow[kind] = self.overflow.get(kind, 0) + 1
+
+    def finalize(self, now: datetime) -> None:
+        """Append one counted collapse span per overflowed kind (F3)."""
+        for kind, count in self.overflow.items():
+            self.spans.append(
+                SpanInput(
+                    span_kind=kind,
+                    name=f"{kind} (collapsed x{count})",
+                    started_at=now,
+                    attributes={"collapsed": True, "collapsed_count": count},
+                )
+            )
+        self.overflow.clear()
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureHandle:
+    """Opaque token returned by :func:`begin_dispatch_capture`.
+
+    Carries the contextvar reset tokens and whether *this* dispatch owns the
+    scope (the root that must persist the trace on exit). Consumed exactly once
+    by :func:`end_dispatch_capture`.
+    """
+
+    owns: bool
+    scope: _CaptureScope | None
+    op_token: Any
+    cap_token: Any
+
+
+#: The active per-trace accumulator for the current dispatch (and its nested
+#: composite children, via contextvar propagation within the same task).
+#: ``None`` = capture is off for this dispatch, so every seam is a no-op.
+_active_capture_var: ContextVar[_CaptureScope | None] = ContextVar(
+    "flight_recorder_active_capture", default=None
+)
+#: The redaction-relevant op context of the *current* dispatch. Rebound per
+#: dispatch (root and each composite child) so vendor-call redaction uses the
+#: op that actually made the call.
+_op_context_var: ContextVar[_OpContext | None] = ContextVar(
+    "flight_recorder_op_context", default=None
+)
+
+_INACTIVE_HANDLE: Final[CaptureHandle] = CaptureHandle(
+    owns=False, scope=None, op_token=None, cap_token=None
+)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-boundary lifecycle (called by the dispatcher)
+# ---------------------------------------------------------------------------
+
+
+async def begin_dispatch_capture(
+    *,
+    audit_id: uuid.UUID,
+    operator: Any,
+    target: Any,
+    descriptor: Any,
+    connector_id: str,
+) -> CaptureHandle:
+    """Open (or join) the capture scope for one dispatch. Never raises (F7).
+
+    * **Root dispatch** (no active scope): consults :func:`should_capture`
+      (F1 precedence + kill switch, fail-open) and, when enabled, binds a fresh
+      :class:`_CaptureScope` + this op's context. The returned handle ``owns``
+      the scope and persists it on exit.
+    * **Nested composite child** (a scope is already active): reuses the parent
+      scope, binds *this* child's op context for correct per-op redaction, and
+      records a ``composite_step`` marker. It does **not** open a new trace.
+
+    Any failure degrades to an inactive handle -- capture simply does not
+    happen for this dispatch, and the dispatch is untouched.
+    """
+    try:
+        existing = _active_capture_var.get()
+        if existing is not None:
+            # Nested composite child: join the parent trace, no new machinery.
+            op_token = _op_context_var.set(_op_context_from(descriptor, connector_id))
+            _record_composite_step(existing, descriptor, connector_id)
+            return CaptureHandle(owns=False, scope=existing, op_token=op_token, cap_token=None)
+
+        tenant_id = getattr(operator, "tenant_id", None)
+        if tenant_id is None:
+            return _INACTIVE_HANDLE
+        target_id = coerce_uuid(getattr(target, "id", None))
+        if not await should_capture(tenant_id=tenant_id, target_id=target_id):
+            return _INACTIVE_HANDLE
+
+        scope = _CaptureScope(audit_id=audit_id, tenant_id=tenant_id, target_id=target_id)
+        cap_token = _active_capture_var.set(scope)
+        op_token = _op_context_var.set(_op_context_from(descriptor, connector_id))
+        return CaptureHandle(owns=True, scope=scope, op_token=op_token, cap_token=cap_token)
+    except Exception:
+        _log.warning("flight_recorder_begin_capture_failed", exc_info=True)
+        return _INACTIVE_HANDLE
+
+
+async def end_dispatch_capture(handle: CaptureHandle) -> None:
+    """Close the capture scope opened by :func:`begin_dispatch_capture` (F7).
+
+    Resets the per-dispatch op context always; for the owning root dispatch,
+    also unbinds the scope and persists the trace on the store's best-effort
+    path. Runs in the dispatcher's ``finally``, so it fires after the audit row
+    has committed -- the trace attaches to a durable ``audit_log.id``. Never
+    raises.
+    """
+    try:
+        if handle.op_token is not None:
+            _op_context_var.reset(handle.op_token)
+        if handle.owns and handle.scope is not None:
+            if handle.cap_token is not None:
+                _active_capture_var.reset(handle.cap_token)
+            await _persist(handle.scope)
+    except Exception:
+        _log.warning("flight_recorder_end_capture_failed", exc_info=True)
+
+
+async def _persist(scope: _CaptureScope) -> None:
+    """Finalize + write the trace, best-effort. Wrapped for F7 defense."""
+    try:
+        scope.finalize(now_utc())
+        await record_trace(
+            audit_id=scope.audit_id,
+            tenant_id=scope.tenant_id,
+            spans=scope.spans,
+            redaction_uncertain=scope.redaction_uncertain,
+        )
+    except Exception:
+        # ``record_trace`` already swallows its own errors; this guard covers
+        # a monkeypatched/raising recorder so a forced failure still cannot
+        # touch the (already-committed) dispatch result (F7).
+        _log.warning("flight_recorder_persist_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Vendor-call span (the shared httpx seam)
+# ---------------------------------------------------------------------------
+
+
+def span_start() -> SpanStart | None:
+    """Return a start marker iff capture is active; else ``None`` (cheap)."""
+    if _active_capture_var.get() is None:
+        return None
+    return SpanStart(started_at=now_utc(), monotonic=time.monotonic())
+
+
+def record_vendor_call(
+    start: SpanStart | None,
+    *,
+    method: str,
+    request_headers: Any,
+    response: Any,
+    request_body: Any = None,
+    request_content_type: str | None = None,
+) -> None:
+    """Capture one generic-connector vendor HTTP call as a span (F7).
+
+    *start* is the marker from :func:`span_start` (``None`` -> capture is off,
+    no-op). *response* is the completed :class:`httpx.Response`; the span is
+    recorded regardless of status so an operator sees vendor 4xx/5xx bodies.
+    The request URL is derived from ``response.request`` **inside** this
+    guarded function so the call site never touches an attribute that could
+    raise into the dispatch. Headers and bodies are **redacted at capture** --
+    no raw byte reaches the :class:`SpanInput`. Any error is logged and
+    swallowed.
+    """
+    scope = _active_capture_var.get()
+    if start is None or scope is None:
+        return
+    try:
+        redaction, url, truncated = _redact_vendor_call(
+            method=method,
+            request_headers=request_headers,
+            response=response,
+            request_body=request_body,
+            request_content_type=request_content_type,
+        )
+        scope.add(
+            SpanInput(
+                span_kind="vendor_call",
+                name=f"{method} {url}",
+                started_at=start.started_at,
+                duration_ms=elapsed_ms(start.monotonic),
+                status=str(getattr(response, "status_code", "")) or None,
+                attributes=_vendor_attributes(redaction, method, url, truncated),
+            )
+        )
+        if redaction.uncertain:
+            scope.redaction_uncertain = True
+    except Exception:
+        _log.warning("flight_recorder_vendor_span_failed", exc_info=True)
+
+
+def _redact_vendor_call(
+    *,
+    method: str,
+    request_headers: Any,
+    response: Any,
+    request_body: Any,
+    request_content_type: str | None,
+) -> tuple[Any, str, bool]:
+    """Cap + redact one vendor call. Returns ``(redaction, safe_url, truncated)``."""
+    op = _op_context_var.get()
+    request_url = getattr(getattr(response, "request", None), "url", None)
+    response_content_type = header_value(response, "content-type")
+    req_body, req_truncated = cap_body(request_body)
+    resp_body, resp_truncated = cap_body(response_content(response))
+    redaction = redact_span(
+        op_id=op.op_id if op else None,
+        connector_id=op.connector_id if op else None,
+        method=method,
+        tags=op.tags if op else (),
+        request_headers=as_mapping(request_headers),
+        response_headers=as_mapping(getattr(response, "headers", None)),
+        request_body=req_body,
+        response_body=resp_body,
+        request_content_type=request_content_type,
+        response_content_type=response_content_type,
+        request_truncated=req_truncated,
+        response_truncated=resp_truncated,
+        body_paths=op.body_paths if op else (),
+        delete_shaped_patterns=op.delete_shaped_patterns if op else None,
+    )
+    return redaction, safe_url(request_url), req_truncated or resp_truncated
+
+
+def _vendor_attributes(redaction: Any, method: str, url: str, truncated: bool) -> dict[str, Any]:
+    op = _op_context_var.get()
+    attributes: dict[str, Any] = {
+        "connector_id": op.connector_id if op else None,
+        "op_id": op.op_id if op else None,
+        "method": method,
+        "url": url,
+        "request_headers": redaction.request_headers,
+        "response_headers": redaction.response_headers,
+        "request_body": redaction.request_body,
+        "response_body": redaction.response_body,
+        "body_recorded": redaction.body_recorded,
+    }
+    if truncated:
+        attributes["truncated"] = True
+    if redaction.reasons:
+        attributes["redaction_reasons"] = list(redaction.reasons)
+    rid = request_id()
+    if rid is not None:
+        attributes["request_id"] = rid
+    return attributes
+
+
+# ---------------------------------------------------------------------------
+# JSONFlux reduction span (the reducer seam)
+# ---------------------------------------------------------------------------
+
+
+def record_jsonflux_reduction(
+    *,
+    op_id: str | None,
+    input_rows: int,
+    total_rows: int,
+    kept_fields: list[str],
+    summary: Any,
+    handle_id: uuid.UUID,
+) -> None:
+    """Capture the JSONFlux reduction as a span (F7).
+
+    Metadata only -- input row count -> kept fields -> output size -> handle id
+    -- so it carries no vendor bytes and never sets redaction-uncertainty.
+    No-op when capture is off. Any error is logged and swallowed.
+    """
+    scope = _active_capture_var.get()
+    if scope is None:
+        return
+    try:
+        attributes: dict[str, Any] = {
+            "op_id": op_id,
+            "input_rows": input_rows,
+            "total_rows": total_rows,
+            "kept_fields": list(kept_fields[:_MAX_JSONFLUX_KEPT_FIELDS]),
+            "kept_field_count": len(kept_fields),
+            "output_bytes": approx_bytes(summary),
+            "handle": str(handle_id),
+        }
+        rid = request_id()
+        if rid is not None:
+            attributes["request_id"] = rid
+        scope.add(
+            SpanInput(
+                span_kind="jsonflux_reduction",
+                name="jsonflux.reduce",
+                started_at=now_utc(),
+                status="ok",
+                attributes=attributes,
+            )
+        )
+    except Exception:
+        _log.warning("flight_recorder_jsonflux_span_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _record_composite_step(scope: _CaptureScope, descriptor: Any, connector_id: str) -> None:
+    """Mark a composite sub-step boundary under the parent trace."""
+    try:
+        attributes: dict[str, Any] = {
+            "op_id": getattr(descriptor, "op_id", None),
+            "connector_id": connector_id,
+            "source_kind": getattr(descriptor, "source_kind", None),
+        }
+        rid = request_id()
+        if rid is not None:
+            attributes["request_id"] = rid
+        scope.add(
+            SpanInput(
+                span_kind="composite_step",
+                name=f"sub-step: {getattr(descriptor, 'op_id', '?')}",
+                started_at=now_utc(),
+                attributes=attributes,
+            )
+        )
+    except Exception:
+        _log.warning("flight_recorder_composite_span_failed", exc_info=True)
+
+
+def _op_context_from(descriptor: Any, connector_id: str) -> _OpContext:
+    """Build the per-dispatch op context for redaction."""
+    tags_raw = getattr(descriptor, "tags", None) or ()
+    tags = tuple(str(tag) for tag in tags_raw)
+    try:
+        from meho_backplane.settings import get_settings
+
+        delete_shaped: tuple[str, ...] | None = tuple(
+            get_settings().service_grant_delete_shaped_patterns
+        )
+    except Exception:
+        delete_shaped = None
+    return _OpContext(
+        op_id=getattr(descriptor, "op_id", None),
+        connector_id=connector_id,
+        tags=tags,
+        # Per-connector body-path config is a connector-authoring follow-up;
+        # the credential-shape scrub + hard-excluded families still protect
+        # every body until a connector declares its paths.
+        body_paths=(),
+        delete_shaped_patterns=delete_shaped,
+    )

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -264,6 +264,7 @@ from meho_backplane.connectors import (
 from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError
 from meho_backplane.connectors.base import Connector, shim_kind
 from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
+from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.operations._audit import (
     audit_and_broadcast_safe,
     parent_audit_id_var,
@@ -695,6 +696,58 @@ async def _execute_and_audit(
     redactor stays deterministic across policy revisions.
     """
     audit_id = uuid.uuid4()
+    # Flight-recorder capture seam (#3214). Opened once at the root dispatch
+    # (F1 should_capture, fail-open) and joined by nested composite children so
+    # every sub-step span lands under the one parent trace. Best-effort (F7):
+    # begin/end never raise, and the trace is persisted in the ``finally`` after
+    # the audit row has committed, so a recorder failure can never fail, block,
+    # or materially slow the dispatch.
+    capture_handle = await flight_recorder_capture.begin_dispatch_capture(
+        audit_id=audit_id,
+        operator=operator,
+        target=target,
+        descriptor=descriptor,
+        connector_id=connector_id,
+    )
+    try:
+        return await _execute_and_audit_inner(
+            op_id=op_id,
+            connector_id=connector_id,
+            descriptor=descriptor,
+            connector_instance=connector_instance,
+            operator=operator,
+            target=target,
+            params=params,
+            params_hash=params_hash,
+            audit_id=audit_id,
+            started=started,
+            scrub_response=scrub_response,
+        )
+    finally:
+        await flight_recorder_capture.end_dispatch_capture(capture_handle)
+
+
+async def _execute_and_audit_inner(
+    *,
+    op_id: str,
+    connector_id: str,
+    descriptor: EndpointDescriptor,
+    connector_instance: Connector | None,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    params_hash: str,
+    audit_id: uuid.UUID,
+    started: float,
+    scrub_response: bool = False,
+) -> OperationResult:
+    """The redact -> reduce -> audit success/error body of :func:`_execute_and_audit`.
+
+    Extracted so :func:`_execute_and_audit` stays a thin wrapper that owns only
+    the flight-recorder capture scope (open before the branch runs, persist in
+    ``finally`` after the audit commits). ``audit_id`` is minted by the caller
+    so the trace and the audit row share one id.
+    """
     branch_result = await _run_branch_with_error_handling(
         op_id=op_id,
         descriptor=descriptor,

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
+# code-quality-allow: file-size — pre-existing 1332-line reducer (predates this
+# rule); #3214 adds only the JSONFlux reduction-span call. Splitting the reducer
+# is a separate refactor, out of scope for this surgical capture-seam change.
+
 """Real JSONFlux reducer — the production default behind the dispatcher seam.
 
 G0.6.1-T3 (#753) of Initiative #750. Bridges the vendored
@@ -77,6 +81,7 @@ from meho_backplane.connectors.schemas import (
     PaginationHint,
     ResultHandle,
 )
+from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.jsonflux.query.engine import QueryEngine
 from meho_backplane.settings import get_settings
 
@@ -416,8 +421,35 @@ class JsonFluxReducer:
         spill_outcome = await self._spill(materialized, context)
         preserved_scalars = _preserved_scalars(payload, envelope_key, context)
         digest = _row_digest(rows, envelope_key, digest_spec)
-        return self._assemble(
+        summary, handle = self._assemble(
             materialized, envelope_key, context, spill_outcome, preserved_scalars, digest
+        )
+        self._record_flux_span(rows, materialized, summary, context)
+        return summary, handle
+
+    @staticmethod
+    def _record_flux_span(
+        rows: list[Any],
+        materialized: _MaterializedSet,
+        summary: Any,
+        context: dict[str, Any] | None,
+    ) -> None:
+        """Emit the flight-recorder JSONFlux reduction span (#3214).
+
+        Metadata only (input rows -> kept fields -> output size -> handle id);
+        best-effort (F7) and a no-op when capture is off, so a non-dispatch
+        reduce or a disabled recorder pays a single contextvar read. The
+        kept-field extraction is fully isinstance-guarded so it can NEVER raise
+        into :meth:`reduce` (which ``_reduce_or_error`` wraps -- a raise here
+        would turn a dispatch success into a connector_error, an F7 violation).
+        """
+        flight_recorder_capture.record_jsonflux_reduction(
+            op_id=context.get("op_id") if context else None,
+            input_rows=len(rows),
+            total_rows=materialized.total_rows,
+            kept_fields=_flux_kept_fields(materialized.schema_),
+            summary=summary,
+            handle_id=materialized.handle_id,
         )
 
     def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
@@ -771,6 +803,25 @@ def _normalize_rows(rows: list[Any]) -> list[dict[str, Any]]:
     if rows and isinstance(rows[0], dict):
         return rows
     return [{_SCALAR_COLUMN: item} for item in rows]
+
+
+def _flux_kept_fields(schema: dict[str, Any] | None) -> list[str]:
+    """Kept-field names for the flight-recorder JSONFlux span (#3214).
+
+    ``_build_json_schema`` nests the object's properties under ``items`` (the
+    set-of-objects contract). Fully isinstance-guarded so it can never raise
+    into :meth:`JsonFluxReducer.reduce` -- capture must never alter a dispatch
+    (F7).
+    """
+    if not isinstance(schema, dict):
+        return []
+    items = schema.get("items")
+    if not isinstance(items, dict):
+        return []
+    props = items.get("properties")
+    if not isinstance(props, dict):
+        return []
+    return [str(key) for key in props]
 
 
 def _build_json_schema(engine: QueryEngine) -> dict[str, Any]:

--- a/backend/tests/test_flight_recorder_capture.py
+++ b/backend/tests/test_flight_recorder_capture.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder capture-seam tests (#3214): vendor-call spans, F3 caps, F7.
+
+Exercises the generic-connector vendor-call span through the **real** shared
+httpx seam (:meth:`HttpConnector._request_json` / ``_post_json``) against a
+respx-mocked endpoint, plus the F3 caps (per-span body truncation, span-count
+and trace-byte overflow collapse) and the F7 best-effort invariant (a forced
+redaction / caps failure never breaks the connector call). The composite,
+JSONFlux, and full-dispatch F7 coverage lives in
+``test_flight_recorder_capture_dispatch.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.adapters import HttpConnector
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import DispatchTrace, DispatchTraceSpan, Tenant
+from meho_backplane.flight_recorder import capture
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.flight_recorder.store import SpanInput
+from meho_backplane.redaction.flight_recorder.verdict import (
+    BODY_OMITTED_MARKER,
+    SECRET_FAMILY_OMITTED_MARKER,
+)
+from meho_backplane.settings import get_settings
+
+_BASE_URL = "https://vcenter.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(*, slug: str, enabled: bool = True) -> UUID:
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        s.add(
+            Tenant(
+                id=tenant_id,
+                slug=slug,
+                name=f"Tenant {slug}",
+                flight_recorder_enabled=enabled,
+            )
+        )
+        await s.commit()
+    return tenant_id
+
+
+def _make_operator(tenant_id: UUID) -> Operator:
+    return Operator(
+        sub="op-capture",
+        name=None,
+        email=None,
+        raw_jwt="tok-secret",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _make_target() -> Any:
+    return SimpleNamespace(
+        name="test-target",
+        host="vcenter.example.com",
+        port=443,
+        id="11111111-1111-1111-1111-111111111111",
+        tenant_id="00000000-0000-0000-0000-000000000000",
+        auth_model="impersonation",
+        verify_tls=True,
+        tls_ca_pin=None,
+        tls_server_name=None,
+        extras={},
+    )
+
+
+def _descriptor(op_id: str, *, tags: tuple[str, ...] = (), source_kind: str = "ingested") -> Any:
+    return SimpleNamespace(op_id=op_id, tags=list(tags), source_kind=source_kind)
+
+
+def span_json(span: DispatchTraceSpan) -> str:
+    """Flatten a span to a string for leak assertions."""
+    return f"{span.name}|{span.attributes}"
+
+
+class _ConcreteHttpConnector(HttpConnector):
+    """Minimal concrete subclass sending a bearer auth header."""
+
+    product = "test-http"
+
+    async def auth_headers(self, target: Any, operator: Operator) -> dict[str, str]:
+        return {"Authorization": f"Bearer {operator.raw_jwt}"}
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+async def _fetch_trace(audit_id: UUID) -> tuple[DispatchTrace | None, list[DispatchTraceSpan]]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        header = (
+            await s.execute(select(DispatchTrace).where(DispatchTrace.audit_id == audit_id))
+        ).scalar_one_or_none()
+        if header is None:
+            return None, []
+        spans = list(
+            (
+                await s.execute(
+                    select(DispatchTraceSpan)
+                    .where(DispatchTraceSpan.trace_id == header.id)
+                    .order_by(DispatchTraceSpan.seq.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return header, spans
+
+
+async def _run_get(
+    conn: _ConcreteHttpConnector,
+    *,
+    operator: Operator,
+    target: Any,
+    op_id: str,
+    audit_id: UUID,
+    path: str = "/api/items",
+) -> Any:
+    """Open a capture scope, run one GET through the seam, close the scope."""
+    handle = await capture.begin_dispatch_capture(
+        audit_id=audit_id,
+        operator=operator,
+        target=target,
+        descriptor=_descriptor(op_id),
+        connector_id="test-http-1.x",
+    )
+    try:
+        return await conn._get_json(target, path, operator=operator)
+    finally:
+        await capture.end_dispatch_capture(handle)
+
+
+# ---------------------------------------------------------------------------
+# Vendor-call span: happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vendor_call_span_captured_and_redacted() -> None:
+    tenant_id = await _seed_tenant(slug="fr-cap-basic")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"items": [1, 2, 3]})
+        result = await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    assert result == {"items": [1, 2, 3]}
+    header, spans = await _fetch_trace(audit_id)
+    assert header is not None
+    assert header.redaction_uncertain is False
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.span_kind == "vendor_call"
+    assert span.status == "200"
+    assert span.name == "GET https://vcenter.example.com/api/items"
+    assert span.duration_ms is not None
+    assert span.attributes["method"] == "GET"
+    assert span.attributes["op_id"] == "svc.items.list"
+    # The auth header is stripped unread by the allowlist (fail-closed F2).
+    assert "authorization" not in span.attributes["request_headers"]
+    # A non-secret response body round-trips redacted.
+    assert span.attributes["response_body"] == {"items": [1, 2, 3]}
+    assert span.attributes["body_recorded"] is True
+
+
+@pytest.mark.asyncio
+async def test_vendor_call_span_carries_no_query_string_in_url() -> None:
+    """The URL is stripped to the request line -- no query values leak."""
+    tenant_id = await _seed_tenant(slug="fr-cap-query")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"ok": True})
+        handle = await capture.begin_dispatch_capture(
+            audit_id=audit_id,
+            operator=operator,
+            target=target,
+            descriptor=_descriptor("svc.items.list"),
+            connector_id="test-http-1.x",
+        )
+        try:
+            await conn._request_json(
+                target, "GET", "/api/items", operator=operator, params={"token": "sekret"}
+            )
+        finally:
+            await capture.end_dispatch_capture(handle)
+    await conn.aclose()
+
+    _, spans = await _fetch_trace(audit_id)
+    assert len(spans) == 1
+    assert "sekret" not in span_json(spans[0])
+    assert "?" not in spans[0].attributes["url"]
+
+
+# ---------------------------------------------------------------------------
+# F3 caps -- body truncation forces redaction-uncertainty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oversize_response_body_truncates_and_marks_uncertain() -> None:
+    tenant_id = await _seed_tenant(slug="fr-cap-trunc")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+    huge = {"blob": "x" * 80_000}  # serializes to >64 KB
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json=huge)
+        await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    header, spans = await _fetch_trace(audit_id)
+    assert header is not None
+    # Truncation ⇒ redaction uncertainty (the engine's rule) ⇒ operator-only.
+    assert header.redaction_uncertain is True
+    assert len(spans) == 1
+    assert spans[0].attributes["truncated"] is True
+    assert spans[0].attributes["response_body"] == BODY_OMITTED_MARKER
+
+
+# ---------------------------------------------------------------------------
+# F2 hard-excluded families -- a login/token op never records a body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secret_family_op_excludes_body() -> None:
+    tenant_id = await _seed_tenant(slug="fr-cap-secret")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    handle = await capture.begin_dispatch_capture(
+        audit_id=audit_id,
+        operator=operator,
+        target=target,
+        descriptor=_descriptor("svc.session.login"),
+        connector_id="test-http-1.x",
+    )
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.post("/login").respond(200, json={"token": "top-secret-value"})
+        try:
+            await conn._post_json(
+                target, "/login", operator=operator, verb="POST", json={"password": "hunter2"}
+            )
+        finally:
+            await capture.end_dispatch_capture(handle)
+    await conn.aclose()
+
+    header, spans = await _fetch_trace(audit_id)
+    assert header is not None
+    # A *placed* secret family is a certain omission -- body blank, not uncertain.
+    assert header.redaction_uncertain is False
+    assert len(spans) == 1
+    assert spans[0].attributes["body_recorded"] is False
+    assert spans[0].attributes["request_body"] == SECRET_FAMILY_OMITTED_MARKER
+    assert spans[0].attributes["response_body"] == SECRET_FAMILY_OMITTED_MARKER
+    assert "top-secret-value" not in span_json(spans[0])
+    assert "hunter2" not in span_json(spans[0])
+
+
+# ---------------------------------------------------------------------------
+# F1 -- capture disabled records nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_capture_off_records_nothing() -> None:
+    tenant_id = await _seed_tenant(slug="fr-cap-off", enabled=False)
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"items": [1]})
+        result = await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    assert result == {"items": [1]}
+    header, spans = await _fetch_trace(audit_id)
+    assert header is None
+    assert spans == []
+
+
+@pytest.mark.asyncio
+async def test_global_kill_switch_records_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLIGHT_RECORDER_ENABLED", "false")
+    get_settings.cache_clear()
+    tenant_id = await _seed_tenant(slug="fr-cap-kill")  # tenant is ON ...
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"items": [1]})
+        await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    # ... but the global kill switch overrides it (F1 precedence).
+    header, _ = await _fetch_trace(audit_id)
+    assert header is None
+
+
+# ---------------------------------------------------------------------------
+# F3 caps -- span-count and trace-byte overflow collapse (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def _span(kind: str = "vendor_call", *, attributes: dict[str, Any] | None = None) -> SpanInput:
+    return SpanInput(
+        span_kind=kind,
+        name="span",
+        started_at=datetime.now(UTC),
+        attributes=attributes or {},
+    )
+
+
+def test_span_count_cap_collapses_overflow() -> None:
+    scope = capture._CaptureScope(audit_id=uuid.uuid4(), tenant_id=uuid.uuid4(), target_id=None)
+    for _ in range(55):
+        scope.add(_span())
+    assert len(scope.spans) == 50
+    assert scope.overflow["vendor_call"] == 5
+    scope.finalize(datetime.now(UTC))
+    collapsed = [s for s in scope.spans if s.attributes.get("collapsed")]
+    assert len(collapsed) == 1
+    assert collapsed[0].attributes["collapsed_count"] == 5
+    assert collapsed[0].span_kind == "vendor_call"
+
+
+def test_trace_byte_cap_collapses_overflow() -> None:
+    scope = capture._CaptureScope(audit_id=uuid.uuid4(), tenant_id=uuid.uuid4(), target_id=None)
+    big = {"blob": "x" * (600 * 1024)}  # ~600 KB each
+    for _ in range(3):
+        scope.add(_span(attributes=big))
+    # First admitted; the next two would breach the 1 MB trace cap -> collapse.
+    assert len(scope.spans) == 1
+    assert scope.overflow["vendor_call"] == 2
+    scope.finalize(datetime.now(UTC))
+    collapsed = [s for s in scope.spans if s.attributes.get("collapsed")]
+    assert collapsed[0].attributes["collapsed_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# F7 -- a forced recorder failure never breaks the connector call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f7_redaction_failure_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A redaction fault drops the span but leaves the connector result intact."""
+
+    def _boom(**_kwargs: Any) -> Any:
+        raise RuntimeError("redaction engine down")
+
+    monkeypatch.setattr(capture, "redact_span", _boom)
+    tenant_id = await _seed_tenant(slug="fr-cap-f7-redact")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"items": [1, 2, 3]})
+        result = await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    assert result == {"items": [1, 2, 3]}  # byte-identical, no exception propagated
+    _, spans = await _fetch_trace(audit_id)
+    assert spans == []  # the span was dropped, not leaked
+
+
+@pytest.mark.asyncio
+async def test_f7_caps_failure_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caps/accounting fault drops the span but leaves the result intact."""
+
+    def _boom(_span: Any) -> int:
+        raise RuntimeError("caps module down")
+
+    monkeypatch.setattr(capture, "approx_span_bytes", _boom)
+    tenant_id = await _seed_tenant(slug="fr-cap-f7-caps")
+    conn = _ConcreteHttpConnector()
+    operator = _make_operator(tenant_id)
+    target = _make_target()
+    audit_id = uuid.uuid4()
+
+    async with respx.mock(base_url=_BASE_URL) as mock:
+        mock.get("/api/items").respond(200, json={"items": [7]})
+        result = await _run_get(
+            conn, operator=operator, target=target, op_id="svc.items.list", audit_id=audit_id
+        )
+    await conn.aclose()
+
+    assert result == {"items": [7]}

--- a/backend/tests/test_flight_recorder_capture_dispatch.py
+++ b/backend/tests/test_flight_recorder_capture_dispatch.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder capture through the full dispatch path (#3214).
+
+Drives the real :func:`meho_backplane.operations.dispatch` to prove:
+
+* **composite sub-step spans** land under the **one** parent trace (no second
+  trace is created for a child dispatch);
+* the **JSONFlux reduction span** is emitted when the reducer mints a handle;
+* the **F7 invariant** -- a forced ``record_trace`` failure leaves the dispatch
+  result byte-identical and the audit row committed.
+
+Shares the typed-op registration harness the dispatcher tests use (in-memory
+SQLite, recording broadcast publisher, autouse reset), plus a capture-enabled
+seeded tenant so ``should_capture`` returns True.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    DispatchTrace,
+    DispatchTraceSpan,
+    EndpointDescriptor,
+    Tenant,
+)
+from meho_backplane.flight_recorder import capture
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.operations import dispatch, register_typed_operation, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture(autouse=True)
+def _capture_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+@pytest.fixture
+def jsonflux_reducer() -> Iterator[None]:
+    """Swap the real :class:`JsonFluxReducer` in as the dispatcher default.
+
+    The v0.2 dispatcher default is :class:`PassThroughReducer` (never reduces),
+    so the reduction-span path only fires with the real reducer installed.
+    """
+    set_default_reducer(JsonFluxReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Handlers (module-level so composite ``handler_ref`` resolves via importlib)
+# ---------------------------------------------------------------------------
+
+
+async def _child_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"echo": params}
+
+
+async def _two_child_composite(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: Any,
+) -> dict[str, Any]:
+    a = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "a"})
+    b = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "b"})
+    return {"a": a.status, "b": b.status}
+
+
+async def _large_list_handler(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    return {"items": [{"n": i} for i in range(60)]}
+
+
+async def _simple_handler(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    return {"ok": True, "value": 42}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_capture_tenant(slug: str) -> UUID:
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        s.add(Tenant(id=tenant_id, slug=slug, name=slug, flight_recorder_enabled=True))
+        await s.commit()
+    return tenant_id
+
+
+def _make_operator(tenant_id: UUID) -> Operator:
+    return Operator(
+        sub="op-capture",
+        name="Cap",
+        email=None,
+        raw_jwt="<jwt>",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeTarget:
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "vault"
+        self.fingerprint = type("_F", (), {"version": None})()
+        self.preferred_impl_id: str | None = None
+        self.id = target_id or uuid.uuid4()
+        self.name = "cap-target"
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+class _NoOpVaultConnector(Connector):
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+async def _insert_composite_descriptor(
+    *, session: AsyncSession, op_id: str, handler_ref: str, embedding: list[float]
+) -> None:
+    session.add(
+        EndpointDescriptor(
+            id=uuid.uuid4(),
+            tenant_id=None,
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=op_id,
+            source_kind="composite",
+            method=None,
+            path=None,
+            handler_ref=handler_ref,
+            summary=f"Composite {op_id}.",
+            description=f"Composite {op_id}.",
+            tags=[],
+            parameter_schema={"type": "object"},
+            response_schema=None,
+            llm_instructions=None,
+            safety_level="safe",
+            requires_approval=False,
+            is_enabled=True,
+            embedding=embedding,
+            custom_description=None,
+            custom_notes=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+
+async def _traces() -> list[DispatchTrace]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        return list((await s.execute(select(DispatchTrace))).scalars().all())
+
+
+async def _spans(trace_id: UUID) -> list[DispatchTraceSpan]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        return list(
+            (
+                await s.execute(
+                    select(DispatchTraceSpan)
+                    .where(DispatchTraceSpan.trace_id == trace_id)
+                    .order_by(DispatchTraceSpan.seq.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Composite sub-step spans land under one parent trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_composite_substeps_under_one_parent_trace(
+    stub_embedding_service: AsyncMock, session: AsyncSession
+) -> None:
+    tenant_id = await _seed_capture_tenant("fr-disp-composite")
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.list",
+        handler=_child_handler,
+        summary="List.",
+        description="List.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    await _insert_composite_descriptor(
+        session=session,
+        op_id="vault.composite.two",
+        handler_ref="tests.test_flight_recorder_capture_dispatch._two_child_composite",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id="vault.composite.two",
+        target=_FakeTarget(),
+        params={},
+    )
+    assert result.status == "ok", result.error
+
+    # Exactly one trace -- the children joined the parent, no second trace.
+    traces = await _traces()
+    assert len(traces) == 1
+    trace = traces[0]
+
+    # The trace hangs off the parent (root) audit row.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        parent = (
+            await s.execute(select(AuditLog).where(AuditLog.path == "vault.composite.two"))
+        ).scalar_one()
+    assert trace.audit_id == parent.id
+    assert parent.parent_audit_id is None
+
+    spans = await _spans(trace.id)
+    step_spans = [s for s in spans if s.span_kind == "composite_step"]
+    assert len(step_spans) == 2
+    assert {s.attributes["op_id"] for s in step_spans} == {"vault.kv.list"}
+
+
+# ---------------------------------------------------------------------------
+# JSONFlux reduction span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jsonflux_reduction_span_recorded(
+    stub_embedding_service: AsyncMock,
+    jsonflux_reducer: None,
+) -> None:
+    tenant_id = await _seed_capture_tenant("fr-disp-flux")
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.big.list",
+        handler=_large_list_handler,
+        summary="Big list.",
+        description="Big list.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id="vault.big.list",
+        target=_FakeTarget(),
+        params={},
+    )
+    assert result.status == "ok", result.error
+    assert result.handle is not None  # the reducer minted a handle
+
+    traces = await _traces()
+    assert len(traces) == 1
+    spans = await _spans(traces[0].id)
+    flux = [s for s in spans if s.span_kind == "jsonflux_reduction"]
+    assert len(flux) == 1
+    assert flux[0].attributes["input_rows"] == 60
+    assert "n" in flux[0].attributes["kept_fields"]
+    assert flux[0].attributes["handle"]
+
+
+# ---------------------------------------------------------------------------
+# F7 -- a forced record_trace failure leaves the dispatch + audit intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f7_forced_record_trace_failure_leaves_dispatch_and_audit_intact(
+    stub_embedding_service: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tenant_id = await _seed_capture_tenant("fr-disp-f7")
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.simple.read",
+        handler=_simple_handler,
+        summary="Simple.",
+        description="Simple.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    async def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("trace store down")
+
+    monkeypatch.setattr(capture, "record_trace", _boom)
+
+    result = await dispatch(
+        operator=_make_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id="vault.simple.read",
+        target=_FakeTarget(),
+        params={},
+    )
+
+    # The dispatch result is byte-identical to the un-instrumented shape ...
+    assert result.status == "ok", result.error
+    assert result.result == {"ok": True, "value": 42}
+
+    # ... the audit row still committed ...
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        audit_count = (
+            await s.execute(
+                select(func.count())
+                .select_from(AuditLog)
+                .where(AuditLog.path == "vault.simple.read")
+            )
+        ).scalar_one()
+    assert audit_count == 1
+
+    # ... and the forced failure left no trace (swallowed, not raised).
+    assert await _traces() == []


### PR DESCRIPTION
Closes #3214

Implements the **capture seam** plus the **F3 caps** and **F7 failure invariant** of
`docs/decisions/dispatch-flight-recorder.md`, composing the storage substrate (#3212) and
the fail-closed redaction engine (#3213) into span production on the **existing** single
dispatch path — no parallel execution path.

## What's in scope
- **Generic vendor-call spans** wrap the shared httpx seam on `HttpConnector._request_json` /
  `_post_json` (`connectors/adapters/http.py`): method, URL (stripped to its request line so
  query/userinfo secrets never leak), status, duration, and **redacted, capped** headers/bodies.
  Recorded before `raise_for_status` so vendor 4xx/5xx bodies are captured too.
- **Composite sub-step spans**: a child dispatch re-enters `dispatch()` and joins the **one**
  parent trace via a shared capture scope bound at the root — no second trace, no new machinery.
  A per-dispatch op-context contextvar means a child's vendor call is redacted against the
  *child's* op family (a child session-mint's body is excluded correctly, not the parent's).
- **JSONFlux reduction span** from `JsonFluxReducer.reduce()`: input rows → kept fields →
  output size → handle id (metadata only, no vendor bytes).
- Wiring at `dispatcher._execute_and_audit` (body extracted into `_execute_and_audit_inner`):
  the scope opens before the branch runs and persists in `finally` after the audit row commits.

## Invariants
- **Capture-before-redaction is absolute** — every header/body passes through the #3213
  `redact_span` before a byte reaches a `SpanInput`; the trace inherits the OR of every span's
  redaction-uncertainty verdict (F5 operator-only degrade).
- **F3 caps at capture**: 64 KB/span body (truncation ⇒ forced redaction-uncertainty),
  1 MB/trace, ~50 spans/dispatch with overflow collapsing into counted per-kind groups.
  Oversize truncates, never errors.
- **F7**: capture is best-effort — every entry point swallows its own errors, the disabled
  path is a single contextvar read, and the trace is persisted on the store's best-effort path
  after the audit commits. A test proves a forced recorder failure leaves the dispatch result
  byte-identical and the audit row committed.
- Respects the F1 config + global kill switch (captures nothing when disabled).

Operator/agent read surfaces (#3215/#3216) and typed-connector span instrumentation (#3217)
remain sibling tasks; this does **not** close #3207.

## New module split (for the 600-line file cap)
`flight_recorder/capture.py` (scope lifecycle + entry points) and
`flight_recorder/_capture_util.py` (pure, never-raising helpers).

## Tests
- 13 new tests (`test_flight_recorder_capture.py` ×10, `test_flight_recorder_capture_dispatch.py` ×3)
  covering vendor-call redaction, URL query-stripping, body truncation → uncertainty, secret-family
  body exclusion, tenant-off / global-kill-switch, span-count + trace-byte overflow collapse,
  composite one-parent-trace, JSONFlux span, and the F7 forced-failure invariant (redaction / caps /
  record_trace raising).
- Broad regression sweep across 17 affected/adjacent modules: 493 passed. ruff + ruff format + mypy
  clean on all touched files.

## Adversarial review
Reviewed cold against F7 propagation, capture-before-redaction leaks, cap bypasses, composite
double-trace, and kill-switch respect. **One F7 finding fixed**: the JSONFlux `kept_fields`
extraction ran inside `reduce()` (which `_reduce_or_error` wraps), so a malformed schema could
have turned a dispatch success into a `connector_error` — moved to a fully isinstance-guarded
`_flux_kept_fields` helper that can never raise. Re-verified green. **Verdict: APPROVE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)