### PR TITLE
fix(connectors): holodeck.config.apply fails closed on CLIXML-corrupted stdout (#3081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `holodeck.config.apply` fails closed instead of reporting false success on a CLIXML-corrupted stdout (#3081)
+
+- `holodeck.config.apply` returned `{applied: true, config_id: null}` while
+  writing **nothing** to the HoloRouter: no config file appeared under
+  `/holodeck-runtime/config/`, so the next runbook step (`instance.start`) had
+  nothing to launch from and proceeded on a false premise. Root cause was the
+  `HoloDeck` PowerShell module's "unapproved verbs" auto-load warning, which
+  `pwsh -EncodedCommand` serialised as a `#< CLIXML … </Objs>` block onto
+  **stdout** ahead of the `ConvertTo-Json` payload — `holodeck.config.show`
+  failed honestly on the same transport, but `config.apply` reported success
+  regardless. Two fixes: (1) the shared `_pwsh` transport seam now strips CLIXML
+  warning/error blocks from stdout before parsing (`strip_clixml`), so every
+  pwsh-backed op tolerates the noise and a warning-only stdout fails closed as
+  empty rather than crashing the parse; and (2) `config.apply` reports
+  `applied: true` **only** with a non-null `config_id` verified on disk (a
+  `Test-Path` verify-after-write folded into the same script), and silences the
+  warning stream at the source (`$WarningPreference`). The self-contradictory
+  `applied: true` / `config_id: null` envelope is now impossible.
+
 ### Added — flight recorder: capture seam + caps + best-effort invariant (#3214)
 
 - Ships the **capture seam** plus the **F3 caps** and **F7 failure invariant**

--- a/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
+++ b/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
@@ -29,11 +29,34 @@ Wire shape
    ``ConvertTo-Json``, and Json output parses with the stdlib :mod:`json`
    without pulling in an undecided CliXml dependency (``pyclixml``).
 3. :func:`pwsh_run` runs ``pwsh -EncodedCommand <encoded>`` over the
-   pooled SSH connection and decodes ``stdout`` via
-   :func:`json.loads`, returning the parsed structure.
+   pooled SSH connection, strips any CLIXML warning/error blocks that
+   leaked onto stdout (see *Warning-stream hygiene* below), then
+   decodes the remaining ``stdout`` via :func:`json.loads`, returning
+   the parsed structure.
 4. Failures surface as a single structured :exc:`PwshRunError` that
    carries the exit status and a truncated stderr fragment but never
    embeds the original script body or any auth material.
+
+Warning-stream hygiene (#3081)
+------------------------------
+
+When a cmdlet (or PowerShell module auto-loading, e.g. ``HoloDeck``'s
+"unapproved verbs" import warning) writes to the warning / error
+stream, ``pwsh`` under ``-EncodedCommand`` can serialise that record
+as a CLIXML block — a ``#< CLIXML`` preamble followed by an ``<Objs>``
+document — **onto stdout**, ahead of the real ``ConvertTo-Json``
+payload. ``-OutputFormat Text`` does **not** reliably suppress this
+(PowerShell issue #5912: it is ignored on a redirected stream), so
+:func:`pwsh_run` defends at the parse boundary: :func:`strip_clixml`
+removes every ``#< CLIXML ... </Objs>`` block from stdout before the
+empty-check and :func:`json.loads`, leaving the JSON payload intact.
+A cmdlet that emits *only* a CLIXML warning (no JSON) strips to empty
+and fails closed via the existing empty-stdout guard — the honest
+failure ``holodeck.config.show`` already reports. Ops that must not
+report false success additionally silence the warning stream at the
+source (``$WarningPreference = 'SilentlyContinue'``), which is the
+reliable workaround; the strip is the universal net for every op that
+does not.
 
 Safety contract
 ---------------
@@ -72,11 +95,18 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 from typing import Any
 
 import structlog
 
-__all__ = ["PWSH_DEFAULT_DEPTH", "PwshRunError", "encode_pwsh_command", "pwsh_run"]
+__all__ = [
+    "PWSH_DEFAULT_DEPTH",
+    "PwshRunError",
+    "encode_pwsh_command",
+    "pwsh_run",
+    "strip_clixml",
+]
 
 _log = structlog.get_logger(__name__)
 
@@ -120,6 +150,40 @@ class PwshRunError(RuntimeError):
         super().__init__(message)
         self.exit_status = exit_status
         self.stderr = stderr[:_STDERR_MAX_LEN]
+
+
+#: One CLIXML block PowerShell can prepend to stdout when a warning / error
+#: record is serialised under ``-EncodedCommand``: the literal ``#< CLIXML``
+#: preamble followed by a single ``<Objs>...</Objs>`` document. The pattern
+#: is non-greedy to the first ``</Objs>`` so multiple stacked blocks (one per
+#: warning) each match their own document, and ``DOTALL`` lets the ``<Objs>``
+#: body span the newlines the serialiser emits. The trailing ``\s*`` also
+#: consumes the newline the serialiser writes after each block, so a JSON
+#: payload trailing the block comes back clean and a warning-only stdout
+#: strips to ``""``. ``ConvertTo-Json`` output never contains ``</Objs>``, so
+#: the payload itself always survives.
+_CLIXML_BLOCK_RE: re.Pattern[str] = re.compile(r"#<\s*CLIXML\b.*?</Objs>\s*", re.DOTALL)
+
+
+def strip_clixml(stdout: str) -> str:
+    """Remove PowerShell CLIXML warning/error blocks polluting *stdout* (#3081).
+
+    ``pwsh -EncodedCommand`` can serialise a warning or error record as a
+    ``#< CLIXML`` preamble + ``<Objs>...</Objs>`` document written to stdout
+    ahead of the real ``ConvertTo-Json`` payload (the ``HoloDeck`` module's
+    "unapproved verbs" import warning is the motivating case). Left in place
+    it makes :func:`json.loads` fail on otherwise-valid output. This removes
+    every such block, leaving the JSON payload — or, when the cmdlet emitted
+    *only* a warning, an empty string that the caller's empty-stdout guard
+    turns into an honest failure.
+
+    Public so the unit suite can assert the strip against fixture text without
+    driving the whole :func:`pwsh_run` transport. A ``stdout`` with no CLIXML
+    marker is returned unchanged (cheap fast-path — the common healthy case).
+    """
+    if "CLIXML" not in stdout:
+        return stdout
+    return _CLIXML_BLOCK_RE.sub("", stdout)
 
 
 def encode_pwsh_command(script: str) -> str:
@@ -209,6 +273,9 @@ async def pwsh_run(
         stdout = ""
     if not isinstance(stderr, str):
         stderr = ""
+    # Strip any CLIXML warning/error block pwsh serialised onto stdout ahead
+    # of the JSON payload (#3081) before the empty-check and json.loads below.
+    stdout = strip_clixml(stdout)
     exit_status: int | None = getattr(proc, "exit_status", None)
 
     # Structured logging discipline (mirrors the SSH adapter's

--- a/backend/src/meho_backplane/connectors/holodeck/ops_deploy.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_deploy.py
@@ -214,10 +214,20 @@ async def holodeck_config_apply(
     schema; :func:`validate_config_apply_params` re-checks it here as
     belt-and-braces for a direct call that bypassed the dispatcher.
 
+    Fail-closed (#3081): the op returns ``applied: true`` **only** when the
+    cmdlet reports a non-null ``configID`` **and** the persisted config file
+    (``/holodeck-runtime/config/<id>.json``) exists on disk (a verify-after-
+    write via ``Test-Path`` folded into the same script). A run that writes
+    nothing -- e.g. the ``HoloDeck`` import warning corrupting stdout, or
+    ``New-HoloDeckConfig`` failing silently -- returns ``{applied: false,
+    config_id, error}`` rather than a self-contradictory ``applied: true`` /
+    ``config_id: null``. The import warning is additionally silenced at the
+    source (``$WarningPreference``) so it never reaches the JSON stream.
+
     Runs only on the ``_approved=True`` resume path (``requires_approval``).
-    Returns ``{applied, config_id, deploy: {version, variant, ...}}`` -- a
-    param-echo of the non-secret applied config; no credential material is
-    read or echoed.
+    On success returns ``{applied: true, config_id, deploy: {version,
+    variant, ...}}`` -- a param-echo of the non-secret applied config; no
+    credential material is read or echoed.
     """
     semantic_errors = validate_config_apply_params(params)
     if semantic_errors:
@@ -232,14 +242,29 @@ async def holodeck_config_apply(
     # $env:VC_USER / $env:VC_PW (staged out-of-band per the runbook). NEVER
     # -Default. The description is the only operator-supplied string
     # interpolated into the script body, and it carries no credential.
+    #
+    # $WarningPreference = 'SilentlyContinue' silences the HoloDeck module's
+    # "unapproved verbs" import warning at the source so it never gets
+    # CLIXML-serialised onto stdout (#3081; the reliable workaround per
+    # PowerShell #5912, complementing the transport's strip_clixml net).
+    #
+    # configWritten is a verify-after-write: New-HoloDeckConfig persists the
+    # config to /holodeck-runtime/config/<configID>.json, so Test-Path on
+    # exactly that file confirms the write actually landed on disk. A run that
+    # returns no real configID leaves the path as ".../.json" -> $false, so
+    # applied:true is impossible without a config genuinely on the appliance.
     quoted_desc = _pwsh_single_quote(description)
     quoted_host = _pwsh_single_quote(str(external_ip)) if external_ip else "$env:VC_HOST"
     script = (
         "$Global:ProgressPreference = 'SilentlyContinue'; "
+        "$Global:WarningPreference = 'SilentlyContinue'; "
         f"$cfg = New-HoloDeckConfig -Description {quoted_desc} "
         f"-TargetHost {quoted_host} -UserName $env:VC_USER -Password $env:VC_PW; "
         "$null = Import-HoloDeckConfig -ConfigID $cfg.configID; "
-        "@{ configID = $cfg.configID } | ConvertTo-Json -Compress"
+        '$cfgPath = "/holodeck-runtime/config/$($cfg.configID).json"; '
+        "@{ configID = $cfg.configID; "
+        "configWritten = [bool](Test-Path -LiteralPath $cfgPath) } "
+        "| ConvertTo-Json -Compress"
     )
 
     try:
@@ -248,6 +273,23 @@ async def holodeck_config_apply(
         return {"applied": False, "error": str(exc)}
 
     config_id = payload.get("configID") if isinstance(payload, dict) else None
+    config_written = bool(payload.get("configWritten")) if isinstance(payload, dict) else False
+    # Fail closed (#3081): only report applied:true when the cmdlet produced a
+    # real configID AND the persisted config file exists on disk. A null/blank
+    # configID or an absent file means nothing was written -- returning
+    # applied:true there converts a silent failure into a believed success and
+    # the next runbook step (instance.start) would proceed on a false premise.
+    if not isinstance(config_id, str) or not config_id.strip() or not config_written:
+        return {
+            "applied": False,
+            "config_id": config_id if isinstance(config_id, str) else None,
+            "error": (
+                "New-HoloDeckConfig did not produce a persisted config on the "
+                "HoloRouter (no configID and/or no config file at "
+                "/holodeck-runtime/config/<id>.json); nothing was written, so "
+                "the deploy config was NOT applied"
+            ),
+        }
     return {
         "applied": True,
         "config_id": config_id,
@@ -1029,7 +1071,9 @@ DEPLOY_OPS: tuple[HolodeckOp, ...] = (
             },
             "output_shape": (
                 "{applied, config_id, deploy: {version, variant, ...non-secret echo}}. "
-                "On a bound violation: {applied: false, error}."
+                "applied is true ONLY with a non-null config_id verified on disk; "
+                "a bound violation or an unwritten config returns {applied: false, "
+                "config_id, error}."
             ),
         },
     ),

--- a/backend/tests/test_connectors_holodeck_deploy.py
+++ b/backend/tests/test_connectors_holodeck_deploy.py
@@ -228,7 +228,7 @@ async def test_config_apply_composes_new_holodeckconfig_without_default() -> Non
         "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
         new_callable=AsyncMock,
     ) as mock_pwsh:
-        mock_pwsh.return_value = {"configID": "hd9mgmt1"}
+        mock_pwsh.return_value = {"configID": "hd9mgmt1", "configWritten": True}
         result = await connector.config_apply(
             _StubTarget(),
             {
@@ -247,6 +247,152 @@ async def test_config_apply_composes_new_holodeckconfig_without_default() -> Non
     assert "Import-HoloDeckConfig" in script
     # Credentials referenced by env-var NAME only -- no interpolated value.
     assert "$env:VC_USER" in script and "$env:VC_PW" in script
+    # #3081: the warning stream is silenced at the source and the write is
+    # verified on disk before the op can report success.
+    assert "$Global:WarningPreference = 'SilentlyContinue'" in script
+    assert "Test-Path" in script and "/holodeck-runtime/config/" in script
+
+
+# ===========================================================================
+# C.1 config.apply fail-closed on an unwritten config (#3081)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_config_apply_fails_closed_on_null_config_id() -> None:
+    """A cmdlet that returns configID:null must NOT report applied:true (#3081).
+
+    The severe defect: config.apply reported ``{applied: true, config_id:
+    null}`` while writing nothing to the HoloRouter. The self-contradictory
+    envelope is now impossible -- a null configID fails closed.
+    """
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.return_value = {"configID": None, "configWritten": False}
+        result = await connector.config_apply(
+            _StubTarget(), {"version": "9.0.2.0", "variant": "management_only"}
+        )
+    assert result["applied"] is False
+    assert result["config_id"] is None
+    assert "NOT applied" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_apply_fails_closed_when_file_not_on_disk() -> None:
+    """A real-looking configID with no persisted file must fail closed (#3081).
+
+    verify-after-write: even when New-HoloDeckConfig returns a plausible
+    configID, applied stays false unless the config file is actually on disk.
+    """
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.return_value = {"configID": "hd9mgmt1", "configWritten": False}
+        result = await connector.config_apply(
+            _StubTarget(), {"version": "9.0.2.0", "variant": "management_only"}
+        )
+    assert result["applied"] is False
+    # The configID is still surfaced for triage, but applied is false.
+    assert result["config_id"] == "hd9mgmt1"
+    assert "NOT applied" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_apply_pwsh_error_fails_closed() -> None:
+    """A PwshRunError (empty/corrupt stdout) surfaces as applied:false (#3081).
+
+    ``holodeck.config.show`` already fails honestly on the same transport;
+    config.apply must too, rather than defaulting to success.
+    """
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.side_effect = PwshRunError(
+            "pwsh -EncodedCommand produced empty stdout; expected ConvertTo-Json output",
+            exit_status=0,
+            stderr="",
+        )
+        result = await connector.config_apply(
+            _StubTarget(), {"version": "9.0.2.0", "variant": "management_only"}
+        )
+    assert result["applied"] is False
+    assert "empty stdout" in result["error"]
+
+
+# ===========================================================================
+# C.2 config.apply end-to-end through the real pwsh transport (#3081)
+# ===========================================================================
+#
+# These drive the REAL pwsh_run by stubbing the SSH exec channel
+# (connector._run_command) instead of mocking pwsh_run, so the CLIXML strip
+# + empty-stdout guard + fail-closed handler are exercised as one chain.
+
+_APPLY_PARAMS = {"version": "9.0.2.0", "variant": "management_only", "external_ip": "vc.lab"}
+_CLEAN_APPLY_JSON = '{"configID":"hd9mgmt1","configWritten":true}'
+_CLIXML_WARNING = (
+    "#< CLIXML\n"
+    '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+    '<S S="warning">The names of some imported commands from the module '
+    "'HoloDeck' include unapproved verbs that might make them less "
+    "discoverable.</S></Objs>\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_config_apply_transport_parses_clixml_polluted_stdout() -> None:
+    """(a) CLIXML warning prepended to valid JSON -> stripped -> applied:true."""
+    connector = HolodeckConnector()
+    polluted = _CLIXML_WARNING + _CLEAN_APPLY_JSON
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = _proc(stdout=polluted, exit_status=0)
+        result = await connector.config_apply(_StubTarget(), dict(_APPLY_PARAMS))
+    assert result["applied"] is True
+    assert result["config_id"] == "hd9mgmt1"
+
+
+@pytest.mark.asyncio
+async def test_config_apply_transport_fails_closed_on_empty_stdout() -> None:
+    """(b) empty stdout -> PwshRunError -> applied:false, never a false success."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = _proc(stdout="", exit_status=0)
+        result = await connector.config_apply(_StubTarget(), dict(_APPLY_PARAMS))
+    assert result["applied"] is False
+    assert "empty stdout" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_apply_transport_succeeds_on_clean_json() -> None:
+    """(c) clean JSON -> applied:true with the parsed config_id."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = _proc(stdout=_CLEAN_APPLY_JSON, exit_status=0)
+        result = await connector.config_apply(_StubTarget(), dict(_APPLY_PARAMS))
+    assert result["applied"] is True
+    assert result["config_id"] == "hd9mgmt1"
+
+
+@pytest.mark.asyncio
+async def test_config_apply_transport_never_true_with_null_config_id() -> None:
+    """The invariant: CLIXML-only stdout (no JSON) can never yield applied:true.
+
+    A fresh HoloRouter where the write silently failed emits only the warning
+    block; stripped, that is empty stdout -> fail-closed. This is the exact
+    #3081 scenario end-to-end.
+    """
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = _proc(stdout=_CLIXML_WARNING, exit_status=0)
+        result = await connector.config_apply(_StubTarget(), dict(_APPLY_PARAMS))
+    assert result["applied"] is False
+    assert not (result["applied"] is True and result["config_id"] is None)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_holodeck_pwsh.py
+++ b/backend/tests/test_connectors_holodeck_pwsh.py
@@ -45,6 +45,7 @@ from meho_backplane.connectors.holodeck._pwsh import (
     PwshRunError,
     encode_pwsh_command,
     pwsh_run,
+    strip_clixml,
 )
 from meho_backplane.settings import get_settings
 
@@ -275,6 +276,62 @@ async def test_pwsh_run_error_truncates_long_stderr() -> None:
     # The truncated stderr still starts with the first bytes -- the
     # cap doesn't drop content from the wrong end.
     assert exc_info.value.stderr.startswith("x" * 100)
+
+
+# ---------------------------------------------------------------------------
+# CLIXML warning-stream hygiene (#3081)
+# ---------------------------------------------------------------------------
+
+_CLIXML_WARNING = (
+    "#< CLIXML\n"
+    '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+    '<S S="warning">The names of some imported commands from the module '
+    "'HoloDeck' include unapproved verbs that might make them less "
+    "discoverable.</S></Objs>\n"
+)
+
+
+def test_strip_clixml_passes_clean_json_through_unchanged() -> None:
+    clean = '{"configID":"hd9mgmt1"}'
+    assert strip_clixml(clean) is clean
+
+
+def test_strip_clixml_removes_leading_warning_block_keeps_json() -> None:
+    payload = '{"configID":"hd9mgmt1","configWritten":true}'
+    assert strip_clixml(_CLIXML_WARNING + payload) == payload
+
+
+def test_strip_clixml_only_warning_strips_to_blank() -> None:
+    """A cmdlet that emits ONLY a CLIXML warning strips to an empty-ish string.
+
+    The remainder is whitespace-only, so the caller's ``stdout.strip()``
+    empty-check turns it into an honest failure rather than a parse crash.
+    """
+    assert strip_clixml(_CLIXML_WARNING).strip() == ""
+
+
+def test_strip_clixml_removes_multiple_stacked_blocks() -> None:
+    payload = "[1,2,3]"
+    stacked = _CLIXML_WARNING + _CLIXML_WARNING + payload
+    assert strip_clixml(stacked) == payload
+
+
+async def test_pwsh_run_parses_json_after_clixml_warning() -> None:
+    """The whole transport tolerates a CLIXML warning ahead of the JSON."""
+    payload = {"configID": "hd9mgmt1", "configWritten": True}
+    connector = _connector_with_run(
+        _proc(stdout=_CLIXML_WARNING + json.dumps(payload), exit_status=0)
+    )
+    result = await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+    assert result == payload
+
+
+async def test_pwsh_run_clixml_only_stdout_fails_closed_as_empty() -> None:
+    """CLIXML-only stdout strips to empty -> the empty-stdout guard fires."""
+    connector = _connector_with_run(_proc(stdout=_CLIXML_WARNING, exit_status=0))
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+    assert "empty stdout" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -77,6 +77,19 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
   base64) and the `-EncodedCommand` argv shape are unchanged from the
   original design.
 
+  **CLIXML warning-stream hygiene (#3081).** `pwsh -EncodedCommand` can
+  serialise a warning / error record — notably the `HoloDeck` module's
+  "unapproved verbs" auto-load warning — as a `#< CLIXML … </Objs>` block
+  written to **stdout** ahead of the real `ConvertTo-Json` payload, which
+  makes `json.loads` fail on otherwise-valid output. `-OutputFormat Text`
+  does not reliably suppress it (PowerShell #5912). `strip_clixml(stdout)`
+  removes every such block before the empty-check and parse; a cmdlet that
+  emits *only* a warning strips to empty and fails closed via the existing
+  empty-stdout guard (the honest failure `config.show` already reports).
+  This is the **single shared seam**, so every pwsh-backed op benefits at
+  once. Ops that must never report false success also silence the warning
+  at the source (`$WarningPreference = 'SilentlyContinue'`).
+
 - **Op metadata** (`ops.py`) — the `HolodeckOp` dataclass and the
   `HOLODECK_OPS` tuple. T1 shipped the single `holodeck.about` canary; T2
   (#854) extends the tuple via `_holodeck_ops()` which splats `READ_OPS`
@@ -392,7 +405,15 @@ broadcast surfaces.
   approves a config that would fail. `validate_config_apply_params` re-expresses
   the same rule as a clear string for the handler belt-and-braces and the direct
   test. It is deliberately **not** pinned credential-class, so it keeps its
-  generic param-echo preview (no secret is ever a param).
+  generic param-echo preview (no secret is ever a param). **Fail-closed
+  (#3081):** the op reports `applied: true` **only** when the cmdlet returns a
+  non-null `configID` **and** the persisted config file
+  (`/holodeck-runtime/config/<id>.json`) exists on disk — a verify-after-write
+  via `Test-Path` folded into the same script. A run that writes nothing (the
+  CLIXML import-warning corrupting stdout, or `New-HoloDeckConfig` failing
+  silently) returns `{applied: false, config_id, error}` instead of the
+  self-contradictory `{applied: true, config_id: null}` that let a runbook
+  proceed on a false premise.
 - **`holodeck.instance.start`** (group `deploy-lifecycle`). Runs a **single-shot
   fail-fast `Connect-VIServer` precheck before launch**: a pwsh script reads the
   persisted config on the appliance, builds a `PSCredential`, and makes exactly


### PR DESCRIPTION
## Summary

- `holodeck.config.apply` returned `{applied: true, config_id: null}` while writing **nothing** to the HoloRouter — the next runbook step (`instance.start`) then launched from a config that was never persisted. Root cause: the `HoloDeck` module's "unapproved verbs" auto-load warning, CLIXML-serialised by `pwsh -EncodedCommand` onto **stdout** ahead of the `ConvertTo-Json` payload. `config.show` failed honestly on the same transport; `config.apply` reported success regardless.
- **Transport seam (`_pwsh.py`)** now strips `#< CLIXML … </Objs>` blocks from stdout (`strip_clixml`) before the empty-check and `json.loads`. This is the single shared seam, so every pwsh-backed op tolerates the noise; a warning-only stdout strips to empty and fails closed via the existing empty-stdout guard, preserving `config.show`'s honest error. `-OutputFormat Text` is deliberately **not** used — it is ignored on redirected streams (PowerShell #5912).
- **Handler (`config.apply`)** reports `applied: true` **only** with a non-null `config_id` verified on disk (a `Test-Path` verify-after-write folded into the same script) and silences the warning at the source (`$WarningPreference`). The self-contradictory `applied: true` / `config_id: null` envelope is now impossible.

## Test plan

- [x] `ruff check` — clean (touched modules + tests)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (no issues in the two touched source files)
- [x] `pytest -k holodeck` — 357 passed
- [x] Transport-driven `config.apply` tests stub the **SSH exec channel** (not `pwsh_run`) so the CLIXML strip + empty-stdout guard + fail-closed handler run as one chain:
  - (a) CLIXML-polluted stdout around valid JSON → parses, `applied: true`
  - (b) empty stdout → `PwshRunError` → `applied: false` (fails structurally)
  - (c) clean JSON → `applied: true`
  - (d) CLIXML-warning-only stdout (the exact #3081 scenario) → strips to empty → `applied: false`; `applied: true` never co-occurs with `config_id: null`
- [x] `strip_clixml` unit tests: clean JSON passthrough, single + stacked warning-block removal, warning-only → blank
- [x] `pwsh_run` tolerates a CLIXML warning ahead of the JSON; warning-only stdout fails closed as empty
- [x] `config.show` honest-failure contract verified unchanged
- [x] `code-quality.py --diff` — pass

Acceptance criteria (from the issue's Suggested acceptance):
- [x] `config.apply` returns `applied: true` only with a non-null `config_id`, verified by read-back (`Test-Path`)
- [x] A cmdlet op whose stdout is not parseable JSON fails loudly rather than defaulting to success
- [x] Import-time warnings never reach the JSON-parsed stream (transport strip + source `$WarningPreference`)
- [x] Regression covered end-to-end via the simulated SSH transport (a live HoloRouter is unreachable from CI; the transport stub reproduces the fresh-9.0.2 scenario)

## Out of scope

- `windows_dns` has its own `_pwsh.py`; #3081 is holodeck-specific and this change is confined to the holodeck seam.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3081
