### PR TITLE
feat(flight-recorder): agent read surface + live trigger — trace as reduced result-handle, gated + degrade (#3216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,44 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: agent read surface — trace as a reduced result-handle, per-tenant gated, redaction-uncertainty degrade (#3216)
+
+- Ships **F5** of the flight-recorder decision
+  (`docs/decisions/dispatch-flight-recorder.md`) — the operator override that
+  makes a captured dispatch trace **readable by an agent**, but only through
+  the existing narrow-waist result-handle idiom. A trace is materialized as a
+  set-shaped result (its ordered spans) and spilled to the same
+  `ResultHandleStore` (Valkey, tenant + operator scoped, TTL-bounded) any large
+  response uses; the agent pages it via the **unchanged** `result_query`
+  meta-tool (`read_result_window`, `MAX_LIMIT=500`). **No new tool** is
+  registered, **no vendor-specific name** reaches the agent surface, and **no
+  raw payload** enters agent context — postulates 5 and 6 intact, and
+  `docs/codebase/mcp.md` + `test_mcp_surface_conformance.py` are untouched.
+- **Per-tenant gate, independent of operator access.** Agent trace readability
+  is a new tri-state per-tenant policy (`tenant.flight_recorder_agent_readable`,
+  migration `0087`): `NULL` inherits the capture default (so it "follows the F1
+  lab-on posture"), `True` forces on, `False` withholds from agents while the
+  operator plane keeps full access. Resolved fail-open to "no agent exposure"
+  by `flight_recorder.config.should_expose_to_agent`.
+- **Redaction-uncertainty degrade (the F5 discharge).** Any trace whose
+  redaction could not be proven complete (`redaction_uncertain=True`) is
+  withheld from the agent handle **entirely** — checked before any span is
+  loaded or spilled — while remaining readable on the operator plane. Composed
+  with the #3213 fail-closed redaction, this discharges the operator's
+  condition (*"as long as there are no secrets in there"*): a secret-bearing /
+  uncertain span never reaches an agent-visible handle. The default on doubt is
+  less agent exposure, never more.
+- **Live trigger wired into the recorder.** After the capture seam
+  (`flight_recorder.capture`, #3214) persists a trace via `record_trace` on the
+  recorder's best-effort path, it mints the agent handle
+  (`flight_recorder.materialize_agent_trace_handle`, gated by
+  `should_expose_to_agent`, degraded on `redaction_uncertain`) and attaches it
+  to the dispatch response as `flight_recorder_trace_handle`. The trigger runs
+  **strictly inside the F7 swallow-everything discipline** — a trigger failure
+  can never fail, block, or slow a dispatch and never alters the dispatch
+  result, and the disabled / gated-off path is a cheap gate check that spills
+  nothing.
+
 ### Fixed — `holodeck.config.apply` fails closed instead of reporting false success on a CLIXML-corrupted stdout (#3081)
 
 - `holodeck.config.apply` returned `{applied: true, config_id: null}` while
@@ -108,6 +146,7 @@ connector-related release-notes line.
   `Test-Path` verify-after-write folded into the same script), and silences the
   warning stream at the source (`$WarningPreference`). The self-contradictory
   `applied: true` / `config_id: null` envelope is now impossible.
+
 
 ### Added — flight recorder: operator read surface — REST trace endpoint + console drawer pane (#3215)
 

--- a/backend/alembic/versions/0087_add_tenant_flight_recorder_agent_readable.py
+++ b/backend/alembic/versions/0087_add_tenant_flight_recorder_agent_readable.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant flight-recorder agent-read gate (#3216, F5).
+
+Revision ID: 0087
+Revises: 0086
+Create Date: 2026-08-31
+
+Task #3216 under Initiative #3207. Ships the per-tenant gate for the
+**agent** read surface of the dispatch flight recorder (decision of record:
+``docs/decisions/dispatch-flight-recorder.md``, F5 -- the operator override
+that makes traces agent-readable through the narrow-waist result-handle
+idiom). The operator plane keeps full trace access independent of this gate;
+this column governs only whether an *agent* may page a tenant's traces.
+
+What this migration adds
+------------------------
+
+``tenant.flight_recorder_agent_readable`` -- a **tri-state** Boolean nullable
+column, mirroring the ``targets.flight_recorder_capture`` override shape
+(migration ``0085``):
+
+* ``NULL`` (default) -- **inherit** the per-tenant capture default
+  (``tenant.flight_recorder_enabled``). This is what makes the gate "follow
+  the F1 default (lab-on)": a lab-class tenant that flipped capture ON gets
+  agent-readable traces by default, with no second flag to set.
+* ``True`` -- force agent-readable ON regardless of the capture default.
+* ``False`` -- force agent-readable OFF while the operator plane keeps full
+  access. This is the independent gate-off the F5 override requires: an
+  operator can withhold traces from agents without turning capture off (which
+  would also blind the operator plane).
+
+Additive-only, per the migration-compatibility house rule -- one ``ADD
+COLUMN`` on ``tenant``, no ALTER of an existing column and no data rewrite.
+The column is **nullable** (NULL = inherit), so the add-column needs no
+backfill and is safe on a populated table.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the single added column. SQLite ALTER-TABLE
+drop-column is supported since 3.35.0 (we run 3.45+), so Alembic batch-mode
+is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0087"
+down_revision: str | None = "0086"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Tri-state agent-read gate (F5): NULL inherit / True on / False off.
+    # Nullable, so no backfill -- existing tenants keep NULL (= inherit the
+    # capture default), preserving the F1 lab-on posture with no flag change.
+    op.add_column(
+        "tenant",
+        sa.Column("flight_recorder_agent_readable", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenant", "flight_recorder_agent_readable")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -745,6 +745,31 @@ class Tenant(Base):
         nullable=True,
         default=None,
     )
+    # Per-tenant gate for the *agent* flight-recorder read surface (#3216, F5
+    # of ``docs/decisions/dispatch-flight-recorder.md`` -- the operator
+    # override that makes traces agent-readable through the narrow-waist
+    # result-handle idiom). **Tri-state**, mirroring the
+    # :attr:`Target.flight_recorder_capture` override shape:
+    #
+    # * ``None`` (default) -- inherit the per-tenant capture default
+    #   (:attr:`flight_recorder_enabled`). This is what makes the gate "follow
+    #   the F1 default (lab-on)": a lab-class tenant with capture ON exposes
+    #   traces to agents by default, no second flag to set.
+    # * ``True`` -- force agent-readable ON.
+    # * ``False`` -- force agent-readable OFF while the operator plane keeps
+    #   full access. The independent gate-off the F5 override requires:
+    #   withhold traces from agents without turning capture (and thus operator
+    #   visibility) off.
+    #
+    # Resolved by :func:`meho_backplane.flight_recorder.config.should_expose_to_agent`
+    # (cache-aware, fail-open to "no agent exposure"). Nullable, so migration
+    # ``0087`` needs no backfill. No index -- read by primary-key lookup on a
+    # cache miss, never a filter predicate.
+    flight_recorder_agent_readable: Mapped[bool | None] = mapped_column(
+        sa.Boolean(),
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(

--- a/backend/src/meho_backplane/flight_recorder/__init__.py
+++ b/backend/src/meho_backplane/flight_recorder/__init__.py
@@ -17,32 +17,51 @@ This package owns:
   (F7), never raising into a dispatch;
 * the retention reaper (:mod:`meho_backplane.flight_recorder.reaper`) -- the
   bounded ``expires_at < now()`` sweep that deletes expired traces, never
-  touching the ``audit_log`` row.
+  touching the ``audit_log`` row;
+* the **agent** read surface (:mod:`meho_backplane.flight_recorder.agent_read`,
+  #3216, F5) -- the per-tenant-gated, redaction-uncertainty-degrading mint that
+  exposes a captured trace to an agent as a reduced ``ResultHandle`` read back
+  through the existing ``result_query`` core (no new tool). Its per-tenant gate
+  lives in :mod:`meho_backplane.flight_recorder.config`
+  (:func:`should_expose_to_agent`).
 
-Explicitly **not** in this package (sibling Tasks under #3207): span
-production / the capture seam (#3214), the fail-closed redaction engine
-(#3213), and the agent read surface. The **operator** read
-(:mod:`meho_backplane.flight_recorder.read`) does live here (#3215) -- it is the
-tenant-scoped trace read the REST route and the console pane both share.
+Explicitly **not** in this package (sibling Task under #3207): the
+fail-closed redaction engine (#3213), which lives in
+:mod:`meho_backplane.redaction.flight_recorder`. Both trace read surfaces do
+live here -- the **operator** read (:mod:`meho_backplane.flight_recorder.read`,
+#3215; the tenant-scoped read the REST route and the console pane both share)
+and the **agent** read (:mod:`meho_backplane.flight_recorder.agent_read`,
+#3216; the gated, degrading mint in the bullet above) -- alongside the capture
+seam (:mod:`meho_backplane.flight_recorder.capture`, #3214).
 """
 
+from meho_backplane.flight_recorder.agent_read import (
+    AGENT_TRACE_HANDLE_EXTRA_KEY,
+    attach_agent_trace_handle,
+    materialize_agent_trace_handle,
+)
 from meho_backplane.flight_recorder.config import (
     compute_expires_at,
     reset_flight_recorder_config_cache_for_testing,
     resolve_retention_days,
     should_capture,
+    should_expose_to_agent,
 )
 from meho_backplane.flight_recorder.read import TraceSpanView, TraceView, load_trace
 from meho_backplane.flight_recorder.store import SpanInput, record_trace
 
 __all__ = [
+    "AGENT_TRACE_HANDLE_EXTRA_KEY",
     "SpanInput",
     "TraceSpanView",
     "TraceView",
+    "attach_agent_trace_handle",
     "compute_expires_at",
     "load_trace",
+    "materialize_agent_trace_handle",
     "record_trace",
     "reset_flight_recorder_config_cache_for_testing",
     "resolve_retention_days",
     "should_capture",
+    "should_expose_to_agent",
 ]

--- a/backend/src/meho_backplane/flight_recorder/agent_read.py
+++ b/backend/src/meho_backplane/flight_recorder/agent_read.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder **agent** read surface (#3216, F5).
+
+Implements F5 of the decision of record
+``docs/decisions/dispatch-flight-recorder.md`` -- the operator override that
+makes a captured trace readable by an agent, but *only* through the existing
+narrow-waist result-handle idiom, per-tenant gated, with a per-trace
+redaction-uncertainty degrade.
+
+The access path (design choice, grounded in the decision + postulates 5/6)
+==========================================================================
+
+An agent obtains a trace handle **exactly the way it obtains any result
+handle**: as a :class:`~meho_backplane.connectors.schemas.ResultHandle` the
+backplane surfaces on the dispatch response envelope, then pages it via the
+**unchanged** ``result_query`` meta-tool
+(:func:`meho_backplane.operations.result_query.read_result_window`). There is
+**no new tool** on the agent surface, **no vendor-specific name**, and **no
+raw payload** in agent context -- the agent pages the ordered spans exactly as
+it pages any set-shaped result (postulates 5 and 6 intact;
+``docs/codebase/mcp.md`` and the surface conformance test are untouched).
+
+This module owns the **mint**: :func:`materialize_agent_trace_handle` takes a
+persisted trace (written by :func:`meho_backplane.flight_recorder.store.record_trace`,
+which the capture seam #3214 calls), applies the per-tenant agent gate (F5,
+:func:`meho_backplane.flight_recorder.config.should_expose_to_agent`) and the
+redaction-uncertainty degrade, and -- only when both permit -- spills the
+ordered spans into the same Valkey read-back store the JSONFlux reducer uses
+(:class:`~meho_backplane.connectors.result_handle_store.ResultHandleStore`),
+scoped to ``(tenant_id, operator_sub)`` with a bounded TTL, returning the
+``ResultHandle`` the agent pages.
+
+The mint's **live trigger** -- the recorder attaching the returned handle to
+the dispatch response envelope after ``record_trace`` -- belongs to the
+capture seam (#3214), which owns the recorder's best-effort path (F7). This
+module does **not** import capture: the boundary is the same sibling-task seam
+:func:`record_trace` already documents. F7 decouples the trace write from the
+dispatch result path, so the handle is produced on the recorder path (where
+``record_trace`` runs), never by slowing the synchronous dispatch return.
+
+The degrade is the load-bearing security property
+=================================================
+
+The operator's F5 condition (*"as long as there are no secrets in there"*) is
+discharged by the composition of the #3213 fail-closed redaction (span bodies
+are redacted + capped at capture) **plus** this degrade: any trace whose
+:attr:`~meho_backplane.db.models.DispatchTrace.redaction_uncertain` flag is set
+is withheld from the agent handle **entirely** -- checked *before* any span is
+loaded or spilled, so a doubtful (potentially secret-bearing) trace can never
+reach an agent-visible handle. The operator plane still reads it. The default
+on doubt is *less* agent exposure, never more.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, Final
+
+import msgspec
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.result_handle_store import (
+    ResultHandleStore,
+    get_result_handle_store,
+)
+from meho_backplane.connectors.schemas import (
+    FetchMore,
+    FetchMoreDrillIn,
+    FetchMoreNativePagination,
+    OperationResult,
+    ResultHandle,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import DispatchTrace, DispatchTraceSpan
+from meho_backplane.flight_recorder.config import should_expose_to_agent
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "AGENT_TRACE_HANDLE_EXTRA_KEY",
+    "attach_agent_trace_handle",
+    "materialize_agent_trace_handle",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Key under which the recorder's live trigger surfaces the agent trace handle
+#: on the dispatch response envelope (:attr:`OperationResult.extras`). A dict --
+#: the JSON-serialized :class:`ResultHandle` -- so the value stays wire-safe in
+#: the free-form ``extras`` bag; the agent pages it via ``result_query`` exactly
+#: as it pages the sibling data handle. Not a new tool, not a new typed field.
+AGENT_TRACE_HANDLE_EXTRA_KEY: Final[str] = "flight_recorder_trace_handle"
+
+#: TTL for a spilled trace handle. Mirrors the production JsonFluxReducer's
+#: default ``ttl_seconds`` (``main.py`` installs ``JsonFluxReducer()`` via
+#: ``set_default_reducer``), so a trace handle expires on the **same** server-
+#: enforced schedule as any reduced result -- no TTL drift from
+#: ResultHandleStore semantics.
+_TRACE_HANDLE_TTL_SECONDS: Final[int] = 3600
+
+#: Inline-sample upper bound (rows), mirroring the reducer's default
+#: ``sample_size``. The sample is *also* byte-bounded (see
+#: :func:`_bounded_sample`) -- a span body can be up to F3's 64 KB cap, so a
+#: count-only bound could ship a heavy inline preview into agent context.
+_SAMPLE_SIZE: Final[int] = 5
+
+#: op_id label stamped on the spilled payload's metadata (store logs only).
+#: NOT a tool name and NOT a vendor identifier -- it never appears in
+#: ``tools/list`` or on the agent surface.
+_TRACE_OP_ID: Final[str] = "flight_recorder.trace"
+
+#: The read-back meta-tool an agent pages the handle with. The existing
+#: working-surface tool -- named here only for the self-documenting
+#: ``fetch_more`` envelope, exactly as the reducer names it.
+_RESULT_QUERY_TOOL: Final[str] = "result_query"
+
+#: Static JSON Schema of one materialized span row. The trace is a set of
+#: these; ``result_query`` pages them.
+_SPAN_ROW_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "seq": {"type": "integer"},
+        "span_kind": {"type": "string"},
+        "name": {"type": "string"},
+        "started_at": {"type": ["string", "null"]},
+        "duration_ms": {"type": ["string", "null"]},
+        "status": {"type": ["string", "null"]},
+        "attributes": {"type": "object"},
+    },
+}
+
+
+def _span_row(span: DispatchTraceSpan) -> dict[str, Any]:
+    """Materialize one persisted span as a JSON-safe row.
+
+    ``attributes`` is already redacted + capped (the #3213 engine scrubbed it
+    at capture time); this read path stores it verbatim. ``duration_ms`` (a
+    ``Decimal``) is serialized as a string to stay JSON-safe and lossless.
+    """
+    return {
+        "seq": span.seq,
+        "span_kind": span.span_kind,
+        "name": span.name,
+        "started_at": span.started_at.isoformat() if span.started_at is not None else None,
+        "duration_ms": None if span.duration_ms is None else str(span.duration_ms),
+        "status": span.status,
+        "attributes": dict(span.attributes) if span.attributes else {},
+    }
+
+
+def _bounded_sample(rows: list[dict[str, Any]], *, byte_budget: int) -> list[dict[str, Any]]:
+    """Inline preview bounded by BOTH a row count and a serialized-byte budget.
+
+    Mirrors the JSONFlux reducer's postulate-6 discipline: the inline sample is
+    sized to a byte budget, not only a count. A trace span body is capped at
+    F3's 64 KB, so a count-only bound could ship hundreds of KB of preview into
+    agent context; this keeps the sample small and pushes the full ordered set
+    to ``result_query``. The first row always ships (a non-empty trace never
+    yields an empty preview), then rows accrue until the next would exceed the
+    budget.
+    """
+    sample: list[dict[str, Any]] = []
+    used = 0
+    for row in rows[:_SAMPLE_SIZE]:
+        encoded = len(msgspec.json.encode(row))
+        if sample and used + encoded > byte_budget:
+            break
+        sample.append(row)
+        used += encoded
+    return sample
+
+
+def _build_handle(
+    *,
+    handle_id: uuid.UUID,
+    audit_id: uuid.UUID,
+    sample_rows: list[dict[str, Any]],
+    total_rows: int,
+    stored_rows: int,
+    minted_at: datetime,
+) -> ResultHandle:
+    """Assemble the ``ResultHandle`` the agent pages, mirroring the reducer.
+
+    The drill-in branch is ``available=True`` naming ``result_query`` and a
+    first-page ``example_call``, exactly as the JSONFlux reducer does for any
+    spilled set; native pagination is ``available=False`` (a trace has none).
+    """
+    return ResultHandle(
+        handle_id=handle_id,
+        summary_md=(
+            f"Flight-recorder trace: {total_rows} span(s) captured for dispatch "
+            f"{audit_id}. Bodies redacted and capped at capture; page the full "
+            "ordered set via `result_query`."
+        ),
+        schema_=_SPAN_ROW_SCHEMA,
+        total_rows=total_rows,
+        sample_rows=tuple(sample_rows),
+        ttl_seconds=_TRACE_HANDLE_TTL_SECONDS,
+        fetch_more=FetchMore(
+            drill_in=FetchMoreDrillIn(
+                available=True,
+                rationale=(
+                    f"Full trace ({stored_rows} of {total_rows} span(s)) is spilled; "
+                    f"page it with {_RESULT_QUERY_TOOL}(handle_id={handle_id})."
+                ),
+                mcp_tool=_RESULT_QUERY_TOOL,
+                example_call={
+                    "tool": _RESULT_QUERY_TOOL,
+                    "args": {"handle_id": str(handle_id), "offset": 0, "limit": 50},
+                },
+                expires_at=minted_at + timedelta(seconds=_TRACE_HANDLE_TTL_SECONDS),
+            ),
+            native_pagination=FetchMoreNativePagination(
+                available=False,
+                rationale=(
+                    "A flight-recorder trace has no native pagination; page it "
+                    "via the result handle."
+                ),
+            ),
+        ),
+    )
+
+
+async def _load_agent_trace_rows(
+    *, tenant_id: uuid.UUID, audit_id: uuid.UUID
+) -> list[dict[str, Any]] | None:
+    """Load the ordered, agent-visible span rows for one trace, or ``None``.
+
+    Returns ``None`` (withhold) when no trace exists for
+    ``(audit_id, tenant_id)`` -- the load is **tenant-scoped**, so another
+    tenant's trace never matches and a cross-tenant read is a miss, not a leak
+    -- or when the trace is **redaction-uncertain**. The uncertainty degrade
+    (F5) is checked *before* any span row is materialized, so a doubtful
+    (potentially secret-bearing) trace never has its spans read here at all.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        header = (
+            await session.execute(
+                select(DispatchTrace).where(
+                    DispatchTrace.audit_id == audit_id,
+                    DispatchTrace.tenant_id == tenant_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if header is None:
+            return None
+        # F5 redaction-uncertainty degrade: withhold ENTIRELY, BEFORE any span
+        # is loaded. The load-bearing property -- a doubtful trace can never
+        # reach an agent-visible handle. Operator plane keeps access.
+        if header.redaction_uncertain:
+            return None
+        spans = list(
+            (
+                await session.execute(
+                    select(DispatchTraceSpan)
+                    .where(DispatchTraceSpan.trace_id == header.id)
+                    .order_by(DispatchTraceSpan.seq.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return [_span_row(span) for span in spans]
+
+
+async def materialize_agent_trace_handle(
+    *,
+    operator: Operator,
+    audit_id: uuid.UUID,
+    store: ResultHandleStore | None = None,
+    now: datetime | None = None,
+) -> ResultHandle | None:
+    """Mint the agent-readable ``ResultHandle`` for a captured trace (F5).
+
+    Returns the handle the agent pages via ``result_query``, or ``None`` when
+    the trace is withheld from the agent surface. ``None`` -- never a raised
+    error -- for every withhold/failure case, so the operator plane is
+    unaffected and the safe default on doubt is *less* agent exposure:
+
+    * the operator has no tenant (it can never own a spilled handle);
+    * the per-tenant agent gate is off (F5,
+      :func:`should_expose_to_agent`) -- checked first, so a gated-off tenant's
+      spans are never even loaded;
+    * no trace exists for ``(audit_id, operator.tenant_id)`` -- which also
+      makes a cross-tenant read a miss (the load is tenant-scoped);
+    * the trace is **redaction-uncertain** -- the F5 degrade: withheld
+      entirely, checked *before* any span is loaded or spilled;
+    * the spill was skipped or failed (empty trace, store unreachable) -- the
+      store is fail-open, and the operator plane still has the trace.
+
+    On success the ordered spans are spilled to the read-back store keyed by
+    ``(tenant_id, operator_sub)`` with a bounded TTL -- the exact scoping
+    :func:`~meho_backplane.operations.result_query.read_result_window` enforces
+    on the read side, so a handle minted for one operator in one tenant is
+    unreadable by any other operator or tenant.
+
+    Parameters
+    ----------
+    operator:
+        The reading agent's identity. ``tenant_id`` + ``sub`` key the spill
+        (and, on the read side, the fetch); the arguments carry no tenant.
+    audit_id:
+        The dispatch's ``audit_log.id`` -- the soft-FK the trace hangs off.
+    store:
+        Injectable read-back store (tests); defaults to the process singleton,
+        the same store the JSONFlux reducer spills into.
+    now:
+        Mint time; defaults to ``datetime.now(UTC)``. Injectable for tests.
+    """
+    minted_at = now if now is not None else datetime.now(UTC)
+    try:
+        tenant_id = operator.tenant_id
+        if tenant_id is None:
+            return None
+
+        # F5 per-tenant gate FIRST: a gated-off tenant's trace is never loaded.
+        if not await should_expose_to_agent(tenant_id=tenant_id):
+            return None
+
+        rows = await _load_agent_trace_rows(tenant_id=tenant_id, audit_id=audit_id)
+        if rows is None:
+            return None
+        total_rows = len(rows)
+
+        handle_id = uuid.uuid4()
+        resolved_store = store if store is not None else get_result_handle_store()
+        settings = get_settings()
+        max_rows = settings.result_handle_max_spill_rows
+        stored = await resolved_store.spill(
+            tenant_id=tenant_id,
+            operator_sub=operator.sub,
+            handle_id=handle_id,
+            op_id=_TRACE_OP_ID,
+            rows=rows,
+            total_rows=total_rows,
+            ttl_seconds=_TRACE_HANDLE_TTL_SECONDS,
+            max_rows=max_rows,
+        )
+        if not stored:
+            # Fail-open: empty trace or unreachable store -> no agent-readable
+            # handle. The operator plane still reads the trace.
+            return None
+
+        return _build_handle(
+            handle_id=handle_id,
+            audit_id=audit_id,
+            sample_rows=_bounded_sample(rows, byte_budget=settings.jsonflux_sample_byte_budget),
+            total_rows=total_rows,
+            stored_rows=min(total_rows, max_rows),
+            minted_at=minted_at,
+        )
+    except Exception:
+        # Best-effort, doubt-reduces-exposure: any unexpected error withholds
+        # the trace from the agent (returns None) rather than surfacing it or
+        # failing the read. Mirrors record_trace's F7 fail-open discipline.
+        _log.warning(
+            "flight_recorder_agent_trace_mint_failed",
+            audit_id=str(audit_id),
+            tenant_id=None if operator.tenant_id is None else str(operator.tenant_id),
+            exc_info=True,
+        )
+        return None
+
+
+async def attach_agent_trace_handle(
+    result: OperationResult,
+    *,
+    operator: Operator,
+    audit_id: uuid.UUID,
+) -> OperationResult:
+    """The recorder's **live trigger** (F5): surface a trace handle on the response.
+
+    Called by the dispatcher for the **owning root dispatch** after the capture
+    seam has persisted the trace via ``record_trace`` (best-effort). Mints the
+    agent-readable handle (:func:`materialize_agent_trace_handle`, which applies
+    the per-tenant gate and the redaction-uncertainty degrade) and, when one is
+    minted, attaches its JSON form to :attr:`OperationResult.extras` under
+    :data:`AGENT_TRACE_HANDLE_EXTRA_KEY`. The agent pages it via the unchanged
+    ``result_query`` meta-tool -- no new tool, no raw payload.
+
+    **Strictly inside the F7 swallow-everything discipline.** This runs after
+    the dispatch result is computed and the audit row committed; it returns the
+    **original, unmodified** ``result`` on every no-handle and every failure
+    path, so a trigger failure can never fail, block, or alter a dispatch. When
+    the tenant gate is off (or capture produced nothing), the mint returns
+    ``None`` after a single cache-aware gate check and nothing is spilled --
+    the disabled path stays cheap.
+    """
+    try:
+        handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id)
+        if handle is None:
+            return result
+        extras = dict(result.extras)
+        extras[AGENT_TRACE_HANDLE_EXTRA_KEY] = handle.model_dump(mode="json")
+        return result.model_copy(update={"extras": extras})
+    except Exception:
+        # F7: a trigger failure never touches the dispatch result.
+        _log.warning(
+            "flight_recorder_agent_trace_attach_failed",
+            audit_id=str(audit_id),
+            exc_info=True,
+        )
+        return result

--- a/backend/src/meho_backplane/flight_recorder/config.py
+++ b/backend/src/meho_backplane/flight_recorder/config.py
@@ -28,10 +28,32 @@ and never captures more than it can prove it should):
   :func:`compute_expires_at` onto the header at write time so the reaper is a
   plain ``expires_at < now()`` sweep and this window math is unit-testable.
 
+* :func:`should_expose_to_agent` -- may an **agent** read this tenant's
+  traces (F5, #3216)? The operator override on F5 makes traces agent-readable
+  through the narrow-waist result-handle idiom, but only through this
+  per-tenant gate, and **independent of the operator plane's full access**.
+  Resolution, fail-open to ``False`` (doubt reduces agent exposure):
+
+  1. **Global kill switch** -- ``settings.flight_recorder_enabled``. ``False``
+     = no capture and no agent exposure anywhere.
+  2. **Per-tenant explicit override** --
+     ``tenant.flight_recorder_agent_readable`` when set: ``True`` force on,
+     ``False`` force off (operator plane unaffected).
+  3. **Inherit the capture default** -- when the override is ``NULL``, follow
+     ``tenant.flight_recorder_enabled`` (the F1 lab-on posture): a lab-class
+     tenant with capture ON exposes traces to agents by default.
+
+  This governs only the **agent** surface; the operator read plane keeps full
+  access regardless. The redaction-uncertainty degrade (a withheld trace) is
+  enforced separately at mint time
+  (:func:`meho_backplane.flight_recorder.agent_read.materialize_agent_trace_handle`),
+  not here -- this resolver is the per-tenant policy, that is the per-trace
+  degrade.
+
 Cache discipline mirrors :mod:`meho_backplane.broadcast.announce_gate`: a 60s
 per-key TTL cache keeps the policy off the DB on the per-dispatch path; only a
-miss awaits a one-row SELECT. One combined tenant cache serves both questions
-(both read the same ``tenant`` row).
+miss awaits a one-row SELECT. One combined tenant cache serves all three
+questions (all read the same ``tenant`` row).
 """
 
 from __future__ import annotations
@@ -53,6 +75,7 @@ __all__ = [
     "reset_flight_recorder_config_cache_for_testing",
     "resolve_retention_days",
     "should_capture",
+    "should_expose_to_agent",
 ]
 
 _log = structlog.get_logger(__name__)
@@ -60,10 +83,11 @@ _log = structlog.get_logger(__name__)
 #: Per-key TTL for both caches, mirroring the announce-gate resolver.
 _CACHE_TTL_SECONDS: Final[float] = 60.0
 
-#: Per-tenant policy cache. Value = ((enabled, retention_days_override),
-#: monotonic_expires_at). A hit is a pure dict lookup; a miss awaits the
-#: one-row SELECT that reads both policy fields at once.
-_TENANT_CACHE: dict[UUID, tuple[tuple[bool, int | None], float]] = {}
+#: Per-tenant policy cache. Value = ((enabled, retention_days_override,
+#: agent_readable_override), monotonic_expires_at). A hit is a pure dict
+#: lookup; a miss awaits the one-row SELECT that reads all three policy fields
+#: at once (capture default F1, retention override F4, agent-read override F5).
+_TENANT_CACHE: dict[UUID, tuple[tuple[bool, int | None, bool | None], float]] = {}
 
 #: Per-target override cache. Value = (override_tri_state, monotonic_expires_at)
 #: where the tri-state is ``True`` / ``False`` / ``None`` (inherit).
@@ -86,13 +110,14 @@ def compute_expires_at(created_at: datetime, retention_days: int) -> datetime:
     return created_at + timedelta(days=retention_days)
 
 
-async def _resolve_tenant_policy(tenant_id: UUID) -> tuple[bool, int | None]:
-    """Return ``(capture_enabled, retention_days_override)`` for *tenant_id*.
+async def _resolve_tenant_policy(tenant_id: UUID) -> tuple[bool, int | None, bool | None]:
+    """Return ``(capture_enabled, retention_days_override, agent_readable_override)``.
 
-    Cache-aware; a miss reads both policy columns in one SELECT. An unknown
-    tenant resolves to ``(False, None)`` (capture OFF, default retention) and
-    is cached so a nonexistent id does not re-query every dispatch. DB errors
-    propagate to the fail-open handlers in the public callers.
+    Cache-aware; a miss reads all three policy columns in one SELECT. An
+    unknown tenant resolves to ``(False, None, None)`` (capture OFF, default
+    retention, agent-read inherits = OFF) and is cached so a nonexistent id
+    does not re-query every dispatch. DB errors propagate to the fail-open
+    handlers in the public callers.
     """
     now = time.monotonic()
     cached = _TENANT_CACHE.get(tenant_id)
@@ -105,10 +130,13 @@ async def _resolve_tenant_policy(tenant_id: UUID) -> tuple[bool, int | None]:
                 select(
                     Tenant.flight_recorder_enabled,
                     Tenant.flight_recorder_retention_days,
+                    Tenant.flight_recorder_agent_readable,
                 ).where(Tenant.id == tenant_id)
             )
         ).one_or_none()
-    policy: tuple[bool, int | None] = (False, None) if row is None else (bool(row[0]), row[1])
+    policy: tuple[bool, int | None, bool | None] = (
+        (False, None, None) if row is None else (bool(row[0]), row[1], row[2])
+    )
     _TENANT_CACHE[tenant_id] = (policy, now + _CACHE_TTL_SECONDS)
     return policy
 
@@ -152,7 +180,7 @@ async def should_capture(*, tenant_id: UUID, target_id: UUID | None = None) -> b
             override = await _resolve_target_override(target_id)
             if override is not None:
                 return override
-        enabled, _ = await _resolve_tenant_policy(tenant_id)
+        enabled, _, _ = await _resolve_tenant_policy(tenant_id)
         return enabled
     except Exception:
         _log.warning(
@@ -171,8 +199,40 @@ async def resolve_retention_days(tenant_id: UUID) -> int:
     """
     default = get_settings().flight_recorder_retention_days_default
     try:
-        _, override = await _resolve_tenant_policy(tenant_id)
+        _, override, _ = await _resolve_tenant_policy(tenant_id)
     except Exception:
         _log.warning("flight_recorder_retention_resolution_failed", tenant_id=str(tenant_id))
         return default
     return override if override is not None else default
+
+
+async def should_expose_to_agent(*, tenant_id: UUID) -> bool:
+    """Whether an **agent** may read this tenant's flight-recorder traces (F5).
+
+    The operator override on F5 makes traces agent-readable through the
+    narrow-waist result-handle idiom, gated per tenant and **independent of
+    the operator plane's full access**. Precedence: global kill switch >
+    per-tenant explicit override > inherit the capture default (the F1 lab-on
+    posture). Fail-open to ``False`` (no agent exposure) on any error -- a
+    resolution failure must never fail a read, and the safe default on doubt
+    is *less* agent exposure, not more.
+
+    This is the per-tenant *policy* gate only. The per-trace
+    redaction-uncertainty degrade (a doubtful trace withheld from the agent
+    handle entirely) is enforced separately at mint time in
+    :func:`meho_backplane.flight_recorder.agent_read.materialize_agent_trace_handle`.
+    """
+    if not get_settings().flight_recorder_enabled:
+        # Global kill switch -- no capture and no agent exposure anywhere.
+        return False
+    try:
+        enabled, _, agent_readable = await _resolve_tenant_policy(tenant_id)
+    except Exception:
+        _log.warning("flight_recorder_agent_read_resolution_failed", tenant_id=str(tenant_id))
+        return False
+    if agent_readable is not None:
+        # Explicit per-tenant override, both directions -- and independent of
+        # the operator plane, which keeps full access regardless of this flag.
+        return agent_readable
+    # Inherit the capture default: "follows the F1 default (lab-on)".
+    return enabled

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -264,6 +264,7 @@ from meho_backplane.connectors import (
 from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError
 from meho_backplane.connectors.base import Connector, shim_kind
 from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
+from meho_backplane.flight_recorder import attach_agent_trace_handle
 from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.operations._audit import (
     audit_and_broadcast_safe,
@@ -710,7 +711,7 @@ async def _execute_and_audit(
         connector_id=connector_id,
     )
     try:
-        return await _execute_and_audit_inner(
+        result = await _execute_and_audit_inner(
             op_id=op_id,
             connector_id=connector_id,
             descriptor=descriptor,
@@ -724,7 +725,23 @@ async def _execute_and_audit(
             scrub_response=scrub_response,
         )
     finally:
+        # Persists the trace via record_trace on the recorder's best-effort
+        # path (owning root only); never raises (F7).
         await flight_recorder_capture.end_dispatch_capture(capture_handle)
+    # Agent read-surface live trigger (#3216, F5). Only the owning ROOT dispatch
+    # (whose OperationResult the agent sees) surfaces a trace handle; nested
+    # composite children never persist their own trace, so they never attach.
+    # ``attach_agent_trace_handle`` is best-effort (F7): it mints the handle
+    # behind the per-tenant gate + redaction-uncertainty degrade and returns the
+    # unmodified ``result`` on every no-handle / failure path, so the trigger can
+    # never fail, block, or alter the dispatch. Runs after the audit commit.
+    if capture_handle.owns and capture_handle.scope is not None:
+        result = await attach_agent_trace_handle(
+            result,
+            operator=operator,
+            audit_id=capture_handle.scope.audit_id,
+        )
+    return result
 
 
 async def _execute_and_audit_inner(

--- a/backend/tests/migrations/test_migration_0087_tenant_flight_recorder_agent_readable.py
+++ b/backend/tests/migrations/test_migration_0087_tenant_flight_recorder_agent_readable.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0087_add_tenant_flight_recorder_agent_readable``.
+
+#3216 flight-recorder agent read gate (F5). Additive-only: one nullable
+``ADD COLUMN`` (``tenant.flight_recorder_agent_readable``, a tri-state
+NULL/True/False override) -- no backfill, no ALTER of an existing column.
+
+Idempotency pinning: every forward / round-trip step targets this migration's
+own revision (``0087``) and its ``down_revision`` (``0086``), never ``head`` --
+so a future head migration cannot make ``upgrade("head")`` re-run this DDL on a
+schema that already has it. SQLite is the test driver; the migration uses only
+generic ``ADD COLUMN`` / ``DROP COLUMN`` DDL so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0087"
+_DOWN_REVISION = "0086"
+_NEW_COLUMN = "flight_recorder_agent_readable"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0087.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, f"sqlite:///{db_path}"
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_agent_read_gate_column(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0087`` adds the nullable tri-state agent-read gate column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _NEW_COLUMN in _columns(sync_url, "tenant")
+
+
+def test_column_is_nullable_tristate(alembic_cfg: tuple[Config, str]) -> None:
+    """The column is nullable (NULL = inherit) so the add-column needs no backfill."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            info = {
+                str(row[1]): row for row in conn.execute(text("PRAGMA table_info(tenant)")).all()
+            }
+    finally:
+        sync_eng.dispose()
+    # PRAGMA table_info row: (cid, name, type, notnull, dflt_value, pk).
+    assert info[_NEW_COLUMN][3] == 0  # notnull == 0 => nullable
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0086`` drops the column; ``upgrade 0087`` restores it."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _NEW_COLUMN in _columns(sync_url, "tenant")
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _NEW_COLUMN not in _columns(sync_url, "tenant")
+
+    command.upgrade(cfg, _REVISION)
+    assert _NEW_COLUMN in _columns(sync_url, "tenant")

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -355,6 +355,7 @@ def test_migration_installs_tenant_table_and_indexes(
                 "announce_gate_enabled",  # #3133 opt-in announce gate flag
                 "flight_recorder_enabled",  # #3212 F1 per-tenant capture default
                 "flight_recorder_retention_days",  # #3212 F4 per-tenant retention
+                "flight_recorder_agent_readable",  # #3216 F5 per-tenant agent-read gate
             }
 
             audit_columns = {col["name"] for col in inspector.get_columns("audit_log")}

--- a/backend/tests/test_flight_recorder_agent_read.py
+++ b/backend/tests/test_flight_recorder_agent_read.py
@@ -1,0 +1,461 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the flight-recorder **agent** read surface (#3216, F5).
+
+Covers :func:`meho_backplane.flight_recorder.agent_read.materialize_agent_trace_handle`
+and the AC of #3216 (F5 of ``docs/decisions/dispatch-flight-recorder.md``):
+
+* an agent pages a **clean** trace end to end -- mint spills the ordered spans,
+  and the **unchanged** ``result_query`` core
+  (:func:`~meho_backplane.operations.result_query.read_result_window`) returns
+  them window by window;
+* **no new tool** is registered on the agent surface by this feature (the mint
+  module registers nothing; the working-surface pin lives in the untouched
+  ``test_mcp_surface_conformance.py``);
+* a **redaction-uncertain** trace is agent-invisible (mint returns ``None``,
+  nothing spilled) yet operator-visible (the trace row is still present) -- the
+  F5 degrade / discharge property: a secret-bearing / uncertain span never
+  reaches the agent handle;
+* the **per-tenant gate off** => no agent access (nothing loaded, nothing
+  spilled) while capture (the operator plane's data source) stays on;
+* handle isolation -- a handle minted for one operator/tenant is unreadable by
+  another operator or another tenant.
+
+Traces are seeded via :func:`meho_backplane.flight_recorder.store.record_trace`
+(the capture seam #3214 is not imported), against the autouse
+``sqlite+aiosqlite`` engine the conftest pre-migrates to head. A shared
+in-memory Valkey fake backs one :class:`ResultHandleStore` injected into both
+the mint (spill) and the ``result_query`` core (fetch), so the round trip
+exercises the real spill + read-back logic without a container.
+"""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.flight_recorder.agent_read as agent_read_mod
+import meho_backplane.operations.result_query as result_query_core
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.result_handle_store import ResultHandleStore
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import DispatchTrace, DispatchTraceSpan, Tenant
+from meho_backplane.flight_recorder.agent_read import materialize_agent_trace_handle
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.flight_recorder.store import SpanInput, record_trace
+from meho_backplane.operations.result_query import ResultHandleNotFoundError, read_result_window
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+class _FakeRedis:
+    """In-memory async Valkey stand-in (mirrors the store's own test double)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.last_ex: int | None = None
+
+    async def set(self, name: str, value: Any, ex: int | None = None) -> None:
+        self.last_ex = ex
+        self.store[name] = value if isinstance(value, bytes) else str(value).encode()
+
+    async def get(self, name: str) -> bytes | None:
+        return self.store.get(name)
+
+
+@pytest.fixture
+def shared_store(monkeypatch: pytest.MonkeyPatch) -> tuple[ResultHandleStore, _FakeRedis]:
+    """One store backed by a fake, wired into BOTH the mint and the read core.
+
+    The mint receives it via its ``store=`` param; the ``result_query`` core
+    resolves it through its patched getter -- so a spill by the mint is
+    readable by :func:`read_result_window`, exactly as in production where both
+    share the process singleton.
+    """
+    fake = _FakeRedis()
+    store = ResultHandleStore(fake)  # type: ignore[arg-type]
+    monkeypatch.setattr(result_query_core, "get_result_handle_store", lambda: store)
+    return store, fake
+
+
+def _operator(tenant_id: uuid.UUID, *, sub: str = "op-a") -> Operator:
+    return Operator(
+        sub=sub,
+        name="Agent",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        scopes=frozenset(),
+        platform_admin=False,
+    )
+
+
+async def _seed_tenant(
+    session: AsyncSession,
+    *,
+    slug: str,
+    enabled: bool = True,
+    agent_readable: bool | None = None,
+) -> uuid.UUID:
+    tenant_id = uuid.uuid4()
+    session.add(
+        Tenant(
+            id=tenant_id,
+            slug=slug,
+            name=f"Tenant {slug}",
+            flight_recorder_enabled=enabled,
+            flight_recorder_agent_readable=agent_readable,
+        )
+    )
+    await session.commit()
+    return tenant_id
+
+
+def _clean_spans(n: int = 3) -> list[SpanInput]:
+    started = datetime(2026, 8, 31, 9, 0, 0, tzinfo=UTC)
+    return [
+        SpanInput(
+            span_kind="vendor_call",
+            name=f"GET /rest/vm/{i}",
+            started_at=started,
+            duration_ms=Decimal("10.25"),
+            status="200",
+            attributes={"method": "GET", "url": f"https://vendor.example/rest/vm/{i}"},
+        )
+        for i in range(n)
+    ]
+
+
+async def _new_tenant(
+    *, slug: str, enabled: bool = True, agent_readable: bool | None = None
+) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        return await _seed_tenant(
+            session, slug=slug, enabled=enabled, agent_readable=agent_readable
+        )
+
+
+# --------------------------------------------------------------------------
+# AC: agent pages a CLEAN trace via result_query (the reuse path)
+# --------------------------------------------------------------------------
+
+
+async def test_agent_pages_clean_trace_via_result_query(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, _fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-clean", enabled=True)  # inherit => agent-readable
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_clean_spans(3))
+
+    operator = _operator(tenant_id)
+    handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id, store=store)
+
+    assert handle is not None
+    assert handle.total_rows == 3
+    # The handle is self-documenting: it points the agent at result_query.
+    assert handle.fetch_more is not None
+    assert handle.fetch_more.drill_in.available is True
+    assert handle.fetch_more.drill_in.mcp_tool == "result_query"
+
+    # Page the FULL ordered set back through the UNCHANGED result_query core.
+    window = await read_result_window(operator, handle.handle_id, offset=0, limit=50)
+    assert window["total_rows"] == 3
+    assert window["returned_rows"] == 3
+    names = [row["name"] for row in window["rows"]]
+    assert names == ["GET /rest/vm/0", "GET /rest/vm/1", "GET /rest/vm/2"]
+    assert [row["seq"] for row in window["rows"]] == [0, 1, 2]
+    assert window["rows"][0]["attributes"]["method"] == "GET"
+
+
+async def test_agent_trace_handle_pages_across_windows(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, _fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-page", enabled=True)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_clean_spans(5))
+
+    operator = _operator(tenant_id)
+    handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id, store=store)
+    assert handle is not None
+
+    first = await read_result_window(operator, handle.handle_id, offset=0, limit=2)
+    assert [r["seq"] for r in first["rows"]] == [0, 1]
+    second = await read_result_window(operator, handle.handle_id, offset=2, limit=2)
+    assert [r["seq"] for r in second["rows"]] == [2, 3]
+    tail = await read_result_window(operator, handle.handle_id, offset=4, limit=2)
+    assert [r["seq"] for r in tail["rows"]] == [4]
+    end = await read_result_window(operator, handle.handle_id, offset=5, limit=2)
+    assert end["rows"] == []
+
+
+async def test_inline_sample_is_byte_bounded_not_a_raw_payload(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    """Postulate 6: heavy span bodies never ship a raw payload inline.
+
+    A span body is capped at F3's 64 KB, so a count-only inline sample could
+    dump hundreds of KB into agent context. The sample is byte-bounded (like
+    the JSONFlux reducer), so a trace of large spans ships a *small* preview
+    while the full ordered set stays reachable via ``result_query``.
+    """
+    store, _fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-bigbodies", enabled=True)
+    audit_id = uuid.uuid4()
+    big_body = "x" * 2000  # ~2 KB redacted body per span; default budget is 4 KB
+    spans = [
+        SpanInput(
+            span_kind="vendor_call",
+            name=f"GET /rest/big/{i}",
+            started_at=datetime(2026, 8, 31, 9, 0, 0, tzinfo=UTC),
+            status="200",
+            attributes={"redacted_body": big_body},
+        )
+        for i in range(5)
+    ]
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=spans)
+
+    operator = _operator(tenant_id)
+    handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id, store=store)
+    assert handle is not None
+    assert handle.total_rows == 5
+    # The inline preview is bounded well below the full set...
+    assert handle.sample_rows is not None
+    assert 1 <= len(handle.sample_rows) < 5
+    # ...yet the FULL ordered set is still retrievable via result_query.
+    window = await read_result_window(operator, handle.handle_id, offset=0, limit=50)
+    assert window["total_rows"] == 5
+    assert window["returned_rows"] == 5
+
+
+# --------------------------------------------------------------------------
+# AC: redaction-uncertain trace is agent-INVISIBLE but operator-VISIBLE
+#     (the F5 discharge: a secret-bearing / uncertain span never reaches the
+#      agent handle)
+# --------------------------------------------------------------------------
+
+
+async def test_redaction_uncertain_trace_is_withheld_from_agent(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-uncertain", enabled=True)
+    audit_id = uuid.uuid4()
+    # A span that could carry a secret, on a trace redaction could not prove clean.
+    secret_span = SpanInput(
+        span_kind="vendor_call",
+        name="POST /login",
+        started_at=datetime(2026, 8, 31, 9, 0, 0, tzinfo=UTC),
+        status="200",
+        attributes={"body": "token=SUPER-SECRET-DO-NOT-LEAK"},
+    )
+    await record_trace(
+        audit_id=audit_id,
+        tenant_id=tenant_id,
+        spans=[secret_span],
+        redaction_uncertain=True,
+    )
+
+    operator = _operator(tenant_id)
+    handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id, store=store)
+
+    # Agent-INVISIBLE: no handle, and NOTHING was spilled to the read-back store.
+    assert handle is None
+    assert fake.store == {}
+
+    # Operator-VISIBLE: the trace (and its uncertainty flag) is retained on the
+    # operator plane's data source, unaffected by the agent degrade.
+    async with get_sessionmaker()() as session:
+        header = (
+            await session.execute(select(DispatchTrace).where(DispatchTrace.audit_id == audit_id))
+        ).scalar_one()
+        span_count = len(
+            (
+                await session.execute(
+                    select(DispatchTraceSpan).where(DispatchTraceSpan.trace_id == header.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert header.redaction_uncertain is True
+    assert span_count == 1
+
+
+# --------------------------------------------------------------------------
+# AC: per-tenant gate OFF => no agent access (operator plane unaffected)
+# --------------------------------------------------------------------------
+
+
+async def test_gate_off_denies_agent_access(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, fake = shared_store
+    # Capture ON (operator plane keeps data) but agent-read explicitly OFF.
+    tenant_id = await _new_tenant(slug="fr-ar-gateoff", enabled=True, agent_readable=False)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_clean_spans(3))
+
+    operator = _operator(tenant_id)
+    handle = await materialize_agent_trace_handle(operator=operator, audit_id=audit_id, store=store)
+
+    assert handle is None
+    assert fake.store == {}  # gate checked BEFORE any load/spill
+
+    # Operator plane still has the trace.
+    async with get_sessionmaker()() as session:
+        header = (
+            await session.execute(select(DispatchTrace).where(DispatchTrace.audit_id == audit_id))
+        ).scalar_one_or_none()
+    assert header is not None
+
+
+async def test_gate_inherit_off_denies_when_capture_off(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, fake = shared_store
+    # NULL override + capture OFF => inherits OFF (a non-lab tenant).
+    tenant_id = await _new_tenant(slug="fr-ar-noncapture", enabled=False)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_clean_spans(2))
+
+    handle = await materialize_agent_trace_handle(
+        operator=_operator(tenant_id), audit_id=audit_id, store=store
+    )
+    assert handle is None
+    assert fake.store == {}
+
+
+# --------------------------------------------------------------------------
+# Handle isolation: cross-operator + cross-tenant
+# --------------------------------------------------------------------------
+
+
+async def test_handle_not_readable_by_another_operator(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, _fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-xop", enabled=True)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=_clean_spans(2))
+
+    minter = _operator(tenant_id, sub="op-a")
+    handle = await materialize_agent_trace_handle(operator=minter, audit_id=audit_id, store=store)
+    assert handle is not None
+
+    # A different operator in the SAME tenant gets a not-found miss, not rows.
+    stranger = _operator(tenant_id, sub="op-b")
+    with pytest.raises(ResultHandleNotFoundError):
+        await read_result_window(stranger, handle.handle_id, offset=0, limit=50)
+
+
+async def test_cross_tenant_audit_id_is_a_miss(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, fake = shared_store
+    owner_tenant = await _new_tenant(slug="fr-ar-owner", enabled=True)
+    other_tenant = await _new_tenant(slug="fr-ar-other", enabled=True)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=owner_tenant, spans=_clean_spans(2))
+
+    # An operator in a DIFFERENT tenant asking for the same audit_id gets None:
+    # the trace load is tenant-scoped, so it never matches.
+    handle = await materialize_agent_trace_handle(
+        operator=_operator(other_tenant), audit_id=audit_id, store=store
+    )
+    assert handle is None
+    assert fake.store == {}
+
+
+# --------------------------------------------------------------------------
+# Edge cases + the no-new-tool guard
+# --------------------------------------------------------------------------
+
+
+async def test_missing_trace_returns_none(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    store, _fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-missing", enabled=True)
+    handle = await materialize_agent_trace_handle(
+        operator=_operator(tenant_id), audit_id=uuid.uuid4(), store=store
+    )
+    assert handle is None
+
+
+async def test_operator_without_tenant_gets_none(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    """The defensive no-tenant guard (parity with ``read_result_window``).
+
+    ``Operator.tenant_id`` is a required ``UUID`` at the model boundary, so a
+    tenant-less operator is only reachable via ``model_construct`` (validation
+    bypassed) -- exactly the belt-and-suspenders state the shared read core
+    also guards. A tenant-less identity can never own a spilled handle.
+    """
+    store, _fake = shared_store
+    operator = Operator.model_construct(
+        sub="op-notenant",
+        name="Agent",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=None,
+        tenant_role=TenantRole.OPERATOR,
+        scopes=frozenset(),
+        platform_admin=False,
+    )
+    handle = await materialize_agent_trace_handle(
+        operator=operator, audit_id=uuid.uuid4(), store=store
+    )
+    assert handle is None
+
+
+async def test_empty_trace_yields_no_handle(
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    """A header-only (0-span) trace has nothing to page -> no handle."""
+    store, fake = shared_store
+    tenant_id = await _new_tenant(slug="fr-ar-empty", enabled=True)
+    audit_id = uuid.uuid4()
+    await record_trace(audit_id=audit_id, tenant_id=tenant_id, spans=[])
+    handle = await materialize_agent_trace_handle(
+        operator=_operator(tenant_id), audit_id=audit_id, store=store
+    )
+    assert handle is None
+    assert fake.store == {}
+
+
+def test_agent_read_registers_no_mcp_tool() -> None:
+    """No new tool on the working surface: the mint module registers nothing.
+
+    The agent reads a trace through the existing ``result_query`` meta-tool;
+    this feature adds NO tool. The authoritative working-surface inventory is
+    pinned separately by the untouched ``test_mcp_surface_conformance.py``.
+    """
+    source = inspect.getsource(agent_read_mod)
+    assert "register_mcp_tool" not in source
+    assert "ToolDefinition" not in source
+    # The read path is the existing tool, referenced by name only.
+    assert "result_query" in source

--- a/backend/tests/test_flight_recorder_agent_read_dispatch.py
+++ b/backend/tests/test_flight_recorder_agent_read_dispatch.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Flight-recorder AGENT read-surface live trigger, through the full dispatch (#3216, F5).
+
+Drives the real :func:`meho_backplane.operations.dispatch` to prove the live
+trigger the recorder wires after ``record_trace``:
+
+* a **clean** trace surfaces an agent handle on the dispatch response
+  (`OperationResult.extras["flight_recorder_trace_handle"]`) that is pageable
+  via the **unchanged** ``result_query`` core;
+* a **redaction-uncertain** trace surfaces **no** handle (agent-invisible) while
+  still persisting for the operator plane;
+* a tenant with the **agent gate off** surfaces no handle (capture — and thus
+  the operator plane — is unaffected);
+* **F7**: a forced trigger (mint) failure leaves the dispatch result
+  byte-identical and the audit row + trace intact.
+
+Shares the typed-op registration harness the capture-dispatch test uses
+(in-memory SQLite, recording broadcast publisher, autouse resets), plus a
+capture-enabled seeded tenant so ``should_capture`` returns True. A shared
+in-memory Valkey fake backs one ``ResultHandleStore`` wired into both the mint
+(spill) and the ``result_query`` core (read).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.flight_recorder.agent_read as agent_read_mod
+import meho_backplane.operations._audit as audit_module
+import meho_backplane.operations.result_query as result_query_core
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.result_handle_store import ResultHandleStore
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, DispatchTrace, EndpointDescriptor, Tenant
+from meho_backplane.flight_recorder import capture
+from meho_backplane.flight_recorder.agent_read import AGENT_TRACE_HANDLE_EXTRA_KEY
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.operations import dispatch, register_typed_operation, reset_dispatcher_caches
+from meho_backplane.operations.result_query import read_result_window
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture(autouse=True)
+def _capture_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    async with get_sessionmaker()() as s:
+        yield s
+
+
+class _FakeRedis:
+    """In-memory async Valkey stand-in (mirrors the store's own test double)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    async def set(self, name: str, value: Any, ex: int | None = None) -> None:
+        self.store[name] = value if isinstance(value, bytes) else str(value).encode()
+
+    async def get(self, name: str) -> bytes | None:
+        return self.store.get(name)
+
+
+@pytest.fixture
+def shared_store(monkeypatch: pytest.MonkeyPatch) -> tuple[ResultHandleStore, _FakeRedis]:
+    """One store wired into BOTH the mint (spill) and the result_query core (read)."""
+    fake = _FakeRedis()
+    store = ResultHandleStore(fake)  # type: ignore[arg-type]
+    monkeypatch.setattr(agent_read_mod, "get_result_handle_store", lambda: store)
+    monkeypatch.setattr(result_query_core, "get_result_handle_store", lambda: store)
+    return store, fake
+
+
+# ---------------------------------------------------------------------------
+# Handlers (module-level so composite ``handler_ref`` resolves via importlib)
+# ---------------------------------------------------------------------------
+
+
+async def _child_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"echo": params}
+
+
+async def _two_child_composite(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: Any,
+) -> dict[str, Any]:
+    a = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "a"})
+    b = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "b"})
+    return {"a": a.status, "b": b.status}
+
+
+# ---------------------------------------------------------------------------
+# Harness helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(slug: str, *, agent_readable: bool | None = None) -> UUID:
+    tenant_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            Tenant(
+                id=tenant_id,
+                slug=slug,
+                name=slug,
+                flight_recorder_enabled=True,
+                flight_recorder_agent_readable=agent_readable,
+            )
+        )
+        await s.commit()
+    return tenant_id
+
+
+def _make_operator(tenant_id: UUID) -> Operator:
+    return Operator(
+        sub="op-agent",
+        name="Agent",
+        email=None,
+        raw_jwt="<jwt>",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeTarget:
+    def __init__(self) -> None:
+        self.product = "vault"
+        self.fingerprint = type("_F", (), {"version": None})()
+        self.preferred_impl_id: str | None = None
+        self.id = uuid.uuid4()
+        self.name = "cap-target"
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+class _NoOpVaultConnector(Connector):
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+async def _register_composite(stub_embedding_service: AsyncMock) -> None:
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.list",
+        handler=_child_handler,
+        summary="List.",
+        description="List.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    async with get_sessionmaker()() as s:
+        s.add(
+            EndpointDescriptor(
+                id=uuid.uuid4(),
+                tenant_id=None,
+                product="vault",
+                version="1.x",
+                impl_id="vault",
+                op_id="vault.composite.two",
+                source_kind="composite",
+                method=None,
+                path=None,
+                handler_ref="tests.test_flight_recorder_agent_read_dispatch._two_child_composite",
+                summary="Composite two.",
+                description="Composite two.",
+                tags=[],
+                parameter_schema={"type": "object"},
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                embedding=stub_embedding_service.encode_one.return_value,
+                custom_description=None,
+                custom_notes=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
+        await s.commit()
+
+
+async def _dispatch_composite(tenant_id: UUID) -> OperationResult:
+    return await dispatch(
+        operator=_make_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id="vault.composite.two",
+        target=_FakeTarget(),
+        params={},
+    )
+
+
+async def _traces() -> list[DispatchTrace]:
+    async with get_sessionmaker()() as s:
+        return list((await s.execute(select(DispatchTrace))).scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Clean trace -> pageable agent handle on the response envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clean_trace_surfaces_pageable_agent_handle(
+    stub_embedding_service: AsyncMock,
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    _store, _fake = shared_store
+    tenant_id = await _seed_tenant("fr-ar-disp-clean")  # capture on, agent inherit => on
+    await _register_composite(stub_embedding_service)
+
+    result = await _dispatch_composite(tenant_id)
+    assert result.status == "ok", result.error
+
+    # The live trigger surfaced a trace handle on the response envelope.
+    assert AGENT_TRACE_HANDLE_EXTRA_KEY in result.extras
+    handle_json = result.extras[AGENT_TRACE_HANDLE_EXTRA_KEY]
+    assert handle_json["fetch_more"]["drill_in"]["mcp_tool"] == "result_query"
+    handle_id = UUID(handle_json["handle_id"])
+
+    # The agent pages the ordered spans back via the UNCHANGED result_query core.
+    operator = _make_operator(tenant_id)
+    window = await read_result_window(operator, handle_id, offset=0, limit=50)
+    assert window["total_rows"] == handle_json["total_rows"]
+    kinds = [row["span_kind"] for row in window["rows"]]
+    assert "composite_step" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Redaction-uncertain trace -> NO agent handle (operator plane keeps it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redaction_uncertain_trace_surfaces_no_agent_handle(
+    stub_embedding_service: AsyncMock,
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, fake = shared_store
+    tenant_id = await _seed_tenant("fr-ar-disp-uncertain")
+    await _register_composite(stub_embedding_service)
+
+    # Force the trace redaction-uncertain (what the #3213 engine sets on a body
+    # it cannot prove clean) while keeping the real persistence path.
+    real_record = capture.record_trace
+
+    async def _force_uncertain(**kwargs: Any) -> Any:
+        kwargs["redaction_uncertain"] = True
+        return await real_record(**kwargs)
+
+    monkeypatch.setattr(capture, "record_trace", _force_uncertain)
+
+    result = await _dispatch_composite(tenant_id)
+    assert result.status == "ok", result.error
+
+    # Agent-INVISIBLE: no handle on the envelope, nothing spilled.
+    assert AGENT_TRACE_HANDLE_EXTRA_KEY not in result.extras
+    assert fake.store == {}
+
+    # Operator-VISIBLE: the uncertain trace is still persisted.
+    traces = await _traces()
+    assert len(traces) == 1
+    assert traces[0].redaction_uncertain is True
+
+
+# ---------------------------------------------------------------------------
+# Per-tenant gate off -> no agent handle (capture / operator plane unaffected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_off_surfaces_no_agent_handle(
+    stub_embedding_service: AsyncMock,
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+) -> None:
+    _store, fake = shared_store
+    # Capture ON (operator plane keeps data) but agent-read explicitly OFF.
+    tenant_id = await _seed_tenant("fr-ar-disp-gateoff", agent_readable=False)
+    await _register_composite(stub_embedding_service)
+
+    result = await _dispatch_composite(tenant_id)
+    assert result.status == "ok", result.error
+
+    assert AGENT_TRACE_HANDLE_EXTRA_KEY not in result.extras
+    assert fake.store == {}  # gate checked before any spill
+    # Capture unaffected: the trace is still persisted for the operator plane.
+    assert len(await _traces()) == 1
+
+
+# ---------------------------------------------------------------------------
+# F7 -- a forced trigger (mint) failure leaves the dispatch byte-identical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f7_forced_trigger_failure_leaves_dispatch_byte_identical(
+    stub_embedding_service: AsyncMock,
+    shared_store: tuple[ResultHandleStore, _FakeRedis],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _fake = shared_store
+    tenant_id = await _seed_tenant("fr-ar-disp-f7")
+    await _register_composite(stub_embedding_service)
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise RuntimeError("mint down")
+
+    monkeypatch.setattr(agent_read_mod, "materialize_agent_trace_handle", _boom)
+
+    result = await _dispatch_composite(tenant_id)
+
+    # Byte-identical dispatch result — the trigger failure was swallowed (F7).
+    assert result.status == "ok", result.error
+    assert result.result == {"a": "ok", "b": "ok"}
+    assert AGENT_TRACE_HANDLE_EXTRA_KEY not in result.extras
+
+    # The audit row committed and the trace persisted — capture is untouched.
+    async with get_sessionmaker()() as s:
+        audit_count = (
+            await s.execute(
+                select(func.count())
+                .select_from(AuditLog)
+                .where(AuditLog.path == "vault.composite.two")
+            )
+        ).scalar_one()
+    assert audit_count == 1
+    assert len(await _traces()) == 1

--- a/backend/tests/test_flight_recorder_config.py
+++ b/backend/tests/test_flight_recorder_config.py
@@ -9,6 +9,9 @@ Covers :mod:`meho_backplane.flight_recorder.config`:
   override > per-tenant default) and its fail-open-to-``False`` behaviour;
 * :func:`resolve_retention_days` (per-tenant override vs global default,
   fail-open to default);
+* :func:`should_expose_to_agent` resolution (kill switch > per-tenant explicit
+  override > inherit the capture default) and its fail-open-to-``False``
+  behaviour (F5, #3216);
 * :func:`compute_expires_at` window math (pure).
 
 Runs against the autouse ``sqlite+aiosqlite`` engine the conftest pre-migrates
@@ -34,6 +37,7 @@ from meho_backplane.flight_recorder.config import (
     reset_flight_recorder_config_cache_for_testing,
     resolve_retention_days,
     should_capture,
+    should_expose_to_agent,
 )
 from meho_backplane.settings import get_settings
 
@@ -56,6 +60,7 @@ async def _seed_tenant(
     slug: str,
     enabled: bool = False,
     retention_days: int | None = None,
+    agent_readable: bool | None = None,
 ) -> uuid.UUID:
     tenant_id = uuid.uuid4()
     session.add(
@@ -65,6 +70,7 @@ async def _seed_tenant(
             name=f"Tenant {slug}",
             flight_recorder_enabled=enabled,
             flight_recorder_retention_days=retention_days,
+            flight_recorder_agent_readable=agent_readable,
         )
     )
     await session.commit()
@@ -167,7 +173,7 @@ async def test_should_capture_fails_open_to_false_on_error(
 ) -> None:
     """A resolver DB error must never fail a dispatch — it resolves to no-capture."""
 
-    async def _boom(_tenant_id: uuid.UUID) -> tuple[bool, int | None]:
+    async def _boom(_tenant_id: uuid.UUID) -> tuple[bool, int | None, bool | None]:
         raise RuntimeError("db down")
 
     monkeypatch.setattr(fr_config, "_resolve_tenant_policy", _boom)
@@ -203,11 +209,88 @@ async def test_retention_honours_global_default_env(monkeypatch: pytest.MonkeyPa
 
 
 async def test_retention_fails_open_to_default_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _boom(_tenant_id: uuid.UUID) -> tuple[bool, int | None]:
+    async def _boom(_tenant_id: uuid.UUID) -> tuple[bool, int | None, bool | None]:
         raise RuntimeError("db down")
 
     monkeypatch.setattr(fr_config, "_resolve_tenant_policy", _boom)
     assert await resolve_retention_days(uuid.uuid4()) == 7
+
+
+# --------------------------------------------------------------------------
+# should_expose_to_agent — per-tenant agent gate (F5, #3216)
+# --------------------------------------------------------------------------
+
+
+async def test_agent_read_off_by_default_for_non_lab_tenant() -> None:
+    """NULL override + capture OFF => agents cannot read (inherits capture)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug="fr-agent-default-off")
+    assert await should_expose_to_agent(tenant_id=tenant_id) is False
+
+
+async def test_agent_read_inherits_capture_default_lab_on() -> None:
+    """NULL override + capture ON => agents can read: "follows the F1 default (lab-on)"."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug="fr-agent-inherit-on", enabled=True)
+    assert await should_expose_to_agent(tenant_id=tenant_id) is True
+
+
+async def test_agent_read_explicit_off_while_capture_on_keeps_operator_access() -> None:
+    """override=False withholds from agents even with capture ON.
+
+    This is the F5 "independent of the operator plane" gate: capture stays ON
+    (so the operator plane keeps full access) while agents are cut off.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(
+            session, slug="fr-agent-off", enabled=True, agent_readable=False
+        )
+    assert await should_expose_to_agent(tenant_id=tenant_id) is False
+    # Capture (and thus the operator plane's data source) is unaffected.
+    assert await should_capture(tenant_id=tenant_id) is True
+
+
+async def test_agent_read_explicit_on_while_capture_off() -> None:
+    """override=True forces agent access on even when the capture default is OFF."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(
+            session, slug="fr-agent-force-on", enabled=False, agent_readable=True
+        )
+    assert await should_expose_to_agent(tenant_id=tenant_id) is True
+
+
+async def test_agent_read_kill_switch_overrides_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The global kill switch beats an explicit agent-readable=True override."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(
+            session, slug="fr-agent-kill", enabled=True, agent_readable=True
+        )
+    monkeypatch.setenv("FLIGHT_RECORDER_ENABLED", "false")
+    get_settings.cache_clear()
+    assert await should_expose_to_agent(tenant_id=tenant_id) is False
+
+
+async def test_agent_read_unknown_tenant_fails_closed() -> None:
+    assert await should_expose_to_agent(tenant_id=uuid.uuid4()) is False
+
+
+async def test_agent_read_fails_open_to_false_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolver DB error withholds agent access (doubt reduces exposure)."""
+
+    async def _boom(_tenant_id: uuid.UUID) -> tuple[bool, int | None, bool | None]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(fr_config, "_resolve_tenant_policy", _boom)
+    assert await should_expose_to_agent(tenant_id=uuid.uuid4()) is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3216

Implements **F5** of `docs/decisions/dispatch-flight-recorder.md` — the operator override that makes a captured dispatch trace **readable by an agent**, but only through the existing narrow-waist result-handle idiom: per-tenant gated, with a per-trace redaction-uncertainty degrade — and **wires the live trigger** now that the capture seam (#3214) is on `main`.

## What ships

- **The mint** (`flight_recorder.agent_read.materialize_agent_trace_handle`): applies the per-tenant agent gate + the redaction-uncertainty degrade, then spills the ordered spans to the same `ResultHandleStore` any large response uses (tenant + operator scoped, TTL 3600s mirroring the reducer) and returns a `ResultHandle` the agent pages via the **unchanged** `result_query` core (`read_result_window`, `MAX_LIMIT=500`). Inline sample is **byte-bounded** (`jsonflux_sample_byte_budget`) so a trace of large (F3-capped 64 KB) span bodies never ships a heavy inline preview.
- **The live trigger** (`agent_read.attach_agent_trace_handle`, called by the dispatcher for the **owning root** dispatch after `end_dispatch_capture` persists via `record_trace`): mints the handle behind the gate + degrade and attaches its JSON form to `OperationResult.extras["flight_recorder_trace_handle"]`. **Strictly inside the F7 swallow-everything discipline** — returns the *original* result on every no-handle / failure path, runs after the audit commit, and the capture-off path is a single `owns` bool check.
- **Per-tenant gate** (tri-state `tenant.flight_recorder_agent_readable`, migration `0087`): `NULL` inherits the capture default (follows the F1 lab-on posture), `True` forces on, `False` withholds from agents while the **operator plane keeps full access**. Resolved fail-open to "no agent exposure" by `should_expose_to_agent`.
- **Redaction-uncertainty degrade (the F5 discharge):** a trace with `redaction_uncertain=True` is withheld from the agent handle **entirely** — checked before any span is loaded or spilled — while staying operator-readable. Composed with the #3213 fail-closed redaction this discharges the operator's condition (*"as long as there are no secrets in there"*).

**No new tool, no vendor-specific name, no raw payload** — postulates 5/6 intact; `docs/codebase/mcp.md` and `test_mcp_surface_conformance.py` are **untouched** and green.

## Access-path design choice

The decision mandates "trace as a reduced `ResultHandle` read back through the existing `result_query` core" but is silent on the mint's trigger, and F7 decouples the trace write from the dispatch result path. Chosen mechanism (narrowest, postulate-safe): the handle rides the dispatch response envelope in `OperationResult.extras` (the free-form bag — not a new typed field, not a tools/list entry), minted on the recorder's best-effort path after `record_trace`, and paged via the unchanged `result_query`.

## Tests

- **Unit** (`test_flight_recorder_agent_read.py`): clean trace pageable via `result_query`; byte-bounded inline sample; redaction-uncertain → agent-invisible/operator-visible; gate off → no access; cross-operator + cross-tenant isolation; no MCP tool registered.
- **Dispatch-level** (`test_flight_recorder_agent_read_dispatch.py`): clean trace → pageable handle on the response envelope; uncertain → no handle; gate off → no handle; **F7** forced trigger (mint) failure → dispatch result byte-identical, audit row + trace intact.
- Gate resolver unit tests (`test_flight_recorder_config.py`), migration `0087` test, tenant column-snapshot update.
- ruff/format/mypy clean (sole mypy error is the pre-existing macOS-only `icmp.py MSG_ERRQUEUE`, green on Linux CI).

## Adversarial review — verdict: APPROVE

Two-phase inline review (five hunts: uncertain/secret→handle, tool-surface creep, tenant-gate bypass, TTL/scope drift, raw-payload leak).
- **Base pass:** fixed a postulate-6 leak — the inline sample was count-bounded (5) but a 64 KB span body meant ~320 KB inline; now byte-bounded like the reducer. Caught a would-be CI red (tenant column-snapshot).
- **Delta re-review (the wiring, F7 + leak focus):** trigger uses the DB-reload mint so the degrade re-checks the persisted flag (no in-memory bypass); handle rides `extras` (no surface creep, conformance green); scoped to the dispatching operator (tenant+sub), root-only via `owns`; reuses the unchanged mint (no TTL/scope drift); attaches `model_dump(mode="json")` not full spans and leaves `result.result` byte-identical; F7 holds (swallows all, runs post-audit, raised dispatches skip the trigger, disabled path is one bool). All five clean; no delta fixes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)