### PR TITLE
feat(runner): per-work-item wrapped-credential brokering — satellite write path (#3191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,34 @@ connector-related release-notes line.
 - The structured `deploy_error` / `deploy_failed` mapping (#3071 family) is
   unchanged for genuine faults.
 
+### Added — satellite write path: per-work-item wrapped-credential brokering (#3191)
+
+- Mechanism 3 of the ratified scoped-hybrid write path (Initiative #2901,
+  `docs/decisions/satellite-write-path.md`, design §3): the write tier never
+  hands a fenced satellite runner a **standing broad** vendor credential (the
+  T3 worst case). Instead the **centre brokers** a short-lived,
+  **single-target-scoped**, Vault-**response-wrapped** credential bound to one
+  work item, with credential TTL bounded ≤ the capability's `expires_at`
+  (`connectors/_shared/wrapped_creds.py::broker_wrapped_credential`).
+- The disk-spooled work item holds only a **single-use unwrap token**
+  (`secret_ref = wrapped:<token>`), never the credential value — the runner
+  **unwraps just-in-time at execution** by presenting the token itself to
+  Vault's unwrap endpoint (an **outbound** dial, push-only preserved #2877),
+  **not** the acting operator's JWT. This closes the empty-JWT edge-credential
+  gap (design §1.4): a `wrapped:` credential resolves on the DB-free runner
+  with **no** chassis `Settings` and **no** operator identity.
+- **Rides the existing credential seam** (#2229 / #2642) — a new `wrapped`
+  backend registered alongside `vault` / `gsm`, so connector handlers resolve
+  a wrapped credential through the unchanged `load_basic_credentials` call.
+  **Fail-closed everywhere:** a second unwrap of a consumed token, an expired
+  token, or a `remote-write` item carrying a standing/broad `secret_ref` is
+  refused. New runner env for the outbound unwrap dial: `MEHO_RUNNER_VAULT_ADDR`
+  (+ optional `MEHO_RUNNER_VAULT_NAMESPACE` / `MEHO_RUNNER_VAULT_TIMEOUT_SECONDS`).
+- Wrapped credentials are transient (they ride the existing `secret_ref` wire
+  field), so there is **no migration**. Wrapped brokering requires Vault
+  (response-wrapping); a Vault-free (`gsm`) deployment has no wrapped-brokering
+  path yet.
+
 ### Added — satellite write path: `remote-write` safety tier + tiered mint gate (#3188)
 
 - Extends the gateway's binary safe-wall into a **satellite-mint tier

--- a/backend/src/meho_backplane/connectors/_shared/__init__.py
+++ b/backend/src/meho_backplane/connectors/_shared/__init__.py
@@ -26,6 +26,13 @@ Exports:
   tenant-unique ``(tenant_id, id)`` per-target cache key (#1642). Every
   connector credential / session / client cache derives its key here so
   same-named targets in different tenants never collapse to one entry.
+* :mod:`meho_backplane.connectors._shared.wrapped_creds` — the per-work-item
+  short-lived response-wrapped credential broker + runner unwrap backend
+  (#3191, satellite write-path mechanism 3), registered under kind
+  ``wrapped`` on the #2229 resolver seam. Imported here so its
+  ``register_credential_backend`` call runs eagerly (as ``gsm_creds`` does
+  for ``gsm``) and the ``wrapped`` kind is present before any credential
+  resolution.
 
 New cross-connector shared modules land alongside these — keep each
 module focused on a single concern (auth, retries, pagination, etc.)
@@ -38,6 +45,14 @@ from meho_backplane.connectors._shared import (
     system_operator,
     vault_creds,
     vcf_auth,
+    wrapped_creds,
 )
 
-__all__ = ["cache_key", "gsm_creds", "system_operator", "vault_creds", "vcf_auth"]
+__all__ = [
+    "cache_key",
+    "gsm_creds",
+    "system_operator",
+    "vault_creds",
+    "vcf_auth",
+    "wrapped_creds",
+]

--- a/backend/src/meho_backplane/connectors/_shared/credential_backend.py
+++ b/backend/src/meho_backplane/connectors/_shared/credential_backend.py
@@ -67,6 +67,7 @@ __all__ = [
     "CredentialBackend",
     "CredentialsReadError",
     "UnknownCredentialBackendError",
+    "parse_credential_scheme",
     "register_credential_backend",
     "resolve_credential_backend",
     "split_credential_ref",
@@ -219,6 +220,27 @@ def resolve_credential_backend(kind: str) -> CredentialBackend:
     return backend
 
 
+def parse_credential_scheme(secret_ref: str) -> str | None:
+    """Return the explicit backend kind prefixing *secret_ref*, or ``None``.
+
+    A ``<kind>:<non-empty>`` value whose prefix before the first colon is a
+    bare scheme token carries an explicit kind; everything else — no colon,
+    an empty remainder, or a non-scheme-token prefix (e.g. a slashed path
+    segment) — is schemeless and returns ``None``.
+
+    Split out from :func:`split_credential_ref` so a caller can resolve the
+    deployment-default backend **lazily** — only for a schemeless ref. That
+    is what lets the DB-free satellite runner resolve an explicit-scheme
+    credential (notably its single-use ``wrapped:`` token) without a
+    ``get_settings()`` call, which the runner cannot make (it has no chassis
+    :class:`~meho_backplane.settings.Settings`).
+    """
+    kind, sep, rest = secret_ref.partition(":")
+    if sep and rest and _SCHEME_TOKEN.match(kind):
+        return kind
+    return None
+
+
 def split_credential_ref(secret_ref: str, *, default_backend: str) -> tuple[str, str]:
     """Split *secret_ref* into ``(kind, store_ref)``.
 
@@ -233,7 +255,7 @@ def split_credential_ref(secret_ref: str, *, default_backend: str) -> tuple[str,
     * ``"vault:targets/vc-01"`` → ``("vault", "targets/vc-01")``
     * ``"gsm:proj/secret#pw"`` → ``("gsm", "proj/secret#pw")``
     """
-    kind, sep, rest = secret_ref.partition(":")
-    if sep and rest and _SCHEME_TOKEN.match(kind):
-        return kind, rest
+    scheme = parse_credential_scheme(secret_ref)
+    if scheme is not None:
+        return scheme, secret_ref.partition(":")[2]
     return default_backend, secret_ref

--- a/backend/src/meho_backplane/connectors/_shared/vault_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/vault_creds.py
@@ -99,6 +99,7 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.auth.vault import vault_client_for_operator
 from meho_backplane.connectors._shared.credential_backend import (
     CredentialsReadError,
+    parse_credential_scheme,
     register_credential_backend,
     resolve_credential_backend,
     split_credential_ref,
@@ -418,7 +419,14 @@ async def _resolve_and_load(
     is handed back so the caller can name it in a missing-field error.
     """
     ref = _require_secret_ref(target)
-    kind, store_ref = split_credential_ref(ref, default_backend=get_settings().credential_backend)
+    # Resolve the deployment-default backend lazily: an explicit ``<kind>:``
+    # ref (notably the satellite runner's single-use ``wrapped:`` token) never
+    # consults ``get_settings()``, so the DB-free runner — which cannot build
+    # the chassis ``Settings`` — resolves it. A schemeless ref keeps today's
+    # behaviour and routes through ``config.credentialBackend``.
+    scheme = parse_credential_scheme(ref)
+    default_backend = scheme if scheme is not None else get_settings().credential_backend
+    kind, store_ref = split_credential_ref(ref, default_backend=default_backend)
     backend = resolve_credential_backend(kind)
     secret_data = await backend.load_secret_data(
         store_ref, operator, target_name=target.name, mount=mount

--- a/backend/src/meho_backplane/connectors/_shared/wrapped_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/wrapped_creds.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-work-item short-lived, response-wrapped credential brokering (#3191).
+
+Mechanism 3 of the satellite write-path composition
+(:doc:`docs/decisions/satellite-write-path.md`, design §3): the write tier
+never hands a fenced, less-trusted runner a **standing broad** vendor
+credential (the T3 worst case). Instead, for one authorised work item, the
+**centre** brokers a short-lived, **single-target-scoped** credential and
+ships only a **single-use unwrap token** (Vault response-wrapping) to the
+runner; the runner **unwraps just-in-time at execution**, uses the
+credential for that one op, and never persists it.
+
+This module **extends the backend-agnostic credential seam**
+(:mod:`~meho_backplane.connectors._shared.credential_backend`,
+:mod:`~meho_backplane.connectors._shared.vault_creds`) rather than forking a
+parallel path — it registers a new backend under the ``wrapped`` scheme, so
+a connector handler resolves a wrapped credential through the same
+:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+call it already uses, unchanged.
+
+The two halves
+==============
+
+**Centre broker** — :func:`broker_wrapped_credential`. Reads *one* target's
+secret under the authorising operator (present at central mint), Vault-
+response-wraps that single payload with a TTL bounded to the capability's
+``expires_at``, and returns only the ``wrapped:<token>`` reference. The
+credential value never leaves the centre.
+
+**Runner backend** — :class:`WrappedCredentialBackend`. Registered under
+kind ``wrapped``. At execution the runner presents the **single-use wrapping
+token itself** to Vault's unwrap endpoint — *not* the acting operator's JWT
+— so the DB-free runner resolves the credential without the empty-``raw_jwt``
+operator identity the read path stumbles on (design §1.4). The unwrap is an
+**outbound** dial (push-only preserved, #2877). Vault consumes the token on
+the first unwrap, so a replay / redelivery unwraps a second time and Vault
+refuses — the credential fails closed, expired or already-consumed.
+
+No standing credential
+======================
+
+The runner holds only the ephemeral, single-use, TTL-bounded wrapping token,
+delivered per work item over its runner-principal-authenticated poll channel.
+It has no standing Vault read policy. :func:`screen_remote_write_credential`
+is the edge fail-closed guard: a ``remote-write`` item whose target carries a
+standing/broad ``secret_ref`` (anything but a ``wrapped:`` token) is refused,
+so a config that would grant a standing runner credential fails closed.
+
+Vault dependency
+================
+
+Response-wrapping is a Vault feature, so wrapped brokering requires Vault
+(``VAULT_ADDR`` on the centre for the wrap; ``MEHO_RUNNER_VAULT_ADDR`` on the
+runner for the outbound unwrap). A Vault-free (``gsm``) deployment has no
+wrapped-brokering path today — an additive future concern, not built
+speculatively here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import hvac
+import hvac.exceptions
+import requests.exceptions
+import structlog
+
+from meho_backplane.auth.vault import vault_client_for_operator
+from meho_backplane.connectors._shared.credential_backend import (
+    CredentialsReadError,
+    register_credential_backend,
+)
+from meho_backplane.connectors._shared.vault_creds import (
+    DEFAULT_KV_MOUNT,
+    load_vault_secret_data,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors._shared.vault_creds import BasicCredentialsTargetLike
+
+__all__ = [
+    "WRAPPED_CREDENTIAL_SCHEME",
+    "WrappedCredential",
+    "WrappedCredentialBackend",
+    "WrappedCredentialError",
+    "broker_wrapped_credential",
+    "is_wrapped_credential_ref",
+    "screen_remote_write_credential",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The credential-seam scheme a per-work-item single-use wrapped credential
+#: rides on: ``wrapped:<vault-wrapping-token>``. Parsed off the target's
+#: ``secret_ref`` by the seam dispatcher exactly like ``vault:`` / ``gsm:``.
+WRAPPED_CREDENTIAL_SCHEME = "wrapped"
+
+#: The runner's outbound Vault address for the just-in-time unwrap. Read from
+#: the environment (not the chassis ``Settings`` the runner cannot build);
+#: fail-closed when unset (the runner needs a Vault to unwrap against).
+_UNWRAP_VAULT_ADDR_ENV = "MEHO_RUNNER_VAULT_ADDR"
+#: Optional Vault namespace (Enterprise) for the unwrap dial.
+_UNWRAP_VAULT_NAMESPACE_ENV = "MEHO_RUNNER_VAULT_NAMESPACE"
+#: Optional per-call timeout (seconds) for the unwrap dial.
+_UNWRAP_VAULT_TIMEOUT_ENV = "MEHO_RUNNER_VAULT_TIMEOUT_SECONDS"
+_DEFAULT_UNWRAP_TIMEOUT_SECONDS = 10.0
+
+
+class WrappedCredentialError(CredentialsReadError):
+    """Brokering- or unwrapping-phase failure for a wrapped credential.
+
+    Subclasses the backend-neutral
+    :class:`~meho_backplane.connectors._shared.credential_backend.CredentialsReadError`
+    (#2642) so a caller that means "the credential could not be read"
+    catches the base. Raised when the capability expiry gives no positive
+    TTL, when Vault response-wrapping returns no token, or when the
+    just-in-time unwrap fails (the single-use token is expired, already
+    consumed, or invalid, or the outbound Vault dial failed). Never echoes a
+    credential value.
+    """
+
+
+@dataclass(frozen=True)
+class WrappedCredential:
+    """The centre-brokered handle shipped to the runner in place of a secret.
+
+    :attr:`unwrap_ref` is the ``wrapped:<token>`` reference set as the
+    runner-bound target descriptor's ``secret_ref`` — the only credential
+    artifact that touches the runner's disk. :attr:`expires_at` bounds the
+    wrapping token's life to at most the capability's expiry;
+    :attr:`wrap_ttl_seconds` is that bound in seconds.
+    """
+
+    unwrap_ref: str
+    expires_at: datetime
+    wrap_ttl_seconds: int
+
+
+def is_wrapped_credential_ref(secret_ref: str | None) -> bool:
+    """Return ``True`` when *secret_ref* is a ``wrapped:<token>`` reference."""
+    if not secret_ref:
+        return False
+    kind, sep, token = secret_ref.partition(":")
+    return kind == WRAPPED_CREDENTIAL_SCHEME and bool(sep) and bool(token)
+
+
+def _bounded_wrap_ttl(
+    capability_expires_at: datetime, requested_ttl_seconds: int | None, *, now: datetime
+) -> int:
+    """Return the wrap TTL, bounded so credential TTL ≤ capability ``expires_at``.
+
+    The wrapping token must never outlive the capability it is bound to, so
+    the TTL is capped at the headroom to ``capability_expires_at``. A
+    caller-*requested* TTL only ever shortens it further. A capability that
+    is already expired (non-positive headroom) cannot broker a credential →
+    :class:`WrappedCredentialError`.
+    """
+    headroom = int((capability_expires_at - now).total_seconds())
+    if headroom <= 0:
+        raise WrappedCredentialError(
+            "cannot broker a wrapped credential: capability expiry "
+            f"{capability_expires_at.isoformat()} is not in the future"
+        )
+    if requested_ttl_seconds is None:
+        return headroom
+    if requested_ttl_seconds <= 0:
+        raise WrappedCredentialError(
+            f"requested wrap TTL must be positive, got {requested_ttl_seconds}"
+        )
+    return min(requested_ttl_seconds, headroom)
+
+
+def _extract_wrap_token(response: object) -> str:
+    """Pull the wrapping token out of a ``sys/wrapping/wrap`` response."""
+    wrap_info = response.get("wrap_info") if isinstance(response, dict) else None
+    token = wrap_info.get("token") if isinstance(wrap_info, dict) else None
+    if not isinstance(token, str) or not token:
+        raise WrappedCredentialError(
+            "vault response-wrap returned no wrapping token; cannot broker a wrapped credential"
+        )
+    return token
+
+
+async def _wrap_payload(operator: Operator, payload: dict[str, object], *, ttl_seconds: int) -> str:
+    """Response-wrap *payload* under *operator*'s Vault identity, return the token.
+
+    Opens a fresh operator-context Vault client and POSTs the payload to
+    ``sys/wrapping/wrap`` with ``X-Vault-Wrap-TTL: ttl_seconds`` (hvac's
+    ``client.sys.wrap``), off the event loop (hvac is synchronous).
+    """
+    async with vault_client_for_operator(operator) as client:
+        response = await asyncio.to_thread(client.sys.wrap, payload=payload, ttl=ttl_seconds)
+    return _extract_wrap_token(response)
+
+
+async def broker_wrapped_credential(
+    target: BasicCredentialsTargetLike,
+    operator: Operator,
+    *,
+    capability_expires_at: datetime,
+    requested_ttl_seconds: int | None = None,
+    mount: str = DEFAULT_KV_MOUNT,
+    now: datetime | None = None,
+) -> WrappedCredential:
+    """Broker a per-work-item single-use wrapped credential for *target*.
+
+    The **centre** side of mechanism 3, called at authorised remote-write
+    mint (where the operator is present with a real JWT). It:
+
+    1. Reads *target*'s secret under *operator*'s identity through the shared
+       credential seam
+       (:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`)
+       — exactly one target's fields, so the wrapped credential is
+       **single-target-scoped** by construction.
+    2. Vault-response-wraps that one payload with a TTL bounded so the
+       credential never outlives the capability
+       (:func:`_bounded_wrap_ttl`) — credential TTL ≤ ``capability_expires_at``.
+    3. Returns only the ``wrapped:<token>`` reference; the credential value
+       never leaves the centre.
+
+    The seam wiring — set the returned :attr:`WrappedCredential.unwrap_ref`
+    as the runner-bound target descriptor's ``secret_ref`` at mint — is the
+    caller's (the approval-bound mint, #3189). This function is the seam.
+
+    Raises:
+        WrappedCredentialError: the capability is already expired, a
+            non-positive TTL was requested, or Vault returned no wrap token.
+        meho_backplane.connectors._shared.credential_backend.CredentialsReadError:
+            the underlying read of *target*'s secret failed.
+        meho_backplane.auth.vault.VaultClientError: Vault is unreachable /
+            unconfigured / denied the role (login-phase failure).
+    """
+    moment = now or datetime.now(UTC)
+    ttl = _bounded_wrap_ttl(capability_expires_at, requested_ttl_seconds, now=moment)
+    secret_data = await load_vault_secret_data(target, operator, mount=mount)
+    token = await _wrap_payload(operator, dict(secret_data), ttl_seconds=ttl)
+
+    _log.info(
+        "wrapped_credential_brokered",
+        target=target.name,
+        wrap_ttl_seconds=ttl,
+        fields=sorted(secret_data.keys()),
+    )
+    return WrappedCredential(
+        unwrap_ref=f"{WRAPPED_CREDENTIAL_SCHEME}:{token}",
+        expires_at=moment + timedelta(seconds=ttl),
+        wrap_ttl_seconds=ttl,
+    )
+
+
+def _unwrap_timeout() -> float:
+    """Return the unwrap dial timeout (seconds) from the environment."""
+    raw = os.environ.get(_UNWRAP_VAULT_TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_UNWRAP_TIMEOUT_SECONDS
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise WrappedCredentialError(
+            f"{_UNWRAP_VAULT_TIMEOUT_ENV} must be a number, got {raw!r}"
+        ) from exc
+
+
+def _build_unwrap_client(wrapping_token: str) -> hvac.Client:
+    """Construct a Vault client that authenticates *as the wrapping token*.
+
+    The runner presents the single-use wrapping token itself (self-
+    authorising unwrap) — no standing runner Vault credential, and no acting-
+    operator JWT. The Vault address is read from the runner's environment
+    (``MEHO_RUNNER_VAULT_ADDR``), fail-closed when unset.
+    """
+    addr = os.environ.get(_UNWRAP_VAULT_ADDR_ENV)
+    if not addr or not addr.strip():
+        raise WrappedCredentialError(
+            f"cannot unwrap a wrapped credential: {_UNWRAP_VAULT_ADDR_ENV} is not "
+            "set; the satellite runner needs an outbound Vault address to unwrap "
+            "per-work-item credentials"
+        )
+    namespace = os.environ.get(_UNWRAP_VAULT_NAMESPACE_ENV) or None
+    return hvac.Client(
+        url=addr.strip().rstrip("/"),
+        namespace=namespace,
+        timeout=_unwrap_timeout(),
+        token=wrapping_token,
+    )
+
+
+def _unwrap_payload(response: object, *, target_name: str) -> dict[str, object]:
+    """Pull the secret-field dict out of a ``sys/wrapping/unwrap`` response."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        raise WrappedCredentialError(
+            f"unwrap for target {target_name!r} returned a malformed payload: "
+            "expected a 'data' object holding the wrapped secret fields"
+        )
+    return data
+
+
+class WrappedCredentialBackend:
+    """Runner-side unwrap of a per-work-item single-use wrapped credential.
+
+    Registered under kind ``wrapped`` on the credential seam, so a connector
+    handler resolving a ``wrapped:<token>`` ``secret_ref`` dispatches here.
+    It presents the wrapping token itself to Vault's unwrap endpoint — the
+    ``operator`` argument (empty ``raw_jwt`` on the runner) is deliberately
+    **ignored**, which is how mechanism 3 closes the empty-JWT gap (§1.4):
+    the runner never needs the acting operator's Vault identity.
+
+    Vault consumes the wrapping token on the first unwrap, so the single-use
+    property is enforced by Vault, not by local state: a second unwrap of the
+    same token (a replay or spool redelivery) fails closed with
+    :class:`WrappedCredentialError`.
+    """
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str = DEFAULT_KV_MOUNT,
+    ) -> dict[str, object]:
+        """Unwrap *secret_ref* (the wrapping token) outbound, just-in-time.
+
+        *secret_ref* is the wrapping token — the ``wrapped:`` scheme is already
+        stripped by the seam dispatcher. Builds an outbound Vault client that
+        authenticates as the token and POSTs to ``sys/wrapping/unwrap`` off the
+        event loop, then returns the unwrapped secret-field dict.
+
+        Raises :class:`WrappedCredentialError` when the token is expired,
+        already consumed, or invalid, when the outbound dial fails, or when the
+        unwrapped payload is malformed.
+        """
+        client = _build_unwrap_client(secret_ref)
+        try:
+            response = await asyncio.to_thread(client.sys.unwrap)
+        except (hvac.exceptions.VaultError, requests.exceptions.RequestException) as exc:
+            raise WrappedCredentialError(
+                f"unwrap failed for target {target_name!r}: the single-use wrapped "
+                "credential is expired, already consumed, or invalid, or Vault was "
+                f"unreachable ({type(exc).__name__})"
+            ) from exc
+        return _unwrap_payload(response, target_name=target_name)
+
+
+def screen_remote_write_credential(target_descriptor: object) -> str | None:
+    """Edge fail-closed guard: a remote-write item must be wrapped, or refuse.
+
+    Returns a refusal reason string when *target_descriptor* does not carry a
+    per-work-item single-use ``wrapped:`` credential — a missing target, or a
+    standing/broad ``secret_ref`` (schemeless, ``vault:``, ``gsm:``, …) that
+    would let the runner perform a standing read. Returns ``None`` when the
+    descriptor carries a wrapped credential and the item may proceed.
+
+    This is mechanism 3's edge check that "standing broad runner credentials
+    are rejected for the write tier": a config that ships a standing
+    ``secret_ref`` to a ``remote-write`` op fails closed here. It composes
+    with (does not replace) the composed remote-write gate
+    (:func:`~meho_backplane.runner.satellite_tier.evaluate_remote_write_gate`,
+    owned by #3189) — the edge screen calls both.
+    """
+    secret_ref = getattr(target_descriptor, "secret_ref", None)
+    if is_wrapped_credential_ref(secret_ref):
+        return None
+    return (
+        "remote-write item refused: it must carry a per-work-item single-use "
+        f"wrapped credential ({WRAPPED_CREDENTIAL_SCHEME}:<token>), not a standing "
+        "broad credential; no standing runner credential is permitted on the "
+        "write tier"
+    )
+
+
+#: The wrapped backend is stateless (it builds a fresh client per unwrap), so
+#: one shared instance serves every runner unwrap. Registered at import under
+#: ``wrapped``; :mod:`meho_backplane.connectors._shared` imports this module so
+#: the kind is present before any credential resolution (mould: ``gsm_creds``).
+register_credential_backend(WRAPPED_CREDENTIAL_SCHEME, WrappedCredentialBackend())

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -39,6 +39,7 @@ from typing import Any
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.wrapped_creds import screen_remote_write_credential
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.operations._handler_resolve import (
     get_or_create_connector_instance,
@@ -100,6 +101,13 @@ def _screen_item(item: RunnerWorkItem) -> str | None:
         decision = evaluate_remote_write_gate(op_id=item.op_id)
         if not decision.permitted:
             return decision.reason
+        # Mechanism 3 (#3191) edge check, composed after the gate: a
+        # remote-write item must carry a per-work-item single-use wrapped
+        # credential — a standing/broad secret_ref is refused, so no standing
+        # runner credential ever rides the write tier.
+        cred_refusal = screen_remote_write_credential(item.target_descriptor)
+        if cred_refusal is not None:
+            return cred_refusal
     if not item.handler_ref.startswith(_CONNECTOR_MODULE_PREFIX):
         return f"handler_ref {item.handler_ref!r} is outside {_CONNECTOR_MODULE_PREFIX}*"
     return None

--- a/backend/tests/test_connectors_wrapped_creds.py
+++ b/backend/tests/test_connectors_wrapped_creds.py
@@ -360,6 +360,54 @@ def test_screen_refuses_when_target_descriptor_is_none() -> None:
     assert WRAPPED_CREDENTIAL_SCHEME in reason
 
 
+async def test_executor_refuses_remote_write_without_wrapped_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end edge enforcement: with the composed gate permitting (its real
+    # wiring is #3189), a remote-write item whose target carries a standing
+    # secret_ref is still refused at the edge by the mechanism-3 credential
+    # screen — no standing runner credential ever rides the write tier.
+    from meho_backplane.runner import executor
+    from meho_backplane.runner.satellite_tier import RemoteWriteGateDecision
+    from meho_backplane.runner.wire import (
+        ResolvedTargetDescriptor,
+        RunnerPrincipal,
+        RunnerWorkItem,
+    )
+
+    monkeypatch.setattr(
+        executor,
+        "evaluate_remote_write_gate",
+        lambda **_kw: RemoteWriteGateDecision(permitted=True, reason="permitted-in-test"),
+    )
+
+    descriptor = ResolvedTargetDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        name="vc-a",
+        product="vmware",
+        host="vc-a.example.internal",
+        secret_ref="targets/vc-a",  # standing/broad — not a wrapped token
+    )
+    item = RunnerWorkItem(
+        check_ref="chk-rw",
+        op_id="vmware.vm.tag_set",
+        product="vmware",
+        handler_ref="meho_backplane.connectors.vmware.ops.tag_set",
+        safety_level="caution",
+        principal=RunnerPrincipal(
+            sub="runner-svc", tenant_id=uuid.uuid4(), tenant_role=TenantRole.READ_ONLY
+        ),
+        target_descriptor=descriptor,
+    )
+
+    result = await executor.execute_work_item(item)
+
+    assert result.status == "refused"
+    assert result.result is None
+    assert "no standing runner credential" in (result.error or "")
+
+
 # ---------------------------------------------------------------------------
 # Seam lazy default — the runner resolves a wrapped: ref with no chassis Settings
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_wrapped_creds.py
+++ b/backend/tests/test_connectors_wrapped_creds.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for per-work-item wrapped-credential brokering (#3191).
+
+Mechanism 3 of the satellite write path: the centre brokers a short-lived,
+single-target-scoped, response-wrapped credential; the runner unwraps it
+just-in-time under the single-use token (not the acting operator's empty
+JWT); a second unwrap fails closed; a remote-write item without a wrapped
+credential is refused at the edge. No live Vault — hvac and the seam read
+are faked.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import hvac
+import hvac.exceptions
+import pytest
+import requests.exceptions
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors._shared import wrapped_creds
+from meho_backplane.connectors._shared.vault_creds import load_vault_secret_data
+from meho_backplane.connectors._shared.wrapped_creds import (
+    WRAPPED_CREDENTIAL_SCHEME,
+    WrappedCredential,
+    WrappedCredentialBackend,
+    WrappedCredentialError,
+    broker_wrapped_credential,
+    is_wrapped_credential_ref,
+    screen_remote_write_credential,
+)
+
+_ADDR_ENV = "MEHO_RUNNER_VAULT_ADDR"
+
+
+def _operator(*, raw_jwt: str = "operator-jwt") -> Operator:
+    return Operator(
+        sub="op-1",
+        raw_jwt=raw_jwt,
+        tenant_id=uuid.uuid4(),
+        tenant_role=TenantRole.READ_ONLY,
+        principal_kind=PrincipalKind.SERVICE,
+    )
+
+
+@dataclass
+class _Target:
+    """Minimal ``BasicCredentialsTargetLike`` for the broker/screen tests."""
+
+    name: str = "vc-a"
+    host: str = "vc-a.example.internal"
+    secret_ref: str | None = "targets/vc-a"
+
+
+# ---------------------------------------------------------------------------
+# Fake Vault client
+# ---------------------------------------------------------------------------
+
+
+class _FakeSys:
+    def __init__(self, client: _FakeVaultClient) -> None:
+        self._client = client
+
+    def wrap(self, payload: dict[str, object] | None = None, ttl: int = 60) -> dict[str, object]:
+        self._client.wrap_payload = payload
+        self._client.wrap_ttl = ttl
+        return {"wrap_info": {"token": self._client.mint_token, "ttl": ttl}}
+
+    def unwrap(self, token: str | None = None) -> dict[str, object]:
+        self._client.unwrap_calls += 1
+        self._client.unwrap_body_token = token
+        if self._client.unwrap_error is not None:
+            raise self._client.unwrap_error
+        # Vault consumes a wrapping token on first unwrap — model single-use.
+        self._client.unwrap_error = hvac.exceptions.InvalidRequest(
+            "wrapping token is not valid or does not exist"
+        )
+        return self._client.unwrap_result
+
+
+class _FakeVaultClient:
+    def __init__(
+        self,
+        *,
+        url: str | None = None,
+        namespace: str | None = None,
+        timeout: float | None = None,
+        token: str | None = None,
+        mint_token: str = "hvs.WRAPTOKEN",
+        unwrap_result: dict[str, object] | None = None,
+        unwrap_error: Exception | None = None,
+    ) -> None:
+        self.url = url
+        self.namespace = namespace
+        self.timeout = timeout
+        self.token = token
+        self.mint_token = mint_token
+        self.unwrap_result = unwrap_result or {"data": {"username": "svc", "password": "pw-A"}}
+        self.unwrap_error = unwrap_error
+        self.unwrap_calls = 0
+        self.unwrap_body_token: str | None = None
+        self.wrap_payload: dict[str, object] | None = None
+        self.wrap_ttl: int | None = None
+        self.sys = _FakeSys(self)
+
+
+# ---------------------------------------------------------------------------
+# is_wrapped_credential_ref
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        ("wrapped:hvs.TOKEN", True),
+        ("wrapped:s.abc123", True),
+        ("wrapped:", False),  # empty token
+        ("targets/vc-a", False),  # schemeless standing ref
+        ("vault:targets/vc-a", False),  # explicit standing ref
+        ("gsm:proj/secret#pw", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_wrapped_credential_ref(ref: str | None, expected: bool) -> None:
+    assert is_wrapped_credential_ref(ref) is expected
+
+
+# ---------------------------------------------------------------------------
+# Broker (centre side)
+# ---------------------------------------------------------------------------
+
+
+def _patch_broker_vault(
+    monkeypatch: pytest.MonkeyPatch, *, secret: dict[str, object], client: _FakeVaultClient
+) -> None:
+    async def _fake_load(
+        target: object, operator: object, *, mount: str = "secret"
+    ) -> dict[str, object]:
+        return dict(secret)
+
+    @contextlib.asynccontextmanager
+    async def _fake_client(operator: object) -> AsyncIterator[_FakeVaultClient]:
+        yield client
+
+    monkeypatch.setattr(wrapped_creds, "load_vault_secret_data", _fake_load)
+    monkeypatch.setattr(wrapped_creds, "vault_client_for_operator", _fake_client)
+
+
+async def test_broker_wraps_exactly_one_targets_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Single-target-scoped: the wrapped payload is exactly the one target's
+    # secret fields, and the returned reference carries only the token — never
+    # the credential value.
+    secret = {"username": "svc", "password": "pw-A"}
+    client = _FakeVaultClient(mint_token="hvs.TOKEN-A")
+    _patch_broker_vault(monkeypatch, secret=secret, client=client)
+    now = datetime.now(UTC)
+
+    wc = await broker_wrapped_credential(
+        _Target(), _operator(), capability_expires_at=now + timedelta(minutes=5), now=now
+    )
+
+    assert isinstance(wc, WrappedCredential)
+    assert wc.unwrap_ref == "wrapped:hvs.TOKEN-A"
+    assert client.wrap_payload == secret  # exactly this target's fields
+    assert "pw-A" not in wc.unwrap_ref  # value never rides the reference
+
+
+async def test_broker_bounds_ttl_to_capability_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    # TTL ≤ capability expiry: a generous requested TTL is capped to the
+    # headroom, and expires_at never exceeds the capability's.
+    client = _FakeVaultClient()
+    _patch_broker_vault(monkeypatch, secret={"username": "svc"}, client=client)
+    now = datetime.now(UTC)
+    expiry = now + timedelta(seconds=30)
+
+    wc = await broker_wrapped_credential(
+        _Target(), _operator(), capability_expires_at=expiry, requested_ttl_seconds=3600, now=now
+    )
+
+    assert wc.wrap_ttl_seconds == 30
+    assert client.wrap_ttl == 30
+    assert wc.expires_at <= expiry
+
+
+async def test_broker_honours_shorter_requested_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeVaultClient()
+    _patch_broker_vault(monkeypatch, secret={"username": "svc"}, client=client)
+    now = datetime.now(UTC)
+
+    wc = await broker_wrapped_credential(
+        _Target(),
+        _operator(),
+        capability_expires_at=now + timedelta(hours=1),
+        requested_ttl_seconds=45,
+        now=now,
+    )
+
+    assert wc.wrap_ttl_seconds == 45
+
+
+async def test_broker_refuses_already_expired_capability(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_broker_vault(monkeypatch, secret={"username": "svc"}, client=_FakeVaultClient())
+    now = datetime.now(UTC)
+
+    with pytest.raises(WrappedCredentialError, match="not in the future"):
+        await broker_wrapped_credential(
+            _Target(), _operator(), capability_expires_at=now - timedelta(seconds=1), now=now
+        )
+
+
+async def test_broker_refuses_non_positive_requested_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_broker_vault(monkeypatch, secret={"username": "svc"}, client=_FakeVaultClient())
+    now = datetime.now(UTC)
+
+    with pytest.raises(WrappedCredentialError, match="must be positive"):
+        await broker_wrapped_credential(
+            _Target(),
+            _operator(),
+            capability_expires_at=now + timedelta(minutes=5),
+            requested_ttl_seconds=0,
+            now=now,
+        )
+
+
+async def test_broker_refuses_when_vault_returns_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NoTokenSys(_FakeSys):
+        def wrap(
+            self, payload: dict[str, object] | None = None, ttl: int = 60
+        ) -> dict[str, object]:
+            return {"wrap_info": {}}  # missing token
+
+    client = _FakeVaultClient()
+    client.sys = _NoTokenSys(client)
+    _patch_broker_vault(monkeypatch, secret={"username": "svc"}, client=client)
+    now = datetime.now(UTC)
+
+    with pytest.raises(WrappedCredentialError, match="no wrapping token"):
+        await broker_wrapped_credential(
+            _Target(), _operator(), capability_expires_at=now + timedelta(minutes=5), now=now
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner unwrap backend (edge side)
+# ---------------------------------------------------------------------------
+
+
+def _patch_hvac_client(monkeypatch: pytest.MonkeyPatch, client: _FakeVaultClient) -> None:
+    captured: dict[str, object] = {}
+
+    def _factory(**kwargs: object) -> _FakeVaultClient:
+        captured.update(kwargs)
+        client.url = kwargs.get("url")  # type: ignore[assignment]
+        client.namespace = kwargs.get("namespace")  # type: ignore[assignment]
+        client.timeout = kwargs.get("timeout")  # type: ignore[assignment]
+        client.token = kwargs.get("token")  # type: ignore[assignment]
+        return client
+
+    monkeypatch.setattr(hvac, "Client", _factory)
+
+
+async def test_backend_unwraps_under_token_not_operator_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # AC#4: the runner presents the single-use wrapping token, NOT the acting
+    # operator — the reconstructed runner operator has an empty raw_jwt, and
+    # the unwrap still succeeds, closing the empty-JWT gap (design §1.4).
+    monkeypatch.setenv(_ADDR_ENV, "https://vault.central:8200/")
+    client = _FakeVaultClient(unwrap_result={"data": {"username": "svc", "password": "pw-A"}})
+    _patch_hvac_client(monkeypatch, client)
+
+    creds = await WrappedCredentialBackend().load_secret_data(
+        "hvs.WRAPTOKEN", _operator(raw_jwt=""), target_name="vc-a"
+    )
+
+    assert creds == {"username": "svc", "password": "pw-A"}
+    # The client authenticated AS the wrapping token (self-authorising unwrap).
+    assert client.token == "hvs.WRAPTOKEN"
+    assert client.url == "https://vault.central:8200"  # trailing slash trimmed
+    assert client.unwrap_calls == 1  # unwrapped exactly once
+
+
+async def test_backend_second_unwrap_of_consumed_token_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Single-use: Vault consumes the token on first unwrap, so a replay /
+    # spool redelivery unwraps a second time and Vault refuses.
+    monkeypatch.setenv(_ADDR_ENV, "https://vault.central:8200")
+    client = _FakeVaultClient()
+    _patch_hvac_client(monkeypatch, client)
+    backend = WrappedCredentialBackend()
+
+    first = await backend.load_secret_data("hvs.WRAPTOKEN", _operator(), target_name="vc-a")
+    assert first["username"] == "svc"
+
+    with pytest.raises(WrappedCredentialError, match="expired, already consumed, or invalid"):
+        await backend.load_secret_data("hvs.WRAPTOKEN", _operator(), target_name="vc-a")
+
+
+async def test_backend_maps_unreachable_vault_to_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_ADDR_ENV, "https://vault.central:8200")
+    client = _FakeVaultClient(unwrap_error=requests.exceptions.ConnectionError("boom"))
+    _patch_hvac_client(monkeypatch, client)
+
+    with pytest.raises(WrappedCredentialError, match="Vault was unreachable"):
+        await WrappedCredentialBackend().load_secret_data(
+            "hvs.WRAPTOKEN", _operator(), target_name="vc-a"
+        )
+
+
+async def test_backend_rejects_malformed_unwrap_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ADDR_ENV, "https://vault.central:8200")
+    client = _FakeVaultClient(unwrap_result={"not_data": {}})
+    _patch_hvac_client(monkeypatch, client)
+
+    with pytest.raises(WrappedCredentialError, match="malformed payload"):
+        await WrappedCredentialBackend().load_secret_data(
+            "hvs.WRAPTOKEN", _operator(), target_name="vc-a"
+        )
+
+
+async def test_backend_fails_closed_without_vault_addr(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ADDR_ENV, raising=False)
+
+    with pytest.raises(WrappedCredentialError, match=_ADDR_ENV):
+        await WrappedCredentialBackend().load_secret_data(
+            "hvs.WRAPTOKEN", _operator(), target_name="vc-a"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge fail-closed screen (standing broad creds rejected on the write tier)
+# ---------------------------------------------------------------------------
+
+
+def test_screen_permits_a_wrapped_credential() -> None:
+    assert screen_remote_write_credential(_Target(secret_ref="wrapped:hvs.TOKEN")) is None
+
+
+@pytest.mark.parametrize("ref", ["targets/vc-a", "vault:targets/vc-a", "gsm:proj/s#pw", None])
+def test_screen_refuses_standing_or_missing_credential(ref: str | None) -> None:
+    reason = screen_remote_write_credential(_Target(secret_ref=ref))
+    assert reason is not None
+    assert "no standing runner credential" in reason
+
+
+def test_screen_refuses_when_target_descriptor_is_none() -> None:
+    reason = screen_remote_write_credential(None)
+    assert reason is not None
+    assert WRAPPED_CREDENTIAL_SCHEME in reason
+
+
+# ---------------------------------------------------------------------------
+# Seam lazy default — the runner resolves a wrapped: ref with no chassis Settings
+# ---------------------------------------------------------------------------
+
+
+async def test_wrapped_ref_resolves_without_get_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The DB-free runner cannot build the chassis Settings. An explicit
+    # ``wrapped:`` ref must resolve through the seam without a get_settings()
+    # call — prove it by making get_settings() raise and asserting resolution
+    # still dispatches to the wrapped backend.
+    calls = {"get_settings": 0}
+
+    def _boom() -> object:
+        calls["get_settings"] += 1
+        raise RuntimeError("chassis Settings unavailable on the runner")
+
+    async def _fake_load_secret_data(
+        self: object, secret_ref: str, operator: object, *, target_name: str, mount: str
+    ) -> dict[str, object]:
+        return {"resolved_token": secret_ref}
+
+    monkeypatch.setattr("meho_backplane.connectors._shared.vault_creds.get_settings", _boom)
+    monkeypatch.setattr(WrappedCredentialBackend, "load_secret_data", _fake_load_secret_data)
+
+    data = await load_vault_secret_data(_Target(secret_ref="wrapped:hvs.TOKEN"), _operator())
+
+    assert data == {"resolved_token": "hvs.TOKEN"}  # scheme stripped, no settings read
+    assert calls["get_settings"] == 0
+
+
+async def test_schemeless_ref_still_consults_get_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Contrast: a schemeless ref keeps today's behaviour and routes through
+    # the deployment default backend (a get_settings() read).
+    calls = {"get_settings": 0}
+
+    def _raise_after_count() -> object:
+        calls["get_settings"] += 1
+        raise RuntimeError("routed through settings")
+
+    monkeypatch.setattr(
+        "meho_backplane.connectors._shared.vault_creds.get_settings", _raise_after_count
+    )
+
+    with pytest.raises(RuntimeError, match="routed through settings"):
+        await load_vault_secret_data(_Target(secret_ref="targets/vc-a"), _operator())
+
+    assert calls["get_settings"] == 1

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -182,6 +182,60 @@ rides a runner — the satellite write-path decision's "delete-shaped
 operations never minted to a satellite," dovetailing with #3196's default
 gate exclusions.
 
+## Per-work-item wrapped-credential brokering — the write path (#3191)
+
+A `remote-write` op mutates a vendor estate, so it needs a **vendor
+credential** at the edge — but the read path's credential resolution stumbles
+on the runner: `load_basic_credentials` resolves a target's `secret_ref`
+through `vault_client_for_operator`, which needs `operator.raw_jwt`, and the
+runner reconstructs its acting operator with an **empty** `raw_jwt` (the
+empty-JWT gap, decision §1.4). Handing the runner a **standing broad** vendor
+credential instead is the write path's worst case (threat T3): a compromised
+fenced host would hold broad estate-mutation power for the credential's whole
+life.
+
+Mechanism 3 (`connectors/_shared/wrapped_creds.py`) resolves both without a
+standing credential and without the operator JWT:
+
+- **Centre broker** (`broker_wrapped_credential`) — at the authorised
+  remote-write mint (where the operator *is* present with a real JWT), the
+  centre reads **one** target's secret and Vault-**response-wraps** that single
+  payload with a TTL bounded so the credential never outlives the capability
+  (`credential TTL ≤ expires_at`). It returns only a `wrapped:<token>`
+  reference; the credential value never leaves the centre. The brokered
+  reference is set as the runner-bound target descriptor's `secret_ref` at
+  mint (the approval-bound mint seam, #3189, calls the broker — this function
+  *is* the seam).
+- **Runner unwrap backend** (`WrappedCredentialBackend`, registered under kind
+  `wrapped` on the shared credential seam) — the disk-spooled item carries only
+  the single-use token as `secret_ref = wrapped:<token>`, honouring the
+  no-durable-artifact rule (`wire.py`). At execution a connector handler's
+  unchanged `load_basic_credentials` call dispatches to this backend, which
+  dials Vault **outbound** (push-only preserved, #2877) and presents the
+  **wrapping token itself** to the unwrap endpoint — *not* the acting operator
+  (its empty `raw_jwt` is ignored). Vault consumes the token on the first
+  unwrap, so single-use is enforced by Vault: a replay or spool redelivery
+  unwraps a second time and Vault refuses.
+- **Seam, not a fork.** `wrapped_creds` registers alongside `vault` / `gsm`
+  (`_shared/__init__.py`, mould: `gsm_creds`) and reuses `load_vault_secret_data`
+  for the centre-side read. Resolving an explicit-scheme ref (the `wrapped:`
+  token) no longer consults the chassis `Settings` (`credential_backend.py::parse_credential_scheme`
+  + the lazy default in `vault_creds._resolve_and_load`), so the **DB-free
+  runner** — which cannot build `Settings` — resolves a wrapped credential.
+
+**Fail-closed at the edge.** `screen_remote_write_credential` (composed after
+the remote-write gate in `executor._screen_item`) refuses a `remote-write`
+item whose target carries a standing/broad `secret_ref` (schemeless, `vault:`,
+`gsm:`, …) or no target at all — only a single-use `wrapped:` credential may
+ride the write tier, so a config that would grant a standing runner credential
+fails closed. An expired or already-consumed token fails closed at unwrap.
+
+**Runner env for the outbound unwrap.** `MEHO_RUNNER_VAULT_ADDR` (required for
+the write tier — the runner needs an outbound Vault to unwrap against; unset
+fails closed), plus optional `MEHO_RUNNER_VAULT_NAMESPACE` (Enterprise) and
+`MEHO_RUNNER_VAULT_TIMEOUT_SECONDS` (default 10). Wrapped brokering is a Vault
+feature; a Vault-free (`gsm`) deployment has no wrapped-brokering path yet.
+
 ## Dead-man switch + mandatory heartbeat (#2501)
 
 A runner that dies, wedges, or loses its network path must not leave its


### PR DESCRIPTION
## Summary

- **Mechanism 3 of the satellite write path** (Initiative #2901, `docs/decisions/satellite-write-path.md` §3): per-work-item **short-lived, single-target-scoped, Vault-response-wrapped** vendor credentials for the `remote-write` tier — no standing broad credential ever lands on a fenced runner (threat T3).
- **Centre broker** (`connectors/_shared/wrapped_creds.py::broker_wrapped_credential`) reads one target's secret under the authorising operator (present at mint) and response-wraps it with a TTL bounded so **credential TTL ≤ capability `expires_at`**; it returns only a `wrapped:<token>` reference — the credential value never leaves the centre.
- **Runner unwrap backend** (`WrappedCredentialBackend`, registered under kind `wrapped` on the existing credential seam) unwraps **just-in-time at execution** on an **outbound** dial (push-only preserved, #2877), presenting the **single-use wrapping token itself** — not the acting operator's empty JWT. This **closes the empty-JWT edge-credential gap** (design §1.4): a `wrapped:` credential resolves on the DB-free runner with no chassis `Settings` and no operator identity.
- **Rides the seam, not a fork**: connector handlers resolve a wrapped credential through the unchanged `load_basic_credentials` call; `wrapped_creds` registers alongside `vault`/`gsm` (mould: `gsm_creds`).

## Scope / sibling sequencing (#2901 write path)

- This PR ships the **credential-brokering mechanism + the edge fail-closed guard** only. It does **not** wire the composed `evaluate_remote_write_gate` and does **not** touch the #3188 tier tests.
- **Mint-path touch-point for the orchestrator / #3189**: the approval-bound remote-write mint should call `broker_wrapped_credential(operator, target, capability_expires_at=expires_at, …)` after the gate permits, and set the returned `WrappedCredential.unwrap_ref` as the runner-bound target descriptor's `secret_ref`. `broker_wrapped_credential` **is** that seam — no edit was made to `mint_gateway_command` (its contested region is #3189's), so there is nothing to rebase there.
- **Edge touch-point**: `screen_remote_write_credential` is composed **after** #3189's gate check in `executor._screen_item` (additive block, clearly delimited). Expect mechanical union churn there with #3189 — keep both sides.

## Fail-closed conformance (each tested)

- Second unwrap of a consumed token → refused (Vault consumes on first unwrap). Expired token → refused. Outbound Vault unreachable → refused.
- A `remote-write` item carrying a standing/broad `secret_ref` (schemeless / `vault:` / `gsm:`) or no target → refused at the edge (`screen_remote_write_credential`) — a config that would grant a standing runner credential fails closed.
- `MEHO_RUNNER_VAULT_ADDR` unset → refused (nothing to unwrap against).
- Never weakened: `dangerous`/`destructive` stay unmintable; `test_satellite_mint_refuses_op_not_safe` + the #3188 tier tests are untouched and green.

## Migration

**None.** Wrapped credentials are transient and ride the existing `secret_ref` wire field — no durable column is needed. (Head on main is `0087`; this PR adds no revision.)

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (4 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (2 warnings are pre-existing `vault_creds.py` debt, not introduced here)
- [x] New `tests/test_connectors_wrapped_creds.py` — broker (single-target scope, TTL ≤ expiry, refusals), unwrap backend (once-only, second-unwrap-fails, token-not-operator identity, malformed/unreachable/no-addr fail-closed), edge screen, seam lazy-default (wrapped ref resolves with no `get_settings()`)
- [x] Adjacent/protected suites green: `test_gateway_commands`, `test_runner_satellite_tier`, `test_runner_executor`, `test_connectors_vault_creds`, `test_connectors_credential_backend`, connector auth suites, `test_connectors_vmware_rest_vm_destroy` — 197 passed
- [x] Import smoke: central app + runner eager-import both register `wrapped` alongside `vault`/`gsm`

## Out of scope (sibling tasks under #2901)

- Composed gate wiring + approval-bound mint (#3189) · revocation (#3192) · store-and-forward effect audit + un-reported-mint alarm.
- Vault-free (`gsm`) deployments: response-wrapping is a Vault feature, so wrapped brokering requires Vault — a later additive concern.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3191
