### PR TITLE
docs(decisions): cross-ref flight recorder into satellite + governed-delete decisions (#3207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,40 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: cross-ref amendments to the satellite write-path + governed-delete decision docs (#3207)
+
+- Discharges the reciprocal cross-references the flight-recorder decision
+  (`docs/decisions/dispatch-flight-recorder.md`) flagged as a deliberate
+  follow-up, now that its caps / redaction / capture landed (#3212–#3217). A
+  dated `## Amendment (2026-08-31)` section is added to each sibling decision
+  doc; docs-only, no code, and **#3207 stays open** (the consumer-proof Task
+  #3218 remains).
+- **`docs/decisions/satellite-write-path.md`** — records that
+  **satellite-executed dispatches are not traced today**: the capture scope is
+  opened only inside the central dispatcher's `_execute_and_audit`
+  (`operations/dispatcher.py:706`), and a runner executes off-net through
+  `runner/executor.py`, which bypasses `dispatcher.dispatch` — so the shared
+  httpx/SSH recorder seams stay inert (no active scope) and the runner has no
+  trace store. Neither the central mint nor the runner's tier-ladder screen
+  (#3188) opens a capture scope; today only `safe`-tier ops execute on a runner
+  (the additive `remote-write` tier is fail-closed until #3189-#3193 wire it),
+  and even a future remote-write execution rides the same
+  `dispatcher.dispatch`-bypassing path, so nothing is traced. Should the
+  satellite path ever record its off-net traffic, the F2 redaction / F3 caps /
+  F4 retention rules are normative for it; that instrumentation is a follow-up
+  task (no issue filed), distinct from the permanent store-and-forward §6 effect
+  audit.
+- **`docs/decisions/governed-delete-operations.md`** — records that the flight
+  recorder's redaction engine **single-sources** its destructive-family
+  body-exclusion with this decision's delete-shaped classifier
+  (`redaction/flight_recorder/families.py` reads
+  `Settings.service_grant_delete_shaped_patterns`, plus the `DELETE` method and
+  `destructive` tag), so a destroy dispatch's trace keeps metadata spans but
+  **never records bodies** (`redact_span` → `body_recorded=False`). The
+  exclusion is a certain omission, not a redaction-uncertainty, so the trace
+  stays agent-readable (F5); the human-approval / preview-hash / blast-radius
+  gates remain approvals-plane artefacts the recorder captures around, never in.
+
 ### Fixed — epoch-in-`impl_id` probe registrations now reaped + rejected (#3061)
 
 - `#2977`'s epoch-reap (migration `0075`) and `IngestRequest._reject_epoch_version`

--- a/docs/decisions/governed-delete-operations.md
+++ b/docs/decisions/governed-delete-operations.md
@@ -231,3 +231,51 @@ render path.
   evoila-bosnia/meho-internal#234.
 - v0.1-spec §7 (approval is a human decision) — the human-only line this tier
   reuses.
+
+## Amendment (2026-08-31) — dispatch flight recorder cross-reference
+
+Added once the dispatch flight recorder's fail-closed redaction engine landed
+([docs/decisions/dispatch-flight-recorder.md](dispatch-flight-recorder.md),
+Initiative [#3207](https://github.com/evoila/meho/issues/3207); redaction #3213,
+capture #3214). It discharges the reciprocal cross-reference that decision
+flagged as a deliberate follow-up ("Interactions with sibling decisions" →
+"Governed delete-shaped operations"). It records only what the merged code does
+today.
+
+**The destructive / delete-shaped family is a hard body-exclusion in the flight
+recorder, single-sourced with this decision's classifier.** The recorder's
+redaction engine classifies every captured span for body exclusion in
+`redaction/flight_recorder/families.py` (`classify_body_exclusion`). It does
+**not** re-declare the delete-shaped patterns: it reads them from the **same
+single source** the grant guard uses — `Settings.service_grant_delete_shaped_patterns`,
+the `_delete_shaped_reason_by_pattern` seam at `operations/service_grants.py`
+this decision reuses (References → "Delete-shaped classifier reused") — and
+applies the same descriptor signals: an HTTP `DELETE` method and the
+`destructive` tag the safety tier (#3196) promotes. An op the classifier places
+into the `destructive` family has its request **and** response bodies **never
+recorded** (`redact_span` sets `body_recorded=False` and emits the omission
+marker, `redaction/flight_recorder/span.py`). Because both classifiers draw on
+one source, the flight recorder's exclusion set and this decision's `destructive`
+tier cannot drift.
+
+**A destroy dispatch's trace carries metadata spans, never the excluded bodies.**
+For a body-excluded destructive op the span still records method, URL, status,
+duration, and allowlisted (non-secret) headers — only the bodies are dropped. The
+exclusion is a **deliberate, certain** omission (`BodyExclusion.uncertain=False`
+for a placed family), not a redaction-uncertainty, so a destroy trace is **not**
+forced operator-only on that account; it stays agent-readable through the
+narrow-waist result-handle idiom (F5), subject to the per-tenant gate, exactly as
+any other trace. The operator-only degrade is reserved for the *unplaceable* op
+(a missing / blank op id), not for a cleanly-excluded destructive one. Each span
+is classified against the op that *made* the call, so within a delete composite
+only the destructive / delete-shaped spans are body-excluded; sibling non-
+destructive sub-steps follow ordinary per-connector redaction.
+
+**The flight recorder records execution, not the approval gate.** A `destructive`
+op reaches the central dispatch path — where the capture scope is opened
+(`operations/dispatcher.py:706`) — only after this decision's mandatory human
+approval clears it (requirement 1), bound to its preview-result hash and
+blast-radius statement (requirements 2–3). Those gates live on the approvals
+plane and the audit row, not in the trace; the flight recorder neither duplicates
+nor bypasses them — it captures the post-approval vendor traffic of the executed
+destroy, with the destructive / delete-shaped spans' bodies excluded as above.

--- a/docs/decisions/satellite-write-path.md
+++ b/docs/decisions/satellite-write-path.md
@@ -139,3 +139,59 @@ Three sub-points are recorded here as recommendations, resolved on PR review:
 - Consumer scenarios in the meho-automation design doc
   (evoila-bosnia/meho-internal#223) are updated to match under the implementation
   Tasks, not here.
+
+## Amendment (2026-08-31) — dispatch flight recorder cross-reference
+
+Added once the dispatch flight recorder's capture, redaction, and storage
+landed ([docs/decisions/dispatch-flight-recorder.md](dispatch-flight-recorder.md),
+Initiative [#3207](https://github.com/evoila/meho/issues/3207); store #3212,
+redaction #3213, capture #3214). It discharges the reciprocal cross-reference
+that decision flagged as a deliberate follow-up ("Interactions with sibling
+decisions" → "Satellite write path"). It records only what the merged code does
+today and grants no new capability.
+
+**Satellite-executed dispatches are not traced today.** The flight recorder's
+capture scope is opened exactly once, inside the central dispatcher's
+`_execute_and_audit` (`operations/dispatcher.py:706` `begin_dispatch_capture` /
+`:730` `end_dispatch_capture`), keyed on the central `audit_log.id`. A satellite
+runner does **not** go through that path: it executes a minted work item off-net
+through `runner/executor.py` (`execute_work_item` → `_invoke`), which — per that
+module's docstring — "reuses the chassis's DB-free handler-resolution primitives
+… but **not** the DB-bound `dispatcher.dispatch`." No capture scope is ever
+opened on the runner, so:
+
+- the shared connector seams the runner loads still *call* the recorder
+  (`flight_recorder.capture.span_start` on the httpx seam
+  `connectors/adapters/http.py`; `flight_recorder.typed.typed_span_start` on the
+  SSH seam `connectors/adapters/ssh.py`), but every call is **inert** — each
+  returns `None` / no-ops while `_active_capture_var` is unset
+  (`flight_recorder/capture.py`, `flight_recorder/typed.py`), so no span is
+  produced; and
+- the runner has no Postgres trace store to persist to — the dedicated trace
+  table and its retention reaper (F6 / F4, #3212) live on the central instance
+  only.
+
+The central satellite **mint** path (`operations/gateway_commands.py`
+`mint_gateway_command`) re-runs the dispatcher's pre-execution ladder and writes
+its own gateway audit row; it does **not** call `_execute_and_audit`, so it opens
+no capture scope and produces no trace either. The satellite-mint tier ladder
+(#3188, `runner/satellite_tier.py`) — mirrored at the mint, the assignment
+materialiser, and the edge executor's `_screen_item` — does not change this:
+`dangerous` / `destructive` ops are `EXCLUDED` and never minted, and the additive
+`remote-write` (`caution`) tier is fail-closed at `evaluate_remote_write_gate`
+until its per-runner allowlist + approval binding is wired (#3189–#3193), so
+today only `safe`-tier ops actually execute on a runner. Even once the write tier
+is provisioned, a `remote-write` item still executes through `execute_work_item`
+→ `_invoke` — the same `dispatcher.dispatch`-bypassing path — so it too opens no
+capture scope. No satellite dispatch, of any tier, is traced today.
+
+**The recording contract is normative if/when remote capture is instrumented.**
+The flight-recorder decision fixes the rules any trace must obey — the F2 header
+allowlist + fail-closed body redaction, the F3 caps (64 KB/span, 1 MB/trace, ~50
+spans), and the F4 retention window. Should the satellite path ever record its
+off-net request/response traffic, that traffic must be captured under those
+**same** rules. That off-net instrumentation does **not** exist today and is
+**not** filed as an issue — it remains a follow-up task. It is distinct from, and
+does not replace, the store-and-forward **effect** audit (mechanism 4 above),
+which stays the permanent v0.1-spec §6 record; the flight recorder is only the
+short-lived request/response exhaust, never that record.


### PR DESCRIPTION
Discharges the two reciprocal cross-reference amendments the dispatch flight-recorder decision (`docs/decisions/dispatch-flight-recorder.md`, merged in #3211) flagged as a deliberate follow-up in its "Interactions with sibling decisions" section — now that the recorder's caps / redaction / capture / surfaces have landed (#3212–#3217, all merged). **Docs-only**, grounded sentence-by-sentence in the merged code; no new capability is claimed.

`Refs #3207` — the initiative **stays open** for the consumer-proof Task #3218; this PR does not close it.

## What each amendment states

**`docs/decisions/satellite-write-path.md`** — *satellite-executed dispatches are not traced today.*
- The flight-recorder capture scope is opened exactly once, inside the central dispatcher's `_execute_and_audit` (`operations/dispatcher.py:706`/`:730`), keyed on the central `audit_log.id`.
- A satellite runner bypasses that path: it executes minted work off-net through `runner/executor.py`, which "reuses the chassis's DB-free handler-resolution primitives … but **not** the DB-bound `dispatcher.dispatch`." So no scope is ever opened on the runner — the shared httpx/SSH recorder seams (`span_start` / `typed_span_start`) return `None`/no-op without an active `_active_capture_var`, and the runner has no Postgres trace store.
- The central **mint** path (`mint_gateway_command`) writes its own gateway audit row and never calls `_execute_and_audit`, so it produces no trace either. Consistent with today's Stage-0 reads-only posture (the runner refuses any non-`safe` op).
- The F2 redaction / F3 caps / F4 retention rules are **normative if/when** the satellite path is ever instrumented to record off-net traffic — that instrumentation does not exist today and no issue is filed, so it is a follow-up task. Distinct from the permanent store-and-forward §6 **effect** audit (mechanism 4), which the flight recorder does not replace.

**`docs/decisions/governed-delete-operations.md`** — *destructive dispatches and the flight recorder.*
- The recorder's redaction engine (`redaction/flight_recorder/families.py`, `classify_body_exclusion`) **single-sources** its destructive-family body-exclusion with this decision's delete-shaped classifier — it reads `Settings.service_grant_delete_shaped_patterns` (the same source the grant guard's `_delete_shaped_reason_by_pattern` uses) plus the HTTP `DELETE` method and the `destructive` tag (#3196). So the exclusion set and the `destructive` safety tier cannot drift.
- A destroy dispatch's trace keeps **metadata spans** (method, URL, status, duration, allowlisted headers) but its bodies are **never recorded** (`redact_span` → `body_recorded=False`).
- The exclusion is a **certain** omission (`BodyExclusion.uncertain=False`), not a redaction-uncertainty, so a destroy trace stays agent-readable through the narrow-waist result-handle idiom (F5) — operator-only degrade is reserved for the *unplaceable* op. Each span is classified against the op that made the call, so within a delete composite only the destructive/delete-shaped spans are body-excluded.
- The human-approval / preview-hash / blast-radius gates (requirements 1–3) remain approvals-plane + audit artefacts; the recorder captures the post-approval execution around them, never in place of them.

## Precedent / house style
- No prior amendment section existed in `docs/decisions/`, so each doc gains a dated `## Amendment (2026-08-31)` section at its end.
- Decision-doc PRs in this series carried a CHANGELOG bullet (#3211, #2901), so an `[Unreleased] → Added` bullet is included to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)