### PR TITLE
feat(connectors): first governed delete — vmware.composite.vm.destroy on the destructive tier (#3198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,38 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — first governed delete: `vmware.composite.vm.destroy` on the destructive tier + conformance (evoila-bosnia/meho-internal#3183 / #3198)
+
+- Models the **first real delete family** into the `destructive` safety
+  tier (decision `docs/decisions/governed-delete-operations.md`,
+  requirement 1). `vmware.composite.vm.destroy` permanently deletes a
+  powered-off VM and all its disks, `safety_level="destructive"` +
+  `requires_approval=True` — the 24th vmware write composite and the first
+  destructive one. **Fail-closed** on a running VM (`status="not_powered_off"`,
+  no implicit power-off) and **dual-arm** (pre-9.0 vim `Destroy_Task`,
+  task-polled; 9.0+ synchronous REST `DELETE:/vcenter/vm/{vm}`). A bespoke
+  preview builder populates the mandatory blast-radius block: object identity
+  (moid / name / power state), enumerated disks (with capacities), NICs, and
+  best-effort snapshots, irreversibility class `permanent`.
+- **Closes three human-side gaps** the tier left. `_non_agent_verdict` now
+  parks the destructive tier for **every** non-agent principal
+  unconditionally (a USER dispatching a `requires_approval=False` destructive
+  op previously auto-executed). `_check_self_approval` refuses self-approval
+  of a destructive row even under `APPROVAL_ALLOW_SELF_APPROVAL` (break-glass
+  does not reach this tier). Registration (`_register_in_session`) fail-fasts
+  a `destructive` descriptor declared `requires_approval=False`.
+- **Composite ops are now previewable when destructive**, so the #3197
+  preview-hash binding reaches the composite surface: `preview_dispatch`
+  binds the logical request tuple (redacted params on the `redacted_body`
+  slot) for a destructive non-ingested op, keeping the hash param-sensitive
+  while every non-destructive typed/composite op keeps its `unavailable`
+  contract.
+- Conformance (`tests/test_connectors_vmware_rest_vm_destroy.py`): agent
+  `DENY`, `ServicePrincipalGrant` refusal, no self-approval under break-glass,
+  satellite mint `OP_NOT_SAFE`, dispatch refused without a matching hash,
+  park refused without a blast-radius block, and the full preview → parked
+  approval (hash + blast radius) → **human** approve → audited resume flow.
+
 ### Added — add-on pairing contract proof plane: reference double, unpaired conformance, versioned-contract docs + trust-model review (#3030)
 
 - Closes Initiative #2900's proof-plane DoD. Adds a reference add-on **test

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 32 composites land before
+``endpoint_descriptor`` upserts for the 33 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -31,7 +31,7 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 23 write composites (G3.1-T6 / #509, the guest-ops write
+* 24 write composites (G3.1-T6 / #509, the guest-ops write
   ``vm.guest.file.write`` / #3100, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
@@ -43,7 +43,9 @@ Scope:
   three host-domain writes ``host.datastore_mount_nfs`` /
   ``host.disk_mark_flash`` / ``host.service_control`` / #3182) -- inherit
   T4's ``safety_level="dangerous"`` +
-  ``requires_approval=True`` defaults.
+  ``requires_approval=True`` defaults. The 24th, the destructive-tier
+  ``vm.destroy`` / #3198, is the first ``safety_level="destructive"``
+  composite (still ``requires_approval=True``) — the governed-delete tier.
   They cover every state-mutating workflow Goal #214 names as
   required for govc-wrapper retirement: ``vm.create``, ``vm.clone``,
   ``vm.clone_from_template`` (folder-template clone via CloneVM_Task,
@@ -97,6 +99,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_create_composite,
     vm_customize_composite,
     vm_deploy_from_library_composite,
+    vm_destroy_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -114,8 +117,9 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 19 write composites' park-time
-# ``proposed_effect`` preview builders (#1608) onto the per-op hook in
+# Side-effect import: registers the 24 write composites' park-time
+# ``proposed_effect`` preview builders (#1608, destructive-tier
+# blast-radius #3198) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
 from meho_backplane.connectors.vmware_rest.composites import _write_preview  # noqa: E402,F401
@@ -146,6 +150,7 @@ __all__ = [
     "vm_create_composite",
     "vm_customize_composite",
     "vm_deploy_from_library_composite",
+    "vm_destroy_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 32 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 33 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -28,8 +28,8 @@ The 9 read composites (T5 / #508 + the 4 guest-ops reads
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 23 write
-composites (T6 / #509, single-VM ``vm.power`` / #2301, the guest-ops
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) 23 of the 24
+write composites (T6 / #509, single-VM ``vm.power`` / #2301, the guest-ops
 write ``vm.guest.file.write`` / #3100, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
 ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
@@ -41,7 +41,11 @@ OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909, and the
 three host-domain writes ``host.datastore_mount_nfs`` /
 ``host.disk_mark_flash`` / ``host.service_control`` / #3182) inherit
 the T4 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity
-at the call site; the helper would default to those values anyway).
+at the call site; the helper would default to those values anyway). The
+24th write composite, ``vm.destroy`` / #3198, is the first
+``safety_level="destructive"`` op (still ``requires_approval=True``) — the
+governed-delete tier (decision
+``docs/decisions/governed-delete-operations.md``).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
 ``requires_approval`` so the policy posture is implied by the row,
 not by global state.
@@ -84,6 +88,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_create_composite,
     vm_customize_composite,
     vm_deploy_from_library_composite,
+    vm_destroy_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -142,6 +147,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_CUSTOMIZE_RESPONSE_SCHEMA,
     VM_DEPLOY_FROM_LIBRARY_PARAMETER_SCHEMA,
     VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA,
+    VM_DESTROY_PARAMETER_SCHEMA,
+    VM_DESTROY_RESPONSE_SCHEMA,
     VM_DEVICE_CDROM_PARAMETER_SCHEMA,
     VM_DEVICE_CDROM_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
@@ -557,6 +564,35 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         group_key="vm",
         tags=["composite", "write", "vm", "snapshot"],
         safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.destroy",
+        handler=vm_destroy_composite,
+        summary="Permanently destroy (delete) a powered-off VM and all its disks.",
+        description=(
+            "The FIRST governed destructive delete (#3198), decision "
+            "docs/decisions/governed-delete-operations.md. Permanently "
+            "destroys a VM and all of its virtual disks. Marked "
+            "safety_level='destructive' — the hardest gate MEHO has: "
+            "mandatory human approval always (no agent path, no standing "
+            "grant, no self-approval even under break-glass), a mandatory "
+            "preview-hash binding, and a mandatory blast-radius statement "
+            "(object identity + enumerated disks/NICs/snapshots + "
+            "irreversibility class) the four-eyes approver reads before "
+            "deciding. Fail-closed on a running VM: a VM that is not "
+            "POWERED_OFF is refused with status='not_powered_off' and never "
+            "powered off implicitly. Dual arm (like vm.create): a resolvable "
+            "pre-9.0 vCenter routes through the vim VirtualMachine.Destroy_Task "
+            "(task-polled); 9.0+ (and unresolved) issues the synchronous REST "
+            "DELETE:/vcenter/vm/{vm}. Equivalent of 'govc vm.destroy' for "
+            "governed operator-facing dispatch."
+        ),
+        parameter_schema=VM_DESTROY_PARAMETER_SCHEMA,
+        response_schema=VM_DESTROY_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle", "destroy", "destructive"],
+        safety_level="destructive",
         requires_approval=True,
     ),
     _CompositeSpec(
@@ -1207,8 +1243,9 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 32 composites total -- 9 read (T5 / #508 + the 4 guest-ops
-    reads / #3100) + 23 write (T6 /
+    Scope: 33 composites total -- 9 read (T5 / #508 + the 4 guest-ops
+    reads / #3100) + 24 write (T6 / #509 + the destructive-tier
+    ``vm.destroy`` / #3198,
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -625,6 +625,10 @@ _VIM_SUB_OPS_FOLDER_CREATE: tuple[str, ...] = (_OP_CREATE_FOLDER,)
 #   list, but still served by the pinned spec and the only shape that
 #   directly carries the vm -> destination-host migration pairs.
 _OP_REVERT_TO_SNAPSHOT_TASK = "POST:/VirtualMachineSnapshot/{moId}/RevertToSnapshot_Task"
+# The pre-9.0 vim destroy arm (#3198). ``VirtualMachine.Destroy_Task`` is the
+# core vim delete method (task-polled); the 9.0+ arm uses the synchronous REST
+# ``DELETE:/vcenter/vm/{vm}`` (:data:`_OP_DELETE_VM`) instead.
+_OP_DESTROY_VM_TASK = "POST:/VirtualMachine/{moId}/Destroy_Task"
 _OP_ENTER_MAINTENANCE_TASK = "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task"
 _OP_EXIT_MAINTENANCE_TASK = "POST:/HostSystem/{moId}/ExitMaintenanceMode_Task"
 _OP_RECONFIGURE_DVS_TASK = "POST:/DistributedVirtualSwitch/{moId}/ReconfigureDvs_Task"
@@ -645,6 +649,7 @@ _MAINTENANCE_VIM_TIMEOUT: Final[int] = 0
 # task poll -- the 600s ``vm.disk.grow`` / ``vm.clone_from_template``
 # convention.
 _SNAPSHOT_REVERT_TASK_TIMEOUT_SECONDS = 600.0
+_VM_DESTROY_TASK_TIMEOUT_SECONDS = 600.0
 _MAINTENANCE_TASK_TIMEOUT_SECONDS = 600.0
 _DVS_RECONFIGURE_TASK_TIMEOUT_SECONDS = 600.0
 _HOST_APPLY_TASK_TIMEOUT_SECONDS = 600.0
@@ -659,6 +664,12 @@ _VIM_SUB_OPS_VM_SNAPSHOT_REVERT: tuple[str, ...] = (
     _OP_REVERT_TO_SNAPSHOT_TASK,
 )
 _VIM_SUB_OPS_VM_MIGRATE: tuple[str, ...] = (_OP_RETRIEVE_PROPERTIES,)
+#: vm.destroy's pre-9.0 vim arm (#3198): the ``Destroy_Task`` delete plus the
+#: best-effort snapshot ``RetrievePropertiesEx`` the blast-radius preview reads.
+_VIM_SUB_OPS_VM_DESTROY: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_DESTROY_VM_TASK,
+)
 _VIM_SUB_OPS_HOST_EVACUATE: tuple[str, ...] = (
     _OP_RETRIEVE_PROPERTIES,
     _OP_ENTER_MAINTENANCE_TASK,
@@ -2800,6 +2811,188 @@ async def vm_snapshot_revert_composite(
         "status": "reverted",
         "snapshot_id": snapshot_moid,
         "candidates": [],
+        "guidance": None,
+    }
+
+
+# ===========================================================================
+# vm.destroy — the first governed destructive delete (#3198)
+# ===========================================================================
+
+
+def _vim_destroy_required(about_version: str | None) -> bool:
+    """``True`` when the live ``about.version`` major is a resolvable pre-9.0.
+
+    The #3198 destroy arm gate, mirroring :func:`_vim_create_required`
+    (#3099): a resolvable pre-9.0 major routes the destroy through the vim
+    ``VirtualMachine.Destroy_Task`` (task-polled) — the pyvmomi coverage the
+    dual-transport connector keeps for older vCenter, where REST lifecycle
+    coverage is partial (the versioned-connector posture). 9.0+ — and an
+    unresolved version — issue the synchronous REST ``DELETE:/vcenter/vm/{vm}``
+    unchanged.
+    """
+    major = about_version.split(".", 1)[0].strip() if about_version else ""
+    return major.isdigit() and int(major) < 9
+
+
+async def _read_vm_snapshots_best_effort(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    vm_moid: str,
+) -> list[dict[str, Any]]:
+    """Best-effort snapshot enumeration for the destroy blast radius (#3198).
+
+    Reads ``VirtualMachine.snapshot`` via the vim ``RetrievePropertiesEx``
+    (the pinned REST spec serves no snapshot resource, #2970) and flattens
+    the tree to ``[{snapshot, name, ...}]`` via :func:`_flatten_snapshot_tree`.
+    A transport fault, or an absent/empty snapshot tree, yields ``[]`` — the
+    enumeration is a reviewer convenience on the blast radius, never
+    load-bearing for the park, so it degrades to "no snapshots enumerated"
+    rather than sinking the whole preview.
+    """
+    try:
+        tree_result = await connector._post_vmomi_json(
+            target,
+            _VMOMI_RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=_build_single_prop_retrieve_params(
+                _VIRTUAL_MACHINE_MO_TYPE, vm_moid, _PROP_SNAPSHOT
+            ),
+        )
+    except httpx.HTTPError:
+        return []
+    snapshot_info = _extract_single_prop(tree_result, _PROP_SNAPSHOT)
+    root_list = snapshot_info.get("rootSnapshotList") if isinstance(snapshot_info, dict) else None
+    return _flatten_snapshot_tree(root_list)
+
+
+async def vm_destroy_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Permanently destroy (delete) a powered-off VM and all of its disks.
+
+    Op-id: ``vmware.composite.vm.destroy``. The FIRST governed destructive
+    delete (#3198) — ``safety_level="destructive"``, so it rides the hardest
+    gate MEHO has (decision ``docs/decisions/governed-delete-operations.md``):
+    mandatory human approval (no agent path, no standing grant, no
+    self-approval even under break-glass), a mandatory preview-hash binding,
+    and a mandatory blast-radius statement (built by
+    :func:`._write_preview._vm_destroy_preview`).
+
+    **Fail-closed on a running VM.** vSphere faults a destroy on a VM that is
+    not powered off, so the composite live-re-reads the power state and
+    refuses with ``status="not_powered_off"`` unless the VM is
+    ``POWERED_OFF``. It issues **no implicit power-off** — powering the VM
+    down is a separate, deliberate decision the operator makes through the
+    governed ``vmware.composite.vm.power`` op first. The re-read happens at
+    dispatch time (post-approval), so a VM powered on between park and
+    approval is still refused.
+
+    **Dual arm** (mirrors :func:`vm_create_composite`): a resolvable pre-9.0
+    ``about.version`` routes the destroy through the vim
+    ``VirtualMachine.Destroy_Task`` (task-polled via the governed
+    :func:`_write_vmomi_sub_op` seam, like ``vm.disk.grow`` #2893); 9.0+ (and
+    an unresolved version) issues the synchronous REST
+    ``DELETE:/vcenter/vm/{vm}`` (:func:`_write_sub_op`). A task fault raises
+    (the dispatcher wraps it ``connector_error``); a poll timeout returns
+    ``status="timeout"`` with the task id.
+    """
+    vm_moid = params["vm"]
+
+    # Fail-closed power-state re-read (post-approval): a running VM faults the
+    # destroy at the vendor, and the composite never powers it off implicitly.
+    info = await _read_vm_info(
+        connector=connector, target=target, operator=operator, vm_moid=vm_moid
+    )
+    if info is None:
+        return {
+            "status": "not_found",
+            "vm_id": None,
+            "power_state": None,
+            "arm": None,
+            "task_id": None,
+            "guidance": f"vm {vm_moid!r} not found or unreadable; nothing destroyed",
+        }
+    power_state = info.get("power_state")
+    if power_state != "POWERED_OFF":
+        return {
+            "status": "not_powered_off",
+            "vm_id": vm_moid,
+            "power_state": power_state,
+            "arm": None,
+            "task_id": None,
+            "guidance": (
+                f"refusing to destroy vm {vm_moid!r} in power state {power_state!r} "
+                "(vSphere faults a destroy on a VM that is not powered off); power "
+                "it off first via vmware.composite.vm.power — the destroy issues no "
+                "implicit power-off"
+            ),
+        }
+
+    about_version = await connector._about_version(target, operator)
+    if _vim_destroy_required(about_version):
+        gate, task_payload = await _write_vmomi_sub_op(
+            connector,
+            target,
+            operator,
+            op_id=_OP_DESTROY_VM_TASK,
+            vmomi_path=f"/{_VIRTUAL_MACHINE_MO_TYPE}/{vm_moid}/Destroy_Task",
+            body={},
+            params={"vm": vm_moid},
+        )
+        if gate is not None:
+            return gate
+        outcome = await poll_vim_task(
+            connector,
+            target,
+            operator,
+            task=_unwrap_value(task_payload),
+            timeout_seconds=_VM_DESTROY_TASK_TIMEOUT_SECONDS,
+        )
+        if outcome.state == TASK_STATE_ERROR:
+            raise RuntimeError(
+                f"vm.destroy: Destroy_Task on vm {vm_moid!r} faulted: "
+                f"{outcome.error_message or '<no fault reported>'}"
+            )
+        if outcome.timed_out:
+            return {
+                "status": "timeout",
+                "vm_id": vm_moid,
+                "power_state": power_state,
+                "arm": "vim",
+                "task_id": outcome.task,
+                "guidance": (
+                    f"Destroy_Task {outcome.task} did not reach a terminal state "
+                    f"within {int(_VM_DESTROY_TASK_TIMEOUT_SECONDS)}s; poll the task — "
+                    "the destroy may still complete in the background"
+                ),
+            }
+        return {
+            "status": "destroyed",
+            "vm_id": vm_moid,
+            "power_state": power_state,
+            "arm": "vim",
+            "task_id": outcome.task,
+            "guidance": None,
+        }
+
+    gate, _payload = await _write_sub_op(
+        connector, target, operator, _OP_DELETE_VM, {"vm": vm_moid}
+    )
+    if gate is not None:
+        return gate
+    return {
+        "status": "destroyed",
+        "vm_id": vm_moid,
+        "power_state": power_state,
+        "arm": "rest",
+        "task_id": None,
         "guidance": None,
     }
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -996,9 +996,7 @@ async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         vm_moid=vm,
     )
     for snap in snapshots:
-        children.append(
-            {"kind": "snapshot", "id": snap.get("snapshot"), "name": snap.get("name")}
-        )
+        children.append({"kind": "snapshot", "id": snap.get("snapshot"), "name": snap.get("name")})
     return {
         "blast_radius": {
             "object": {

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -152,6 +152,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     _read_cdrom,
     _read_ethernet_nic,
     _read_vm_info,
+    _read_vm_snapshots_best_effort,
     _resolve_cluster_hosts,
     _resolve_cluster_name,
     _resolve_disk_info,
@@ -185,6 +186,25 @@ def _vm_identity(row: dict[str, Any]) -> dict[str, Any]:
 def _host_identity(row: dict[str, Any]) -> dict[str, Any]:
     """Identity-only projection of a cluster-host listing row."""
     return {key: row[key] for key in ("host", "name") if row.get(key) is not None}
+
+
+def _map_items(value: Any) -> list[tuple[str, Any]]:
+    """Yield ``(id, detail)`` pairs from a vCenter ``map<id, Info>`` field.
+
+    vCenter serialises map fields (``Vm.Info.disks`` / ``Vm.Info.nics``)
+    either as a JSON object (modern ``/api``) or as a list of
+    ``{"key", "value"}`` pairs (legacy ``/rest``). Normalises both to a list
+    of ``(id, detail)`` tuples; any other shape yields ``[]``.
+    """
+    if isinstance(value, dict):
+        return [(str(key), detail) for key, detail in value.items()]
+    if isinstance(value, list):
+        items: list[tuple[str, Any]] = []
+        for entry in value:
+            if isinstance(entry, dict) and "key" in entry:
+                items.append((str(entry["key"]), entry.get("value")))
+        return items
+    return []
 
 
 def _capped_resolution(
@@ -923,11 +943,82 @@ async def _guest_file_write_preview(ctx: PreviewContext) -> dict[str, Any] | Non
     }
 
 
-#: op_id → builder for the 23 write composites. Module-level so the
+async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.destroy`` — the mandatory destructive-tier blast radius (#3198).
+
+    The load-bearing destructive-tier builder: it populates the
+    ``blast_radius`` block the park gate requires
+    (:func:`~meho_backplane.operations._preview.blast_radius_missing_reason`)
+    — object identity, enumerated child objects, irreversibility class — so
+    the four-eyes approver reads *exactly what dies* before deciding. The
+    dispatcher promotes this ``blast_radius`` sub-dict to the top of
+    ``proposed_effect`` (#3197).
+
+    Live-reads the VM's ``Vm.Info`` (identity + power state + disks with
+    capacities + NICs, one read-only GET via the shared
+    :func:`._write._read_vm_info`) and best-effort enumerates snapshots (vim
+    ``RetrievePropertiesEx`` via :func:`._write._read_vm_snapshots_best_effort`).
+    Declines (``None`` → identifier-only default → the park is refused
+    ``blast_radius_required``, fail-closed) without a resolved connector or
+    when the VM cannot be read. The destroy sub-op never fires here.
+    """
+    vm = ctx.params.get("vm")
+    if not isinstance(vm, str) or ctx.connector_instance is None:
+        return None
+    info = await _read_vm_info(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+    )
+    if info is None:
+        return None
+    children: list[dict[str, Any]] = []
+    for disk_id, disk in _map_items(info.get("disks")):
+        entry: dict[str, Any] = {"kind": "disk", "id": disk_id}
+        capacity = disk.get("capacity") if isinstance(disk, dict) else None
+        if isinstance(capacity, int) and not isinstance(capacity, bool):
+            entry["capacity_bytes"] = capacity
+        label = disk.get("label") if isinstance(disk, dict) else None
+        if isinstance(label, str):
+            entry["label"] = label
+        children.append(entry)
+    for nic_id, nic in _map_items(info.get("nics")):
+        nic_entry: dict[str, Any] = {"kind": "nic", "id": nic_id}
+        mac = nic.get("mac_address") if isinstance(nic, dict) else None
+        if isinstance(mac, str):
+            nic_entry["mac_address"] = mac
+        children.append(nic_entry)
+    snapshots = await _read_vm_snapshots_best_effort(
+        ctx.connector_instance,  # type: ignore[arg-type]
+        ctx.target,
+        ctx.operator,
+        vm_moid=vm,
+    )
+    for snap in snapshots:
+        children.append(
+            {"kind": "snapshot", "id": snap.get("snapshot"), "name": snap.get("name")}
+        )
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "vm",
+                "moid": vm,
+                "name": info.get("name"),
+                "power_state": info.get("power_state"),
+            },
+            "children": children,
+            "irreversibility": "permanent",
+        },
+    }
+
+
+#: op_id → builder for the 24 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.guest.file.write": _guest_file_write_preview,
     "vmware.composite.vm.create": _vm_create_preview,
+    "vmware.composite.vm.destroy": _vm_destroy_preview,
     "vmware.composite.vm.clone": _vm_clone_preview,
     "vmware.composite.vm.deploy_from_library": _vm_deploy_from_library_preview,
     "vmware.composite.vm.clone_from_template": _vm_clone_from_template_preview,
@@ -953,7 +1044,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 23 write-composite park-time preview builders. Import-time.
+    """Wire the 24 write-composite park-time preview builders. Import-time.
 
     The 9 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -25,7 +25,7 @@ Conventions
   schema verbatim on ``describe_operation`` calls.
 * The 9 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 23 write composites inherit T4's
+  each. 23 of the 24 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
   (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, the mutating
   VI-JSON ``vm.disk.grow`` / #2893, the folder-template
@@ -33,8 +33,10 @@ Conventions
   writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895,
   the #2891 hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
   ``vm.device.cdrom``, and the two GOSC composites
-  ``guest.customization_spec.create`` / ``vm.customize`` / #2892). The schema
-  text reflects which side of that line
+  ``guest.customization_spec.create`` / ``vm.customize`` / #2892). The 24th,
+  ``vm.destroy`` / #3198, is the first ``safety_level="destructive"``
+  composite (still ``requires_approval=True``) — the governed-delete tier.
+  The schema text reflects which side of that line
   each composite sits on; the registration call site enforces the
   policy.
 """
@@ -91,6 +93,8 @@ __all__ = [
     "VM_CREATE_RESPONSE_SCHEMA",
     "VM_CUSTOMIZE_PARAMETER_SCHEMA",
     "VM_CUSTOMIZE_RESPONSE_SCHEMA",
+    "VM_DESTROY_PARAMETER_SCHEMA",
+    "VM_DESTROY_RESPONSE_SCHEMA",
     "VM_DEVICE_CDROM_PARAMETER_SCHEMA",
     "VM_DEVICE_CDROM_RESPONSE_SCHEMA",
     "VM_DISK_GROW_PARAMETER_SCHEMA",
@@ -1012,6 +1016,30 @@ VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA: dict[str, Any] = {
 }
 
 
+#: ``vmware.composite.vm.destroy`` parameter schema (#3198).
+#:
+#: The first governed destructive delete. A single required ``vm`` moid —
+#: the destroy takes no ``force`` flag: a powered-on VM is refused
+#: (``status='not_powered_off'``), never implicitly powered off, and the
+#: mandatory human approval is the confirmation, not a param.
+VM_DESTROY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Target VM moid to permanently destroy. The VM must be "
+                "POWERED_OFF — a running VM is refused with "
+                "``status='not_powered_off'`` (no implicit power-off)."
+            ),
+        },
+    },
+    "required": ["vm"],
+    "additionalProperties": False,
+}
+
+
 #: ``vmware.composite.vm.migrate`` parameter schema.
 #:
 #: DRS-deferred relocation. No-recommendation path returns
@@ -1570,6 +1598,50 @@ VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA: dict[str, Any] = {
         "guidance": {
             "type": ["string", "null"],
             "description": ("Operator hint on ambiguous/not_found; ``null`` on successful revert."),
+        },
+    },
+    "required": ["status"],
+}
+
+
+#: ``vmware.composite.vm.destroy`` response schema (#3198).
+VM_DESTROY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["destroyed", "not_powered_off", "not_found", "timeout"],
+            "description": (
+                "``'destroyed'`` on a successful delete; ``'not_powered_off'`` "
+                "when the VM is not POWERED_OFF (refused fail-closed, no "
+                "implicit power-off); ``'not_found'`` when the VM cannot be "
+                "read; ``'timeout'`` when the vim Destroy_Task poll deadline "
+                "elapsed (the destroy may still complete in the background)."
+            ),
+        },
+        "vm_id": {
+            "type": ["string", "null"],
+            "description": "The destroyed VM's moid; ``null`` on not_found.",
+        },
+        "power_state": {
+            "type": ["string", "null"],
+            "description": "The VM's power state at dispatch time (the fail-closed gate reads it).",
+        },
+        "arm": {
+            "type": ["string", "null"],
+            "enum": ["vim", "rest", None],
+            "description": (
+                "Which delete arm ran: ``'vim'`` (pre-9.0 Destroy_Task) or "
+                "``'rest'`` (9.0+ DELETE:/vcenter/vm/{vm}); ``null`` when refused."
+            ),
+        },
+        "task_id": {
+            "type": ["string", "null"],
+            "description": "The vim Destroy_Task moid on the vim arm; ``null`` on the REST arm.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": "Operator hint on refusal/timeout; ``null`` on a successful destroy.",
         },
     },
     "required": ["status"],

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -106,6 +106,39 @@ def compute_preview_hash(envelope: Mapping[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _preview_unavailable_envelope(
+    *,
+    op_id: str,
+    connector_id: str,
+    source_kind: str,
+) -> dict[str, Any]:
+    """Structured ``unavailable`` envelope for a non-previewable typed/composite op.
+
+    A ``typed`` / ``composite`` op runs a Python handler with no single
+    literal HTTP request to preview. (A ``destructive`` composite is the
+    exception — it is routed to :func:`_build_composite_preview` instead of
+    here, #3198.)
+    """
+    return {
+        "status": "unavailable",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": source_kind,
+        "error": (
+            f"preview_unavailable: op {op_id!r} is source_kind="
+            f"{source_kind!r}, not an HTTP-ingested op -- it "
+            "runs a typed/composite handler with no single literal HTTP "
+            "request to preview. The dispatch-request preview covers "
+            "source_kind='ingested' ops only."
+        ),
+        "extras": {
+            "error_code": "preview_unavailable",
+            "reason": "not_ingested",
+            "source_kind": source_kind,
+        },
+    }
+
+
 def _invalid_op_schema_envelope(
     *,
     op_id: str,
@@ -193,25 +226,19 @@ async def _resolve_previewable_descriptor(
     # A ``typed`` / ``composite`` op invokes a Python handler (which may
     # itself make zero or many HTTP calls, or none); there is no one
     # method/path/body to preview. Say so explicitly rather than fabricate.
-    if descriptor.source_kind != "ingested":
-        return {
-            "status": "unavailable",
-            "op_id": op_id,
-            "connector_id": connector_id,
-            "source_kind": descriptor.source_kind,
-            "error": (
-                f"preview_unavailable: op {op_id!r} is source_kind="
-                f"{descriptor.source_kind!r}, not an HTTP-ingested op -- it "
-                "runs a typed/composite handler with no single literal HTTP "
-                "request to preview. The dispatch-request preview covers "
-                "source_kind='ingested' ops only."
-            ),
-            "extras": {
-                "error_code": "preview_unavailable",
-                "reason": "not_ingested",
-                "source_kind": descriptor.source_kind,
-            },
-        }
+    #
+    # #3198 exception: the ``destructive`` tier MUST be previewable, because
+    # the governed-delete gate refuses to park a destructive op unless a
+    # ``preview_operation`` of the identical tuple bound a matching hash
+    # (decision requirement 2). A composite/typed destructive op has no
+    # literal HTTP request, so its preview binds the logical request tuple
+    # (params on the ``redacted_body`` slot) instead — see
+    # :func:`_build_composite_preview`. Scoped to ``destructive`` so every
+    # non-destructive typed/composite op keeps the "unavailable" contract.
+    if descriptor.source_kind != "ingested" and descriptor.safety_level != "destructive":
+        return _preview_unavailable_envelope(
+            op_id=op_id, connector_id=connector_id, source_kind=descriptor.source_kind
+        )
 
     # --- Step 3: parameter_schema validation (mirrors dispatch) -----------
     try:
@@ -410,6 +437,60 @@ def _ok_ingested_envelope(
     return envelope
 
 
+#: Sentinel ``method`` for a destructive composite/typed preview (#3198) —
+#: there is no HTTP verb, but the slot is one of the hashed keys, so a
+#: constant keeps the hash stable while the params on ``redacted_body`` make
+#: it param-sensitive.
+_COMPOSITE_PREVIEW_METHOD: Final[str] = "COMPOSITE"
+
+
+def _build_composite_preview(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the params-bound preview for a ``destructive`` non-ingested op (#3198).
+
+    A composite / typed op has no single literal HTTP request, so the
+    preview-hash binding (decision ``governed-delete-operations.md``
+    requirement 2) binds the *logical request tuple* instead: the redacted
+    params ride the ``redacted_body`` slot, so :func:`compute_preview_hash`
+    — unchanged — is param-sensitive (two different deletes hash
+    differently) while ``method`` (a ``COMPOSITE`` sentinel) and
+    ``resolved_path`` (the ``op_id``) name the op. Only reached for the
+    ``destructive`` tier (the gate in :func:`_resolve_previewable_descriptor`),
+    so the non-destructive typed/composite surface keeps its
+    ``"unavailable"`` contract. No handler runs and nothing is sent — this
+    is a pure request-shape projection.
+    """
+    redacted_body = _redact_request_body(
+        params, connector_id=connector_id, operator=operator, op_id=op_id
+    )
+    _log.info(
+        "preview_dispatch_composite",
+        connector_id=connector_id,
+        op_id=op_id,
+        source_kind=descriptor.source_kind,
+        safety_level=descriptor.safety_level,
+        tenant_id=str(operator.tenant_id),
+    )
+    envelope: dict[str, Any] = {
+        "status": "ok",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": descriptor.source_kind,
+        "method": _COMPOSITE_PREVIEW_METHOD,
+        "resolved_path": op_id,
+        "query": None,
+        "redacted_body": redacted_body,
+    }
+    envelope["preview_hash"] = compute_preview_hash(envelope)
+    return envelope
+
+
 async def preview_dispatch(
     *,
     operator: Operator,
@@ -470,6 +551,16 @@ async def preview_dispatch(
     )
     if isinstance(resolved, dict):
         return resolved  # structured unknown_op / unavailable / invalid_params
+    if resolved.source_kind != "ingested":
+        # A destructive composite/typed op cleared the previewability gate
+        # (#3198) — bind the logical request tuple, no handler runs.
+        return _build_composite_preview(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            descriptor=resolved,
+            params=params,
+        )
     return await _build_ingested_preview(
         operator=operator,
         connector_id=connector_id,

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -267,7 +267,22 @@ async def _non_agent_verdict(
     is_service = operator.principal_kind is PrincipalKind.SERVICE
 
     gate_reason: str | None = None
-    if descriptor.requires_approval:
+    if descriptor.safety_level == "destructive":
+        # #3198: the destructive tier is mandatory-human-approval for EVERY
+        # non-agent principal — it parks regardless of ``requires_approval``
+        # and regardless of principal kind. Without this branch a USER
+        # dispatching a destructive op declared ``requires_approval=False``
+        # would auto-execute below (the safety_level→park mapping lived only
+        # on the ``elif is_service`` branch), bypassing the preview-hash +
+        # blast-radius gate entirely. No standing grant can pre-clear it
+        # either: ``consult_and_record_grant`` refuses the destructive tier
+        # (decision ``governed-delete-operations.md`` requirement 1).
+        gate_reason = (
+            "safety_level=destructive; mandatory human approval — every "
+            "non-agent principal parks (routed to the approval queue), never "
+            "auto-executes, and no standing grant can pre-clear it (#3183)"
+        )
+    elif descriptor.requires_approval:
         gate_reason = "requires_approval is True; routed to the approval queue (G11.7-T1)"
     elif is_service:
         gate_reason = _service_safety_gate_reason(descriptor)

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -1140,6 +1140,15 @@ def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
     comparison is on the stable ``sub`` claim, so a renamed display name
     cannot launder a self-approval.
 
+    **The destructive tier does not honour break-glass (#3198).** For a
+    ``safety_level="destructive"`` request self-approval is refused
+    *unconditionally* — even under ``APPROVAL_ALLOW_SELF_APPROVAL`` — so a
+    governed delete is genuine four-eyes on every deployment (decision
+    ``governed-delete-operations.md`` requirement 1: "no self-approval, even
+    under break-glass"; a single-operator tenant uses the agent-requester
+    pattern, never self-approval). The tier is read off the durable
+    ``proposed_effect`` envelope the dispatcher stamped at park time.
+
     Imported lazily to keep the queue module decoupled from settings at
     import time (mirrors the local ``TenantRole`` import in
     :func:`_check_reviewer_role`).
@@ -1147,9 +1156,12 @@ def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
     if operator.sub != request.principal_sub:
         return
 
+    effect = request.proposed_effect or {}
+    is_destructive = effect.get("safety_level") == "destructive"
+
     from meho_backplane.settings import get_settings
 
-    if get_settings().approval_allow_self_approval:
+    if not is_destructive and get_settings().approval_allow_self_approval:
         _log.warning(
             "approval_self_approval_break_glass",
             approval_request_id=str(request.id),

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -1401,6 +1401,21 @@ async def _register_in_session(
     so ORM-side defaults (``id``, ``created_at``, ``updated_at``) are
     populated even when the caller defers the commit.
     """
+    # #3198 fail-fast: the destructive tier is human-approval-always by
+    # construction, so a descriptor that declares ``safety_level="destructive"``
+    # with ``requires_approval=False`` is inconsistent — it would (absent the
+    # dispatcher's own destructive park) invite the auto-execute path. Refuse
+    # it at registration time rather than let an ill-declared row exist. This
+    # is belt-and-suspenders with the runtime guarantee in
+    # ``_non_agent_verdict`` (which parks the destructive tier for every
+    # non-agent principal regardless of this flag).
+    if safety_level == "destructive" and not requires_approval:
+        raise ValueError(
+            f"op {op_id!r} declares safety_level='destructive' but "
+            "requires_approval=False; the destructive tier is "
+            "human-approval-always — register it with requires_approval=True"
+        )
+
     log = structlog.get_logger()
     now = datetime.now(UTC)
 

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -473,6 +473,66 @@ def test_vm_disk_grow_vi_json_paths_exist_in_the_pinned_spec() -> None:
 
 
 # ---------------------------------------------------------------------------
+# vm.destroy VI-JSON sub-op reconciliation (#3198)
+# ---------------------------------------------------------------------------
+#
+# vm.destroy's pre-9.0 delete arm is vi-json, not vcenter REST:
+# ``POST:/VirtualMachine/{moId}/Destroy_Task`` (the core vim delete) plus the
+# best-effort snapshot ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx``
+# the blast-radius preview reads. These are declared in
+# ``_write._VIM_SUB_OPS_VM_DESTROY`` (deliberately NOT in the ``_SUB_OPS_*``
+# namespace, so the vcenter.yaml sweep skips them). The 9.0+ arm is the
+# synchronous REST ``DELETE:/vcenter/vm/{vm}`` — a plain vcenter.yaml path.
+
+
+def test_vm_destroy_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
+    """Pin the destroy vi-json manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_VM_DESTROY) == {
+        "POST:/VirtualMachine/{moId}/Destroy_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+
+
+def test_vm_destroy_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The destroy vi-json op_ids are byte-for-byte what the parser emits."""
+    required = set(_write._VIM_SUB_OPS_VM_DESTROY)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_vm_destroy_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each destroy vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    ``VirtualMachine.Destroy_Task`` is a core vim25 method; the definitive
+    #3198 grounding is that the connector's pre-9.0 delete arm targets a path
+    the pinned spec serves. Skips when the spec-shelf is not configured (the
+    canary's convention), so CI — where the env vars are wired — is the
+    operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_VM_DESTROY:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "destroy vi-json sub-op targets a path the spec does not serve"
+        )
+
+
+# ---------------------------------------------------------------------------
 # vm.clone_from_template VI-JSON sub-op reconciliation (#2894)
 # ---------------------------------------------------------------------------
 #

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -196,8 +196,8 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 32 total: 9 reads
-    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 23 writes (T6 #509 +
+    # Embedding service called once per composite -- 33 total: 9 reads
+    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 24 writes (T6 #509 +
     # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     # folder-template vm.clone_from_template #2894 + vim cluster/inventory
     # writes cluster.drs_rule.create + folder.create #2895 + the #2891
@@ -205,10 +205,11 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # create/apply #2892 + OVF/OVA content-library deploy
     # vm.deploy_from_library #2909 + the three host-domain writes
     # host.datastore_mount_nfs / host.disk_mark_flash / host.service_control
-    # #3182 + the guest-ops write vm.guest.file.write #3100). (The former
+    # #3182 + the guest-ops write vm.guest.file.write #3100 + the
+    # destructive-tier vm.destroy #3198). (The former
     # host.network_uplinks / host.vsan_health reads were re-shipped as typed
     # ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 32
+    assert stub_embedding_service.encode_one.call_count == 33
 
 
 @pytest.mark.asyncio
@@ -455,22 +456,23 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> read rows persist; embedding stays at 32.
+    """Running the registrar twice -> read rows persist; embedding stays at 33.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
     persist after the combined registrar (9 reads incl. the 4 guest-ops
-    reads #3100 + 23 writes / T6 + single-VM vm.power #2301 + mutating
+    reads #3100 + 24 writes / T6 + single-VM vm.power #2301 + mutating
     VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
     #2894 + vim cluster/inventory writes cluster.drs_rule.create +
     folder.create #2895 + the #2891 hardware writes vm.resize /
     vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
     content-library deploy vm.deploy_from_library #2909 + the three
-    host-domain writes #3182 + guest-ops write vm.guest.file.write #3100).
+    host-domain writes #3182 + guest-ops write vm.guest.file.write #3100 +
+    the destructive-tier vm.destroy #3198).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 32
+    assert first_count == 33
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -559,7 +559,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 32 composite rows the registrar upserts. Reaching a business status
+    the 33 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -77,6 +77,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.vm.deploy_from_library",
         "vmware.composite.vm.clone_from_template",
         "vmware.composite.vm.snapshot.revert",
+        "vmware.composite.vm.destroy",
         "vmware.composite.vm.migrate",
         "vmware.composite.vm.power",
         "vmware.composite.vm.power.bulk",
@@ -306,14 +307,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 23 write composites register a builder (criterion 4)
+# Wiring — all 24 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 23
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 24
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -10,15 +10,17 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 23 expected write ``op_id`` rows land in ``endpoint_descriptor``
-  with ``source_kind="composite"``, ``safety_level="dangerous"``,
-  ``requires_approval=True`` (T4's defaults intentionally inherited).
+* All 24 expected write ``op_id`` rows land in ``endpoint_descriptor``
+  with ``source_kind="composite"``, ``requires_approval=True``, and
+  ``safety_level="dangerous"`` (T4's defaults intentionally inherited) —
+  except the destructive-tier ``vm.destroy`` / #3198, which is
+  ``safety_level="destructive"``.
 * Each row's ``handler_ref`` resolves to the module-level dotted path
   in ``composites/_write``.
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` per the canary's stub-LLM taxonomy.
 * Combined with the 9 read composites (#508's 5 + the 4 guest-ops
-  reads / #3100), the registrar produces **32 rows** total. (The former
+  reads / #3100), the registrar produces **33 rows** total. (The former
   host.network_uplinks / host.vsan_health reads were re-shipped as typed
   ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
@@ -69,18 +71,20 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 23 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 24 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
-# hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom, and the
-# GOSC composites guest.customization_spec.create + vm.customize / #2892).
+# hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom, the
+# GOSC composites guest.customization_spec.create + vm.customize / #2892,
+# and the destructive-tier vm.destroy / #3198).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
     "vmware.composite.vm.deploy_from_library",
     "vmware.composite.vm.clone_from_template",
     "vmware.composite.vm.snapshot.revert",
+    "vmware.composite.vm.destroy",
     "vmware.composite.vm.migrate",
     "vmware.composite.vm.power",
     "vmware.composite.vm.power.bulk",
@@ -119,11 +123,12 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
 )
 
-# 32 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 23 write
+# 33 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 24 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
-# writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892).
+# writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892
+# + the destructive-tier vm.destroy / #3198).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -142,6 +147,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.vm.snapshot.revert": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_snapshot_revert_composite"
+    ),
+    "vmware.composite.vm.destroy": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_destroy_composite"
     ),
     "vmware.composite.vm.migrate": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_migrate_composite"
@@ -207,6 +215,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.deploy_from_library": "vm",
     "vmware.composite.vm.clone_from_template": "vm",
     "vmware.composite.vm.snapshot.revert": "vm",
+    "vmware.composite.vm.destroy": "vm",
     "vmware.composite.vm.migrate": "vm",
     "vmware.composite.vm.power": "vm",
     "vmware.composite.vm.power.bulk": "vm",
@@ -268,7 +277,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 23 write composites land alongside the 9 reads (32 total)
+# 24 write composites land alongside the 9 reads (33 total)
 # ---------------------------------------------------------------------------
 
 
@@ -276,7 +285,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_all_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 23 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 24 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -293,14 +302,15 @@ async def test_register_vmware_composite_operations_inserts_all_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_twenty_nine_composite_rows(
+async def test_full_registration_produces_thirty_three_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """9 reads (#508 + guest-ops reads #3100) + 23 writes (#509 + vm.power #2301 +
+    """9 reads (#508 + guest-ops reads #3100) + 24 writes (#509 + vm.power #2301 +
     vm.disk.grow #2893 + vm.clone_from_template #2894 + cluster.drs_rule.create +
     folder.create #2895 + #2891 hardware writes vm.resize / vm.nic.repoint /
     vm.device.cdrom + GOSC create/apply #2892 + OVF deploy #2909 + host-domain
-    writes #3182 + guest-ops write vm.guest.file.write #3100) = 32 rows. DoD bar."""
+    writes #3182 + guest-ops write vm.guest.file.write #3100 + destructive-tier
+    vm.destroy #3198) = 33 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -314,7 +324,7 @@ async def test_full_registration_produces_twenty_nine_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 32
+    assert len(rows) == 33
 
 
 @pytest.mark.asyncio
@@ -327,6 +337,10 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
     every dispatch. A misconfigured read-override would silently
     permit unauthenticated mutation; pinning the policy here means CI
     catches a regression before lifespan-startup.
+
+    The one exception is the destructive-tier ``vm.destroy`` (#3198): it is
+    ``safety_level="destructive"`` (a strictly harder tier than
+    ``dangerous``), still ``requires_approval=True``.
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
@@ -340,12 +354,15 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 18 write rows before iterating —
+    # Prove the query actually returned all 24 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
-        assert row.safety_level == "dangerous", (
-            f"{row.op_id}: expected dangerous, got {row.safety_level!r}"
+        expected_level = (
+            "destructive" if row.op_id == "vmware.composite.vm.destroy" else "dangerous"
+        )
+        assert row.safety_level == expected_level, (
+            f"{row.op_id}: expected {expected_level}, got {row.safety_level!r}"
         )
         assert row.requires_approval is True, (
             f"{row.op_id}: expected requires_approval=True, got {row.requires_approval!r}"
@@ -613,17 +630,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_twenty_nine(
+async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 32 rows total, embedding called 32x once."""
+    """Running the registrar twice -> 33 rows total, embedding called 33x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 32
+    assert first_count == 33
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 32.
+    # pipeline; the row count stays at 33.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -637,7 +654,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_twenty_
             .scalars()
             .all()
         )
-    assert len(rows) == 32
+    assert len(rows) == 33
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_vm_destroy.py
+++ b/backend/tests/test_connectors_vmware_rest_vm_destroy.py
@@ -1,0 +1,733 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Conformance tests for the first governed destructive delete (#3198).
+
+``vmware.composite.vm.destroy`` is the first ``safety_level="destructive"``
+op modeled into the tier decided in
+``docs/decisions/governed-delete-operations.md``. These tests prove the
+hardest gate MEHO has holds on every surface *for this op*:
+
+* **No agent execution path** — an AGENT principal is DENY'd (never parks,
+  never runs).
+* **No standing-grant path** — ``ServicePrincipalGrant`` refuses the op.
+* **No self-approval, even under ``APPROVAL_ALLOW_SELF_APPROVAL``** — the
+  destructive tier ignores the break-glass switch.
+* **No satellite mint** — the gateway refuses with ``OP_NOT_SAFE``.
+* **Dispatch refused without a matching preview hash** and **park refused
+  without a blast-radius block** (the #3197 binding, now reachable on the
+  composite surface).
+* The **full governed flow**: preview → parked approval carrying the hash +
+  blast radius → a *distinct human* approves → audited resume executes the
+  delete. Plus the fail-closed power-state gate, the dual arm, and the two
+  structural gaps this task closed (USER auto-execute, registration
+  fail-fast).
+
+Fixtures mirror ``test_connectors_vmware_rest_composites_write_e2e.py`` (the
+recording connector double seeded as the resolved instance, the autouse-
+migrated SQLite engine, the deterministic embedding stub).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
+from meho_backplane.connectors.vmware_rest.composites import register_vmware_composite_operations
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.operations.typed_register import register_composite_operation
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "vmware-rest-9.0"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003198")
+_OP_ID = "vmware.composite.vm.destroy"
+_VM = "vm-1"
+_PARAMS: dict[str, Any] = {"vm": _VM}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(
+    *,
+    sub: str = "op-destroy",
+    principal_kind: PrincipalKind = PrincipalKind.USER,
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="VM Destroy Conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "9.0") -> None:
+        self.version = version
+
+
+class _FakeVmwareTarget:
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "vmware"
+        self.fingerprint = _FakeFingerprint(version="9.0")
+        self.preferred_impl_id: str | None = "vmware-rest"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = "test-vcenter"
+        self.host = "vcenter.test"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+def _retrieve_result(obj_type: str, moid: str, prop: str, val: Any) -> dict[str, Any]:
+    return {
+        "objects": [
+            {"obj": {"type": obj_type, "value": moid}, "propSet": [{"name": prop, "val": val}]}
+        ]
+    }
+
+
+def _task_moref(value: str) -> dict[str, str]:
+    return {"type": "Task", "value": value}
+
+
+class _RecordingVmwareConnector:
+    """Records the sub-calls the destroy composite + its preview issue."""
+
+    _MOUNT = "/api"
+
+    def __init__(self, *, about_version: str | None = None) -> None:
+        self.responses: dict[str, Any] = {}
+        self.vmomi_responses: dict[str, Any] = {}
+        self.calls: list[tuple[str, str]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+        self._about = about_version
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _about_version(self, target: Any, operator: Operator) -> str | None:
+        del target, operator
+        return self._about
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append(("GET", spec))
+        return self.responses.get(spec, {"value": {}})
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+        timeout: Any = None,
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append((verb, spec))
+        return self.responses.get(spec, {"value": {}})
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/RetrievePropertiesEx"):
+            spec_type = json["specSet"][0]["propSet"][0]["type"]
+            if spec_type in self.vmomi_responses:
+                return self.vmomi_responses[spec_type]
+            if spec_type == "Task":
+                task_moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+                return _retrieve_result("Task", task_moid, "info", {"state": "success"})
+            raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+        return self.vmomi_responses[path]
+
+
+def _seed_connector(recorder: _RecordingVmwareConnector) -> None:
+    register_connector_v2(
+        product="vmware", version="9.0", impl_id="vmware-rest", cls=VmwareRestConnector
+    )
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
+
+
+async def _bootstrap(
+    recorder: _RecordingVmwareConnector, stub_embedding_service: AsyncMock
+) -> None:
+    _seed_connector(recorder)
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+
+
+def _powered_off_vm(**overrides: Any) -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "name": "doomed-vm",
+        "power_state": "POWERED_OFF",
+        "disks": {"disk-2000": {"capacity": 42949672960, "label": "Hard disk 1"}},
+        "nics": {"nic-4000": {"mac_address": "00:50:56:aa:bb:cc"}},
+    }
+    info.update(overrides)
+    return info
+
+
+def _seed_vm_reads(
+    recorder: _RecordingVmwareConnector, *, vm: str = _VM, **info_overrides: Any
+) -> None:
+    """Seed the VM.Info REST read + an empty snapshot vim read the preview needs."""
+    recorder.responses[f"/vcenter/vm/{vm}"] = {"value": _powered_off_vm(**info_overrides)}
+    recorder.vmomi_responses["VirtualMachine"] = _retrieve_result(
+        "VirtualMachine", vm, "snapshot", {}
+    )
+
+
+async def _seed_target(name: str = "test-vcenter") -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=name,
+                aliases=[],
+                product="vmware",
+                host="vcenter.test",
+                port=443,
+                fqdn=None,
+                secret_ref=None,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "9.0"},
+                preferred_impl_id="vmware-rest",
+                notes="seeded by test_connectors_vmware_rest_vm_destroy",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _pending_count() -> int:
+    from sqlalchemy import func, select
+
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+# ---------------------------------------------------------------------------
+# The op is registered destructive + requires_approval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_op_registered_destructive_requires_approval(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    recorder = _RecordingVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+    async with get_sessionmaker()() as s:
+        from sqlalchemy import select
+
+        row = (
+            await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == _OP_ID))
+        ).scalar_one()
+    assert row.safety_level == "destructive"
+    assert row.requires_approval is True
+    assert row.source_kind == "composite"
+
+
+# ---------------------------------------------------------------------------
+# The full governed flow (the keystone)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_preview_park_approve_resume(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """preview → park (hash + blast radius) → distinct human approve → resume DELETE."""
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder)
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+
+    # 1) Preview binds a param-sensitive hash even though the op is a composite.
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    bound_hash = preview["preview_hash"]
+    assert isinstance(bound_hash, str) and len(bound_hash) == 64
+
+    # 2) Governed call presenting the bound hash parks; nothing executed.
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert all(verb == "GET" for verb, _ in recorder.calls), recorder.calls  # no write pre-approval
+
+    # 3) The parked row carries the bound hash + the blast-radius statement.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    blast = effect["blast_radius"]
+    assert blast["object"] == {
+        "kind": "vm",
+        "moid": _VM,
+        "name": "doomed-vm",
+        "power_state": "POWERED_OFF",
+    }
+    assert {
+        "kind": "disk",
+        "id": "disk-2000",
+        "capacity_bytes": 42949672960,
+        "label": "Hard disk 1",
+    } in blast["children"]
+    assert {"kind": "nic", "id": "nic-4000", "mac_address": "00:50:56:aa:bb:cc"} in blast[
+        "children"
+    ]
+    assert blast["irreversibility"] == "permanent"
+
+    # 4) A DIFFERENT operator approves (four-eyes) — the binding re-verifies.
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    # 5) Audited resume → the REST delete executes exactly once (9.0 arm).
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "destroyed"
+    assert resume.result["arm"] == "rest"
+    assert ("DELETE", "/vcenter/vm/vm-1") in recorder.calls
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2 — dispatch refused without a matching preview hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refused_without_preview_hash(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder)
+    await _bootstrap(recorder, stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeVmwareTarget(),
+        params=_PARAMS,
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert recorder.calls == [] or all(v == "GET" for v, _ in recorder.calls)
+    assert await _pending_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3 — park refused without a blast-radius block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_park_refused_without_blast_radius(stub_embedding_service: AsyncMock) -> None:
+    """When the VM can't be read the builder declines → no blast radius → refused."""
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    # VM.Info read returns a non-dict → _read_vm_info None → builder returns None.
+    recorder.responses[f"/vcenter/vm/{_VM}"] = {"value": None}
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert await _pending_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# No agent execution path — an AGENT principal is DENY'd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_principal_is_denied(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder)
+    await _bootstrap(recorder, stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeVmwareTarget(),
+        params=_PARAMS,
+    )
+    assert result.status == "denied", result
+    assert recorder.calls == []  # never executed
+    assert await _pending_count() == 0  # never parked either
+
+
+# ---------------------------------------------------------------------------
+# No standing-grant path — ServicePrincipalGrant refuses the op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_grant_refuses_destroy() -> None:
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "destroy" in str(exc.value).lower() or "delete-shaped" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# No self-approval, even under APPROVAL_ALLOW_SELF_APPROVAL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_self_approval_even_under_break_glass(
+    stub_embedding_service: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder)
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Break-glass ON — it does NOT reach the destructive tier.
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+# ---------------------------------------------------------------------------
+# No satellite mint — the gateway refuses with OP_NOT_SAFE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_satellite_mint_refuses_op_not_safe(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on a running VM — refused, no delete, no implicit power-off
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_powered_on_vm_refused_fail_closed(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder, power_state="POWERED_ON")
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "not_powered_off"
+    assert resume.result["power_state"] == "POWERED_ON"
+    # No delete of any kind fired — REST or vim.
+    assert all(verb == "GET" for verb, _ in recorder.calls), recorder.calls
+    assert not any("Destroy_Task" in path for path, _ in recorder.vmomi_calls)
+
+
+# ---------------------------------------------------------------------------
+# Dual arm — a pre-9.0 target routes through the vim Destroy_Task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vim_arm_pre_9_0_destroy_task(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector(about_version="8.0.3")
+    _seed_vm_reads(recorder)
+    recorder.vmomi_responses[f"/VirtualMachine/{_VM}/Destroy_Task"] = _task_moref("task-77")
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "destroyed"
+    assert resume.result["arm"] == "vim"
+    assert resume.result["task_id"] == "task-77"
+    assert any(
+        path.endswith(f"/VirtualMachine/{_VM}/Destroy_Task") for path, _ in recorder.vmomi_calls
+    )
+    # The 9.0-only REST DELETE never fired on the vim arm.
+    assert ("DELETE", "/vcenter/vm/vm-1") not in recorder.calls
+
+
+# ---------------------------------------------------------------------------
+# Structural gap 1 — registration fail-fast: destructive ⇒ requires_approval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registration_rejects_destructive_without_requires_approval(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    from meho_backplane.connectors.vmware_rest.composites._write import vm_destroy_composite
+
+    with pytest.raises(ValueError, match="requires_approval"):
+        await register_composite_operation(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            op_id="vmware.composite.vm.destroy_broken",
+            handler=vm_destroy_composite,
+            summary="broken destructive op",
+            description="a destructive op that (illegally) does not require approval",
+            parameter_schema={"type": "object", "properties": {"vm": {"type": "string"}}},
+            when_to_use=None,
+            group_key=None,
+            safety_level="destructive",
+            requires_approval=False,
+            embedding_service=stub_embedding_service,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Structural gap 2 — a USER never auto-executes a destructive op, even when
+# the descriptor is (mis)declared requires_approval=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_never_auto_executes_destructive_without_requires_approval(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The runtime guarantee: destructive parks for a USER regardless of the flag.
+
+    Registers the op normally (requires_approval=True), then flips the stored
+    descriptor to requires_approval=False directly in the DB — the shape the
+    fail-fast guard would refuse but which a hand-edited row could produce.
+    A USER dispatch presenting the bound hash still PARKS (awaiting_approval),
+    never auto-executes. Without the ``_non_agent_verdict`` destructive branch
+    this would run the delete.
+    """
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    _seed_vm_reads(recorder)
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    from sqlalchemy import update
+
+    async with get_sessionmaker()() as s:
+        await s.execute(
+            update(EndpointDescriptor)
+            .where(EndpointDescriptor.op_id == _OP_ID)
+            .values(requires_approval=False)
+        )
+        await s.commit()
+    reset_dispatcher_caches()
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": "test-vcenter",
+        "params": _PARAMS,
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+
+    assert call["status"] == "awaiting_approval", call
+    assert all(verb == "GET" for verb, _ in recorder.calls), recorder.calls  # no write ran
+    assert ("DELETE", "/vcenter/vm/vm-1") not in recorder.calls
+
+
+# ---------------------------------------------------------------------------
+# The composite preview hash is param-sensitive (the #3198 extension)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_composite_preview_hash_is_param_sensitive(stub_embedding_service: AsyncMock) -> None:
+    recorder = _RecordingVmwareConnector(about_version="9.0.0")
+    await _bootstrap(recorder, stub_embedding_service)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    base = {"connector_id": _CONNECTOR_ID, "op_id": _OP_ID, "target": "test-vcenter"}
+
+    p1 = await preview_operation(requester, {**base, "params": {"vm": "vm-1"}})
+    p1b = await preview_operation(requester, {**base, "params": {"vm": "vm-1"}})
+    p2 = await preview_operation(requester, {**base, "params": {"vm": "vm-2"}})
+    assert p1["status"] == "ok"
+    assert p1["preview_hash"] == p1b["preview_hash"]  # stable for identical args
+    assert p1["preview_hash"] != p2["preview_hash"]  # a different delete → different hash

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -614,6 +614,55 @@ reached as a composite subop is a separate governance seam (a follow-up,
 not this task). In practice an agent cannot reach it: the destructive tier
 is `DENY` for agent principals at `resolve_verdict`.
 
+## First governed delete: `vmware.composite.vm.destroy` (#3198)
+
+Requirement 1 of
+[`docs/decisions/governed-delete-operations.md`](../decisions/governed-delete-operations.md)
+— one real delete family modeled into the tier end-to-end. The op is
+`vmware.composite.vm.destroy` (`safety_level="destructive"`,
+`requires_approval=True`; the dual-arm handler + blast-radius preview
+builder are documented in
+[`connectors-vmware-rest.md`](connectors-vmware-rest.md)). Wiring it in
+surfaced — and this task closed — three gaps in the tier's *human*-side
+enforcement that #3196/#3197 left, plus one machinery limitation:
+
+- **A composite/typed op is now previewable when it is `destructive`.**
+  `preview_dispatch` returns `unavailable` for non-ingested ops (they have
+  no single literal HTTP request), which would make the requirement-2 hash
+  binding impossible on the composite surface. The gate in
+  `_resolve_previewable_descriptor` now lets a `destructive` non-ingested op
+  through to `_build_composite_preview`, which binds the *logical request
+  tuple*: the redacted params ride the `redacted_body` slot, so
+  `compute_preview_hash` (unchanged) is param-sensitive while a `COMPOSITE`
+  sentinel `method` + the `op_id` as `resolved_path` name the op. Scoped to
+  `destructive` so every non-destructive typed/composite op keeps its
+  `unavailable` contract.
+- **The USER auto-execute hole.** `_non_agent_verdict` (`operations/_validate.py`)
+  previously parked a human only on `requires_approval`; the
+  `safety_level→park` mapping lived on the service-principal branch alone.
+  A USER dispatching a `destructive` op declared `requires_approval=False`
+  would therefore auto-execute, bypassing the whole gate. The verdict now
+  parks the `destructive` tier for **every** non-agent principal,
+  unconditionally — and no standing grant can pre-clear it
+  (`consult_and_record_grant` already refuses the tier).
+- **The self-approval break-glass hole.** `_check_self_approval`
+  (`operations/approval_queue.py`) honoured `APPROVAL_ALLOW_SELF_APPROVAL`
+  for every tier. It now refuses self-approval of a `destructive` row
+  *unconditionally* — the break-glass switch does not reach this tier
+  (decision requirement 1). A single-operator tenant uses the
+  agent-requester pattern, never self-approval.
+- **Registration fail-fast.** `_register_in_session` (`operations/typed_register.py`)
+  now rejects a `destructive` descriptor declared `requires_approval=False`
+  at registration time — an inconsistent row can't exist. Belt-and-suspenders
+  with the runtime park guarantee above.
+
+Conformance for the op — no agent path (agent verdict `DENY`), no standing
+grant (`ServicePrincipalGrant` refuses), no self-approval even under
+break-glass, no satellite mint (`MintRefusalCode.OP_NOT_SAFE`), dispatch
+refused without a matching hash, park refused without a blast-radius block,
+and the full preview→park→human-approve→audited-resume flow — is pinned in
+`tests/test_connectors_vmware_rest_vm_destroy.py`.
+
 ## Uniform op-identity envelope (#2681)
 
 The preview base varies by outcome — a bespoke `{op_class, preview}`, the

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -12,8 +12,8 @@ vSphere 8.5+ / ESXi 8.5+ targets, plus 32 hand-authored composites
 that orchestrate cross-spec workflows: 9 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`; plus the four guest-operations reads `#3100`) and 23 write
-composites (G3.1-T6 / `#509`, the
+in `#2258`; plus the four guest-operations reads `#3100`) and 24 write
+composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
@@ -235,8 +235,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (`StartProgramInGuest`) is a deliberately deferred tier.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 32
-  `_CompositeSpec` rows (9 read + 23 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 33
+  `_CompositeSpec` rows (9 read + 24 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -366,7 +366,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    queued registrar and upserts: the 32 `vmware.composite.*` rows with
    `source_kind="composite"` (9 reads with `safety_level="safe"` +
    `requires_approval=False`; 23 writes with `safety_level="dangerous"`
-   + `requires_approval=True`), plus the `vmware.host.usage` row with
+   + `requires_approval=True`, and the destructive-tier `vm.destroy` with
+   `safety_level="destructive"` + `requires_approval=True` / `#3198`),
+   plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
    it depends on no ingested descriptor.
@@ -461,7 +463,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 32 composites (9 reads + 23 writes) land as `source_kind="composite"`
+The 33 composites (9 reads + 24 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -528,7 +530,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 32 composites are hand-authored aggregators the connector ships as
+The 33 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -854,6 +856,47 @@ capacity diff (`{vm, name, disk, disk_label, current_capacity_bytes,
 requested_capacity_bytes, delta_bytes}`) — the delta is the decision the
 approver makes; a failing disk read parks with the #1628
 `preview_unavailable` marker (the delta is unknowable).
+
+### Governed destructive delete (`vm.destroy`, #3198)
+
+`vmware.composite.vm.destroy` is the connector's — and MEHO's — **first
+`safety_level="destructive"`** op: the first delete family modeled into the
+governed-delete tier (decision
+[`governed-delete-operations.md`](../decisions/governed-delete-operations.md)).
+Op id: `vmware.composite.vm.destroy` (the reconcile string the teardown
+tooling matches; group `vm`, tags `composite / write / vm / lifecycle /
+destroy / destructive`). Params: one required `vm` moid — no `force` flag,
+because the mandatory human approval *is* the confirmation.
+
+The destructive tier is enforced generically (see
+[`approvals.md`](approvals.md#first-governed-delete-vmwarecompositevmdestroy-3198)):
+mandatory human approval always (agent verdict `DENY`, no standing grant,
+no self-approval even under break-glass), a mandatory preview-hash binding,
+and a mandatory blast-radius block. Two things are connector-specific:
+
+- **Fail-closed on a running VM.** The handler live-re-reads `Vm.Info`
+  (`GET:/vcenter/vm/{vm}`) at dispatch time (post-approval, so a VM powered
+  on between park and approval is still caught) and refuses with
+  `status="not_powered_off"` unless `power_state == "POWERED_OFF"`. It
+  issues **no implicit power-off** — vSphere faults a destroy on a running
+  VM, and powering it down is a separate deliberate decision through
+  `vmware.composite.vm.power`.
+- **Dual arm** (mirrors `vm.create`'s `_vim_create_required` gate). A
+  resolvable pre-9.0 `about.version` routes through the vim
+  `VirtualMachine.Destroy_Task` (task-polled via the governed
+  `_write_vmomi_sub_op` seam, #2893 substrate); 9.0+ (and an unresolved
+  version) issues the synchronous REST `DELETE:/vcenter/vm/{vm}`. The vim
+  arm's `Destroy_Task` + the preview's snapshot `RetrievePropertiesEx` are
+  declared in `_write._VIM_SUB_OPS_VM_DESTROY` and reconciled against the
+  pinned `vi-json.yaml` (the same lane as disk-grow).
+
+The blast-radius preview builder (`_write_preview._vm_destroy_preview`)
+live-reads `Vm.Info` for object identity (moid / name / power state) plus
+the enumerated disks (with capacities) and NICs, and best-effort enumerates
+snapshots via the vim snapshot read (`_read_vm_snapshots_best_effort` — a
+fault yields "no snapshots enumerated", never sinks the park). It declines
+(`None` → the park is refused `blast_radius_required`, fail-closed) when the
+VM cannot be read.
 
 ### Two clone ops: content-library vs folder-template (`vm.clone_from_template`, #2894)
 


### PR DESCRIPTION
## Summary

- Models the **first real governed delete** into the `destructive` safety tier (decision `docs/decisions/governed-delete-operations.md`, requirement 1): **`vmware.composite.vm.destroy`** — the exact registered `op_id` literal (group `vm`, `safety_level="destructive"`, `requires_approval=True`). It permanently deletes a powered-off VM and all its disks; it is the 33rd vmware composite and the first destructive one.
- **Fail-closed on a running VM** (`status="not_powered_off"`, no implicit power-off) and **dual-arm** like `vm.create`: pre-9.0 → vim `VirtualMachine.Destroy_Task` (task-polled via the governed `_write_vmomi_sub_op` seam); 9.0+ → synchronous REST `DELETE:/vcenter/vm/{vm}`. A bespoke preview builder populates the mandatory blast-radius block: object identity (moid/name/power state), enumerated disks (with capacities), NICs, best-effort snapshots, irreversibility `permanent`.
- **Closes three structural gaps** in the destructive tier's human-side enforcement that #3196/#3197 left:
  - **USER auto-execute hole** (the pre-existing gap flagged by #3197's worker): `_non_agent_verdict` now parks the `destructive` tier for **every** non-agent principal unconditionally — previously a USER dispatching a `requires_approval=False` destructive op auto-executed. No standing grant can pre-clear it.
  - **Self-approval break-glass hole**: `_check_self_approval` refuses self-approval of a destructive row even under `APPROVAL_ALLOW_SELF_APPROVAL`.
  - **Registration fail-fast**: `_register_in_session` rejects a `destructive` descriptor declared `requires_approval=False`.
- **Makes composites previewable when destructive** so the #3197 preview-hash binding reaches the composite surface: `preview_dispatch` binds the logical request tuple (redacted params on the `redacted_body` slot) for a destructive non-ingested op; every non-destructive typed/composite op keeps its `unavailable` contract.

## Registered op_id (load-bearing for the teardown pack)

**`vmware.composite.vm.destroy`** — dispatched via `call_operation(connector_id="vmware-rest-9.0", op_id="vmware.composite.vm.destroy", target, params={"vm": "<moid>"})`. The REST arm sends `DELETE:/vcenter/vm/{vm}`; the vim arm sends `POST:/VirtualMachine/{moId}/Destroy_Task`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed modules) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] New conformance suite `tests/test_connectors_vmware_rest_vm_destroy.py` (13 tests): agent verdict `DENY`; `ServicePrincipalGrant` refusal; **no self-approval even under `APPROVAL_ALLOW_SELF_APPROVAL`**; satellite mint `MintRefusalCode.OP_NOT_SAFE`; dispatch refused without a matching preview hash; park refused without a blast-radius block; the **full governed flow** (preview → parked approval carrying hash + blast radius → distinct-human approve → audited resume executes DELETE); powered-on fail-closed; the vim `Destroy_Task` arm; registration fail-fast; the USER-never-auto-executes guarantee; param-sensitive composite hash.
- [x] Count assertions updated in lockstep (32→33 total, 23→24 write) across `_register`/`_write_preview`/`schemas`/`__init__` + the register/write_register/write_preview tests; the "every write row is dangerous" test special-cases destroy as destructive.
- [x] Spec-reconcile lane added for the vim `Destroy_Task` arm (mirrors disk-grow).
- [x] Existing suites re-run green: request_preview, destructive_preview_binding, permission_resolver, service_grants, gateway_commands, approval_queue, ui_approvals, typed_register, composite write_e2e.

## Docs

- `docs/codebase/approvals.md` — the first governed delete + the three gap closures + the composite-preview binding.
- `docs/codebase/connectors-vmware-rest.md` — `vm.destroy` (dual arm, fail-closed power-state, blast-radius builder).

## Out of scope / notes

- The composite-subop park path (`enforce_subop_policy`) is not destructive-gated — unchanged from #3197's scope note (an agent cannot reach it: destructive is `DENY` for agents).
- Adjacent findings: pre-existing file-size warnings on the large connector/operations modules I touched (not introduced here).

Closes #3198
