### PR TITLE
feat(flight-recorder): operator read surface — REST trace endpoint + console drawer pane (#3215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: operator read surface — REST trace endpoint + console drawer pane (#3215)
+
+- Ships the **operator read surface** of the flight-recorder decision
+  (`docs/decisions/dispatch-flight-recorder.md`): an operator (and a paired
+  add-on using its operator-granted principal) can now see, for one governed
+  dispatch, the actual vendor request/response traffic and how the backplane
+  processed it. Two fronts over one tenant-scoped read: a new REST route
+  **`GET /api/v1/audit/{audit_id}/trace`** behind the operator claim (alongside
+  `GET /api/v1/audit/show/{audit_id}`), and a new **Flight recorder** pane in
+  the audit-row console drawer (after Lineage). Both return the ordered spans —
+  vendor calls (method / URL / status / duration), composite sub-steps, and the
+  JSONFlux reduction (input rows → kept fields → output size → handle id) — with
+  the **redacted, capped** headers/bodies and truncation markers the capture
+  and redaction seams (#3213 / #3214) already stored; the read surface renders
+  what is stored and never re-processes, un-redacts, or writes. The **operator
+  plane keeps full access independent of the agent gate** — including
+  redaction-uncertain traces, with the uncertainty flag **surfaced** (a banner
+  in the pane, a `redaction_uncertain` field in the REST body) so an operator
+  sees when a trace was withheld from agents. Absence has two levels: a missing
+  or cross-tenant **audit row** is a `404` (never `403`, matching `/show`, so
+  existence never leaks across tenants); an audit row that exists but carries
+  **no captured trace** is a `200` empty state (capture is per-tenant opt-in and
+  best-effort). Tenant isolation is enforced twice — the audit-existence check
+  and the trace read are both tenant-scoped. No change to the MCP surface (the
+  agent read is a separate task); REST + console only. (#3215)
 ### Added — flight recorder: capture seam + caps + best-effort invariant (#3214)
 
 - Ships the **capture seam** plus the **F3 caps** and **F7 failure invariant**

--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -123,7 +123,11 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.api.v1.audit_models import AuditQueryRequest, AuditReplayResult
+from meho_backplane.api.v1.audit_models import (
+    AuditQueryRequest,
+    AuditReplayResult,
+    AuditTraceResult,
+)
 from meho_backplane.audit_query import (
     AuditEntry,
     AuditQueryFilters,
@@ -140,6 +144,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
+from meho_backplane.flight_recorder import load_trace
 
 __all__ = ["router"]
 
@@ -171,6 +176,12 @@ _AUDIT_QUERY_OP_ID: Final[str] = "meho.audit.query"
 #: ``op_class="audit_query"`` so the broadcast event stays aggregate-
 #: only (no ``ReplayNode`` tree in the SSE / Slack payload).
 _AUDIT_REPLAY_OP_ID: Final[str] = "meho_audit_replay"
+
+#: op_id the flight-recorder trace route (#3215) emits. Distinct from the
+#: query / replay op_ids so operators can tell trace-read usage apart in
+#: ``audit_log``; shares ``op_class="audit_query"`` so the read stays
+#: aggregate-only on the broadcast feed (it reveals the investigation target).
+_AUDIT_TRACE_OP_ID: Final[str] = "meho_audit_trace"
 
 #: Hard cap on the number of anchor rows a single replay may carry. A
 #: session above this returns 413 from the route's count-first guard
@@ -393,6 +404,57 @@ async def show(
     if not result.rows:
         raise HTTPException(status_code=404, detail="audit row not found")
     return result.rows[0]
+
+
+@router.get("/{audit_id}/trace", response_model=AuditTraceResult)
+async def trace(
+    audit_id: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> AuditTraceResult:
+    """Fetch the flight-recorder trace for one dispatch, scoped to the tenant.
+
+    The **operator read surface** of the dispatch flight recorder
+    (``docs/decisions/dispatch-flight-recorder.md``): the ordered, already
+    redacted+capped spans a governed dispatch produced. Read-only — it renders
+    what the capture/redaction seams (#3213/#3214) stored and never
+    re-processes, un-redacts, or writes.
+
+    Operator plane keeps **full** access, independent of the agent gate: unlike
+    the agent read (a sibling task) this serves redaction-uncertain traces too,
+    surfacing ``trace.redaction_uncertain`` so an operator sees when a trace was
+    withheld from agents. Paired add-ons consume this same route with their
+    operator principal — no separate add-on surface.
+
+    Absence has two levels. A missing / cross-tenant **audit row** is a 404
+    (never 403), matching :func:`show`: the existence check runs through the
+    tenant-scoped substrate, so a foreign ``audit_id`` yields zero rows and
+    existence never leaks. An audit row that exists but carries **no trace** is
+    a 200 with ``trace_present=False`` — capture is a best-effort opt-in
+    (F1/F7), so "no trace" is a normal observable state, not an error.
+
+    Tenant isolation is enforced twice: the existence check is tenant-scoped,
+    and :func:`~meho_backplane.flight_recorder.load_trace` additionally filters
+    the trace header on ``tenant_id`` as defence in depth.
+    """
+    _bind_audit_overrides(_AUDIT_TRACE_OP_ID)
+    # Audit-existence gate first: 404 (never 403) on a missing / cross-tenant
+    # row, exactly as ``show`` does — so a probing operator cannot distinguish
+    # "no such dispatch" from "dispatch in another tenant".
+    audit = await _dispatch(
+        AuditQueryFilters(audit_id=audit_id, limit=1), tenant_id=operator.tenant_id
+    )
+    if not audit.rows:
+        raise HTTPException(status_code=404, detail="audit row not found")
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        view = await load_trace(session, audit_id=audit_id, tenant_id=operator.tenant_id)
+
+    return AuditTraceResult(
+        audit_id=audit_id,
+        trace_present=view is not None,
+        trace=view,
+    )
 
 
 async def _count_session_rows(

--- a/backend/src/meho_backplane/api/v1/audit_models.py
+++ b/backend/src/meho_backplane/api/v1/audit_models.py
@@ -42,13 +42,17 @@ import uuid
 from pydantic import BaseModel, ConfigDict, Field
 
 from meho_backplane.audit_query import AuditEntry, AuditQueryResult, ReplayNode
+from meho_backplane.flight_recorder import TraceSpanView, TraceView
 
 __all__ = [
     "AuditEntry",
     "AuditQueryRequest",
     "AuditQueryResult",
     "AuditReplayResult",
+    "AuditTraceResult",
     "ReplayNode",
+    "TraceSpanView",
+    "TraceView",
 ]
 
 
@@ -134,3 +138,39 @@ class AuditReplayResult(BaseModel):
     tenant_id: uuid.UUID
     row_count: int
     excluded_null_session_count: int
+
+
+class AuditTraceResult(BaseModel):
+    """200 body for ``GET /api/v1/audit/{audit_id}/trace`` (#3215).
+
+    The operator read surface of the dispatch flight recorder
+    (``docs/decisions/dispatch-flight-recorder.md``). Wraps the tenant-scoped
+    :class:`~meho_backplane.flight_recorder.TraceView` with the echoed
+    ``audit_id`` and a ``trace_present`` discriminator, the same REST-envelope
+    layering :class:`AuditReplayResult` follows over the substrate's
+    :class:`ReplayNode`.
+
+    Two-level absence semantics -- distinct on purpose:
+
+    * The **audit row** being missing or in another tenant is a 404 from the
+      route, matching ``GET /show/{audit_id}``: existence never leaks across
+      the tenant boundary.
+    * The audit row existing but carrying **no captured trace** is *not* a 404 --
+      it is a 200 with ``trace_present=False`` and ``trace=None``. Capture is a
+      per-tenant/per-target opt-in and best-effort (F1/F7), so "no trace" is a
+      normal state an operator must be able to observe, not an error. The
+      console pane renders a "no trace captured" empty state for this case.
+
+    ``trace.redaction_uncertain`` surfaces the F5 degrade flag so an operator
+    (and a paired add-on reading over this route with its operator principal)
+    can see when a trace was withheld from the agent handle. The operator plane
+    keeps **full** access regardless of that flag.
+
+    Frozen like the models it carries.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    audit_id: uuid.UUID
+    trace_present: bool
+    trace: TraceView | None = None

--- a/backend/src/meho_backplane/flight_recorder/__init__.py
+++ b/backend/src/meho_backplane/flight_recorder/__init__.py
@@ -21,7 +21,9 @@ This package owns:
 
 Explicitly **not** in this package (sibling Tasks under #3207): span
 production / the capture seam (#3214), the fail-closed redaction engine
-(#3213), and the operator + agent read surfaces.
+(#3213), and the agent read surface. The **operator** read
+(:mod:`meho_backplane.flight_recorder.read`) does live here (#3215) -- it is the
+tenant-scoped trace read the REST route and the console pane both share.
 """
 
 from meho_backplane.flight_recorder.config import (
@@ -30,11 +32,15 @@ from meho_backplane.flight_recorder.config import (
     resolve_retention_days,
     should_capture,
 )
+from meho_backplane.flight_recorder.read import TraceSpanView, TraceView, load_trace
 from meho_backplane.flight_recorder.store import SpanInput, record_trace
 
 __all__ = [
     "SpanInput",
+    "TraceSpanView",
+    "TraceView",
     "compute_expires_at",
+    "load_trace",
     "record_trace",
     "reset_flight_recorder_config_cache_for_testing",
     "resolve_retention_days",

--- a/backend/src/meho_backplane/flight_recorder/read.py
+++ b/backend/src/meho_backplane/flight_recorder/read.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder tenant-scoped trace read (#3215, operator read surface).
+
+The read counterpart to :mod:`meho_backplane.flight_recorder.store`. The store
+(#3212) owns persistence and explicitly ships *no* read surface; this module is
+the single tenant-scoped read the operator plane shares between its two fronts:
+
+* the REST route ``GET /api/v1/audit/{id}/trace`` (:mod:`meho_backplane.api.v1.audit`);
+* the console trace pane in the audit drawer
+  (:mod:`meho_backplane.ui.routes.audit`).
+
+Both surfaces call :func:`load_trace` with the same ``(audit_id, tenant_id)``
+pair, so the tenant boundary is enforced in **one** place. The function is
+strictly read-only: it never re-processes, never un-redacts, and has no write
+path. It renders exactly what the capture/redaction seams (#3213/#3214) already
+stored -- bodies are redacted and capped at capture time, and the header-level
+``redaction_uncertain`` flag (F5) is surfaced verbatim so an operator can see
+when a trace was withheld from the agent handle.
+
+Access posture (per ``docs/decisions/dispatch-flight-recorder.md``, F5): the
+operator plane keeps **full** trace access -- including redaction-uncertain
+traces -- independent of the agent gate. This module is the operator-plane read;
+it applies no agent-side degrade, only the tenant scope.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import DispatchTrace, DispatchTraceSpan
+
+__all__ = ["TraceSpanView", "TraceView", "load_trace"]
+
+
+class TraceSpanView(BaseModel):
+    """One ordered span of a dispatch trace, safe to serve to the operator.
+
+    Mirrors :class:`~meho_backplane.db.models.DispatchTraceSpan` field-for-field
+    -- the frequently-queried axes (:attr:`status`, :attr:`duration_ms`) are
+    typed columns, and the redacted/capped span detail (method, URL, redacted
+    headers, the redacted body + truncation marker, JSONFlux input/kept/output
+    sizes, the result-handle id) rides the free-form :attr:`attributes` mapping.
+    The read surface renders these as stored -- it never re-processes them.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    seq: int
+    span_kind: str
+    name: str
+    started_at: datetime
+    duration_ms: Decimal | None
+    status: str | None
+    attributes: dict[str, Any]
+
+
+class TraceView(BaseModel):
+    """A dispatch trace header plus its ordered spans, tenant-scoped.
+
+    Returned by :func:`load_trace` when a trace exists for the ``(audit_id,
+    tenant_id)`` pair. :attr:`redaction_uncertain` is the F5 degrade flag read
+    straight off the header: ``True`` means the capture/redaction seam could not
+    prove the trace fully redacted, so it was withheld from the agent handle and
+    is readable on the operator plane alone. The operator surface surfaces the
+    flag rather than acting on it -- an operator sees everything, and sees which
+    traces the agent could not.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    trace_id: uuid.UUID
+    audit_id: uuid.UUID
+    tenant_id: uuid.UUID
+    created_at: datetime
+    expires_at: datetime
+    redaction_uncertain: bool
+    spans: list[TraceSpanView]
+
+
+async def load_trace(
+    session: AsyncSession,
+    *,
+    audit_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+) -> TraceView | None:
+    """Load the trace for ``(audit_id, tenant_id)``; ``None`` when none exists.
+
+    Two tenant-scoped reads: the header (unique on ``audit_id``, filtered on
+    ``tenant_id`` as defence in depth even though a trace is only ever written
+    for the owning tenant), then its spans ordered by ``seq``. Returning
+    ``None`` for a missing trace is distinct from a missing *audit row*: the
+    caller decides the surface semantics (the REST route 404s only when the
+    audit row is absent/cross-tenant, and renders an empty-trace state when the
+    audit row exists but carries no trace).
+
+    The ``tenant_id`` filter on the header is the load-bearing isolation guard:
+    a trace is never returned for a tenant that does not own it, regardless of
+    how the caller resolved ``audit_id``.
+    """
+    header = (
+        await session.execute(
+            select(DispatchTrace).where(
+                DispatchTrace.audit_id == audit_id,
+                DispatchTrace.tenant_id == tenant_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if header is None:
+        return None
+
+    span_rows = (
+        (
+            await session.execute(
+                select(DispatchTraceSpan)
+                .where(DispatchTraceSpan.trace_id == header.id)
+                .order_by(DispatchTraceSpan.seq.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return TraceView(
+        trace_id=header.id,
+        audit_id=header.audit_id,
+        tenant_id=header.tenant_id,
+        created_at=header.created_at,
+        expires_at=header.expires_at,
+        redaction_uncertain=header.redaction_uncertain,
+        spans=[
+            TraceSpanView(
+                seq=span.seq,
+                span_kind=span.span_kind,
+                name=span.name,
+                started_at=span.started_at,
+                duration_ms=span.duration_ms,
+                status=span.status,
+                attributes=dict(span.attributes),
+            )
+            for span in span_rows
+        ],
+    )

--- a/backend/src/meho_backplane/ui/routes/audit/routes.py
+++ b/backend/src/meho_backplane/ui/routes/audit/routes.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line audit console router
+# (predates #3215, which adds only the drawer trace-pane hook); splitting the
+# surface router is out of scope for this task.
 
 """Audit-query forensic console: a filter form over unbounded history.
 
@@ -107,10 +110,12 @@ from meho_backplane.audit_query import (
 from meho_backplane.broadcast import classify_op
 from meho_backplane.db.engine import get_raw_session, get_sessionmaker
 from meho_backplane.db.models import AuditLog
+from meho_backplane.flight_recorder import load_trace
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.references import resolve_audit_references
 from meho_backplane.ui.roles import is_ui_tenant_admin
+from meho_backplane.ui.routes.audit.trace_pane import project_trace
 from meho_backplane.ui.routes.broadcast.aggregate_gate import (
     AGGREGATE_ONLY_OP_CLASSES,
     INTERNAL_PAYLOAD_KEYS,
@@ -392,6 +397,19 @@ async def _build_drawer_context(
     references = await resolve_audit_references(
         db_session, row, op_id=op_id, op_class=op_class, is_admin=is_admin
     )
+    # Flight-recorder trace pane (#3215). Operator-plane read: full access
+    # (redaction-uncertain traces included), tenant-scoped on the row's own
+    # tenant (the row was already resolved under ``session.tenant_id`` by the
+    # caller, and ``load_trace`` re-filters the trace header on ``tenant_id``).
+    # A resolved row always carries a tenant (``fetch_audit_row`` matches on a
+    # concrete ``tenant_id``, and ``NULL = :id`` never matches), so the guard's
+    # else branch is unreachable for a resolved row -- it only satisfies the
+    # nullable column type and shows the empty state for the impossible case.
+    trace_view = (
+        await load_trace(db_session, audit_id=row.id, tenant_id=row.tenant_id)
+        if row.tenant_id is not None
+        else None
+    )
     return {
         "row": row,
         "op_id": op_id,
@@ -399,6 +417,7 @@ async def _build_drawer_context(
         "badge_class": _badge_class(op_class),
         "aggregate_only": aggregate_only,
         "request_payload": request_payload,
+        "trace": project_trace(trace_view),
         # The single-source gated op-class set (from the shared
         # broadcast aggregate_gate) names the withheld classes in the 🔒
         # placeholder copy, so the drawer text stays honest about which

--- a/backend/src/meho_backplane/ui/routes/audit/trace_pane.py
+++ b/backend/src/meho_backplane/ui/routes/audit/trace_pane.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Projection for the audit drawer's flight-recorder trace pane (#3215).
+
+The console trace pane (a new section in ``audit/_drawer.html`` after Lineage)
+renders the operator read surface of the dispatch flight recorder
+(``docs/decisions/dispatch-flight-recorder.md``): the ordered, already
+redacted+capped spans a governed dispatch produced. This module turns a
+:class:`~meho_backplane.flight_recorder.TraceView` into a flat, render-ready
+context dict.
+
+Why a projection (not the raw view) is handed to the template: the drawer
+templating runs under Jinja ``StrictUndefined``, so every key the template
+reads must exist. :func:`project_trace` normalises each span into a fixed key
+set (present, ``None`` when absent) drawn from the attribute contract the
+capture seam writes (``vendor_call`` / ``composite_step`` / ``jsonflux_reduction``
+/ ``typed`` / ``opaque``), plus an ``other_attributes`` catch-all so a span kind
+whose exact shape is not yet frozen (typed spans, #3217) still renders every
+stored, already-redacted datum rather than silently dropping it.
+
+Read-only and non-mutating: it never re-processes or un-redacts a body. The
+redacted body value (a structure, ``None``, or a fixed ``[MEHO-…]`` omission
+marker) is passed through verbatim; the template escapes it at render time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.flight_recorder import TraceSpanView, TraceView
+
+__all__ = ["project_trace"]
+
+#: DaisyUI badge variant per enumerated span kind. An unknown kind (a future
+#: span kind landing before this map is updated) falls back to ``badge-ghost``
+#: so it still renders, just uncoloured.
+_SPAN_KIND_BADGES: Final[dict[str, str]] = {
+    "vendor_call": "badge-primary",
+    "composite_step": "badge-secondary",
+    "jsonflux_reduction": "badge-accent",
+    "typed": "badge-info",
+    "opaque": "badge-ghost",
+}
+
+#: Attribute keys surfaced as first-class fields in the projected span. Anything
+#: outside this set is collected into ``other_attributes`` so no stored datum is
+#: hidden from an operator (e.g. typed-span metadata, #3217).
+_SURFACED_ATTR_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "method",
+        "url",
+        "connector_id",
+        "op_id",
+        "source_kind",
+        "request_id",
+        "request_headers",
+        "response_headers",
+        "request_body",
+        "response_body",
+        "body_recorded",
+        "truncated",
+        "redaction_reasons",
+        "input_rows",
+        "total_rows",
+        "kept_fields",
+        "kept_field_count",
+        "output_bytes",
+        "handle",
+        "collapsed",
+        "collapsed_count",
+    }
+)
+
+
+def _span_status_tone(status: str | None) -> str:
+    """Map a span status to a DaisyUI badge tone.
+
+    ``status`` is an HTTP code as text (``"200"`` / ``"503"``) or ``"ok"`` /
+    ``"error"`` for non-HTTP spans. 2xx / ``ok`` are success; 4xx / 5xx /
+    ``error`` are error; anything else (or absent) is neutral.
+    """
+    if not status:
+        return "badge-ghost"
+    if status == "ok" or status.startswith("2"):
+        return "badge-success"
+    if status == "error" or status.startswith(("4", "5")):
+        return "badge-error"
+    return "badge-ghost"
+
+
+def _project_span(span: TraceSpanView) -> dict[str, Any]:
+    """Normalise one span into the fixed key set the template reads."""
+    attrs = span.attributes
+    return {
+        "seq": span.seq,
+        "span_kind": span.span_kind,
+        "kind_badge": _SPAN_KIND_BADGES.get(span.span_kind, "badge-ghost"),
+        "name": span.name,
+        "status": span.status,
+        "status_tone": _span_status_tone(span.status),
+        "duration_ms": span.duration_ms,
+        "started_at": span.started_at.isoformat(),
+        # vendor_call / composite_step identity
+        "method": attrs.get("method"),
+        "url": attrs.get("url"),
+        "connector_id": attrs.get("connector_id"),
+        "op_id": attrs.get("op_id"),
+        "source_kind": attrs.get("source_kind"),
+        "request_id": attrs.get("request_id"),
+        # redacted headers/bodies (rendered as-stored; template escapes them)
+        "request_headers": attrs.get("request_headers") or {},
+        "response_headers": attrs.get("response_headers") or {},
+        "request_body": attrs.get("request_body"),
+        "response_body": attrs.get("response_body"),
+        "request_body_present": attrs.get("request_body") is not None,
+        "response_body_present": attrs.get("response_body") is not None,
+        "body_recorded": bool(attrs.get("body_recorded", True)),
+        "truncated": bool(attrs.get("truncated")),
+        "redaction_reasons": attrs.get("redaction_reasons") or [],
+        # jsonflux_reduction metadata
+        "input_rows": attrs.get("input_rows"),
+        "total_rows": attrs.get("total_rows"),
+        "kept_fields": attrs.get("kept_fields") or [],
+        "kept_field_count": attrs.get("kept_field_count"),
+        "output_bytes": attrs.get("output_bytes"),
+        "handle": attrs.get("handle"),
+        # overflow-collapse groups (F3)
+        "collapsed": bool(attrs.get("collapsed")),
+        "collapsed_count": attrs.get("collapsed_count"),
+        # everything else stored on the span, so nothing is hidden
+        "other_attributes": {k: v for k, v in attrs.items() if k not in _SURFACED_ATTR_KEYS},
+    }
+
+
+def project_trace(trace: TraceView | None) -> dict[str, Any]:
+    """Turn a :class:`TraceView` (or its absence) into the drawer pane context.
+
+    Always returns a dict with a ``present`` discriminator so the template can
+    branch without hitting ``StrictUndefined``. When ``trace`` is ``None`` (the
+    audit row exists but no trace was captured — a normal best-effort/opt-in
+    state, not an error) the pane renders its empty state.
+
+    ``redaction_uncertain`` is surfaced verbatim (F5): the operator plane sees
+    every trace, and sees which ones were withheld from the agent handle.
+    """
+    if trace is None:
+        return {"present": False, "spans": []}
+    return {
+        "present": True,
+        "redaction_uncertain": trace.redaction_uncertain,
+        "trace_id": str(trace.trace_id),
+        "created_at": trace.created_at.isoformat(),
+        "expires_at": trace.expires_at.isoformat(),
+        "span_count": len(trace.spans),
+        "spans": [_project_span(span) for span in trace.spans],
+    }

--- a/backend/src/meho_backplane/ui/templates/audit/_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/audit/_drawer.html
@@ -20,9 +20,14 @@
                        method/path, humanized status + timestamp.
     4. Lineage      -- labelled parent / replay-session / run links
                        (replay TENANT_ADMIN-gated, disabled w/ tooltip).
-    5. Identifiers  -- the raw audit_id / request_id / work_ref (the raw
+    5. Flight recorder -- the operator read of the dispatch trace (#3215):
+                       ordered redacted+capped spans w/ method/URL/status/
+                       duration, expandable redacted bodies + truncation
+                       markers, and the redaction-uncertainty banner. Empty
+                       state when no trace was captured (opt-in/best-effort).
+    6. Identifiers  -- the raw audit_id / request_id / work_ref (the raw
                        ids always reachable here, plus on every chip title).
-    6. Payload      -- the full request payload JSON when the op is not
+    7. Payload      -- the full request payload JSON when the op is not
                        aggregate-only; the 🔒 placeholder otherwise
                        (a sensitive op never leaks its payload -- decision #3).
 
@@ -35,6 +40,8 @@
     request_payload-- dict: the stripped request payload (empty when gated)
     gated_op_classes -- list[str]: the withheld op-class names (🔒 copy)
     references     -- AuditReferences: resolved named/linked substance
+    trace          -- dict: projected flight-recorder trace pane (#3215);
+                       always carries a ``present`` discriminator
 -#}
 {% from "_references.html" import what_happened, principal_chip, operation_ref, target_ref, status_badge, timestamp, work_ref_ref, lineage %}
 <aside
@@ -98,6 +105,168 @@
 
     {# ---------- Lineage (labelled parent / replay / run links) ---------- #}
     {{ lineage(references, "audit") }}
+
+    {# ---------- Flight recorder trace (operator read surface, #3215) ---------- #}
+    <section aria-label="Flight recorder trace">
+      <h3 class="text-sm font-semibold uppercase opacity-60">Flight recorder</h3>
+      {% if not trace.present %}
+        <p class="text-sm opacity-60">
+          No trace captured for this dispatch (capture is per-tenant opt-in and best-effort).
+        </p>
+      {% else %}
+        {% if trace.redaction_uncertain %}
+          <p class="flex items-center gap-1 text-sm text-warning" role="status">
+            <span aria-hidden="true">&#x26A0;&#xFE0F;</span>
+            <span>
+              Redaction uncertain — this trace was withheld from agents and is
+              visible on the operator plane only.
+            </span>
+          </p>
+        {% endif %}
+        <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+          <dt class="opacity-60">Spans</dt>
+          <dd>{{ trace.span_count }}</dd>
+          <dt class="opacity-60">Captured</dt>
+          <dd><time datetime="{{ trace.created_at }}">{{ trace.created_at }} UTC</time></dd>
+          <dt class="opacity-60">Expires</dt>
+          <dd><time datetime="{{ trace.expires_at }}">{{ trace.expires_at }} UTC</time></dd>
+          <dt class="opacity-60">Trace ID</dt>
+          <dd class="font-mono break-all">{{ trace.trace_id }}</dd>
+        </dl>
+        {% if trace.spans %}
+          <ol class="mt-2 space-y-2" aria-label="Trace spans">
+            {% for span in trace.spans %}
+              <li class="border-base-300 rounded border p-2">
+                <details>
+                  <summary class="flex cursor-pointer flex-wrap items-center gap-2 text-sm">
+                    <span class="font-mono text-xs opacity-50">#{{ span.seq }}</span>
+                    <span class="badge badge-sm {{ span.kind_badge }}">{{ span.span_kind }}</span>
+                    <span class="font-mono text-xs break-all">{{ span.name }}</span>
+                    {% if span.status %}
+                      <span class="badge badge-sm {{ span.status_tone }}">{{ span.status }}</span>
+                    {% endif %}
+                    {% if span.duration_ms is not none %}
+                      <span class="text-xs opacity-60">{{ span.duration_ms }} ms</span>
+                    {% endif %}
+                    {% if span.truncated %}
+                      <span
+                        class="badge badge-warning badge-xs"
+                        title="Body exceeded the capture cap and was truncated at capture time."
+                      >truncated</span>
+                    {% endif %}
+                  </summary>
+                  <div class="mt-2 space-y-2 text-xs">
+                    <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                      {% if span.method %}
+                        <dt class="opacity-60">Method</dt>
+                        <dd><span class="badge badge-outline badge-xs">{{ span.method }}</span></dd>
+                      {% endif %}
+                      {% if span.url %}
+                        <dt class="opacity-60">URL</dt>
+                        <dd class="font-mono break-all">{{ span.url }}</dd>
+                      {% endif %}
+                      {% if span.op_id %}
+                        <dt class="opacity-60">Operation</dt>
+                        <dd class="font-mono break-all">{{ span.op_id }}</dd>
+                      {% endif %}
+                      {% if span.connector_id %}
+                        <dt class="opacity-60">Connector</dt>
+                        <dd class="font-mono break-all">{{ span.connector_id }}</dd>
+                      {% endif %}
+                      {% if span.source_kind %}
+                        <dt class="opacity-60">Source kind</dt>
+                        <dd>{{ span.source_kind }}</dd>
+                      {% endif %}
+                      <dt class="opacity-60">Started</dt>
+                      <dd><time datetime="{{ span.started_at }}">{{ span.started_at }}</time></dd>
+                    </dl>
+
+                    {% if span.collapsed %}
+                      <p class="opacity-60">
+                        Collapsed group of {{ span.collapsed_count }} spans (capture cap reached).
+                      </p>
+                    {% endif %}
+
+                    {% if span.input_rows is not none or span.handle %}
+                      <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                        {% if span.input_rows is not none %}
+                          <dt class="opacity-60">Input rows</dt>
+                          <dd>
+                            {{ span.input_rows }}{% if span.total_rows is not none %} / {{ span.total_rows }} total{% endif %}
+                          </dd>
+                        {% endif %}
+                        {% if span.kept_fields %}
+                          <dt class="opacity-60">Kept fields</dt>
+                          <dd class="font-mono break-all">{{ span.kept_fields | join(", ") }}</dd>
+                        {% endif %}
+                        {% if span.output_bytes is not none %}
+                          <dt class="opacity-60">Output bytes</dt>
+                          <dd>{{ span.output_bytes }}</dd>
+                        {% endif %}
+                        {% if span.handle %}
+                          <dt class="opacity-60">Handle</dt>
+                          <dd class="font-mono break-all">{{ span.handle }}</dd>
+                        {% endif %}
+                      </dl>
+                    {% endif %}
+
+                    {% if span.redaction_reasons %}
+                      <div>
+                        <p class="opacity-60">Redaction notes</p>
+                        <ul class="list-disc pl-4">
+                          {% for reason in span.redaction_reasons %}
+                            <li>{{ reason }}</li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% endif %}
+
+                    {% if span.request_headers %}
+                      <details>
+                        <summary class="cursor-pointer opacity-60">
+                          Request headers ({{ span.request_headers | length }})
+                        </summary>
+                        <pre class="bg-base-200 mt-1 max-h-48 overflow-auto rounded p-2">{{ span.request_headers | tojson(indent=2) }}</pre>
+                      </details>
+                    {% endif %}
+                    {% if span.request_body_present %}
+                      <details>
+                        <summary class="cursor-pointer opacity-60">Request body (redacted)</summary>
+                        <pre class="bg-base-200 mt-1 max-h-72 overflow-auto rounded p-2">{{ span.request_body | tojson(indent=2) }}</pre>
+                      </details>
+                    {% endif %}
+
+                    {% if span.response_headers %}
+                      <details>
+                        <summary class="cursor-pointer opacity-60">
+                          Response headers ({{ span.response_headers | length }})
+                        </summary>
+                        <pre class="bg-base-200 mt-1 max-h-48 overflow-auto rounded p-2">{{ span.response_headers | tojson(indent=2) }}</pre>
+                      </details>
+                    {% endif %}
+                    {% if span.response_body_present %}
+                      <details>
+                        <summary class="cursor-pointer opacity-60">Response body (redacted)</summary>
+                        <pre class="bg-base-200 mt-1 max-h-72 overflow-auto rounded p-2">{{ span.response_body | tojson(indent=2) }}</pre>
+                      </details>
+                    {% elif not span.body_recorded %}
+                      <p class="opacity-60">Body not recorded (secret-bearing op family).</p>
+                    {% endif %}
+
+                    {% if span.other_attributes %}
+                      <details>
+                        <summary class="cursor-pointer opacity-60">Other attributes</summary>
+                        <pre class="bg-base-200 mt-1 max-h-48 overflow-auto rounded p-2">{{ span.other_attributes | tojson(indent=2) }}</pre>
+                      </details>
+                    {% endif %}
+                  </div>
+                </details>
+              </li>
+            {% endfor %}
+          </ol>
+        {% endif %}
+      {% endif %}
+    </section>
 
     {# ---------- Identifiers (raw ids, always reachable) ---------- #}
     <section aria-label="Identifiers">

--- a/backend/src/meho_backplane/ui/templates/audit/index.html
+++ b/backend/src/meho_backplane/ui/templates/audit/index.html
@@ -184,7 +184,7 @@
               badge_class=drawer.badge_class, aggregate_only=drawer.aggregate_only,
               request_payload=drawer.request_payload,
               gated_op_classes=drawer.gated_op_classes,
-              references=drawer.references %}
+              references=drawer.references, trace=drawer.trace %}
         {% include "audit/_drawer.html" %}
       {% endwith %}
     {% else %}

--- a/backend/tests/test_api_audit_trace_route.py
+++ b/backend/tests/test_api_audit_trace_route.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``GET /api/v1/audit/{audit_id}/trace`` (#3215).
+
+The operator read surface of the dispatch flight recorder
+(``docs/decisions/dispatch-flight-recorder.md``): the REST route that serves one
+dispatch's ordered, already redacted+capped spans behind the operator claim.
+
+Coverage:
+
+* RBAC -- operator claim required (``read_only`` → 403, unauthenticated → 401,
+  ``tenant_admin`` → 200).
+* Tenant isolation -- a cross-tenant ``audit_id`` returns 404 (never 403, never
+  the other tenant's trace); existence never leaks.
+* 404 semantics -- a missing audit row is 404, matching ``/show``.
+* Empty state -- an audit row that exists but carries no captured trace is a
+  200 with ``trace_present=False`` (not a 404): capture is opt-in/best-effort.
+* Trace rendering -- a seeded trace returns its ordered spans with the redacted
+  bodies, the truncation marker, and the redaction-uncertainty flag.
+
+The capture seam (#3214) is not yet on ``main``; per the task, traces are
+seeded directly via :func:`meho_backplane.flight_recorder.record_trace` with the
+attribute shape the capture seam writes -- the read surface must render what is
+stored regardless of who wrote it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.api.v1.audit import router as audit_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Tenant
+from meho_backplane.flight_recorder import SpanInput, record_trace
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.redaction.flight_recorder.verdict import BODY_OMITTED_MARKER
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT_A = UUID("33333333-3333-3333-3333-333333333333")
+_TENANT_B = UUID("44444444-4444-4444-4444-444444444444")
+_BASE = datetime(2026, 8, 30, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` reads + reset the flight-recorder cache."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(audit_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-1",
+    role: TenantRole = TenantRole.OPERATOR,
+    tenant_id: UUID = _TENANT_A,
+) -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+
+
+async def _seed_tenant(tenant_id: UUID, slug: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+
+
+async def _seed_audit_row(
+    *,
+    tenant_id: UUID,
+    audit_id: UUID | None = None,
+    second: int = 0,
+) -> UUID:
+    audit_id = audit_id or uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AuditLog(
+                id=audit_id,
+                occurred_at=_BASE + timedelta(seconds=second),
+                operator_sub="op-actor",
+                tenant_id=tenant_id,
+                method="POST",
+                path="/mcp",
+                status_code=200,
+                duration_ms=Decimal("1.0"),
+                payload={"op_id": "vsphere.vm.list", "op_class": "read"},
+            )
+        )
+        await session.commit()
+    return audit_id
+
+
+def _vendor_and_flux_spans() -> list[SpanInput]:
+    """A realistic vendor_call + jsonflux_reduction pair (capture-seam shape)."""
+    return [
+        SpanInput(
+            span_kind="vendor_call",
+            name="GET /rest/vcenter/vm",
+            started_at=_BASE,
+            duration_ms=Decimal("12.50"),
+            status="200",
+            attributes={
+                "connector_id": "vmware-rest-9.0",
+                "op_id": "vsphere.vm.list",
+                "method": "GET",
+                "url": "https://vendor.example/rest/vcenter/vm",
+                "request_headers": {"accept": "application/json"},
+                "response_headers": {"content-type": "application/json"},
+                "request_body": None,
+                "response_body": {"value": [{"vm": "vm-1", "name": "web-01"}]},
+                "body_recorded": True,
+            },
+        ),
+        SpanInput(
+            span_kind="jsonflux_reduction",
+            name="jsonflux.reduce",
+            started_at=_BASE + timedelta(milliseconds=13),
+            status="ok",
+            attributes={
+                "op_id": "vsphere.vm.list",
+                "input_rows": 4000,
+                "total_rows": 4000,
+                "kept_fields": ["vm", "name"],
+                "kept_field_count": 2,
+                "output_bytes": 128,
+                "handle": "h-abc-123",
+            },
+        ),
+    ]
+
+
+async def _seed_trace(
+    *,
+    audit_id: UUID,
+    tenant_id: UUID,
+    spans: list[SpanInput],
+    redaction_uncertain: bool = False,
+) -> UUID:
+    trace_id = await record_trace(
+        audit_id=audit_id,
+        tenant_id=tenant_id,
+        spans=spans,
+        redaction_uncertain=redaction_uncertain,
+        now=_BASE,
+    )
+    assert trace_id is not None, "record_trace returned None (seed failed)"
+    return trace_id
+
+
+# ---------------------------------------------------------------------------
+# Happy path: a seeded trace renders its ordered spans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_returns_ordered_spans_for_captured_trace(client: TestClient) -> None:
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)
+    await _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=_vendor_and_flux_spans())
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["audit_id"] == str(audit_id)
+    assert body["trace_present"] is True
+    trace = body["trace"]
+    assert trace["redaction_uncertain"] is False
+    spans = trace["spans"]
+    assert [s["seq"] for s in spans] == [0, 1]
+    assert spans[0]["span_kind"] == "vendor_call"
+    assert spans[0]["attributes"]["method"] == "GET"
+    assert spans[0]["attributes"]["url"] == "https://vendor.example/rest/vcenter/vm"
+    assert spans[0]["attributes"]["response_body"] == {"value": [{"vm": "vm-1", "name": "web-01"}]}
+    assert spans[1]["span_kind"] == "jsonflux_reduction"
+    assert spans[1]["attributes"]["handle"] == "h-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_trace_surfaces_truncation_and_uncertainty(client: TestClient) -> None:
+    """A truncated + redaction-uncertain trace surfaces both markers (F5/F3)."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)
+    spans = [
+        SpanInput(
+            span_kind="vendor_call",
+            name="POST /rest/big",
+            started_at=_BASE,
+            duration_ms=Decimal("99.00"),
+            status="200",
+            attributes={
+                "method": "POST",
+                "url": "https://vendor.example/rest/big",
+                "request_headers": {},
+                "response_headers": {},
+                "request_body": None,
+                "response_body": BODY_OMITTED_MARKER,
+                "body_recorded": True,
+                "truncated": True,
+                "redaction_reasons": ["response body truncated at 64 KB cap"],
+            },
+        ),
+    ]
+    await _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=spans, redaction_uncertain=True)
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    trace = resp.json()["trace"]
+    # F5 degrade flag is surfaced so an operator sees the trace was withheld
+    # from the agent handle.
+    assert trace["redaction_uncertain"] is True
+    span = trace["spans"][0]
+    assert span["attributes"]["truncated"] is True
+    assert span["attributes"]["response_body"] == BODY_OMITTED_MARKER
+
+
+# ---------------------------------------------------------------------------
+# Empty state: audit row exists but no trace captured → 200, not 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_audit_exists_but_no_trace_returns_200_empty(client: TestClient) -> None:
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)  # no trace seeded
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["trace_present"] is False
+    assert body["trace"] is None
+
+
+# ---------------------------------------------------------------------------
+# 404 semantics + tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_missing_audit_row_returns_404(client: TestClient) -> None:
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{uuid.uuid4()}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 404
+    assert resp.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_trace_cross_tenant_returns_404_never_leaks(client: TestClient) -> None:
+    """A tenant-B operator requesting tenant-A's dispatch gets 404, not the trace."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    await _seed_tenant(_TENANT_B, "tenant-b")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)
+    await _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=_vendor_and_flux_spans())
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_B)  # caller is tenant B
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 404  # never 403, never 200
+    assert resp.status_code != 403
+    # The tenant-A vendor URL must never appear in a tenant-B response.
+    assert "vendor.example" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+def test_trace_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.get(f"/api/v1/audit/{uuid.uuid4()}/trace")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_trace_read_only_role_returns_403(client: TestClient) -> None:
+    """``read_only`` is below the operator gate — 403 before any trace read."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)
+    await _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=_vendor_and_flux_spans())
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, role=TenantRole.READ_ONLY)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 403
+    assert "vendor.example" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_trace_tenant_admin_role_returns_200(client: TestClient) -> None:
+    """``tenant_admin`` clears the operator gate (operator minimum)."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = await _seed_audit_row(tenant_id=_TENANT_A)
+    await _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=_vendor_and_flux_spans())
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, role=TenantRole.TENANT_ADMIN)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/{audit_id}/trace",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["trace_present"] is True
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI mount surface
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_lists_trace_route(client: TestClient) -> None:
+    schema = client.get("/openapi.json").json()
+    paths = schema["paths"]
+    assert "/api/v1/audit/{audit_id}/trace" in paths
+    get = paths["/api/v1/audit/{audit_id}/trace"]["get"]
+    assert "audit" in get["tags"]
+    ok_schema = get["responses"]["200"]["content"]["application/json"]["schema"]
+    assert ok_schema["$ref"].endswith("/AuditTraceResult")

--- a/backend/tests/test_flight_recorder_read.py
+++ b/backend/tests/test_flight_recorder_read.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the flight-recorder tenant-scoped trace read (#3215).
+
+Covers :func:`meho_backplane.flight_recorder.read.load_trace` -- the single
+tenant-scoped read the operator REST route and the console pane both share:
+
+* a seeded trace loads its header + ordered spans (``seq`` ascending);
+* a missing trace returns ``None`` (distinct from a missing audit row -- the
+  caller owns the surface semantics);
+* tenant isolation: a trace owned by another tenant is never returned, even for
+  the same ``audit_id`` -- the load-bearing defence-in-depth guard.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+from meho_backplane.flight_recorder import SpanInput, load_trace, record_trace
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.settings import get_settings
+
+_BASE = datetime(2026, 8, 30, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+async def _seed_tenant(slug: str) -> uuid.UUID:
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+    return tenant_id
+
+
+def _spans() -> list[SpanInput]:
+    return [
+        SpanInput(
+            span_kind="vendor_call",
+            name="GET /rest/vm",
+            started_at=_BASE,
+            duration_ms=Decimal("12.50"),
+            status="200",
+            attributes={"method": "GET", "url": "https://vendor.example/rest/vm"},
+        ),
+        SpanInput(
+            span_kind="jsonflux_reduction",
+            name="jsonflux.reduce",
+            started_at=_BASE + timedelta(milliseconds=13),
+            status="ok",
+            attributes={"input_rows": 4000, "kept_fields": ["name"], "handle": "h-1"},
+        ),
+    ]
+
+
+async def test_load_trace_returns_ordered_spans() -> None:
+    tenant_id = await _seed_tenant("fr-read-basic")
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_spans(), now=_BASE)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        view = await load_trace(session, audit_id=audit_id, tenant_id=tenant_id)
+
+    assert view is not None
+    assert view.audit_id == audit_id
+    assert view.tenant_id == tenant_id
+    assert view.redaction_uncertain is False
+    assert [s.seq for s in view.spans] == [0, 1]
+    assert view.spans[0].span_kind == "vendor_call"
+    assert view.spans[0].attributes["url"] == "https://vendor.example/rest/vm"
+    assert view.spans[1].attributes["handle"] == "h-1"
+
+
+async def test_load_trace_returns_none_when_absent() -> None:
+    tenant_id = await _seed_tenant("fr-read-absent")
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        view = await load_trace(session, audit_id=uuid.uuid4(), tenant_id=tenant_id)
+    assert view is None
+
+
+async def test_load_trace_is_tenant_scoped() -> None:
+    """A trace owned by tenant B is never returned for tenant A (defence in depth).
+
+    The unique index is on ``audit_id`` alone, so only one trace exists per
+    dispatch; this seeds the trace under tenant B and proves that reading with
+    tenant A's id -- even for that exact ``audit_id`` -- yields ``None`` rather
+    than another tenant's trace.
+    """
+    tenant_a = await _seed_tenant("fr-read-a")
+    tenant_b = await _seed_tenant("fr-read-b")
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_b, spans=_spans(), now=_BASE)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        as_a = await load_trace(session, audit_id=audit_id, tenant_id=tenant_a)
+        as_b = await load_trace(session, audit_id=audit_id, tenant_id=tenant_b)
+
+    assert as_a is None  # tenant A cannot read tenant B's trace
+    assert as_b is not None  # the owning tenant still can

--- a/backend/tests/test_ui_audit_drawer_trace.py
+++ b/backend/tests/test_ui_audit_drawer_trace.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the audit drawer's flight-recorder trace pane (#3215).
+
+The console read surface of the dispatch flight recorder: a new section in
+``audit/_drawer.html`` (after Lineage) rendered via the drawer route
+``GET /ui/audit/show/{audit_id}``. Covers:
+
+* a captured trace renders its ordered spans with method / URL / status /
+  duration and the redacted bodies;
+* the truncation marker + the redaction-uncertainty banner are visible;
+* the empty state ("no trace captured") shows when an audit row carries no
+  trace (best-effort / opt-in capture, not an error);
+* vendor-controlled body text is HTML-escaped (never rendered as live markup),
+  the template-injection guard.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_audit_drawer` (session-cookie
+HTTP edge + DB-seeded rows). Traces are seeded directly via
+:func:`meho_backplane.flight_recorder.record_trace` -- the capture seam (#3214)
+is not yet on ``main`` and the read surface renders what is stored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import AuditLog, Tenant
+from meho_backplane.flight_recorder import SpanInput, record_trace
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.redaction.flight_recorder.verdict import BODY_OMITTED_MARKER
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import clear_discovery_cache, reset_verifier_store_for_testing
+from meho_backplane.ui.auth.session_store import create_session, reset_fernet_cache_for_testing
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+
+_BACKPLANE_URL = "https://meho.test"
+_DEFAULT_ISSUER = "https://keycloak.test/realms/meho"
+_DEFAULT_AUDIENCE = "meho-backplane"
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OPERATOR_SUB = "op-self"
+_BASE = datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_flight_recorder_config_cache_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_flight_recorder_config_cache_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_audit_row(*, tenant_id: uuid.UUID, row_id: uuid.UUID | None = None) -> uuid.UUID:
+    resolved_id = row_id or uuid.uuid4()
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                AuditLog(
+                    id=resolved_id,
+                    occurred_at=_BASE,
+                    operator_sub="op-actor",
+                    tenant_id=tenant_id,
+                    method="POST",
+                    path="/mcp",
+                    status_code=200,
+                    duration_ms=Decimal("1.0"),
+                    payload={"op_id": "vsphere.vm.list", "op_class": "read"},
+                )
+            )
+        return resolved_id
+
+    return asyncio.run(_do())
+
+
+def _seed_trace(
+    *,
+    audit_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    spans: list[SpanInput],
+    redaction_uncertain: bool = False,
+) -> None:
+    async def _do() -> None:
+        trace_id = await record_trace(
+            audit_id=audit_id,
+            tenant_id=tenant_id,
+            spans=spans,
+            redaction_uncertain=redaction_uncertain,
+            now=_BASE,
+        )
+        assert trace_id is not None, "record_trace returned None (seed failed)"
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(*, tenant_id: uuid.UUID, operator_sub: str = _OPERATOR_SUB) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _vendor_and_flux_spans(*, response_body: Any = None) -> list[SpanInput]:
+    body = response_body if response_body is not None else {"value": [{"vm": "vm-1"}]}
+    return [
+        SpanInput(
+            span_kind="vendor_call",
+            name="GET /rest/vcenter/vm",
+            started_at=_BASE,
+            duration_ms=Decimal("12.50"),
+            status="200",
+            attributes={
+                "connector_id": "vmware-rest-9.0",
+                "op_id": "vsphere.vm.list",
+                "method": "GET",
+                "url": "https://vendor.example/rest/vcenter/vm",
+                "request_headers": {"accept": "application/json"},
+                "response_headers": {"content-type": "application/json"},
+                "request_body": None,
+                "response_body": body,
+                "body_recorded": True,
+            },
+        ),
+        SpanInput(
+            span_kind="jsonflux_reduction",
+            name="jsonflux.reduce",
+            started_at=_BASE + timedelta(milliseconds=13),
+            status="ok",
+            attributes={
+                "op_id": "vsphere.vm.list",
+                "input_rows": 4000,
+                "kept_fields": ["vm", "name"],
+                "handle": "h-abc-123",
+            },
+        ),
+    ]
+
+
+def test_drawer_renders_trace_pane_with_spans() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = _seed_audit_row(tenant_id=_TENANT_A)
+    _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=_vendor_and_flux_spans())
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/audit/show/{audit_id}")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Flight recorder" in body
+    # Per-span human-investigable substance (not GUIDs).
+    assert "vendor_call" in body
+    assert "https://vendor.example/rest/vcenter/vm" in body
+    assert "jsonflux_reduction" in body
+    assert "h-abc-123" in body  # the result-handle id
+    # Not the empty state.
+    assert "No trace captured" not in body
+
+
+def test_drawer_trace_pane_shows_truncation_and_uncertainty() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = _seed_audit_row(tenant_id=_TENANT_A)
+    spans = [
+        SpanInput(
+            span_kind="vendor_call",
+            name="POST /rest/big",
+            started_at=_BASE,
+            duration_ms=Decimal("99.00"),
+            status="200",
+            attributes={
+                "method": "POST",
+                "url": "https://vendor.example/rest/big",
+                "request_headers": {},
+                "response_headers": {},
+                "request_body": None,
+                "response_body": BODY_OMITTED_MARKER,
+                "body_recorded": True,
+                "truncated": True,
+                "redaction_reasons": ["response body truncated at 64 KB cap"],
+            },
+        ),
+    ]
+    _seed_trace(audit_id=audit_id, tenant_id=_TENANT_A, spans=spans, redaction_uncertain=True)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/audit/show/{audit_id}")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "truncated" in body
+    assert "Redaction uncertain" in body  # F5 operator-only banner
+    assert "operator plane only" in body
+    assert BODY_OMITTED_MARKER in body
+    assert "truncated at 64 KB cap" in body  # the redaction reason is surfaced
+
+
+def test_drawer_trace_pane_empty_state_when_no_trace() -> None:
+    _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = _seed_audit_row(tenant_id=_TENANT_A)  # no trace seeded
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/audit/show/{audit_id}")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Flight recorder" in body
+    assert "No trace captured" in body
+
+
+def test_drawer_trace_body_is_html_escaped() -> None:
+    """Vendor-controlled body text is escaped — never rendered as live markup."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    audit_id = _seed_audit_row(tenant_id=_TENANT_A)
+    injection = {"note": "<script>alert(1)</script>"}
+    _seed_trace(
+        audit_id=audit_id,
+        tenant_id=_TENANT_A,
+        spans=_vendor_and_flux_spans(response_body=injection),
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/audit/show/{audit_id}")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The raw <script> tag must never reach the DOM as live markup: Jinja's
+    # ``tojson`` escapes ``<`` / ``>`` to unicode inside the rendered JSON.
+    assert "<script>alert(1)</script>" not in body
+    assert "<script>" not in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6340,6 +6340,60 @@
         }
       }
     },
+    "/api/v1/audit/{audit_id}/trace": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "Trace",
+        "description": "Fetch the flight-recorder trace for one dispatch, scoped to the tenant.\n\nThe **operator read surface** of the dispatch flight recorder\n(``docs/decisions/dispatch-flight-recorder.md``): the ordered, already\nredacted+capped spans a governed dispatch produced. Read-only \u2014 it renders\nwhat the capture/redaction seams (#3213/#3214) stored and never\nre-processes, un-redacts, or writes.\n\nOperator plane keeps **full** access, independent of the agent gate: unlike\nthe agent read (a sibling task) this serves redaction-uncertain traces too,\nsurfacing ``trace.redaction_uncertain`` so an operator sees when a trace was\nwithheld from agents. Paired add-ons consume this same route with their\noperator principal \u2014 no separate add-on surface.\n\nAbsence has two levels. A missing / cross-tenant **audit row** is a 404\n(never 403), matching :func:`show`: the existence check runs through the\ntenant-scoped substrate, so a foreign ``audit_id`` yields zero rows and\nexistence never leaks. An audit row that exists but carries **no trace** is\na 200 with ``trace_present=False`` \u2014 capture is a best-effort opt-in\n(F1/F7), so \"no trace\" is a normal observable state, not an error.\n\nTenant isolation is enforced twice: the existence check is tenant-scoped,\nand :func:`~meho_backplane.flight_recorder.load_trace` additionally filters\nthe trace header on ``tenant_id`` as defence in depth.",
+        "operationId": "trace_api_v1_audit__audit_id__trace_get",
+        "parameters": [
+          {
+            "name": "audit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Audit Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditTraceResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/audit/sessions/{session_id}/replay": {
       "get": {
         "tags": [
@@ -22245,6 +22299,30 @@
         "title": "AuditReplayResult",
         "description": "200 body for ``GET /api/v1/audit/sessions/{session_id}/replay``.\n\nWraps the substrate's :class:`ReplayNode` forest with the echoed\nrequest identity. ``tenant_id`` is always the operator's tenant\n(lifted from the JWT by the route), never client-supplied, so the\necho is a confirmation of the boundary the query ran under \u2014 not a\nvalue the caller chose.\n\n``row_count`` is the count of *anchor* rows in the session \u2014 rows\nwhose ``agent_session_id`` equals ``session_id`` within the\noperator's tenant. It is the same number the route's count-first\n413 guard evaluates, so a session that returns 200 reports a\n``row_count`` identical to what its over-cap sibling would report\nat 413. NULL-session lineage children pulled into ``root`` by the\nreplay closure (a composite ``dispatch_child`` whose own\n``agent_session_id`` is NULL but whose ``parent_audit_id`` links\ninto the session) are present in the tree but are not counted \u2014\n\"session rows\" are defined by the ``agent_session_id`` anchor, not\nby tree membership.\n\nAn unknown session id, or one belonging to another tenant, yields\n``root=[]`` / ``row_count=0`` \u2014 never a 404 \u2014 so a foreign session\nis indistinguishable from an empty one and existence never leaks\nacross tenants (the same non-leakage posture\n``GET /show/{audit_id}`` takes).\n\n``excluded_null_session_count`` (#2700) is the tenant-scoped tally\nof ``method=MCP`` audit rows whose ``agent_session_id`` is NULL \u2014\ncalls from clients that never negotiated a session via the\n``initialize`` handshake. Such rows can never anchor or be walked by\n*any* session replay, so a ``row_count=0`` response with a non-zero\n``excluded_null_session_count`` tells an investigator the empty\nforest is not the same as an empty history: there is un-negotiated\nMCP traffic this forensic surface structurally cannot see. It is a\ntenant-wide count, independent of ``session_id`` (the un-negotiated\nrows belong to no session), and mirrors the honest\n``when_negotiated`` capture label the deploy's ``/status`` reports.\n\nFrozen like the substrate models it carries."
       },
+      "AuditTraceResult": {
+        "properties": {
+          "audit_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Audit Id"
+          },
+          "trace_present": {
+            "type": "boolean",
+            "title": "Trace Present"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceView",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "audit_id",
+          "trace_present"
+        ],
+        "title": "AuditTraceResult",
+        "description": "200 body for ``GET /api/v1/audit/{audit_id}/trace`` (#3215).\n\nThe operator read surface of the dispatch flight recorder\n(``docs/decisions/dispatch-flight-recorder.md``). Wraps the tenant-scoped\n:class:`~meho_backplane.flight_recorder.TraceView` with the echoed\n``audit_id`` and a ``trace_present`` discriminator, the same REST-envelope\nlayering :class:`AuditReplayResult` follows over the substrate's\n:class:`ReplayNode`.\n\nTwo-level absence semantics -- distinct on purpose:\n\n* The **audit row** being missing or in another tenant is a 404 from the\n  route, matching ``GET /show/{audit_id}``: existence never leaks across\n  the tenant boundary.\n* The audit row existing but carrying **no captured trace** is *not* a 404 --\n  it is a 200 with ``trace_present=False`` and ``trace=None``. Capture is a\n  per-tenant/per-target opt-in and best-effort (F1/F7), so \"no trace\" is a\n  normal state an operator must be able to observe, not an error. The\n  console pane renders a \"no trace captured\" empty state for this case.\n\n``trace.redaction_uncertain`` surfaces the F5 degrade flag so an operator\n(and a paired add-on reading over this route with its operator principal)\ncan see when a trace was withheld from the agent handle. The operator plane\nkeeps **full** access regardless of that flag.\n\nFrozen like the models it carries."
+      },
       "AuthConfigResponse": {
         "properties": {
           "keycloak_issuer": {
@@ -32761,6 +32839,107 @@
         ],
         "title": "TopologyTimelineResult",
         "description": "Page of timeline rows plus the forward-only continuation cursor.\n\n``next_cursor`` is :data:`None` when fewer than ``limit`` rows\nwere available (the query reached the end of the matching set).\nConsumers iterate by re-issuing the same filter with\n``cursor = next_cursor`` until ``next_cursor`` is None.\n\nThe cursor is opaque (base64-encoded JSON over ``(valid_from,\nhistory_id, source)``) -- consumers treat it as a token. Stability\nunder concurrent inserts: a new history row landing in the window\nbetween page N and page N+1 is naturally placed by the keyset\ncompare (``(valid_from, history_id) < (cursor.ts, cursor.id)``)\nand either appears on a later page (if it falls below the cursor)\nor never (if it lands above the cursor). No row is duplicated or\nskipped by the act of paging."
+      },
+      "TraceSpanView": {
+        "properties": {
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          },
+          "span_kind": {
+            "type": "string",
+            "title": "Span Kind"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "duration_ms": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "nullable": true,
+            "title": "Duration Ms"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "title": "Status"
+          },
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "seq",
+          "span_kind",
+          "name",
+          "started_at",
+          "duration_ms",
+          "status",
+          "attributes"
+        ],
+        "title": "TraceSpanView",
+        "description": "One ordered span of a dispatch trace, safe to serve to the operator.\n\nMirrors :class:`~meho_backplane.db.models.DispatchTraceSpan` field-for-field\n-- the frequently-queried axes (:attr:`status`, :attr:`duration_ms`) are\ntyped columns, and the redacted/capped span detail (method, URL, redacted\nheaders, the redacted body + truncation marker, JSONFlux input/kept/output\nsizes, the result-handle id) rides the free-form :attr:`attributes` mapping.\nThe read surface renders these as stored -- it never re-processes them."
+      },
+      "TraceView": {
+        "properties": {
+          "trace_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Trace Id"
+          },
+          "audit_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Audit Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          },
+          "redaction_uncertain": {
+            "type": "boolean",
+            "title": "Redaction Uncertain"
+          },
+          "spans": {
+            "items": {
+              "$ref": "#/components/schemas/TraceSpanView"
+            },
+            "type": "array",
+            "title": "Spans"
+          }
+        },
+        "type": "object",
+        "required": [
+          "trace_id",
+          "audit_id",
+          "tenant_id",
+          "created_at",
+          "expires_at",
+          "redaction_uncertain",
+          "spans"
+        ],
+        "title": "TraceView",
+        "description": "A dispatch trace header plus its ordered spans, tenant-scoped.\n\nReturned by :func:`load_trace` when a trace exists for the ``(audit_id,\ntenant_id)`` pair. :attr:`redaction_uncertain` is the F5 degrade flag read\nstraight off the header: ``True`` means the capture/redaction seam could not\nprove the trace fully redacted, so it was withheld from the agent handle and\nis readable on the operator plane alone. The operator surface surfaces the\nflag rather than acting on it -- an operator sees everything, and sees which\ntraces the agent could not."
       },
       "UISessionContext": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1484,6 +1484,48 @@ type AuditReplayResult struct {
 	TenantId                 openapi_types.UUID `json:"tenant_id"`
 }
 
+// AuditTraceResult 200 body for “GET /api/v1/audit/{audit_id}/trace“ (#3215).
+//
+// The operator read surface of the dispatch flight recorder
+// (“docs/decisions/dispatch-flight-recorder.md“). Wraps the tenant-scoped
+// :class:`~meho_backplane.flight_recorder.TraceView` with the echoed
+// “audit_id“ and a “trace_present“ discriminator, the same REST-envelope
+// layering :class:`AuditReplayResult` follows over the substrate's
+// :class:`ReplayNode`.
+//
+// Two-level absence semantics -- distinct on purpose:
+//
+//   - The **audit row** being missing or in another tenant is a 404 from the
+//     route, matching “GET /show/{audit_id}“: existence never leaks across
+//     the tenant boundary.
+//   - The audit row existing but carrying **no captured trace** is *not* a 404 --
+//     it is a 200 with “trace_present=False“ and “trace=None“. Capture is a
+//     per-tenant/per-target opt-in and best-effort (F1/F7), so "no trace" is a
+//     normal state an operator must be able to observe, not an error. The
+//     console pane renders a "no trace captured" empty state for this case.
+//
+// “trace.redaction_uncertain“ surfaces the F5 degrade flag so an operator
+// (and a paired add-on reading over this route with its operator principal)
+// can see when a trace was withheld from the agent handle. The operator plane
+// keeps **full** access regardless of that flag.
+//
+// Frozen like the models it carries.
+type AuditTraceResult struct {
+	AuditId openapi_types.UUID `json:"audit_id"`
+
+	// Trace A dispatch trace header plus its ordered spans, tenant-scoped.
+	//
+	// Returned by :func:`load_trace` when a trace exists for the ``(audit_id,
+	// tenant_id)`` pair. :attr:`redaction_uncertain` is the F5 degrade flag read
+	// straight off the header: ``True`` means the capture/redaction seam could not
+	// prove the trace fully redacted, so it was withheld from the agent handle and
+	// is readable on the operator plane alone. The operator surface surfaces the
+	// flag rather than acting on it -- an operator sees everything, and sees which
+	// traces the agent could not.
+	Trace        *TraceView `json:"trace,omitempty"`
+	TracePresent bool       `json:"trace_present"`
+}
+
 // AuthConfigResponse OAuth discovery surface returned to “meho login“.
 //
 // Field names match the CLI's expected JSON keys (“keycloak_issuer“,
@@ -8302,6 +8344,43 @@ type TopologyTimelineResult struct {
 	Rows       []TopologyTimelineEntry `json:"rows"`
 }
 
+// TraceSpanView One ordered span of a dispatch trace, safe to serve to the operator.
+//
+// Mirrors :class:`~meho_backplane.db.models.DispatchTraceSpan` field-for-field
+// -- the frequently-queried axes (:attr:`status`, :attr:`duration_ms`) are
+// typed columns, and the redacted/capped span detail (method, URL, redacted
+// headers, the redacted body + truncation marker, JSONFlux input/kept/output
+// sizes, the result-handle id) rides the free-form :attr:`attributes` mapping.
+// The read surface renders these as stored -- it never re-processes them.
+type TraceSpanView struct {
+	Attributes map[string]interface{} `json:"attributes"`
+	DurationMs *string                `json:"duration_ms"`
+	Name       string                 `json:"name"`
+	Seq        int                    `json:"seq"`
+	SpanKind   string                 `json:"span_kind"`
+	StartedAt  time.Time              `json:"started_at"`
+	Status     *string                `json:"status"`
+}
+
+// TraceView A dispatch trace header plus its ordered spans, tenant-scoped.
+//
+// Returned by :func:`load_trace` when a trace exists for the “(audit_id,
+// tenant_id)“ pair. :attr:`redaction_uncertain` is the F5 degrade flag read
+// straight off the header: “True“ means the capture/redaction seam could not
+// prove the trace fully redacted, so it was withheld from the agent handle and
+// is readable on the operator plane alone. The operator surface surfaces the
+// flag rather than acting on it -- an operator sees everything, and sees which
+// traces the agent could not.
+type TraceView struct {
+	AuditId            openapi_types.UUID `json:"audit_id"`
+	CreatedAt          time.Time          `json:"created_at"`
+	ExpiresAt          time.Time          `json:"expires_at"`
+	RedactionUncertain bool               `json:"redaction_uncertain"`
+	Spans              []TraceSpanView    `json:"spans"`
+	TenantId           openapi_types.UUID `json:"tenant_id"`
+	TraceId            openapi_types.UUID `json:"trace_id"`
+}
+
 // UISessionContext Per-request session identity exposed on “request.state“.
 //
 // Frozen so a route handler that stashes the context on a logger
@@ -8846,6 +8925,11 @@ type ShowApiV1AuditShowAuditIdGetParams struct {
 type WhoTouchedApiV1AuditWhoTouchedTargetGetParams struct {
 	Since         *string `form:"since,omitempty" json:"since,omitempty"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// TraceApiV1AuditAuditIdTraceGetParams defines parameters for TraceApiV1AuditAuditIdTraceGet.
+type TraceApiV1AuditAuditIdTraceGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -11917,6 +12001,9 @@ type ClientInterface interface {
 	// WhoTouchedApiV1AuditWhoTouchedTargetGet request
 	WhoTouchedApiV1AuditWhoTouchedTargetGet(ctx context.Context, target string, params *WhoTouchedApiV1AuditWhoTouchedTargetGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// TraceApiV1AuditAuditIdTraceGet request
+	TraceApiV1AuditAuditIdTraceGet(ctx context.Context, auditId openapi_types.UUID, params *TraceApiV1AuditAuditIdTraceGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AuthConfigApiV1AuthConfigGet request
 	AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13896,6 +13983,18 @@ func (c *Client) ShowApiV1AuditShowAuditIdGet(ctx context.Context, auditId opena
 
 func (c *Client) WhoTouchedApiV1AuditWhoTouchedTargetGet(ctx context.Context, target string, params *WhoTouchedApiV1AuditWhoTouchedTargetGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWhoTouchedApiV1AuditWhoTouchedTargetGetRequest(c.Server, target, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TraceApiV1AuditAuditIdTraceGet(ctx context.Context, auditId openapi_types.UUID, params *TraceApiV1AuditAuditIdTraceGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTraceApiV1AuditAuditIdTraceGetRequest(c.Server, auditId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -22414,6 +22513,55 @@ func NewWhoTouchedApiV1AuditWhoTouchedTargetGetRequest(server string, target str
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewTraceApiV1AuditAuditIdTraceGetRequest generates requests for TraceApiV1AuditAuditIdTraceGet
+func NewTraceApiV1AuditAuditIdTraceGetRequest(server string, auditId openapi_types.UUID, params *TraceApiV1AuditAuditIdTraceGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "audit_id", runtime.ParamLocationPath, auditId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/audit/%s/trace", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -41159,6 +41307,9 @@ type ClientWithResponsesInterface interface {
 	// WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse request
 	WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse(ctx context.Context, target string, params *WhoTouchedApiV1AuditWhoTouchedTargetGetParams, reqEditors ...RequestEditorFn) (*WhoTouchedApiV1AuditWhoTouchedTargetGetResponse, error)
 
+	// TraceApiV1AuditAuditIdTraceGetWithResponse request
+	TraceApiV1AuditAuditIdTraceGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *TraceApiV1AuditAuditIdTraceGetParams, reqEditors ...RequestEditorFn) (*TraceApiV1AuditAuditIdTraceGetResponse, error)
+
 	// AuthConfigApiV1AuthConfigGetWithResponse request
 	AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error)
 
@@ -43430,6 +43581,29 @@ func (r WhoTouchedApiV1AuditWhoTouchedTargetGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r WhoTouchedApiV1AuditWhoTouchedTargetGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type TraceApiV1AuditAuditIdTraceGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AuditTraceResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r TraceApiV1AuditAuditIdTraceGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TraceApiV1AuditAuditIdTraceGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -51329,6 +51503,15 @@ func (c *ClientWithResponses) WhoTouchedApiV1AuditWhoTouchedTargetGetWithRespons
 	return ParseWhoTouchedApiV1AuditWhoTouchedTargetGetResponse(rsp)
 }
 
+// TraceApiV1AuditAuditIdTraceGetWithResponse request returning *TraceApiV1AuditAuditIdTraceGetResponse
+func (c *ClientWithResponses) TraceApiV1AuditAuditIdTraceGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *TraceApiV1AuditAuditIdTraceGetParams, reqEditors ...RequestEditorFn) (*TraceApiV1AuditAuditIdTraceGetResponse, error) {
+	rsp, err := c.TraceApiV1AuditAuditIdTraceGet(ctx, auditId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTraceApiV1AuditAuditIdTraceGetResponse(rsp)
+}
+
 // AuthConfigApiV1AuthConfigGetWithResponse request returning *AuthConfigApiV1AuthConfigGetResponse
 func (c *ClientWithResponses) AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error) {
 	rsp, err := c.AuthConfigApiV1AuthConfigGet(ctx, reqEditors...)
@@ -56936,6 +57119,39 @@ func ParseWhoTouchedApiV1AuditWhoTouchedTargetGetResponse(rsp *http.Response) (*
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AuditQueryResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseTraceApiV1AuditAuditIdTraceGetResponse parses an HTTP response from a TraceApiV1AuditAuditIdTraceGetWithResponse call
+func ParseTraceApiV1AuditAuditIdTraceGetResponse(rsp *http.Response) (*TraceApiV1AuditAuditIdTraceGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TraceApiV1AuditAuditIdTraceGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AuditTraceResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -182,6 +182,7 @@ tenant-scoping invariant is enforced one layer up.
 | `GET /api/v1/audit/by-work-ref/{ref}` | Path param (`{ref:path}` converter — a work_ref carries embedded slashes, `#` is percent-encoded) becomes `filters.work_ref` (exact match); `since` query has **no** default window (a change-ticket lookup wants the whole governed history of the ref, not just the last 24h). The "show every write authorised by ticket X" lookup (work_ref I1-T3 #1658). | Pre-canned shortcut. |
 | `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Substrate returns 0 rows for cross-tenant lookups → router raises **404** (not 403) so existence never leaks. | Single-row fetch. |
+| `GET /api/v1/audit/{audit_id}/trace` | The dispatch flight-recorder read (#3215). Audit-existence check via the same tenant-scoped substrate (`audit_id`, `limit=1`) → **404** (not 403) on a missing / cross-tenant row, matching `show`. Then `flight_recorder.load_trace(audit_id, tenant_id)` loads the trace header + ordered spans (tenant-scoped again as defence in depth). 200 body is `AuditTraceResult` (`{audit_id, trace_present, trace}`); an audit row with **no** captured trace is a `200` with `trace_present=false` (capture is opt-in/best-effort, not an error), and `trace.redaction_uncertain` surfaces the F5 degrade flag. Operator plane keeps full access independent of the agent gate. | Flight-recorder trace (#3215). |
 | `GET /api/v1/audit/sessions/{session_id}/replay` | Dispatches `replay_session(session_id, tenant_id=operator.tenant_id, ...)`. 200 body is `AuditReplayResult` (`{root: [ReplayNode], session_id, tenant_id, row_count, excluded_null_session_count}`). Unknown / foreign session → `root=[]` / `row_count=0` (**not** 404 — same non-leakage as `show`). `row_count > 10_000` → **413** `{"detail": "session_too_large", "row_count": n}` from a count-first guard run *before* the recursive tree build. **`tenant_admin`-gated (#1843)** — see RBAC below. | Per-session replay (G8.2-T4). |
 
 The replay route's **413 cap** is a cheap tenant-scoped
@@ -196,8 +197,9 @@ counted — "session rows" are defined by the `agent_session_id` anchor.
 
 Every route binds two audit-override contextvars **before** the substrate
 call — `audit_op_class="audit_query"` (always) plus an `audit_op_id`:
-`"meho.audit.query"` for the four query routes and `"meho_audit_replay"`
-for the replay route (so operators can tell replay usage apart from
+`"meho.audit.query"` for the four query routes, `"meho_audit_replay"` for
+the replay route, and `"meho_audit_trace"` for the flight-recorder trace
+route (so operators can tell replay and trace-read usage apart from
 flat-query usage in `audit_log`). The shared `audit_query` op_class flips
 the broadcast event to aggregate-only (`{op_id, result_status,
 row_count}` only, never the request filter or the replayed `ReplayNode`
@@ -206,11 +208,14 @@ returns — and on the 413 path before raising — so the broadcast event's
 `row_count` field reflects the actual cardinality. The shape mirrors
 `api/v1/retrieve_usage.py`.
 
-RBAC: the five flat / self-scoped routes (`query`, `who-touched`,
-`by-work-ref`, `my-recent`, `show`) require `operator` minimum —
-`read_only` → 403; `operator` / `tenant_admin` → 200. These mirror the
-operator-gated MCP `query_audit` tool (including its self-session-only
-`shape="tree"` path).
+RBAC: the flat / self-scoped operator routes (`query`, `who-touched`,
+`by-work-ref`, `my-recent`, `show`, and the flight-recorder `trace`)
+require `operator` minimum — `read_only` → 403; `operator` /
+`tenant_admin` → 200. These mirror the operator-gated MCP `query_audit`
+tool (including its self-session-only `shape="tree"` path). The
+flight-recorder trace read stays on the operator plane with **full**
+access independent of the agent gate (the agent read is a separate task);
+the console pane renders the same trace through the audit-row drawer.
 
 **Tenant-broadcast read surfaces (#2084).** Within a tenant, `query` and
 `show` are principal-agnostic by design: `POST /api/v1/audit/query` (with


### PR DESCRIPTION
Closes #3215

Implements the **operator read surface** of the accepted decision
`docs/decisions/dispatch-flight-recorder.md`: the REST trace endpoint and the
console trace pane. The operator plane keeps **full** trace access, independent
of the agent gate (a separate task). Read-only — renders what the storage
(#3212), redaction (#3213), and capture (#3214) seams already stored; never
re-processes, un-redacts, or writes.

## What's in scope
- **Tenant-scoped read** (`flight_recorder/read.py`): `TraceView` /
  `TraceSpanView` / `load_trace(session, *, audit_id, tenant_id)` — the single
  read both fronts share, filtering the trace header on `tenant_id` as defence
  in depth. The store (#3212) explicitly shipped no read surface; this is it.
- **REST** `GET /api/v1/audit/{audit_id}/trace` behind `_require_operator`,
  alongside `GET /api/v1/audit/show/{audit_id}`. Missing/cross-tenant audit row
  → **404** (never 403 — existence never leaks, matching `/show`); audit row
  present but **no captured trace** → **200** with `trace_present=false`
  (capture is per-tenant opt-in and best-effort, not an error). Distinct
  `op_id` `meho_audit_trace`, aggregate-only broadcast. New `AuditTraceResult`
  envelope; `trace.redaction_uncertain` surfaces the F5 degrade flag.
- **Console** "Flight recorder" pane in the audit-row drawer (after Lineage),
  projected by `ui/routes/audit/trace_pane.py`: per-span method / URL / status /
  duration, expandable **redacted** headers + bodies with truncation markers,
  JSONFlux input→kept→output→handle, and the redaction-uncertainty banner.
- **Paired add-ons** consume the same REST route with their operator-granted
  principal — no separate surface. **No MCP-surface change** (REST + console
  only; the agent read is a sibling task).

## Tenant isolation (enforced twice)
The REST route's audit-existence check runs through the tenant-scoped substrate
(tenant from JWT, never client input) **and** `load_trace` re-filters the trace
header on `tenant_id`. The drawer resolves the row via the session's tenant,
then loads the trace on that same tenant.

## Security review points
- **Escaping**: the pane renders vendor-controlled body text via Jinja
  autoescape + `tojson` (HTML-safe); URLs render as text, never in an `href`;
  badge classes come from fixed maps, not vendor input. Guarded by a test that
  proves an injected `<script>` is neutralized.
- **No write path / no un-redaction**: all SELECT; stored redacted attributes
  rendered verbatim.

## Tests (16 new)
- `test_api_audit_trace_route.py` (9): RBAC (operator required, read-only 403,
  unauth 401, tenant-admin 200), cross-tenant 404 (no leak), missing-audit 404,
  empty-state 200, ordered spans, truncation + redaction-uncertainty, OpenAPI.
- `test_flight_recorder_read.py` (3): ordered load, absent→None, **tenant
  isolation** (tenant B's trace never returned for tenant A).
- `test_ui_audit_drawer_trace.py` (4): pane renders spans, truncation +
  uncertainty banner, empty state, **HTML-escaping** guard.
- Regression: 80 passed across touched/adjacent suites on the rebased base
  (audit routes/drawer, all flight_recorder). ruff + ruff format + mypy clean
  on all `src` files (CI mypy scope is `files=["src"]`).

## Docs
- CHANGELOG `### Added` block on top of `[Unreleased]`.
- `docs/codebase/audit_query.md` route table + op_id + RBAC paragraphs.

## Inline adversarial review — verdict: APPROVE
Cold re-read of the full diff against tenant-isolation, claim-gate, write/
un-redaction, template-injection, and convention-drift. **One finding found and
fixed**: the `?audit_id=` deep-link page's `{% with %}` in `index.html` omitted
`trace`, tripping Jinja `StrictUndefined` (caught by the existing
`test_page_deep_link_pre_renders_drawer`; fixed and re-verified green). One
note: `ui/routes/audit/routes.py` was already >600 lines pre-#3215, so the
repo-standard `# code-quality-allow: file-size` directive was applied (splitting
the surface router is out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)