### PR TITLE
fix(connectors): reap + reject epoch-in-impl_id probe registrations (#3061)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — epoch-in-`impl_id` probe registrations now reaped + rejected (#3061)
+
+- `#2977`'s epoch-reap (migration `0075`) and `IngestRequest._reject_epoch_version`
+  both key on the connector **`version`** column, but the accreting
+  `fleet-rest-probe-<epoch>` rows carry the epoch in the **`impl_id`** tail
+  with a legitimate `version="9.0"` — so `0075` matched nothing and a
+  v0.29.0 lab deploy still returned 9 stale rows post-migration. Two guards
+  close the sibling shape: **migration `0088`** (down_revision `0087`;
+  `0087` is a coordinated peer migration, #3216) reaps
+  `endpoint_descriptor` (`source_kind='ingested'`) + `operation_group` rows
+  whose `impl_id` ends in `-probe-<epoch>` (≥ 9 trailing digits after a
+  `-probe-` segment; dialect-branched PG regex / SQLite `GLOB`,
+  tenant-scope-inclusive, no-op `downgrade()`); and
+  `IngestRequest._reject_probe_epoch_impl_id` rejects the same shape at the
+  ingest boundary on every surface (`422
+  connector_impl_id_probe_epoch_rejected`). The stable `*-probe` impls and
+  every real product-line impl_id are untouched (regression-fenced over the
+  whole registered catalog). The per-run epoch is minted by consumer-side
+  fingerprint/probe glue in a different repo (`claude-rdc-hetzner-dc`), so
+  the boundary guard is the backplane's durable defence; no backplane code
+  mints these rows.
+
 ### Added — flight recorder: capture seam + caps + best-effort invariant (#3214)
 
 - Ships the **capture seam** plus the **F3 caps** and **F7 failure invariant**

--- a/backend/alembic/versions/0088_reap_probe_epoch_impl_id_registrations.py
+++ b/backend/alembic/versions/0088_reap_probe_epoch_impl_id_registrations.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reap probe-epoch-impl_id connector registrations (#3061).
+
+Revision ID: 0088
+Revises: 0087
+Create Date: 2026-08-31
+
+Task #3061, follow-up to #2977 (Initiative #3020, G0.40 hardening). Sibling
+of ``0075_reap_epoch_versioned_connector_registrations``, which reaped the
+same class of debris keyed on the **wrong column**.
+
+The defect ``0075`` targeted
+---------------------------
+
+A consumer-side probe-then-ingest loop mints a *fresh* connector per probe
+run, so the catalog grows one row per run with nothing to reap it (the
+ingest upsert dedups on the ``(product, version, impl_id)`` triple, so a
+changed key never matches an existing row — it INSERTs). ``0075`` closed
+this by reaping rows whose **``version``** is a bare Unix-epoch integer,
+and the paired ``IngestRequest._reject_epoch_version`` guard rejects that
+shape at registration.
+
+Why ``0075`` missed the rows still on the lab
+---------------------------------------------
+
+The rows actually accreting carry the epoch in the **``impl_id``**, not the
+``version``: ``impl_id="fleet-rest-probe-<epoch>"`` with a *legitimate*
+``version="9.0"`` (rendering ``connector_id="fleet-rest-probe-<epoch>-9.0"``).
+``0075``'s predicate (``version ~ '^[0-9]{9,}$'``) never matched — ``"9.0"``
+is not an epoch — so a v0.29.0 lab deploy that had applied ``0075`` still
+returned 9 ``fleet-rest-probe-<epoch>-9.0`` rows post-migration (epochs
+``1784123249 .. 1786183253``, Jul→Aug 2026). #2977's own body named this
+exact shape — *"reap ``<impl>-probe-<epoch>`` rows"* — but the shipped
+predicate looked for ``<impl>-<epoch>`` (epoch-as-version).
+
+What this migration reaps
+-------------------------
+
+``endpoint_descriptor`` (guarded ``source_kind = 'ingested'``) and
+``operation_group`` rows whose **``impl_id``** ends in ``-probe-<epoch>``:
+a ``-probe-`` segment followed by a bare integer of at least 9 digits at
+the end of the string. A 9-digit floor catches any Unix epoch (10 digits
+since 2001-09, staying 10 until 2286) while the ``-probe-`` anchor and the
+end-of-string digit run keep it off every legitimate connector: the stable
+probe impls end in a bare ``-probe`` with no trailing epoch
+(``net-probe`` / ``nsx-rest-probe`` / ``sddc-rest-probe`` /
+``vmware-rest-probe`` / ``fleet-rest-probe``), and every real product-line
+impl_id carries no ``-probe-<digits>`` tail at all
+(``fleet-rest`` / ``vmware-rest`` / ``vcd`` / ``vrops8``). The paired
+registration-time guard
+(:meth:`meho_backplane.operations.ingest.api_schemas.IngestRequest._reject_probe_epoch_impl_id`)
+rejects the same shape on every ingest surface so the class cannot recur;
+this migration is the one-time cleanup of the rows that leaked in before it.
+
+Complements, not replaces, ``0075``: an epoch can live in either column
+(``version`` — ``0075``; ``impl_id`` tail — this one), and the two
+predicates target disjoint row sets. Both keep ``0075``'s properties: the
+cleanup is **tenant-scope-inclusive** (the debris is a consumer-side
+tenant ingest, illegitimate at any scope, so no ``tenant_id`` filter);
+``endpoint_descriptor`` additionally guards ``source_kind = 'ingested'``
+(typed/composite connectors are hand-coded and never carry a probe-epoch
+impl_id, but the guard makes the blast radius provably ingest-only);
+``operation_group`` has no ``source_kind`` column so the impl_id predicate
+alone is diagnostic there. Descriptors are retired before groups, same
+ordering as ``0049`` / ``0052`` / ``0075``.
+
+Portability
+-----------
+
+The predicate is dialect-branched. PostgreSQL uses a POSIX regex
+(``impl_id ~ '-probe-[0-9]{9,}$'``). SQLite — which has no regex operator
+without a registered function — expresses the identical set as a ``GLOB``
+requiring a ``-probe-`` segment followed by at least nine digits, ANDed
+with "the string ends in a digit" (``NOT GLOB '*[^0-9]'``) so the epoch
+must run to the end exactly as the PG ``$`` anchor demands. No UUID bind
+params are threaded (the predicate keys only on the ``Text`` ``impl_id`` /
+``source_kind`` columns), so the ``docs/codebase/migrations.md`` UUID-hex
+gotcha does not apply.
+
+Additive-only forward, no-op back
+---------------------------------
+
+``upgrade()`` runs no DDL — only two DML DELETEs — so it clears
+``scripts/ci/check_migration_compat.py`` (which bans destructive DDL, not
+row deletion) and an older image reading the post-cleanup schema is
+unaffected. ``downgrade()`` is a documented no-op: the reaped rows were
+non-idempotent probe debris no dispatch / review probe wanted, and
+re-INSERTing fabricated epoch rows would re-introduce the unbounded growth
+this migration removes. Same shape as ``0049`` / ``0052`` / ``0075``.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0088"
+down_revision: str | None = "0087"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _probe_epoch_impl_id_predicate(dialect_name: str) -> sa.sql.elements.TextClause:
+    """Return the dialect-portable "``impl_id`` ends in ``-probe-<epoch>``" WHERE.
+
+    A ``-probe-`` segment followed by a bare integer of at least 9 digits
+    running to the end of the string. PostgreSQL uses a POSIX regex;
+    SQLite (no regex operator without a registered function) expresses the
+    same set as a ``GLOB`` for ``-probe-`` + nine digits, ANDed with "ends
+    in a digit" so the digit run reaches the end exactly as the PG ``$``
+    anchor demands. Both reference the bare ``impl_id`` column, which
+    resolves against the single table of each ``DELETE`` this predicate is
+    attached to.
+    """
+    if dialect_name == "postgresql":
+        return sa.text("impl_id ~ '-probe-[0-9]{9,}$'")
+    return sa.text(
+        "impl_id GLOB '*-probe-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]*' "
+        "AND impl_id NOT GLOB '*[^0-9]'"
+    )
+
+
+def upgrade() -> None:
+    """Delete every probe-epoch-impl_id ingested descriptor + group row, any scope."""
+    bind = op.get_bind()
+    probe_epoch = _probe_epoch_impl_id_predicate(bind.dialect.name)
+
+    descriptor = sa.table(
+        "endpoint_descriptor",
+        sa.column("source_kind", sa.Text()),
+        sa.column("impl_id", sa.Text()),
+    )
+    group = sa.table(
+        "operation_group",
+        sa.column("impl_id", sa.Text()),
+    )
+
+    bind.execute(
+        sa.delete(descriptor).where(
+            descriptor.c.source_kind == "ingested",
+            probe_epoch,
+        )
+    )
+    bind.execute(sa.delete(group).where(probe_epoch))
+
+
+def downgrade() -> None:
+    """No-op by design.
+
+    The reaped rows were non-idempotent probe debris (a fresh connector
+    per probe run, the defect #3061 fixes) that no dispatch / review probe
+    wanted; re-INSERTing fabricated epoch rows would re-introduce the
+    unbounded growth. No DDL runs in ``upgrade()``, so there is nothing to
+    undo at the schema layer either. Same documented-no-op shape as
+    ``0049`` / ``0052`` / ``0075``. The function stays defined so
+    ``alembic downgrade -1`` resolves the symbol cleanly.
+    """
+    # Intentionally empty -- see docstring.

--- a/backend/alembic/versions/0088_reap_probe_epoch_impl_id_registrations.py
+++ b/backend/alembic/versions/0088_reap_probe_epoch_impl_id_registrations.py
@@ -73,8 +73,13 @@ The predicate is dialect-branched. PostgreSQL uses a POSIX regex
 (``impl_id ~ '-probe-[0-9]{9,}$'``). SQLite — which has no regex operator
 without a registered function — expresses the identical set as a ``GLOB``
 requiring a ``-probe-`` segment followed by at least nine digits, ANDed
-with "the string ends in a digit" (``NOT GLOB '*[^0-9]'``) so the epoch
-must run to the end exactly as the PG ``$`` anchor demands. No UUID bind
+with "no non-digit follows the ``-probe-`` segment"
+(``NOT GLOB '*-probe-*[^0-9]*'``) so the digit run reaches the end exactly
+as the PG ``$`` anchor demands. That second clause is chosen over the
+looser "ends in a digit" so the two branches agree on every realistic
+(single-``-probe-``) impl_id and, where they cannot (a contrived
+multi-``-probe-`` string), the SQLite branch under-reaps rather than
+over-reaps — the safe direction for a destructive DELETE. No UUID bind
 params are threaded (the predicate keys only on the ``Text`` ``impl_id`` /
 ``source_kind`` columns), so the ``docs/codebase/migrations.md`` UUID-hex
 gotcha does not apply.
@@ -119,7 +124,7 @@ def _probe_epoch_impl_id_predicate(dialect_name: str) -> sa.sql.elements.TextCla
         return sa.text("impl_id ~ '-probe-[0-9]{9,}$'")
     return sa.text(
         "impl_id GLOB '*-probe-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]*' "
-        "AND impl_id NOT GLOB '*[^0-9]'"
+        "AND impl_id NOT GLOB '*-probe-*[^0-9]*'"
     )
 
 

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -55,6 +55,7 @@ staged`` will hit.
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 from uuid import UUID
 
@@ -147,6 +148,34 @@ def _version_looks_like_epoch(version: str) -> bool:
     connector version never matches (they carry ``.`` / letters / ``-``).
     """
     return version.isascii() and version.isdigit() and len(version) >= _EPOCH_VERSION_MIN_DIGITS
+
+
+#: Matches an ``impl_id`` ending in ``-probe-<epoch>`` — a ``-probe-``
+#: segment followed by a bare integer of at least
+#: :data:`_EPOCH_VERSION_MIN_DIGITS` digits running to the end of the
+#: string. The sibling of :func:`_version_looks_like_epoch` for the
+#: #3061 shape, where the epoch rides the ``impl_id`` tail rather than
+#: the ``version``. The ``-probe-`` anchor plus the trailing digit run
+#: keep it off every legitimate connector: the stable probe impls end in
+#: a bare ``-probe`` with no epoch (``net-probe`` / ``nsx-rest-probe`` /
+#: ``fleet-rest-probe``), and no real product-line impl_id
+#: (``fleet-rest`` / ``vmware-rest`` / ``vcd``) carries a
+#: ``-probe-<digits>`` tail at all. ``[0-9]`` (not ``\d``) keeps it
+#: ASCII-exact, identical to the migration's POSIX-regex reap predicate.
+_PROBE_EPOCH_IMPL_ID_RE = re.compile(rf"-probe-[0-9]{{{_EPOCH_VERSION_MIN_DIGITS},}}$")
+
+
+def _impl_id_looks_like_probe_epoch(impl_id: str) -> bool:
+    """Return whether *impl_id* ends in the ``-probe-<epoch>`` accretion shape.
+
+    The #3061 companion to :func:`_version_looks_like_epoch`: the
+    consumer probe-then-ingest loop that keeps a *stable* ``version``
+    (``9.0``) instead mints a per-run epoch into the ``impl_id``
+    (``fleet-rest-probe-<epoch>``), so a changed ``impl_id`` renders a
+    fresh ``(product, version, impl_id)`` triple on every run — the same
+    unbounded-catalog defect #2977 fixed for the ``version`` column.
+    """
+    return _PROBE_EPOCH_IMPL_ID_RE.search(impl_id) is not None
 
 
 class IngestRequest(BaseModel):
@@ -521,6 +550,48 @@ class IngestRequest(BaseModel):
                 "ingest, minting the unbounded '<impl>-probe-<epoch>' "
                 "catalog rows #2977 fixes. Re-ingest under a stable "
                 "product-line version. See docs/codebase/error-message-shape.md."
+            )
+        return value
+
+    @field_validator("impl_id")
+    @classmethod
+    def _reject_probe_epoch_impl_id(cls, value: str | None) -> str | None:
+        """Reject an ``impl_id`` ending in ``-probe-<epoch>`` (#3061).
+
+        The sibling shape to the epoch-``version`` guard above:
+        :meth:`_reject_epoch_version` catches the consumer probe-then-ingest
+        loop that stamps the epoch as ``version``, but the loop that filed
+        #3061 keeps a *legitimate* ``version`` (``9.0``) and mints the
+        per-run epoch into the ``impl_id`` instead
+        (``fleet-rest-probe-<epoch>``, rendering
+        ``connector_id="fleet-rest-probe-<epoch>-9.0"``). ``9.0`` is a real
+        product-line version, so the ``version`` guard never fires — yet a
+        changed ``impl_id`` still renders a fresh ``(product, version,
+        impl_id)`` triple, so the upsert INSERTs a new connector per run
+        and the catalog grows without bound exactly as #2977 described.
+        Rejecting the shape here — on the one :class:`IngestRequest` both
+        the REST route and the ``meho_connector_ingest`` MCP tool construct
+        through — stops the growth at the source on every surface; the
+        ``0088`` data migration reaps the rows already leaked in. The
+        upstream fingerprint/probe glue that mints the epoch is
+        consumer-side (a different repo), so this boundary guard is the
+        backplane's durable defence.
+
+        ``None`` (the catalog-driven shape, where ``impl_id`` is resolved
+        server-side from the packaged — and therefore never epoch —
+        catalog entry) passes untouched. The ``snake_case`` classifier
+        follows the T11 error-message-shape convention so callers branch
+        without re-parsing the prose.
+        """
+        if value is not None and _impl_id_looks_like_probe_epoch(value):
+            raise ValueError(
+                "connector_impl_id_probe_epoch_rejected: impl_id "
+                f"{value!r} ends in a '-probe-<epoch>' Unix-epoch tail, not a "
+                "stable impl_id (e.g. 'fleet-rest', 'fleet-rest-probe'). A "
+                "per-run epoch renders a fresh connector_id on every ingest, "
+                "minting the unbounded '<impl>-probe-<epoch>' catalog rows "
+                "#3061 fixes. Re-ingest under a stable impl_id. "
+                "See docs/codebase/error-message-shape.md."
             )
         return value
 

--- a/backend/tests/migrations/test_migration_0088_reap_probe_epoch_impl_id_registrations.py
+++ b/backend/tests/migrations/test_migration_0088_reap_probe_epoch_impl_id_registrations.py
@@ -1,0 +1,521 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0088_reap_probe_epoch_impl_id_registrations``.
+
+Initiative #3020 (G0.40 hardening), Task #3061 — the #2977 follow-up.
+Sibling of ``0075``: the migration reaps ``endpoint_descriptor`` /
+``operation_group`` rows whose ``impl_id`` ends in ``-probe-<epoch>`` (a
+``-probe-`` segment then a bare Unix-epoch integer, >= 9 digits) — the
+``fleet-rest-probe-<epoch>`` catalog debris that carries a *legitimate*
+``version="9.0"``, so ``0075``'s version-keyed predicate never touched it.
+
+Three properties distinguish it, and all are pinned here:
+
+* **Keyed on the impl_id tail, not the version.** The reaped rows carry a
+  real product-line ``version`` (``9.0``); the epoch is in the ``impl_id``
+  (:func:`test_probe_epoch_impl_id_rows_reaped`). A stable ``impl_id``
+  under the same version survives (:func:`test_stable_impl_id_rows_preserved`).
+* **The ``-probe-`` anchor discriminates.** A bare ``-probe`` impl_id with
+  no epoch tail — the "one probe registration per impl" pattern #2977 asked
+  for — survives (:func:`test_bare_probe_impl_id_preserved`); a sub-9-digit
+  tail is not an epoch and survives
+  (:func:`test_short_probe_tail_preserved`).
+* **Tenant-scope-inclusive + ``source_kind`` guarded.** A tenant-scoped
+  epoch row IS reaped (:func:`test_tenant_scoped_probe_epoch_rows_reaped`);
+  ``endpoint_descriptor`` guards on ``source_kind = 'ingested'`` so a typed
+  row survives (:func:`test_typed_probe_epoch_descriptor_preserved`).
+
+Revision pin: every test drives the forward pass with
+``command.upgrade(cfg, "0088")`` (this migration's own revision, NOT
+``head``) so future sibling migrations cannot leak into the contract.
+Sync-test constraint identical to
+:mod:`tests.migrations.test_migration_0075_reap_epoch_versioned_connector_registrations`:
+``alembic.command`` drives env.py's async cookbook via ``asyncio.run``,
+so the test functions stay sync.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+#: This migration's own revision -- the forward-pass target (NOT ``head``).
+_THIS_REVISION: Final[str] = "0088"
+#: The immediately preceding head this migration revises.
+_DOWN_REVISION: Final[str] = "0087"
+
+#: A representative probe-epoch ``impl_id`` -- the exact shape the lab
+#: still carried post-``0075`` (``fleet-rest-probe-<epoch>``, epoch in the
+#: impl_id tail, a *legitimate* version alongside).
+_PROBE_EPOCH_IMPL_ID: Final[str] = "fleet-rest-probe-1784123249"
+#: The stable, dispatch-canonical fleet impl_id -- must always survive.
+_STABLE_IMPL_ID: Final[str] = "fleet-rest"
+#: The stable "one probe registration per impl" impl_id (no epoch tail) --
+#: the #2977 ask (c) pattern; must survive the ``-probe-<epoch>`` reap.
+_BARE_PROBE_IMPL_ID: Final[str] = "fleet-rest-probe"
+#: A real product-line version the reaped rows legitimately carry.
+_STABLE_VERSION: Final[str] = "9.0"
+
+#: Stable seed timestamp -- lets assertions tell "row untouched" apart.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as
+    :mod:`tests.migrations.test_migration_0075_reap_epoch_versioned_connector_registrations`:
+    sync fixture (``alembic.command`` calls ``asyncio.run`` internally),
+    per-test SQLite file under ``tmp_path``, settings + engine caches
+    reset on both sides so the alembic env reads *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0088.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    op_id: str,
+    version: str,
+    source_kind: str = "ingested",
+) -> UUID:
+    """Insert one minimal ``endpoint_descriptor`` row at the migration base.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration runs against. UUID binds use ``.hex`` per
+    ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :op_id,
+                        :source_kind, :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "op_id": op_id,
+                    "source_kind": source_kind,
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _insert_group_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    group_key: str,
+    version: str,
+) -> UUID:
+    """Insert one minimal ``operation_group`` row at the migration base."""
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO operation_group (
+                        id, tenant_id, product, version, impl_id, group_key,
+                        name, when_to_use, review_status, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :group_key,
+                        :name, 'seeded for 0088 reap test', 'enabled', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "group_key": group_key,
+                    "name": group_key.title(),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _row_exists(sync_url: str, table: str, row_id: UUID) -> bool:
+    """Return whether a row with ``row_id`` is still present in ``table``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).scalar_one()
+            return int(count) == 1
+    finally:
+        sync_eng.dispose()
+
+
+def _read_updated_at(sync_url: str, table: str, row_id: UUID) -> str:
+    """Return ``updated_at`` for one row, as a string."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(f"SELECT updated_at FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).one()
+            return str(row.updated_at)
+    finally:
+        sync_eng.dispose()
+
+
+def test_probe_epoch_impl_id_rows_reaped(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A ``fleet-rest-probe-<epoch>`` descriptor + group are reaped.
+
+    The signature #3061 defect: an ingested connector whose ``impl_id``
+    ends in a per-run epoch while the ``version`` is a *legitimate* ``9.0``
+    (which is why ``0075``'s version-keyed reap missed it). Both row
+    surfaces the dispatch / review layer reads are cleared.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    epoch_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+    epoch_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        group_key="system",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch_descriptor), (
+        "the probe-epoch-impl_id descriptor must be reaped"
+    )
+    assert not _row_exists(sync_url, "operation_group", epoch_group), (
+        "the probe-epoch-impl_id group must be reaped under the same predicate"
+    )
+
+
+def test_stable_impl_id_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The genuine ``fleet-rest`` connector survives untouched.
+
+    Same product + version as the epoch row, but a stable dispatch-canonical
+    ``impl_id`` -- proves the reap keys on the ``-probe-<epoch>`` tail, not
+    on product or version.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    stable_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_STABLE_IMPL_ID,
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+    stable_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_STABLE_IMPL_ID,
+        group_key="inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    for table, row_id in (
+        ("endpoint_descriptor", stable_descriptor),
+        ("operation_group", stable_group),
+    ):
+        assert _row_exists(sync_url, table, row_id), f"the stable-impl_id {table} row must survive"
+        assert _read_updated_at(sync_url, table, row_id) == _SEED_TS, (
+            f"the surviving {table} row must not be touched"
+        )
+
+
+def test_bare_probe_impl_id_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A bare ``-probe`` impl_id (no epoch tail) survives.
+
+    ``fleet-rest-probe`` is the stable "one probe registration per impl"
+    pattern #2977 ask (c) proposed -- it ends in ``-probe`` with no
+    ``-<epoch>`` tail, so the ``-probe-[0-9]{9,}$`` predicate must not
+    reach it. This is the discriminator that separates the accreting shape
+    from the legitimate probe impl.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    bare_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_BARE_PROBE_IMPL_ID,
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+    bare_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_BARE_PROBE_IMPL_ID,
+        group_key="system",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", bare_descriptor), (
+        "a bare -probe impl_id (no epoch tail) must survive"
+    )
+    assert _row_exists(sync_url, "operation_group", bare_group), (
+        "a bare -probe group (no epoch tail) must survive"
+    )
+
+
+def test_short_probe_tail_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A sub-9-digit ``-probe-`` tail is not an epoch and survives.
+
+    ``fleet-rest-probe-12345678`` (8 trailing digits) is below the 9-digit
+    epoch floor, so the predicate leaves it alone -- the threshold does not
+    over-reach onto a short numeric probe suffix.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    short_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe-12345678",
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", short_descriptor), (
+        "a sub-9-digit -probe- tail is not an epoch and must survive"
+    )
+
+
+def test_tenant_scoped_probe_epoch_rows_reaped(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Tenant-scoped probe-epoch rows ARE reaped (tenant-inclusive).
+
+    Unlike ``0049`` / ``0052`` (which never delete a tenant row), the
+    epoch debris is a consumer-side tenant ingest, so the cleanup spans
+    every scope -- same posture as ``0075``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    tenant_id = uuid4()
+    tenant_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+    tenant_group = _insert_group_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        group_key="system",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", tenant_descriptor), (
+        "a tenant-scoped probe-epoch descriptor must be reaped (tenant-inclusive)"
+    )
+    assert not _row_exists(sync_url, "operation_group", tenant_group), (
+        "a tenant-scoped probe-epoch group must be reaped (tenant-inclusive)"
+    )
+
+
+def test_typed_probe_epoch_descriptor_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``source_kind`` guard: a typed descriptor is never reaped.
+
+    Typed / composite connectors are hand-coded and can never carry a
+    probe-epoch impl_id, but the ``source_kind = 'ingested'`` guard makes
+    the ``endpoint_descriptor`` blast radius provably ingest-only even in
+    the impossible case a typed row's impl_id took the shape.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    typed_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+        source_kind="typed",
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", typed_descriptor), (
+        "a typed descriptor must survive the ingested-only reap guard"
+    )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Replaying ``upgrade()`` on a cleaned DB deletes nothing further.
+
+    Stamp-back replay pinned to this migration's own revision
+    (``stamp("0087") -> upgrade("0088")``), never ``head``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    epoch = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_PROBE_EPOCH_IMPL_ID,
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+    survivor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_STABLE_IMPL_ID,
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch)
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor)
+
+    command.stamp(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", epoch), (
+        "the epoch row stays gone on replay"
+    )
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor), (
+        "the stable survivor must persist across an idempotent replay"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", survivor) == _SEED_TS, (
+        "a no-op replay must not disturb the surviving row"
+    )
+
+
+def test_downgrade_is_a_clean_noop(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade()`` runs without error and touches nothing.
+
+    The reap is one-directional (the debris carried no operator value),
+    so the downgrade is a documented no-op -- a surviving row is
+    unchanged across the up/down cycle.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    survivor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id=_STABLE_IMPL_ID,
+        op_id="GET:/api/inventory",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+    command.downgrade(cfg, _DOWN_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor), (
+        "the no-op downgrade must leave the surviving row in place"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", survivor) == _SEED_TS, (
+        "the no-op downgrade must not disturb the surviving row"
+    )

--- a/backend/tests/migrations/test_migration_0088_reap_probe_epoch_impl_id_registrations.py
+++ b/backend/tests/migrations/test_migration_0088_reap_probe_epoch_impl_id_registrations.py
@@ -373,6 +373,36 @@ def test_short_probe_tail_preserved(
     )
 
 
+def test_probe_epoch_not_at_tail_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """An epoch that is not the impl_id tail is not the accretion shape.
+
+    ``fleet-rest-probe-123456789-extra`` carries a 9-digit run after
+    ``-probe-`` but the epoch does not reach the end of the string, so the
+    ``-probe-[0-9]{9,}$`` predicate must not match it. Pins that the SQLite
+    branch (``NOT GLOB '*-probe-*[^0-9]*'``) agrees with the PG ``$`` anchor
+    and does not over-reap -- the safe direction for a destructive DELETE.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    non_tail_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="fleet",
+        impl_id="fleet-rest-probe-123456789-extra",
+        op_id="GET:/api/probe",
+        version=_STABLE_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", non_tail_descriptor), (
+        "an epoch not at the impl_id tail is not the accretion shape and must survive"
+    )
+
+
 def test_tenant_scoped_probe_epoch_rows_reaped(
     alembic_cfg: tuple[Config, str],
 ) -> None:

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -3932,6 +3932,136 @@ def test_ingest_returns_422_on_epoch_version(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #3061 — reject probe-epoch impl_id (epoch in the impl_id tail, not version)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_request_rejects_probe_epoch_impl_id() -> None:
+    """``IngestRequest`` rejects an ``impl_id`` ending in ``-probe-<epoch>`` (#3061).
+
+    The shape ``0075`` missed: the epoch rides the ``impl_id`` tail while
+    the ``version`` is a legitimate ``9.0``, so the version-keyed guard
+    never fires. The impl_id guard fires on the one validator both the REST
+    route and the MCP tool construct through, so every surface fails closed.
+    """
+    from pydantic import ValidationError
+
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    with pytest.raises(ValidationError) as exc_info:
+        IngestRequest(
+            product="fleet",
+            version="9.0",
+            impl_id="fleet-rest-probe-1784123249",
+            specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+        )
+    assert "connector_impl_id_probe_epoch_rejected" in str(exc_info.value)
+
+
+def test_ingest_request_accepts_stable_probe_impl_id() -> None:
+    """A bare ``-probe`` impl_id (no epoch tail) passes untouched.
+
+    ``fleet-rest-probe`` is the stable "one probe registration per impl"
+    pattern #2977 asked for; it must not trip the ``-probe-<epoch>`` guard.
+    """
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    req = IngestRequest(
+        product="fleet",
+        version="9.0",
+        impl_id="fleet-rest-probe",
+        specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+    )
+    assert req.impl_id == "fleet-rest-probe"
+
+
+@pytest.mark.parametrize(
+    ("impl_id", "rejected"),
+    [
+        ("fleet-rest-probe-1784123249", True),  # 10-digit epoch tail — the defect
+        ("fleet-rest-probe-169999999", True),  # 9-digit — at the floor, still an epoch
+        ("fleet-rest-probe-16999999", False),  # 8-digit — below the floor
+        ("fleet-rest-probe", False),  # bare -probe, no epoch tail
+        ("fleet-rest", False),  # stable dispatch-canonical impl_id
+        ("net-probe", False),  # sibling stable probe impl
+        ("vmware-rest-probe", False),  # sibling stable probe impl
+        ("vcd", False),  # single-token impl_id
+        ("fleet-rest-probe-1784123249-extra", False),  # epoch not at the tail
+    ],
+)
+def test_ingest_request_probe_epoch_impl_id_boundary(impl_id: str, rejected: bool) -> None:
+    """Lock the ``-probe-<epoch>`` shape: 9+ trailing digits after ``-probe-`` rejected."""
+    from pydantic import ValidationError
+
+    from meho_backplane.operations.ingest import IngestRequest, SpecSource
+
+    def _build() -> IngestRequest:
+        return IngestRequest(
+            product="fleet",
+            version="9.0",
+            impl_id=impl_id,
+            specs=[SpecSource(uri="https://specs.test/never-fetched.yaml")],
+        )
+
+    if rejected:
+        with pytest.raises(ValidationError, match="connector_impl_id_probe_epoch_rejected"):
+            _build()
+    else:
+        assert _build().impl_id == impl_id
+
+
+def test_probe_epoch_guard_spares_every_registered_impl_id() -> None:
+    """No shipped connector's ``impl_id`` matches the ``-probe-<epoch>`` guard.
+
+    The guard is a blanket predicate on the ingest boundary, so a
+    false-positive would reject a legitimate re-ingest. Enumerate every
+    registered ``(product, version, impl_id)`` triple in the v2 registry
+    and assert none of the impl_ids trip the predicate — a live regression
+    fence over the whole connector catalog (``vcd`` / ``vrops8`` /
+    ``vmware-rest`` / the stable ``*-probe`` impls all included).
+    """
+    from meho_backplane.connectors.registry import (
+        _eager_import_connectors,
+        list_connector_impls,
+    )
+    from meho_backplane.operations.ingest.api_schemas import _impl_id_looks_like_probe_epoch
+
+    _eager_import_connectors()
+    impls = list_connector_impls()
+    assert impls, "expected a populated v2 connector registry"
+
+    offenders = [
+        impl_id
+        for (_product, _version, impl_id) in impls
+        if _impl_id_looks_like_probe_epoch(impl_id)
+    ]
+    assert not offenders, f"registered impl_ids must not match the probe-epoch guard: {offenders}"
+
+
+def test_ingest_returns_422_on_probe_epoch_impl_id(client: TestClient) -> None:
+    """End-to-end: POST with a ``-probe-<epoch>`` impl_id → 422 with the classifier.
+
+    Validation fails at body-parse (before the handler, so no spec is
+    fetched); the ``snake_case`` classifier surfaces in the 422 body.
+    """
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "fleet",
+                "version": "9.0",
+                "impl_id": "fleet-rest-probe-1784123249",
+                "specs": [{"uri": "https://specs.test/never-fetched.yaml"}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    assert "connector_impl_id_probe_epoch_rejected" in response.text
+
+
+# ---------------------------------------------------------------------------
 # G0.14-T9 (#1150) — catalog-driven REST ingest shape
 # ---------------------------------------------------------------------------
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1248,11 +1248,47 @@ divergence above took:
   PG POSIX regex, SQLite `length` + `NOT GLOB`), not a product/impl_id
   allowlist. `downgrade()` is a documented no-op.
 
+The epoch can ride either coordinate — the #3061 follow-up
+----------------------------------------------------------
+
+`0075` and `_reject_epoch_version` both key on the **`version`** column,
+but the rows actually accreting on the lab carried the epoch in the
+**`impl_id`** tail with a *legitimate* `version="9.0"`:
+`impl_id="fleet-rest-probe-<epoch>"`, rendering
+`connector_id="fleet-rest-probe-<epoch>-9.0"`. `"9.0"` is not an epoch, so
+the version-keyed reap matched nothing and a v0.29.0 lab deploy still
+returned 9 such rows post-`0075`. #3061 closes the sibling shape with the
+same prevention-plus-cleanup pair, keyed on `impl_id` instead:
+
+- **Prevention.** `IngestRequest._reject_probe_epoch_impl_id` rejects an
+  `impl_id` ending in `-probe-<epoch>` (a `-probe-` segment then ≥ 9
+  trailing digits) with a `422 connector_impl_id_probe_epoch_rejected`,
+  on the same all-surfaces `IngestRequest` validator. The `-probe-` anchor
+  and end-of-string digit run keep it off the stable probe impls
+  (`net-probe` / `nsx-rest-probe` / `fleet-rest-probe` — bare `-probe`, no
+  epoch) and every real impl_id (`fleet-rest` / `vmware-rest` / `vcd`).
+- **Cleanup.** Migration `0088_reap_probe_epoch_impl_id_registrations`
+  reaps the leaked rows keyed on the `impl_id` tail (PG `impl_id ~
+  '-probe-[0-9]{9,}$'`, SQLite `GLOB` + `NOT GLOB '*[^0-9]'`), same
+  `source_kind='ingested'` guard, tenant-inclusive, no-op `downgrade()`.
+  It complements `0075` — the two predicates target disjoint row sets.
+
+The producer that mints the per-run epoch is the fingerprint/probe glue on
+the **consumer** side (a different repo, `claude-rdc-hetzner-dc`), not this
+backplane — the fleet connector's `fingerprint`/`probe` path returns a
+`FingerprintResult` and registers no epoch impl_id — so the ingest-boundary
+guard is the backplane's durable defence; the consumer separately switches
+to a stable impl_id (as `net-probe` does).
+
 Regression coverage:
 `tests/test_api_v1_connectors_ingest.py::test_ingest_request_epoch_version_boundary`
-(plus the REST 422 and schema cases),
+and `::test_ingest_request_probe_epoch_impl_id_boundary`
+(plus the REST 422 and schema cases, and
+`::test_probe_epoch_guard_spares_every_registered_impl_id` — a live fence
+over the whole registered catalog),
 `tests/test_mcp_tools_connector_ingest.py::test_inline_epoch_version_rejected_before_service`,
 `tests/migrations/test_migration_0075_reap_epoch_versioned_connector_registrations.py`,
+`tests/migrations/test_migration_0088_reap_probe_epoch_impl_id_registrations.py`,
 and the scope-isolation invariant the "counts bleed across duplicates"
 symptom was mistaken for (documented semantics — `total` counts only
 rendered-group ops) in


### PR DESCRIPTION
## Summary

- **The bug (#3061, follow-up to #2977):** migration `0075` and
  `IngestRequest._reject_epoch_version` both key on the connector **`version`**
  column (`^[0-9]{9,}$`), but the accreting `fleet-rest-probe-<epoch>` rows
  carry the epoch in the **`impl_id`** tail with a *legitimate* `version="9.0"`
  (rendering `connector_id="fleet-rest-probe-<epoch>-9.0"`). `"9.0"` is not an
  epoch, so `0075`'s reap matched **nothing** — a v0.29.0 lab deploy that had
  applied `0075` still returned 9 stale rows (epochs `1784123249..1786183253`).
- **Cleanup — migration `0088`:** reaps `endpoint_descriptor`
  (`source_kind='ingested'`) + `operation_group` rows whose `impl_id` ends in
  `-probe-<epoch>` (a `-probe-` segment then ≥ 9 trailing digits).
  Dialect-branched (PG `impl_id ~ '-probe-[0-9]{9,}$'`, SQLite `GLOB` +
  `NOT GLOB '*[^0-9]'`), tenant-scope-inclusive, no-op `downgrade()`. It
  **complements** `0075` — the two predicates target disjoint row sets (epoch
  in `version` vs. epoch in `impl_id`).
- **Prevention — ingest guard:** `IngestRequest._reject_probe_epoch_impl_id`
  rejects the same shape at registration on every surface (REST + MCP + CLI
  share the one validator) with `422 connector_impl_id_probe_epoch_rejected`.
- **Producer disposition (issue Ask #1):** the per-run epoch is minted by the
  fingerprint/probe glue on the **consumer** side
  (`claude-rdc-hetzner-dc`), **not** this backplane — the fleet connector's
  `fingerprint`/`probe` path returns a `FingerprintResult` and registers no
  epoch impl_id (verified: no epoch-minting code exists anywhere in
  `evoila/meho`). So a source-side "reuse a stable impl_id" change lives in a
  different repo and is out of scope here; the ingest-boundary guard is the
  backplane's durable defence, and the consumer separately switches to a
  stable impl_id (as `net-probe` does). This mirrors exactly how #2977 split
  prevention (boundary guard) from the consumer-side producer.

## Migration numbering (coordinated)

**`0088` → down_revision `0087`.** `0087` is a peer session's in-flight
migration (`0087_add_tenant_flight_recorder_agent_readable`, work item #3216),
not yet on `main` at open time. Per orchestrator coordination I own `0088`.
**The migrations CI lane will red until #3216 lands `0087` on `main`** (alembic
can't resolve the chain `0086 → 0087 → 0088` without it); it goes green on the
natural stagger once their migration merges ahead of this one. Locally the
migration + guard suites were validated against a throwaway `0087` chain stub
(never committed).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (`api_schemas.py`)
- [x] `pytest tests/migrations/` — **410 passed** (incl. new
  `test_migration_0088_*` — 8 cases: reap, stable-impl survives, **bare
  `-probe` survives**, sub-9-digit tail survives, tenant-inclusive,
  `source_kind` guard, idempotent replay, no-op downgrade)
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — **135 passed** (incl.
  impl_id boundary parametrization + REST 422 + **registry-wide negative fence**
  `test_probe_epoch_guard_spares_every_registered_impl_id` proving no shipped
  impl_id — `vcd` / `vrops8` / `vmware-rest` / the stable `*-probe` impls —
  trips the guard)
- [x] `pytest tests/test_mcp_tools_connector_ingest.py` — 31 passed
  (cross-surface guard intact)
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope

- Source-side producer fix (consumer repo `claude-rdc-hetzner-dc` — see
  Producer disposition above).
- The secondary #2977 duplicate-registration observations
  (`sddc-rest-probe-9.0` under two products, doubled `vmware-rest-probe`) —
  not this issue's headline; left for a separate follow-up.

## Notes

- `docs/codebase/spec-ingestion.md` "Version integrity at the ingest boundary"
  section extended with the #3061 impl_id-tail shape + producer disposition.
- `api_schemas.py` carries two pre-existing code-quality warnings (file 1200
  lines; `_exactly_one_request_shape` 95 lines) — untouched by this change.

Closes #3061
