### PR TITLE
feat(gateway): signed remote-write work items + approval-bound minting (#3189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,43 @@ connector-related release-notes line.
   the satellite gate by default everywhere, so delete-shaped work never rides
   a runner (#3225's conformance stays green).
 
+### Added — satellite write path: signed work items + approval-bound minting (#3189)
+
+- Lands **mechanism 1** of the satellite write-path composed gate (Initiative
+  #2901, design `docs/research/2901-satellite-write-path.md` §3): the caution
+  (`remote-write`) tier is now authorised by a **committed, single-use,
+  param-bound approval** plus a **real Ed25519 signature** over the canonical
+  work item, verified offline at the DB-free edge.
+- **Approval-bound minting.** `mint_gateway_command` routes a `REMOTE_WRITE` op
+  to `_mint_remote_write`, which mints **only** against a committed, un-consumed
+  `ApprovalRequest` for the identical `(op, target, params_hash)` — the human
+  approval decision **is** the authorization, so the live policy gate is
+  bypassed for this tier (the mould of `approve_request`'s `_approved=True`
+  re-dispatch). The binding is **param-bound** (the `params_hash` swap defence,
+  #1503 / #3197) and **single-use** (the approval's one-way `resumed_at` latch,
+  claimed atomically in the mint session). No approval →
+  `REMOTE_WRITE_GATE_UNSATISFIED`; unprovisioned signing key →
+  `REMOTE_WRITE_SIGNING_UNAVAILABLE` (both fail-closed).
+- **Signed capability (write-tier-only #2500 reversal).** The centre signs the
+  canonical payload (`op_id` + `params_hash` + `target_scope` + `expires_at`)
+  with its Ed25519 **signing (private) key** and stamps the signature on the
+  `gateway_command` row (new `signature` column, **migration 0088**). New
+  edge-safe module `runner/work_item_signing.py` (stdlib + `cryptography`,
+  no DB import); the runner holds only the **verification (public) key**,
+  provisioned at enrollment, so a compromised runner cannot forge a capability.
+  The DB consume latch is **retained unchanged** for at-most-once acceptance.
+- **Edge verification.** `_screen_item` (`runner/executor.py`) verifies the
+  signature + freshness + target scope on every `REMOTE_WRITE` item **before**
+  any handler import — an unsigned, tampered, out-of-scope, or expired item
+  fails closed. New settings: `SATELLITE_WRITE_SIGNING_KEY` (central) /
+  `SATELLITE_WRITE_VERIFY_KEY` (runner).
+- The per-runner **allowlist** (mechanism 2, #3190) remains a fail-closed seam
+  (`evaluate_remote_write_gate`, untouched): a remote-write op mints only when
+  the op-class is on the runner's allowlist **and** this approval binding
+  authorises it. Until #3190 wires the allowlist at the mint (the marked
+  composition point in `_mint_remote_write`), the edge allowlist re-check keeps
+  the tier closed end-to-end.
+
 ### Added — flight recorder: typed-connector spans across every typed family (#3217)
 
 - Extends the flight recorder (`docs/decisions/dispatch-flight-recorder.md`, **F8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,7 +245,7 @@ connector-related release-notes line.
 - **Signed capability (write-tier-only #2500 reversal).** The centre signs the
   canonical payload (`op_id` + `params_hash` + `target_scope` + `expires_at`)
   with its Ed25519 **signing (private) key** and stamps the signature on the
-  `gateway_command` row (new `signature` column, **migration 0088**). New
+  `gateway_command` row (new `signature` column, **migration 0089**). New
   edge-safe module `runner/work_item_signing.py` (stdlib + `cryptography`,
   no DB import); the runner holds only the **verification (public) key**,
   provisioned at enrollment, so a compromised runner cannot forge a capability.

--- a/backend/alembic/versions/0088_add_gateway_command_signature.py
+++ b/backend/alembic/versions/0088_add_gateway_command_signature.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``gateway_command.signature`` for the signed remote-write capability.
+
+Revision ID: 0088
+Revises: 0087
+Create Date: 2026-08-31
+
+Task #3189 under Initiative #2901 (satellite write path), design
+``docs/research/2901-satellite-write-path.md`` §3 mechanism 1. The
+``remote-write`` (caution) tier reverses #2500 *for the write tier only*: a
+capability is minted only against a committed approval and is stamped with a
+**real Ed25519 signature** over its canonical serialisation, created once at
+mint (authorization time) so the DB-free runner can verify integrity +
+freshness + target-scope offline before executing. This migration ships the
+storage half: the column that persists that signature on the durable
+``gateway_command`` row so it can be delivered on the later poll and so it
+stands as the non-repudiation anchor the store-and-forward effect audit
+references. The signing / edge-verification code ships in the same task.
+
+What this migration adds
+------------------------
+
+* ``gateway_command.signature text NULL`` -- base64 Ed25519 signature over the
+  canonical work-item payload (``op_id`` + ``params_hash`` + ``target_scope``
+  + ``expires_at``). Stamped by ``mint_gateway_command`` for a ``remote-write``
+  mint only.
+
+Why nullable (no ``server_default``)
+------------------------------------
+
+Signing is a **remote-write-tier property only**: a ``safe`` capability (the
+read path, every row today) carries no signature -- the opaque-UUID PK + DB
+consume latch remain its authorization (#2500 stands for the read tier). The
+column is therefore ``NULL`` for every ``safe`` row and every pre-0088 row. A
+nullable ``ADD COLUMN`` needs no backfill default -- existing rows take
+``NULL`` (the correct "unsigned" state) with no table rewrite. Mirrors the
+``approval_request.preview_hash`` add (migration ``0086``), nullable for the
+same "the property is tier-specific, absent rows have no value" reason.
+
+Migration-chain note (single linear head)
+------------------------------------------
+
+Numbered ``0088`` with ``down_revision = "0087"`` -- the head on
+``origin/main`` (``0087_add_tenant_flight_recorder_agent_readable``). The
+chain is a single linear head ``0086 -> 0087 -> 0088``, which the ``Python
+(database migrations)`` CI gate requires. Concurrent sibling tasks under
+#2901 (#3191 credential brokering, #3192 revocation) take the numbers *after*
+this one (``0089`` onward, coordinated).
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column. SQLite's ALTER TABLE drop-column has been
+supported since 3.35.0 (we're on 3.45+); Alembic's batch-mode fallback isn't
+required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0088"
+down_revision: str | None = "0087"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``signature`` column to ``gateway_command``."""
+    op.add_column(
+        "gateway_command",
+        sa.Column("signature", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``signature`` column added in :func:`upgrade`."""
+    op.drop_column("gateway_command", "signature")

--- a/backend/alembic/versions/0089_add_gateway_command_signature.py
+++ b/backend/alembic/versions/0089_add_gateway_command_signature.py
@@ -3,8 +3,8 @@
 
 """Add ``gateway_command.signature`` for the signed remote-write capability.
 
-Revision ID: 0088
-Revises: 0087
+Revision ID: 0089
+Revises: 0088
 Create Date: 2026-08-31
 
 Task #3189 under Initiative #2901 (satellite write path), design
@@ -33,7 +33,7 @@ Why nullable (no ``server_default``)
 Signing is a **remote-write-tier property only**: a ``safe`` capability (the
 read path, every row today) carries no signature -- the opaque-UUID PK + DB
 consume latch remain its authorization (#2500 stands for the read tier). The
-column is therefore ``NULL`` for every ``safe`` row and every pre-0088 row. A
+column is therefore ``NULL`` for every ``safe`` row and every pre-0089 row. A
 nullable ``ADD COLUMN`` needs no backfill default -- existing rows take
 ``NULL`` (the correct "unsigned" state) with no table rewrite. Mirrors the
 ``approval_request.preview_hash`` add (migration ``0086``), nullable for the
@@ -42,12 +42,13 @@ same "the property is tier-specific, absent rows have no value" reason.
 Migration-chain note (single linear head)
 ------------------------------------------
 
-Numbered ``0088`` with ``down_revision = "0087"`` -- the head on
-``origin/main`` (``0087_add_tenant_flight_recorder_agent_readable``). The
-chain is a single linear head ``0086 -> 0087 -> 0088``, which the ``Python
-(database migrations)`` CI gate requires. Concurrent sibling tasks under
-#2901 (#3191 credential brokering, #3192 revocation) take the numbers *after*
-this one (``0089`` onward, coordinated).
+Numbered ``0089`` with ``down_revision = "0088"`` -- the head on
+``origin/main`` after ``0088_reap_probe_epoch_impl_id_registrations`` (the
+#3061 follow-up) landed while this task was in flight. The chain is a single
+linear head ``0087 -> 0088 -> 0089``, which the ``Python (database
+migrations)`` CI gate requires. Concurrent sibling task #3192 (revocation)
+takes the number *after* this one (``0090`` onward, coordinated); #3191
+(credential brokering) shipped no migration.
 
 Reversibility contract
 ----------------------
@@ -63,8 +64,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0088"
-down_revision: str | None = "0087"
+revision: str = "0089"
+down_revision: str | None = "0088"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import datetime
 from typing import Annotated, Any, Final, Literal
 
 import structlog
@@ -117,6 +118,12 @@ class GatewayCommandEnvelope(BaseModel):
     # ``None`` for a targetless synthetic op (net.*); a resolved descriptor
     # the runner's handler duck-reads otherwise.
     target_descriptor: dict[str, Any] | None
+    # Remote-write signing (#3189): the centre's Ed25519 ``signature`` over the
+    # canonical work-item payload and the ``expires_at`` freshness bound it
+    # covers, both verified offline at the edge. ``None`` for a ``safe``
+    # capability (the read path, unsigned) — signing is a write-tier property.
+    signature: str | None = None
+    expires_at: datetime | None = None
 
 
 class GatewayResultBody(BaseModel):
@@ -160,6 +167,8 @@ def _envelope(command: GatewayCommand) -> GatewayCommandEnvelope:
         op_id=command.op_id,
         params=command.params,
         target_descriptor=command.target_descriptor,
+        signature=command.signature,
+        expires_at=command.expires_at,
     )
 
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6249,7 +6249,7 @@ class GatewayCommand(Base):
         nullable=True,
         default=None,
     )
-    # Signed remote-write capability (#3189, migration 0088). Base64 Ed25519
+    # Signed remote-write capability (#3189, migration 0089). Base64 Ed25519
     # signature over the canonical work-item payload (op_id + params_hash +
     # target_scope + expires_at), stamped by ``mint_gateway_command`` for a
     # ``remote-write`` (caution) mint only and verified offline at the edge

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6249,6 +6249,18 @@ class GatewayCommand(Base):
         nullable=True,
         default=None,
     )
+    # Signed remote-write capability (#3189, migration 0088). Base64 Ed25519
+    # signature over the canonical work-item payload (op_id + params_hash +
+    # target_scope + expires_at), stamped by ``mint_gateway_command`` for a
+    # ``remote-write`` (caution) mint only and verified offline at the edge
+    # (``runner.executor._screen_item``). NULL for every ``safe`` row -- the
+    # read path keeps the opaque-UUID PK + consume latch as its authorization
+    # (#2500), reversed only for the write tier.
+    signature: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -108,8 +108,10 @@ __all__ = [
     "UnauthorizedApprovalError",
     "approve_request",
     "claim_resume",
+    "consume_remote_write_approval",
     "create_pending_request",
     "expire_stale_requests",
+    "find_remote_write_approval",
     "get_request",
     "list_pending",
     "publish_approval_event",
@@ -776,6 +778,99 @@ async def claim_resume(
         won = cast(CursorResult[Any], raw_result).rowcount == 1
         await session.commit()
     return won
+
+
+async def find_remote_write_approval(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    op_id: str,
+    target_id: uuid.UUID | None,
+    params_hash: str,
+) -> ApprovalRequest | None:
+    """Find the committed approval that authorises a remote-write mint (read-only).
+
+    Mechanism 1 of the satellite write-path composed gate (#3189, design §3):
+    the ``remote-write`` (caution) tier mints a capability **only** against a
+    committed :class:`ApprovalRequest` for the *identical*
+    ``(tenant, op, target, params_hash)`` -- the human approval decision is the
+    mint's authorization, exactly as :func:`resume_dispatch_after_approval`
+    re-dispatches an approved op with the policy gate bypassed
+    (``dispatch(..., _approved=True)``). The ``params_hash`` predicate is the
+    swap defence (#1503 / #3197): a mint whose params differ from the approved
+    ones matches no row and is refused.
+
+    Read-only: it never mutates a row, so the mint can refuse fail-closed (no
+    approval, or -- later -- the signing key is unavailable) **without**
+    consuming an approval. The single-use consumption is a separate atomic
+    step, :func:`consume_remote_write_approval`, run only once the mint is
+    certain to proceed. Returns the newest matching un-consumed
+    (``resumed_at IS NULL``) approval, or ``None``.
+    """
+    target_clause = (
+        ApprovalRequest.target_id == target_id
+        if target_id is not None
+        else ApprovalRequest.target_id.is_(None)
+    )
+    stmt = (
+        select(ApprovalRequest)
+        .where(
+            ApprovalRequest.tenant_id == tenant_id,
+            ApprovalRequest.op_id == op_id,
+            ApprovalRequest.params_hash == params_hash,
+            ApprovalRequest.status == ApprovalRequestStatus.APPROVED.value,
+            ApprovalRequest.resumed_at.is_(None),
+            target_clause,
+        )
+        .order_by(ApprovalRequest.decided_at.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+async def consume_remote_write_approval(
+    session: AsyncSession,
+    request: ApprovalRequest,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Atomically claim a remote-write approval as single-use, in the mint session.
+
+    Wins the same one-way ``resumed_at`` conditional-``UPDATE`` latch the
+    re-dispatch path uses (:func:`claim_resume`) and the command consume path
+    mirrors (``consume_command``), but run **in the caller's mint session**
+    (flushed, not committed on its own) so the approval is consumed **iff** the
+    mint commits: a rolled-back mint frees the approval, and two concurrent
+    mints cannot both bind the same approval (the loser touches zero rows and
+    gets ``False``). A caution op destined for a runner is executed by the
+    mint, so the mint is the sole consumer of ``resumed_at`` -- there is no
+    competing direct re-dispatch for a runner-targeted op.
+
+    Returns ``True`` when this caller set ``resumed_at`` (owns the single mint),
+    ``False`` when a racing mint already claimed it.
+    """
+    stamp = now or _now()
+    claimed = await session.execute(
+        update(ApprovalRequest)
+        .where(
+            ApprovalRequest.id == request.id,
+            ApprovalRequest.resumed_at.is_(None),
+        )
+        .values(resumed_at=stamp)
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    if cast(CursorResult[Any], claimed).rowcount != 1:
+        return False
+    request.resumed_at = stamp
+    _log.info(
+        "remote_write_approval_bound",
+        approval_request_id=str(request.id),
+        op_id=request.op_id,
+        tenant_id=str(request.tenant_id),
+    )
+    return True
 
 
 async def resume_dispatch_after_approval(

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -83,10 +83,19 @@ from meho_backplane.operations._validate import (
     policy_gate,
     validate_params,
 )
+from meho_backplane.operations.approval_queue import (
+    consume_remote_write_approval,
+    find_remote_write_approval,
+)
 from meho_backplane.runner.satellite_tier import (
     SatelliteMintTier,
     classify_satellite_tier,
-    evaluate_remote_write_gate,
+)
+from meho_backplane.runner.work_item_signing import (
+    TARGETLESS_SCOPE,
+    SigningKeyUnavailableError,
+    load_signing_key,
+    sign_remote_write_item,
 )
 
 __all__ = [
@@ -144,9 +153,13 @@ class MintRefusalCode(StrEnum):
     :attr:`~meho_backplane.runner.satellite_tier.SatelliteMintTier.EXCLUDED`
     tier (``dangerous`` / ``destructive`` — never minted to a satellite);
     ``REMOTE_WRITE_GATE_UNSATISFIED`` is the fail-closed refusal of the
-    additive ``remote-write`` tier while its composed gate is unprovisioned
-    (#3188); ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate
-    verdicts that are not ``AUTO_EXECUTE``.
+    additive ``remote-write`` tier when no committed, single-use approval
+    binds the mint (mechanism 1, #3189 — and, once #3190 lands, when the
+    op-class is off the runner's allowlist); ``REMOTE_WRITE_SIGNING_UNAVAILABLE``
+    refuses a remote-write mint that cannot be signed because the central
+    signing key is not provisioned (#3189); ``POLICY_DENIED`` /
+    ``NEEDS_APPROVAL`` are the policy-gate verdicts that are not
+    ``AUTO_EXECUTE``.
     """
 
     DESCRIPTOR_UNKNOWN = "descriptor_unknown"
@@ -154,6 +167,7 @@ class MintRefusalCode(StrEnum):
     INVALID_OP_SCHEMA = "invalid_op_schema"
     OP_NOT_SAFE = "op_not_safe"
     REMOTE_WRITE_GATE_UNSATISFIED = "remote_write_gate_unsatisfied"
+    REMOTE_WRITE_SIGNING_UNAVAILABLE = "remote_write_signing_unavailable"
     POLICY_DENIED = "policy_denied"
     NEEDS_APPROVAL = "needs_approval"
 
@@ -182,6 +196,25 @@ class MintResult:
 def _refused(code: MintRefusalCode, reason: str) -> MintResult:
     """Build a fail-closed refusal result (no rows written)."""
     return MintResult(refusal_code=code, refusal_reason=reason)
+
+
+def _refuse_remote_write(
+    code: MintRefusalCode,
+    reason: str,
+    *,
+    op_id: str,
+    operator: Operator,
+    runner_id: str,
+) -> MintResult:
+    """Log + build a fail-closed ``remote-write`` mint refusal (no rows written)."""
+    structlog.get_logger(__name__).warning(
+        "gateway_command_mint_refused_remote_write",
+        reason=code.value,
+        op_id=op_id,
+        operator_sub=operator.sub,
+        runner_id=runner_id,
+    )
+    return _refused(code, reason)
 
 
 def _refuse_unvalidatable_params(
@@ -307,11 +340,16 @@ async def mint_gateway_command(
        generalised, checked **before** the policy gate (so a refused op never
        reaches it and is never parked): ``EXCLUDED`` (``dangerous`` /
        ``destructive``) → :attr:`MintRefusalCode.OP_NOT_SAFE`, never minted
-       (composes with #3183); ``REMOTE_WRITE`` (``caution``) → the composed
-       gate, fail-closed until the siblings wire it →
-       :attr:`MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`; ``SAFE`` falls
-       through to the policy gate, semantics unchanged.
-    4. ``policy_gate`` — any verdict other than ``AUTO_EXECUTE`` refuses
+       (composes with #3183); ``REMOTE_WRITE`` (``caution``) →
+       :func:`_mint_remote_write` (mechanism 1, #3189): mints **only** against
+       a committed, single-use, param-bound ``ApprovalRequest`` — bypassing
+       the live policy gate, since the human approval decision is the
+       authorization — and stamps an Ed25519 **signature** on the capability;
+       no approval → :attr:`MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`,
+       unprovisioned signing key → :attr:`MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE`.
+       ``SAFE`` falls through to the policy gate, semantics unchanged.
+    4. ``policy_gate`` (``SAFE`` tier only) — any verdict other than
+       ``AUTO_EXECUTE`` refuses
        (``DENY`` → :attr:`MintRefusalCode.POLICY_DENIED`, ``NEEDS_APPROVAL``
        → :attr:`MintRefusalCode.NEEDS_APPROVAL`); the defensive
        ``is not AUTO_EXECUTE`` branch denies any unexpected verdict.
@@ -399,22 +437,25 @@ async def mint_gateway_command(
             "dangerous/destructive ops are never minted to a satellite",
         )
     if tier is SatelliteMintTier.REMOTE_WRITE:
-        # The additive write tier, separate from the untouched `safe` wall.
-        # Its composed gate (per-runner allowlist + approval/policy binding)
-        # is wired by sibling tasks (#3189-#3193); until then it is fail-closed.
-        gate = evaluate_remote_write_gate(op_id=op_id, runner_id=runner_id)
-        if not gate.permitted:
-            structlog.get_logger(__name__).warning(
-                "gateway_command_mint_refused_remote_write",
-                reason=MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED.value,
-                op_id=op_id,
-                safety_level=descriptor.safety_level,
-                operator_sub=operator.sub,
-                runner_id=runner_id,
-            )
-            return _refused(MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED, gate.reason)
+        # The additive write tier (mechanism 1, #3189): a caution op mints
+        # only against a committed, single-use, param-bound approval, and the
+        # minted capability is signed for offline edge verification. Delegated
+        # so the safe path below stays the untouched Step-4 policy gate.
+        return await _mint_remote_write(
+            session,
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+            params_hash=params_hash,
+            runner_id=runner_id,
+            target_descriptor=target_descriptor,
+            expires_at=expires_at,
+            started=started,
+        )
 
-    # --- Step 4: policy gate (only AUTO_EXECUTE mints) -------------------
+    # --- Step 4: policy gate (only AUTO_EXECUTE mints the SAFE tier) ------
     verdict, gate_reason = await policy_gate(
         operator=operator, descriptor=descriptor, target=target
     )
@@ -436,7 +477,147 @@ async def mint_gateway_command(
             gate_reason or f"policy gate returned {verdict.value!r}, not auto-execute",
         )
 
-    # --- Mint: synchronous audit row + bound command row -----------------
+    # --- Mint the SAFE-tier capability (unsigned; #2500 authorization) ----
+    return await _finalize_mint(
+        session,
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        runner_id=runner_id,
+        target_descriptor=target_descriptor,
+        expires_at=expires_at,
+        started=started,
+    )
+
+
+async def _mint_remote_write(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    target: Any,
+    params: dict[str, Any],
+    params_hash: str,
+    runner_id: str,
+    target_descriptor: dict[str, Any] | None,
+    expires_at: datetime | None,
+    started: float,
+) -> MintResult:
+    """Mint a signed remote-write capability against a committed approval (#3189).
+
+    Mechanism 1 of the composed write-path gate: the caution tier mints
+    **only** against a committed, single-use, param-bound ``ApprovalRequest``
+    for the identical ``(op, target, params_hash)`` — the human approval
+    decision is the authorization (policy gate bypassed for this tier, the
+    mould of ``approve_request``'s ``_approved=True`` re-dispatch). On a win
+    the capability is **signed** for offline edge verification.
+
+    **Composition point for #3190** (mechanism 2, the per-runner allowlist):
+    the allowlist check slots in below, ANDed with this approval binding.
+    Until #3190 wires it at the mint, the edge allowlist re-check
+    (``executor._screen_item`` → ``evaluate_remote_write_gate``, still
+    fail-closed) keeps the tier closed end-to-end.
+
+    Order matters: the approval is located read-only and the signing key
+    checked **before** the single-use latch is claimed, so a fail-closed
+    refusal never consumes an approval (the "a refusal writes no rows"
+    invariant holds).
+    """
+    from meho_backplane.settings import get_settings
+
+    raw_target_id = getattr(target, "id", None) if target is not None else None
+    target_id = raw_target_id if isinstance(raw_target_id, uuid.UUID) else None
+
+    # #3190 allowlist check composes here, ANDed with the approval binding.
+    approval = await find_remote_write_approval(
+        session,
+        tenant_id=operator.tenant_id,
+        op_id=op_id,
+        target_id=target_id,
+        params_hash=params_hash,
+    )
+    if approval is None:
+        return _refuse_remote_write(
+            MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED,
+            f"remote-write op {op_id!r} refused: no committed, unconsumed approval "
+            "binding for this (op, target, params); the caution tier mints only "
+            "against a human-approved ApprovalRequest (mechanism 1)",
+            op_id=op_id,
+            operator=operator,
+            runner_id=runner_id,
+        )
+
+    try:
+        signing_key = load_signing_key(get_settings().satellite_write_signing_key)
+    except SigningKeyUnavailableError as exc:
+        return _refuse_remote_write(
+            MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE,
+            f"remote-write op {op_id!r} refused: {exc}",
+            op_id=op_id,
+            operator=operator,
+            runner_id=runner_id,
+        )
+
+    # Claim the single-use latch only now the mint is certain to proceed. A
+    # racing mint that already claimed this approval loses (touches zero rows),
+    # so an approval binds at most one capability.
+    if not await consume_remote_write_approval(session, approval):
+        return _refuse_remote_write(
+            MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED,
+            f"remote-write op {op_id!r} refused: the binding approval "
+            f"{approval.id} was already consumed by a concurrent mint",
+            op_id=op_id,
+            operator=operator,
+            runner_id=runner_id,
+        )
+
+    return await _finalize_mint(
+        session,
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        runner_id=runner_id,
+        target_descriptor=target_descriptor,
+        expires_at=expires_at,
+        started=started,
+        signing_key=signing_key,
+        approval_request_id=approval.id,
+    )
+
+
+async def _finalize_mint(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    target: Any,
+    params: dict[str, Any],
+    params_hash: str,
+    runner_id: str,
+    target_descriptor: dict[str, Any] | None,
+    expires_at: datetime | None,
+    started: float,
+    signing_key: Any | None = None,
+    approval_request_id: uuid.UUID | None = None,
+) -> MintResult:
+    """Enqueue the bound command, optionally sign it, and write the mint audit row.
+
+    Shared tail of both mint paths (safe and remote-write). When *signing_key*
+    is supplied (the remote-write tier), the capability is signed over its
+    canonical payload — computed against the row's *bounded* ``expires_at``,
+    so the signed freshness bound matches what the runner will verify — and
+    the signature is stamped on the command row (migration 0088). The mint
+    audit payload records ``approval_request_id`` / ``signed`` for the
+    remote-write lineage; the safe path leaves both unset (unchanged shape).
+    """
     mint_audit_id = uuid.uuid4()
     command = await enqueue_command(
         session,
@@ -450,6 +631,30 @@ async def mint_gateway_command(
         expires_at=expires_at,
         mint_audit_id=mint_audit_id,
     )
+    signed = False
+    if signing_key is not None:
+        command.signature = sign_remote_write_item(
+            signing_key,
+            op_id=op_id,
+            params_hash=params_hash,
+            target_scope=_target_scope(target),
+            expires_at=command.expires_at,
+        )
+        await session.flush()
+        signed = True
+
+    payload: dict[str, Any] = {
+        "command_id": str(command.id),
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "runner_id": runner_id,
+        "params_hash": params_hash,
+        "result_status": "minted",
+    }
+    if approval_request_id is not None:
+        payload["approval_request_id"] = str(approval_request_id)
+    if signed:
+        payload["signed"] = True
     await _write_gateway_audit_row(
         session,
         audit_id=mint_audit_id,
@@ -458,14 +663,7 @@ async def mint_gateway_command(
         status_code=_MINT_AUDIT_STATUS,
         duration_ms=(time.monotonic() - started) * 1000,
         target_id=getattr(target, "id", None) if target is not None else None,
-        payload={
-            "command_id": str(command.id),
-            "op_id": op_id,
-            "connector_id": connector_id,
-            "runner_id": runner_id,
-            "params_hash": params_hash,
-            "result_status": "minted",
-        },
+        payload=payload,
     )
     structlog.get_logger(__name__).info(
         "gateway_command_minted",
@@ -475,8 +673,20 @@ async def mint_gateway_command(
         runner_id=runner_id,
         tenant_id=str(operator.tenant_id),
         expires_at=command.expires_at.isoformat(),
+        signed=signed,
     )
     return MintResult(command=command, mint_audit_id=mint_audit_id)
+
+
+def _target_scope(target: Any) -> str:
+    """The canonical ``target_scope`` the signature binds — target id or targetless.
+
+    Mirrors the edge's reconstruction (``str(target_descriptor.id)`` or
+    :data:`~meho_backplane.runner.work_item_signing.TARGETLESS_SCOPE`), so the
+    scope the centre signs and the scope the runner verifies agree.
+    """
+    raw_target_id = getattr(target, "id", None) if target is not None else None
+    return str(raw_target_id) if isinstance(raw_target_id, uuid.UUID) else TARGETLESS_SCOPE
 
 
 async def consume_command(

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -18,9 +18,11 @@ owned by #2500):
   :mod:`~meho_backplane.runner.satellite_tier` ladder (the same source of
   truth the central mint and the assignment materialiser use). An
   ``EXCLUDED`` (``dangerous`` / ``destructive``) item is refused outright;
-  a ``REMOTE_WRITE`` (``caution``) item is re-screened through the composed
-  gate and fails closed until the runner is authorised for the tier; only a
-  ``SAFE`` item proceeds.
+  a ``REMOTE_WRITE`` (``caution``) item has its centre-issued Ed25519
+  signature verified offline (integrity + freshness + target scope, #3189)
+  and is then re-screened through the allowlist gate, failing closed at
+  every step until the runner is authorised for the tier; only a ``SAFE``
+  item proceeds.
 * **connector-tree-only** — a ``handler_ref`` that does not resolve inside
   ``meho_backplane.connectors.*`` is refused. The lexical prefix is
   checked *before* import (an import has module-load side effects) and the
@@ -34,6 +36,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -52,6 +55,13 @@ from meho_backplane.runner.satellite_tier import (
 )
 from meho_backplane.runner.spool import ExecutedCommandStore
 from meho_backplane.runner.wire import RunnerResult, RunnerWorkItem
+from meho_backplane.runner.work_item_signing import (
+    TARGETLESS_SCOPE,
+    SigningKeyUnavailableError,
+    load_verify_key,
+    params_digest,
+    verify_remote_write_item,
+)
 
 __all__ = ["execute_command_once", "execute_work_item"]
 
@@ -93,15 +103,74 @@ def _screen_item(item: RunnerWorkItem) -> str | None:
             "ops are never dispatched to a runner"
         )
     if tier is SatelliteMintTier.REMOTE_WRITE:
-        # A remote-write item still fails closed at the edge if the runner is
-        # not authorised for the tier (mechanism 2's edge re-check). The
-        # allowlist/signature machinery is a sibling task; until it exists the
-        # gate refuses every remote-write item.
+        # Mechanism 1 edge check (#3189): verify the centre's signature +
+        # freshness + target scope offline, before any allowlist re-check or
+        # import. A bad / expired / out-of-scope (or unsigned) item fails
+        # closed here.
+        signature_refusal = _verify_remote_write_signature(item)
+        if signature_refusal is not None:
+            return signature_refusal
+        # Mechanism 2 edge re-check (#3190): the per-runner allowlist. Still
+        # fail-closed until #3190 wires it, so a validly-signed remote-write
+        # item does not execute at the edge until the allowlist is provisioned
+        # — the tier stays closed end-to-end.
         decision = evaluate_remote_write_gate(op_id=item.op_id)
         if not decision.permitted:
             return decision.reason
     if not item.handler_ref.startswith(_CONNECTOR_MODULE_PREFIX):
         return f"handler_ref {item.handler_ref!r} is outside {_CONNECTOR_MODULE_PREFIX}*"
+    return None
+
+
+def _verify_remote_write_signature(item: RunnerWorkItem) -> str | None:
+    """Verify a remote-write item's signature, or a fail-closed refusal reason.
+
+    Mechanism 1's edge half (#3189): the DB-free runner independently verifies
+    the centre's Ed25519 signature over the canonical work-item payload
+    (integrity over ``op_id`` + ``params_hash``, the ``target_scope`` binding)
+    and the ``expires_at`` freshness bound, using the verification (public) key
+    provisioned at enrollment. Every refusal reason names ``remote-write`` so
+    the tier is legible in the refusal log.
+
+    The order is integrity/scope first, then freshness: a tampered op/params or
+    a re-pointed target breaks the signature (caught first); a genuine but
+    stale capability has a valid signature but is refused by the ``expires_at``
+    check. An unsigned item, a missing freshness bound, or an unprovisioned
+    verification key all fail closed.
+    """
+    from meho_backplane.settings import get_settings
+
+    prefix = f"remote-write op {item.op_id!r} refused"
+    if not item.signature:
+        return (
+            f"{prefix}: work item is unsigned; the caution tier requires "
+            "a centrally-signed capability"
+        )
+    if item.expires_at is None:
+        return f"{prefix}: signed work item carries no expires_at freshness bound"
+    try:
+        verify_key = load_verify_key(get_settings().satellite_write_verify_key)
+    except SigningKeyUnavailableError as exc:
+        return f"{prefix}: {exc}"
+
+    target_scope = (
+        str(item.target_descriptor.id) if item.target_descriptor is not None else TARGETLESS_SCOPE
+    )
+    verified = verify_remote_write_item(
+        verify_key,
+        item.signature,
+        op_id=item.op_id,
+        params_hash=params_digest(item.params),
+        target_scope=target_scope,
+        expires_at=item.expires_at,
+    )
+    if not verified:
+        return (
+            f"{prefix}: signature verification failed "
+            "(tampered op/params, out-of-scope target, or wrong key)"
+        )
+    if datetime.now(UTC) >= item.expires_at:
+        return f"{prefix}: signed capability expired at {item.expires_at.isoformat()}"
     return None
 
 

--- a/backend/src/meho_backplane/runner/wire.py
+++ b/backend/src/meho_backplane/runner/wire.py
@@ -29,6 +29,7 @@ treats it purely as a cache key — it never parses it.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -134,6 +135,16 @@ class RunnerWorkItem(BaseModel):
     ``params``, the ``safety_level`` the runner re-checks (defence in
     depth), the principal context, and the resolved target descriptor
     (``None`` for targetless synthetic ops such as ``net.*``).
+
+    Remote-write signing (#3189): a ``caution`` / ``remote-write`` item
+    additionally carries the centre's Ed25519 ``signature`` over its
+    canonical payload and the ``expires_at`` freshness bound the signature
+    covers, both verified in
+    :func:`~meho_backplane.runner.executor._screen_item` before execution.
+    Both are ``None`` for a ``safe`` read item (the recurring assignment
+    path materialises only ``safe`` ops and never signs them) -- signing is
+    a write-tier property, so their absence on a ``safe`` item is correct,
+    not a missing field.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -148,6 +159,8 @@ class RunnerWorkItem(BaseModel):
     safety_level: str
     principal: RunnerPrincipal
     target_descriptor: ResolvedTargetDescriptor | None = None
+    signature: str | None = None
+    expires_at: datetime | None = None
 
 
 class RunnerAssignment(BaseModel):

--- a/backend/src/meho_backplane/runner/work_item_signing.py
+++ b/backend/src/meho_backplane/runner/work_item_signing.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Ed25519 signing + edge verification of ``remote-write`` work items (#3189).
+
+Mechanism 1 (part 2) of the satellite write-path composed gate (Initiative
+#2901, design ``docs/research/2901-satellite-write-path.md`` §3, decision
+``docs/decisions/satellite-write-path.md``): a **real signature** over the
+canonical serialisation of a ``remote-write`` work item, created **once at
+authorization time** by the central mint and verified **offline at the edge**
+by the DB-free runner.
+
+This is the deliberate, write-tier-only reversal of #2500 ("the token is a
+bare DB-row PK, not a JWT"). For a ``safe`` read an edge-verifiable signature
+bought nothing over the central consume latch; for a **write** the signature
+is the offline integrity + freshness + target-scope check against transit
+tampering (threat T2) and the non-repudiation anchor the store-and-forward
+effect audit references. The DB consume latch is **retained unchanged** for
+at-most-once acceptance — the signature does not replace central state.
+
+Key custody (asymmetric on purpose): the **signing (private) key is custodied
+centrally** and used only by the central mint
+(:func:`~meho_backplane.operations.gateway_commands.mint_gateway_command`); the
+**verification (public) key is provisioned to the runner at enrollment**.
+Ed25519 rather than an HMAC precisely so a compromised runner — which holds
+only the public key — cannot forge a work item (a symmetric secret on the
+fenced host would let it mint its own capabilities, defeating T2 and the
+non-repudiation property).
+
+This module lives beside :mod:`meho_backplane.runner.wire` and
+:mod:`meho_backplane.runner.satellite_tier` — the other central+edge shared
+contracts — and imports only the standard library and ``cryptography`` (which
+does **not** pull the DB stack), so verifying a signature on the DB-free
+runner never imports the central Postgres layer.
+
+The signed payload is exactly the three checks the edge performs — integrity
+over ``op_id`` + ``params_hash``, ``target_scope``, and the ``expires_at``
+freshness bound — so a tampered op/params/target breaks the signature and a
+validly-signed-but-stale item is caught by the separate freshness check at the
+edge (see :func:`~meho_backplane.runner.executor._screen_item`).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+__all__ = [
+    "TARGETLESS_SCOPE",
+    "SigningKeyUnavailableError",
+    "load_signing_key",
+    "load_verify_key",
+    "params_digest",
+    "remote_write_signing_bytes",
+    "sign_remote_write_item",
+    "verify_remote_write_item",
+]
+
+#: The canonical ``target_scope`` token for a targetless synthetic op (an item
+#: with no resolved target descriptor). A concrete op signs ``str(target.id)``.
+TARGETLESS_SCOPE = ""
+
+#: The signed-payload schema marker — a future incompatible change to the
+#: signed fields is a visible bump, never a silent reinterpretation.
+_PAYLOAD_VERSION = 1
+
+
+class SigningKeyUnavailableError(Exception):
+    """The Ed25519 signing / verification key is not provisioned or malformed.
+
+    Raised by :func:`load_signing_key` / :func:`load_verify_key` when the
+    configured key is empty (not provisioned) or is not a valid base64
+    32-byte Ed25519 key. Both the central mint and the edge treat this as
+    **fail-closed**: a ``remote-write`` capability is neither minted nor
+    executed when the key seam is unavailable.
+    """
+
+
+def params_digest(params: dict[str, Any]) -> str:
+    """Return the stable SHA-256 hex digest over the canonicalised *params*.
+
+    An **edge-safe mirror** of
+    :func:`meho_backplane.operations._validate.compute_params_hash`: identical
+    canonicalisation (``json.dumps(..., sort_keys=True, default=str,
+    separators=(",", ":"))`` then SHA-256) so the digest the centre signs and
+    the digest the runner recomputes over the params it is about to execute
+    agree byte-for-byte. Duplicated here — rather than imported — because
+    ``operations._validate`` pulls the DB stack, which must never load on the
+    DB-free runner. The two are pinned equal by a unit test.
+    """
+    canonical = json.dumps(params, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _canonical_expires_at(expires_at: datetime) -> str:
+    """Normalise *expires_at* to a canonical UTC ISO-8601 string.
+
+    Both ends must serialise the freshness bound identically for the signature
+    to verify, so a naive datetime is treated as UTC and every value is
+    converted to UTC before formatting.
+    """
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    return expires_at.astimezone(UTC).isoformat()
+
+
+def remote_write_signing_bytes(
+    *,
+    op_id: str,
+    params_hash: str,
+    target_scope: str,
+    expires_at: datetime,
+) -> bytes:
+    """Return the canonical byte serialisation the signature is computed over.
+
+    Deterministic (sorted keys, tight separators) so the centre's signing
+    input and the runner's verification input are byte-identical. The four
+    fields map one-to-one onto the edge checks: integrity over
+    ``op_id`` + ``params_hash``, the ``target_scope`` binding, and the
+    ``expires_at`` freshness bound.
+    """
+    payload = {
+        "v": _PAYLOAD_VERSION,
+        "op_id": op_id,
+        "params_hash": params_hash,
+        "target_scope": target_scope,
+        "expires_at": _canonical_expires_at(expires_at),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def load_signing_key(raw_b64: str) -> Ed25519PrivateKey:
+    """Load the central Ed25519 **signing** key from a base64 32-byte seed.
+
+    Raises :class:`SigningKeyUnavailableError` when unset or malformed — the
+    mint fails closed rather than minting an unsigned remote-write capability.
+    """
+    seed = _decode_key(raw_b64, role="signing")
+    try:
+        return Ed25519PrivateKey.from_private_bytes(seed)
+    except ValueError as exc:  # not 32 bytes
+        raise SigningKeyUnavailableError(
+            f"satellite-write signing key is not a valid Ed25519 private key: {exc}"
+        ) from exc
+
+
+def load_verify_key(raw_b64: str) -> Ed25519PublicKey:
+    """Load the runner's Ed25519 **verification** key from a base64 32-byte key.
+
+    Raises :class:`SigningKeyUnavailableError` when unset or malformed — the
+    edge fails closed rather than executing an unverifiable remote-write item.
+    """
+    key = _decode_key(raw_b64, role="verification")
+    try:
+        return Ed25519PublicKey.from_public_bytes(key)
+    except ValueError as exc:  # not 32 bytes
+        raise SigningKeyUnavailableError(
+            f"satellite-write verification key is not a valid Ed25519 public key: {exc}"
+        ) from exc
+
+
+def _decode_key(raw_b64: str, *, role: str) -> bytes:
+    """Base64-decode a configured key, raising a fail-closed error on any fault."""
+    if not raw_b64:
+        raise SigningKeyUnavailableError(
+            f"satellite-write {role} key is not provisioned "
+            "(remote-write capabilities are refused fail-closed)"
+        )
+    try:
+        return base64.b64decode(raw_b64, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise SigningKeyUnavailableError(
+            f"satellite-write {role} key is not valid base64: {exc}"
+        ) from exc
+
+
+def sign_remote_write_item(
+    signing_key: Ed25519PrivateKey,
+    *,
+    op_id: str,
+    params_hash: str,
+    target_scope: str,
+    expires_at: datetime,
+) -> str:
+    """Sign the canonical work-item payload, returning a base64 signature."""
+    message = remote_write_signing_bytes(
+        op_id=op_id,
+        params_hash=params_hash,
+        target_scope=target_scope,
+        expires_at=expires_at,
+    )
+    return base64.b64encode(signing_key.sign(message)).decode("ascii")
+
+
+def verify_remote_write_item(
+    verify_key: Ed25519PublicKey,
+    signature_b64: str,
+    *,
+    op_id: str,
+    params_hash: str,
+    target_scope: str,
+    expires_at: datetime,
+) -> bool:
+    """Return ``True`` iff *signature_b64* is a valid signature over the payload.
+
+    Fail-closed: a malformed base64 signature or any integrity/scope mismatch
+    returns ``False`` (never raises). The **freshness** bound is verified
+    separately by the caller against ``expires_at`` — a signature over a stale
+    item is cryptographically valid but must still be refused.
+    """
+    try:
+        signature = base64.b64decode(signature_b64, validate=True)
+    except (ValueError, TypeError):
+        return False
+    message = remote_write_signing_bytes(
+        op_id=op_id,
+        params_hash=params_hash,
+        target_scope=target_scope,
+        expires_at=expires_at,
+    )
+    try:
+        verify_key.verify(signature, message)
+    except InvalidSignature:
+        return False
+    return True

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1332,6 +1332,25 @@ class Settings(BaseModel):
     gateway_deadman_enabled: bool = True
     gateway_deadman_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
     gateway_runner_stale_after_multiplier: int = Field(default=3, ge=1, le=100)
+    # Initiative #2901 (#3189) -- satellite write-path work-item signing keys.
+    # Asymmetric Ed25519 (mechanism 1, design §3): the central instance holds
+    # the SIGNING (private) key and stamps a signature on every remote-write
+    # capability at mint; the runner holds only the VERIFICATION (public) key,
+    # provisioned at enrollment, and verifies the signature offline before
+    # executing. Split fields so each deployment populates only the key its
+    # role needs (private on central, public on the runner) -- a compromised
+    # runner never holds the signing secret. Both are base64-encoded raw
+    # 32-byte Ed25519 keys; default ``""`` is fail-closed -- remote-write
+    # mints (central) and remote-write executions (edge) are refused until the
+    # respective key is provisioned. Production renders these from a
+    # Vault-managed secret into the pod env (same chain as DATABASE_URL);
+    # generate a pair with ``python -c 'import base64; from
+    # cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey;
+    # k=Ed25519PrivateKey.generate();
+    # print(base64.b64encode(k.private_bytes_raw()).decode());
+    # print(base64.b64encode(k.public_key().public_bytes_raw()).decode())'``.
+    satellite_write_signing_key: str = ""
+    satellite_write_verify_key: str = ""
     ui_keycloak_client_id: str = ""
     ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
@@ -2092,6 +2111,8 @@ def get_settings() -> Settings:
         gateway_runner_stale_after_multiplier=int(
             os.environ.get("GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER", "3"),
         ),
+        satellite_write_signing_key=os.environ.get("SATELLITE_WRITE_SIGNING_KEY", "").strip(),
+        satellite_write_verify_key=os.environ.get("SATELLITE_WRITE_VERIFY_KEY", "").strip(),
         ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", "").strip(),
         ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", "").strip(),
         ui_session_encryption_key=os.environ.get("UI_SESSION_ENCRYPTION_KEY", "").strip(),

--- a/backend/tests/test_connectors_wrapped_creds.py
+++ b/backend/tests/test_connectors_wrapped_creds.py
@@ -363,10 +363,16 @@ def test_screen_refuses_when_target_descriptor_is_none() -> None:
 async def test_executor_refuses_remote_write_without_wrapped_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # End-to-end edge enforcement: with the composed gate permitting (its real
-    # wiring is #3189), a remote-write item whose target carries a standing
-    # secret_ref is still refused at the edge by the mechanism-3 credential
-    # screen — no standing runner credential ever rides the write tier.
+    # End-to-end edge enforcement: with the mechanism-1 signature check (#3189)
+    # satisfied and the allowlist gate permitting (its real wiring is #3190), a
+    # remote-write item whose target carries a standing secret_ref is still
+    # refused at the edge by the mechanism-3 credential screen — no standing
+    # runner credential ever rides the write tier.
+    import base64
+    from datetime import UTC, datetime, timedelta
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
     from meho_backplane.runner import executor
     from meho_backplane.runner.satellite_tier import RemoteWriteGateDecision
     from meho_backplane.runner.wire import (
@@ -374,12 +380,24 @@ async def test_executor_refuses_remote_write_without_wrapped_credential(
         RunnerPrincipal,
         RunnerWorkItem,
     )
+    from meho_backplane.runner.work_item_signing import params_digest, sign_remote_write_item
+    from meho_backplane.settings import get_settings
 
     monkeypatch.setattr(
         executor,
         "evaluate_remote_write_gate",
         lambda **_kw: RemoteWriteGateDecision(permitted=True, reason="permitted-in-test"),
     )
+
+    # Provision the verify key + sign the item so it clears the mechanism-1
+    # signature screen and reaches the mechanism-3 credential screen under test.
+    signing_key = Ed25519PrivateKey.generate()
+    verify_b64 = base64.b64encode(signing_key.public_key().public_bytes_raw()).decode("ascii")
+    monkeypatch.setenv("SATELLITE_WRITE_VERIFY_KEY", verify_b64)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
 
     descriptor = ResolvedTargetDescriptor(
         id=uuid.uuid4(),
@@ -388,6 +406,15 @@ async def test_executor_refuses_remote_write_without_wrapped_credential(
         product="vmware",
         host="vc-a.example.internal",
         secret_ref="targets/vc-a",  # standing/broad — not a wrapped token
+    )
+    expires_at = datetime.now(UTC) + timedelta(minutes=5)
+    params: dict[str, object] = {}
+    signature = sign_remote_write_item(
+        signing_key,
+        op_id="vmware.vm.tag_set",
+        params_hash=params_digest(params),
+        target_scope=str(descriptor.id),
+        expires_at=expires_at,
     )
     item = RunnerWorkItem(
         check_ref="chk-rw",
@@ -399,6 +426,9 @@ async def test_executor_refuses_remote_write_without_wrapped_credential(
             sub="runner-svc", tenant_id=uuid.uuid4(), tenant_role=TenantRole.READ_ONLY
         ),
         target_descriptor=descriptor,
+        params=params,
+        signature=signature,
+        expires_at=expires_at,
     )
 
     result = await executor.execute_work_item(item)

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -17,10 +17,12 @@ against the real ``gateway_command`` / ``audit_log`` tables.
 
 from __future__ import annotations
 
+import base64
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from sqlalchemy import func, select, update
 from structlog.testing import capture_logs
 
@@ -29,6 +31,7 @@ from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     ApprovalRequest,
+    ApprovalRequestStatus,
     AuditLog,
     EndpointDescriptor,
     GatewayCommand,
@@ -49,6 +52,11 @@ from meho_backplane.operations.gateway_commands import (
     consume_command,
     mint_gateway_command,
 )
+from meho_backplane.runner.work_item_signing import (
+    TARGETLESS_SCOPE,
+    load_verify_key,
+    verify_remote_write_item,
+)
 from meho_backplane.settings import get_settings
 
 _TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
@@ -56,6 +64,11 @@ _RUNNER = "runner-a"
 _CONNECTOR_ID = "net-1.x"
 _OP_ID = "net.ping"
 _PARAMS: dict[str, object] = {"host": "10.0.0.1"}
+
+# A fixed Ed25519 keypair for the remote-write signing tests (base64 raw keys).
+_SIGNING_KEYPAIR = Ed25519PrivateKey.generate()
+_SIGNING_KEY_B64 = base64.b64encode(_SIGNING_KEYPAIR.private_bytes_raw()).decode("ascii")
+_VERIFY_KEY_B64 = base64.b64encode(_SIGNING_KEYPAIR.public_key().public_bytes_raw()).decode("ascii")
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +83,42 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    # Provision the central signing key so an approval-bound remote-write mint
+    # can sign (the no-approval / no-key refusals are asserted explicitly).
+    monkeypatch.setenv("SATELLITE_WRITE_SIGNING_KEY", _SIGNING_KEY_B64)
     get_settings.cache_clear()
+
+
+async def _seed_committed_approval(
+    *,
+    params: dict[str, object] | None = None,
+    target_id: uuid.UUID | None = None,
+    op_id: str = _OP_ID,
+) -> uuid.UUID:
+    """Insert an ``approved``, un-consumed ApprovalRequest and return its id."""
+    resolved = params if params is not None else dict(_PARAMS)
+    now = datetime.now(UTC)
+    approval = ApprovalRequest(
+        id=uuid.uuid4(),
+        tenant_id=_TENANT,
+        principal_sub="requester-sub",
+        op_id=op_id,
+        connector_id=_CONNECTOR_ID,
+        target_id=target_id,
+        params_hash=compute_params_hash(resolved),
+        params=resolved,
+        proposed_effect={"op_id": op_id},
+        status=ApprovalRequestStatus.APPROVED.value,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        decided_at=now,
+        reviewed_by="approver-sub",
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(approval)
+        await session.commit()
+    return approval.id
 
 
 async def _seed_tenant() -> None:
@@ -223,6 +271,171 @@ async def test_mint_refuses_remote_write_gate_unsatisfied(
     assert "remote-write" in (result.refusal_reason or "")
     assert await _count(GatewayCommand) == 0
     assert await _count(ApprovalRequest) == 0
+
+
+# ---------------------------------------------------------------------------
+# Remote-write tier — approval-bound minting + signing (#3189, mechanism 1)
+# ---------------------------------------------------------------------------
+
+
+async def _mint_caution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    params: dict[str, object] | None = None,
+    target: object = None,
+) -> gc.MintResult:
+    """Mint a ``caution`` (remote-write) op through the real mint orchestration."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level="caution"))
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params=params if params is not None else dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        await session.commit()
+    return result
+
+
+async def _approval_resumed_at(approval_id: uuid.UUID) -> datetime | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(ApprovalRequest, approval_id)
+        assert row is not None
+        return row.resumed_at
+
+
+async def test_mint_remote_write_binds_approval_and_signs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caution op mints — signed — against a committed approval (mechanism 1).
+
+    The human approval decision is the authorization (policy gate bypassed for
+    this tier); the minted capability carries a verifiable Ed25519 signature,
+    the audit row records the approval lineage + signed marker, and the
+    approval is consumed single-use.
+    """
+    approval_id = await _seed_committed_approval()
+
+    result = await _mint_caution(monkeypatch)
+
+    assert result.minted
+    command = result.command
+    assert command is not None and command.signature is not None
+    # The signature verifies under the provisioned verify key over the canonical
+    # payload (op_id + params_hash + targetless scope + the bounded expires_at).
+    assert (
+        verify_remote_write_item(
+            load_verify_key(_VERIFY_KEY_B64),
+            command.signature,
+            op_id=_OP_ID,
+            params_hash=compute_params_hash(_PARAMS),
+            target_scope=TARGETLESS_SCOPE,
+            expires_at=command.expires_at,
+        )
+        is True
+    )
+    assert await _count(GatewayCommand) == 1
+    # Single-use: the binding approval is now consumed.
+    assert await _approval_resumed_at(approval_id) is not None
+    # The mint audit row carries the approval lineage + signed marker.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        audit = (
+            await session.execute(select(AuditLog).where(AuditLog.path == "gateway.command.mint"))
+        ).scalar_one()
+    assert audit.payload["approval_request_id"] == str(approval_id)
+    assert audit.payload["signed"] is True
+
+
+async def test_mint_remote_write_refused_on_params_swap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mint whose params differ from the approved ones binds no approval.
+
+    The ``params_hash`` predicate is the swap defence (#1503 / #3197): the
+    seeded approval is never matched, never consumed, and no capability mints.
+    """
+    approval_id = await _seed_committed_approval(params={"host": "10.0.0.1"})
+
+    result = await _mint_caution(monkeypatch, params={"host": "10.9.9.9"})
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED
+    assert await _count(GatewayCommand) == 0
+    assert await _approval_resumed_at(approval_id) is None
+
+
+async def test_mint_remote_write_approval_is_single_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One committed approval mints at most one capability."""
+    await _seed_committed_approval()
+
+    first = await _mint_caution(monkeypatch)
+    second = await _mint_caution(monkeypatch)
+
+    assert first.minted
+    assert not second.minted
+    assert second.refusal_code is MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED
+    assert await _count(GatewayCommand) == 1
+
+
+async def test_mint_remote_write_refused_without_signing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No central signing key → fail-closed refusal, and the approval is untouched.
+
+    The signing key is checked before the single-use latch is claimed, so a
+    fail-closed mint never wastes an approval.
+    """
+    approval_id = await _seed_committed_approval()
+    monkeypatch.setenv("SATELLITE_WRITE_SIGNING_KEY", "")
+    get_settings.cache_clear()
+
+    result = await _mint_caution(monkeypatch)
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE
+    assert await _count(GatewayCommand) == 0
+    assert await _approval_resumed_at(approval_id) is None
+
+
+async def test_mint_remote_write_ignores_non_approved_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A still-pending (un-decided) request does not authorise a mint."""
+    now = datetime.now(UTC)
+    await _seed_tenant()
+    pending = ApprovalRequest(
+        id=uuid.uuid4(),
+        tenant_id=_TENANT,
+        principal_sub="requester-sub",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        params_hash=compute_params_hash(_PARAMS),
+        params=dict(_PARAMS),
+        proposed_effect={"op_id": _OP_ID},
+        status=ApprovalRequestStatus.PENDING.value,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(pending)
+        await session.commit()
+
+    result = await _mint_caution(monkeypatch)
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED
+    assert await _count(GatewayCommand) == 0
 
 
 async def test_mint_refuses_poisoned_parameter_schema(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_runner_executor.py
+++ b/backend/tests/test_runner_executor.py
@@ -13,13 +13,26 @@ error result rather than a raised tick error.
 from __future__ import annotations
 
 import asyncio
+import base64
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from meho_backplane.auth.operator import TenantRole
-from meho_backplane.runner.executor import execute_work_item
-from meho_backplane.runner.wire import RunnerPrincipal, RunnerWorkItem
+from meho_backplane.runner.executor import _verify_remote_write_signature, execute_work_item
+from meho_backplane.runner.wire import (
+    ResolvedTargetDescriptor,
+    RunnerPrincipal,
+    RunnerWorkItem,
+)
+from meho_backplane.runner.work_item_signing import (
+    TARGETLESS_SCOPE,
+    params_digest,
+    sign_remote_write_item,
+)
+from meho_backplane.settings import get_settings
 
 _ALLOWLIST_ENV = "MEHO_NETDIAG_PROBE_ALLOWLIST"
 _NET_TCP_CHECK_REF = "meho_backplane.connectors.net.ops.net_tcp_check"
@@ -130,3 +143,140 @@ async def test_handler_exception_becomes_structured_error(
     assert result.status == "error"
     assert result.result is None
     assert "KeyError" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Remote-write signature verification at the edge (#3189, mechanism 1)
+# ---------------------------------------------------------------------------
+
+
+def _provision_verify_key(monkeypatch: pytest.MonkeyPatch) -> Ed25519PrivateKey:
+    """Generate a keypair, provision the runner's verify key, return the signer."""
+    key = Ed25519PrivateKey.generate()
+    verify_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode("ascii")
+    monkeypatch.setenv("SATELLITE_WRITE_VERIFY_KEY", verify_b64)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    return key
+
+
+def _target_descriptor(target_id: uuid.UUID) -> ResolvedTargetDescriptor:
+    return ResolvedTargetDescriptor(
+        id=target_id,
+        tenant_id=uuid.uuid4(),
+        name="vc-a",
+        product="vmware",
+        host="vc-a.example",
+    )
+
+
+def _signed_rw_item(
+    signing_key: Ed25519PrivateKey,
+    *,
+    expires_at: datetime,
+    target_descriptor: ResolvedTargetDescriptor | None = None,
+    op_id: str = "vmware.vm.tag_set",
+    params: dict[str, object] | None = None,
+) -> RunnerWorkItem:
+    params = params if params is not None else {"tag": "prod"}
+    target_scope = str(target_descriptor.id) if target_descriptor is not None else TARGETLESS_SCOPE
+    signature = sign_remote_write_item(
+        signing_key,
+        op_id=op_id,
+        params_hash=params_digest(params),
+        target_scope=target_scope,
+        expires_at=expires_at,
+    )
+    return RunnerWorkItem(
+        check_ref="chk-rw",
+        op_id=op_id,
+        product="vmware",
+        version="9.0",
+        impl_id="rest",
+        handler_ref="meho_backplane.connectors.vmware.ops.vm_tag_set",
+        params=params,
+        safety_level="caution",
+        principal=_principal(),
+        target_descriptor=target_descriptor,
+        signature=signature,
+        expires_at=expires_at,
+    )
+
+
+def test_verify_passes_for_a_validly_signed_fresh_item(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+    # The signature half passes; the remaining edge refusal (the still-fail-closed
+    # allowlist gate, #3190) is a *different* mechanism, asserted separately below.
+    assert _verify_remote_write_signature(item) is None
+
+
+def test_unsigned_remote_write_item_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    _provision_verify_key(monkeypatch)
+    item = _tcp_check_item(host="127.0.0.1", port=9, safety_level="caution", check_ref="chk-rw")
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "unsigned" in refusal and "remote-write" in refusal
+
+
+def test_missing_freshness_bound_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+    item = item.model_copy(update={"expires_at": None})
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "expires_at" in refusal
+
+
+def test_tampered_params_break_the_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+    item = item.model_copy(update={"params": {"tag": "attacker"}})
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "signature verification failed" in refusal
+
+
+def test_out_of_scope_target_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    signed_for = _target_descriptor(uuid.uuid4())
+    item = _signed_rw_item(
+        signing_key,
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        target_descriptor=signed_for,
+    )
+    # Re-point the delivered item at a *different* target than the one signed.
+    item = item.model_copy(update={"target_descriptor": _target_descriptor(uuid.uuid4())})
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "signature verification failed" in refusal
+
+
+def test_expired_but_validly_signed_item_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    # A cryptographically valid signature over a past deadline — the separate
+    # freshness check must still refuse it.
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) - timedelta(seconds=1))
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "expired" in refusal
+
+
+def test_refused_when_no_verify_key_provisioned(monkeypatch: pytest.MonkeyPatch) -> None:
+    signing_key = _provision_verify_key(monkeypatch)
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+    monkeypatch.setenv("SATELLITE_WRITE_VERIFY_KEY", "")
+    get_settings.cache_clear()
+    refusal = _verify_remote_write_signature(item)
+    assert refusal is not None and "remote-write" in refusal
+
+
+async def test_tampered_signed_item_is_refused_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Through the real execute_work_item path: a tampered signed caution item is
+    # refused before the handler is ever resolved.
+    signing_key = _provision_verify_key(monkeypatch)
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+    item = item.model_copy(update={"params": {"tag": "attacker"}})
+
+    result = await execute_work_item(item)
+
+    assert result.status == "refused"
+    assert result.result is None
+    assert "remote-write" in (result.error or "")

--- a/backend/tests/test_work_item_signing.py
+++ b/backend/tests/test_work_item_signing.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Ed25519 signing + edge verification of remote-write work items (#3189).
+
+Pure-function tests for :mod:`meho_backplane.runner.work_item_signing` — the
+edge-safe signing seam (mechanism 1 of the satellite write-path composed gate).
+No DB, no session.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.runner.work_item_signing import (
+    TARGETLESS_SCOPE,
+    SigningKeyUnavailableError,
+    load_signing_key,
+    load_verify_key,
+    params_digest,
+    sign_remote_write_item,
+    verify_remote_write_item,
+)
+
+_EXPIRES = datetime(2099, 1, 1, tzinfo=UTC)
+_SCOPE = "11111111-1111-1111-1111-111111111111"
+
+
+def _keypair() -> tuple[str, str]:
+    """A fresh (signing_b64, verify_b64) Ed25519 pair as base64 raw 32-byte keys."""
+    key = Ed25519PrivateKey.generate()
+    signing_b64 = base64.b64encode(key.private_bytes_raw()).decode("ascii")
+    verify_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode("ascii")
+    return signing_b64, verify_b64
+
+
+def _sign(
+    signing_b64: str,
+    *,
+    op_id: str = "vmware.vm.tag_set",
+    params_hash: str = "abc123",
+    target_scope: str = _SCOPE,
+    expires_at: datetime = _EXPIRES,
+) -> str:
+    return sign_remote_write_item(
+        load_signing_key(signing_b64),
+        op_id=op_id,
+        params_hash=params_hash,
+        target_scope=target_scope,
+        expires_at=expires_at,
+    )
+
+
+def _verify(
+    verify_b64: str,
+    signature: str,
+    *,
+    op_id: str = "vmware.vm.tag_set",
+    params_hash: str = "abc123",
+    target_scope: str = _SCOPE,
+    expires_at: datetime = _EXPIRES,
+) -> bool:
+    return verify_remote_write_item(
+        load_verify_key(verify_b64),
+        signature,
+        op_id=op_id,
+        params_hash=params_hash,
+        target_scope=target_scope,
+        expires_at=expires_at,
+    )
+
+
+def test_params_digest_matches_compute_params_hash() -> None:
+    # The edge-safe mirror must equal the DB-coupled canonical hash byte-for-byte,
+    # so the digest the centre signs and the runner recomputes always agree.
+    params = {"z": 1, "a": [3, 2, 1], "id": uuid.uuid4(), "when": datetime(2026, 1, 1, tzinfo=UTC)}
+    assert params_digest(params) == compute_params_hash(params)
+    assert params_digest({}) == compute_params_hash({})
+
+
+def test_sign_then_verify_roundtrip() -> None:
+    signing_b64, verify_b64 = _keypair()
+    assert _verify(verify_b64, _sign(signing_b64)) is True
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        {"op_id": "vmware.vm.destroy"},
+        {"params_hash": "deadbeef"},
+        {"target_scope": "22222222-2222-2222-2222-222222222222"},
+        {"expires_at": _EXPIRES + timedelta(days=1)},
+    ],
+)
+def test_verify_fails_on_any_tampered_field(tamper: dict[str, object]) -> None:
+    # Every signed field is bound: changing op / params / target-scope / freshness
+    # after signing breaks verification (integrity + scope + freshness anchor).
+    signing_b64, verify_b64 = _keypair()
+    signature = _sign(signing_b64)
+    assert _verify(verify_b64, signature, **tamper) is False  # type: ignore[arg-type]
+
+
+def test_verify_fails_with_wrong_key() -> None:
+    signing_b64, _ = _keypair()
+    _, other_verify_b64 = _keypair()
+    # A signature from key A does not verify under key B — the non-repudiation
+    # property (only the central signing key can mint a valid capability).
+    assert _verify(other_verify_b64, _sign(signing_b64)) is False
+
+
+def test_verify_fails_on_malformed_signature() -> None:
+    _, verify_b64 = _keypair()
+    assert _verify(verify_b64, "not-base64!!") is False
+
+
+def test_targetless_scope_roundtrips() -> None:
+    signing_b64, verify_b64 = _keypair()
+    signature = _sign(signing_b64, target_scope=TARGETLESS_SCOPE)
+    assert _verify(verify_b64, signature, target_scope=TARGETLESS_SCOPE) is True
+
+
+def test_expires_at_naive_is_treated_as_utc() -> None:
+    # A naive datetime must sign/verify identically to its UTC-aware twin, so a
+    # DB round-trip that drops tzinfo cannot break verification.
+    signing_b64, verify_b64 = _keypair()
+    aware = datetime(2099, 6, 1, 12, 0, tzinfo=UTC)
+    naive = datetime(2099, 6, 1, 12, 0)
+    signature = _sign(signing_b64, expires_at=aware)
+    assert _verify(verify_b64, signature, expires_at=naive) is True
+
+
+@pytest.mark.parametrize("bad", ["", "not-base64!!", base64.b64encode(b"tooshort").decode("ascii")])
+def test_load_signing_key_fails_closed(bad: str) -> None:
+    with pytest.raises(SigningKeyUnavailableError):
+        load_signing_key(bad)
+
+
+@pytest.mark.parametrize("bad", ["", "not-base64!!", base64.b64encode(b"tooshort").decode("ascii")])
+def test_load_verify_key_fails_closed(bad: str) -> None:
+    with pytest.raises(SigningKeyUnavailableError):
+        load_verify_key(bad)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -27190,6 +27190,17 @@
             "type": "object",
             "nullable": true,
             "title": "Target Descriptor"
+          },
+          "signature": {
+            "type": "string",
+            "nullable": true,
+            "title": "Signature"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Expires At"
           }
         },
         "type": "object",
@@ -30263,6 +30274,17 @@
           "target_descriptor": {
             "$ref": "#/components/schemas/ResolvedTargetDescriptor",
             "nullable": true
+          },
+          "signature": {
+            "type": "string",
+            "nullable": true,
+            "title": "Signature"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Expires At"
           }
         },
         "type": "object",
@@ -30275,7 +30297,7 @@
           "principal"
         ],
         "title": "RunnerWorkItem",
-        "description": "One centrally-authorized operation for the runner to execute.\n\nCarries the fields the runner needs to resolve and invoke a handler\nentirely locally: the dotted ``handler_ref`` (resolved via\n:func:`~meho_backplane.operations._handler_resolve.import_handler`),\nthe ``(product, version, impl_id)`` registry key used to rebind a\nbound-method handler against its connector instance, the validated\n``params``, the ``safety_level`` the runner re-checks (defence in\ndepth), the principal context, and the resolved target descriptor\n(``None`` for targetless synthetic ops such as ``net.*``)."
+        "description": "One centrally-authorized operation for the runner to execute.\n\nCarries the fields the runner needs to resolve and invoke a handler\nentirely locally: the dotted ``handler_ref`` (resolved via\n:func:`~meho_backplane.operations._handler_resolve.import_handler`),\nthe ``(product, version, impl_id)`` registry key used to rebind a\nbound-method handler against its connector instance, the validated\n``params``, the ``safety_level`` the runner re-checks (defence in\ndepth), the principal context, and the resolved target descriptor\n(``None`` for targetless synthetic ops such as ``net.*``).\n\nRemote-write signing (#3189): a ``caution`` / ``remote-write`` item\nadditionally carries the centre's Ed25519 ``signature`` over its\ncanonical payload and the ``expires_at`` freshness bound the signature\ncovers, both verified in\n:func:`~meho_backplane.runner.executor._screen_item` before execution.\nBoth are ``None`` for a ``safe`` read item (the recurring assignment\npath materialises only ``safe`` ops and never signs them) -- signing is\na write-tier property, so their absence on a ``safe`` item is correct,\nnot a missing field."
       },
       "SafetyChangeModel": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4623,9 +4623,11 @@ type FreshnessCompare struct {
 
 // GatewayCommandEnvelope The claimed-command envelope returned by “GET .../next“ (200).
 type GatewayCommandEnvelope struct {
+	ExpiresAt        *time.Time              `json:"expires_at"`
 	Id               openapi_types.UUID      `json:"id"`
 	OpId             string                  `json:"op_id"`
 	Params           map[string]interface{}  `json:"params"`
+	Signature        *string                 `json:"signature"`
 	TargetDescriptor *map[string]interface{} `json:"target_descriptor"`
 }
 
@@ -6622,8 +6624,19 @@ type RunnerResultBatch struct {
 // “params“, the “safety_level“ the runner re-checks (defence in
 // depth), the principal context, and the resolved target descriptor
 // (“None“ for targetless synthetic ops such as “net.*“).
+//
+// Remote-write signing (#3189): a “caution“ / “remote-write“ item
+// additionally carries the centre's Ed25519 “signature“ over its
+// canonical payload and the “expires_at“ freshness bound the signature
+// covers, both verified in
+// :func:`~meho_backplane.runner.executor._screen_item` before execution.
+// Both are “None“ for a “safe“ read item (the recurring assignment
+// path materialises only “safe“ ops and never signs them) -- signing is
+// a write-tier property, so their absence on a “safe“ item is correct,
+// not a missing field.
 type RunnerWorkItem struct {
 	CheckRef   string                  `json:"check_ref"`
+	ExpiresAt  *time.Time              `json:"expires_at"`
 	HandlerRef string                  `json:"handler_ref"`
 	ImplId     *string                 `json:"impl_id,omitempty"`
 	OpId       string                  `json:"op_id"`
@@ -6638,6 +6651,7 @@ type RunnerWorkItem struct {
 	Principal   RunnerPrincipal `json:"principal"`
 	Product     string          `json:"product"`
 	SafetyLevel string          `json:"safety_level"`
+	Signature   *string         `json:"signature"`
 
 	// TargetDescriptor Centrally-resolved target attributes a connector handler reads.
 	//

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -163,18 +163,58 @@ through):
   `remote-write` work rides the one-shot capability-mint path, not this
   document.
 - **Edge executor** — `_screen_item` (`runner/executor.py`): re-screens the
-  delivered item independently, refusing `EXCLUDED` outright and re-checking
-  `REMOTE_WRITE` through the same gate seam (mechanism 2's "checked at mint
-  *and* re-checked at the edge").
+  delivered item independently, refusing `EXCLUDED` outright, verifying a
+  `REMOTE_WRITE` item's signature (mechanism 1, below) and re-checking it
+  through the allowlist gate seam (mechanism 2's "checked at mint *and*
+  re-checked at the edge").
 
-**The composed gate is a seam.** `evaluate_remote_write_gate` is fail-closed
-by construction: a `remote-write` op mints only when its op-class is on the
-runner's enrollment allowlist **and** policy `AUTO_EXECUTE` (idempotent
-subset) or a committed `ApprovalRequest` (caution subset) authorises it —
-the four-mechanism composition of design §3. That allowlist + approval +
-work-item-signing machinery is filed as sibling tasks (#3189-#3193); until it
-lands there is no way to authorise a remote-write capability, so the seam
-refuses every remote-write op at both the mint and the edge.
+### Mechanism 1 — signed work items + approval-bound minting (#3189)
+
+The caution (`remote-write`) tier is authorised by a **composition** of
+mechanisms; #3189 lands the first: a real Ed25519 signature over the canonical
+work item, plus approval-bound minting.
+
+- **Approval-bound minting.** `mint_gateway_command` routes a `REMOTE_WRITE`
+  op to `_mint_remote_write`, which mints **only** against a committed,
+  un-consumed `ApprovalRequest` for the identical `(op, target, params_hash)`
+  (`find_remote_write_approval` / `consume_remote_write_approval` in
+  `operations/approval_queue.py`). The human approval decision **is** the
+  authorization, so the live policy gate is bypassed for this tier — the exact
+  mould of `approve_request`'s `_approved=True` re-dispatch. The binding is
+  **param-bound** (the `params_hash` predicate is the #1503 / #3197 swap
+  defence) and **single-use** (the approval's one-way `resumed_at` latch,
+  claimed in the mint session so it is consumed iff the mint commits). No
+  approval → `MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`.
+- **Signed capability.** On a bound mint the centre signs the canonical
+  payload (`op_id` + `params_hash` + `target_scope` + `expires_at`) with its
+  Ed25519 **signing (private) key** and stamps the base64 signature on the
+  `gateway_command` row (`signature` column, migration `0088`). This is the
+  deliberate, **write-tier-only** reversal of #2500: for a `safe` read an
+  edge-verifiable signature bought nothing, but for a write it is the offline
+  integrity + freshness + target-scope check against transit tampering (T2)
+  and the non-repudiation anchor the effect audit references. Asymmetric on
+  purpose (`runner/work_item_signing.py`, stdlib + `cryptography` only, no DB
+  import): the runner holds only the **verification (public) key**, provisioned
+  at enrollment, so a compromised runner cannot forge a capability. No signing
+  key → `MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE` (fail-closed). The
+  DB consume latch (`consume_command`) is **retained unchanged** for
+  at-most-once acceptance — the signature does not replace central state.
+- **Edge verification.** `_verify_remote_write_signature` (`runner/executor.py`)
+  reconstructs the canonical payload from the delivered item, verifies the
+  signature with the provisioned public key (integrity + target-scope), then
+  refuses a stale item on the separate `expires_at` freshness check. An
+  unsigned, tampered, out-of-scope, expired, or unverifiable-key item all fail
+  closed **before** any handler import.
+
+**The allowlist gate is still a seam.** `evaluate_remote_write_gate` remains
+fail-closed by construction — mechanism 2 (the per-runner enrollment
+allowlist, #3190) is not yet wired, so it refuses at the edge. A remote-write
+op mints only when its op-class is on the runner's allowlist **and** the #3189
+approval binding authorises it — the composition of design §3. The mint's
+allowlist check is the marked composition point in `_mint_remote_write`; until
+#3190 wires it there, the edge allowlist re-check keeps the tier closed
+end-to-end. Credential brokering (#3191) and revocation hardening (#3192) are
+the remaining sibling mechanisms.
 
 **Composition with #3183.** The destructive tier is `EXCLUDED` by this ladder
 everywhere, so delete-shaped work stays central-or-break-glass and never

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -188,7 +188,7 @@ work item, plus approval-bound minting.
 - **Signed capability.** On a bound mint the centre signs the canonical
   payload (`op_id` + `params_hash` + `target_scope` + `expires_at`) with its
   Ed25519 **signing (private) key** and stamps the base64 signature on the
-  `gateway_command` row (`signature` column, migration `0088`). This is the
+  `gateway_command` row (`signature` column, migration `0089`). This is the
   deliberate, **write-tier-only** reversal of #2500: for a `safe` read an
   edge-verifiable signature bought nothing, but for a write it is the offline
   integrity + freshness + target-scope check against transit tampering (T2)


### PR DESCRIPTION
## Summary

Lands **mechanism 1** of the satellite write-path composed gate (Initiative #2901, design `docs/research/2901-satellite-write-path.md` §3) on top of the just-merged #3188 tier foundation:

- **Approval-bound minting.** `mint_gateway_command` routes a `REMOTE_WRITE` (caution) op to `_mint_remote_write`, which mints **only** against a committed, un-consumed `ApprovalRequest` for the identical `(op, target, params_hash)`. The human approval decision **is** the authorization, so the live policy gate is bypassed for this tier (the mould of `approve_request`'s `_approved=True` re-dispatch). The binding is **param-bound** (the `params_hash` swap defence, #1503/#3197) and **single-use** (the approval's one-way `resumed_at` latch, claimed atomically in the mint session so it is consumed iff the mint commits).
- **Signed capability (write-tier-only #2500 reversal).** On a bound mint the centre signs the canonical payload (`op_id` + `params_hash` + `target_scope` + `expires_at`) with its Ed25519 **signing (private) key** and stamps the signature on the `gateway_command` row. New edge-safe module `runner/work_item_signing.py` (stdlib + `cryptography`, no DB import); the runner holds only the **verification (public) key**, so a compromised runner cannot forge a capability. The DB consume latch is **retained unchanged** for at-most-once acceptance.
- **Edge verification.** `_screen_item` verifies signature + freshness + target scope on every `REMOTE_WRITE` item **before** any handler import — unsigned, tampered, out-of-scope, or expired items all fail closed.

## Migration — **0088**, `down_revision = "0087"` (stated loudly)

- Adds a nullable `gateway_command.signature text` column. **`0088 → 0087`** — `0087` (`add_tenant_flight_recorder_agent_readable`) is the head on `origin/main`; `alembic heads` shows a single linear head `0088`.
- **Coordination note:** the pre-brief expected `0088` to be occupied by PR #3230 (→ I would take `0089/0088`), but PR #3230 is unrelated (`reap epoch-in-impl_id probe registrations`, no migration) and the real chain head is `0087`, so I took the next free number **0088**. Sibling tasks **#3191** (credential brokering) and **#3192** (revocation) were told their numbers *after* mine and should take **0089+**. If a concurrent PR also grabbed 0088, the migrations lane will flag multiple heads and I will rebump.

## Gate composition point left for #3190 (allowlist, mechanism 2)

`evaluate_remote_write_gate` is **untouched** and stays fail-closed as #3190's allowlist seam (the #3188 tier tests remain green and unmodified). The mint-side allowlist check slots in at the marked comment in `_mint_remote_write` (`# #3190 allowlist check composes here, ANDed with the approval binding`); the edge already re-checks `evaluate_remote_write_gate` after signature verification in `_screen_item`. Until #3190 wires the allowlist at the mint, the edge allowlist re-check keeps the tier **closed end-to-end** — a validly-signed, approval-bound capability still does not execute at the edge.

## Peer-doc note (PR #3242)

A peer's docs-only PR #3242 adds an `## Amendment (2026-08-31)` section to `docs/decisions/satellite-write-path.md`. This PR does **not** touch that file. If the amendment's "mint writes its own audit row, no trace" wording needs reconciling with the approval-bound mint here (the remote-write mint writes a synchronous `gateway.command.mint` audit row carrying `approval_request_id` + `signed`), that is flagged for the orchestrator to coordinate with the peer — not edited unilaterally here.

## Test plan

- [x] `ruff check src/ tests/` — clean (the pre-existing RUF034 in `alembic/versions/0023` is outside CI's ruff scope and not in this diff)
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (only the pre-existing macOS-only `icmp.py:MSG_ERRQUEUE` quirk, which passes on CI's Linux)
- [x] `code-quality.py --diff` — 0 blockers
- [x] New `tests/test_work_item_signing.py` — sign/verify roundtrip, `params_digest` == `compute_params_hash`, every tampered field + wrong key + malformed sig refused, key loaders fail closed
- [x] `tests/test_gateway_commands.py` — approval-bound mint signs + records lineage + consumes single-use; params-swap not bound; single-use; no-signing-key fail-closed (approval untouched); pending request ignored. **#3188 `test_mint_refuses_remote_write_gate_unsatisfied` stays green + unchanged.**
- [x] `tests/test_runner_executor.py` — valid signature passes; unsigned/tampered/out-of-scope/expired/no-verify-key refused; end-to-end tampered item refused. **#3188 edge tests stay green + unchanged.**
- [x] Regression sweep (649 passed): approval / dispatcher / settings / gateway_queue; plus migrations + gateway API + assignment + dedup (440 passed)

## Out of scope (sibling tasks under #2901)

- #3190 — per-runner capability allowlist (mechanism 2). Composition point left clean, as above.
- #3191 — per-work-item wrapped-credential brokering (mechanism 3).
- #3192 — revocation hardening for write-capable runners.
- Store-and-forward tamper-evident effect audit + un-reported-mint alarm (mechanism 4).
- The runner poll→work-item loop that consumes `GatewayCommandEnvelope` (still unwired: `execute_command_once` has no production caller). The `signature`/`expires_at` fields are added to the envelope + `RunnerWorkItem` so that loop lands them when it is built.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3189

## Sibling integration note — #3191 / PR #3244 (credential brokering)

Confirmed **no overlap in `mint_gateway_command`**: this PR does approval-binding + signing only and invents **no** credential handling — per-work-item wrapped-credential brokering is #3191's `connectors/_shared/wrapped_creds.py::broker_wrapped_credential` seam, which my gate would call *after* it permits (mechanism 3, out of scope here). #3244 merges before this PR; on rebase, the only union is in `executor._screen_item`: my signature-verify + allowlist re-check stay **first**, #3191's additive `screen_remote_write_credential` block coexists **after** them (authenticity → allowlist → credential resolution — the correct defence-in-depth order). No `mint_gateway_command` conflict expected.

---

## Update — rebased/merged onto main (head `6903a71a`)

`origin/main` advanced while this was in flight; merged in (no force-push). Two integrations resolved:

- **Migration is now `0089 → 0088`** (was 0088). The #3061 follow-up `0088_reap_probe_epoch_impl_id_registrations` landed as 0088, so mine moved to **0089** (`down_revision = "0088"`); `alembic heads` = single `0089`. Migration-number references in `db/models.py`, CHANGELOG, and the docs synced. Sibling #3192 (revocation) takes 0090+.
- **#3191 (wrapped-credential brokering) merged** and is now integrated: the composed `executor._screen_item` order is **signature (mech 1, #3189) → allowlist seam (mech 2, #3190) → credential (mech 3, #3191)** — auto-merged coherently. Updated #3191's `test_executor_refuses_remote_write_without_wrapped_credential` to present a validly-signed item so it clears the signature screen and still reaches the credential refusal under test.
- CLI OpenAPI snapshot + Go client regenerated for the new envelope/work-item `signature` + `expires_at` fields.

## Update 2 — merged #3192 (revocation); migration now `0092`

`origin/main` advanced again with #3192 (revocation hardening) + its migration `0091`. Merged (no force-push) and integrated:

- **Migration renumbered `0089 → 0092`** (`down_revision = "0091"`); chain is `0088 → 0091 → 0092`, `alembic heads` = single `0092`.
- **Composed mint order**: a `REMOTE_WRITE` op now runs #3192's revocation check (revoked runner → `RUNNER_REVOKED`) **before** #3189's approval-bound signed mint. Both new refusal codes and both helpers coexist.
- **`GatewayCommand`** carries both new columns: #3189's nullable `signature` + #3192's `safety_level`. Threaded `safety_level` through `_mint_remote_write → _finalize_mint → enqueue_command` so a remote-write mint stamps its real `caution` level (which #3192's delivery-path revocation re-check reads).
- Full local gates green on the merged tree (ruff/format/mypy/144 targeted tests/code-quality 0 blockers).
