### PR TITLE
feat(gateway): satellite write path — revocation hardening for write-capable runners (Stage-3 gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — satellite write path: revocation hardening for write-capable runners (#3192)
+
+- Closes the T8 already-minted-write gap: a **revoked** runner can no longer
+  obtain **or execute** a `remote-write` capability, while the read path's
+  coarse kill switch (Keycloak `enabled=false` + token TTL + dead-man switch)
+  stays deliberately unchanged. This is the **Stage-3 gate** of the satellite
+  write-path decision (recommendation 3) — the write tier does not reach
+  steady state on TTL + dead-man alone.
+- **No new mint:** `mint_gateway_command` refuses a `remote-write` mint for a
+  revoked runner with `MintRefusalCode.RUNNER_REVOKED`, checked (off the
+  runner principal's live `revoked` column) *before* the composed gate and
+  scoped to the write tier — a `safe` mint is untouched.
+- **No delivery of an already-minted write:** the poll route threads the
+  runner's live `revoked` flag into `claim_next_command`, which narrows a
+  revoked runner's claim to non-`remote-write` rows, so a write minted before
+  revocation is never delivered afterwards (it stays `pending` and expires
+  under its TTL) — a queued `safe` read still delivers. Backed by a new
+  denormalised `gateway_command.safety_level` column (migration `0091`).
+- **Auditable:** revoking a runner writes a tamper-evident internal audit row
+  (`path='runner.principal.revoked'`), distinct from the liveness dead-man
+  flip. The residual in-flight (already-`delivered`) window is bounded by the
+  capability TTL and the #3191 credential seam.
+
 ### Fixed — large `deploy_from_library` OVAs: async dispatch survives caller disconnect + a 3 h sync read ceiling (#3176)
 
 - `vmware.composite.vm.deploy_from_library` of a **multi-GB** content-library

--- a/backend/alembic/versions/0091_add_gateway_command_safety_level.py
+++ b/backend/alembic/versions/0091_add_gateway_command_safety_level.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``gateway_command.safety_level`` for write-capable-runner revocation (#3192).
+
+Revision ID: 0091
+Revises: 0087
+Create Date: 2026-08-31
+
+Initiative #2901 (satellite write path), Task #3192 — revocation hardening
+for write-capable runners (the Stage-3 gate of decision
+``docs/decisions/satellite-write-path.md``, recommendation 3 / threat T8).
+
+One column on ``gateway_command``:
+
+* ``safety_level`` — Text NOT NULL. The op's ``safety_level`` denormalised
+  onto the command row at mint, so the DB-side delivery path
+  (``claim_next_command``) can tier-scope the revocation refusal to the
+  ``remote-write`` tier without re-resolving the descriptor. A revoked
+  runner's claim narrows to ``safety_level NOT IN`` the remote-write set,
+  so an already-minted, not-yet-expired ``remote-write`` capability is never
+  delivered post-revocation, while a ``safe`` (read) capability is
+  unaffected — the read path's coarse kill switch stays unchanged. Same
+  "bind at mint, check at delivery without a re-lookup" discipline as the
+  ``params_hash`` / ``expires_at`` capability columns (``0061``).
+
+Serialized order (house Alembic rule): this extends the current head
+``0087`` (#3216's ``tenant.flight_recorder_agent_readable``) at author time.
+The **number 0091** is chosen to sit clear of the concurrent racers under
+this same #2901 initiative: sibling #3230 already claims ``0088``
+(``reap_probe_epoch_impl_id_registrations``), and ``0089`` / ``0090`` are
+reserved for #3189 / #3191; 0091 is the next free number after those, so
+there is no duplicate-revision-id clash. Only the ``down_revision`` pointer
+to the real current head is load-bearing, never the number — if a sibling
+migration lands on main first (e.g. #3230's ``0088`` chaining ``0087``),
+re-point this ``down_revision`` to the new head before merge so ``0087``
+keeps a single child (no branched heads). The orchestrator re-points at
+merge if the race lands differently.
+
+NOT NULL ADD COLUMN on an empty clean-slate table
+-------------------------------------------------
+
+``gateway_command`` is a clean-slate table (``0059``), so it is empty in
+every environment. ``safety_level`` is added NOT NULL with a **constant**
+``server_default`` (``'safe'`` — house pattern ``0044`` / ``0057`` / ``0061``):
+SQLite's ``ALTER TABLE ADD COLUMN`` forbids an expression default on a NOT
+NULL column, so the default is a literal constant. ``'safe'`` is the
+read-tier fail-safe — a legacy or direct-enqueue row that omits the level is
+classified as a read, never a remote-write, so the revocation filter never
+mis-refuses a read — but no real minted row sees it: the mint /
+``enqueue_command`` path stamps the descriptor's true ``safety_level``.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` adds the column; ``downgrade()`` drops it. Purely additive on
+the way up (no destructive DDL), so the migration-compat CI guard passes.
+SQLite drop-column is supported since 3.35.0 (we're on 3.45+), so Alembic
+batch mode is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0091"
+down_revision: str | None = "0087"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``safety_level`` column to ``gateway_command``."""
+    op.add_column(
+        "gateway_command",
+        sa.Column(
+            "safety_level",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'safe'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``safety_level`` column."""
+    op.drop_column("gateway_command", "safety_level")

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -208,8 +208,15 @@ async def poll_next_command(
     sessionmaker = get_sessionmaker()
 
     # Scope gate first: bind the token's runner_id to the named row (#2502).
+    # The resolved principal carries the live ``revoked`` flag (#3192): read
+    # it here (once per poll) and thread it into the claim so a revoked runner
+    # is never delivered an already-minted remote-write, while its safe (read)
+    # queue still drains -- the read path's coarse kill switch is unchanged.
+    # ``expire_on_commit=False`` keeps the attribute readable after the
+    # scope gate commits its heartbeat and the session block closes.
     async with sessionmaker() as session:
-        await assert_runner_scope(operator, runner_name=runner, session=session)
+        principal = await assert_runner_scope(operator, runner_name=runner, session=session)
+        runner_revoked = principal.revoked
 
     effective_wait = clamp_longpoll_wait(wait)
     loop = asyncio.get_running_loop()
@@ -219,7 +226,10 @@ async def poll_next_command(
         while True:
             async with sessionmaker() as session:
                 command = await claim_next_command(
-                    session, tenant_id=operator.tenant_id, runner_id=runner
+                    session,
+                    tenant_id=operator.tenant_id,
+                    runner_id=runner,
+                    runner_revoked=runner_revoked,
                 )
                 if command is not None:
                     envelope = _envelope(command)

--- a/backend/src/meho_backplane/auth/runner_principals.py
+++ b/backend/src/meho_backplane/auth/runner_principals.py
@@ -49,6 +49,7 @@ token-issuing runner as revoked.
 from __future__ import annotations
 
 import re
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import Final
@@ -66,6 +67,7 @@ from meho_backplane.auth.keycloak_admin import (
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import RunnerPrincipal
+from meho_backplane.memory.audit import INTERNAL_METHOD, write_internal_audit_row
 from meho_backplane.scheduler.vault_credentials import (
     SchedulerVaultNotConfiguredError,
     write_agent_secret,
@@ -97,6 +99,19 @@ NAME_MAX_LENGTH: Final[int] = 128
 
 #: Convention: the Keycloak clientId for a runner principal.
 _CLIENT_ID_PREFIX: str = "runner:"
+
+#: Audit ``path`` for a runner-principal revocation (#3192). Revocation is the
+#: write-path kill switch (satellite write-path decision, mechanism 4:
+#: "revocation observable"); this row is the tamper-evident trail that a
+#: runner's write capability was withdrawn, distinct from the liveness
+#: ``gateway.runner.stale`` dead-man flip. Written on the central clock with a
+#: system-attributed ``operator_sub`` (the service method takes no operator).
+_REVOKE_AUDIT_PATH: str = "runner.principal.revoked"
+
+#: System identity stamped on the revocation audit row (the revoke service
+#: method is invoked by the REST route but does not thread the operator sub);
+#: a stable name so audit filters can partition by this background source.
+_REVOKE_AUDIT_SUB: str = "system:runner-principal-revoke"
 
 #: ``tenant_role`` stamped into the runner client's access token. Read-only
 #: credential scope in v1 (vs the agent's ``tenant_admin``): a runner is a
@@ -478,6 +493,28 @@ class RunnerPrincipalService:
             return None
         return RunnerPrincipalRead.model_validate(row)
 
+    async def _disable_keycloak_client(
+        self, keycloak_internal_id: str, *, tenant_id: uuid.UUID, name: str
+    ) -> None:
+        """Disable the runner's Keycloak client — the authoritative kill switch.
+
+        Called *before* the DB row is marked revoked so a non-404 failure
+        aborts the revoke without falsely reporting a still-token-issuing
+        runner as revoked. A Keycloak *not-found* is treated as success (the
+        client is already gone) and the caller still marks the row revoked.
+        """
+        kc_client = KeycloakAdminClient.from_settings()
+        try:
+            async with kc_client:
+                await kc_client.disable_client(keycloak_internal_id)
+        except KeycloakClientNotFoundError:
+            self._log.warning(
+                "runner_principal_revoke_keycloak_not_found",
+                tenant_id=str(tenant_id),
+                name=name,
+                keycloak_internal_id=keycloak_internal_id,
+            )
+
     async def revoke(
         self,
         tenant_id: uuid.UUID,
@@ -507,6 +544,7 @@ class RunnerPrincipalService:
             On a non-404 Keycloak Admin API failure — the DB row is left
             unchanged, so the runner stays active and the operator can retry.
         """
+        started = time.monotonic()
         sessionmaker = get_sessionmaker()
         # Phase 1: validate + fetch the Keycloak internal id (read-only).
         async with sessionmaker() as session:
@@ -523,19 +561,9 @@ class RunnerPrincipalService:
             keycloak_internal_id = row.keycloak_internal_id
 
         # Phase 2: disable the Keycloak client FIRST (authoritative kill
-        # switch). A non-404 failure propagates before any DB write, so a
-        # runner is never marked revoked while it can still mint tokens.
-        kc_client = KeycloakAdminClient.from_settings()
-        try:
-            async with kc_client:
-                await kc_client.disable_client(keycloak_internal_id)
-        except KeycloakClientNotFoundError:
-            self._log.warning(
-                "runner_principal_revoke_keycloak_not_found",
-                tenant_id=str(tenant_id),
-                name=name,
-                keycloak_internal_id=keycloak_internal_id,
-            )
+        # switch) — before any DB write, so a runner is never marked revoked
+        # while it can still mint tokens.
+        await self._disable_keycloak_client(keycloak_internal_id, tenant_id=tenant_id, name=name)
 
         # Phase 3: persist revoked=true now that the client is disabled.
         async with sessionmaker() as session:
@@ -556,6 +584,20 @@ class RunnerPrincipalService:
             await session.refresh(row)
             entry = RunnerPrincipalRead.model_validate(row)
             await session.commit()
+
+        # Revocation audit trail (#3192, mechanism 4): a tamper-evident row
+        # proving the runner's write capability was withdrawn, on the central
+        # clock, distinct from the liveness dead-man flip. Written after the
+        # DB commit so it records only a completed revocation.
+        await write_internal_audit_row(
+            operator_sub=_REVOKE_AUDIT_SUB,
+            tenant_id=tenant_id,
+            method=INTERNAL_METHOD,
+            path=_REVOKE_AUDIT_PATH,
+            status_code=200,
+            duration_ms=(time.monotonic() - started) * 1000,
+            payload={"runner": name, "keycloak_internal_id": keycloak_internal_id},
+        )
 
         self._log.info(
             "runner_principal_revoke",

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6158,6 +6158,20 @@ class GatewayCommand(Base):
       result's audit row stamps ``parent_audit_id = mint_audit_id`` so a
       remote execution forms one audit subtree.
 
+    Revocation hardening (#3192, migration ``0091``)
+    ------------------------------------------------
+
+    * ``safety_level`` -- Text NOT NULL. The op's ``safety_level``
+      denormalised at mint so the delivery path can tier-scope the
+      write-capable-runner revocation refusal without a second descriptor
+      lookup: a revoked runner's ``claim_next_command`` narrows to
+      ``safety_level NOT IN`` the remote-write set, so an already-minted
+      ``remote-write`` capability is never delivered post-revocation while a
+      ``safe`` (read) capability is unaffected. The constant ``'safe'``
+      server_default is the read-tier fail-safe for the ADD COLUMN on the
+      empty clean-slate table; every minted row is stamped by
+      ``enqueue_command``.
+
     Index
     -----
 
@@ -6248,6 +6262,22 @@ class GatewayCommand(Base):
         Uuid(),
         nullable=True,
         default=None,
+    )
+    # --- Revocation hardening (#3192, migration 0091) ------------------
+    # The op's ``safety_level`` denormalised onto the row at mint, so the
+    # DB-side delivery path can tier-scope the write-capable-runner
+    # revocation refusal (``claim_next_command``) without a second
+    # descriptor lookup -- the same "bind at mint, check at delivery"
+    # discipline ``params_hash`` / ``expires_at`` follow. NOT NULL with a
+    # constant ``'safe'`` server_default: the ADD COLUMN lands on the empty
+    # clean-slate table (SQLite forbids an expression default here), and
+    # ``'safe'`` is the read-tier default so a legacy / direct-enqueue row
+    # is never mis-classified as a remote-write. ``enqueue_command`` stamps
+    # the descriptor's real level on every minted row.
+    safety_level: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=sa.text("'safe'"),
     )
 
     __table_args__ = (

--- a/backend/src/meho_backplane/gateway/queue.py
+++ b/backend/src/meho_backplane/gateway/queue.py
@@ -51,11 +51,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Final
 
 import structlog
-from sqlalchemy import select, update
+from sqlalchemy import Select, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
 from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.runner.satellite_tier import REMOTE_WRITE_SAFETY_LEVELS
 
 __all__ = [
     "GATEWAY_COMMAND_DEFAULT_TTL",
@@ -174,6 +175,7 @@ async def enqueue_command(
     params_hash: str | None = None,
     expires_at: datetime | None = None,
     mint_audit_id: uuid.UUID | None = None,
+    safety_level: str = "safe",
 ) -> GatewayCommand:
     """Insert a ``pending`` :class:`GatewayCommand` for a runner.
 
@@ -208,6 +210,11 @@ async def enqueue_command(
             ceiling); the default TTL when omitted.
         mint_audit_id: The id of the synchronous ``gateway.command.mint``
             audit row, stamped for result → mint audit lineage.
+        safety_level: The op's ``safety_level`` (#3192), denormalised onto
+            the row so the delivery path can tier-scope the
+            write-capable-runner revocation refusal without re-resolving the
+            descriptor. Defaults to ``'safe'`` (the read tier) for direct
+            enqueues; the mint path passes the descriptor's real level.
 
     Returns:
         The flushed :class:`GatewayCommand` row (with its generated ``id``).
@@ -225,6 +232,7 @@ async def enqueue_command(
         params_hash=params_hash if params_hash is not None else compute_params_hash(params),
         expires_at=bound_capability_expiry(expires_at),
         mint_audit_id=mint_audit_id,
+        safety_level=safety_level,
     )
     session.add(command)
     await session.flush()
@@ -239,11 +247,72 @@ async def enqueue_command(
     return command
 
 
+def _pending_claim_stmt(
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    now: datetime,
+    runner_revoked: bool,
+    for_update: bool,
+) -> Select[tuple[GatewayCommand]]:
+    """Build the oldest-claimable-``pending``-row SELECT for a runner.
+
+    Capability predicate (#2500): only an unexpired (``expires_at > now``),
+    unconsumed (``consumed_at IS NULL``) ``pending`` row is a candidate.
+    Revocation hardening (#3192): when *runner_revoked* the candidate set is
+    narrowed to ``safety_level NOT IN REMOTE_WRITE_SAFETY_LEVELS`` -- a
+    revoked runner never claims an already-minted remote-write, while a
+    ``safe`` (read) row still delivers (the coarse read-path kill switch is
+    unchanged). The NOT NULL ``safety_level`` column keeps that a pure
+    two-valued predicate. *for_update* adds ``FOR UPDATE SKIP LOCKED`` (PG
+    only; a no-op clause on SQLite).
+    """
+    stmt = (
+        select(GatewayCommand)
+        .where(
+            GatewayCommand.tenant_id == tenant_id,
+            GatewayCommand.runner_id == runner_id,
+            GatewayCommand.status == GatewayCommandStatus.PENDING.value,
+            GatewayCommand.expires_at > now,
+            GatewayCommand.consumed_at.is_(None),
+        )
+        .order_by(GatewayCommand.enqueued_at.asc())
+        .limit(1)
+    )
+    if runner_revoked:
+        stmt = stmt.where(GatewayCommand.safety_level.not_in(REMOTE_WRITE_SAFETY_LEVELS))
+    if for_update:
+        stmt = stmt.with_for_update(skip_locked=True)
+    return stmt
+
+
+def _params_hash_intact(row: GatewayCommand, *, tenant_id: uuid.UUID, runner_id: str) -> bool:
+    """Post-mint substitution defence (#2500): stored params still hash true.
+
+    A mismatch means the ``params`` column was mutated after mint -- a tamper
+    signal, not a race -- so delivery is refused fail-closed (the row stays
+    pending) and logged at error level for an operator, the same swap defence
+    ``approve_request`` runs. Returns ``True`` when the row's params still
+    hash to its bound ``params_hash``.
+    """
+    if compute_params_hash(row.params) == row.params_hash:
+        return True
+    structlog.get_logger(__name__).error(
+        "gateway_command_params_hash_mismatch",
+        command_id=str(row.id),
+        tenant_id=str(tenant_id),
+        runner_id=runner_id,
+        op_id=row.op_id,
+    )
+    return False
+
+
 async def claim_next_command(
     session: AsyncSession,
     *,
     tenant_id: uuid.UUID,
     runner_id: str,
+    runner_revoked: bool = False,
 ) -> GatewayCommand | None:
     """Claim the oldest ``pending`` command for a runner; flip it ``delivered``.
 
@@ -261,55 +330,33 @@ async def claim_next_command(
     stamped) on a win, or ``None`` when the queue is empty **or** a
     concurrent claimer won the row between the SELECT and the UPDATE.
 
-    Capability predicate (#2500): only an **unexpired** (``expires_at >
-    now``), **unconsumed** (``consumed_at IS NULL``) ``pending`` row is
-    claimable, so an expired or already-consumed capability is never
-    delivered. Before flipping the row the stored ``params`` are re-hashed
-    against ``params_hash``; a mismatch (post-mint substitution) refuses
-    delivery (returns ``None`` + an error log) — the same swap defence
-    ``approve_request`` runs, here guarding the params column.
+    The claim candidate is built by :func:`_pending_claim_stmt` (the #2500
+    capability predicate + the #3192 revocation narrowing) and the stored
+    ``params`` are re-hashed by :func:`_params_hash_intact` before the flip.
 
     Args:
         session: Open :class:`AsyncSession`; flushed, not committed. The
             caller commits to persist the ``pending -> delivered`` flip.
         tenant_id: The runner's tenant (every query is tenant-scoped).
         runner_id: The runner principal name whose queue to claim from.
+        runner_revoked: When ``True``, exclude ``remote-write``-tier rows
+            from the claim (the runner is revoked, #3192); ``safe`` rows
+            still deliver, so the read path's coarse kill switch is unchanged.
     """
     conn = await session.connection()
     now = datetime.now(UTC)
-    stmt = (
-        select(GatewayCommand)
-        .where(
-            GatewayCommand.tenant_id == tenant_id,
-            GatewayCommand.runner_id == runner_id,
-            GatewayCommand.status == GatewayCommandStatus.PENDING.value,
-            # Capability binding (#2500): never deliver an expired or an
-            # already-consumed command.
-            GatewayCommand.expires_at > now,
-            GatewayCommand.consumed_at.is_(None),
-        )
-        .order_by(GatewayCommand.enqueued_at.asc())
-        .limit(1)
+    stmt = _pending_claim_stmt(
+        tenant_id=tenant_id,
+        runner_id=runner_id,
+        now=now,
+        runner_revoked=runner_revoked,
+        for_update=conn.dialect.name == "postgresql",
     )
-    if conn.dialect.name == "postgresql":
-        stmt = stmt.with_for_update(skip_locked=True)
     row = (await session.execute(stmt)).scalar_one_or_none()
     if row is None:
         return None
 
-    # Post-mint substitution defence (#2500): the stored params must still
-    # hash to the bound params_hash, else refuse delivery. A mismatch means
-    # the params column was mutated after mint — a tamper signal, not a race
-    # — so it is fail-closed (the row stays pending, undelivered) and logged
-    # at error level for an operator to investigate.
-    if compute_params_hash(row.params) != row.params_hash:
-        structlog.get_logger(__name__).error(
-            "gateway_command_params_hash_mismatch",
-            command_id=str(row.id),
-            tenant_id=str(tenant_id),
-            runner_id=runner_id,
-            op_id=row.op_id,
-        )
+    if not _params_hash_intact(row, tenant_id=tenant_id, runner_id=runner_id):
         return None
 
     # Conditional flip: the predicate + write commit together, so a second

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -59,7 +59,7 @@ from enum import StrEnum
 from typing import Any
 
 import structlog
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
@@ -69,6 +69,7 @@ from meho_backplane.db.models import (
     GatewayCommand,
     GatewayCommandStatus,
     PermissionVerdict,
+    RunnerPrincipal,
 )
 from meho_backplane.gateway.queue import (
     GatewayCommandNotDeliveredError,
@@ -97,6 +98,12 @@ __all__ = [
     "consume_command",
     "mint_gateway_command",
 ]
+
+# code-quality-allow: file-size — the gateway command lifecycle (mint ladder +
+# consume latch + result-accept + audit lineage) is one cohesive
+# transaction-discipline contract; the #3192 revocation gate nudged it past the
+# 600-line limit. Splitting the module is its own refactor task (tracked with
+# the mint-ladder function-size debt below), not part of this security change.
 
 # NOTE: the structlog logger is resolved per-call at each log site below
 # rather than held as a module-level proxy. Production sets
@@ -145,7 +152,10 @@ class MintRefusalCode(StrEnum):
     tier (``dangerous`` / ``destructive`` — never minted to a satellite);
     ``REMOTE_WRITE_GATE_UNSATISFIED`` is the fail-closed refusal of the
     additive ``remote-write`` tier while its composed gate is unprovisioned
-    (#3188); ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate
+    (#3188); ``RUNNER_REVOKED`` is the write-tier revocation refusal (#3192,
+    the Stage-3 gate) — a revoked runner gets no new ``remote-write`` mint,
+    checked before the composed gate so a revoked runner reads the specific
+    refusal; ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate
     verdicts that are not ``AUTO_EXECUTE``.
     """
 
@@ -154,6 +164,7 @@ class MintRefusalCode(StrEnum):
     INVALID_OP_SCHEMA = "invalid_op_schema"
     OP_NOT_SAFE = "op_not_safe"
     REMOTE_WRITE_GATE_UNSATISFIED = "remote_write_gate_unsatisfied"
+    RUNNER_REVOKED = "runner_revoked"
     POLICY_DENIED = "policy_denied"
     NEEDS_APPROVAL = "needs_approval"
 
@@ -182,6 +193,30 @@ class MintResult:
 def _refused(code: MintRefusalCode, reason: str) -> MintResult:
     """Build a fail-closed refusal result (no rows written)."""
     return MintResult(refusal_code=code, refusal_reason=reason)
+
+
+async def _runner_is_revoked(
+    session: AsyncSession, *, tenant_id: uuid.UUID, runner_name: str
+) -> bool:
+    """Whether the named runner principal is revoked in this tenant (#3192).
+
+    One indexed read on the unique ``(tenant_id, name)`` runner index — the
+    same row :func:`meho_backplane.auth.runner_guard.assert_runner_scope`
+    resolves, read here for its ``revoked`` column only (the read path
+    deliberately does **not** consult it; the write tier does). A name that
+    resolves to **no** row returns ``False``: an unknown runner is not this
+    check's concern (its remote-write mint still fails closed at the composed
+    ``evaluate_remote_write_gate`` seam / the enrollment allowlist, #3189),
+    so the revocation check stays scoped to the "row exists and is revoked"
+    case it owns and adds no new existence oracle.
+    """
+    revoked = await session.scalar(
+        select(RunnerPrincipal.revoked).where(
+            RunnerPrincipal.tenant_id == tenant_id,
+            RunnerPrincipal.name == runner_name,
+        )
+    )
+    return bool(revoked)
 
 
 def _refuse_unvalidatable_params(
@@ -307,8 +342,10 @@ async def mint_gateway_command(
        generalised, checked **before** the policy gate (so a refused op never
        reaches it and is never parked): ``EXCLUDED`` (``dangerous`` /
        ``destructive``) → :attr:`MintRefusalCode.OP_NOT_SAFE`, never minted
-       (composes with #3183); ``REMOTE_WRITE`` (``caution``) → the composed
-       gate, fail-closed until the siblings wire it →
+       (composes with #3183); ``REMOTE_WRITE`` (``caution``) → the write-tier
+       revocation check (#3192 — a revoked runner →
+       :attr:`MintRefusalCode.RUNNER_REVOKED`) then the composed gate,
+       fail-closed until the siblings wire it →
        :attr:`MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`; ``SAFE`` falls
        through to the policy gate, semantics unchanged.
     4. ``policy_gate`` — any verdict other than ``AUTO_EXECUTE`` refuses
@@ -399,6 +436,27 @@ async def mint_gateway_command(
             "dangerous/destructive ops are never minted to a satellite",
         )
     if tier is SatelliteMintTier.REMOTE_WRITE:
+        # Revocation hardening (#3192, the Stage-3 gate): a revoked runner
+        # gets no new remote-write mint. Checked *before* the composed gate
+        # so a revoked runner reads the specific RUNNER_REVOKED refusal, and
+        # scoped to the write tier only -- a `safe` mint never reaches here,
+        # so the read path's coarse kill switch is untouched. The delivery
+        # path (`claim_next_command`) re-checks live `revoked` for the
+        # already-minted-write gap; this is the mint-side half.
+        if await _runner_is_revoked(session, tenant_id=operator.tenant_id, runner_name=runner_id):
+            structlog.get_logger(__name__).warning(
+                "gateway_command_mint_refused_runner_revoked",
+                reason=MintRefusalCode.RUNNER_REVOKED.value,
+                op_id=op_id,
+                safety_level=descriptor.safety_level,
+                operator_sub=operator.sub,
+                runner_id=runner_id,
+            )
+            return _refused(
+                MintRefusalCode.RUNNER_REVOKED,
+                f"runner {runner_id!r} is revoked; no remote-write capability "
+                "is minted to a revoked runner",
+            )
         # The additive write tier, separate from the untouched `safe` wall.
         # Its composed gate (per-runner allowlist + approval/policy binding)
         # is wired by sibling tasks (#3189-#3193); until then it is fail-closed.
@@ -449,6 +507,7 @@ async def mint_gateway_command(
         params_hash=params_hash,
         expires_at=expires_at,
         mint_audit_id=mint_audit_id,
+        safety_level=descriptor.safety_level,
     )
     await _write_gateway_audit_row(
         session,

--- a/backend/src/meho_backplane/runner/satellite_tier.py
+++ b/backend/src/meho_backplane/runner/satellite_tier.py
@@ -49,11 +49,25 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 __all__ = [
+    "REMOTE_WRITE_SAFETY_LEVELS",
     "RemoteWriteGateDecision",
     "SatelliteMintTier",
     "classify_satellite_tier",
     "evaluate_remote_write_gate",
 ]
+
+#: The ``safety_level`` values that classify into
+#: :attr:`SatelliteMintTier.REMOTE_WRITE`. The SQL-expressible companion of
+#: :func:`classify_satellite_tier` for callers that must tier-scope a query
+#: without importing the classifier into the database layer — the
+#: revocation-hardening delivery filter (#3192,
+#: :func:`meho_backplane.gateway.queue.claim_next_command`) narrows a revoked
+#: runner's claim to non-remote-write rows via
+#: ``safety_level NOT IN REMOTE_WRITE_SAFETY_LEVELS``. Kept in lock-step with
+#: :func:`classify_satellite_tier` by ``tests/test_runner_satellite_tier.py``:
+#: a level added to the classifier's ``REMOTE_WRITE`` branch must be added
+#: here, or the drift guard fails.
+REMOTE_WRITE_SAFETY_LEVELS: frozenset[str] = frozenset({"caution"})
 
 
 class SatelliteMintTier(StrEnum):

--- a/backend/tests/migrations/test_migration_0091_add_gateway_command_safety_level.py
+++ b/backend/tests/migrations/test_migration_0091_add_gateway_command_safety_level.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0091`` (#3192).
+
+Initiative #2901 (satellite write path), Task #3192 — revocation hardening.
+Adds the ``safety_level`` column to ``gateway_command`` so the delivery path
+can tier-scope the write-capable-runner revocation refusal.
+
+Asserts the column lands after ``upgrade 0091``, round-trips (downgrade to
+``0087`` drops it, re-upgrade re-adds it), and that the NOT NULL ADD COLUMN
+lands on the empty clean-slate table via its ``'safe'`` server default.
+
+**Idempotency pinning (0049/0050/0055 footgun).** Every forward / round-trip
+step targets this migration's **own** revision (``0091``) and its
+``down_revision`` (``0087``), never ``head`` — so a future head migration
+cannot make ``upgrade("head")`` re-run this ``add_column`` on a schema that
+already has it. SQLite is the test driver and the migration uses only
+generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0091"
+_DOWN_REVISION = "0087"
+_TABLE = "gateway_command"
+_COLUMN = "safety_level"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0091.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({_TABLE})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_safety_level_column(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0091`` adds the ``safety_level`` column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _COLUMN in _columns(sync_url)
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0087"`` drops the column; ``upgrade "0091"`` re-adds it.
+
+    Pinned to this migration's own revision on both legs (never ``head``) so
+    a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _COLUMN in _columns(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _COLUMN not in _columns(sync_url)
+
+    command.upgrade(cfg, _REVISION)
+    assert _COLUMN in _columns(sync_url)
+
+
+def test_safety_level_is_not_null_with_safe_default(alembic_cfg: tuple[Config, str]) -> None:
+    """The NOT NULL ``safety_level`` ADD COLUMN lands on the empty table.
+
+    A raw insert that omits ``safety_level`` succeeds via its constant
+    ``'safe'`` server default (the read-tier fail-safe) — proving the ADD
+    COLUMN is valid on the empty clean-slate table across dialects rather
+    than requiring a backfill, and that a row that never named a level is a
+    read (never a remote-write the revocation filter would refuse).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            # FK enforcement stays off (SQLite default) so the bogus tenant_id
+            # does not mask the column under test.
+            conn.execute(
+                text(
+                    "INSERT INTO gateway_command "
+                    "(id, tenant_id, runner_id, op_id, params, status, "
+                    "enqueued_by_sub, enqueued_at, params_hash, expires_at) "
+                    "VALUES ('cmd-1', 'ten-1', 'runner-a', 'net.ping', '{}', "
+                    "'pending', 'sub-1', '2026-08-31', 'h', '2026-08-31')"
+                )
+            )
+            safety_level = conn.execute(
+                text("SELECT safety_level FROM gateway_command WHERE id = 'cmd-1'")
+            ).scalar_one()
+    finally:
+        sync_eng.dispose()
+
+    assert safety_level == "safe"

--- a/backend/tests/test_api_v1_runner_principals.py
+++ b/backend/tests/test_api_v1_runner_principals.py
@@ -46,7 +46,7 @@ from meho_backplane.auth.keycloak_admin import (
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.auth.runner_principals import NAME_MAX_LENGTH
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import RunnerPrincipal, Tenant
+from meho_backplane.db.models import AuditLog, RunnerPrincipal, Tenant
 from meho_backplane.main import app
 from meho_backplane.settings import get_settings
 
@@ -226,6 +226,57 @@ async def test_full_lifecycle_round_trip(client: TestClient) -> None:
     rows = await _fetch_principals(_TENANT_A)
     assert len(rows) == 1
     assert rows[0].revoked is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_writes_audit_trail(client: TestClient) -> None:
+    """Revoking a runner leaves a tamper-evident audit row (#3192, mechanism 4).
+
+    Revocation is the write-path kill switch; the audit row proving a runner's
+    write capability was withdrawn is distinct from the liveness dead-man flip.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-rev-audit")
+    tok = _token(key)
+    factory = _mock_kc_ok()
+
+    with (
+        patch(
+            "meho_backplane.auth.runner_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {tok}"}
+
+        created = client.post(
+            "/api/v1/runner-principals",
+            json={"name": "edge-runner"},
+            headers=headers,
+        )
+        assert created.status_code == 201, created.text
+
+        revoked = client.delete("/api/v1/runner-principals/edge-runner/revoke", headers=headers)
+        assert revoked.status_code == 200, revoked.text
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        audit_rows = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.path == "runner.principal.revoked")
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(audit_rows) == 1
+    row = audit_rows[0]
+    assert row.method == "INTERNAL"
+    assert row.tenant_id == _TENANT_A
+    assert row.payload["runner"] == "edge-runner"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -34,6 +34,7 @@ from meho_backplane.db.models import (
     GatewayCommand,
     GatewayCommandStatus,
     PermissionVerdict,
+    RunnerPrincipal,
     Tenant,
 )
 from meho_backplane.gateway.queue import (
@@ -127,7 +128,9 @@ async def _count(model: type) -> int:
         return (await session.execute(select(func.count()).select_from(model))).scalar_one()
 
 
-async def _enqueue(*, params: dict[str, object] | None = None) -> uuid.UUID:
+async def _enqueue(
+    *, params: dict[str, object] | None = None, safety_level: str = "safe"
+) -> uuid.UUID:
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         command = await enqueue_command(
@@ -137,10 +140,34 @@ async def _enqueue(*, params: dict[str, object] | None = None) -> uuid.UUID:
             op_id=_OP_ID,
             params=params if params is not None else dict(_PARAMS),
             enqueued_by_sub="enq-sub",
+            safety_level=safety_level,
         )
         command_id = command.id
         await session.commit()
         return command_id
+
+
+async def _seed_runner_principal(*, revoked: bool, name: str = _RUNNER) -> None:
+    """Seed a runner principal row so the mint-time revocation lookup resolves.
+
+    The mint's ``_runner_is_revoked`` reads ``revoked`` off the unique
+    ``(tenant_id, name)`` row; without a row it is treated as not-revoked.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            RunnerPrincipal(
+                id=uuid.uuid4(),
+                tenant_id=_TENANT,
+                name=name,
+                keycloak_client_id=f"runner:{name}",
+                keycloak_internal_id=f"kc-{name}",
+                owner_sub="owner-sub",
+                created_by_sub="creator-sub",
+                revoked=revoked,
+            )
+        )
+        await session.commit()
 
 
 async def _claim() -> None:
@@ -559,3 +586,126 @@ async def test_result_audit_links_to_mint_row(monkeypatch: pytest.MonkeyPatch) -
         assert command.status == GatewayCommandStatus.SUCCEEDED.value
         assert command.consumed_at is not None
         assert command.result == {"reachable": True}
+
+
+# ---------------------------------------------------------------------------
+# Revocation hardening for write-capable runners (#3192, the Stage-3 gate)
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_refuses_remote_write_for_revoked_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revoked runner gets no new remote-write mint — RUNNER_REVOKED, no rows.
+
+    The write-tier revocation check fires *before* the composed gate, so a
+    revoked runner reads the specific ``RUNNER_REVOKED`` refusal rather than
+    the generic gate-unsatisfied one, and no command / approval row is written.
+    """
+    await _seed_tenant()
+    await _seed_runner_principal(revoked=True)
+    _patch_lookup(monkeypatch, _descriptor(safety_level="caution"))
+
+    async def _gate_must_not_run(**_kwargs: object) -> tuple[PermissionVerdict, str | None]:
+        raise AssertionError("policy_gate must not be consulted for a revoked-runner refusal")
+
+    monkeypatch.setattr(gc, "policy_gate", _gate_must_not_run)
+
+    sessionmaker = get_sessionmaker()
+    with capture_logs() as logs:
+        async with sessionmaker() as session:
+            result = await mint_gateway_command(
+                session,
+                operator=_operator(),
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=None,
+                params=dict(_PARAMS),
+                runner_id=_RUNNER,
+            )
+            await session.commit()
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.RUNNER_REVOKED
+    assert _RUNNER in (result.refusal_reason or "")
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+    assert any(entry["event"] == "gateway_command_mint_refused_runner_revoked" for entry in logs)
+
+
+async def test_mint_allows_safe_op_for_revoked_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``safe`` (read) op still mints for a revoked runner — read path unchanged.
+
+    The revocation check is scoped to the ``remote-write`` tier: a ``safe``
+    mint never reaches it, so the read path's coarse kill switch is untouched
+    and an already-authored read capability still mints.
+    """
+    await _seed_tenant()
+    await _seed_runner_principal(revoked=True)
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe"))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        command_safety = result.command.safety_level if result.command else None
+        await session.commit()
+
+    assert result.minted
+    assert command_safety == "safe"
+    assert await _count(GatewayCommand) == 1
+
+
+async def test_revoked_runner_delivery_skips_remote_write_keeps_safe() -> None:
+    """A revoked runner's already-minted remote-write is not delivered; its safe is.
+
+    The materialisation (claim) half of the Stage-3 gate: a queued
+    ``remote-write`` command minted before revocation is never handed to a
+    revoked runner (it stays ``pending``, expiring under its TTL), while a
+    queued ``safe`` command still delivers — the read path is unaffected.
+    """
+    await _seed_tenant()
+    # A remote-write command enqueued first (older), a safe command second.
+    write_cmd = await _enqueue(safety_level="caution")
+    safe_cmd = await _enqueue(safety_level="safe")
+
+    sessionmaker = get_sessionmaker()
+
+    # A revoked runner claims the safe command, skipping the older remote-write.
+    async with sessionmaker() as session:
+        row = await claim_next_command(
+            session, tenant_id=_TENANT, runner_id=_RUNNER, runner_revoked=True
+        )
+        await session.commit()
+    assert row is not None and row.id == safe_cmd
+
+    # The remote-write command was never delivered — it stays pending.
+    async with sessionmaker() as session:
+        write_row = await session.get(GatewayCommand, write_cmd)
+        assert write_row is not None
+        assert write_row.status == GatewayCommandStatus.PENDING.value
+
+    # A revoked runner with only remote-write work claims nothing.
+    async with sessionmaker() as session:
+        assert (
+            await claim_next_command(
+                session, tenant_id=_TENANT, runner_id=_RUNNER, runner_revoked=True
+            )
+            is None
+        )
+
+    # A non-revoked runner would deliver that same remote-write row — proving
+    # the exclusion is the revocation flag, not a stuck row.
+    async with sessionmaker() as session:
+        row = await claim_next_command(
+            session, tenant_id=_TENANT, runner_id=_RUNNER, runner_revoked=False
+        )
+        await session.commit()
+    assert row is not None and row.id == write_cmd

--- a/backend/tests/test_runner_satellite_tier.py
+++ b/backend/tests/test_runner_satellite_tier.py
@@ -12,10 +12,16 @@ from __future__ import annotations
 import pytest
 
 from meho_backplane.runner.satellite_tier import (
+    REMOTE_WRITE_SAFETY_LEVELS,
     SatelliteMintTier,
     classify_satellite_tier,
     evaluate_remote_write_gate,
 )
+
+# Every ``safety_level`` value the classifier recognises (the closed
+# ``safe < caution < dangerous < destructive`` enum, #3196), used to prove
+# REMOTE_WRITE_SAFETY_LEVELS stays in lock-step with classify_satellite_tier.
+_ALL_SAFETY_LEVELS = ("safe", "caution", "dangerous", "destructive")
 
 
 @pytest.mark.parametrize(
@@ -54,3 +60,19 @@ def test_remote_write_gate_reason_omits_runner_when_absent() -> None:
 
     assert decision.permitted is False
     assert "for runner" not in decision.reason
+
+
+def test_remote_write_safety_levels_match_classifier() -> None:
+    # Drift guard (#3192): REMOTE_WRITE_SAFETY_LEVELS is the SQL-expressible
+    # twin of classify_satellite_tier, used to tier-scope the revocation
+    # delivery filter. A level whose classification is REMOTE_WRITE must be in
+    # the set, and no other level may be — else a revoked runner's delivery
+    # filter refuses the wrong tier.
+    classifier_remote_write = {
+        level
+        for level in _ALL_SAFETY_LEVELS
+        if classify_satellite_tier(level) is SatelliteMintTier.REMOTE_WRITE
+    }
+    assert classifier_remote_write == REMOTE_WRITE_SAFETY_LEVELS
+    # Concretely, only ``caution`` today.
+    assert frozenset({"caution"}) == REMOTE_WRITE_SAFETY_LEVELS

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -182,6 +182,69 @@ rides a runner — the satellite write-path decision's "delete-shaped
 operations never minted to a satellite," dovetailing with #3196's default
 gate exclusions.
 
+### Revocation hardening for write-capable runners (#3192, the Stage-3 gate)
+
+The read path's revocation is deliberately **coarse**: `assert_runner_scope`
+does **not** consult `revoked` (`auth/runner_guard.py`); a revoked runner is
+stopped by Keycloak `enabled=false` (blocks new token grants) + a short
+access-token TTL + the #2501 dead-man switch, so revocation latency ≈ token
+TTL. Fine for a read (a stale read at a silent edge changes nothing). For an
+already-minted **write**, that latency is the T8 gap: a revoked-but-not-yet-
+expired runner could still execute the mutation (blast radius = allowlist ×
+credential lifetime × **revocation latency**). The decision
+(`docs/decisions/satellite-write-path.md`, recommendation 3) answers this
+with **TTL + dead-man initially, and a per-mint revocation check as the
+Stage-3 gate** — so the write tier does not reach steady state without it.
+
+The revocation check is a **separate central gate** from the composed
+`evaluate_remote_write_gate` (which composes the four mechanisms; #3189 wires
+it): revocation is its own Stage-3 term, enforced live off the runner
+principal's `revoked` column, **scoped to the `remote-write` tier only** so
+the read path's coarse kill switch is untouched.
+
+- **No new mint to a revoked runner** — `mint_gateway_command`
+  (`operations/gateway_commands.py`): in the `REMOTE_WRITE` branch, a DB read
+  of `runner_principal.revoked` (`_runner_is_revoked`) refuses with
+  `MintRefusalCode.RUNNER_REVOKED` **before** the composed gate, so a revoked
+  runner reads the specific refusal and no command row is written. A `safe`
+  mint never reaches this branch.
+- **No delivery of an already-minted write** (the materialisation half) —
+  `claim_next_command` (`gateway/queue.py`): the poll route reads the live
+  `revoked` flag off the scope-gate row (once per poll) and threads
+  `runner_revoked` into the claim, which narrows to `safety_level NOT IN
+  REMOTE_WRITE_SAFETY_LEVELS`. So a `remote-write` command minted *before*
+  revocation is never handed to the runner post-revocation (it stays
+  `pending` and expires under its capability TTL), while a queued `safe`
+  command still delivers. This needs the op's `safety_level` denormalised
+  onto the command row at mint (migration `0091`) — the same "bind at mint,
+  check at delivery without a re-lookup" discipline as `params_hash` /
+  `expires_at`.
+- **At the edge** — `_screen_item` (`runner/executor.py`): the DB-free edge
+  cannot itself read `revoked`, but it already fail-closes on **every**
+  `remote-write` item through the unprovisioned composed gate
+  (`test_remote_write_op_is_refused_without_invocation`), so an
+  already-delivered write in a revoked runner's spool still refuses at
+  execution today. The live per-runner edge revocation signal composes
+  through the credential seam (#3191): a revoked runner's just-in-time
+  wrapped-credential unwrap must fail, so a delivered-but-not-yet-executed
+  write cannot resolve its secret. That linkage is #3191's concern; this task
+  owns only the mint + delivery gate and the audit trail.
+- **Observable / auditable** (mechanism 4) — `RunnerPrincipalService.revoke`
+  (`auth/runner_principals.py`) writes an internal audit row
+  (`method='INTERNAL'`, `path='runner.principal.revoked'`) on the central
+  clock, the tamper-evident trail that a runner's write capability was
+  withdrawn — distinct from the liveness `gateway.runner.stale` dead-man flip.
+
+**Residual (bounded, not eliminated).** A command already flipped
+`delivered` before revocation is off-net and cannot be recalled centrally;
+that window is bounded by the capability TTL (default 5 min) plus the #3191
+credential seam and the un-reported-mint security alarm (a sibling seam).
+
+**Stage-3 promotion criterion.** A `remote-write` domain does **not** advance
+to Stage 3 (standing capability within-allowlist) until this per-mint +
+per-delivery revocation check is in force — the write tier does not reach
+steady state on TTL + dead-man alone.
+
 ## Dead-man switch + mandatory heartbeat (#2501)
 
 A runner that dies, wedges, or loses its network path must not leave its


### PR DESCRIPTION
## Summary

- Closes the **T8 already-minted-write gap** for the satellite write path (Initiative #2901, decision `docs/decisions/satellite-write-path.md`, recommendation 3 — the **Stage-3 gate**): a **revoked** runner can no longer **obtain** or **execute** a `remote-write` capability.
- The **read path's coarse kill switch is unchanged** — `assert_runner_scope` still does not consult `revoked`; revocation for reads stays Keycloak `enabled=false` + token TTL + the #2501 dead-man switch. This hardening is scoped to the `remote-write` tier only.
- Revocation is a **separate central gate** from the composed `evaluate_remote_write_gate` (which #3189 owns): it reads the runner principal's live `revoked` column at mint and at delivery.

## What changed

- **No new mint** — `mint_gateway_command` refuses a `remote-write` mint for a revoked runner with a new `MintRefusalCode.RUNNER_REVOKED`, checked **before** the composed gate (specific refusal) and only in the `REMOTE_WRITE` branch (a `safe` mint never reaches it).
- **No delivery of an already-minted write** (materialisation) — `poll_next_command` reads the live `revoked` flag off the scope-gate `RunnerPrincipal` row and threads `runner_revoked` into `claim_next_command`, which narrows the claim to `safety_level NOT IN REMOTE_WRITE_SAFETY_LEVELS`. A write minted **before** revocation is never delivered afterwards (stays `pending`, expires under its capability TTL); a queued `safe` read still delivers.
- **Schema** — new denormalised `gateway_command.safety_level` column (**migration 0091**) so delivery can tier-scope without a descriptor re-lookup, mirroring the `params_hash` / `expires_at` "bind at mint, check at delivery" discipline (0061).
- **Auditable** — `RunnerPrincipalService.revoke` writes a tamper-evident internal audit row (`method='INTERNAL'`, `path='runner.principal.revoked'`), distinct from the liveness `gateway.runner.stale` flip.
- **Docs** — `docs/codebase/satellite-runner.md` gains the Stage-3 revocation-hardening section + the Stage-3 promotion criterion; CHANGELOG `[Unreleased]` entry added.

## Revocation → credential seam (#3191)

The DB-free edge cannot itself read `revoked`; it already fail-closes on **every** `remote-write` item through the unprovisioned composed gate (`test_remote_write_op_is_refused_without_invocation`), so an already-`delivered` write in a revoked runner's spool still refuses at execution today. The **live per-runner edge revocation signal composes through #3191's credential brokering** — a revoked runner's just-in-time wrapped-credential unwrap must fail. This PR implements only its own side (mint + delivery gate + audit) against the narrowest interface and does not reach into #3191's concern. The residual in-flight (already-`delivered`) window is bounded by the capability TTL + the #3191 seam + the un-reported-mint alarm.

## Migration coordination (0091)

Chosen to sit clear of concurrent racers under #2901: #3230 already claims `0088`; `0089`/`0090` are reserved for #3189/#3191 (note: #3191's PR #3244 ships **no** migration). `down_revision` points at the current real head `0087`; alembic `heads` is a single head `0091`. If #3230's `0088` lands on main first, `down_revision` must be re-pointed to the new head before merge (no branched heads) — the orchestrator re-points if the race lands differently. Stated loudly in the migration docstring.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (Success: no issues found)
- [x] `code-quality.py --diff` — 0 blockers (extracted `_pending_claim_stmt` / `_params_hash_intact` in `queue.py` and `_disable_keycloak_client` in `runner_principals.py`; file-size escape-valve on the pre-existing large `gateway_commands.py` mint-ladder module)
- [x] **Acceptance:** per-mint + per-delivery revocation check (`test_mint_refuses_remote_write_for_revoked_runner`, `test_revoked_runner_delivery_skips_remote_write_keeps_safe`); a write minted before revocation is refused after (delivery test); read unaffected (`test_mint_allows_safe_op_for_revoked_runner` + the safe-delivery assertion); audit trail (`test_revoke_writes_audit_trail`); drift guard (`test_remote_write_safety_levels_match_classifier`); migration lands + round-trips (`test_migration_0091_*`).
- [x] Untouched conformance stays green — `test_satellite_mint_refuses_op_not_safe` + `test_runner_satellite_tier.py` + `test_remote_write_op_is_refused_without_invocation`.
- [x] Broad regression: gateway commands / API / deadman / runner loop+client / sensor / assignment / migrations / db-models suites all pass.

## Out of scope

- #3189 (signing + approval-binding — the composed-gate wiring); #3191 (credential brokering — the edge revocation seam noted above).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3192
