### PR TITLE
feat(flight-recorder): typed-connector spans across every typed family (#3217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,44 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: typed-connector spans across every typed family (#3217)
+
+- Extends the flight recorder (`docs/decisions/dispatch-flight-recorder.md`, **F8
+  — the operator override "all of them in v1"**) to **typed** connectors, the
+  analog of the generic-connector `vendor_call` seam (#3214). A new
+  `meho_backplane.flight_recorder.typed` module rides the **same** per-dispatch
+  capture scope + op context — no parallel state — and exposes two seams:
+  - a **shared typed-dispatch seam** (`typed_dispatch_span`, wired once into
+    `dispatch_typed`) that brackets **every** typed handler invocation and emits
+    a real (non-`opaque`) `typed` span — operation id, target, duration, and
+    outcome — keyed on **`impl_id`** so both implementations of a dual-impl
+    product (`fleet` / `sddc` / `vcfa` / `vrli` / `vrops`) are distinguished. It
+    is metadata-only (it never records `params` or any vendor payload), so it
+    carries no secret and never degrades the trace; and
+  - a **transport-enricher seam** (`typed_span_start` + `record_typed_call`)
+    that redacts request/response-shaped detail through the **same** fail-closed
+    engine the vendor-call seam uses. Wired into the shared SSH seam
+    (`SshConnector._run_command`), so **every** SSH-based typed connector (bind9,
+    holodeck, pfsense, rke2, windows_dns) records one span per command with no
+    per-connector edit; the command + output are handed to the engine as plain
+    text, which cannot prove them secret-free and so **omits both and degrades
+    the trace to operator-only (F5)** — an SSH command or its output never
+    reaches a span un-redacted. REST-backed typed connectors are already covered
+    by the generic `vendor_call` seam; the direct-SDK families (hvac /
+    kubernetes / pymongo / postgres / gcloud) are covered by the shared `typed`
+    span at op granularity.
+- Coverage is **by construction**: because the seam sits on the one typed-dispatch
+  path, all 37 registered typed implementations — every class-based family plus
+  the builtin `product.*` families (net, mail, secret, topology, targets) — emit
+  real `typed` spans, retiring the transitional `opaque` fallback. A
+  **registry-driven conformance sweep** enumerates the typed families from the
+  live registrar set and asserts each produces a `typed` span through the seam,
+  so a newly added typed connector that skips instrumentation fails CI.
+- The **F7 invariant** holds for typed spans: capture is best-effort, the
+  disabled path is a single contextvar read, and a recorder or redaction failure
+  is swallowed and can never fail, block, or slow a typed dispatch — the
+  handler's own exception always propagates unchanged.
+
 ### Added — flight recorder: agent read surface — trace as a reduced result-handle, per-tenant gated, redaction-uncertainty degrade (#3216)
 
 - Ships **F5** of the flight-recorder decision
@@ -146,7 +184,6 @@ connector-related release-notes line.
   `Test-Path` verify-after-write folded into the same script), and silences the
   warning stream at the source (`$WarningPreference`). The self-contradictory
   `applied: true` / `config_id: null` envelope is now impossible.
-
 
 ### Added — flight recorder: operator read surface — REST trace endpoint + console drawer pane (#3215)
 

--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -71,6 +71,7 @@ from meho_backplane.connectors._shared.vault_creds import (
 )
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.flight_recorder import typed as flight_recorder_typed
 
 logger = structlog.get_logger()
 
@@ -79,6 +80,55 @@ logger = structlog.get_logger()
 type Target = Any
 
 _POOL_TTL_S: float = 300.0  # 5-minute idle eviction window
+
+
+def _ssh_output(result: Any) -> str | None:
+    """Combine an ``SSHCompletedProcess``'s stdout + stderr, never raising (F7).
+
+    The value is handed to the flight recorder's redaction engine as plain
+    text and dropped fail-closed there; this helper only assembles it and
+    must not propagate any attribute-access fault into the dispatch path.
+    """
+    try:
+        chunks: list[str] = []
+        for attr in ("stdout", "stderr"):
+            value = getattr(result, attr, None)
+            if value:
+                chunks.append(value if isinstance(value, str) else str(value))
+        return "\n".join(chunks) if chunks else None
+    except Exception:
+        return None
+
+
+def _record_ssh_span(
+    start: flight_recorder_typed.TypedSpanStart | None,
+    *,
+    cmd: str,
+    result: Any,
+) -> None:
+    """Record one SSH command as a ``typed`` span, best-effort (F7).
+
+    Extracts the exit status + output *inside* this guarded function so the
+    call site never touches an attribute that could raise into the dispatch
+    (the same discipline the vendor-call seam uses). ``record_typed_call``
+    passes the command + output through the fail-closed redaction engine.
+    """
+    if start is None:
+        return
+    try:
+        exit_status = getattr(result, "exit_status", None)
+        flight_recorder_typed.record_typed_call(
+            start,
+            kind="typed",
+            status=str(exit_status) if exit_status is not None else "ok",
+            request_body=cmd,
+            response_body=_ssh_output(result),
+            request_content_type="text/plain",
+            response_content_type="text/plain",
+            extra={"transport": "ssh", "exit_status": exit_status},
+        )
+    except Exception:
+        logger.warning("flight_recorder_ssh_span_failed", exc_info=True)
 
 
 class ConnectorUnreachableError(RuntimeError):
@@ -237,7 +287,18 @@ class SshConnector(Connector):
         Raises :exc:`asyncio.TimeoutError` when *timeout* is exceeded.
         """
         conn = await self._connect(target, operator)
+        # Flight-recorder typed span (#3217, F8) -- the shared SSH-transport
+        # seam, so every SSH-based typed connector (bind9 / holodeck / pfsense
+        # / rke2 / windows_dns) records one span per command with no
+        # per-connector edit. ``typed_span_start`` is one contextvar read
+        # (``None`` when capture is off, so the seam pays nothing). The
+        # command + output are handed to the fail-closed redaction engine as
+        # plain text: it cannot prove a free-text shell blob secret-free, so it
+        # omits both and degrades the trace to operator-only (F5) -- an SSH
+        # command / its output never reaches a span un-redacted.
+        _fr_start = flight_recorder_typed.typed_span_start(f"ssh {getattr(target, 'name', '?')}")
         result = await asyncio.wait_for(conn.run(cmd, check=False), timeout=timeout)
+        _record_ssh_span(_fr_start, cmd=cmd, result=result)
         logger.info(
             "ssh_command_executed",
             target=target.name,

--- a/backend/src/meho_backplane/flight_recorder/capture.py
+++ b/backend/src/meho_backplane/flight_recorder/capture.py
@@ -124,11 +124,15 @@ class _OpContext:
 
     Rebound per dispatch so a vendor call is redacted against the op that made
     it (a composite child's session mint is excluded by the child's family,
-    not the parent's).
+    not the parent's). ``impl_id`` + ``product`` are carried so a typed span
+    is keyed on the **implementation** (F8: both impls of a dual-impl product
+    are distinguished), not just the product.
     """
 
     op_id: str | None
     connector_id: str | None
+    impl_id: str | None
+    product: str | None
     tags: tuple[str, ...]
     body_paths: tuple[str, ...]
     delete_shaped_patterns: tuple[str, ...] | None
@@ -505,6 +509,8 @@ def _op_context_from(descriptor: Any, connector_id: str) -> _OpContext:
     return _OpContext(
         op_id=getattr(descriptor, "op_id", None),
         connector_id=connector_id,
+        impl_id=getattr(descriptor, "impl_id", None),
+        product=getattr(descriptor, "product", None),
         tags=tags,
         # Per-connector body-path config is a connector-authoring follow-up;
         # the credential-shape scrub + hard-excluded families still protect

--- a/backend/src/meho_backplane/flight_recorder/typed.py
+++ b/backend/src/meho_backplane/flight_recorder/typed.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-connector spans -- the typed handler seam + transport enrichers (#3217, F8).
+
+The span-production layer for **typed** connectors, the F8 analog of the
+generic-connector ``vendor_call`` seam in
+:mod:`meho_backplane.flight_recorder.capture`. Per the decision of record
+``docs/decisions/dispatch-flight-recorder.md`` (F8, the operator override
+"all of them in v1"), every typed connector family emits real spans, not the
+transitional ``opaque`` fallback.
+
+Two entry points, one scope
+---------------------------
+Both ride the **same** per-dispatch capture scope + op context that
+:mod:`.capture` binds on the dispatcher's contextvars -- no parallel state:
+
+* :func:`typed_dispatch_span` -- the **shared seam**. The typed-dispatch
+  branch (:func:`meho_backplane.operations._branches.dispatch_typed`) opens
+  it around **every** typed handler invocation, so every typed family --
+  class-based and the builtin ``product.*`` families alike -- emits a real
+  (non-``opaque``) ``typed`` span through the one seam with no per-connector
+  edit: operation id, target, duration, and outcome. It is metadata-only (no
+  ``params``, no vendor payload), so it carries no secret and never sets
+  redaction-uncertainty. Keyed on ``impl_id`` (F8), so both implementations
+  of a dual-impl product are distinguished.
+* :func:`typed_span_start` + :func:`record_typed_call` -- the **transport
+  enricher** seam. A transport with request/response-shaped detail records
+  its own richer span under the same trace. REST-backed typed connectors are
+  already covered by the shared httpx ``vendor_call`` seam; the SSH families
+  (bind9 / holodeck / pfsense / rke2 / windows_dns) record per-command spans
+  from the shared :meth:`SshConnector._run_command` seam. The direct-SDK
+  families (hvac / kubernetes / pymongo / postgres and the googleapiclient-
+  and REST-backed gcloud) are covered by the shared ``typed`` span at the
+  op granularity, the natural unit for a one-op-one-SDK-interaction handler.
+
+Redaction + F7
+--------------
+Any body handed to :func:`record_typed_call` is capped (F3) and passed
+through the **same** fail-closed engine the vendor-call seam uses
+(:func:`meho_backplane.redaction.flight_recorder.redact_span`): a body it
+cannot prove secret-free -- a plain-text SSH command or its output, a
+secret-family op's body -- is omitted and the trace degrades to operator-only
+(F5). Every function is best-effort (F7): the disabled path is one contextvar
+read, every exception is logged and swallowed, and a handler's own exception
+always propagates unchanged (the shared seam records the failure outcome,
+then re-raises).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import structlog
+
+from meho_backplane.flight_recorder._capture_util import (
+    cap_body,
+    elapsed_ms,
+    now_utc,
+    request_id,
+)
+from meho_backplane.flight_recorder.capture import (
+    _active_capture_var,
+    _op_context_var,
+    _OpContext,
+)
+from meho_backplane.flight_recorder.store import SpanInput
+from meho_backplane.redaction.flight_recorder import redact_span
+
+__all__ = [
+    "TypedSpanStart",
+    "record_typed_call",
+    "typed_dispatch_span",
+    "typed_span_start",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TypedSpanStart:
+    """A cheap start marker for one typed span.
+
+    Returned by :func:`typed_span_start` **only** when capture is active for
+    the current dispatch, so a typed handler / SSH-transport seam pays for
+    nothing (one contextvar read) when the recorder is off. Carries the span
+    label plus the wall-clock + monotonic references for the duration.
+    """
+
+    started_at: datetime
+    monotonic: float
+    name: str
+
+
+def typed_span_start(name: str) -> TypedSpanStart | None:
+    """Return a typed-span start marker iff capture is active; else ``None``.
+
+    The one-contextvar-read gate every typed seam opens *before* the SDK /
+    vendor interaction, so the disabled path stays free (F7).
+    """
+    if _active_capture_var.get() is None:
+        return None
+    return TypedSpanStart(started_at=now_utc(), monotonic=time.monotonic(), name=name)
+
+
+def record_typed_call(
+    start: TypedSpanStart | None,
+    *,
+    kind: str = "typed",
+    status: str | None = "ok",
+    request_body: Any = None,
+    response_body: Any = None,
+    request_content_type: str | None = None,
+    response_content_type: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Capture one typed-handler / typed-transport interaction as a span (F8, F7).
+
+    *start* is the marker from :func:`typed_span_start` (``None`` -> no-op).
+    The span records the op context (``op_id`` / ``connector_id`` /
+    ``impl_id`` / ``product``), keyed on the implementation not the product.
+    Any body is capped + redacted (see module docstring); a bodiless call is
+    metadata-only and never sets redaction-uncertainty. ``kind`` is
+    ``"typed"`` (instrumented) or ``"opaque"`` (transitional fallback). Any
+    error is logged and swallowed (F7).
+    """
+    scope = _active_capture_var.get()
+    if start is None or scope is None:
+        return
+    try:
+        op = _op_context_var.get()
+        attributes = _typed_base_attributes(op, extra)
+        uncertain = False
+        if request_body is not None or response_body is not None:
+            uncertain = _record_typed_bodies(
+                attributes,
+                op,
+                request_body=request_body,
+                response_body=response_body,
+                request_content_type=request_content_type,
+                response_content_type=response_content_type,
+            )
+        rid = request_id()
+        if rid is not None:
+            attributes["request_id"] = rid
+        scope.add(
+            SpanInput(
+                span_kind=kind,
+                name=start.name,
+                started_at=start.started_at,
+                duration_ms=elapsed_ms(start.monotonic),
+                status=status,
+                attributes=attributes,
+            )
+        )
+        if uncertain:
+            scope.redaction_uncertain = True
+    except Exception:
+        _log.warning("flight_recorder_typed_span_failed", exc_info=True)
+
+
+def _typed_base_attributes(op: _OpContext | None, extra: dict[str, Any] | None) -> dict[str, Any]:
+    """The op-context axes every typed span carries, plus any caller *extra*."""
+    attributes: dict[str, Any] = {
+        "op_id": op.op_id if op else None,
+        "connector_id": op.connector_id if op else None,
+        "impl_id": op.impl_id if op else None,
+        "product": op.product if op else None,
+    }
+    if extra:
+        attributes.update(extra)
+    return attributes
+
+
+def _record_typed_bodies(
+    attributes: dict[str, Any],
+    op: _OpContext | None,
+    *,
+    request_body: Any,
+    response_body: Any,
+    request_content_type: str | None,
+    response_content_type: str | None,
+) -> bool:
+    """Cap + redact a typed span's bodies onto *attributes*; return uncertainty.
+
+    Reuses the fail-closed engine (:func:`redact_span`) exactly as the
+    vendor-call seam does, so a typed body is held to the identical redaction
+    contract. Returns the OR of the two bodies' redaction-uncertainty (the F5
+    operator-only degrade signal).
+    """
+    req_body, req_truncated = cap_body(request_body)
+    resp_body, resp_truncated = cap_body(response_body)
+    redaction = redact_span(
+        op_id=op.op_id if op else None,
+        connector_id=op.connector_id if op else None,
+        tags=op.tags if op else (),
+        request_headers=None,
+        response_headers=None,
+        request_body=req_body,
+        response_body=resp_body,
+        request_content_type=request_content_type,
+        response_content_type=response_content_type,
+        request_truncated=req_truncated,
+        response_truncated=resp_truncated,
+        body_paths=op.body_paths if op else (),
+        delete_shaped_patterns=op.delete_shaped_patterns if op else None,
+    )
+    attributes["request_body"] = redaction.request_body
+    attributes["response_body"] = redaction.response_body
+    attributes["body_recorded"] = redaction.body_recorded
+    if req_truncated or resp_truncated:
+        attributes["truncated"] = True
+    if redaction.reasons:
+        attributes["redaction_reasons"] = list(redaction.reasons)
+    return redaction.uncertain
+
+
+@contextmanager
+def typed_dispatch_span(*, target: Any = None) -> Iterator[None]:
+    """Bracket one typed-handler dispatch as a ``typed`` span (F8, F7).
+
+    The shared typed-dispatch seam. Opened by
+    :func:`meho_backplane.operations._branches.dispatch_typed` around every
+    typed handler invocation, so every typed family emits a real
+    (non-``opaque``) span -- op id, target, duration, outcome -- with no
+    per-connector edit. Metadata-only, so it never records a secret and never
+    sets redaction-uncertainty; transports add their own richer spans.
+
+    Cheap no-op when capture is off (**one** contextvar read -- the disabled
+    path never reads the op context or builds the span name). Best-effort (F7):
+    a recorder failure is swallowed, and the handler's own exception always
+    propagates unchanged -- the span records the outcome
+    (``error:<ExceptionClass>``), then re-raises.
+    """
+    # Gate on the single active-capture read first, so the disabled path costs
+    # exactly one contextvar read -- the op-context read + name build happen
+    # only when a trace is actually being recorded.
+    if _active_capture_var.get() is None:
+        yield
+        return
+    start = TypedSpanStart(
+        started_at=now_utc(), monotonic=time.monotonic(), name=_typed_dispatch_span_name()
+    )
+    status = "ok"
+    try:
+        yield
+    except BaseException as exc:
+        status = f"error:{type(exc).__name__}"
+        raise
+    finally:
+        # ``record_typed_call`` already swallows its own errors; this guard
+        # covers a monkeypatched/raising recorder so a forced failure in the
+        # ``finally`` can never propagate into (and fail) the dispatch (F7).
+        try:
+            record_typed_call(
+                start, kind="typed", status=status, extra=_typed_dispatch_extra(target)
+            )
+        except Exception:
+            _log.warning("flight_recorder_typed_dispatch_span_failed", exc_info=True)
+
+
+def _typed_dispatch_span_name() -> str:
+    """The shared typed-dispatch span label: the op id (or ``"typed"``)."""
+    op = _op_context_var.get()
+    if op is not None and op.op_id:
+        return op.op_id
+    return "typed"
+
+
+def _typed_dispatch_extra(target: Any) -> dict[str, Any] | None:
+    """The non-secret ``target`` label for the shared typed-dispatch span."""
+    name = _safe_target_name(target)
+    return {"target": name} if name else None
+
+
+def _safe_target_name(target: Any) -> str | None:
+    """Read ``target.name`` defensively -- a name access must never raise (F7)."""
+    try:
+        name = getattr(target, "name", None)
+    except Exception:
+        return None
+    return name if isinstance(name, str) else None

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -40,6 +40,7 @@ from urllib.parse import quote
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.base import Connector
 from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.flight_recorder import typed as flight_recorder_typed
 from meho_backplane.operations._rfc6570 import RFC6570_PATH_OPERATORS
 
 __all__ = [
@@ -497,9 +498,18 @@ async def dispatch_typed(
             f"instance-cache fault, not a missing handler — do not mask it as "
             f"handler_unreachable."
         )
-    if "operator" in param_names:
-        return await handler(operator=operator, target=target, params=params)
-    return await handler(target=target, params=params)
+    # Flight-recorder typed span (#3217, F8). The shared typed-handler seam:
+    # every typed connector family emits a real (non-``opaque``) ``typed``
+    # span -- op id, target, duration, outcome -- through this one bracket,
+    # with no per-connector edit. Metadata-only (never records ``params`` or
+    # any vendor payload), best-effort (F7): a recorder failure is swallowed
+    # and the handler's own exception propagates unchanged. The ``self``-check
+    # above is left outside the span deliberately -- an unbound handler is a
+    # dispatcher-resolution fault, not a typed vendor interaction.
+    with flight_recorder_typed.typed_dispatch_span(target=target):
+        if "operator" in param_names:
+            return await handler(operator=operator, target=target, params=params)
+        return await handler(target=target, params=params)
 
 
 async def dispatch_composite(

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -1,0 +1,781 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-connector flight-recorder spans (#3217, F8).
+
+Covers the typed span API + the v1 instrumentation wave per the decision of
+record ``docs/decisions/dispatch-flight-recorder.md`` (F8, "all of them"):
+
+* the shared typed-dispatch seam
+  (:func:`meho_backplane.flight_recorder.typed.typed_dispatch_span`, wired at
+  :func:`meho_backplane.operations._branches.dispatch_typed`) records a real
+  (non-``opaque``) ``typed`` span for every typed op -- op id, target,
+  duration, outcome -- keyed on ``impl_id``;
+* the transport enricher seam
+  (:func:`meho_backplane.flight_recorder.typed.record_typed_call`) redacts any
+  request/response detail through the same fail-closed engine, proven on the
+  shared SSH seam (``SshConnector._run_command``);
+* the F7 invariant: a recorder / redaction failure can never fail, block, or
+  slow a typed dispatch;
+* the **registry-driven conformance sweep**: every registered typed connector
+  family produces a ``typed`` span through the seam, so a newly added typed
+  connector that skips the seam fails CI.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any, NamedTuple
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import (
+    _eager_import_connectors,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    DispatchTrace,
+    DispatchTraceSpan,
+    EndpointDescriptor,
+    Tenant,
+)
+from meho_backplane.flight_recorder import capture
+from meho_backplane.flight_recorder import typed as typed_mod
+from meho_backplane.flight_recorder.config import reset_flight_recorder_config_cache_for_testing
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+    run_typed_op_registrars,
+)
+from meho_backplane.operations._branches import dispatch_typed
+from meho_backplane.redaction.flight_recorder import (
+    BODY_OMITTED_MARKER,
+    SECRET_FAMILY_OMITTED_MARKER,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# DB-free helpers -- drive the seam against a manually-bound capture scope
+# ---------------------------------------------------------------------------
+
+
+def _op_ctx(
+    *,
+    op_id: str = "widget.thing.describe",
+    connector_id: str = "widget-1.x",
+    impl_id: str = "widget",
+    product: str = "widget",
+    tags: tuple[str, ...] = (),
+) -> capture._OpContext:
+    """Build a redaction op context with ``delete_shaped_patterns=()`` set.
+
+    The explicit empty tuple keeps these unit tests settings-independent (no
+    lazy ``get_settings`` read inside the redaction engine).
+    """
+    return capture._OpContext(
+        op_id=op_id,
+        connector_id=connector_id,
+        impl_id=impl_id,
+        product=product,
+        tags=tags,
+        body_paths=(),
+        delete_shaped_patterns=(),
+    )
+
+
+@contextmanager
+def _active_scope(op: capture._OpContext) -> Iterator[capture._CaptureScope]:
+    """Bind an active capture scope + op context on the contextvars.
+
+    Reaches into :mod:`meho_backplane.flight_recorder.capture` internals on
+    purpose: the typed seam rides the *same* scope machinery the dispatcher
+    binds, so a DB-free unit test drives it by setting those contextvars
+    directly (the same shape ``begin_dispatch_capture`` produces).
+    """
+    scope = capture._CaptureScope(audit_id=uuid.uuid4(), tenant_id=uuid.uuid4(), target_id=None)
+    cap_token = capture._active_capture_var.set(scope)
+    op_token = capture._op_context_var.set(op)
+    try:
+        yield scope
+    finally:
+        capture._op_context_var.reset(op_token)
+        capture._active_capture_var.reset(cap_token)
+
+
+class _Target:
+    def __init__(self, name: str = "cap-target") -> None:
+        self.name = name
+
+
+async def _stub_typed_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"ok": True}
+
+
+def _typed_spans(scope: capture._CaptureScope) -> list[Any]:
+    return [s for s in scope.spans if s.span_kind == "typed"]
+
+
+# ---------------------------------------------------------------------------
+# Shared typed-dispatch seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_span_records_typed_span() -> None:
+    """The shared seam emits one ``typed`` span keyed on impl_id + op id."""
+    op = _op_ctx(op_id="vault.kv.list", impl_id="vault", product="vault")
+    with _active_scope(op) as scope:
+        result = await dispatch_typed(
+            handler=_stub_typed_handler,
+            operator=None,  # type: ignore[arg-type]
+            target=_Target("the-vault"),
+            params={"secret_path": "kv/creds"},
+        )
+    assert result == {"ok": True}
+    typed = _typed_spans(scope)
+    assert len(typed) == 1
+    span = typed[0]
+    assert span.span_kind == "typed"
+    assert span.name == "vault.kv.list"
+    assert span.status == "ok"
+    assert span.duration_ms is not None
+    assert span.attributes["op_id"] == "vault.kv.list"
+    assert span.attributes["impl_id"] == "vault"
+    assert span.attributes["product"] == "vault"
+    assert span.attributes["target"] == "the-vault"
+    # Metadata-only: the (secret-shaped) params never reach the span.
+    assert "params" not in span.attributes
+    assert "request_body" not in span.attributes
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_span_is_metadata_only_never_uncertain() -> None:
+    """The shared seam records no body, so it never degrades the trace (F5)."""
+    op = _op_ctx(op_id="vault.kv.read", impl_id="vault", product="vault")
+    with _active_scope(op) as scope:
+        await dispatch_typed(
+            handler=_stub_typed_handler,
+            operator=None,  # type: ignore[arg-type]
+            target=_Target(),
+            params={},
+        )
+    assert scope.redaction_uncertain is False
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_span_records_error_outcome_and_reraises() -> None:
+    """A handler exception is recorded as the outcome, then propagates (F7)."""
+
+    async def _boom(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+        raise ValueError("vendor exploded")
+
+    op = _op_ctx(op_id="widget.do", impl_id="widget", product="widget")
+    with _active_scope(op) as scope, pytest.raises(ValueError, match="vendor exploded"):
+        await dispatch_typed(
+            handler=_boom,
+            operator=None,  # type: ignore[arg-type]
+            target=_Target(),
+            params={},
+        )
+    typed = _typed_spans(scope)
+    assert len(typed) == 1
+    assert typed[0].status == "error:ValueError"
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_span_swallows_recorder_failure() -> None:
+    """A raising recorder in the ``finally`` never fails the dispatch (F7)."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("recorder down")
+
+    op = _op_ctx()
+    with _active_scope(op):
+        # Force the record path to raise; the seam's guarded ``finally`` must
+        # swallow it and return the handler result byte-identically.
+        original = typed_mod.record_typed_call
+        typed_mod.record_typed_call = _boom  # type: ignore[assignment]
+        try:
+            result = await dispatch_typed(
+                handler=_stub_typed_handler,
+                operator=None,  # type: ignore[arg-type]
+                target=_Target(),
+                params={},
+            )
+        finally:
+            typed_mod.record_typed_call = original  # type: ignore[assignment]
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_capture_off_is_noop() -> None:
+    """With no active scope the seam yields the handler result, no span, cheap."""
+    # No _active_scope: the contextvar is unset.
+    assert typed_mod.typed_span_start("x") is None
+    result = await dispatch_typed(
+        handler=_stub_typed_handler,
+        operator=None,  # type: ignore[arg-type]
+        target=_Target(),
+        params={},
+    )
+    assert result == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# record_typed_call redaction (the transport-enricher seam)
+# ---------------------------------------------------------------------------
+
+
+def test_record_typed_call_no_bodies_is_metadata_only() -> None:
+    op = _op_ctx(op_id="k8s.pod.list", impl_id="k8s", product="k8s")
+    with _active_scope(op) as scope:
+        start = typed_mod.typed_span_start("k8s.pod.list")
+        typed_mod.record_typed_call(start, kind="typed", status="ok", extra={"transport": "k8s"})
+    span = _typed_spans(scope)[0]
+    assert span.attributes["transport"] == "k8s"
+    assert "request_body" not in span.attributes
+    assert scope.redaction_uncertain is False
+
+
+def test_record_typed_call_plaintext_body_omitted_and_uncertain() -> None:
+    """A benign op's free-text body cannot be proven secret-free -> omit + degrade."""
+    op = _op_ctx(op_id="widget.thing.describe", impl_id="widget", product="widget")
+    with _active_scope(op) as scope:
+        start = typed_mod.typed_span_start("cmd")
+        typed_mod.record_typed_call(
+            start,
+            kind="typed",
+            request_body="named-checkzone example.com /etc/zone",
+            response_body="zone example.com/IN: loaded serial 42\nOK",
+            request_content_type="text/plain",
+            response_content_type="text/plain",
+        )
+    span = _typed_spans(scope)[0]
+    assert span.attributes["request_body"] == BODY_OMITTED_MARKER
+    assert span.attributes["response_body"] == BODY_OMITTED_MARKER
+    assert span.attributes["body_recorded"] is True
+    assert scope.redaction_uncertain is True  # F5 operator-only degrade
+
+
+def test_record_typed_call_secret_family_body_excluded_but_certain() -> None:
+    """A secret-family op never records a body, and that omission is certain."""
+    op = _op_ctx(op_id="acme.token.mint", impl_id="widget", product="widget")
+    with _active_scope(op) as scope:
+        start = typed_mod.typed_span_start("mint")
+        typed_mod.record_typed_call(
+            start,
+            kind="typed",
+            request_body={"grant": "client_credentials"},
+            response_body={"access_token": "super-secret"},
+            request_content_type="application/json",
+            response_content_type="application/json",
+        )
+    span = _typed_spans(scope)[0]
+    assert span.attributes["body_recorded"] is False
+    assert span.attributes["request_body"] == SECRET_FAMILY_OMITTED_MARKER
+    assert span.attributes["response_body"] == SECRET_FAMILY_OMITTED_MARKER
+    # A placed family exclusion is deliberate + safe -> stays agent-readable.
+    assert scope.redaction_uncertain is False
+
+
+def test_record_typed_call_off_scope_is_noop() -> None:
+    # No active scope: start marker is None, record is a no-op, nothing raises.
+    assert typed_mod.typed_span_start("x") is None
+    typed_mod.record_typed_call(None, kind="typed", request_body="anything")
+
+
+# ---------------------------------------------------------------------------
+# SSH transport enricher (the shared SSH seam)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSshResult:
+    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int | None = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+class _FakeConn:
+    def __init__(self, result: _FakeSshResult) -> None:
+        self._result = result
+        self.commands: list[str] = []
+
+    async def run(self, cmd: str, check: bool = False) -> _FakeSshResult:
+        self.commands.append(cmd)
+        return self._result
+
+
+class _StubSshConnector(SshConnector):
+    product = "bind9"
+    version = "9.x"
+    impl_id = "bind9-ssh"
+
+    def __init__(self, result: _FakeSshResult) -> None:
+        super().__init__()
+        self._fake = _FakeConn(result)
+
+    async def _connect(self, target: Any, operator: Any = None) -> _FakeConn:  # type: ignore[override]
+        return self._fake
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_ssh_command_emits_typed_span_with_omitted_bodies() -> None:
+    """Every SSH command records one ``typed`` span; command + output dropped."""
+    conn = _StubSshConnector(_FakeSshResult(stdout="zone loaded\n", exit_status=0))
+    op = _op_ctx(op_id="bind9.zone.list", impl_id="bind9-ssh", product="bind9")
+    with _active_scope(op) as scope:
+        result = await conn._run_command(
+            _Target("lab-dns"), "named-checkzone x /etc/z", operator=None
+        )
+    assert result.exit_status == 0
+    typed = _typed_spans(scope)
+    assert len(typed) == 1
+    span = typed[0]
+    assert span.attributes["transport"] == "ssh"
+    assert span.attributes["exit_status"] == 0
+    assert span.attributes["impl_id"] == "bind9-ssh"
+    # SSH command + output are plain text -> engine drops both fail-closed.
+    assert span.attributes["request_body"] == BODY_OMITTED_MARKER
+    assert span.attributes["response_body"] == BODY_OMITTED_MARKER
+    assert scope.redaction_uncertain is True  # SSH traces degrade to operator-only
+
+
+@pytest.mark.asyncio
+async def test_ssh_span_failure_never_breaks_the_command() -> None:
+    """A raising recorder never propagates into the SSH dispatch path (F7)."""
+    conn = _StubSshConnector(_FakeSshResult(stdout="ok", exit_status=0))
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("recorder down")
+
+    op = _op_ctx(op_id="bind9.zone.list", impl_id="bind9-ssh", product="bind9")
+    with _active_scope(op):
+        original = typed_mod.record_typed_call
+        typed_mod.record_typed_call = _boom  # type: ignore[assignment]
+        try:
+            result = await conn._run_command(_Target("lab-dns"), "echo hi", operator=None)
+        finally:
+            typed_mod.record_typed_call = original  # type: ignore[assignment]
+    assert result.exit_status == 0  # the command result is untouched
+
+
+@pytest.mark.asyncio
+async def test_ssh_span_capture_off_is_noop() -> None:
+    conn = _StubSshConnector(_FakeSshResult(stdout="ok", exit_status=0))
+    # No active scope -> typed_span_start returns None -> no span, no error.
+    result = await conn._run_command(_Target("lab-dns"), "echo hi", operator=None)
+    assert result.exit_status == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry-driven conformance sweep (F8: all typed families instrumented)
+# ---------------------------------------------------------------------------
+
+#: The typed connector families expected to register ``source_kind='typed'``
+#: ops. Derived from the live registry, one entry per ``impl_id``. A newly
+#: added typed family fails :func:`test_expected_typed_families_are_covered`
+#: until it is added here -- the "name the gap" guard. github + hetzner_robot
+#: are intentionally absent: they register composite / ingested ops, covered
+#: by the composite + vendor_call seams, not the typed handler seam.
+_EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
+    {
+        "argocd-api",
+        "bind9-ssh",
+        "fleet-lcm",
+        "fleet-rest",
+        "gcloud-rest",
+        "harbor-rest",
+        "holodeck-ssh",
+        "installer-rest",
+        "k8s",
+        "keycloak-admin",
+        "loki-api",
+        "mail-smtp",
+        "mongodb-wire",
+        "net-probe",
+        "nsx-rest",
+        "pfsense-ssh",
+        "postgres-wire",
+        "prometheus-api",
+        "proxmox-api",
+        "rabbitmq-management",
+        "rke2-ssh",
+        "sddc-rest",
+        "sddc-vcf5",
+        "secret-broker",
+        "targets-registry",
+        "tempo-api",
+        "topology-graph",
+        "vault",
+        "vcd-rest",
+        "vcfa-rest",
+        "vcfa-vra8",
+        "vmware-rest",
+        "vrli-rest",
+        "vrli-vrli8",
+        "vrops-rest",
+        "vrops-vrops8",
+        "windns-ssh",
+    }
+)
+
+#: Dual-impl products whose two implementations both register typed ops under
+#: distinct ``impl_id``s (F8: keyed on impl_id, both covered).
+_DUAL_IMPL_PAIRS: tuple[tuple[str, str], ...] = (
+    ("fleet-rest", "fleet-lcm"),
+    ("sddc-rest", "sddc-vcf5"),
+    ("vcfa-rest", "vcfa-vra8"),
+    ("vrli-rest", "vrli-vrli8"),
+    ("vrops-rest", "vrops-vrops8"),
+)
+
+
+class _DescRef(NamedTuple):
+    op_id: str
+    impl_id: str
+    product: str
+    tags: tuple[str, ...]
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def typed_descriptors(stub_embedding_service: AsyncMock) -> list[_DescRef]:
+    """Register every connector's typed ops, then return the typed descriptors.
+
+    Registry-driven: runs the exact registrar set the FastAPI lifespan runs,
+    so a newly added typed connector is enumerated automatically.
+    """
+    _eager_import_connectors()
+    await run_typed_op_registrars(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            await session.execute(
+                select(
+                    EndpointDescriptor.op_id,
+                    EndpointDescriptor.impl_id,
+                    EndpointDescriptor.product,
+                    EndpointDescriptor.tags,
+                ).where(EndpointDescriptor.source_kind == "typed")
+            )
+        ).all()
+    return [
+        _DescRef(op_id, impl_id, product, tuple(tags or ()))
+        for op_id, impl_id, product, tags in rows
+    ]
+
+
+def _representative_by_impl(descriptors: list[_DescRef]) -> dict[str, _DescRef]:
+    by_impl: dict[str, _DescRef] = {}
+    for desc in descriptors:
+        by_impl.setdefault(desc.impl_id, desc)
+    return by_impl
+
+
+@pytest.mark.asyncio
+async def test_typed_enumeration_is_not_vacuous(typed_descriptors: list[_DescRef]) -> None:
+    """Guard against a broken enumeration silently covering nothing."""
+    assert len(typed_descriptors) >= 200
+    impls = {d.impl_id for d in typed_descriptors}
+    assert len(impls) >= 30
+
+
+@pytest.mark.asyncio
+async def test_expected_typed_families_are_covered(typed_descriptors: list[_DescRef]) -> None:
+    """Every expected typed family registers typed ops (regression guard)."""
+    impls = {d.impl_id for d in typed_descriptors}
+    missing = _EXPECTED_TYPED_IMPLS - impls
+    assert not missing, f"expected typed families missing from the registry: {sorted(missing)}"
+    added = impls - _EXPECTED_TYPED_IMPLS
+    assert not added, (
+        "new typed connector family/families not covered by the F8 wave -- add the "
+        f"impl_id(s) to _EXPECTED_TYPED_IMPLS after confirming the seam spans them: {sorted(added)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dual_impl_products_have_both_impls(typed_descriptors: list[_DescRef]) -> None:
+    """Both implementations of each dual-impl product register typed ops (F8)."""
+    impls = {d.impl_id for d in typed_descriptors}
+    for modern, legacy in _DUAL_IMPL_PAIRS:
+        assert modern in impls and legacy in impls, (
+            f"dual-impl product incomplete: {modern}/{legacy}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_typed_family_emits_a_typed_span_through_the_seam(
+    typed_descriptors: list[_DescRef],
+) -> None:
+    """The load-bearing coverage proof: each typed impl produces a ``typed``
+    (non-``opaque``) span through the shared seam, keyed on its impl_id.
+
+    Registry-driven, so a typed op that bypasses the seam -- or a family added
+    without instrumentation -- fails here (no span keyed on its impl_id).
+    """
+    representatives = _representative_by_impl(typed_descriptors)
+    assert set(representatives) == _EXPECTED_TYPED_IMPLS
+    for impl_id, desc in representatives.items():
+        op = capture._op_context_from(desc, f"{impl_id}-conn")
+        with _active_scope(op) as scope:
+            await dispatch_typed(
+                handler=_stub_typed_handler,
+                operator=None,  # type: ignore[arg-type]
+                target=_Target(f"{impl_id}-target"),
+                params={},
+            )
+        typed = _typed_spans(scope)
+        assert typed, f"impl {impl_id!r} produced no typed span through the seam"
+        assert typed[0].span_kind == "typed"
+        assert typed[0].attributes["impl_id"] == impl_id
+        assert typed[0].attributes["op_id"] == desc.op_id
+
+
+# ---------------------------------------------------------------------------
+# Full-dispatch: composites do not double-record; typed children do span
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_dispatch_state() -> Iterator[None]:
+    """Clean dispatcher caches + connector registry around a full-dispatch test.
+
+    Deliberately **not** autouse: the conformance sweep needs the eagerly
+    imported connector registry left intact, so only the full-dispatch test
+    below requests this reset.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def _capture_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+class _NoOpVaultConnector(Connector):
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+class _FakeTarget:
+    def __init__(self) -> None:
+        self.product = "vault"
+        self.fingerprint = type("_F", (), {"version": None})()
+        self.preferred_impl_id: str | None = None
+        self.id = uuid.uuid4()
+        self.name = "cap-target"
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+async def _child_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return {"echo": params}
+
+
+async def _two_child_composite(
+    operator: Operator, target: Any, params: dict[str, Any], dispatch_child: Any
+) -> dict[str, Any]:
+    a = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "a"})
+    b = await dispatch_child(connector_id="vault-1.x", op_id="vault.kv.list", params={"p": "b"})
+    return {"a": a.status, "b": b.status}
+
+
+async def _seed_capture_tenant(slug: str) -> UUID:
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        s.add(Tenant(id=tenant_id, slug=slug, name=slug, flight_recorder_enabled=True))
+        await s.commit()
+    return tenant_id
+
+
+def _make_operator(tenant_id: UUID) -> Operator:
+    return Operator(
+        sub="op-typed",
+        name="Cap",
+        email=None,
+        raw_jwt="<jwt>",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _insert_composite_descriptor(
+    *, session: AsyncSession, op_id: str, handler_ref: str, embedding: list[float]
+) -> None:
+    session.add(
+        EndpointDescriptor(
+            id=uuid.uuid4(),
+            tenant_id=None,
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=op_id,
+            source_kind="composite",
+            method=None,
+            path=None,
+            handler_ref=handler_ref,
+            summary=f"Composite {op_id}.",
+            description=f"Composite {op_id}.",
+            tags=[],
+            parameter_schema={"type": "object"},
+            response_schema=None,
+            llm_instructions=None,
+            safety_level="safe",
+            requires_approval=False,
+            is_enabled=True,
+            embedding=embedding,
+            custom_description=None,
+            custom_notes=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+async def _spans_for_single_trace() -> list[DispatchTraceSpan]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        traces = list((await s.execute(select(DispatchTrace))).scalars().all())
+        assert len(traces) == 1, f"expected exactly one trace, got {len(traces)}"
+        return list(
+            (
+                await s.execute(
+                    select(DispatchTraceSpan)
+                    .where(DispatchTraceSpan.trace_id == traces[0].id)
+                    .order_by(DispatchTraceSpan.seq.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+@pytest.mark.asyncio
+async def test_composite_children_span_but_composite_does_not_double_record(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    _reset_dispatch_state: None,
+    _capture_broadcast: list[BroadcastEvent],
+) -> None:
+    """A composite's typed children each get a ``typed`` span; the composite
+    parent (routed via ``dispatch_composite``) records only its
+    ``composite_step`` markers -- no double ``typed`` span for the parent.
+    """
+    tenant_id = await _seed_capture_tenant("fr-typed-composite")
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.list",
+        handler=_child_handler,
+        summary="List.",
+        description="List.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    await _insert_composite_descriptor(
+        session=session,
+        op_id="vault.composite.two",
+        handler_ref="tests.test_flight_recorder_typed_spans._two_child_composite",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id="vault.composite.two",
+        target=_FakeTarget(),
+        params={},
+    )
+    assert result.status == "ok", result.error
+
+    spans = await _spans_for_single_trace()
+    typed = [s for s in spans if s.span_kind == "typed"]
+    steps = [s for s in spans if s.span_kind == "composite_step"]
+    # Two typed children -> two typed spans; both keyed on the child op.
+    assert len(typed) == 2
+    assert {s.attributes["op_id"] for s in typed} == {"vault.kv.list"}
+    assert {s.attributes["impl_id"] for s in typed} == {"vault"}
+    # The composite parent itself never emits a typed span (no double-record).
+    assert "vault.composite.two" not in {s.attributes.get("op_id") for s in typed}
+    assert len(steps) == 2


### PR DESCRIPTION
Closes #3217

Implements **F8** of `docs/decisions/dispatch-flight-recorder.md` — the operator override "all of them in v1": typed connectors are instrumented with real (non-`opaque`) spans across **every** typed family, not a deferred wave.

## Seam design — ONE shared seam + thin transport enrichers

New module `meho_backplane.flight_recorder.typed` rides the **same** per-dispatch capture scope + op context as the generic `vendor_call` seam (#3214) — no parallel state:

- **Shared typed-dispatch seam** (`typed_dispatch_span`) wired **once** into `dispatch_typed` (`operations/_branches.py`). Brackets every typed handler and emits a `typed` span — op id, target, duration, outcome — keyed on **`impl_id`** so both impls of each dual-impl product (fleet/sddc/vcfa/vrli/vrops) are distinguished. Metadata-only: never records `params` or vendor payload, carries no secret, never degrades the trace. Error outcome is the exception **class name only** (`error:ValueError`), never the message.
- **Transport-enricher seam** (`typed_span_start` + `record_typed_call`) routes request/response detail through the **same** fail-closed `redact_span`. Wired into the shared SSH seam `SshConnector._run_command`, so all SSH families (bind9, holodeck, pfsense, rke2, windows_dns) get per-command spans with no per-connector edit; command + output are plain text → the engine omits both fail-closed and degrades the trace to operator-only (F5).

`_OpContext` extended with `impl_id`/`product` (single-source of the redaction op context).

## Coverage — by construction (37 typed impls)

Because the seam sits on the one typed-dispatch path, all 37 registered typed implementations — every class-based family plus the builtin `product.*` families (net/mail/secret/topology/targets) and **both** impls of the five dual-impl products — emit real `typed` spans, retiring the transitional `opaque` fallback. A **registry-driven conformance sweep** enumerates typed families from the live registrar set and asserts each produces a `typed` span keyed on impl_id, so a newly added typed connector that skips the seam fails CI. (github/hetzner_robot register composite/ingested ops, covered by the composite + vendor_call seams — correctly excluded.)

## F7 invariant

Capture is best-effort; the disabled path is a **single contextvar read**; a recorder/redaction failure is swallowed and can never fail, block, or slow a typed dispatch — the handler's own exception always propagates unchanged.

## Tests / quality

17 new tests in `test_flight_recorder_typed_spans.py` (shared-seam, redaction, SSH enricher, F7 forced-failure per path, registry-driven conformance sweep, composite no-double-record). Full flight-recorder suite green; ruff + ruff-format + mypy clean. No migration (span_kind is free-text; `typed`/`opaque` already anticipated by #3212).

## Inline adversarial review verdict: **APPROVE**

- **(a) F7** — every recorder path swallows its own errors; finally double-guarded against a raising recorder; handler exceptions propagate. Tested per SDK/transport family.
- **(b) Redaction** — shared seam is secret-free metadata; SSH command+output go through `redact_span` as text/plain → omitted fail-closed + operator-only degrade; SSH output/command never reach a span un-redacted; k8s secret-adjacent reads get metadata-only spans.
- **(c) Coverage** — registry-driven sweep, exact-set match; a new typed family fails CI until acknowledged.
- **(d) Double-spans** — composites route via `dispatch_composite` (not `dispatch_typed`): parent records only `composite_step` markers, children get `typed` spans. Tested.
- **(e) Performance — 1 issue found and FIXED** — the disabled path of `typed_dispatch_span` originally did two contextvar reads; reordered to gate on a single `_active_capture_var.get()` before any op-context read or name build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)