### PR TITLE
feat(gateway): satellite-mint tier ladder — additive remote-write tier (#3188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,33 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — satellite write path: `remote-write` safety tier + tiered mint gate (#3188)
+
+- Extends the gateway's binary safe-wall into a **satellite-mint tier
+  ladder** — the foundation seam of the ratified scoped-hybrid write path
+  (Initiative #2901, `docs/decisions/satellite-write-path.md`). A single
+  source of truth (`runner/satellite_tier.py`) classifies the existing
+  `safe < caution < dangerous < destructive` `safety_level` enum (#3196)
+  into three tiers: `safe` → `SAFE` (mints on `AUTO_EXECUTE`, **unchanged**);
+  `caution` → `REMOTE_WRITE` (the additive, separately-gated write tier);
+  `dangerous`/`destructive` → `EXCLUDED` (**never** minted to a satellite).
+  It is a runtime classification, **not** a new `safety_level` value, so
+  there is **no migration**.
+- **Three-layer mirror, each fail-closed independently** (defence in depth):
+  the central mint (`mint_gateway_command` — `EXCLUDED` keeps
+  `MintRefusalCode.OP_NOT_SAFE`; `REMOTE_WRITE` refuses with the new
+  `REMOTE_WRITE_GATE_UNSATISFIED`), the assignment materialiser
+  (`assignment_service` — only `SAFE`-tier ops are authorable into the
+  recurring assignment), and the edge executor (`_screen_item` — re-screens
+  the delivered item against the same ladder).
+- The `remote-write` **composed gate** (`evaluate_remote_write_gate`) is a
+  fail-closed **seam**: a remote-write op mints only under a per-runner
+  allowlist + approval/policy binding, wired by the sibling tasks
+  (#3189-#3193). Until then it refuses every remote-write op at both the mint
+  and the edge. Composes with #3183: the `destructive` tier is excluded by
+  the satellite gate by default everywhere, so delete-shaped work never rides
+  a runner (#3225's conformance stays green).
+
 ### Added — flight recorder: capture seam + caps + best-effort invariant (#3214)
 
 - Ships the **capture seam** plus the **F3 caps** and **F7 failure invariant**

--- a/backend/src/meho_backplane/gateway/assignment_service.py
+++ b/backend/src/meho_backplane/gateway/assignment_service.py
@@ -52,6 +52,7 @@ from meho_backplane.gateway.errors import (
 from meho_backplane.gateway.schemas import AssignmentDocument, AuthoredCheckItem
 from meho_backplane.operations._lookup import lookup_descriptor
 from meho_backplane.runner import wire
+from meho_backplane.runner.satellite_tier import SatelliteMintTier, classify_satellite_tier
 from meho_backplane.targets.resolver import (
     AmbiguousTargetError,
     TargetNotFoundError,
@@ -67,8 +68,18 @@ __all__ = [
 
 _log = structlog.get_logger(__name__)
 
-#: v1 authorizes read-only workloads only.
-_SAFE_LEVEL = "safe"
+
+def _is_safe_tier(descriptor: EndpointDescriptor) -> bool:
+    """True when *descriptor* sits in the satellite-mint ``SAFE`` tier (#3188).
+
+    The recurring assignment authorises only the read-only ``SAFE`` tier;
+    ``remote-write`` (``caution``) work rides the one-shot capability-mint path
+    (``mint_gateway_command``), not this document, and the ``EXCLUDED``
+    (``dangerous`` / ``destructive``) tier never rides a runner at all.
+    Classified against the ladder shared with the central mint and the edge
+    executor — the three-layer mirror.
+    """
+    return classify_satellite_tier(descriptor.safety_level) is SatelliteMintTier.SAFE
 
 
 def descriptor_from_target(target: TargetORM) -> wire.ResolvedTargetDescriptor:
@@ -178,7 +189,7 @@ async def _validate_authored_item(
             reason=f"no enabled descriptor for connector "
             f"({cls.product}, {cls.version}, {cls.impl_id})",
         )
-    if descriptor.safety_level != _SAFE_LEVEL:
+    if not _is_safe_tier(descriptor):
         raise AssignmentOpNotSafeError(
             check_ref=item.check_ref, op=item.op, safety_level=descriptor.safety_level
         )
@@ -277,14 +288,13 @@ async def _materialize_item(
 
 
 def _is_runnable_safe(descriptor: EndpointDescriptor | None) -> bool:
-    """True when *descriptor* is an enabled, safe op the runner can execute.
+    """True when *descriptor* is an enabled, ``SAFE``-tier op the runner can execute.
 
     Requires a non-empty ``handler_ref``: the runner executes an op by
     importing that dotted handler, so a descriptor without one (an
-    ingested/generic op) is not remotely runnable and is dropped.
+    ingested/generic op) is not remotely runnable and is dropped. The tier
+    check routes through the shared satellite-mint ladder (#3188) so a
+    ``remote-write`` or ``EXCLUDED`` op is never materialised into the
+    recurring assignment.
     """
-    return (
-        descriptor is not None
-        and descriptor.safety_level == _SAFE_LEVEL
-        and bool(descriptor.handler_ref)
-    )
+    return descriptor is not None and _is_safe_tier(descriptor) and bool(descriptor.handler_ref)

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -83,6 +83,11 @@ from meho_backplane.operations._validate import (
     policy_gate,
     validate_params,
 )
+from meho_backplane.runner.satellite_tier import (
+    SatelliteMintTier,
+    classify_satellite_tier,
+    evaluate_remote_write_gate,
+)
 
 __all__ = [
     "GatewayCommandAlreadyConsumedError",
@@ -135,16 +140,20 @@ class MintRefusalCode(StrEnum):
     """Closed vocabulary of central mint refusals.
 
     Every value is a fail-closed outcome: the command is **not** minted, so
-    it never reaches a runner. ``OP_NOT_SAFE`` is the v1 read-only wall;
-    ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate verdicts that
-    are not ``AUTO_EXECUTE`` (change-ops-over-gateway is v2, so a
-    ``needs-approval`` verdict is refused here rather than parked).
+    it never reaches a runner. ``OP_NOT_SAFE`` walls off the
+    :attr:`~meho_backplane.runner.satellite_tier.SatelliteMintTier.EXCLUDED`
+    tier (``dangerous`` / ``destructive`` — never minted to a satellite);
+    ``REMOTE_WRITE_GATE_UNSATISFIED`` is the fail-closed refusal of the
+    additive ``remote-write`` tier while its composed gate is unprovisioned
+    (#3188); ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate
+    verdicts that are not ``AUTO_EXECUTE``.
     """
 
     DESCRIPTOR_UNKNOWN = "descriptor_unknown"
     INVALID_PARAMS = "invalid_params"
     INVALID_OP_SCHEMA = "invalid_op_schema"
     OP_NOT_SAFE = "op_not_safe"
+    REMOTE_WRITE_GATE_UNSATISFIED = "remote_write_gate_unsatisfied"
     POLICY_DENIED = "policy_denied"
     NEEDS_APPROVAL = "needs_approval"
 
@@ -293,10 +302,15 @@ async def mint_gateway_command(
     2. ``validate_params`` — invalid params → :attr:`MintRefusalCode.INVALID_PARAMS`;
        a stored schema whose own ``$ref`` cannot resolve (#3095) →
        :attr:`MintRefusalCode.INVALID_OP_SCHEMA`.
-    3. **safe-only wall** — ``descriptor.safety_level != 'safe'`` →
-       :attr:`MintRefusalCode.OP_NOT_SAFE`. Checked **before** the policy
-       gate so a non-``safe`` op is refused without even consulting it (and
-       so a ``requires_approval`` non-``safe`` op is never parked).
+    3. **satellite-mint tier ladder** (#3188,
+       :mod:`~meho_backplane.runner.satellite_tier`) — the safe-only wall
+       generalised, checked **before** the policy gate (so a refused op never
+       reaches it and is never parked): ``EXCLUDED`` (``dangerous`` /
+       ``destructive``) → :attr:`MintRefusalCode.OP_NOT_SAFE`, never minted
+       (composes with #3183); ``REMOTE_WRITE`` (``caution``) → the composed
+       gate, fail-closed until the siblings wire it →
+       :attr:`MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`; ``SAFE`` falls
+       through to the policy gate, semantics unchanged.
     4. ``policy_gate`` — any verdict other than ``AUTO_EXECUTE`` refuses
        (``DENY`` → :attr:`MintRefusalCode.POLICY_DENIED`, ``NEEDS_APPROVAL``
        → :attr:`MintRefusalCode.NEEDS_APPROVAL`); the defensive
@@ -362,12 +376,15 @@ async def mint_gateway_command(
     if params_refusal is not None:
         return params_refusal
 
-    # --- Safe-only wall (v1 read-only guarantee) -------------------------
-    # Bound to the real op-identity metadata read straight off the
-    # descriptor (dispatcher.py:1772), NOT a re-derived value. Checked
-    # before the policy gate so a non-'safe' op is refused centrally and is
-    # never parked — change-ops-over-gateway is a v2 follow-on (#2415).
-    if descriptor.safety_level != "safe":
+    # --- Satellite-mint tier ladder (#3188) ------------------------------
+    # The safe-only wall generalised, bound to the real op-identity metadata
+    # read straight off the descriptor (dispatcher.py:1772). Classified against
+    # the single source of truth shared with the edge executor and the
+    # assignment materialiser (defence in depth), before the policy gate so a
+    # refused op is never parked.
+    tier = classify_satellite_tier(descriptor.safety_level)
+    if tier is SatelliteMintTier.EXCLUDED:
+        # dangerous / destructive — never minted (composes with #3183).
         structlog.get_logger(__name__).warning(
             "gateway_command_mint_refused_non_safe",
             reason=MintRefusalCode.OP_NOT_SAFE.value,
@@ -378,9 +395,24 @@ async def mint_gateway_command(
         )
         return _refused(
             MintRefusalCode.OP_NOT_SAFE,
-            f"op {op_id!r} has safety_level {descriptor.safety_level!r}; the gateway "
-            "mints only safety_level='safe' ops in v1",
+            f"op {op_id!r} has safety_level {descriptor.safety_level!r}; "
+            "dangerous/destructive ops are never minted to a satellite",
         )
+    if tier is SatelliteMintTier.REMOTE_WRITE:
+        # The additive write tier, separate from the untouched `safe` wall.
+        # Its composed gate (per-runner allowlist + approval/policy binding)
+        # is wired by sibling tasks (#3189-#3193); until then it is fail-closed.
+        gate = evaluate_remote_write_gate(op_id=op_id, runner_id=runner_id)
+        if not gate.permitted:
+            structlog.get_logger(__name__).warning(
+                "gateway_command_mint_refused_remote_write",
+                reason=MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED.value,
+                op_id=op_id,
+                safety_level=descriptor.safety_level,
+                operator_sub=operator.sub,
+                runner_id=runner_id,
+            )
+            return _refused(MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED, gate.reason)
 
     # --- Step 4: policy gate (only AUTO_EXECUTE mints) -------------------
     verdict, gate_reason = await policy_gate(

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -13,8 +13,14 @@ Two fail-closed guards make the runner a strictly bounded executor
 (defence in depth — central mint is the real authorization boundary,
 owned by #2500):
 
-* **safe-only** — any item whose ``safety_level`` is not ``"safe"`` is
-  refused without invoking anything (v1 authorizes read-only workloads).
+* **satellite-mint tier ladder** (#3188) — the item's ``safety_level`` is
+  classified against the shared
+  :mod:`~meho_backplane.runner.satellite_tier` ladder (the same source of
+  truth the central mint and the assignment materialiser use). An
+  ``EXCLUDED`` (``dangerous`` / ``destructive``) item is refused outright;
+  a ``REMOTE_WRITE`` (``caution``) item is re-screened through the composed
+  gate and fails closed until the runner is authorised for the tier; only a
+  ``SAFE`` item proceeds.
 * **connector-tree-only** — a ``handler_ref`` that does not resolve inside
   ``meho_backplane.connectors.*`` is refused. The lexical prefix is
   checked *before* import (an import has module-load side effects) and the
@@ -39,6 +45,11 @@ from meho_backplane.operations._handler_resolve import (
     import_handler,
     is_unbound_method,
 )
+from meho_backplane.runner.satellite_tier import (
+    SatelliteMintTier,
+    classify_satellite_tier,
+    evaluate_remote_write_gate,
+)
 from meho_backplane.runner.spool import ExecutedCommandStore
 from meho_backplane.runner.wire import RunnerResult, RunnerWorkItem
 
@@ -46,7 +57,6 @@ __all__ = ["execute_command_once", "execute_work_item"]
 
 _log = structlog.get_logger(__name__)
 
-_ALLOWED_SAFETY_LEVEL = "safe"
 _CONNECTOR_MODULE_PREFIX = "meho_backplane.connectors."
 
 
@@ -70,11 +80,26 @@ def _result(
 def _screen_item(item: RunnerWorkItem) -> str | None:
     """Pre-import fail-closed screen: a refusal reason, or ``None`` to proceed.
 
-    Both checks run before any import so an out-of-tree ``handler_ref``
-    never triggers a module-load side effect.
+    Mirrors the central mint's satellite-mint tier ladder (#3188) against the
+    same shared classifier — defence in depth, the runner independently
+    re-checking what the centre already gated. Every check runs before any
+    import so an out-of-tree ``handler_ref`` never triggers a module-load side
+    effect.
     """
-    if item.safety_level != _ALLOWED_SAFETY_LEVEL:
-        return f"safety_level {item.safety_level!r} refused; runner executes only 'safe' ops"
+    tier = classify_satellite_tier(item.safety_level)
+    if tier is SatelliteMintTier.EXCLUDED:
+        return (
+            f"safety_level {item.safety_level!r} refused; dangerous/destructive "
+            "ops are never dispatched to a runner"
+        )
+    if tier is SatelliteMintTier.REMOTE_WRITE:
+        # A remote-write item still fails closed at the edge if the runner is
+        # not authorised for the tier (mechanism 2's edge re-check). The
+        # allowlist/signature machinery is a sibling task; until it exists the
+        # gate refuses every remote-write item.
+        decision = evaluate_remote_write_gate(op_id=item.op_id)
+        if not decision.permitted:
+            return decision.reason
     if not item.handler_ref.startswith(_CONNECTOR_MODULE_PREFIX):
         return f"handler_ref {item.handler_ref!r} is outside {_CONNECTOR_MODULE_PREFIX}*"
     return None

--- a/backend/src/meho_backplane/runner/satellite_tier.py
+++ b/backend/src/meho_backplane/runner/satellite_tier.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Satellite-mint tier ladder — which safety levels may ride a runner (#3188).
+
+The single source of truth for the satellite write-path gate, shared by the
+three fail-closed layers that must move in lockstep (design §1.1 /
+`docs/decisions/satellite-write-path.md`):
+
+* the **central mint** (:func:`meho_backplane.operations.gateway_commands.mint_gateway_command`),
+* the **assignment materialiser** (:mod:`meho_backplane.gateway.assignment_service`), and
+* the **edge executor** (:func:`meho_backplane.runner.executor._screen_item`).
+
+Each layer classifies a descriptor's ``safety_level`` into a
+:class:`SatelliteMintTier` and enforces the same ladder independently — the
+defence-in-depth premise the read path relies on (a compromised or buggy
+single layer cannot alone punch a write through).
+
+This module lives beside :mod:`meho_backplane.runner.wire` — the other
+central+edge shared contract — precisely because the edge (runner) is
+**DB-free**: the classifier and the gate seam import only the standard
+library, so importing them on the runner never pulls the central DB stack.
+
+The ladder (``safety_level`` → tier), composing with the destructive tier
+(#3196/#3183):
+
+* ``safe`` → :attr:`SatelliteMintTier.SAFE` — mints on ``AUTO_EXECUTE``, the
+  Stage-0 read path, semantics **unchanged**.
+* ``caution`` → :attr:`SatelliteMintTier.REMOTE_WRITE` — the additive,
+  separately-gated write tier. Mints **only** through the composed gate
+  (:func:`evaluate_remote_write_gate`); until the sibling tasks (#3189-#3193)
+  wire an allowlist + approval/signing mechanism the gate is fail-closed, so
+  no remote-write capability is ever authorised.
+* ``dangerous`` / ``destructive`` (and any unknown level) →
+  :attr:`SatelliteMintTier.EXCLUDED` — **never** minted to a satellite. This
+  is where the write path composes with #3183: the destructive tier is
+  excluded by the satellite gate by default everywhere, so delete-shaped work
+  stays central-or-break-glass and never rides a runner.
+
+The write tier does **not** widen what ``safe`` means and is **not** a new
+``safety_level`` value: it is a runtime classification of the existing
+``safe < caution < dangerous < destructive`` enum (#3196), so it needs no
+schema migration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+__all__ = [
+    "RemoteWriteGateDecision",
+    "SatelliteMintTier",
+    "classify_satellite_tier",
+    "evaluate_remote_write_gate",
+]
+
+
+class SatelliteMintTier(StrEnum):
+    """Which satellite-mint tier an op's ``safety_level`` falls into.
+
+    Distinct from the ``safety_level`` enum itself: this is the gate a runner
+    dispatch is screened against, not the intrinsic danger classification.
+    """
+
+    #: ``safe`` — mints on ``AUTO_EXECUTE`` (Stage-0 read path, unchanged).
+    SAFE = "safe"
+    #: ``caution`` — the additive write tier, gated by :func:`evaluate_remote_write_gate`.
+    REMOTE_WRITE = "remote_write"
+    #: ``dangerous`` / ``destructive`` / unknown — never minted to a satellite.
+    EXCLUDED = "excluded"
+
+
+def classify_satellite_tier(safety_level: str) -> SatelliteMintTier:
+    """Map a descriptor ``safety_level`` onto its :class:`SatelliteMintTier`.
+
+    Fail-closed on the default: any level other than ``safe`` / ``caution``
+    (i.e. ``dangerous``, ``destructive``, or an unrecognised value) is
+    :attr:`SatelliteMintTier.EXCLUDED`, so a level added upstream is refused
+    from riding a runner until this ladder is deliberately updated.
+    """
+    if safety_level == "safe":
+        return SatelliteMintTier.SAFE
+    if safety_level == "caution":
+        return SatelliteMintTier.REMOTE_WRITE
+    return SatelliteMintTier.EXCLUDED
+
+
+@dataclass(frozen=True)
+class RemoteWriteGateDecision:
+    """The outcome of the composed remote-write gate.
+
+    :attr:`permitted` is ``True`` only when the op-class is authorised to ride
+    the runner as a remote write; :attr:`reason` explains a refusal (and is
+    surfaced verbatim in the mint refusal / edge refusal).
+    """
+
+    permitted: bool
+    reason: str
+
+
+#: The invariant part of every fail-closed remote-write refusal reason.
+_UNPROVISIONED_REASON = (
+    "the composed write-path gate (per-runner allowlist + approval/policy "
+    "binding) is not provisioned; no runner is authorised for the "
+    "remote-write tier"
+)
+
+
+def evaluate_remote_write_gate(
+    *, op_id: str, runner_id: str | None = None
+) -> RemoteWriteGateDecision:
+    """The composed remote-write gate — fail-closed until the siblings wire it.
+
+    A ``remote-write`` op mints (and executes at the edge) **only** when its
+    op-class is on the runner's enrollment allowlist **and** either policy
+    ``AUTO_EXECUTE`` (the idempotent subset) or a committed ``ApprovalRequest``
+    (the caution subset) authorises it — the four-mechanism composition of
+    design §3. That allowlist + approval/signing machinery is filed as sibling
+    tasks (#3189-#3193) and does not exist yet, so there is no way to authorise
+    a remote-write capability: this seam refuses **every** remote-write op.
+
+    Both the central mint and the edge executor call this independently —
+    mechanism 2's "checked at mint *and* re-checked at the edge" — so a
+    remote-write item fails closed at each layer on its own.
+    """
+    subject = f"remote-write op {op_id!r}"
+    if runner_id is not None:
+        subject += f" for runner {runner_id!r}"
+    return RemoteWriteGateDecision(
+        permitted=False,
+        reason=f"{subject} refused: {_UNPROVISIONED_REASON}",
+    )

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -155,13 +155,15 @@ async def _claim() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("level", ["caution", "dangerous", "destructive"])
-async def test_mint_refuses_non_safe_op(monkeypatch: pytest.MonkeyPatch, level: str) -> None:
-    """A non-'safe' op is refused before the policy gate — no rows written.
+async def _mint_refused_before_policy_gate(
+    monkeypatch: pytest.MonkeyPatch, *, level: str
+) -> gc.MintResult:
+    """Mint an op at *level* with the policy gate wired to blow up if consulted.
 
-    The ``destructive`` tier (#3183) is transitively excluded from every
-    satellite by this same safe-only wall: a delete is never minted to a
-    runner, agreeing with the satellite write-path decision (#2901 / #3187).
+    The satellite-mint tier ladder (#3188) refuses an ``EXCLUDED`` or
+    unauthorised ``remote-write`` op **before** the policy gate, so a
+    consulted gate is a bug. Returns the refusal result for the caller to
+    assert the exact code + zero rows written.
     """
     await _seed_tenant()
     _patch_lookup(monkeypatch, _descriptor(safety_level=level))
@@ -183,9 +185,42 @@ async def test_mint_refuses_non_safe_op(monkeypatch: pytest.MonkeyPatch, level: 
             runner_id=_RUNNER,
         )
         await session.commit()
+    return result
+
+
+@pytest.mark.parametrize("level", ["dangerous", "destructive"])
+async def test_mint_refuses_excluded_op(monkeypatch: pytest.MonkeyPatch, level: str) -> None:
+    """A ``dangerous`` / ``destructive`` op is never minted — no rows written.
+
+    The ``EXCLUDED`` tier keeps the ``OP_NOT_SAFE`` refusal: the destructive
+    tier (#3183/#3196) is excluded from every satellite by default, so a
+    delete is never minted to a runner (#3225 conformance, satellite write-path
+    decision #2901 / #3187).
+    """
+    result = await _mint_refused_before_policy_gate(monkeypatch, level=level)
 
     assert not result.minted
     assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+
+
+async def test_mint_refuses_remote_write_gate_unsatisfied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``caution`` (remote-write) op is refused fail-closed — no rows written.
+
+    The additive ``remote-write`` tier mints only through the composed gate
+    (per-runner allowlist + approval/policy), wired by the sibling tasks
+    (#3189-#3193). Until then the gate is fail-closed, so a remote-write op is
+    refused with the tier's own refusal code — distinct from ``OP_NOT_SAFE`` —
+    before the policy gate and without parking.
+    """
+    result = await _mint_refused_before_policy_gate(monkeypatch, level="caution")
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED
+    assert "remote-write" in (result.refusal_reason or "")
     assert await _count(GatewayCommand) == 0
     assert await _count(ApprovalRequest) == 0
 

--- a/backend/tests/test_runner_executor.py
+++ b/backend/tests/test_runner_executor.py
@@ -73,11 +73,13 @@ async def test_safe_op_executes_and_returns_structured_result(
     assert len(result.result_uid) == 32
 
 
-async def test_non_safe_op_is_refused_without_invocation(
+async def test_remote_write_op_is_refused_without_invocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # An allowlisted host would let the probe succeed *if* it ran — proving
-    # the refusal short-circuits before the handler is ever invoked.
+    # the refusal short-circuits before the handler is ever invoked. A
+    # `caution` op is the `remote-write` tier: it fails closed at the edge
+    # (mechanism 2's edge re-check) until the runner is authorised (#3188).
     monkeypatch.setenv(_ALLOWLIST_ENV, "127.0.0.1")
     item = _tcp_check_item(host="127.0.0.1", port=9, safety_level="caution", check_ref="chk-2")
 
@@ -85,7 +87,24 @@ async def test_non_safe_op_is_refused_without_invocation(
 
     assert result.status == "refused"
     assert result.result is None
-    assert "caution" in (result.error or "")
+    assert "remote-write" in (result.error or "")
+
+
+@pytest.mark.parametrize("level", ["dangerous", "destructive"])
+async def test_excluded_op_is_refused_without_invocation(
+    monkeypatch: pytest.MonkeyPatch, level: str
+) -> None:
+    # `dangerous` / `destructive` are the EXCLUDED tier — never dispatched to
+    # a runner, refused at the edge as defence in depth (#3188).
+    monkeypatch.setenv(_ALLOWLIST_ENV, "127.0.0.1")
+    item = _tcp_check_item(host="127.0.0.1", port=9, safety_level=level, check_ref="chk-x")
+
+    result = await execute_work_item(item)
+
+    assert result.status == "refused"
+    assert result.result is None
+    assert level in (result.error or "")
+    assert "never dispatched" in (result.error or "")
 
 
 async def test_out_of_tree_handler_ref_is_refused_fail_closed() -> None:

--- a/backend/tests/test_runner_satellite_tier.py
+++ b/backend/tests/test_runner_satellite_tier.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Satellite-mint tier ladder — the shared classifier + composed gate (#3188).
+
+The single source of truth the three fail-closed layers mirror. These are
+pure-function tests: no DB, no session.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.runner.satellite_tier import (
+    SatelliteMintTier,
+    classify_satellite_tier,
+    evaluate_remote_write_gate,
+)
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        ("safe", SatelliteMintTier.SAFE),
+        ("caution", SatelliteMintTier.REMOTE_WRITE),
+        ("dangerous", SatelliteMintTier.EXCLUDED),
+        ("destructive", SatelliteMintTier.EXCLUDED),
+    ],
+)
+def test_classify_maps_each_safety_level(level: str, expected: SatelliteMintTier) -> None:
+    assert classify_satellite_tier(level) is expected
+
+
+def test_classify_is_fail_closed_on_unknown_level() -> None:
+    # A level added upstream without updating the ladder is EXCLUDED, never
+    # silently minted to a runner.
+    assert classify_satellite_tier("apocalyptic") is SatelliteMintTier.EXCLUDED
+
+
+def test_remote_write_gate_is_fail_closed() -> None:
+    # The composed gate (allowlist + approval/policy) is unprovisioned until
+    # the sibling tasks wire it, so it refuses every remote-write op.
+    decision = evaluate_remote_write_gate(op_id="net.ping", runner_id="runner-a")
+
+    assert decision.permitted is False
+    assert "net.ping" in decision.reason
+    assert "runner-a" in decision.reason
+    assert "remote-write" in decision.reason
+
+
+def test_remote_write_gate_reason_omits_runner_when_absent() -> None:
+    # The edge re-check has no runner_id to hand; the reason stays coherent.
+    decision = evaluate_remote_write_gate(op_id="net.ping")
+
+    assert decision.permitted is False
+    assert "for runner" not in decision.reason

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -101,7 +101,10 @@ Each tick (`run_one_tick`):
 `execute_work_item` is fail-closed defence in depth (the real
 authorization boundary is central minting, #2500):
 
-1. Refuse any item whose `safety_level != "safe"`.
+1. Classify the item's `safety_level` against the shared satellite-mint
+   tier ladder (see below) and refuse anything but a `SAFE`-tier item —
+   an `EXCLUDED` (`dangerous`/`destructive`) item outright, a `remote-write`
+   (`caution`) item through the fail-closed edge re-check.
 2. Refuse any `handler_ref` not lexically under
    `meho_backplane.connectors.` — checked **before** import (import has
    module-load side effects) and re-checked on the resolved callable's
@@ -120,6 +123,64 @@ authorization boundary is central minting, #2500):
 5. Invoke `handler(operator, target, params)`. A handler exception
    becomes a structured `error` result — a failed check is a result,
    never a crashed tick.
+
+## Satellite-mint tier ladder — the write path (#3188)
+
+The read path refuses any non-`safe` op at three independent layers. The
+write path (Initiative #2901, decision
+`docs/decisions/satellite-write-path.md`) generalises that binary safe-wall
+into a **tier ladder** without widening what `safe` means. The ladder is a
+runtime classification of the existing `safe < caution < dangerous <
+destructive` `safety_level` enum (#3196) — **not** a new `safety_level`
+value, so it needs no migration:
+
+| `safety_level` | Satellite tier | Mint outcome |
+|---|---|---|
+| `safe` | `SAFE` | mints on `AUTO_EXECUTE` — the read path, **unchanged** |
+| `caution` | `REMOTE_WRITE` | mints **only** through the composed write-path gate; fail-closed today |
+| `dangerous`, `destructive` (or unknown) | `EXCLUDED` | **never** minted to a satellite |
+
+The single source of truth is `runner/satellite_tier.py`
+(`classify_satellite_tier` + the `evaluate_remote_write_gate` seam). It
+lives beside `runner/wire.py` — the other central+edge shared contract — and
+imports only the standard library, so classifying a tier on the **DB-free**
+runner never pulls the central stack.
+
+**The three-layer mirror.** All three fail-closed layers classify against
+that one ladder (defence in depth — no single layer alone can punch a write
+through):
+
+- **Central mint** — `mint_gateway_command`
+  (`operations/gateway_commands.py`): `EXCLUDED` → `MintRefusalCode.OP_NOT_SAFE`
+  (the code #3225's conformance test asserts for `vmware.composite.vm.destroy`);
+  `REMOTE_WRITE` → the composed gate, refused with
+  `MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED` until it is provisioned;
+  `SAFE` → the unchanged policy gate. All checked **before** the policy gate,
+  so a refused op is never parked.
+- **Assignment materialiser** — `_is_runnable_safe` /
+  `_validate_authored_item` (`gateway/assignment_service.py`): only `SAFE`-tier
+  ops are authorable into (and materialised from) the recurring assignment;
+  `remote-write` work rides the one-shot capability-mint path, not this
+  document.
+- **Edge executor** — `_screen_item` (`runner/executor.py`): re-screens the
+  delivered item independently, refusing `EXCLUDED` outright and re-checking
+  `REMOTE_WRITE` through the same gate seam (mechanism 2's "checked at mint
+  *and* re-checked at the edge").
+
+**The composed gate is a seam.** `evaluate_remote_write_gate` is fail-closed
+by construction: a `remote-write` op mints only when its op-class is on the
+runner's enrollment allowlist **and** policy `AUTO_EXECUTE` (idempotent
+subset) or a committed `ApprovalRequest` (caution subset) authorises it —
+the four-mechanism composition of design §3. That allowlist + approval +
+work-item-signing machinery is filed as sibling tasks (#3189-#3193); until it
+lands there is no way to authorise a remote-write capability, so the seam
+refuses every remote-write op at both the mint and the edge.
+
+**Composition with #3183.** The destructive tier is `EXCLUDED` by this ladder
+everywhere, so delete-shaped work stays central-or-break-glass and never
+rides a runner — the satellite write-path decision's "delete-shaped
+operations never minted to a satellite," dovetailing with #3196's default
+gate exclusions.
 
 ## Dead-man switch + mandatory heartbeat (#2501)
 
@@ -228,13 +289,15 @@ default), `GATEWAY_DEADMAN_TICK_INTERVAL_SECONDS` (default 30),
 - The outbound long-poll command plane
   (`GET /gateway/{runner}/next` / `POST /gateway/{runner}/result`) — #2498.
 - Single-use capability-command minting + request-id dedup — #2500. The
-  runner's `safe`-only executor guard is defence in depth, not the mint
-  rule. The central mint wall (`mint_gateway_command`) refuses any
-  `safety_level != "safe"` op with `MintRefusalCode.OP_NOT_SAFE` *before*
-  the policy gate, so the `destructive` tier (#3183) is transitively
-  excluded from every satellite the day it exists — **deletes are never
-  minted to a satellite**, agreeing with the satellite write-path decision
-  (#2901 / #3187).
+  runner's tier-ladder executor guard is defence in depth, not the mint
+  rule. The central mint wall (`mint_gateway_command`) classifies each op
+  against the satellite-mint tier ladder (#3188, see above) *before* the
+  policy gate: `EXCLUDED` (`dangerous`/`destructive`) refuses with
+  `MintRefusalCode.OP_NOT_SAFE`, so the `destructive` tier (#3183) is
+  excluded from every satellite — **deletes are never minted to a
+  satellite** — while the additive `remote-write` tier fails closed until
+  its composed gate is provisioned (satellite write-path decision
+  #2901 / #3187).
 - Heartbeat + central stale/unknown flipping — #2501.
 - The scoped per-runner service principal + credential scoping — #2502.
   `MEHO_RUNNER_TOKEN` is the seam it fills; this chassis treats it as an


### PR DESCRIPTION
## Summary

- Generalises the gateway's binary safe-wall into a **satellite-mint tier ladder** — the foundation seam of the ratified scoped-hybrid write path (Initiative #2901, `docs/decisions/satellite-write-path.md`). Every other write-path task rides this one.
- A single source of truth (`runner/satellite_tier.py`) classifies the existing `safe < caution < dangerous < destructive` `safety_level` enum (#3196) into three tiers: `safe` → `SAFE` (mints on `AUTO_EXECUTE`, **unchanged**); `caution` → `REMOTE_WRITE` (the additive, separately-gated write tier); `dangerous`/`destructive` → `EXCLUDED` (**never** minted to a satellite).
- **`remote-write` is a satellite-mint tier, not a new `safety_level` value** — a runtime classification of the existing enum, so there is **no migration** (chain head 0086 untouched).
- The ladder is mirrored, **each layer fail-closed independently** (defence in depth), across the three layers a write path must punch through: central mint (`mint_gateway_command`), assignment materialiser (`assignment_service`), edge executor (`_screen_item`).
- The `remote-write` **composed gate** (`evaluate_remote_write_gate`) is a fail-closed **seam**: it refuses every remote-write op until the per-runner allowlist + approval/policy binding is wired by the sibling tasks (#3189-#3193).

### Tier-gating shape

| `safety_level` | Satellite tier | Mint outcome |
|---|---|---|
| `safe` | `SAFE` | mints on `AUTO_EXECUTE` — read path, **unchanged** |
| `caution` | `REMOTE_WRITE` | composed gate → fail-closed today → `REMOTE_WRITE_GATE_UNSATISFIED` |
| `dangerous`, `destructive` (or unknown) | `EXCLUDED` | `OP_NOT_SAFE` — **never** minted |

### Composition with #3183 / #3196

The `destructive` tier is `EXCLUDED` by the satellite ladder everywhere, so delete-shaped work stays central-or-break-glass and never rides a runner. `EXCLUDED` keeps the exact `MintRefusalCode.OP_NOT_SAFE` that #3225's conformance test (`test_satellite_mint_refuses_op_not_safe`, `vmware.composite.vm.destroy`) asserts — **still green**.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (changed src) — Success, no issues
- [x] `pytest tests/test_runner_satellite_tier.py` — new pure-fn coverage of the classifier + fail-closed gate
- [x] **remote-write refused at mint when gate unsatisfied** — `test_mint_refuses_remote_write_gate_unsatisfied` (caution → `REMOTE_WRITE_GATE_UNSATISFIED`, no rows, policy gate not consulted)
- [x] **refused independently at the edge** — `test_remote_write_op_is_refused_without_invocation`
- [x] **safe unaffected** — existing safe-mint tests pass unchanged
- [x] **dangerous/destructive never minted** — `test_mint_refuses_excluded_op` + `test_excluded_op_is_refused_without_invocation`
- [x] **#3225 conformance stays green** — `test_satellite_mint_refuses_op_not_safe` passes
- [x] `code-quality.py --diff` — 0 blockers (kept `gateway_commands.py` under the 600-line limit)
- [x] Import smoke — no circular import from the new cross-package `runner.satellite_tier` import

## Out of scope (sibling tasks under #2901)

- The composed gate's real mechanisms — per-runner allowlist, approval-bound minting, work-item signing + edge verification, short-lived wrapped credentials, store-and-forward effect audit, un-reported-mint alarm (#3189-#3193 and the rest of §4). This PR ships the tier ladder + three-layer mirror + fail-closed refusal paths, with the composed gate as a seam.

Closes #3188
