### PR TITLE
feat(connectors): register bind9.record.delete on the governed-delete tier (#3231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,45 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — governed delete on bind9: `bind9.record.delete` on the destructive tier + conformance (#3231 / #3198)
+
+- Registers the **second governed delete** — and the first
+  `safety_level="destructive"` op on a **typed SSH connector** — on the
+  bind9 connector (decision `docs/decisions/governed-delete-operations.md`,
+  requirement 1; the `vmware.composite.vm.destroy` tier machinery, #3198,
+  needed no change to reach a typed op). `bind9.record.delete` deletes
+  **exactly one** DNS record scoped by `(zone, name, type, rdata?)` — never
+  zone-wide, never a wildcard, never a whole-rrset sweep — for the
+  DNS-retirement leg of a governed environment teardown in a shared zone.
+  `safety_level="destructive"` + `requires_approval=True`: mandatory human
+  approval (no agent path, no standing grant, no self-approval even under
+  break-glass), a mandatory preview-hash binding, and a mandatory
+  blast-radius statement (the exact record + its sibling values,
+  `irreversibility="recreatable"`).
+- Deliberately narrower than the existing caution-tier
+  `bind9.record.remove` (which clears every A + AAAA at a name): `type` is
+  required and `rdata` disambiguates a multi-value name. **Fail-closed
+  structured refusals** mirror `vm.destroy`'s shape — `not_found` (no silent
+  success), `ambiguous` (candidates named), `unmanaged_zone` — with a
+  dispatch-time fail-closed re-read. The atomic-apply verify predicate
+  confirms the single deleted value is gone (`deleted=True` only then;
+  siblings preserved; a `view` switches to the view-precise `rndc
+  zonestatus` check).
+- Folds into the delete-shaped classifier via the **single source**
+  (`safety_level="destructive"` on the resolved descriptor), never a
+  re-declared pattern list (the #3213 fail-open lesson) — a conformance test
+  proves the `ServicePrincipalGrant` refusal holds with the op-id glob
+  patterns blanked. The park-time blast radius is built by a read-only
+  preview builder wired onto the `_preview` hook (mirroring
+  `argocd.ops_write_preview`).
+- Conformance (`tests/test_connectors_bind9_record_delete.py`): agent
+  `DENY`, `ServicePrincipalGrant` refusal (single-source + pattern),
+  no self-approval under break-glass, satellite mint `OP_NOT_SAFE`,
+  dispatch refused without a matching hash, park refused without a
+  blast-radius block, the fail-closed refusal paths, and the full
+  preview → parked approval (hash + blast radius) → **distinct human**
+  approve → audited resume flow deleting exactly one record.
+
 ### Added — satellite write path: per-runner capability allowlist (#3190)
 
 - Mechanism 2 of the composed write-tier gate: a per-runner-principal

--- a/backend/src/meho_backplane/connectors/bind9/__init__.py
+++ b/backend/src/meho_backplane/connectors/bind9/__init__.py
@@ -35,6 +35,7 @@ tie-break ladder unambiguous: only the v2 triple advertises this
 class.
 """
 
+from meho_backplane.connectors.bind9 import ops_record_delete_preview  # noqa: F401
 from meho_backplane.connectors.bind9.connector import Bind9Connector
 from meho_backplane.connectors.bind9.ops import BIND9_OPS, Bind9Op
 from meho_backplane.connectors.registry import register_connector_v2

--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -746,6 +746,27 @@ class Bind9Connector(SshConnector):
 
         return await _bind9_record_remove(self, target, params, operator)
 
+    async def bind9_record_delete(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``bind9.record.delete`` op (#3231).
+
+        Governed single-record delete on the ``destructive`` safety tier
+        (decision ``docs/decisions/governed-delete-operations.md``). Deletes
+        exactly one record scoped by ``(zone, name, type, rdata?)`` via the T3
+        atomic-apply primitive; the dispatcher's destructive-tier gate
+        (mandatory human approval + preview-hash binding + blast-radius) sits
+        in front of this handler.
+        """
+        from meho_backplane.connectors.bind9.ops_record import (
+            bind9_record_delete as _bind9_record_delete,
+        )
+
+        return await _bind9_record_delete(self, target, params, operator)
+
     async def bind9_config_show(
         self,
         target: Target,

--- a/backend/src/meho_backplane/connectors/bind9/ops.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops.py
@@ -144,11 +144,12 @@ def _bind9_ops() -> tuple[Bind9Op, ...]:
     Composition: ``bind9.about`` (T1 canary) + ``ZONE_OPS`` (T2 read:
     ``bind9.zone.list`` / ``bind9.zone.read``) + ``RECORD_OPS`` (T2
     read ``bind9.record.get`` + T3 writes ``bind9.record.add`` /
-    ``bind9.record.remove``) + ``CONFIG_OPS`` (T2 read
+    ``bind9.record.remove`` + the #3231 governed-delete-tier
+    ``bind9.record.delete``) + ``CONFIG_OPS`` (T2 read
     ``bind9.config.show`` + T4 writes ``bind9.config.apply_file``,
     ``bind9.config.apply_views``, ``bind9.config.backup``,
-    ``bind9.config.reload``). Eleven ops total -- the full Initiative
-    #367 §4 op surface.
+    ``bind9.config.reload``). Twelve ops total -- the Initiative #367 §4
+    op surface plus the #3231 governed single-record delete.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -173,8 +174,9 @@ def _bind9_ops() -> tuple[Bind9Op, ...]:
 #: ``bind9.config.show``); T3 (#589) adds the record-write group
 #: (``bind9.record.add/remove``); T4 (#590) adds the config-write
 #: group (``bind9.config.apply_file``, ``bind9.config.apply_views``,
-#: ``bind9.config.backup``, ``bind9.config.reload``) -- 11 ops in
-#: total, the full Initiative #367 §4 surface. The shape of each
+#: ``bind9.config.backup``, ``bind9.config.reload``); #3231 adds the
+#: governed-delete-tier ``bind9.record.delete`` -- 12 ops in total. The
+#: shape of each
 #: follow-on PR is "import a new module-level tuple and splat it
 #: into :data:`BIND9_OPS` via :func:`_bind9_ops`" -- the registration
 #: walk in :meth:`Bind9Connector.register_operations` does not need to

--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -97,6 +97,8 @@ if TYPE_CHECKING:
 __all__ = [
     "BIND9_RECORD_ADD_LLM_INSTRUCTIONS",
     "BIND9_RECORD_ADD_PARAMETER_SCHEMA",
+    "BIND9_RECORD_DELETE_LLM_INSTRUCTIONS",
+    "BIND9_RECORD_DELETE_PARAMETER_SCHEMA",
     "BIND9_RECORD_GET_LLM_INSTRUCTIONS",
     "BIND9_RECORD_GET_PARAMETER_SCHEMA",
     "BIND9_RECORD_REMOVE_LLM_INSTRUCTIONS",
@@ -105,6 +107,7 @@ __all__ = [
     "RemoteCommandError",
     "ZoneResolutionError",
     "bind9_record_add",
+    "bind9_record_delete",
     "bind9_record_get",
     "bind9_record_remove",
     "parse_dig_answer",
@@ -711,6 +714,166 @@ def _remove_record_from_zonefile(
 
 
 # ---------------------------------------------------------------------------
+# Scoped single-record delete (governed-delete tier, #3231)
+# ---------------------------------------------------------------------------
+#
+# ``bind9.record.delete`` (safety_level=destructive) deletes exactly ONE
+# record scoped by (zone, name, type, and — where the name carries more than
+# one value of that type — rdata). It is deliberately narrower than
+# ``bind9.record.remove`` (which clears every A + AAAA at a name in one
+# caution-tier write): a governed delete on the destructive tier must name
+# the single record that dies, never a zone-wide or multi-value sweep.
+
+
+def _canon_rdata(record_type: str, value: str) -> str:
+    """Return the canonical wire-form text of *value* for *record_type*.
+
+    dnspython normalises rdata to a canonical form (IPv6 zero-compression,
+    lower-case hex, etc.), so ``2001:DB8:0:0::1`` and ``2001:db8::1`` compare
+    equal. Raises :class:`dns.exception.DNSException` on a value that is not
+    valid rdata for the type.
+    """
+    rdtype = dns.rdatatype.from_text(record_type)
+    return dns.rdata.from_text(dns.rdataclass.IN, rdtype, value).to_text()
+
+
+def _rdata_matches(candidate: str, target: str, record_type: str) -> bool:
+    """``True`` when *candidate* and *target* are the same rdata value.
+
+    Compares the raw strings first (cheap, exact), then falls back to the
+    canonical wire form so an operator-typed value in a non-canonical
+    spelling still matches the stored record. A *target* that is not valid
+    rdata for the type never matches (fail-closed: an unparseable
+    disambiguator resolves to "no such record", not a wrong deletion).
+    """
+    if candidate == target:
+        return True
+    try:
+        return _canon_rdata(record_type, candidate) == _canon_rdata(record_type, target)
+    except dns.exception.DNSException:
+        return False
+
+
+def _find_record_matches(
+    zonefile_text: str,
+    *,
+    zone_name: str,
+    fqdn: str,
+    record_type: str,
+) -> list[str]:
+    """Return the rdata values currently at ``(fqdn, record_type)`` in the zone.
+
+    Pure function over the zonefile text. One entry per record value in the
+    rrset (canonical wire form), in a stable sorted order so the blast-radius
+    children and the ambiguity candidates are deterministic. An absent name /
+    rrset yields ``[]`` (a legitimate "record does not exist" statement, not
+    an error). Used by both the preview builder (blast radius + ambiguity
+    visibility) and the handler (fail-closed re-read) so the two paths cannot
+    drift on what "matches".
+    """
+    origin = zone_name if zone_name.endswith(".") else zone_name + "."
+    zone = dns.zone.from_text(
+        zonefile_text,
+        origin=origin,
+        relativize=False,
+        check_origin=False,
+    )
+    fqdn_abs = fqdn if fqdn.endswith(".") else fqdn + "."
+    name = dns.name.from_text(fqdn_abs)
+    rdtype = dns.rdatatype.from_text(record_type)
+    rds = zone.get_rdataset(name, rdtype)
+    if rds is None:
+        return []
+    return sorted(rd.to_text() for rd in rds)
+
+
+def _resolve_delete_target(
+    matches: list[str],
+    *,
+    record_type: str,
+    rdata_param: str | None,
+) -> tuple[str | None, str]:
+    """Resolve the single rdata value to delete, or a refusal status.
+
+    Returns ``(target_rdata, status)`` where ``status`` is one of:
+
+    * ``"ok"`` — exactly one record is targeted; ``target_rdata`` is the
+      stored value to remove.
+    * ``"not_found"`` — no record matches (name/type absent, or a supplied
+      ``rdata`` is not among the values).
+    * ``"ambiguous"`` — the name carries more than one value of the type and
+      no ``rdata`` was supplied to pick one; ``target_rdata`` is ``None`` and
+      the caller names ``matches`` as the candidates.
+
+    Fail-closed by construction: it never returns ``"ok"`` for anything but a
+    single, uniquely-identified record.
+    """
+    if not matches:
+        return None, "not_found"
+    if rdata_param is not None:
+        hits = [m for m in matches if _rdata_matches(rdata_param, m, record_type)]
+        if len(hits) == 1:
+            return hits[0], "ok"
+        if not hits:
+            return None, "not_found"
+        # More than one stored value canonicalises to the same rdata — not a
+        # shape a real zonefile produces (dnspython de-dupes rrsets), but the
+        # branch stays fail-closed rather than deleting an arbitrary one.
+        return None, "ambiguous"
+    if len(matches) == 1:
+        return matches[0], "ok"
+    return None, "ambiguous"
+
+
+def _delete_one_record_from_zonefile(
+    zonefile_text: str,
+    *,
+    zone_name: str,
+    fqdn: str,
+    record_type: str,
+    rdata: str,
+) -> str:
+    """Return new zonefile text with exactly the one ``(fqdn, type, rdata)`` gone.
+
+    Pure transformation — parses with dnspython, removes the single rdata
+    from the rrset (deleting the whole rrset only when that was its last
+    value), bumps the SOA serial, renders. Every other record at the name —
+    including other values of the *same* type — is preserved. The caller
+    (:func:`bind9_record_delete`) resolves *rdata* to a value it has already
+    confirmed is present via :func:`_resolve_delete_target`, so this never
+    silently no-ops.
+
+    Raises :class:`ValueError` if the resolved rdata is unexpectedly absent
+    (a between-read race the handler's re-read is meant to catch) rather than
+    bumping the serial on a phantom delete.
+    """
+    origin = zone_name if zone_name.endswith(".") else zone_name + "."
+    zone = dns.zone.from_text(
+        zonefile_text,
+        origin=origin,
+        relativize=False,
+        check_origin=False,
+    )
+    fqdn_abs = fqdn if fqdn.endswith(".") else fqdn + "."
+    name = dns.name.from_text(fqdn_abs)
+    rdtype = dns.rdatatype.from_text(record_type)
+    rds = zone.get_rdataset(name, rdtype)
+    if rds is None:
+        raise ValueError(f"no {record_type} rrset at {fqdn!r} to delete from")
+    victim = next(
+        (rd for rd in rds if _rdata_matches(rdata, rd.to_text(), record_type)),
+        None,
+    )
+    if victim is None:
+        raise ValueError(f"{record_type} value {rdata!r} not present at {fqdn!r}")
+    rds.remove(victim)  # type: ignore[no-untyped-call]
+    if len(rds) == 0:
+        zone.delete_rdataset(name, rdtype)
+    _bump_soa_serial(zone)
+    return _zonefile_text(zone)
+
+
+# ---------------------------------------------------------------------------
 # Write handlers
 # ---------------------------------------------------------------------------
 
@@ -840,6 +1003,35 @@ def _dig_remove_verify(fqdn: str) -> str:
         'printf "%s still resolves after remove (A: %s AAAA: %s)\\n" '
         f'{quoted_fqdn} "$A" "$AAAA"; '
         "exit 1"
+    )
+
+
+def _dig_value_absent_verify(fqdn: str, record_type: str, rdata: str) -> str:
+    """Scoped verify predicate for ``record.delete`` — one value gone, others kept.
+
+    The post-delete verification read for a single-record scoped delete: the
+    deleted ``(type, rdata)`` value must be absent from
+    ``dig @localhost <fqdn> <type> +short``, while any *other* values at the
+    same name/type legitimately remain (this is why ``record.remove``'s
+    "resolves to nothing" predicate is wrong here). ``grep -qxF`` is literal
+    whole-line so a substring cannot false-match. ``record_type`` is one of
+    the enum-validated A / AAAA tokens (never operator-free-text), so it is
+    safe to interpolate; ``fqdn`` / ``rdata`` are ``shlex.quote``-wrapped. On
+    a still-present value the observed ``dig`` output is echoed so the
+    ``AtomicApplyError`` detail is diagnosable (the #2897 discipline).
+    """
+    quoted_fqdn = shlex.quote(fqdn)
+    quoted_rdata = shlex.quote(rdata)
+    # ``if <present> then <diagnose>; exit 1; fi; exit 0`` — a grep miss (the
+    # value is gone, the success case) falls through to ``exit 0`` and never
+    # aborts early under the pipeline's ``set -e``.
+    return (
+        f"ANSWER=$(dig @localhost {quoted_fqdn} {record_type} +short 2>&1) || true; "
+        f'if printf "%s\\n" "$ANSWER" | grep -qxF {quoted_rdata}; then '
+        f'printf "{record_type} value %s still resolves for %s after delete; '
+        f'dig +short returned:\\n%s\\n" {quoted_rdata} {quoted_fqdn} "$ANSWER"; '
+        "exit 1; fi; "
+        "exit 0"
     )
 
 
@@ -1101,6 +1293,216 @@ async def bind9_record_remove(
         "op_class": "write",
         "result_state_before": apply_result.state_before,
         "result_state_after": apply_result.state_after,
+    }
+
+
+def _delete_refusal(
+    status: str,
+    *,
+    fqdn: str,
+    record_type: str,
+    rdata: str | None,
+    zone: str | None,
+    view: str | None,
+    guidance: str,
+    candidates: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a structured, fail-closed ``record.delete`` refusal envelope.
+
+    Mirrors the destructive-tier refusal shape of ``vmware.composite.vm.destroy``
+    (#3198): a ``status`` naming the refusal reason, ``deleted=False`` (never
+    a silent success), and an operator-actionable ``guidance`` sentence.
+    ``candidates`` carries the competing rdata values on the ``ambiguous``
+    path so the operator can re-issue with the ``rdata`` that picks one.
+    """
+    return {
+        "status": status,
+        "deleted": False,
+        "fqdn": fqdn,
+        "type": record_type,
+        "rdata": rdata,
+        "zone": zone,
+        "file": None,
+        "view": view,
+        "candidates": candidates or [],
+        "op_class": "write",
+        "result_state_before": None,
+        "result_state_after": None,
+        "guidance": guidance,
+    }
+
+
+async def bind9_record_delete(
+    connector: Bind9Connector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``bind9.record.delete`` -- governed single-record delete (#3231).
+
+    The bind9 arm of the governed-delete tier (decision
+    ``docs/decisions/governed-delete-operations.md``): ``safety_level=
+    destructive`` + ``requires_approval=True``, so it rides the hardest gate
+    MEHO has — mandatory human approval (no agent path, no standing grant, no
+    self-approval even under break-glass), a mandatory preview-hash binding,
+    and a mandatory blast-radius statement (built by
+    :func:`._ops_record_delete_preview._bind9_record_delete_preview`).
+
+    Deletes **exactly one** record scoped by ``(zone, name, type, rdata?)`` —
+    never zone-wide, never a multi-value sweep. ``type`` is required (unlike
+    ``record.remove``, which clears both A and AAAA at a name); ``rdata`` is
+    required only to disambiguate a name that carries more than one value of
+    that type.
+
+    **Fail-closed re-read at dispatch time (post-approval).** Like
+    ``vm.destroy``'s power-state re-read, the handler re-resolves the target
+    against live state — a record added/changed between park and approval is
+    caught — and returns a structured refusal rather than a broad or wrong
+    deletion:
+
+    * ``unmanaged_zone`` — no writable zone this server serves owns the FQDN
+      (or a split-horizon zone needs a ``view``); nothing is touched.
+    * ``not_found`` — the ``(name, type[, rdata])`` resolves to no record;
+      ``deleted=False`` (never a silent success).
+    * ``ambiguous`` — the name carries multiple values of the type and no
+      ``rdata`` was supplied; refused with the candidate values named.
+
+    On a uniquely-resolved target it removes that one value via the atomic
+    stage-validate-commit-reload-verify-rollback primitive. The verify
+    predicate is the **post-delete verification read** — the deleted value
+    must be absent from ``dig`` (a ``view`` switches it to the view-precise
+    ``rndc zonestatus`` serial check, #2897) — so ``deleted=True`` is
+    returned only after the record is confirmed gone; any verify miss rolls
+    the zone back byte-identical and raises :class:`AtomicApplyError`.
+    """
+    fqdn: str = params["fqdn"]
+    record_type: str = params["type"].upper()
+    rdata_param: str | None = params.get("rdata")
+    explicit_zone: str | None = params.get("zone")
+    explicit_view: str | None = params.get("view")
+
+    if record_type not in _WRITE_SUPPORTED_TYPES:
+        raise ValueError(
+            f"record.delete only supports A / AAAA; got type={record_type!r}. "
+            f"CNAME / MX / TXT deletes are out of scope."
+        )
+
+    sudo_password = await _sudo_password_from_target(connector, target, operator)
+
+    try:
+        zone_name, zonefile_path, view = await _resolve_zone_and_path(
+            connector,
+            target,
+            fqdn=fqdn,
+            explicit_zone=explicit_zone,
+            explicit_view=explicit_view,
+            operator=operator,
+        )
+    except ZoneResolutionError as exc:
+        return _delete_refusal(
+            "unmanaged_zone",
+            fqdn=fqdn,
+            record_type=record_type,
+            rdata=rdata_param,
+            zone=explicit_zone,
+            view=explicit_view,
+            guidance=str(exc),
+            candidates=exc.candidates,
+        )
+
+    current_text = await _read_zonefile_text(connector, target, zonefile_path, operator)
+    try:
+        matches = _find_record_matches(
+            current_text, zone_name=zone_name, fqdn=fqdn, record_type=record_type
+        )
+    except dns.exception.DNSException as exc:
+        raise ValueError(f"failed to parse zonefile for zone {zone_name!r}: {exc}") from exc
+
+    target_rdata, status = _resolve_delete_target(
+        matches, record_type=record_type, rdata_param=rdata_param
+    )
+    if status == "not_found":
+        detail = f" with rdata {rdata_param!r}" if rdata_param is not None else ""
+        return _delete_refusal(
+            "not_found",
+            fqdn=fqdn,
+            record_type=record_type,
+            rdata=rdata_param,
+            zone=zone_name,
+            view=view,
+            guidance=(
+                f"no {record_type} record at {fqdn!r}{detail} in zone {zone_name!r}; "
+                "nothing deleted"
+            ),
+        )
+    if status == "ambiguous":
+        return _delete_refusal(
+            "ambiguous",
+            fqdn=fqdn,
+            record_type=record_type,
+            rdata=rdata_param,
+            zone=zone_name,
+            view=view,
+            candidates=matches,
+            guidance=(
+                f"{fqdn!r} carries {len(matches)} {record_type} records "
+                f"({', '.join(matches)}); pass ``rdata`` to name the single "
+                "record to delete — this op never deletes more than one"
+            ),
+        )
+
+    assert target_rdata is not None  # status == "ok" ⇒ a resolved value
+    try:
+        new_text = _delete_one_record_from_zonefile(
+            current_text,
+            zone_name=zone_name,
+            fqdn=fqdn,
+            record_type=record_type,
+            rdata=target_rdata,
+        )
+    except (dns.exception.DNSException, ValueError) as exc:
+        raise ValueError(f"failed to transform zonefile for zone {zone_name!r}: {exc}") from exc
+
+    # View-aware verify — see bind9_record_add for the #2897 rationale. The
+    # no-views path asserts the deleted VALUE is gone (others at the name may
+    # remain), not that the name stops resolving.
+    if explicit_view is not None:
+        verify_cmd = _zonestatus_serial_verify(
+            zone_name, explicit_view, _soa_serial_from_text(new_text, zone_name)
+        )
+    else:
+        verify_cmd = _dig_value_absent_verify(fqdn, record_type, target_rdata)
+
+    apply_result = await atomic_apply(
+        connector,
+        target,
+        operator=operator,
+        sudo_password=sudo_password,
+        audit_slice_path=zonefile_path,
+        zone_name=zone_name,
+        staged_bytes=new_text.encode("utf-8"),
+        verify_command=verify_cmd,
+    )
+
+    # Chassis audit enrichment — see bind9_record_add for rationale.
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=apply_result.state_before,
+        audit_state_after=apply_result.state_after,
+    )
+    return {
+        "status": "deleted",
+        "deleted": True,
+        "fqdn": fqdn,
+        "type": record_type,
+        "rdata": target_rdata,
+        "zone": zone_name,
+        "file": zonefile_path,
+        "view": view,
+        "candidates": [],
+        "op_class": "write",
+        "result_state_before": apply_result.state_before,
+        "result_state_after": apply_result.state_after,
+        "guidance": None,
     }
 
 
@@ -1372,6 +1774,178 @@ BIND9_RECORD_REMOVE_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
+_DELETE_WARNING = (
+    "GOVERNED DELETE (destructive tier). This op deletes exactly ONE record "
+    "scoped by (zone, name, type, and — when the name carries more than one "
+    "value of that type — rdata); it never deletes zone-wide, a wildcard "
+    "match, or a whole rrset. It is ``safety_level=destructive`` + "
+    "``requires_approval=True``: the hardest gate MEHO has — mandatory human "
+    "approval always (no agent path, no standing grant, no self-approval even "
+    "under break-glass), a mandatory preview-hash binding, and a mandatory "
+    "blast-radius statement (the exact zone / name / type / rdata that dies, "
+    "plus the record's sibling values) the four-eyes approver reads before "
+    "deciding. Change is global and atomic: the atomic-apply primitive stages, "
+    "runs ``named-checkzone`` + ``rndc reload`` + a verify predicate that "
+    "confirms the deleted value is gone, and rolls the ``/etc/bind/`` tree "
+    "back byte-identical on any failure. Prefer ``bind9.record.delete`` over "
+    "``bind9.record.remove`` when a shared zone must retire a single record "
+    "under governance (environment teardown); ``record.remove`` is the "
+    "un-governed caution-tier both-families clear."
+)
+
+
+BIND9_RECORD_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "fqdn": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Fully-qualified domain name of the record to delete, e.g. "
+                "``api.example.test``. Trailing dot optional. The handler "
+                "resolves the owning zone from ``named-checkconf -p`` by "
+                "longest-suffix match unless ``zone`` is set explicitly; an "
+                "FQDN outside every writable zone is refused "
+                "``unmanaged_zone``."
+            ),
+        },
+        "type": {
+            "type": "string",
+            "enum": sorted(_WRITE_SUPPORTED_TYPES),
+            "description": (
+                "Record type to delete — required. Only A and AAAA are "
+                "supported. Required (unlike ``record.remove``, which clears "
+                "both A and AAAA) because a governed delete must name the "
+                "single record type that dies."
+            ),
+        },
+        "rdata": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. The exact record value to delete (e.g. the IP for "
+                "an A record). Required only when the name carries more than "
+                "one value of the type: without it a multi-value name is "
+                "refused ``ambiguous`` with the candidate values named. "
+                "Compared in canonical form, so a non-canonical spelling "
+                "still matches."
+            ),
+        },
+        "zone": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. Owning zone name. When omitted, resolved by "
+                "longest-suffix match against ``named-checkconf -p`` the same "
+                "way ``record.add`` / ``record.remove`` do."
+            ),
+        },
+        "view": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. Split-horizon view that owns the zone. Required "
+                "only when the zone is declared in more than one view "
+                "(otherwise the resolve step refuses ``unmanaged_zone`` and "
+                "lists the candidate views). Selects which view's zonefile is "
+                "edited and switches verification to the view-precise "
+                "``rndc zonestatus`` check."
+            ),
+        },
+    },
+    "required": ["fqdn", "type"],
+    "additionalProperties": False,
+}
+
+
+_BIND9_RECORD_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_found", "ambiguous", "unmanaged_zone"],
+            "description": (
+                "``'deleted'`` on a successful single-record delete; "
+                "``'not_found'`` when the (name, type[, rdata]) resolves to no "
+                "record (deleted=False, no silent success); ``'ambiguous'`` "
+                "when the name carries multiple values of the type and no "
+                "``rdata`` was given (candidates named); ``'unmanaged_zone'`` "
+                "when no writable zone this server serves owns the FQDN."
+            ),
+        },
+        "deleted": {
+            "type": "boolean",
+            "description": (
+                "``True`` only after the record is verified gone (the "
+                "atomic-apply verify predicate passed); ``False`` on every "
+                "refusal path."
+            ),
+        },
+        "fqdn": {"type": "string"},
+        "type": {"type": "string", "enum": sorted(_WRITE_SUPPORTED_TYPES)},
+        "rdata": {
+            "type": ["string", "null"],
+            "description": (
+                "The deleted value on success; the requested rdata (or null) on a refusal."
+            ),
+        },
+        "zone": {"type": ["string", "null"]},
+        "file": {"type": ["string", "null"]},
+        "view": {"type": ["string", "null"]},
+        "candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "The competing rdata values on the ``ambiguous`` refusal; empty otherwise."
+            ),
+        },
+        "op_class": {"type": "string", "enum": ["write"]},
+        "result_state_before": {"type": ["string", "null"]},
+        "result_state_after": {"type": ["string", "null"]},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "deleted", "fqdn", "type"],
+    "additionalProperties": False,
+}
+
+
+BIND9_RECORD_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete a single DNS record from a bind9-served zone under "
+        "governance — the DNS-retirement leg of an environment teardown in a "
+        "shared zone. " + _DELETE_WARNING
+    ),
+    "parameter_hints": {
+        "fqdn": "Required. The FQDN of the record to delete. Trailing dot optional.",
+        "type": "Required. ``A`` or ``AAAA`` — the single record type to delete.",
+        "rdata": (
+            "Optional. The exact value to delete; required only to "
+            "disambiguate a name with more than one value of the type (the "
+            "``ambiguous`` refusal names the candidates)."
+        ),
+        "zone": (
+            "Optional. Owning zone. Omit to let the handler pick the "
+            "longest-suffix-matching zone automatically."
+        ),
+        "view": (
+            "Optional. Split-horizon view that owns the zone. Needed only "
+            "when the zone is declared in multiple views."
+        ),
+    },
+    "output_shape": (
+        "{'status', 'deleted', 'fqdn', 'type', 'rdata', 'zone', 'file', "
+        "'view', 'candidates', 'op_class': 'write', 'result_state_before', "
+        "'result_state_after', 'guidance'}. ``deleted`` is True only after "
+        "the delete is verified; ``status`` names the refusal on the "
+        "not_found / ambiguous / unmanaged_zone paths."
+    ),
+}
+
+
 # ---------------------------------------------------------------------------
 # Op metadata table
 # ---------------------------------------------------------------------------
@@ -1442,5 +2016,29 @@ RECORD_OPS: tuple[Bind9Op, ...] = (
         safety_level="caution",
         requires_approval=False,
         llm_instructions=BIND9_RECORD_REMOVE_LLM_INSTRUCTIONS,
+    ),
+    Bind9Op(
+        op_id="bind9.record.delete",
+        handler_attr="bind9_record_delete",
+        summary="Delete ONE governed record (zone/name/type[/rdata]) — destructive tier.",
+        description=(
+            "The bind9 arm of the governed-delete tier (#3231, decision "
+            "docs/decisions/governed-delete-operations.md). Deletes exactly "
+            "one record scoped by (zone, name, type, and — where the name "
+            "carries multiple values of that type — rdata); never zone-wide, "
+            "never a wildcard match, never a whole-rrset sweep. Atomic "
+            "stage-validate-commit-reload-verify-rollback; the verify "
+            "predicate confirms the deleted value is gone (deleted=True only "
+            "then). Fail-closed structured refusals: ``not_found`` (no such "
+            "record), ``ambiguous`` (multiple values, no rdata — candidates "
+            "named), ``unmanaged_zone`` (no writable zone owns the FQDN). " + _DELETE_WARNING
+        ),
+        parameter_schema=BIND9_RECORD_DELETE_PARAMETER_SCHEMA,
+        response_schema=_BIND9_RECORD_DELETE_RESPONSE_SCHEMA,
+        group_key="record",
+        tags=("write", "record", "delete", "destructive", "atomic-apply"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=BIND9_RECORD_DELETE_LLM_INSTRUCTIONS,
     ),
 )

--- a/backend/src/meho_backplane/connectors/bind9/ops_record_delete_preview.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record_delete_preview.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time blast-radius preview builder for ``bind9.record.delete`` (#3231).
+
+The bind9 arm of the governed-delete tier (decision
+``docs/decisions/governed-delete-operations.md``, requirement 3) wires the one
+op that can compute a mandatory blast-radius statement onto the per-op builder
+hook shipped by #1437 (:mod:`meho_backplane.operations._preview`) — mirroring
+how :mod:`meho_backplane.connectors.argocd.ops_write_preview` wires ArgoCD's
+write previews.
+
+The builder is **read-only**: it resolves the owning zone
+(``named-checkconf -p``) and reads the current zonefile (``cat``) via the same
+helpers the handler uses, but never stages, reloads, or deletes. It returns a
+``{"blast_radius": {...}}`` sub-dict that the dispatcher promotes to the top of
+``ApprovalRequest.proposed_effect`` (#3197), so a ``destructive`` op cannot
+park without the approver seeing *exactly which record dies*:
+
+* ``object`` — the record identity ``{kind, zone, name, type, view, rdata?}``.
+* ``children`` — the record's current sibling values at that name/type, each
+  ``{kind: "record_value", type, rdata}`` (empty is a valid "no such record
+  currently" statement — the handler then refuses ``not_found`` post-approval;
+  more than one with no ``rdata`` in params is the ``ambiguous`` shape).
+* ``irreversibility`` — ``"recreatable"``: a deleted DNS record can be
+  re-added from the captured ``rdata`` (via ``bind9.record.add``), unlike a
+  destroyed VM disk. The class is honest so the approver weighs the real cost
+  (live resolution breaks immediately for every consumer) against the recovery
+  path.
+
+Declines (returns ``None`` → identifier-only default → the park is refused
+``blast_radius_required``, fail-closed) when the connector/target is
+unresolved, when the zone is not one this server writably serves (a
+``ZoneResolutionError`` — the "zone not managed → refuse" contract at park
+time), or when the zonefile cannot be read.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.bind9.connector import Bind9Connector
+from meho_backplane.connectors.bind9.ops_record import (
+    RemoteCommandError,
+    ZoneResolutionError,
+    _find_record_matches,
+    _read_zonefile_text,
+    _resolve_zone_and_path,
+)
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    register_preview_builder,
+)
+
+if TYPE_CHECKING:
+    import dns.exception  # noqa: F401 -- referenced only in the except clause below
+
+_DELETE_OP_ID = "bind9.record.delete"
+
+#: Only A / AAAA are deletable (mirrors ``ops_record._WRITE_SUPPORTED_TYPES``);
+#: an out-of-set type declines the preview rather than build a blast radius the
+#: handler would reject.
+_PREVIEWABLE_TYPES: frozenset[str] = frozenset({"A", "AAAA"})
+
+
+async def _bind9_record_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Build the mandatory destructive-tier blast radius for ``record.delete``.
+
+    Read-only. See the module docstring for the shape and the decline
+    contract. Never issues a write — the delete stays parked until a human
+    approves.
+    """
+    connector = ctx.connector_instance
+    if not isinstance(connector, Bind9Connector) or ctx.target is None:
+        return None
+    fqdn = ctx.params.get("fqdn")
+    record_type = ctx.params.get("type")
+    if not isinstance(fqdn, str) or not isinstance(record_type, str):
+        return None
+    record_type = record_type.upper()
+    if record_type not in _PREVIEWABLE_TYPES:
+        return None
+    rdata_param = ctx.params.get("rdata")
+    explicit_zone = ctx.params.get("zone")
+    explicit_view = ctx.params.get("view")
+
+    try:
+        zone_name, zonefile_path, view = await _resolve_zone_and_path(
+            connector,
+            ctx.target,
+            fqdn=fqdn,
+            explicit_zone=explicit_zone if isinstance(explicit_zone, str) else None,
+            explicit_view=explicit_view if isinstance(explicit_view, str) else None,
+            operator=ctx.operator,
+        )
+    except (ZoneResolutionError, RemoteCommandError):
+        # Zone not managed here / named-checkconf failed → decline → the park
+        # is refused blast_radius_required (fail-closed). The handler also
+        # re-refuses unmanaged_zone post-approval as defence-in-depth.
+        return None
+
+    try:
+        current_text = await _read_zonefile_text(connector, ctx.target, zonefile_path, ctx.operator)
+    except RemoteCommandError:
+        return None
+
+    import dns.exception
+
+    try:
+        matches = _find_record_matches(
+            current_text, zone_name=zone_name, fqdn=fqdn, record_type=record_type
+        )
+    except dns.exception.DNSException:
+        return None
+
+    obj: dict[str, Any] = {
+        "kind": "dns_record",
+        "zone": zone_name,
+        "name": fqdn if fqdn.endswith(".") else fqdn + ".",
+        "type": record_type,
+        "view": view,
+    }
+    if isinstance(rdata_param, str) and rdata_param:
+        obj["rdata"] = rdata_param
+    children = [{"kind": "record_value", "type": record_type, "rdata": value} for value in matches]
+    return {
+        "blast_radius": {
+            "object": obj,
+            "children": children,
+            "irreversibility": "recreatable",
+            "match_count": len(matches),
+        },
+    }
+
+
+def _register_bind9_delete_preview_builder() -> None:
+    """Wire the ``bind9.record.delete`` park-time preview builder. Import-time.
+
+    Idempotent (``register_preview_builder`` overwrites), so a test reload is
+    a no-op-equivalent — same contract as the ArgoCD / vmware wirings.
+    """
+    register_preview_builder(_DELETE_OP_ID, _bind9_record_delete_preview)
+
+
+_register_bind9_delete_preview_builder()

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -13,7 +13,7 @@ Postgres-backed ``audit_log``.
 What this harness proves (Task #591 DoD)
 =========================================
 
-* All 11 bind9 ops registered into ``endpoint_descriptor`` via
+* All 12 bind9 ops registered into ``endpoint_descriptor`` via
   :func:`~meho_backplane.operations.typed_register.register_typed_operation`
   by ``Bind9Connector.register_operations()``. The full set is reachable
   via ``search_operations(connector_id="bind9-ssh-9.x", query=...)``;
@@ -128,7 +128,8 @@ _TARGET_NAME: str = "bind9-e2e"
 #: Every op id this harness exercises. Pinned here (rather than
 #: re-derived from ``BIND9_OPS``) so a registration regression
 #: surfaces as a clear "missing op" assertion failure rather than a
-#: silent test-count change. The eleven ops correspond to G3.4-T1..T4.
+#: silent test-count change. The twelve ops correspond to G3.4-T1..T4
+#: plus the #3231 governed-delete-tier ``bind9.record.delete``.
 EXPECTED_OP_IDS: tuple[str, ...] = (
     "bind9.about",
     "bind9.zone.list",
@@ -136,6 +137,7 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "bind9.record.get",
     "bind9.record.add",
     "bind9.record.remove",
+    "bind9.record.delete",
     "bind9.config.show",
     "bind9.config.apply_file",
     "bind9.config.apply_views",

--- a/backend/tests/test_connectors_bind9_config.py
+++ b/backend/tests/test_connectors_bind9_config.py
@@ -784,12 +784,12 @@ class TestT4OpsRegistration:
     """The new T4 ops carry the right safety + audit metadata."""
 
     def test_all_four_t4_ops_registered(self) -> None:
-        """Eleven total ops -- the full Initiative #367 §4 surface."""
+        """Twelve total ops -- the Initiative #367 §4 surface + #3231 delete."""
         op_ids = {op.op_id for op in BIND9_OPS}
         for expected in _T4_OP_IDS:
             assert expected in op_ids
-        # All eleven landed.
-        assert len(BIND9_OPS) == 11
+        # All twelve landed (11 from #367 §4 + the #3231 governed delete).
+        assert len(BIND9_OPS) == 12
 
     @pytest.mark.parametrize(
         "op_id, expected_safety, expected_requires_approval",

--- a/backend/tests/test_connectors_bind9_record_delete.py
+++ b/backend/tests/test_connectors_bind9_record_delete.py
@@ -1,0 +1,902 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Conformance + unit tests for the bind9 governed record-delete (#3231).
+
+``bind9.record.delete`` is the bind9 arm of the governed-delete tier decided
+in ``docs/decisions/governed-delete-operations.md`` and first modeled by
+``vmware.composite.vm.destroy`` (#3198 / PR #3225). It is the first
+``safety_level="destructive"`` op on a typed SSH connector. These tests prove:
+
+* **Scoped to ONE record.** The delete only ever removes the single
+  ``(zone, name, type, rdata?)`` record; a name with multiple values keeps its
+  siblings, and a multi-value name with no ``rdata`` refuses ``ambiguous``.
+* **Fail-closed structured refusals** (mirroring ``vm.destroy``'s
+  ``not_powered_off``): ``not_found`` (no silent success), ``ambiguous``
+  (candidates named), ``unmanaged_zone`` (no writable zone owns the FQDN).
+* **The tier holds on every surface** for this op: agent ``DENY``,
+  ``ServicePrincipalGrant`` refusal — proven to fold via the *single source*
+  (``safety_level="destructive"``), not a local pattern list — no
+  self-approval under break-glass, no satellite mint, dispatch refused without
+  a matching preview hash, park refused without a blast-radius block.
+* **The full governed flow**: preview → parked approval carrying the hash +
+  blast radius → a *distinct human* approves → audited resume executes the
+  atomic delete and verifies the value is gone.
+
+The SSH transport is mocked by a ``_RecordingBind9Connector`` subclass seeded
+as the resolved instance (the ``_SeededBind9Connector`` pattern from
+``test_operations_handler_resolve.py``); the autouse-migrated SQLite engine
+and the ``encode_endpoint_text`` patch (``test_connectors_bind9.py``) keep
+registration off fastembed. All fixtures are synthetic (``example.test`` /
+RFC 5737 + RFC 3849 documentation addresses) — no lab names/IPs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.connectors.bind9  # noqa: F401 -- registers the connector at import
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.bind9 import Bind9Connector
+from meho_backplane.connectors.bind9.ops_record import (
+    _delete_one_record_from_zonefile,
+    _dig_value_absent_verify,
+    _find_record_matches,
+    _resolve_delete_target,
+    _soa_serial_from_text,
+    bind9_record_delete,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import typed_register as tr_module
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.operations.typed_register import register_composite_operation
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "bind9-ssh-9.x"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003231")
+_OP_ID = "bind9.record.delete"
+_ZONE = "example.test"
+_ZONEFILE_PATH = "/etc/bind/db.example.test"
+_TARGET_NAME = "test-dns"
+
+# `named-checkconf -p` declaring one writable master zone.
+_CHECKCONF = 'zone "example.test" {\n\ttype master;\n\tfile "/etc/bind/db.example.test";\n};\n'
+
+# A checkconf whose only zone does NOT suffix the requested FQDN — the
+# "zone not managed here" shape.
+_CHECKCONF_OTHER = 'zone "other.test" {\n\ttype master;\n\tfile "/etc/bind/db.other.test";\n};\n'
+
+# Split-horizon checkconf: example.test declared once per view (#2897).
+_CHECKCONF_MULTIVIEW = (
+    'view "internal" {\n'
+    "\tmatch-clients { 10.0.0.0/8; localhost; };\n"
+    '\tzone "example.test" {\n'
+    "\t\ttype master;\n"
+    '\t\tfile "/etc/bind/internal/db.example.test";\n'
+    "\t};\n"
+    "};\n"
+    'view "external" {\n'
+    "\tmatch-clients { any; };\n"
+    '\tzone "example.test" {\n'
+    "\t\ttype master;\n"
+    '\t\tfile "/etc/bind/external/db.example.test";\n'
+    "\t};\n"
+    "};\n"
+)
+
+# Zonefile: `web` single A, `api` two A values (round-robin), `host6` AAAA.
+# Addresses from RFC 5737 (192.0.2.0/24) + RFC 3849 (2001:db8::/32).
+_ZONEFILE = """$TTL 3600
+@ IN SOA ns1.example.test. admin.example.test. (
+    2026080101 3600 600 604800 86400 )
+@   IN NS ns1.example.test.
+ns1 IN A 192.0.2.1
+web IN A 192.0.2.20
+api IN A 192.0.2.10
+api IN A 192.0.2.11
+host6 IN AAAA 2001:db8::1
+"""
+
+# atomic_apply pipeline success output (sentinel-delimited state snapshots).
+_SUDO_SUCCESS = (
+    "===STATE_BEFORE_BEGIN===\n<old>\n===STATE_BEFORE_END===\n"
+    "===STATE_AFTER_BEGIN===\n<new>\n===STATE_AFTER_END===\n"
+    "===SUCCESS===\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    async with get_sessionmaker()() as s:
+        yield s
+
+
+def _proc(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    p = MagicMock()
+    p.stdout = stdout
+    p.stderr = stderr
+    p.exit_status = exit_status
+    return p
+
+
+def _staged_zonefile(sudo_script: str) -> str:
+    """Decode the base64 staged zonefile bytes out of an atomic-apply script.
+
+    ``atomic_apply`` base64-encodes the staged bytes into
+    ``export BIND9_STAGED_B64='...'`` (the verify command rides plaintext in
+    ``BIND9_VERIFY_CMD``), so staged-content assertions must decode this slot
+    rather than grep the whole script (which also contains the verify text).
+    """
+    import base64
+    import re
+
+    m = re.search(r"BIND9_STAGED_B64='([^']*)'", sudo_script)
+    assert m is not None, "no BIND9_STAGED_B64 in the atomic-apply script"
+    return base64.b64decode(m.group(1)).decode("utf-8")
+
+
+class _RecordingBind9Connector(Bind9Connector):
+    """A Bind9Connector whose SSH transport is canned + recorded.
+
+    Overrides only the three IO seams the delete handler + its preview
+    builder touch: ``_resolve_secret`` (sudo password), ``_run_command``
+    (``named-checkconf -p`` + ``cat``), ``_remote_bash_with_sudo`` (the
+    atomic-apply pipeline). A subclass (not a duck type) so the resolver's
+    bound-method rebind + the ``_CONNECTOR_INSTANCE_CACHE`` seeding behave
+    exactly as in production (the ``_SeededBind9Connector`` pattern).
+    """
+
+    def __init__(
+        self,
+        *,
+        checkconf: str = _CHECKCONF,
+        zonefile: str = _ZONEFILE,
+        sudo_output: str = _SUDO_SUCCESS,
+    ) -> None:
+        super().__init__()
+        self._checkconf = checkconf
+        self._zonefile = zonefile
+        self._sudo_output = sudo_output
+        self.run_calls: list[str] = []
+        self.sudo_calls: list[str] = []
+
+    async def _resolve_secret(
+        self, target: Any, operator: Operator | None = None
+    ) -> dict[str, Any]:
+        return {"username": "root", "password": "test-sudo-pwd"}  # NOSONAR -- unit stub
+
+    async def _run_command(
+        self, target: Any, cmd: str, *, operator: Operator | None = None, timeout: float = 30.0
+    ) -> Any:
+        self.run_calls.append(cmd)
+        if cmd.startswith("named-checkconf"):
+            return _proc(self._checkconf)
+        if cmd.startswith("cat "):
+            return _proc(self._zonefile)
+        raise AssertionError(f"unexpected _run_command {cmd!r}")
+
+    async def _remote_bash_with_sudo(
+        self,
+        target: Any,
+        script: str,
+        *,
+        operator: Operator | None = None,
+        sudo_password: str,
+        timeout: float = 60.0,
+    ) -> Any:
+        self.sudo_calls.append(script)
+        return _proc(self._sudo_output)
+
+
+def _make_operator(
+    *, sub: str = "op-1", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="bind9 delete conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "9.18.24") -> None:
+        self.version = version
+
+
+class _FakeBind9Target:
+    """Duck-typed target for direct ``dispatch(...)`` (no DB name-resolve)."""
+
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "bind9"
+        self.fingerprint = _FakeFingerprint()
+        self.preferred_impl_id: str | None = "bind9-ssh"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = _TARGET_NAME
+        self.host = "dns.example.test"
+        self.port = 22
+        self.auth_model = "shared_service_account"
+        self.secret_ref = "meho/testing/bind9/test-dns"
+
+
+def _seed_instance(recorder: _RecordingBind9Connector) -> None:
+    _CONNECTOR_INSTANCE_CACHE[Bind9Connector] = recorder  # type: ignore[assignment]
+
+
+async def _register_ops() -> None:
+    with patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)):
+        await Bind9Connector.register_operations()
+
+
+async def _bootstrap(recorder: _RecordingBind9Connector) -> None:
+    await _register_ops()
+    _seed_instance(recorder)
+
+
+async def _seed_target() -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="bind9",
+                host="dns.example.test",
+                port=22,
+                fqdn=None,
+                secret_ref="meho/testing/bind9/test-dns",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "9.18.24"},
+                preferred_impl_id="bind9-ssh",
+                notes="seeded by test_connectors_bind9_record_delete",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+def _args(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": _TARGET_NAME,
+        "params": {"fqdn": "web.example.test", "type": "A"},
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# Pure-function unit tests — scoping is the load-bearing safety property
+# ===========================================================================
+
+
+def test_find_record_matches_single_multi_and_absent() -> None:
+    assert _find_record_matches(
+        _ZONEFILE, zone_name=_ZONE, fqdn="web.example.test", record_type="A"
+    ) == ["192.0.2.20"]
+    assert _find_record_matches(
+        _ZONEFILE, zone_name=_ZONE, fqdn="api.example.test", record_type="A"
+    ) == ["192.0.2.10", "192.0.2.11"]
+    assert (
+        _find_record_matches(_ZONEFILE, zone_name=_ZONE, fqdn="nope.example.test", record_type="A")
+        == []
+    )
+
+
+def test_find_record_matches_is_canonical_for_ipv6() -> None:
+    assert _find_record_matches(
+        _ZONEFILE, zone_name=_ZONE, fqdn="host6.example.test", record_type="AAAA"
+    ) == ["2001:db8::1"]
+
+
+def test_resolve_delete_target_ok_notfound_ambiguous() -> None:
+    single = ["192.0.2.20"]
+    multi = ["192.0.2.10", "192.0.2.11"]
+    assert _resolve_delete_target(single, record_type="A", rdata_param=None) == ("192.0.2.20", "ok")
+    assert _resolve_delete_target([], record_type="A", rdata_param=None) == (None, "not_found")
+    assert _resolve_delete_target(multi, record_type="A", rdata_param=None) == (None, "ambiguous")
+    # rdata pins exactly one of a multi-value set.
+    assert _resolve_delete_target(multi, record_type="A", rdata_param="192.0.2.11") == (
+        "192.0.2.11",
+        "ok",
+    )
+    # rdata not present → not_found (never a wrong deletion).
+    assert _resolve_delete_target(multi, record_type="A", rdata_param="192.0.2.99") == (
+        None,
+        "not_found",
+    )
+
+
+def test_resolve_delete_target_rdata_canonical_match() -> None:
+    # A non-canonical IPv6 spelling still resolves to the stored value.
+    assert _resolve_delete_target(
+        ["2001:db8::1"], record_type="AAAA", rdata_param="2001:0DB8:0:0::1"
+    ) == ("2001:db8::1", "ok")
+
+
+def test_delete_one_record_keeps_siblings() -> None:
+    """Deleting ONE value of a multi-value name leaves the other intact."""
+    new = _delete_one_record_from_zonefile(
+        _ZONEFILE, zone_name=_ZONE, fqdn="api.example.test", record_type="A", rdata="192.0.2.10"
+    )
+    remaining = _find_record_matches(new, zone_name=_ZONE, fqdn="api.example.test", record_type="A")
+    assert remaining == ["192.0.2.11"]
+    # Untouched names are preserved; SOA serial advances exactly once.
+    assert _find_record_matches(new, zone_name=_ZONE, fqdn="web.example.test", record_type="A") == [
+        "192.0.2.20"
+    ]
+    assert _soa_serial_from_text(new, _ZONE) == _soa_serial_from_text(_ZONEFILE, _ZONE) + 1
+
+
+def test_delete_one_record_removes_last_value_rrset() -> None:
+    new = _delete_one_record_from_zonefile(
+        _ZONEFILE, zone_name=_ZONE, fqdn="web.example.test", record_type="A", rdata="192.0.2.20"
+    )
+    assert (
+        _find_record_matches(new, zone_name=_ZONE, fqdn="web.example.test", record_type="A") == []
+    )
+
+
+def test_delete_one_record_absent_value_raises() -> None:
+    with pytest.raises(ValueError, match="not present"):
+        _delete_one_record_from_zonefile(
+            _ZONEFILE, zone_name=_ZONE, fqdn="web.example.test", record_type="A", rdata="192.0.2.99"
+        )
+
+
+def test_dig_value_absent_verify_is_scoped_and_quoted() -> None:
+    """The verify predicate checks the one VALUE, and shell-quotes its inputs."""
+    cmd = _dig_value_absent_verify("web.example.test", "A", "192.0.2.20")
+    assert "dig @localhost web.example.test A +short" in cmd
+    assert "grep -qxF 192.0.2.20" in cmd  # literal whole-line, single value
+    # A metacharacter-laden value is quoted, not interpolated raw.
+    danger = _dig_value_absent_verify("x.example.test", "A", "1.2.3.4; rm -rf /")
+    assert "'1.2.3.4; rm -rf /'" in danger
+
+
+# ===========================================================================
+# Handler-level tests (patched SSH; direct handler call)
+# ===========================================================================
+
+
+async def test_handler_happy_path_single_value() -> None:
+    connector = _RecordingBind9Connector()
+    result = await bind9_record_delete(
+        connector, _FakeBind9Target(), {"fqdn": "web.example.test", "type": "A"}
+    )
+    assert result["status"] == "deleted"
+    assert result["deleted"] is True
+    assert result["rdata"] == "192.0.2.20"
+    assert result["zone"] == _ZONE
+    assert result["file"] == _ZONEFILE_PATH
+    assert result["op_class"] == "write"
+    assert result["result_state_before"] == "<old>"
+    assert result["result_state_after"] == "<new>"
+    assert len(connector.sudo_calls) == 1  # exactly one atomic apply
+
+
+async def test_handler_rdata_pins_one_of_multi() -> None:
+    connector = _RecordingBind9Connector()
+    result = await bind9_record_delete(
+        connector,
+        _FakeBind9Target(),
+        {"fqdn": "api.example.test", "type": "A", "rdata": "192.0.2.10"},
+    )
+    assert result["status"] == "deleted"
+    assert result["rdata"] == "192.0.2.10"
+    # The staged zonefile keeps the sibling value (192.0.2.11).
+    staged = _staged_zonefile(connector.sudo_calls[0])
+    assert "192.0.2.11" in staged
+    assert "192.0.2.10" not in staged
+
+
+async def test_handler_ambiguous_refuses_with_candidates_no_write() -> None:
+    connector = _RecordingBind9Connector()
+    result = await bind9_record_delete(
+        connector, _FakeBind9Target(), {"fqdn": "api.example.test", "type": "A"}
+    )
+    assert result["status"] == "ambiguous"
+    assert result["deleted"] is False
+    assert result["candidates"] == ["192.0.2.10", "192.0.2.11"]
+    assert connector.sudo_calls == []  # nothing staged
+
+
+async def test_handler_not_found_refuses_no_write() -> None:
+    connector = _RecordingBind9Connector()
+    result = await bind9_record_delete(
+        connector, _FakeBind9Target(), {"fqdn": "nope.example.test", "type": "A"}
+    )
+    assert result["status"] == "not_found"
+    assert result["deleted"] is False
+    assert connector.sudo_calls == []
+
+
+async def test_handler_not_found_when_rdata_absent() -> None:
+    connector = _RecordingBind9Connector()
+    result = await bind9_record_delete(
+        connector,
+        _FakeBind9Target(),
+        {"fqdn": "api.example.test", "type": "A", "rdata": "192.0.2.99"},
+    )
+    assert result["status"] == "not_found"
+    assert result["deleted"] is False
+    assert connector.sudo_calls == []
+
+
+async def test_handler_unmanaged_zone_refuses_no_write() -> None:
+    connector = _RecordingBind9Connector(checkconf=_CHECKCONF_OTHER)
+    result = await bind9_record_delete(
+        connector, _FakeBind9Target(), {"fqdn": "web.example.test", "type": "A"}
+    )
+    assert result["status"] == "unmanaged_zone"
+    assert result["deleted"] is False
+    assert connector.sudo_calls == []
+
+
+async def test_handler_multiview_without_view_is_unmanaged() -> None:
+    connector = _RecordingBind9Connector(checkconf=_CHECKCONF_MULTIVIEW)
+    result = await bind9_record_delete(
+        connector, _FakeBind9Target(), {"fqdn": "web.example.test", "type": "A"}
+    )
+    assert result["status"] == "unmanaged_zone"
+    assert "view" in result["guidance"].lower()
+    assert connector.sudo_calls == []
+
+
+async def test_handler_view_uses_zonestatus_verify() -> None:
+    connector = _RecordingBind9Connector(
+        checkconf=_CHECKCONF_MULTIVIEW,
+        zonefile="$TTL 3600\n@ IN SOA ns1.example.test. admin.example.test. "
+        "( 5 3600 600 604800 86400 )\n@ IN NS ns1.example.test.\nweb IN A 192.0.2.20\n",
+    )
+    result = await bind9_record_delete(
+        connector,
+        _FakeBind9Target(),
+        {"fqdn": "web.example.test", "type": "A", "view": "internal"},
+    )
+    assert result["status"] == "deleted"
+    assert result["view"] == "internal"
+    # A view switches the verify predicate to the view-precise zonestatus.
+    assert "rndc zonestatus" in connector.sudo_calls[0]
+
+
+async def test_handler_rejects_unsupported_type() -> None:
+    connector = _RecordingBind9Connector()
+    with pytest.raises(ValueError, match="A / AAAA"):
+        await bind9_record_delete(
+            connector, _FakeBind9Target(), {"fqdn": "web.example.test", "type": "CNAME"}
+        )
+
+
+# ===========================================================================
+# Registration — the op is destructive + requires_approval
+# ===========================================================================
+
+
+async def test_op_registered_destructive_requires_approval() -> None:
+    await _register_ops()
+    async with get_sessionmaker()() as s:
+        row = (
+            await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == _OP_ID))
+        ).scalar_one()
+    assert row.safety_level == "destructive"
+    assert row.requires_approval is True
+    assert row.source_kind == "typed"
+    assert "destructive" in (row.tags or [])
+
+
+# ===========================================================================
+# The full governed flow (the keystone)
+# ===========================================================================
+
+
+async def test_full_governed_flow_preview_park_approve_resume() -> None:
+    """preview → park (hash + blast radius) → distinct human approve → atomic delete."""
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()  # web.example.test A — a single-value record
+
+    # 1) Preview binds a param-sensitive hash even for a typed op.
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    bound_hash = preview["preview_hash"]
+    assert isinstance(bound_hash, str) and len(bound_hash) == 64
+
+    # 2) Governed call presenting the bound hash parks; no write ran.
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert recorder.sudo_calls == []  # nothing staged pre-approval
+
+    # 3) The parked row carries the bound hash + the scoped blast radius.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    blast = effect["blast_radius"]
+    assert blast["object"] == {
+        "kind": "dns_record",
+        "zone": _ZONE,
+        "name": "web.example.test.",
+        "type": "A",
+        "view": None,
+    }
+    assert blast["children"] == [{"kind": "record_value", "type": "A", "rdata": "192.0.2.20"}]
+    assert blast["irreversibility"] == "recreatable"
+
+    # 4) A DIFFERENT operator approves (four-eyes) — the binding re-verifies.
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    # 5) Audited resume → the atomic delete stages exactly once.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["deleted"] is True
+    assert resume.result["rdata"] == "192.0.2.20"
+    assert len(recorder.sudo_calls) == 1
+    # The verify predicate scopes to the deleted value, not the whole name.
+    assert "grep -qxF 192.0.2.20" in recorder.sudo_calls[0]
+
+
+# ===========================================================================
+# Requirement 2 — dispatch refused without a matching preview hash
+# ===========================================================================
+
+
+async def test_dispatch_refused_without_preview_hash() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeBind9Target(),
+        params={"fqdn": "web.example.test", "type": "A"},
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert recorder.sudo_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
+# Requirement 3 — park refused without a blast-radius block
+# ===========================================================================
+
+
+async def test_park_refused_without_blast_radius_unmanaged_zone() -> None:
+    """An unmanaged zone → preview builder declines → park refused (fail-closed)."""
+    recorder = _RecordingBind9Connector(checkconf=_CHECKCONF_OTHER)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert recorder.sudo_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
+# No agent execution path — an AGENT principal is DENY'd
+# ===========================================================================
+
+
+async def test_agent_principal_is_denied() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeBind9Target(),
+        params={"fqdn": "web.example.test", "type": "A"},
+    )
+    assert result.status == "denied", result
+    assert recorder.sudo_calls == []  # never executed
+    assert await _pending_count() == 0  # never parked either
+
+
+# ===========================================================================
+# No standing-grant path — ServicePrincipalGrant refuses the op
+# ===========================================================================
+
+
+async def test_service_grant_refuses_delete() -> None:
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "delete-shaped" in str(exc.value).lower() or "destructive" in str(exc.value).lower()
+
+
+async def test_service_grant_refuses_via_single_source_not_pattern_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adversarial (b): the op folds destructive via the SINGLE SOURCE.
+
+    Blank out the op-id pattern list (``service_grant_delete_shaped_patterns``)
+    so the glob check cannot fire, register the descriptor, and prove the
+    grant is STILL refused — by ``safety_level="destructive"`` on the resolved
+    descriptor (``_delete_shaped_reason_by_descriptor``), never a local list.
+    This is the #3213 fail-open guard: classification is single-sourced.
+    """
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    monkeypatch.setattr(get_settings(), "service_grant_delete_shaped_patterns", (), raising=False)
+
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "destructive" in str(exc.value).lower()
+
+
+# ===========================================================================
+# No self-approval, even under APPROVAL_ALLOW_SELF_APPROVAL
+# ===========================================================================
+
+
+async def test_no_self_approval_even_under_break_glass(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Break-glass ON — it does NOT reach the destructive tier.
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+# ===========================================================================
+# No satellite mint — the gateway refuses with OP_NOT_SAFE
+# ===========================================================================
+
+
+async def test_satellite_mint_refuses_op_not_safe() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params={"fqdn": "web.example.test", "type": "A"},
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+
+
+# ===========================================================================
+# Structural gap 1 — registration fail-fast: destructive ⇒ requires_approval
+# ===========================================================================
+
+
+async def test_registration_rejects_destructive_without_requires_approval() -> None:
+    with (
+        pytest.raises(ValueError, match="requires_approval"),
+        patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)),
+    ):
+        await register_composite_operation(
+            product="bind9",
+            version="9.x",
+            impl_id="bind9-ssh",
+            op_id="bind9.record.delete_broken",
+            handler=bind9_record_delete,
+            summary="broken destructive op",
+            description="a destructive op that (illegally) does not require approval",
+            parameter_schema={"type": "object", "properties": {"fqdn": {"type": "string"}}},
+            when_to_use=None,
+            group_key=None,
+            safety_level="destructive",
+            requires_approval=False,
+        )
+
+
+# ===========================================================================
+# Structural gap 2 — a USER never auto-executes destructive, even if the
+# stored descriptor is (mis)declared requires_approval=False
+# ===========================================================================
+
+
+async def test_user_never_auto_executes_destructive_without_requires_approval() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    async with get_sessionmaker()() as s:
+        await s.execute(
+            update(EndpointDescriptor)
+            .where(EndpointDescriptor.op_id == _OP_ID)
+            .values(requires_approval=False)
+        )
+        await s.commit()
+    reset_dispatcher_caches()
+    _seed_instance(recorder)
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+
+    assert call["status"] == "awaiting_approval", call
+    assert recorder.sudo_calls == []  # no write ran despite requires_approval=False
+
+
+# ===========================================================================
+# The typed-op preview hash is param-sensitive (the #3197 binding on a typed op)
+# ===========================================================================
+
+
+async def test_preview_hash_is_param_sensitive() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    base = {"connector_id": _CONNECTOR_ID, "op_id": _OP_ID, "target": _TARGET_NAME}
+
+    p1 = await preview_operation(
+        requester, {**base, "params": {"fqdn": "web.example.test", "type": "A"}}
+    )
+    p1b = await preview_operation(
+        requester, {**base, "params": {"fqdn": "web.example.test", "type": "A"}}
+    )
+    p2 = await preview_operation(
+        requester,
+        {**base, "params": {"fqdn": "web.example.test", "type": "A", "rdata": "192.0.2.20"}},
+    )
+    assert p1["status"] == "ok"
+    assert p1["preview_hash"] == p1b["preview_hash"]  # stable for identical args
+    assert p1["preview_hash"] != p2["preview_hash"]  # a different delete → different hash
+
+
+# ===========================================================================
+# Adversarial (a) — a multi-value park names the record + enumerates siblings;
+# the resolved delete removes only ONE value
+# ===========================================================================
+
+
+async def test_multi_value_park_blast_radius_then_scoped_delete() -> None:
+    recorder = _RecordingBind9Connector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    # api.example.test has two A values; pin one with rdata.
+    args = _args(params={"fqdn": "api.example.test", "type": "A", "rdata": "192.0.2.10"})
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    # The object names the exact record incl. the pinned rdata; children
+    # enumerate BOTH current values so the approver sees the full set.
+    assert blast["object"]["name"] == "api.example.test."
+    assert blast["object"]["rdata"] == "192.0.2.10"
+    assert {c["rdata"] for c in blast["children"]} == {"192.0.2.10", "192.0.2.11"}
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.result["status"] == "deleted"
+    # Only the pinned value is staged out; the sibling survives.
+    staged = _staged_zonefile(recorder.sudo_calls[0])
+    assert "192.0.2.11" in staged
+    assert "192.0.2.10" not in staged

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -663,6 +663,26 @@ refused without a matching hash, park refused without a blast-radius block,
 and the full preview→park→human-approve→audited-resume flow — is pinned in
 `tests/test_connectors_vmware_rest_vm_destroy.py`.
 
+### Second governed delete: `bind9.record.delete` (#3231)
+
+The bind9 arm of the tier — and the **first `destructive` op on a typed SSH
+connector** (the vm.destroy machinery above needed no change to reach it, so
+this Task added no gate code, only the op). `bind9.record.delete` deletes
+exactly one DNS record scoped by `(zone, name, type, rdata?)`, for the
+DNS-retirement leg of a governed environment teardown in a shared zone. It
+reuses everything above unchanged: the typed op is `destructive` +
+`requires_approval=True`, so it folds into the delete-shaped classifier via
+the single-source `safety_level` (`_delete_shaped_reason_by_descriptor`); the
+`destructive` previewability gate already covers typed ops (not only
+composites); its blast radius (`ops_record_delete_preview`) names the exact
+record + its sibling values with `irreversibility="recreatable"`. Fail-closed
+structured refusals mirror `vm.destroy`'s `not_powered_off`: `not_found`,
+`ambiguous` (candidates named), `unmanaged_zone`. Conformance is pinned in
+`tests/test_connectors_bind9_record_delete.py` — including a monkeypatch test
+proving the grant refusal folds via the single source with the op-id glob
+patterns blanked (the #3213 fail-open guard). See
+`connectors-bind9.md` for the handler/preview layout.
+
 ## Uniform op-identity envelope (#2681)
 
 The preview base varies by outcome — a bespoke `{op_class, preview}`, the

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -188,7 +188,7 @@ the most-specific class first (`PermissionDenied` is a subclass of
 `DisconnectError` in asyncssh) so the dispatch maps to the right
 reason.
 
-## Shipped op surface (T1 + T2 + T3 + T4 = 11 ops)
+## Shipped op surface (T1 + T2 + T3 + T4 + #3231 = 12 ops)
 
 | Op id | Handler | Safety | Description |
 | ----- | ------- | ------ | ----------- |
@@ -198,6 +198,7 @@ reason.
 | `bind9.record.get` | `Bind9Connector.bind9_record_get` | `safe` | `dig @localhost <fqdn> <type>` parsed into structured rows; defaults to A; supports A / AAAA / CNAME / MX / TXT |
 | `bind9.record.add` | `Bind9Connector.bind9_record_add` | `caution` | Atomic A/AAAA record write with snapshot rollback; resolves owning zone via longest-suffix match when `zone` omitted; optional `view` disambiguates split-horizon zones (#2897); verify predicate = `dig` returns the new IP, or `rndc zonestatus` serial-match when a `view` is given |
 | `bind9.record.remove` | `Bind9Connector.bind9_record_remove` | `caution` | Atomic remove of A + AAAA at the given FQDN with snapshot rollback; same `view` disambiguation as `record.add`; verify predicate = `dig` no longer resolves the FQDN, or `rndc zonestatus` serial-match when a `view` is given |
+| `bind9.record.delete` | `Bind9Connector.bind9_record_delete` | `destructive` | Governed-delete tier (#3231): deletes exactly ONE record scoped by `(zone, name, type, rdata?)` — never zone-wide, never a whole-rrset sweep. Mandatory human approval + preview-hash binding + blast-radius (the exact record + its siblings). Fail-closed structured refusals `not_found` / `ambiguous` (candidates named) / `unmanaged_zone`; verify predicate confirms the single deleted value is gone (view → `rndc zonestatus`) |
 | `bind9.config.show` | `Bind9Connector.bind9_config_show` | `safe` | Read named.conf or an included fragment under the bind config root; path-safety filter refuses traversal with no content leaked |
 | `bind9.config.apply_file` | `Bind9Connector.bind9_config_apply_file` | `dangerous` | Atomic single-fragment write via T3's primitive; validate = `named-checkconf -p`; verify = config still parses after live reload |
 | `bind9.config.apply_views` | `Bind9Connector.bind9_config_apply_views` | `dangerous` | Atomic multi-file tree write (tar mode of T3's primitive); validate = `named-checkconf -p`; verify = caller-supplied `dig` or fallback parse check |
@@ -209,6 +210,51 @@ views file can dark the whole resolver. The production-path gate
 (G7/G10) keys on `safety_level`, so the apply ops carry an additional
 warning in their `description` + `llm_instructions` that any agent
 proposing the write sees.
+
+### Governed single-record delete (`bind9.record.delete`, #3231)
+
+`bind9.record.delete` is the bind9 arm of the governed-delete tier
+(decision `docs/decisions/governed-delete-operations.md`, first modeled by
+`vmware.composite.vm.destroy` / #3198) — and the **first
+`safety_level="destructive"` op on a typed SSH connector**. It rides the
+hardest gate MEHO has: mandatory human approval (no agent path, no standing
+grant, no self-approval even under break-glass), a mandatory preview-hash
+binding, and a mandatory blast-radius statement. It folds into the
+delete-shaped classifier via the **single source** — its
+`safety_level="destructive"` (not a re-declared pattern list, per the #3213
+fail-open lesson); `ServicePrincipalGrantService.create` refuses it even with
+the op-id glob patterns blanked.
+
+It is deliberately **narrower** than `bind9.record.remove`: `remove` clears
+every A + AAAA at a name in one caution-tier write, while `delete` removes
+**exactly one** record scoped by `(zone, name, type, rdata?)`. `type` is
+required; `rdata` is required only to disambiguate a name that carries more
+than one value of that type.
+
+Layout mirrors the record write ops:
+
+* **Handler** `ops_record.bind9_record_delete` — a fail-closed re-read at
+  dispatch time (post-approval, like `vm.destroy`'s power-state re-read):
+  resolves the owning zone (`unmanaged_zone` refusal on a
+  `ZoneResolutionError`), reads the zonefile, and resolves the target via the
+  pure `_resolve_delete_target` — `not_found` (no silent success),
+  `ambiguous` (candidates named), or a single value. On a unique target it
+  removes that one value via the T3 atomic-apply primitive
+  (`_delete_one_record_from_zonefile` keeps siblings), with a verify predicate
+  (`_dig_value_absent_verify`, or the view-precise `rndc zonestatus`) that
+  confirms the deleted value is gone — `deleted=True` only then.
+* **Preview builder** `ops_record_delete_preview._bind9_record_delete_preview`
+  — read-only; wired onto the `_preview` hook (mirroring
+  `argocd.ops_write_preview`) via a side-effect import in `bind9/__init__.py`.
+  Builds the `blast_radius` block (object = the exact record; children = its
+  current sibling values; `irreversibility="recreatable"` — a DNS record can
+  be re-added from the captured rdata). Declines (→ park refused
+  `blast_radius_required`) when the zone is unmanaged or the zonefile is
+  unreadable.
+
+All refusal envelopes carry `status` / `deleted=False` / `guidance` — the
+`vm.destroy` structured-refusal shape. See the approvals-plane note in
+`approvals.md`.
 
 ## Atomic-apply primitive (T3 #589)
 


### PR DESCRIPTION
Closes #3231.

Registers **`bind9.record.delete`** on the governed-delete (destructive) tier — the second governed delete after `vmware.composite.vm.destroy` (#3198 / PR #3225) and the **first `safety_level="destructive"` op on a typed SSH connector**. Unblocks the DNS-retirement leg of governed environment teardown, which returned `unknown_op` for the pack's `bind9.record.delete` placeholder.

## Design
- Deletes **exactly one** record scoped by `(zone, name, type, rdata?)` — never zone-wide, never a wildcard, never a whole-rrset sweep. Deliberately narrower than the existing caution-tier `bind9.record.remove` (which clears both A+AAAA at a name). `type` is required; `rdata` disambiguates a multi-value name.
- `safety_level="destructive"` + `requires_approval=True`. The vm.destroy tier machinery needed **zero changes** to reach a typed op — this Task added only the op, a read-only blast-radius preview builder (wired onto the `_preview` hook, mirroring `argocd.ops_write_preview`), and conformance.
- Folds into the delete-shaped classifier via the **single source** (`safety_level=destructive` on the resolved descriptor), never a re-declared pattern list (the #3213 fail-open lesson).
- **Fail-closed structured refusals** mirror vm.destroy's `not_powered_off` shape: `not_found` (no silent success), `ambiguous` (candidates named), `unmanaged_zone` — plus a dispatch-time fail-closed re-read. The atomic-apply verify predicate confirms the single deleted value is gone (`deleted=True` only then; siblings preserved; a `view` switches to the view-precise `rndc zonestatus` check). Blast-radius `irreversibility="recreatable"` (a DNS record is re-addable from the captured rdata).

## Scope notes
- **No CLI verb** (mirrors vm.destroy — governed deletes go through the generic `call_operation` path, which handles preview+approval; the auto-executing `record add/remove` convenience shape is wrong for a destructive op).
- **No REST route / no migration** (typed op) → CLI OpenAPI snapshot unaffected. No spec-reconcile lane (typed/SSH connector, no ingested spec — N/A).

## Tests / gates
- `tests/test_connectors_bind9_record_delete.py` — 30 tests: op registration + schema, pure-function scoping proofs, handler refusal/happy paths, and the destructive-tier conformance suite (agent `DENY`, `ServicePrincipalGrant` refusal incl. a **single-source** proof with the op-id glob patterns blanked, no self-approval under break-glass, satellite mint `OP_NOT_SAFE`, dispatch refused without a matching preview hash, park refused without a blast-radius block, and the full preview → parked approval → distinct-human approve → audited resume flow deleting exactly one record).
- Full bind9 + destructive-tier suites: 277 pass. `ruff` / `ruff format` / `mypy` clean.

## Review
Inline adversarial review (budget 3) hunted broader-than-one-record execution, classifier-fold single-sourcing, refusal completeness, approval bypass, and preview-hash binding gaps — no new defects. **Verdict: APPROVE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)