### PR TITLE
fix(connectors): deploy_from_library async-safe + 3h sync ceiling (#3176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — large `deploy_from_library` OVAs: async dispatch survives caller disconnect + a 3 h sync read ceiling (#3176)
+
+- `vmware.composite.vm.deploy_from_library` of a **multi-GB** content-library
+  item (a 4.7 GB installer OVA to an NFS datastore on the Hetzner fabric) hit
+  two failure modes. **(b) Caller disconnect rolled the deploy back:** on the
+  synchronous path the OVF POST is awaited inside the request handler, so a
+  client that dropped mid-transfer cancelled the task, closed the connection,
+  and vCenter rolled the half-created VM back. This is now cured by dispatching
+  the deploy in **async governed mode** (`async: true` → `202` + a durable run
+  handle, #3079 / PR #3201): the dispatch runs on an independent background task
+  that owns the vCenter POST, so a dropped caller no longer propagates
+  cancellation into the in-flight copy. Async is the **supported mode for
+  multi-GB items** (documented on the handler + the connector doc); the
+  synchronous path stays the default for small items.
+- **(a) Transfer outrunning the read ceiling:** the synchronous deploy's
+  `_LIBRARY_ITEM_DEPLOY_TIMEOUT` read/write cap is raised from 30 min to **3 h**
+  — the 4.7 GB copy outran the original 30-min window live while vCenter kept
+  copying. This is a **bounded mitigation**, not the durable fix: a still-larger
+  item or a slower fabric can outrun any fixed ceiling. The durable fix — a
+  typed pyvmomi `HttpNfcLease` import that uncouples completion from one
+  blocking read — is tracked under #2890.
+- The structured `deploy_error` / `deploy_failed` mapping (#3071 family) is
+  unchanged for genuine faults.
+
 ### Added — flight recorder: operator read surface — REST trace endpoint + console drawer pane (#3215)
 
 - Ships the **operator read surface** of the flight-recorder decision

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -206,11 +206,24 @@ _OP_DEPLOY_OVF_LIBRARY_ITEM = "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}
 # well past the connector's 30s client-default read timeout and used to fault
 # with a false ``deploy_error`` while vCenter finished the copy server-side
 # (#3076). This override grants only these two calls a generous read/write
-# ceiling (30 min); connect/pool stay at the fast client default so a dead
-# target still fails fast, and every *other* call on the connector keeps the
-# unchanged 30s default (raising the global client timeout would make ordinary
-# reads hang on a dead target).
-_LIBRARY_ITEM_DEPLOY_TIMEOUT = httpx.Timeout(connect=5.0, read=1800.0, write=1800.0, pool=5.0)
+# ceiling; connect/pool stay at the fast client default so a dead target still
+# fails fast, and every *other* call on the connector keeps the unchanged 30s
+# default (raising the global client timeout would make ordinary reads hang on
+# a dead target).
+#
+# The ceiling is 3 hours, widened from the original 30 min (#3176): a 4.7 GB
+# installer OVA copied to an NFS datastore on the Hetzner fabric outran the
+# 30-min window live, faulting mid-transfer while vCenter kept copying.
+# Widening the read cap is a *bounded mitigation*, not the durable fix — a
+# still-larger item or a slower fabric can outrun any fixed ceiling, and on
+# this synchronous path a caller that disconnects mid-wait still aborts + rolls
+# the deploy back. The durable fixes are orthogonal and live elsewhere: async
+# governed dispatch (#3079) decouples completion from the request connection so
+# a dropped caller no longer cancels the in-flight deploy (the supported mode
+# for multi-GB items — see ``vm_deploy_from_library_composite``'s docstring),
+# and a typed pyvmomi ``HttpNfcLease`` import (#2890) would uncouple completion
+# from a single blocking read entirely.
+_LIBRARY_ITEM_DEPLOY_TIMEOUT = httpx.Timeout(connect=5.0, read=10800.0, write=10800.0, pool=5.0)
 _OP_FIND_LIBRARY = "POST:/content/library?action=find"
 _OP_FIND_LIBRARY_ITEM = "POST:/content/library/item?action=find"
 # Content-library item type discriminator for OVF/OVA templates — the find
@@ -2570,6 +2583,18 @@ async def vm_deploy_from_library_composite(
     itself faults (HTTP 400/404 for invalid / missing placement resources) —
     so a placement or network-mapping error is a structured status, never a
     raw vendor error. With ``power_on`` the deployed VM is started best-effort.
+
+    **Calling convention for large items.** The OVF deploy is *synchronous* —
+    the POST is held open for the whole server-side copy, bounded by
+    :data:`_LIBRARY_ITEM_DEPLOY_TIMEOUT` (3 h; #3176). Small items deploy fine
+    on the default sync path, but a **multi-GB installer OVA should be
+    dispatched in async mode** (``call_operation`` with ``async=true`` → HTTP
+    202 + a durable run handle, #3079): the deploy then runs on a background
+    task that owns the vCenter POST, so a caller that disconnects mid-transfer
+    no longer cancels the in-flight deploy — on the sync path a dropped caller
+    propagates cancellation into the POST and vCenter rolls the half-created VM
+    back. The sync ceiling stays a bounded mitigation; an item large enough to
+    outrun 3 h still needs the typed ``HttpNfcLease`` import (#2890).
     """
     try:
         item_id, resolution_error = await _resolve_deploy_library_item(

--- a/backend/tests/test_operation_run_service.py
+++ b/backend/tests/test_operation_run_service.py
@@ -23,6 +23,8 @@ Runs against the ``sqlite+aiosqlite`` engine the autouse
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
 from collections.abc import Iterator
 from types import SimpleNamespace
@@ -140,6 +142,93 @@ async def test_submit_call_persists_result_envelope_retrievable_via_handle(
         "duration_ms": 42.0,
     }
     assert post.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_async_dispatch_survives_caller_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller that disconnects mid-flight does not abort the in-flight dispatch (#3176).
+
+    This is failure mode (b) on a large ``deploy_from_library``: on the
+    synchronous path the multi-GB OVF POST is awaited *inside* the request
+    handler, so a client disconnect cancels that task, closes the connection,
+    and vCenter rolls the half-created VM back. Async mode anchors the dispatch
+    in an independent background task (``asyncio.create_task``), decoupled from
+    the request — cancelling the caller cannot propagate into the in-flight
+    deploy. This drives that end to end: the dispatch blocks (modelling the
+    server-side transfer that outruns a read ceiling), the caller task is
+    cancelled, and the deploy still runs to completion with its envelope
+    persisted on the durable run row.
+    """
+    deploy_args = {
+        "connector_id": "vmware-rest-9.0",
+        "op_id": "vmware.composite.vm.deploy_from_library",
+        "target": "dc-vcenter",
+        "params": {"library_item": "installer-appliance", "name": "vm-installer"},
+    }
+    deploy_in_flight = asyncio.Event()
+    release_transfer = asyncio.Event()
+    deploy_completed = False
+
+    async def slow_deploy(operator: Operator, arguments: dict[str, object]) -> dict[str, object]:
+        nonlocal deploy_completed
+        deploy_in_flight.set()  # vCenter accepted the POST; the copy is running
+        await release_transfer.wait()  # the multi-GB copy that outruns a read ceiling
+        deploy_completed = True
+        return {
+            "status": "deployed",
+            "op_id": arguments["op_id"],
+            "result": {"vm_id": "vm-4700", "library_item_id": "item-installer"},
+        }
+
+    monkeypatch.setattr(meta_tools, "call_operation", slow_deploy)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+    operator = _operator(tenant_id=tenant_id)
+    service = OperationRunService()
+
+    captured: dict[str, uuid.UUID] = {}
+
+    async def caller() -> None:
+        # Models the async ``/operations/call`` request handler: submit, take
+        # the 202 handle, then hold the (now idle) connection to poll later.
+        captured["run_id"] = await service.submit_call(operator, dict(deploy_args))
+        await asyncio.sleep(3600)  # client still connected, waiting to poll
+
+    caller_task = asyncio.create_task(caller())
+
+    # Let the caller submit and the background dispatch reach the in-flight
+    # point (no DB IO happens once the dispatch is parked on the event).
+    await asyncio.wait_for(deploy_in_flight.wait(), timeout=5)
+    run_id = captured["run_id"]
+    background = service._store[run_id].task
+    assert not background.done()
+
+    # The client disconnects mid-transfer: its request task is cancelled.
+    caller_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await caller_task
+
+    # The in-flight deploy is untouched — the background task owns the POST and
+    # is a sibling of (not a child of) the cancelled caller task.
+    assert not background.done()
+    assert not background.cancelled()
+    assert not deploy_completed
+
+    # The server-side transfer finishes; the background task finalises.
+    release_transfer.set()
+    await background
+
+    assert deploy_completed
+    row = await service.poll(operator, run_id)
+    assert row.status == OperationRunStatus.SUCCEEDED.value
+    assert row.result is not None
+    assert row.result["status"] == "deployed"
+    assert row.result["result"]["vm_id"] == "vm-4700"
+    assert row.ended_at is not None
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1046,8 +1046,10 @@ which any real appliance copy blows past — so the POST used to raise
 (`vm.clone`: a raw `connector_error`) while vCenter finished the copy
 server-side. The two deploy sub-ops now pass a per-request `timeout`
 override, `_LIBRARY_ITEM_DEPLOY_TIMEOUT`
-(`connect=5 / read=1800 / write=1800 / pool=5` — a 30-min read/write
-ceiling), threaded `composite → _write_sub_op → HttpConnector._post_json →
+(`connect=5 / read=10800 / write=10800 / pool=5` — a 3-hour read/write
+ceiling, widened from the original 30 min after a 4.7 GB installer OVA to an
+NFS datastore on the Hetzner fabric outran that window live, #3176), threaded
+`composite → _write_sub_op → HttpConnector._post_json →
 client.request(timeout=)`. The override defaults to
 `httpx.USE_CLIENT_DEFAULT`, so **every other call keeps the unchanged 30s
 client default** — the global client timeout is deliberately *not* raised,
@@ -1057,6 +1059,24 @@ When a deploy genuinely faults at the transport layer, the structured
 detail names the exception *type* — `transport fault (ReadTimeout)` — since
 `str(httpx.ReadTimeout())` is the empty string (the `_vsphere_fault_detail`
 helper, #3076).
+
+**Async dispatch is the supported mode for multi-GB deploys (#3176 / #3079).**
+Widening the read ceiling is a *bounded* mitigation: a still-larger item or a
+slower fabric can outrun any fixed window, and on the synchronous path a caller
+that disconnects mid-transfer aborts the deploy session — vCenter rolls the
+half-created VM back (the second live failure mode on the 4.7 GB installer
+OVA). Both are cured by dispatching the deploy in **async governed mode**
+(`POST /api/v1/operations/call` with `async: true`, or the `call_operation`
+meta-tool's async flag; #3079 / PR #3201): the dispatch runs on a durable
+background task that owns the vCenter POST, the route returns `202` + a run
+handle (`GET /api/v1/operations/runs/{handle}` polls it, and the completed
+`DeploymentResult` envelope is persisted on the run row), and because that task
+is spawned via `asyncio.create_task` — independent of the request handler
+task — a dropped caller no longer propagates cancellation into the in-flight
+copy. The synchronous path stays the default for small items but is bounded by
+the ceiling above; an item large enough to outrun even 3 h needs the durable
+typed `HttpNfcLease` import (#2890), which streams disks against a lease with
+progress instead of coupling completion to one blocking read.
 
 **204 / empty-body write acks (#3082).** Several vCenter write endpoints
 acknowledge success with **204 No Content** and no body — the power actions


### PR DESCRIPTION
## Summary

Narrowed scope of #3176 (operator-directed, 2026-08-31 — see the
[scope-ratification comment](https://github.com/evoila/meho/issues/3176#issuecomment-5475923166),
upholding the [attempt-1 pushback](https://github.com/evoila/meho/issues/3176#issuecomment-5475805559)).
The original ask — poll the library-item deploy via `vmw-task=true` — is
infeasible: the pinned `vcenter.yaml` serves no `$Task` variant of
`Vcenter.Ovf.LibraryItem_deploy` (#2970). This ships the two fixes that use
mechanisms that actually exist today.

- **Failure mode (b) — caller disconnect rolled the deploy back** — is solved
  by **async governed dispatch** (#3079 / PR #3201, merged): `POST
  /api/v1/operations/call` with `async: true` runs the deploy on an independent
  `asyncio` background task that owns the vCenter POST, returns `202` + a
  durable run handle, and persists the completed envelope on the run row. A
  dropped caller cancels only the request handler task — a *sibling* of the
  background task — so the in-flight deploy is not aborted. The composite path
  works under async dispatch by construction (it routes through the same
  `call_operation`). A new test proves the survival property.
- **Failure mode (a) — transfer outrunning the read ceiling** — gets a bounded
  mitigation: `_LIBRARY_ITEM_DEPLOY_TIMEOUT` read/write raised 30 min → **3 h**
  (a 4.7 GB OVA → NFS on the Hetzner fabric outran 30 min live). The comment
  records this is a mitigation, not the durable fix (a typed `HttpNfcLease`
  import, tracked under #2890).
- **Docs**: the handler docstring + the connector doc's deploy section now state
  the calling convention — async is the supported mode for multi-GB items; the
  sync path stays for small items, bounded by the ceiling.

**Out of scope** (per the narrowing): no `vmw-task` variant of the library-item
deploy, no `Ovfs_deploy$Task` URL bridge, no `HttpNfcLease` work. The `#3071`
structured `deploy_error`/`deploy_failed` mapping is unchanged.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1671 files)
- [x] `mypy src/` — clean on touched files (the one reported error is a
  pre-existing macOS-only `socket.MSG_ERRQUEUE` false positive in
  `connectors/net/icmp.py`, a file this PR does not touch; Linux CI passes it)
- [x] `pytest tests/test_operation_run_service.py` — 10 passed, incl. the new
  `test_async_dispatch_survives_caller_disconnect` (submits async, cancels the
  caller mid-transfer, asserts the background dispatch is neither done nor
  cancelled, releases the transfer, then asserts the run finalises `succeeded`
  with the deploy envelope persisted)
- [x] deploy composite + write-body reconcile lanes — 281 passed / 4 skipped;
  reconcile 3 passed / 3 skipped (no spec fiction introduced)
- [x] `code-quality.py --diff` — 0 blockers (12 pre-existing function-size
  warnings on unmodified composites in the touched file)

## Out of scope

- Durable async-completion path (typed pyvmomi `HttpNfcLease` import) — tracked
  under #2890.
- Concurrent siblings on shared files: CHANGELOG only (mechanical union).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3176
