### PR TITLE
feat(gateway): satellite store-and-forward effect audit + un-reported-mint alarm (#3193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,41 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — satellite write path: store-and-forward tamper-evident effect audit + un-reported-mint alarm (#3193)
+
+- Mechanism 4 of the composed write-tier gate: the two **compensating controls**
+  for the consciously-recorded v0.1-spec §6 exception (a satellite write's
+  **effect** cannot be synchronously audited at the centre — the runner has no DB
+  and the mutation is off-net). The **mint** stays synchronously audited; the
+  **effect** is store-and-forward with a detector for its absence. The existing
+  `gateway.command.mint` / `gateway.command.result` split lineage is preserved.
+- **Tamper-evident effect audit:** the runner writes a **hash-chained**
+  (sequence-numbered, per-runner) effect record **before** each remote-write
+  mutation and **after** it, referencing the signed work item (#3189) as its
+  non-repudiation anchor, and forwards them with the result report on
+  `POST /gateway/{runner}/result` (push-only preserved). The centre ingests each
+  into `audit_log` with a `store-and-forward` provenance marker, links it to the
+  mint audit row (`parent_audit_id = gateway_command.mint_audit_id`), and
+  **verifies the chain** against the persisted per-runner head
+  (`runner_effect_chain`, migration `0094`): a sequence gap, a broken link, a
+  tampered body, or a record forging another runner's chain is refused — the
+  whole submission rolls back (the capability stays unconsumed) and a durable
+  `gateway.command.effect.quarantine` **security** audit row is written.
+- **Un-reported-mint alarm:** a central sweeper (the `gateway/deadman.py` mould —
+  central-clock, advisory-lock-elected, conditional-`UPDATE` idempotent) raises a
+  **security** event (`path='gateway.command.unreported_mint'`,
+  `event_class='security'`) exactly once for a minted `remote-write` capability
+  past `expires_at` still unconsumed — its effect never came back (threat T4).
+  Deliberately distinct from the #2501 dead-man switch's **liveness** flip
+  (`gateway.runner.stale`): a live runner can still execute-but-not-report one
+  write. New `gateway_command.unreported_alarm_at` latch (migration `0094`);
+  gated on `GATEWAY_UNREPORTED_MINT_ENABLED` (default on),
+  `GATEWAY_UNREPORTED_MINT_TICK_INTERVAL_SECONDS` (default 60).
+- Residual (bounded, not eliminated): a fully compromised runner can fabricate a
+  self-consistent alternate chain; tamper evidence catches transit tampering +
+  dropped records, not a lying edge — bounded by the composition (allowlist ×
+  credential TTL) and the alarm. Documented in `docs/codebase/satellite-runner.md`.
+
 ### Added — satellite write path: revocation hardening for write-capable runners (#3192)
 
 - Closes the T8 already-minted-write gap: a **revoked** runner can no longer

--- a/backend/alembic/versions/0094_satellite_effect_audit.py
+++ b/backend/alembic/versions/0094_satellite_effect_audit.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Satellite effect audit + un-reported-mint alarm storage (#3193).
+
+Revision ID: 0094
+Revises: 0092
+Create Date: 2026-09-01
+
+Initiative #2901 (satellite write path), Task #3193 — mechanism 4 of the
+composed write-tier gate (design ``docs/research/2901-satellite-write-path.md``
+§3, decision ``docs/decisions/satellite-write-path.md``): the tamper-evident
+store-and-forward effect audit and the un-reported-mint security alarm, the two
+compensating controls for the consciously-recorded v0.1-spec §6 exception.
+
+What this migration adds
+------------------------
+
+1. ``gateway_command.unreported_alarm_at timestamptz NULL`` — the one-way latch
+   the un-reported-mint sweeper (``gateway/unreported_mint.py``, the
+   ``deadman.py`` mould) flips when a minted ``remote-write`` capability passes
+   ``expires_at`` still ``consumed_at IS NULL`` (its effect was never reported,
+   threat T4). The ``unreported_alarm_at IS NULL`` predicate + a conditional
+   ``UPDATE`` rowcount gate keep "exactly one security audit row per unreported
+   mint" true across ticks / replicas — the same discipline
+   ``runner_assignments.stale_at`` follows for the *liveness* dead-man flip;
+   this is the *security* alarm, kept distinct. Nullable with no
+   ``server_default``: an un-flipped capability is ``NULL`` (the correct "not
+   yet alarmed" state) and a nullable ``ADD COLUMN`` needs no backfill, mirroring
+   the ``signature`` add (``0092``).
+
+2. ``runner_effect_chain`` — the per-runner head of the store-and-forward
+   effect-audit hash chain. The centre verifies chain continuity *across*
+   forwards against this row (``last_seq`` / ``last_hash``); a sequence gap or a
+   broken link is detected here and refused / quarantined. Keyed on
+   ``(tenant_id, runner_id)`` via a composite unique index; ``runner_id`` is the
+   runner principal **name** (the wire identity). Additive-only: a fresh table +
+   its unique index, no ALTER of an existing object beyond the nullable column
+   above.
+
+Migration-chain note (single linear head)
+------------------------------------------
+
+Numbered ``0094`` with ``down_revision = "0092"`` — the head on ``origin/main``
+at author/push time (``0092_add_gateway_command_signature``, #3189). The sibling
+#3190 (per-runner allowlist) runs concurrently under this same #2901 initiative
+and owns ``0093`` if it needs a migration; this task deliberately skips ``0093``
+so the two never collide on a revision id. If #3190 lands **no** migration (or
+lands after this), the chain is ``0092 -> 0094`` linear, which the ``Python
+(database migrations)`` CI gate requires; only the ``down_revision`` pointer is
+load-bearing, never the number, so the orchestrator re-points at merge if the
+race lands differently.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the table (and its index) and the column. SQLite ALTER
+TABLE drop-column is supported since 3.35.0 (we're on 3.45+); Alembic's
+batch-mode fallback is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0094"
+down_revision: str | None = "0092"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the un-reported-mint latch column + the effect-chain head table."""
+    op.add_column(
+        "gateway_command",
+        sa.Column("unreported_alarm_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+    op.create_table(
+        "runner_effect_chain",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), sa.ForeignKey("tenant.id"), nullable=False),
+        sa.Column("runner_id", sa.Text(), nullable=False),
+        sa.Column("last_seq", sa.BigInteger(), nullable=False),
+        sa.Column("last_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+    op.create_index(
+        "runner_effect_chain_runner_uq",
+        "runner_effect_chain",
+        ["tenant_id", "runner_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the effect-chain head table + the un-reported-mint latch column."""
+    op.drop_index("runner_effect_chain_runner_uq", table_name="runner_effect_chain")
+    op.drop_table("runner_effect_chain")
+    op.drop_column("gateway_command", "unreported_alarm_at")

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -70,6 +70,11 @@ from meho_backplane.auth.runner_guard import assert_runner_scope, require_runner
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
 from meho_backplane.gateway.deadman import clear_runner_stale
+from meho_backplane.gateway.effect_ingest import (
+    EffectChainTamperError,
+    ingest_effect_records,
+    quarantine_effect_chain,
+)
 from meho_backplane.gateway.queue import (
     GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS,
     GATEWAY_LONGPOLL_MAX_WAIT_SECONDS,
@@ -82,6 +87,7 @@ from meho_backplane.operations.gateway_commands import (
     GatewayCommandAlreadyConsumedError,
     accept_command_result,
 )
+from meho_backplane.runner.effect_audit import EffectAuditRecord
 
 __all__ = ["router"]
 
@@ -143,6 +149,15 @@ class GatewayResultBody(BaseModel):
         default=None,
         description="Failure summary (for a 'failed' outcome).",
     )
+    # Store-and-forward effect audit (#3193, mechanism 4): the runner forwards
+    # its hash-chained effect records with the result report. Empty for a
+    # ``safe`` read (which mints no signed capability and records no effect) and
+    # for a legacy runner that predates the field — the ingest is a no-op then,
+    # so the field is backward-compatible.
+    effect_records: list[EffectAuditRecord] = Field(
+        default_factory=list,
+        description="Tamper-evident store-and-forward effect audit records to ingest.",
+    )
 
 
 class GatewayResultAck(BaseModel):
@@ -158,6 +173,35 @@ class GatewayResultAck(BaseModel):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _ingest_effect_or_quarantine(
+    session: Any,
+    *,
+    operator: Operator,
+    runner: str,
+    records: list[EffectAuditRecord],
+) -> None:
+    """Verify + ingest a runner's forwarded effect chain, or quarantine a tamper.
+
+    Store-and-forward effect audit (#3193, mechanism 4). A broken chain (gap /
+    transit tampering / cross-runner forge) rolls the whole submission back — a
+    tampered report is **not** accepted, so the capability stays unconsumed and
+    the un-reported-mint alarm can still fire — and the tamper is recorded as a
+    durable security audit row. An empty ``records`` list (a ``safe`` read or a
+    legacy runner) is a no-op, so the field is backward-compatible.
+    """
+    if not records:
+        return
+    try:
+        await ingest_effect_records(session, operator=operator, runner_id=runner, records=records)
+    except EffectChainTamperError as tamper:
+        await session.rollback()
+        await quarantine_effect_chain(tenant_id=operator.tenant_id, runner_id=runner, error=tamper)
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=f"effect_chain_tamper: {tamper.reason}",
+        ) from tamper
 
 
 def _envelope(command: GatewayCommand) -> GatewayCommandEnvelope:
@@ -298,6 +342,11 @@ async def report_command_result(
             # the runner is alive and reporting, so reset any dead-man flip
             # marker the central sweeper set (sweeper only flips; this clears).
             await clear_runner_stale(session, tenant_id=operator.tenant_id, runner_name=runner)
+            # Store-and-forward effect audit ingest (#3193, mechanism 4) on the
+            # same session, so a clean report commits result + effect atomically.
+            await _ingest_effect_or_quarantine(
+                session, operator=operator, runner=runner, records=body.effect_records
+            )
             ack = GatewayResultAck(
                 command_id=command.id,
                 status=command.status,

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6291,6 +6291,22 @@ class GatewayCommand(Base):
         nullable=False,
         server_default=sa.text("'safe'"),
     )
+    # --- Un-reported-mint security alarm (#3193, migration 0094) --------
+    # The one-way latch the un-reported-mint sweeper
+    # (``gateway/unreported_mint.py``, the ``deadman.py`` mould) flips when a
+    # minted ``remote-write`` capability passes ``expires_at`` still
+    # ``consumed_at IS NULL`` -- its effect was never reported (threat T4). The
+    # ``unreported_alarm_at IS NULL`` predicate + the conditional-``UPDATE``
+    # rowcount gate keep "exactly one security audit row per unreported mint"
+    # true across ticks / replicas, the same discipline as
+    # ``runner_assignments.stale_at``. NULL for every reported, unexpired, or
+    # ``safe`` capability. This is the security alarm, distinct from the
+    # liveness ``stale_at`` dead-man flip.
+    unreported_alarm_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -6304,6 +6320,75 @@ class GatewayCommand(Base):
         sa.CheckConstraint(
             _ck_in("status", _GATEWAY_COMMAND_STATUSES),
             name="ck_gateway_command_status",
+        ),
+    )
+
+
+class RunnerEffectChain(Base):
+    """Per-runner head of the store-and-forward effect-audit hash chain (#3193).
+
+    Initiative #2901 (satellite write path), Task #3193 — mechanism 4 of the
+    composed write-tier gate. A satellite runner keeps a local, hash-chained
+    record of every remote **write** effect it attempts
+    (:mod:`meho_backplane.runner.effect_audit`) and forwards it on next contact.
+    The centre ingests each record into ``audit_log`` and **verifies the chain**
+    (:mod:`meho_backplane.gateway.effect_ingest`); to verify continuity *across*
+    forwards it must remember, per runner, the last sequence number and hash it
+    accepted. This row is that head.
+
+    A ``seq`` that is not exactly ``last_seq + 1`` (a gap — a dropped or
+    suppressed record) or a ``prev_hash`` that is not ``last_hash`` (a broken
+    link — transit tampering) is detected against this row and refused /
+    quarantined. The head is keyed on ``(tenant_id, runner_id)`` where
+    ``runner_id`` is the runner principal **name** (the wire identity, matching
+    ``gateway_command.runner_id``); the centre binds ingest to the authenticated
+    runner, so one runner cannot advance another's chain.
+
+    Schema decisions
+    ----------------
+
+    * ``id`` — UUID primary key (PG ``gen_random_uuid()`` / ORM ``uuid.uuid4``).
+    * ``tenant_id`` — UUID NOT NULL, real FK to ``tenant.id`` (the newer
+      clean-slate discipline, as ``gateway_command`` / ``runner_principal``).
+    * ``runner_id`` — Text NOT NULL. The runner principal **name**.
+    * ``last_seq`` — BigInteger NOT NULL. The highest sequence number ingested
+      for this runner. Seeded on first ingest.
+    * ``last_hash`` — Text NOT NULL. That record's ``record_hash`` — the
+      ``prev_hash`` the next forwarded record must carry.
+    * ``updated_at`` — ``timestamptz`` NOT NULL, advanced on each accepted
+      forward.
+
+    A partial-free composite unique index ``(tenant_id, runner_id)`` enforces one
+    head per runner and serves the ingest lookup.
+    """
+
+    __tablename__ = "runner_effect_chain"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    runner_id: Mapped[str] = mapped_column(Text, nullable=False)
+    last_seq: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    last_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "runner_effect_chain_runner_uq",
+            "tenant_id",
+            "runner_id",
+            unique=True,
         ),
     )
 

--- a/backend/src/meho_backplane/gateway/effect_ingest.py
+++ b/backend/src/meho_backplane/gateway/effect_ingest.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central ingest + chain verification for satellite effect audit records (#3193).
+
+The centre half of mechanism 4 (design ``docs/research/2901-satellite-write-path.md``
+§3, decision ``docs/decisions/satellite-write-path.md``). A satellite runner
+forwards its local hash-chained effect audit records
+(:mod:`meho_backplane.runner.effect_audit`) on next contact; this module ingests
+them into ``audit_log`` with a ``store-and-forward`` provenance marker **only
+after verifying the chain** against the persisted per-runner head
+(:class:`~meho_backplane.db.models.RunnerEffectChain`).
+
+Three verified properties, each fail-closed:
+
+* **Continuity / gap detection.** A record's ``seq`` must be exactly
+  ``head.last_seq + 1``; a hole (a dropped or suppressed record) is refused.
+* **Link integrity.** A record's ``prev_hash`` must equal the head's
+  ``last_hash`` and its ``record_hash`` must re-derive from the canonical body —
+  any transit tampering breaks one of these.
+* **Runner binding.** A record's ``runner_id`` must equal the authenticated
+  runner; one runner cannot extend another's chain (the sibling-forge defence —
+  the runner name comes from the unforgeable token, not the request body).
+
+A break raises :class:`EffectChainTamperError`; the runner-facing endpoint rolls
+back the whole result submission (so a tampered report is *not* accepted — the
+un-reported-mint alarm then fires on the un-consumed capability) and
+:func:`quarantine_effect_chain` records the security event. A clean batch writes
+one ``audit_log`` row per record, each linked to its mint audit row
+(``gateway_command.mint_audit_id``) so the store-and-forward effect joins the
+mint/result audit subtree the split lineage (#2500) already forms.
+
+Residual (design §3, mechanism 4): a **fully compromised** runner holds its own
+genesis and can forge a self-consistent alternate chain. Tamper evidence catches
+transit tampering + dropped records, **not** a lying edge; that residual is
+bounded by the composition (allowlist x credential TTL) and the un-reported-mint
+alarm, never by this verification alone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.models import AuditLog, GatewayCommand, RunnerEffectChain
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    write_internal_audit_row,
+)
+from meho_backplane.runner.effect_audit import (
+    GENESIS_PREV_HASH,
+    EffectAuditRecord,
+    canonical_record_body,
+    compute_record_hash,
+)
+
+__all__ = [
+    "EFFECT_AUDIT_METHOD",
+    "EFFECT_AUDIT_PATH",
+    "EFFECT_QUARANTINE_PATH",
+    "STORE_AND_FORWARD_PROVENANCE",
+    "EffectChainTamperError",
+    "ingest_effect_records",
+    "quarantine_effect_chain",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: ``audit_log.method`` channel for an ingested effect record — the same
+#: ``GATEWAY`` channel the mint / result rows use, so an effect row sits in the
+#: mint's audit subtree via ``parent_audit_id``.
+EFFECT_AUDIT_METHOD: str = "GATEWAY"
+#: ``audit_log.path`` for an ingested, chain-verified effect record.
+EFFECT_AUDIT_PATH: str = "gateway.command.effect"
+#: ``audit_log.path`` for a quarantined (tamper-detected) forward — an
+#: ``INTERNAL``-channel **security** event, distinct from a normal effect row.
+EFFECT_QUARANTINE_PATH: str = "gateway.command.effect.quarantine"
+#: The provenance marker stamped on every store-and-forward effect row's payload
+#: (the effect was audited at the edge and forwarded, not synchronously at the
+#: centre — the recorded v0.1-spec §6 exception).
+STORE_AND_FORWARD_PROVENANCE: str = "store-and-forward"
+
+#: Synthetic identity for centre-detected effect-chain security events.
+_SECURITY_OPERATOR_SUB: str = "system:satellite-effect-audit"
+
+
+class EffectChainTamperError(Exception):
+    """A forwarded effect record broke the chain — refuse / quarantine.
+
+    Carries the offending ``seq`` and a human reason; the endpoint surfaces the
+    reason and :func:`quarantine_effect_chain` records it.
+    """
+
+    def __init__(self, reason: str, *, seq: int | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.seq = seq
+
+
+async def ingest_effect_records(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    runner_id: str,
+    records: list[EffectAuditRecord],
+) -> list[uuid.UUID]:
+    """Verify a forwarded effect chain and ingest it into ``audit_log``.
+
+    Verifies each record against the persisted per-runner head (continuity,
+    link integrity, runner binding), writes one ``audit_log`` row per record
+    (store-and-forward provenance, linked to the mint audit row), and advances
+    the head. Flushed, **not** committed — the caller owns the commit so the
+    effect rows land atomically with the accepted result.
+
+    Raises:
+        EffectChainTamperError: a gap, a broken link, a body mismatch, or a
+            record claiming a different runner. No partial ingest — the caller
+            rolls the whole submission back.
+    """
+    if not records:
+        return []
+
+    head = await _load_head(session, tenant_id=operator.tenant_id, runner_id=runner_id)
+    last_seq = head.last_seq if head is not None else -1
+    last_hash = head.last_hash if head is not None else GENESIS_PREV_HASH
+
+    written: list[uuid.UUID] = []
+    for record in records:
+        _verify_link(record, runner_id=runner_id, last_seq=last_seq, last_hash=last_hash)
+        audit_id = await _write_effect_audit_row(session, operator=operator, record=record)
+        written.append(audit_id)
+        last_seq = record.seq
+        last_hash = record.record_hash
+
+    await _persist_head(
+        session,
+        head=head,
+        tenant_id=operator.tenant_id,
+        runner_id=runner_id,
+        last_seq=last_seq,
+        last_hash=last_hash,
+    )
+    await session.flush()
+    _log.info(
+        "satellite_effect_chain_ingested",
+        runner_id=runner_id,
+        tenant_id=str(operator.tenant_id),
+        records=len(records),
+        head_seq=last_seq,
+    )
+    return written
+
+
+def _verify_link(
+    record: EffectAuditRecord,
+    *,
+    runner_id: str,
+    last_seq: int,
+    last_hash: str,
+) -> None:
+    """Fail-closed verification of one record against the running head."""
+    if record.runner_id != runner_id:
+        raise EffectChainTamperError(
+            f"effect record claims runner {record.runner_id!r} but was forwarded by "
+            f"{runner_id!r}; a runner cannot extend another runner's chain",
+            seq=record.seq,
+        )
+    expected_seq = last_seq + 1
+    if record.seq != expected_seq:
+        raise EffectChainTamperError(
+            f"effect chain gap for runner {runner_id!r}: expected seq {expected_seq}, "
+            f"got {record.seq} (a dropped or suppressed record breaks the chain)",
+            seq=record.seq,
+        )
+    if record.prev_hash != last_hash:
+        raise EffectChainTamperError(
+            f"effect chain broken link for runner {runner_id!r} at seq {record.seq}: "
+            "prev_hash does not match the accepted head (transit tampering)",
+            seq=record.seq,
+        )
+    canonical = canonical_record_body(
+        runner_id=record.runner_id,
+        seq=record.seq,
+        phase=record.phase,
+        command_id=record.command_id,
+        op_id=record.op_id,
+        params_hash=record.params_hash,
+        signature=record.signature,
+        target_scope=record.target_scope,
+        outcome=record.outcome,
+        recorded_at=record.recorded_at,
+    )
+    if compute_record_hash(record.prev_hash, canonical) != record.record_hash:
+        raise EffectChainTamperError(
+            f"effect record body tampered for runner {runner_id!r} at seq {record.seq}: "
+            "record_hash does not re-derive from the record body",
+            seq=record.seq,
+        )
+
+
+async def _write_effect_audit_row(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    record: EffectAuditRecord,
+) -> uuid.UUID:
+    """Insert one store-and-forward ``audit_log`` row for a verified record.
+
+    ``parent_audit_id`` links to the mint audit row via the command the record
+    references, so the remote effect joins the mint/result subtree; ``linked``
+    is ``False`` when no minted command matches (a residual: a lying edge may
+    reference a capability that was never minted — recorded, not fatal here).
+    """
+    mint_audit_id, linked = await _resolve_mint_link(
+        session, tenant_id=operator.tenant_id, runner_id=record.runner_id, record=record
+    )
+    audit_id = uuid.uuid4()
+    payload: dict[str, Any] = {
+        "provenance": STORE_AND_FORWARD_PROVENANCE,
+        "runner_id": record.runner_id,
+        "seq": record.seq,
+        "phase": str(record.phase),
+        "command_id": record.command_id,
+        "op_id": record.op_id,
+        "params_hash": record.params_hash,
+        "signature": record.signature,
+        "target_scope": record.target_scope,
+        "outcome": record.outcome,
+        "recorded_at": record.recorded_at,
+        "record_hash": record.record_hash,
+        "chain_verified": True,
+        "linked": linked,
+    }
+    session.add(
+        AuditLog(
+            id=audit_id,
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator.sub,
+            tenant_id=operator.tenant_id,
+            parent_audit_id=mint_audit_id,
+            method=EFFECT_AUDIT_METHOD,
+            path=EFFECT_AUDIT_PATH,
+            status_code=200,
+            request_id=None,
+            duration_ms=None,
+            payload=payload,
+        )
+    )
+    await session.flush()
+    return audit_id
+
+
+async def _resolve_mint_link(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    record: EffectAuditRecord,
+) -> tuple[uuid.UUID | None, bool]:
+    """Resolve the mint audit id the effect record links to, if the command exists."""
+    try:
+        command_uuid = uuid.UUID(record.command_id)
+    except (ValueError, AttributeError):
+        return (None, False)
+    row = (
+        await session.execute(
+            select(GatewayCommand.mint_audit_id).where(
+                GatewayCommand.id == command_uuid,
+                GatewayCommand.tenant_id == tenant_id,
+                GatewayCommand.runner_id == runner_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return (None, False)
+    return (row, True)
+
+
+async def _load_head(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+) -> RunnerEffectChain | None:
+    return (
+        await session.execute(
+            select(RunnerEffectChain).where(
+                RunnerEffectChain.tenant_id == tenant_id,
+                RunnerEffectChain.runner_id == runner_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def _persist_head(
+    session: AsyncSession,
+    *,
+    head: RunnerEffectChain | None,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    last_seq: int,
+    last_hash: str,
+) -> None:
+    """Insert or advance the per-runner chain head."""
+    now = datetime.now(UTC)
+    if head is None:
+        session.add(
+            RunnerEffectChain(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                runner_id=runner_id,
+                last_seq=last_seq,
+                last_hash=last_hash,
+                updated_at=now,
+            )
+        )
+        return
+    head.last_seq = last_seq
+    head.last_hash = last_hash
+    head.updated_at = now
+
+
+async def quarantine_effect_chain(
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    error: EffectChainTamperError,
+) -> uuid.UUID:
+    """Record a tamper-detected forward as a security audit row (own session).
+
+    Written on its own committed transaction (the
+    :func:`~meho_backplane.memory.audit.write_internal_audit_row` mould) so it
+    survives the caller's rollback of the rejected result submission — the whole
+    point is a durable, forensically-visible record that a runner's forwarded
+    chain broke. ``event_class='security'`` marks it distinct from a benign
+    effect row at audit-query time.
+    """
+    return await write_internal_audit_row(
+        operator_sub=_SECURITY_OPERATOR_SUB,
+        tenant_id=tenant_id,
+        method=INTERNAL_METHOD,
+        path=EFFECT_QUARANTINE_PATH,
+        status_code=409,
+        duration_ms=0.0,
+        payload={
+            "event_class": "security",
+            "runner": runner_id,
+            "reason": error.reason,
+            "seq": error.seq,
+        },
+    )

--- a/backend/src/meho_backplane/gateway/unreported_mint.py
+++ b/backend/src/meho_backplane/gateway/unreported_mint.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central un-reported-mint security alarm sweeper (#2901, #3193).
+
+Mechanism 4's centre-side half (design ``docs/research/2901-satellite-write-path.md``
+§3, decision ``docs/decisions/satellite-write-path.md``): a minted
+``remote-write`` capability whose effect is never reported is the un-audited
+mutation window (threat T4). Because the **mint** is audited synchronously at
+authorization (``gateway.command.mint``), the centre always knows a write
+capability was granted — so it can detect, within the expiry window, that its
+effect never came back. This sweeper raises a **security** event on exactly that:
+a ``remote-write`` command past ``expires_at`` still ``consumed_at IS NULL``.
+
+Distinct from the liveness dead-man
+-----------------------------------
+
+This is **not** the #2501 dead-man switch (:mod:`meho_backplane.gateway.deadman`),
+which flags a runner's *liveness* (``last_seen_at`` behind the cutoff). This
+sweeper flags a *security* condition (a specific minted write went unreported)
+on a distinct audit ``path`` (:data:`GATEWAY_UNREPORTED_MINT_PATH` vs the
+dead-man's ``gateway.runner.stale``). A runner can be perfectly live and still
+execute-but-not-report a single write — the exact gap the liveness monitor
+cannot see.
+
+Design moulds (copied from :mod:`meho_backplane.gateway.deadman`)
+----------------------------------------------------------------
+
+* Interval-tick loop + start/stop pair the FastAPI lifespan owns (in-process
+  interval-tick sweeper, **not** the DB-bound scheduler trigger loop).
+* Fixed non-blocking advisory lock elects one replica per tick (no-op on
+  SQLite) on a dedicated pinned connection (the tick commits mid-lock, #3010).
+* Central-clock only: the expiry cutoff is ``datetime.now(UTC)`` against the
+  central-stamped ``expires_at``; no runner-reported timestamp participates.
+* Idempotent conditional flip: ``UPDATE ... WHERE unreported_alarm_at IS NULL``
+  whose ``rowcount`` gates the audit write, so "exactly one security audit row
+  per unreported mint" holds across ticks / replicas.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select, update
+
+from meho_backplane.db.advisory import advisory_lock
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GatewayCommand
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    write_internal_audit_row,
+)
+from meho_backplane.metrics import note_loop_tick
+from meho_backplane.runner.satellite_tier import REMOTE_WRITE_SAFETY_LEVELS
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "GATEWAY_UNREPORTED_MINT_PATH",
+    "start_gateway_unreported_mint_sweeper",
+    "stop_gateway_unreported_mint_sweeper",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Canonical internal-audit ``path`` for an un-reported-mint security alarm.
+#: Distinct from the dead-man switch's ``gateway.runner.stale`` (liveness) so
+#: audit queries partition security alarms from liveness flips by ``path``.
+GATEWAY_UNREPORTED_MINT_PATH: str = "gateway.command.unreported_mint"
+
+#: The event-class marker on the alarm payload — a **security** event, not a
+#: liveness one. G8 audit-query consumers filter on it.
+_SECURITY_EVENT_CLASS: str = "security"
+
+#: The synthetic identity attributed to the alarm's audit rows.
+_SECURITY_OPERATOR_SUB: str = "system:unreported-mint-alarm"
+
+#: The fixed advisory-lock key held during a tick. Same hashing shape the
+#: dead-man sweeper / reaper use; a single scalar because this is a singleton
+#: sweep, not a per-row claimer.
+_UNREPORTED_MINT_ADVISORY_LOCK_KEY: int = (
+    int.from_bytes(
+        hashlib.blake2b(b"gateway_unreported_mint:v1", digest_size=8).digest(),
+        "big",
+    )
+    & 0x7FFF_FFFF_FFFF_FFFF
+)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Coerce a possibly-naive ``timestamptz`` read to UTC-aware (aiosqlite)."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def _run_one_tick() -> None:
+    """One sweep: alarm on minted remote-writes past expiry, unreported.
+
+    Two-phase shape (dead-man mould):
+
+    1. Acquire the single advisory lock (skip the tick on PG if another replica
+       won).
+    2. Select ``remote-write`` command rows past ``expires_at`` still
+       ``consumed_at IS NULL`` and not yet alarmed, flip each with a conditional
+       ``UPDATE ... WHERE unreported_alarm_at IS NULL``, and collect the ones
+       this tick won (``rowcount == 1``).
+
+    Commits the flips once, then writes one internal **security** audit row per
+    won flip (mutate + commit, then audit). An audit-write failure is logged
+    loud but never rolls back a flip.
+    """
+    tick_started = time.perf_counter()
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    # (tenant_id, command_id, runner_id, op_id, lapse_seconds) per won flip.
+    flipped: list[tuple[uuid.UUID, uuid.UUID, str, str, float]] = []
+    async with advisory_lock(
+        _UNREPORTED_MINT_ADVISORY_LOCK_KEY, subsystem="gateway_unreported_mint"
+    ) as locked:
+        if not locked:
+            _log.debug("gateway_unreported_mint_tick_skipped_lock_held")
+            return
+        async with sessionmaker() as session:
+            candidate_stmt = (
+                select(
+                    GatewayCommand.id,
+                    GatewayCommand.tenant_id,
+                    GatewayCommand.runner_id,
+                    GatewayCommand.op_id,
+                    GatewayCommand.expires_at,
+                )
+                .where(
+                    GatewayCommand.safety_level.in_(sorted(REMOTE_WRITE_SAFETY_LEVELS)),
+                    GatewayCommand.consumed_at.is_(None),
+                    GatewayCommand.expires_at < now,
+                    GatewayCommand.unreported_alarm_at.is_(None),
+                )
+                .order_by(GatewayCommand.expires_at.asc())
+            )
+            candidates = (await session.execute(candidate_stmt)).all()
+            for command_id, tenant_id, runner_id, op_id, expires_at in candidates:
+                result = await session.execute(
+                    update(GatewayCommand)
+                    .where(
+                        GatewayCommand.id == command_id,
+                        GatewayCommand.unreported_alarm_at.is_(None),
+                    )
+                    .values(unreported_alarm_at=now)
+                )
+                # ``rowcount`` is only typed on the concrete ``CursorResult`` an
+                # UPDATE produces at runtime; the ignore mirrors ``deadman.py``.
+                won_flip: int = result.rowcount  # type: ignore[attr-defined]
+                if won_flip == 1:
+                    lapse_seconds = (now - _as_utc(expires_at)).total_seconds()
+                    flipped.append((tenant_id, command_id, runner_id, op_id, lapse_seconds))
+            await session.commit()
+
+    if not flipped:
+        _log.debug("gateway_unreported_mint_tick_clean")
+        return
+
+    duration_ms = (time.perf_counter() - tick_started) * 1000.0
+    await _audit_alarms(flipped, duration_ms=duration_ms)
+    _log.warning(
+        "gateway_unreported_mint_tick_done",
+        alarmed=len(flipped),
+        duration_ms=duration_ms,
+    )
+
+
+async def _audit_alarms(
+    flipped: list[tuple[uuid.UUID, uuid.UUID, str, str, float]],
+    *,
+    duration_ms: float,
+) -> None:
+    """Write one internal **security** audit row per won alarm, isolating failures."""
+    for tenant_id, command_id, runner_id, op_id, lapse_seconds in flipped:
+        try:
+            await write_internal_audit_row(
+                operator_sub=_SECURITY_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                method=INTERNAL_METHOD,
+                path=GATEWAY_UNREPORTED_MINT_PATH,
+                status_code=200,
+                duration_ms=duration_ms,
+                payload={
+                    "event_class": _SECURITY_EVENT_CLASS,
+                    "command_id": str(command_id),
+                    "runner": runner_id,
+                    "op_id": op_id,
+                    "lapse_seconds": lapse_seconds,
+                },
+            )
+        except Exception:
+            # An audit-write failure must not stall the tick (the flip is already
+            # committed; we cannot roll it back). Surface it loud for operators.
+            _log.exception(
+                "gateway_unreported_mint_audit_write_failed",
+                tenant_id=str(tenant_id),
+                command_id=str(command_id),
+                runner=runner_id,
+            )
+
+
+async def _sweeper_loop() -> None:
+    """The forever loop: sleep one cadence, sweep, repeat (dead-man mould)."""
+    interval = get_settings().gateway_unreported_mint_tick_interval_seconds
+    _log.info("gateway_unreported_mint_sweeper_started", interval_seconds=interval)
+    while True:
+        await asyncio.sleep(get_settings().gateway_unreported_mint_tick_interval_seconds)
+        try:
+            await _run_one_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning("gateway_unreported_mint_tick_failed", exc_info=True)
+        note_loop_tick(
+            "gateway_unreported_mint",
+            get_settings().gateway_unreported_mint_tick_interval_seconds,
+        )
+
+
+def start_gateway_unreported_mint_sweeper() -> asyncio.Task[None]:
+    """Start the background alarm sweeper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind
+    ``GATEWAY_UNREPORTED_MINT_ENABLED`` (default on). Returning the task keeps a
+    strong reference alive so it is not garbage-collected mid-flight.
+    """
+    return asyncio.create_task(_sweeper_loop(), name="gateway-unreported-mint-sweeper")
+
+
+async def stop_gateway_unreported_mint_sweeper(task: asyncio.Task[None]) -> None:
+    """Cancel the sweeper task and await its unwind (dead-man mould)."""
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -153,6 +153,10 @@ from meho_backplane.gateway.deadman import (
     start_gateway_deadman_sweeper,
     stop_gateway_deadman_sweeper,
 )
+from meho_backplane.gateway.unreported_mint import (
+    start_gateway_unreported_mint_sweeper,
+    stop_gateway_unreported_mint_sweeper,
+)
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
@@ -484,6 +488,7 @@ class _BackgroundTasks:
     flight_recorder_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
     gateway_deadman: asyncio.Task[None] | None
+    gateway_unreported_mint: asyncio.Task[None] | None
 
 
 # Deliberately-flat lifespan task registry: the length is per-task
@@ -601,6 +606,15 @@ def _start_background_tasks() -> _BackgroundTasks:
     gateway_deadman: asyncio.Task[None] | None = None
     if settings.gateway_deadman_enabled:
         gateway_deadman = start_gateway_deadman_sweeper()
+    # Initiative #2901 (#3193) — un-reported-mint security alarm. A separate
+    # sweeper from the dead-man switch above: it flags a minted remote-write
+    # capability whose effect went unreported past ``expires_at`` (threat T4), a
+    # security condition distinct from the liveness ``stale_at`` flip. Gated on
+    # GATEWAY_UNREPORTED_MINT_ENABLED (default-on); an external monitor can
+    # disable the in-tree sweep.
+    gateway_unreported_mint: asyncio.Task[None] | None = None
+    if settings.gateway_unreported_mint_enabled:
+        gateway_unreported_mint = start_gateway_unreported_mint_sweeper()
     return _BackgroundTasks(
         topology_scheduler=topology_scheduler,
         memory_expiry=memory_expiry,
@@ -617,6 +631,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         flight_recorder_reaper=flight_recorder_reaper,
         event_drain=event_drain,
         gateway_deadman=gateway_deadman,
+        gateway_unreported_mint=gateway_unreported_mint,
     )
 
 
@@ -628,6 +643,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
     branches (``None`` task handles) are tolerated cleanly so a
     disable-and-shutdown sequence does not raise.
     """
+    if tasks.gateway_unreported_mint is not None:
+        await stop_gateway_unreported_mint_sweeper(tasks.gateway_unreported_mint)
     if tasks.gateway_deadman is not None:
         await stop_gateway_deadman_sweeper(tasks.gateway_deadman)
     if tasks.event_drain is not None:

--- a/backend/src/meho_backplane/runner/effect_audit.py
+++ b/backend/src/meho_backplane/runner/effect_audit.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runner-side tamper-evident store-and-forward effect audit (#2901, #3193).
+
+Mechanism 4 of the composed satellite write-path gate (design
+``docs/research/2901-satellite-write-path.md`` §3, decision
+``docs/decisions/satellite-write-path.md``). True synchronous-at-centre audit
+of a remote **write** effect is structurally impossible — the executing side
+(a satellite runner) has no Postgres and the mutation is off-net — so
+v0.1-spec §6 cannot hold for the effect. This module is the runner half of the
+consciously-recorded §6 exception: instead of pretending to audit synchronously,
+the runner keeps a local **hash-chained** record of every write effect it
+attempts and forwards it on next contact, where the centre ingests and verifies
+the chain (:mod:`meho_backplane.gateway.effect_ingest`).
+
+What the chain buys
+-------------------
+
+* **Tamper evidence in transit.** Each record's ``record_hash`` folds in the
+  previous record's hash, so altering any forwarded record's body (or its link)
+  breaks the chain at ingest.
+* **Gap detection.** The per-runner ``seq`` is strictly monotonic; a dropped or
+  suppressed record leaves a hole the centre detects (a compromised runner that
+  executes-but-omits a record cannot hide the omission — the chain no longer
+  links).
+* **Non-repudiation anchor.** Each record references the signed work item's
+  Ed25519 ``signature`` (#3189), binding the recorded effect to the exact
+  centrally-authorised capability.
+
+What it does **not** buy (the acknowledged residual): a fully compromised runner
+holds its own genesis and can fabricate a *self-consistent* alternate chain from
+scratch. Tamper evidence catches transit tampering and dropped records, **not** a
+lying edge — that residual is bounded by the composition (allowlist x credential
+TTL) and by the centre's un-reported-mint alarm, never by this record alone.
+
+DB-free by construction
+-----------------------
+
+Like :mod:`meho_backplane.runner.satellite_tier` and
+:mod:`meho_backplane.runner.work_item_signing`, this module imports only the
+standard library + pydantic, so it runs on the DB-free runner **and** is
+imported verbatim by the central ingest verifier (one hashing definition, both
+ends). The chain persists to disk (mould:
+:class:`meho_backplane.runner.spool.ResultSpool`) so a runner restart continues
+the same chain rather than rewinding ``seq`` to zero — a rewind would read as a
+gap at the centre.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "GENESIS_PREV_HASH",
+    "EffectAuditChain",
+    "EffectAuditRecord",
+    "EffectChainStateError",
+    "EffectPhase",
+    "canonical_record_body",
+    "compute_record_hash",
+]
+
+_log = structlog.get_logger(__name__)
+
+_TMP_SUFFIX = ".tmp"
+
+
+class EffectChainStateError(Exception):
+    """The on-disk chain head is corrupt / unrecoverable — refuse to guess."""
+
+
+#: The ``prev_hash`` of the very first record on a runner's chain (``seq == 0``).
+#: A fixed, well-known sentinel so the centre can verify a fresh runner's genesis
+#: record without a prior head. 64 hex chars keeps it shape-compatible with a
+#: real sha256 digest.
+GENESIS_PREV_HASH: str = "0" * 64
+
+
+class EffectPhase(StrEnum):
+    """The two records the runner writes per executed write item.
+
+    * :attr:`INTENT` — written **before** the mutation is attempted (the runner
+      is about to execute a centrally-authorised write). Its presence without a
+      matching :attr:`OUTCOME` is itself evidence (the runner crashed or was
+      cut off mid-write).
+    * :attr:`OUTCOME` — written **after** the handler returns, carrying the
+      runner-level result status.
+    """
+
+    INTENT = "intent"
+    OUTCOME = "outcome"
+
+
+class EffectAuditRecord(BaseModel):
+    """One tamper-evident link in a runner's effect-audit chain.
+
+    Frozen wire model shared verbatim with the central ingest verifier. The
+    hashed body is every field **except** ``record_hash`` (see
+    :func:`canonical_record_body`); ``record_hash`` folds in ``prev_hash`` so the
+    records form a chain the centre re-derives link by link.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    #: The runner principal **name** (wire identity — matches
+    #: ``gateway_command.runner_id`` and ``RunnerResultBatch.runner_id``). The
+    #: centre binds this to the authenticated runner at ingest, so one runner
+    #: cannot extend another's chain.
+    runner_id: str
+    #: Strictly-monotonic per-runner sequence number (starts at 0). A gap is a
+    #: dropped/suppressed record.
+    seq: int
+    phase: EffectPhase
+    #: The delivered ``gateway_command.id`` this effect belongs to — the centre's
+    #: link key to the mint audit row (``gateway_command.mint_audit_id``).
+    command_id: str
+    op_id: str
+    params_hash: str
+    #: The centre's base64 Ed25519 signature over the signed work item (#3189) —
+    #: the non-repudiation anchor. ``None`` only if the capability was unsigned
+    #: (which the write tier never mints).
+    signature: str | None = None
+    target_scope: str
+    #: The runner-level outcome (``ok`` / ``error`` / ``refused``) — set on an
+    #: :attr:`EffectPhase.OUTCOME` record, ``None`` on an :attr:`EffectPhase.INTENT`.
+    outcome: str | None = None
+    #: Runner-clock ISO-8601 timestamp. Advisory only — the centre never trusts a
+    #: runner clock for a security decision; it is recorded for forensics.
+    recorded_at: str
+    #: The previous record's ``record_hash`` (:data:`GENESIS_PREV_HASH` for
+    #: ``seq == 0``).
+    prev_hash: str
+    #: ``sha256(prev_hash + canonical_record_body(...))``.
+    record_hash: str
+
+
+def canonical_record_body(
+    *,
+    runner_id: str,
+    seq: int,
+    phase: EffectPhase | str,
+    command_id: str,
+    op_id: str,
+    params_hash: str,
+    signature: str | None,
+    target_scope: str,
+    outcome: str | None,
+    recorded_at: str,
+) -> str:
+    """Deterministic JSON serialisation of the hashed body (record_hash excluded).
+
+    ``sort_keys`` + compact separators make the encoding stable across Python
+    versions and dict-insertion order, so the runner and the centre derive an
+    identical string for an identical record.
+    """
+    body: dict[str, Any] = {
+        "runner_id": runner_id,
+        "seq": seq,
+        "phase": str(phase),
+        "command_id": command_id,
+        "op_id": op_id,
+        "params_hash": params_hash,
+        "signature": signature,
+        "target_scope": target_scope,
+        "outcome": outcome,
+        "recorded_at": recorded_at,
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def compute_record_hash(prev_hash: str, canonical_body: str) -> str:
+    """The chain hash: ``sha256(prev_hash + canonical_body)`` as hex.
+
+    Folding ``prev_hash`` into every record's hash is what chains them: a change
+    to any earlier record changes its ``record_hash``, which must equal the next
+    record's ``prev_hash``, which is folded into *its* hash — so a single edit
+    invalidates every downstream link.
+    """
+    return hashlib.sha256((prev_hash + canonical_body).encode("utf-8")).hexdigest()
+
+
+class EffectAuditChain:
+    """A runner's on-disk hash-chained effect audit log, drained on forward.
+
+    Two persisted concerns in one directory:
+
+    * ``head.json`` — ``{"last_seq": N, "last_hash": "..."}``, the chain head.
+      Persisted **separately** from the forwardable records so draining
+      forwarded records never rewinds the head. Atomic (tmp + :func:`os.replace`,
+      the :class:`~meho_backplane.runner.spool.ResultSpool` mould).
+    * ``<seq:012d>.json`` — one un-forwarded :class:`EffectAuditRecord` per file,
+      lexically sorted == seq order. Deleted once forwarded.
+
+    Not thread-safe: the runner tick loop is single-threaded, and a write item is
+    executed to completion (intent → mutation → outcome) before the next, so the
+    append sequence is naturally serial.
+    """
+
+    _HEAD_NAME = "head.json"
+
+    def __init__(self, chain_dir: str | os.PathLike[str], *, runner_id: str) -> None:
+        self._dir = Path(chain_dir)
+        self._runner_id = runner_id
+
+    # -- head persistence --------------------------------------------------
+
+    def _head_path(self) -> Path:
+        return self._dir / self._HEAD_NAME
+
+    def _read_head(self) -> tuple[int, str]:
+        """Return ``(last_seq, last_hash)``; the genesis head for a fresh chain."""
+        try:
+            raw = self._head_path().read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return (-1, GENESIS_PREV_HASH)
+        try:
+            head = json.loads(raw)
+            return (int(head["last_seq"]), str(head["last_hash"]))
+        except (ValueError, KeyError, TypeError) as exc:
+            # A corrupt head is unrecoverable — refusing to guess is safer than
+            # silently rewinding the chain (which reads as a gap at the centre).
+            raise EffectChainStateError(f"corrupt effect-audit head: {exc}") from exc
+
+    def _write_head(self, last_seq: int, last_hash: str) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        final = self._head_path()
+        tmp = final.with_suffix(final.suffix + _TMP_SUFFIX)
+        tmp.write_text(
+            json.dumps({"last_seq": last_seq, "last_hash": last_hash}),
+            encoding="utf-8",
+        )
+        os.replace(tmp, final)
+
+    # -- append -----------------------------------------------------------
+
+    def _append(
+        self,
+        *,
+        phase: EffectPhase,
+        command_id: str,
+        op_id: str,
+        params_hash: str,
+        signature: str | None,
+        target_scope: str,
+        outcome: str | None,
+    ) -> EffectAuditRecord:
+        last_seq, last_hash = self._read_head()
+        seq = last_seq + 1
+        recorded_at = datetime.now(UTC).isoformat()
+        canonical = canonical_record_body(
+            runner_id=self._runner_id,
+            seq=seq,
+            phase=phase,
+            command_id=command_id,
+            op_id=op_id,
+            params_hash=params_hash,
+            signature=signature,
+            target_scope=target_scope,
+            outcome=outcome,
+            recorded_at=recorded_at,
+        )
+        record_hash = compute_record_hash(last_hash, canonical)
+        record = EffectAuditRecord(
+            runner_id=self._runner_id,
+            seq=seq,
+            phase=phase,
+            command_id=command_id,
+            op_id=op_id,
+            params_hash=params_hash,
+            signature=signature,
+            target_scope=target_scope,
+            outcome=outcome,
+            recorded_at=recorded_at,
+            prev_hash=last_hash,
+            record_hash=record_hash,
+        )
+        # Persist the record first, then advance the head: a crash between the
+        # two re-derives the same seq/hash on the next append (idempotent), never
+        # a gap. The reverse order could advance the head past a record that was
+        # never written — an unrecoverable hole.
+        self._write_record(record)
+        self._write_head(seq, record_hash)
+        return record
+
+    def record_intent(
+        self,
+        *,
+        command_id: str,
+        op_id: str,
+        params_hash: str,
+        signature: str | None,
+        target_scope: str,
+    ) -> EffectAuditRecord:
+        """Append the pre-mutation :attr:`EffectPhase.INTENT` record."""
+        return self._append(
+            phase=EffectPhase.INTENT,
+            command_id=command_id,
+            op_id=op_id,
+            params_hash=params_hash,
+            signature=signature,
+            target_scope=target_scope,
+            outcome=None,
+        )
+
+    def record_outcome(
+        self,
+        *,
+        command_id: str,
+        op_id: str,
+        params_hash: str,
+        signature: str | None,
+        target_scope: str,
+        outcome: str,
+    ) -> EffectAuditRecord:
+        """Append the post-mutation :attr:`EffectPhase.OUTCOME` record."""
+        return self._append(
+            phase=EffectPhase.OUTCOME,
+            command_id=command_id,
+            op_id=op_id,
+            params_hash=params_hash,
+            signature=signature,
+            target_scope=target_scope,
+            outcome=outcome,
+        )
+
+    # -- forward ----------------------------------------------------------
+
+    def unforwarded(self) -> list[EffectAuditRecord]:
+        """Return the un-forwarded records, seq-ascending (oldest first)."""
+        out: list[EffectAuditRecord] = []
+        for path in self._record_files():
+            try:
+                out.append(EffectAuditRecord.model_validate_json(path.read_text(encoding="utf-8")))
+            except (OSError, ValueError) as exc:
+                _log.warning("runner_effect_chain_unreadable", path=str(path), error=str(exc))
+        return out
+
+    def mark_forwarded(self, up_to_seq: int) -> None:
+        """Delete forwarded record files with ``seq <= up_to_seq``.
+
+        The head is untouched: forwarding drains the spool but the chain must
+        keep climbing from where it left off, or a later record would re-use a
+        seq the centre already ingested.
+        """
+        for path in self._record_files():
+            if self._seq_of(path) <= up_to_seq:
+                with contextlib.suppress(FileNotFoundError):
+                    path.unlink()
+
+    # -- internals --------------------------------------------------------
+
+    def _record_path(self, seq: int) -> Path:
+        return self._dir / f"{seq:012d}.json"
+
+    def _write_record(self, record: EffectAuditRecord) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        final = self._record_path(record.seq)
+        tmp = final.with_suffix(final.suffix + _TMP_SUFFIX)
+        tmp.write_text(record.model_dump_json(), encoding="utf-8")
+        os.replace(tmp, final)
+
+    def _record_files(self) -> list[Path]:
+        if not self._dir.exists():
+            return []
+        return sorted(
+            p
+            for p in self._dir.glob("*.json")
+            if p.name != self._HEAD_NAME and not p.name.endswith(_TMP_SUFFIX)
+        )
+
+    @staticmethod
+    def _seq_of(path: Path) -> int:
+        return int(path.stem)

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -49,6 +49,7 @@ from meho_backplane.operations._handler_resolve import (
     import_handler,
     is_unbound_method,
 )
+from meho_backplane.runner.effect_audit import EffectAuditChain
 from meho_backplane.runner.satellite_tier import (
     SatelliteMintTier,
     classify_satellite_tier,
@@ -182,6 +183,61 @@ def _verify_remote_write_signature(item: RunnerWorkItem) -> str | None:
     return None
 
 
+def _remote_write_effect_keys(item: RunnerWorkItem) -> tuple[str, str]:
+    """The ``(params_hash, target_scope)`` a remote-write effect record binds.
+
+    Mirrors the centre's canonical binding (:func:`params_digest` over the
+    item params, ``str(target.id)`` or :data:`TARGETLESS_SCOPE`) so the runner's
+    recorded effect references the same identity the mint signed.
+    """
+    target_scope = (
+        str(item.target_descriptor.id) if item.target_descriptor is not None else TARGETLESS_SCOPE
+    )
+    return params_digest(item.params), target_scope
+
+
+async def _invoke_recording_effect(
+    handler: Callable[..., Awaitable[Any]],
+    item: RunnerWorkItem,
+    *,
+    effect_chain: EffectAuditChain | None,
+    command_id: str | None,
+) -> RunnerResult:
+    """Invoke *handler*, bracketing a remote-write mutation with effect records.
+
+    Mechanism 4 (#3193): for a ``remote-write`` item with a chain provided, the
+    runner appends a tamper-evident **intent** record *before* the mutation and
+    an **outcome** record *after*, referencing the signed work item (#3189) as
+    the non-repudiation anchor. A ``safe`` item, or a call with no chain, invokes
+    unchanged — effect audit is a write-tier concern only.
+    """
+    if (
+        effect_chain is None
+        or command_id is None
+        or classify_satellite_tier(item.safety_level) is not SatelliteMintTier.REMOTE_WRITE
+    ):
+        return await _invoke(handler, item)
+
+    params_hash, target_scope = _remote_write_effect_keys(item)
+    effect_chain.record_intent(
+        command_id=command_id,
+        op_id=item.op_id,
+        params_hash=params_hash,
+        signature=item.signature,
+        target_scope=target_scope,
+    )
+    result = await _invoke(handler, item)
+    effect_chain.record_outcome(
+        command_id=command_id,
+        op_id=item.op_id,
+        params_hash=params_hash,
+        signature=item.signature,
+        target_scope=target_scope,
+        outcome=result.status,
+    )
+    return result
+
+
 async def _invoke(handler: Callable[..., Awaitable[Any]], item: RunnerWorkItem) -> RunnerResult:
     """Invoke *handler* and wrap its outcome as a structured result."""
     operator = _build_operator(item)
@@ -206,6 +262,8 @@ async def execute_command_once(
     command_id: str,
     item: RunnerWorkItem,
     store: ExecutedCommandStore,
+    *,
+    effect_chain: EffectAuditChain | None = None,
 ) -> RunnerResult:
     """Execute a gateway command at most once, keyed on its UUID request id.
 
@@ -245,13 +303,29 @@ async def execute_command_once(
             "no spooled result to re-submit",
         )
 
-    result = await execute_work_item(item)
+    # Only thread the effect-audit seam when a chain is in play, so the no-audit
+    # path calls ``execute_work_item(item)`` with its original shape (#2500).
+    if effect_chain is None:
+        result = await execute_work_item(item)
+    else:
+        result = await execute_work_item(item, effect_chain=effect_chain, command_id=command_id)
     store.store_result(command_id, result)
     return result
 
 
-async def execute_work_item(item: RunnerWorkItem) -> RunnerResult:
-    """Execute *item* locally and return a structured :class:`RunnerResult`."""
+async def execute_work_item(
+    item: RunnerWorkItem,
+    *,
+    effect_chain: EffectAuditChain | None = None,
+    command_id: str | None = None,
+) -> RunnerResult:
+    """Execute *item* locally and return a structured :class:`RunnerResult`.
+
+    When *effect_chain* + *command_id* are supplied and the item is a
+    ``remote-write`` capability, the mutation is bracketed by a tamper-evident
+    intent/outcome pair on the runner's store-and-forward effect chain (#3193);
+    a ``safe`` item or an omitted chain executes exactly as before.
+    """
     refusal = _screen_item(item)
     if refusal is not None:
         _log.warning(
@@ -289,7 +363,12 @@ async def execute_work_item(item: RunnerWorkItem) -> RunnerResult:
             error=f"handler_ref {item.handler_ref!r} resolved outside {_CONNECTOR_MODULE_PREFIX}*",
         )
 
-    return await _invoke(_maybe_bind_method(handler, item), item)
+    return await _invoke_recording_effect(
+        _maybe_bind_method(handler, item),
+        item,
+        effect_chain=effect_chain,
+        command_id=command_id,
+    )
 
 
 def _maybe_bind_method(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1332,6 +1332,16 @@ class Settings(BaseModel):
     gateway_deadman_enabled: bool = True
     gateway_deadman_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
     gateway_runner_stale_after_multiplier: int = Field(default=3, ge=1, le=100)
+    # Initiative #2901 (#3193) -- un-reported-mint security alarm. A separate
+    # sweeper from the dead-man switch above: it flags a *security* condition (a
+    # minted remote-write capability past ``expires_at`` still unconsumed, so its
+    # effect was never reported -- threat T4), distinct from the liveness
+    # ``stale_at`` flip. Default-on for the same reason central enforcement is
+    # mandatory; an external monitor can disable the in-tree sweep. The cadence
+    # is its own knob (not the dead-man's) because the two monitors watch
+    # different clocks -- liveness vs capability expiry.
+    gateway_unreported_mint_enabled: bool = True
+    gateway_unreported_mint_tick_interval_seconds: int = Field(default=60, ge=5, le=3600)
     # Initiative #2901 (#3189) -- satellite write-path work-item signing keys.
     # Asymmetric Ed25519 (mechanism 1, design §3): the central instance holds
     # the SIGNING (private) key and stamps a signature on every remote-write
@@ -2110,6 +2120,12 @@ def get_settings() -> Settings:
         ),
         gateway_runner_stale_after_multiplier=int(
             os.environ.get("GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER", "3"),
+        ),
+        gateway_unreported_mint_enabled=parse_bool_env(
+            os.environ.get("GATEWAY_UNREPORTED_MINT_ENABLED", "true"),
+        ),
+        gateway_unreported_mint_tick_interval_seconds=int(
+            os.environ.get("GATEWAY_UNREPORTED_MINT_TICK_INTERVAL_SECONDS", "60"),
         ),
         satellite_write_signing_key=os.environ.get("SATELLITE_WRITE_SIGNING_KEY", "").strip(),
         satellite_write_verify_key=os.environ.get("SATELLITE_WRITE_VERIFY_KEY", "").strip(),

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -235,6 +235,14 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # PG-backed acceptance test errors at setup with ``cannot truncate a
     # table referenced in a foreign key constraint``.
     "gateway_command",
+    # ``runner_effect_chain.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
+    # from migration ``0094`` (#3193 satellite effect audit — the per-runner
+    # effect-chain head). Same rule: PG rejects truncating ``tenant`` unless
+    # every referencing table is listed in the same statement, so
+    # ``runner_effect_chain`` must appear here or every PG-backed acceptance
+    # test errors at setup with ``cannot truncate a table referenced in a
+    # foreign key constraint``.
+    "runner_effect_chain",
     # ``graph_edge_history`` carries a real FK ``graph_edge(id) ON DELETE
     # SET NULL`` per migration ``0012`` (#856 T1); the same applies to
     # ``graph_node_history``. PG rejects a TRUNCATE on the parent table

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -470,6 +470,11 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   ``REFERENCES tenant(id)`` FK and ``dispatch_trace_span`` a real
         #   ``REFERENCES dispatch_trace(id) ON DELETE CASCADE`` FK; both must be
         #   listed alongside ``tenant`` or PG rejects the per-test TRUNCATE.
+        # * ``runner_effect_chain`` — migration 0094 (#3193 satellite effect
+        #   audit): a real ``REFERENCES tenant(id)`` FK (the per-runner
+        #   effect-chain head), so it must be truncated in the same statement as
+        #   ``tenant`` or PG rejects the per-test TRUNCATE with ``cannot truncate
+        #   a table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
@@ -477,7 +482,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
-                "event_outbox, event_source, gateway_command, "
+                "event_outbox, event_source, gateway_command, runner_effect_chain, "
                 "service_principal_grant, addon_pairing, operation_run, "
                 "addon_capability, addon_orchestration_run, "
                 "service_principal_grant, addon_pairing, addon_step_event, "
@@ -551,7 +556,7 @@ async def pg_engine_empty_tenant(
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
-                "event_outbox, event_source, gateway_command, "
+                "event_outbox, event_source, gateway_command, runner_effect_chain, "
                 "service_principal_grant, addon_pairing, operation_run, "
                 "addon_capability, addon_orchestration_run, "
                 "service_principal_grant, addon_pairing, addon_step_event, "

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -362,6 +362,16 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                     # hits the real get_settings() -> KeyError on
                     # KEYCLOAK_ISSUER_URL, since this test pins no env).
                     gateway_deadman_enabled=False,
+                    # Initiative #2901 (#3193) added the un-reported-mint
+                    # security-alarm sweeper, gated on
+                    # GATEWAY_UNREPORTED_MINT_ENABLED (default on). Pin it off
+                    # for the same reason as the dead-man flag above — a bare
+                    # MagicMock attribute is truthy, so without this the gate
+                    # reads True and the real
+                    # start_gateway_unreported_mint_sweeper runs _sweeper_loop,
+                    # which hits the real get_settings() -> KeyError on
+                    # KEYCLOAK_ISSUER_URL (this test pins no env).
+                    gateway_unreported_mint_enabled=False,
                     # #3079 async governed dispatch added an operation_run
                     # reaper to the lifespan, gated on
                     # OPERATION_RUN_REAPER_ENABLED (default on). Pin it off — a
@@ -436,6 +446,12 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 # #2501 gateway dead-man sweeper — same defensive patch.
                 start_gateway_deadman_sweeper=MagicMock(),
                 stop_gateway_deadman_sweeper=AsyncMock(),
+                # #3193 gateway un-reported-mint security-alarm sweeper — same
+                # defensive patch (the gate above is pinned off) so a future
+                # default flip can't smuggle the real sweeper (and its
+                # get_settings() tick read) back into this env-free test.
+                start_gateway_unreported_mint_sweeper=MagicMock(),
+                stop_gateway_unreported_mint_sweeper=AsyncMock(),
                 # #3079 async governed dispatch operation_run reaper — same
                 # defensive patch (the gate above is pinned off) so a future
                 # default flip can't smuggle the real reaper (and the topology
@@ -584,6 +600,12 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 # #2501 gateway dead-man sweeper — same defensive patch.
                 start_gateway_deadman_sweeper=MagicMock(),
                 stop_gateway_deadman_sweeper=AsyncMock(),
+                # #3193 gateway un-reported-mint security-alarm sweeper — same
+                # defensive patch (the gate above is pinned off) so a future
+                # default flip can't smuggle the real sweeper (and its
+                # get_settings() tick read) back into this env-free test.
+                start_gateway_unreported_mint_sweeper=MagicMock(),
+                stop_gateway_unreported_mint_sweeper=AsyncMock(),
                 # #3079 async governed dispatch operation_run reaper — same
                 # defensive patch (the gate above is pinned off) so a future
                 # default flip can't smuggle the real reaper (and the topology

--- a/backend/tests/test_effect_ingest.py
+++ b/backend/tests/test_effect_ingest.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central ingest + chain verification for satellite effect audit (#2901, #3193).
+
+Fail-closed conformance for mechanism 4's centre half
+(:mod:`meho_backplane.gateway.effect_ingest`):
+
+* a normal round-trip links the effect rows to the mint audit row
+  (``parent_audit_id = gateway_command.mint_audit_id``), store-and-forward
+  provenance stamped;
+* a **sequence gap** on ingest is flagged tamper-evident (raises, no partial
+  ingest);
+* a **tampered body** (record_hash no longer re-derives) is flagged;
+* a **broken link** (prev_hash not matching the accepted head) is flagged;
+* a runner **cannot forge a sibling runner's** chain (the record's ``runner_id``
+  must equal the authenticated runner).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GatewayCommand, RunnerEffectChain, Tenant
+from meho_backplane.gateway.effect_ingest import (
+    EFFECT_AUDIT_PATH,
+    STORE_AND_FORWARD_PROVENANCE,
+    EffectChainTamperError,
+    ingest_effect_records,
+)
+from meho_backplane.runner.effect_audit import EffectAuditChain, EffectAuditRecord
+from meho_backplane.settings import get_settings
+
+_RUNNER = "runner-w"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    return Operator(
+        sub=f"runner:{_RUNNER}",
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.RUNNER,
+    )
+
+
+async def _seed_tenant(tenant_id: uuid.UUID) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        ).scalar_one_or_none() is None:
+            slug = f"t-{tenant_id.hex[:8]}"
+            session.add(Tenant(id=tenant_id, slug=slug, name=slug))
+            await session.commit()
+
+
+async def _seed_minted_command(
+    *,
+    tenant_id: uuid.UUID,
+    command_id: uuid.UUID,
+    runner_id: str = _RUNNER,
+) -> uuid.UUID:
+    """Seed a minted remote-write command + its synchronous mint audit row.
+
+    Returns the ``mint_audit_id`` the effect rows must link back to.
+    """
+    mint_audit_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AuditLog(
+                id=mint_audit_id,
+                operator_sub="op-admin",
+                tenant_id=tenant_id,
+                method="GATEWAY",
+                path="gateway.command.mint",
+                status_code=200,
+                payload={},
+            )
+        )
+        session.add(
+            GatewayCommand(
+                id=command_id,
+                tenant_id=tenant_id,
+                runner_id=runner_id,
+                op_id="vmware.vm.tag.set",
+                params={"tag": "prod"},
+                enqueued_by_sub="op-admin",
+                params_hash="ph-1",
+                safety_level="caution",
+                mint_audit_id=mint_audit_id,
+                signature="sig-1",
+            )
+        )
+        await session.commit()
+    return mint_audit_id
+
+
+def _build_records(
+    tmp_path: Path,
+    *,
+    runner_id: str,
+    command_id: str,
+) -> list[EffectAuditRecord]:
+    """A valid two-record (intent + outcome) chain for one command.
+
+    A fresh unique sub-directory per call so a test that builds two independent
+    chains (the broken-link case) never shares a head.
+    """
+    chain = EffectAuditChain(tmp_path / f"chain-{uuid.uuid4().hex}", runner_id=runner_id)
+    chain.record_intent(
+        command_id=command_id,
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+    )
+    chain.record_outcome(
+        command_id=command_id,
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+        outcome="ok",
+    )
+    return chain.unforwarded()
+
+
+async def _effect_rows(tenant_id: uuid.UUID) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == EFFECT_AUDIT_PATH)))
+            .scalars()
+            .all()
+        )
+    return [r for r in rows if r.tenant_id == tenant_id]
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_links_mint_audit_row(tmp_path: Path) -> None:
+    """AC: a clean chain ingests, provenance-marked, linked to the mint audit row."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    mint_audit_id = await _seed_minted_command(tenant_id=tenant, command_id=command_id)
+    records = _build_records(tmp_path, runner_id=_RUNNER, command_id=command_id.hex)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        written = await ingest_effect_records(
+            session, operator=_operator(tenant), runner_id=_RUNNER, records=records
+        )
+        await session.commit()
+    assert len(written) == 2
+
+    rows = sorted(await _effect_rows(tenant), key=lambda r: r.payload["seq"])
+    assert len(rows) == 2
+    for row in rows:
+        assert row.payload["provenance"] == STORE_AND_FORWARD_PROVENANCE
+        assert row.payload["chain_verified"] is True
+        assert row.payload["linked"] is True
+        assert row.parent_audit_id == mint_audit_id, "effect links to the mint audit row"
+    assert [r.payload["phase"] for r in rows] == ["intent", "outcome"]
+
+    # The per-runner head advanced to the last accepted seq.
+    async with sessionmaker() as session:
+        head = (
+            await session.execute(
+                select(RunnerEffectChain).where(RunnerEffectChain.tenant_id == tenant)
+            )
+        ).scalar_one()
+    assert head.last_seq == 1
+    assert head.runner_id == _RUNNER
+
+
+@pytest.mark.asyncio
+async def test_sequence_gap_is_flagged_tamper_evident(tmp_path: Path) -> None:
+    """AC: a dropped/suppressed record (seq gap) is detected on ingest."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_minted_command(tenant_id=tenant, command_id=command_id)
+    records = _build_records(tmp_path, runner_id=_RUNNER, command_id=command_id.hex)
+
+    # Forward only the SECOND record (seq 1) — seq 0 is dropped, so the very
+    # first ingested record is a gap against the genesis head (expected 0).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        with pytest.raises(EffectChainTamperError) as exc:
+            await ingest_effect_records(
+                session, operator=_operator(tenant), runner_id=_RUNNER, records=[records[1]]
+            )
+    assert exc.value.seq == 1
+    assert "gap" in exc.value.reason
+
+    # No effect rows and no head were written (no partial ingest).
+    assert await _effect_rows(tenant) == []
+
+
+@pytest.mark.asyncio
+async def test_tampered_body_is_flagged(tmp_path: Path) -> None:
+    """Conformance: an altered record body (record_hash no longer derives) is caught."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_minted_command(tenant_id=tenant, command_id=command_id)
+    records = _build_records(tmp_path, runner_id=_RUNNER, command_id=command_id.hex)
+
+    # Mutate the op_id in place without recomputing record_hash — the classic
+    # transit tamper. seq (0) and prev_hash (genesis) still line up, so only the
+    # record_hash re-derivation catches it.
+    tampered = records[0].model_copy(update={"op_id": "vmware.vm.destroy"})
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        with pytest.raises(EffectChainTamperError) as exc:
+            await ingest_effect_records(
+                session, operator=_operator(tenant), runner_id=_RUNNER, records=[tampered]
+            )
+    assert "record_hash" in exc.value.reason or "tampered" in exc.value.reason
+
+
+@pytest.mark.asyncio
+async def test_broken_link_is_flagged(tmp_path: Path) -> None:
+    """Conformance: a valid record whose prev_hash misses the accepted head is caught."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_minted_command(tenant_id=tenant, command_id=command_id)
+
+    # Ingest a genuine seq-0 record so the head is at seq 0 / hash0.
+    chain_a = _build_records(tmp_path, runner_id=_RUNNER, command_id=command_id.hex)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await ingest_effect_records(
+            session, operator=_operator(tenant), runner_id=_RUNNER, records=[chain_a[0]]
+        )
+        await session.commit()
+
+    # A DIFFERENT chain's seq-1 record: self-consistent (record_hash derives from
+    # its own prev_hash) and seq==1 matches the head, but its prev_hash is that
+    # other chain's seq-0 hash, not the accepted head — the broken-link branch.
+    chain_b = _build_records(tmp_path, runner_id=_RUNNER, command_id=command_id.hex)
+    async with sessionmaker() as session:
+        with pytest.raises(EffectChainTamperError) as exc:
+            await ingest_effect_records(
+                session, operator=_operator(tenant), runner_id=_RUNNER, records=[chain_b[1]]
+            )
+    assert exc.value.seq == 1
+    assert "link" in exc.value.reason or "prev_hash" in exc.value.reason
+
+
+@pytest.mark.asyncio
+async def test_runner_cannot_forge_a_sibling_runners_chain(tmp_path: Path) -> None:
+    """Conformance: a record claiming another runner is rejected (keying/identity)."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_minted_command(tenant_id=tenant, command_id=command_id, runner_id="runner-victim")
+
+    # Records authored under "runner-victim" but forwarded on runner-w's channel.
+    forged = _build_records(tmp_path, runner_id="runner-victim", command_id=command_id.hex)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        with pytest.raises(EffectChainTamperError) as exc:
+            await ingest_effect_records(
+                session, operator=_operator(tenant), runner_id=_RUNNER, records=forged
+            )
+    assert "another runner" in exc.value.reason
+    assert await _effect_rows(tenant) == []

--- a/backend/tests/test_executor_effect_hook.py
+++ b/backend/tests/test_executor_effect_hook.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The executor's effect-audit bracketing hook (#3193, mechanism 4).
+
+Verifies that executing a ``remote-write`` item with an effect chain brackets the
+mutation with an intent record (before) and an outcome record (after), while a
+``safe`` item — or a call with no chain — records nothing (effect audit is a
+write-tier concern only). Driven through the private bracketing helper with a
+stub handler so the hook is tested without the full #3189 signing apparatus that
+edge screening otherwise requires.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.runner.effect_audit import EffectAuditChain
+from meho_backplane.runner.executor import _invoke_recording_effect
+from meho_backplane.runner.wire import RunnerPrincipal, RunnerWorkItem
+
+_RUNNER = "runner-hook"
+
+
+def _item(safety_level: str) -> RunnerWorkItem:
+    return RunnerWorkItem(
+        check_ref="chk-1",
+        op_id="vmware.vm.tag.set",
+        product="vmware",
+        handler_ref="meho_backplane.connectors.stub.handler",
+        params={"tag": "prod"},
+        safety_level=safety_level,
+        principal=RunnerPrincipal(
+            sub="runner-sub",
+            tenant_id=uuid.uuid4(),
+            tenant_role=TenantRole.OPERATOR,
+        ),
+        signature="sig-1",
+    )
+
+
+async def _stub_handler(_operator: Any, _target: Any, _params: dict[str, Any]) -> dict[str, Any]:
+    return {"ok": True}
+
+
+def _chain(tmp_path: Path) -> EffectAuditChain:
+    return EffectAuditChain(tmp_path / "chain", runner_id=_RUNNER)
+
+
+@pytest.mark.asyncio
+async def test_remote_write_brackets_intent_and_outcome(tmp_path: Path) -> None:
+    """A caution item records an intent (before) + an outcome (after)."""
+    chain = _chain(tmp_path)
+    result = await _invoke_recording_effect(
+        _stub_handler, _item("caution"), effect_chain=chain, command_id="cmd-1"
+    )
+    assert result.status == "ok"
+
+    records = chain.unforwarded()
+    assert [r.phase.value for r in records] == ["intent", "outcome"]
+    assert records[0].outcome is None
+    assert records[1].outcome == "ok"
+    assert records[1].signature == "sig-1"  # non-repudiation anchor carried
+    assert records[1].command_id == "cmd-1"
+
+
+@pytest.mark.asyncio
+async def test_safe_item_records_nothing(tmp_path: Path) -> None:
+    """A safe (read) item never touches the effect chain even when one is supplied."""
+    chain = _chain(tmp_path)
+    await _invoke_recording_effect(
+        _stub_handler, _item("safe"), effect_chain=chain, command_id="cmd-1"
+    )
+    assert chain.unforwarded() == []
+
+
+@pytest.mark.asyncio
+async def test_remote_write_without_chain_records_nothing(tmp_path: Path) -> None:
+    """No chain / no command id → the mutation runs unbracketed (backward-compatible)."""
+    chain = _chain(tmp_path)
+    await _invoke_recording_effect(
+        _stub_handler, _item("caution"), effect_chain=None, command_id="cmd-1"
+    )
+    await _invoke_recording_effect(
+        _stub_handler, _item("caution"), effect_chain=chain, command_id=None
+    )
+    assert chain.unforwarded() == []

--- a/backend/tests/test_gateway_effect_endpoint.py
+++ b/backend/tests/test_gateway_effect_endpoint.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end wiring of the effect-audit ingest into ``POST /gateway/{runner}/result``.
+
+Proves mechanism 4's forward surface (#3193): a runner forwards its hash-chained
+effect records alongside the command result over the real runner-plane endpoint,
+under the real middleware + runner-scope guard.
+
+* A **clean** report accepts the result AND ingests the effect chain in one
+  transaction — the effect rows link to the mint audit row.
+* A **tampered** report is refused ``409``: the whole submission rolls back (the
+  command is *not* consumed, so the un-reported-mint alarm can still fire) and a
+  durable quarantine security audit row is written.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+from sqlalchemy import select
+
+from meho_backplane.api.v1.gateway import router as gateway_router
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    GatewayCommand,
+    GatewayCommandStatus,
+    RunnerEffectChain,
+    RunnerPrincipal,
+    Tenant,
+)
+from meho_backplane.gateway.effect_ingest import EFFECT_AUDIT_PATH, EFFECT_QUARANTINE_PATH
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.runner.effect_audit import EffectAuditChain, EffectAuditRecord
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_RUNNER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_RUNNER_NAME = "runner-eff-ep"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(gateway_router)
+    return app
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_build_app()),
+        base_url="https://testserver",
+    ) as ac:
+        yield ac
+
+
+def _runner_token(key: object) -> str:
+    return mint_token(
+        key,
+        sub="runner-sub",
+        tenant_id=str(_TENANT),
+        tenant_role="read_only",
+        principal_kind="runner",
+        runner_id=str(_RUNNER_ID),
+    )
+
+
+async def _seed() -> tuple[uuid.UUID, uuid.UUID]:
+    """Seed tenant + runner principal + a delivered remote-write command.
+
+    Returns ``(command_id, mint_audit_id)``.
+    """
+    command_id = uuid.uuid4()
+    mint_audit_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=_TENANT, slug="tenant-eff", name="tenant-eff"))
+        session.add(
+            RunnerPrincipal(
+                id=_RUNNER_ID,
+                tenant_id=_TENANT,
+                name=_RUNNER_NAME,
+                keycloak_client_id=f"runner:{_RUNNER_NAME}:{_RUNNER_ID}",
+                keycloak_internal_id=f"kc-{_RUNNER_ID}",
+                owner_sub="op-admin",
+                created_by_sub="op-admin",
+                last_seen_at=now,
+            )
+        )
+        session.add(
+            AuditLog(
+                id=mint_audit_id,
+                operator_sub="op-admin",
+                tenant_id=_TENANT,
+                method="GATEWAY",
+                path="gateway.command.mint",
+                status_code=200,
+                payload={},
+            )
+        )
+        session.add(
+            GatewayCommand(
+                id=command_id,
+                tenant_id=_TENANT,
+                runner_id=_RUNNER_NAME,
+                op_id="vmware.vm.tag.set",
+                params={"tag": "prod"},
+                enqueued_by_sub="op-admin",
+                params_hash="ph-1",
+                safety_level="caution",
+                signature="sig-1",
+                status=GatewayCommandStatus.DELIVERED.value,
+                delivered_at=now,
+                expires_at=now + timedelta(minutes=5),
+                mint_audit_id=mint_audit_id,
+            )
+        )
+        await session.commit()
+    return command_id, mint_audit_id
+
+
+def _records(tmp_path, command_id: uuid.UUID) -> list[EffectAuditRecord]:
+    chain = EffectAuditChain(tmp_path / "chain", runner_id=_RUNNER_NAME)
+    chain.record_intent(
+        command_id=command_id.hex,
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+    )
+    chain.record_outcome(
+        command_id=command_id.hex,
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+        outcome="ok",
+    )
+    return chain.unforwarded()
+
+
+def _as_json(records: list[EffectAuditRecord]) -> list[dict]:
+    return [r.model_dump(mode="json") for r in records]
+
+
+@pytest.mark.asyncio
+async def test_clean_report_ingests_and_links_effect_chain(
+    client: httpx.AsyncClient, tmp_path
+) -> None:
+    """A clean forward accepts the result and links the effect rows to the mint row."""
+    command_id, mint_audit_id = await _seed()
+    records = _records(tmp_path, command_id)
+
+    key = make_rsa_keypair("kid-eff")
+    headers = {"Authorization": f"Bearer {_runner_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = await client.post(
+            f"/api/v1/gateway/{_RUNNER_NAME}/result",
+            headers=headers,
+            json={
+                "command_id": str(command_id),
+                "outcome": "succeeded",
+                "result": {},
+                "effect_records": _as_json(records),
+            },
+        )
+    assert resp.status_code == 200, resp.text
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        effect_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == EFFECT_AUDIT_PATH)))
+            .scalars()
+            .all()
+        )
+        command = await session.get(GatewayCommand, command_id)
+        head = (
+            await session.execute(
+                select(RunnerEffectChain).where(RunnerEffectChain.runner_id == _RUNNER_NAME)
+            )
+        ).scalar_one()
+    assert len(effect_rows) == 2
+    assert all(r.parent_audit_id == mint_audit_id for r in effect_rows)
+    assert command is not None and command.consumed_at is not None  # result accepted
+    assert head.last_seq == 1
+
+
+@pytest.mark.asyncio
+async def test_tampered_report_is_refused_and_quarantined(
+    client: httpx.AsyncClient, tmp_path
+) -> None:
+    """A tampered effect chain 409s, rolls back the result, and quarantines."""
+    command_id, _ = await _seed()
+    records = _records(tmp_path, command_id)
+    # Tamper the outcome record's op_id without recomputing its record_hash.
+    tampered = [records[0], records[1].model_copy(update={"op_id": "vmware.vm.destroy"})]
+
+    key = make_rsa_keypair("kid-eff")
+    headers = {"Authorization": f"Bearer {_runner_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = await client.post(
+            f"/api/v1/gateway/{_RUNNER_NAME}/result",
+            headers=headers,
+            json={
+                "command_id": str(command_id),
+                "outcome": "succeeded",
+                "result": {},
+                "effect_records": _as_json(tampered),
+            },
+        )
+    assert resp.status_code == 409, resp.text
+    assert "effect_chain_tamper" in resp.text
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        command = await session.get(GatewayCommand, command_id)
+        effect_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == EFFECT_AUDIT_PATH)))
+            .scalars()
+            .all()
+        )
+        quarantine_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == EFFECT_QUARANTINE_PATH)))
+            .scalars()
+            .all()
+        )
+    # The whole submission rolled back: the command is NOT consumed (so the
+    # un-reported-mint alarm can still fire), and no effect rows were written.
+    assert command is not None and command.consumed_at is None
+    assert effect_rows == []
+    # But the tamper is durably recorded as a security event.
+    assert len(quarantine_rows) == 1
+    assert quarantine_rows[0].payload["event_class"] == "security"
+    assert quarantine_rows[0].payload["runner"] == _RUNNER_NAME

--- a/backend/tests/test_gateway_unreported_mint.py
+++ b/backend/tests/test_gateway_unreported_mint.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central un-reported-mint security alarm sweeper (#2901, #3193, mechanism 4).
+
+Fail-closed conformance for :mod:`meho_backplane.gateway.unreported_mint`:
+
+* an un-reported minted **remote-write** capability past ``expires_at`` fires the
+  security alarm **exactly once** (a second tick is a no-op);
+* a **reported** (consumed) write does not fire it;
+* a **safe** (read) capability past expiry does not fire it (wrong tier);
+* an **unexpired** remote-write does not fire it.
+
+The alarm is a distinct **security** event (``gateway.command.unreported_mint``,
+``event_class='security'``), separate from the liveness dead-man flip
+(``gateway.runner.stale``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GatewayCommand, Tenant
+from meho_backplane.gateway.unreported_mint import (
+    GATEWAY_UNREPORTED_MINT_PATH,
+    _run_one_tick,
+)
+from meho_backplane.settings import get_settings
+
+_RUNNER = "runner-uw"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(tenant_id: uuid.UUID) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        ).scalar_one_or_none() is None:
+            slug = f"t-{tenant_id.hex[:8]}"
+            session.add(Tenant(id=tenant_id, slug=slug, name=slug))
+            await session.commit()
+
+
+async def _seed_command(
+    *,
+    tenant_id: uuid.UUID,
+    command_id: uuid.UUID,
+    safety_level: str,
+    expires_in_seconds: float,
+    consumed: bool,
+) -> None:
+    """Seed one gateway_command with explicit expiry / tier / consumption state."""
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            GatewayCommand(
+                id=command_id,
+                tenant_id=tenant_id,
+                runner_id=_RUNNER,
+                op_id="vmware.vm.tag.set",
+                params={"tag": "prod"},
+                enqueued_by_sub="op-admin",
+                params_hash="ph-1",
+                safety_level=safety_level,
+                expires_at=now + timedelta(seconds=expires_in_seconds),
+                consumed_at=now if consumed else None,
+            )
+        )
+        await session.commit()
+
+
+async def _alarm_rows(command_id: uuid.UUID | None = None) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.path == GATEWAY_UNREPORTED_MINT_PATH)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    if command_id is None:
+        return list(rows)
+    return [r for r in rows if r.payload.get("command_id") == str(command_id)]
+
+
+async def _alarm_at(command_id: uuid.UUID) -> datetime | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return await session.scalar(
+            select(GatewayCommand.unreported_alarm_at).where(GatewayCommand.id == command_id)
+        )
+
+
+@pytest.mark.asyncio
+async def test_unreported_remote_write_past_expiry_alarms_once() -> None:
+    """AC: an unreported minted write past expiry fires the security alarm exactly once."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_command(
+        tenant_id=tenant,
+        command_id=command_id,
+        safety_level="caution",
+        expires_in_seconds=-600,  # expired 10 minutes ago
+        consumed=False,
+    )
+
+    await _run_one_tick()
+
+    assert await _alarm_at(command_id) is not None, "the latch must be flipped"
+    rows = await _alarm_rows(command_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.method == "INTERNAL"
+    assert row.path == GATEWAY_UNREPORTED_MINT_PATH
+    assert row.payload["event_class"] == "security"
+    assert row.payload["runner"] == _RUNNER
+    assert row.payload["op_id"] == "vmware.vm.tag.set"
+    assert row.payload["lapse_seconds"] >= 0
+
+    # Idempotent: a second tick flips nothing and writes no extra audit row.
+    await _run_one_tick()
+    assert len(await _alarm_rows(command_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_reported_write_does_not_alarm() -> None:
+    """AC: a reported (consumed) write past expiry does not fire the alarm."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_command(
+        tenant_id=tenant,
+        command_id=command_id,
+        safety_level="caution",
+        expires_in_seconds=-600,
+        consumed=True,  # its effect WAS reported
+    )
+
+    await _run_one_tick()
+
+    assert await _alarm_at(command_id) is None
+    assert await _alarm_rows(command_id) == []
+
+
+@pytest.mark.asyncio
+async def test_safe_capability_past_expiry_does_not_alarm() -> None:
+    """A ``safe`` (read) capability past expiry is not a remote-write — no alarm."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_command(
+        tenant_id=tenant,
+        command_id=command_id,
+        safety_level="safe",
+        expires_in_seconds=-600,
+        consumed=False,
+    )
+
+    await _run_one_tick()
+
+    assert await _alarm_at(command_id) is None
+    assert await _alarm_rows(command_id) == []
+
+
+@pytest.mark.asyncio
+async def test_unexpired_remote_write_does_not_alarm() -> None:
+    """A remote-write still within its expiry window has not gone unreported yet."""
+    tenant = uuid.uuid4()
+    command_id = uuid.uuid4()
+    await _seed_tenant(tenant)
+    await _seed_command(
+        tenant_id=tenant,
+        command_id=command_id,
+        safety_level="caution",
+        expires_in_seconds=600,  # expires 10 minutes from now
+        consumed=False,
+    )
+
+    await _run_one_tick()
+
+    assert await _alarm_at(command_id) is None
+    assert await _alarm_rows(command_id) == []

--- a/backend/tests/test_runner_effect_audit.py
+++ b/backend/tests/test_runner_effect_audit.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runner-side store-and-forward effect-audit chain (#2901, #3193, mechanism 4).
+
+Covers the DB-free runner half: the hash-chained record writer produces a
+strictly-monotonic, self-linking chain; the head persists across a restart (so a
+runner cannot rewind ``seq`` — which would read as a gap at the centre); and the
+forwarding drain removes only forwarded records while the head keeps climbing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from meho_backplane.runner.effect_audit import (
+    GENESIS_PREV_HASH,
+    EffectAuditChain,
+    EffectChainStateError,
+    EffectPhase,
+    canonical_record_body,
+    compute_record_hash,
+)
+
+_RUNNER = "runner-eff"
+
+
+def _chain(tmp_path: Path) -> EffectAuditChain:
+    return EffectAuditChain(tmp_path / "effect-chain", runner_id=_RUNNER)
+
+
+def _intent(chain: EffectAuditChain, *, command_id: str = "cmd-1"):
+    return chain.record_intent(
+        command_id=command_id,
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+    )
+
+
+def test_intent_then_outcome_form_a_monotonic_self_linking_chain(tmp_path: Path) -> None:
+    """AC: one intent record before, one outcome record after; hash-chained per seq."""
+    chain = _chain(tmp_path)
+
+    intent = _intent(chain)
+    assert intent.seq == 0
+    assert intent.phase is EffectPhase.INTENT
+    assert intent.prev_hash == GENESIS_PREV_HASH
+    assert intent.outcome is None
+
+    outcome = chain.record_outcome(
+        command_id="cmd-1",
+        op_id="vmware.vm.tag.set",
+        params_hash="ph-1",
+        signature="sig-1",
+        target_scope="scope-1",
+        outcome="ok",
+    )
+    assert outcome.seq == 1
+    assert outcome.phase is EffectPhase.OUTCOME
+    assert outcome.outcome == "ok"
+    # The link: the outcome's prev_hash is exactly the intent's record_hash.
+    assert outcome.prev_hash == intent.record_hash
+
+    # Each record_hash re-derives from its own canonical body (tamper anchor).
+    for rec in (intent, outcome):
+        canonical = canonical_record_body(
+            runner_id=rec.runner_id,
+            seq=rec.seq,
+            phase=rec.phase,
+            command_id=rec.command_id,
+            op_id=rec.op_id,
+            params_hash=rec.params_hash,
+            signature=rec.signature,
+            target_scope=rec.target_scope,
+            outcome=rec.outcome,
+            recorded_at=rec.recorded_at,
+        )
+        assert compute_record_hash(rec.prev_hash, canonical) == rec.record_hash
+
+
+def test_head_persists_across_restart_no_rewind(tmp_path: Path) -> None:
+    """A fresh chain object on the same dir continues the seq, never rewinds to 0."""
+    first = _chain(tmp_path)
+    r0 = _intent(first)
+    r1 = first.record_outcome(
+        command_id="cmd-1",
+        op_id="op",
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+        outcome="ok",
+    )
+
+    # "Restart": a brand-new chain object bound to the same directory.
+    restarted = _chain(tmp_path)
+    r2 = restarted.record_intent(
+        command_id="cmd-2",
+        op_id="op",
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+    )
+    assert r2.seq == 2, "the head must persist across a restart, not rewind seq"
+    assert r2.prev_hash == r1.record_hash
+    assert r0.seq == 0 and r1.seq == 1
+
+
+def test_forwarding_drains_records_but_head_keeps_climbing(tmp_path: Path) -> None:
+    """``mark_forwarded`` deletes forwarded records; the next seq still climbs."""
+    chain = _chain(tmp_path)
+    r0 = _intent(chain, command_id="cmd-1")
+    r1 = chain.record_outcome(
+        command_id="cmd-1",
+        op_id="op",
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+        outcome="ok",
+    )
+
+    pending = chain.unforwarded()
+    assert [r.seq for r in pending] == [0, 1]
+
+    chain.mark_forwarded(r0.seq)
+    assert [r.seq for r in chain.unforwarded()] == [1]
+
+    # Head is untouched by the drain: a new record continues after seq 1.
+    r2 = chain.record_intent(
+        command_id="cmd-2",
+        op_id="op",
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+    )
+    assert r2.seq == 2
+    assert r2.prev_hash == r1.record_hash
+
+    chain.mark_forwarded(r2.seq)
+    assert chain.unforwarded() == []
+
+
+def test_compute_record_hash_is_body_sensitive() -> None:
+    """A single body byte change yields a different chain hash (tamper anchor)."""
+    body_a = canonical_record_body(
+        runner_id="r",
+        seq=0,
+        phase=EffectPhase.INTENT,
+        command_id="cmd",
+        op_id="op",
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+        outcome=None,
+        recorded_at="2026-09-01T00:00:00+00:00",
+    )
+    body_b = canonical_record_body(
+        runner_id="r",
+        seq=0,
+        phase=EffectPhase.INTENT,
+        command_id="cmd",
+        op_id="op-EVIL",  # one field changed
+        params_hash="ph",
+        signature="sig",
+        target_scope="scope",
+        outcome=None,
+        recorded_at="2026-09-01T00:00:00+00:00",
+    )
+    assert compute_record_hash(GENESIS_PREV_HASH, body_a) != compute_record_hash(
+        GENESIS_PREV_HASH, body_b
+    )
+
+
+def test_corrupt_head_refuses_to_guess(tmp_path: Path) -> None:
+    """A corrupt on-disk head raises rather than silently rewinding the chain."""
+    chain = _chain(tmp_path)
+    _intent(chain)
+    # Corrupt the persisted head.
+    head_file = tmp_path / "effect-chain" / "head.json"
+    head_file.write_text("{ not json", encoding="utf-8")
+    with pytest.raises(EffectChainStateError):
+        _intent(chain, command_id="cmd-2")

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -26640,6 +26640,83 @@
         "title": "EditTemplateResponse",
         "description": "Response for ``meho_runbook_edit_template``.\n\n:attr:`version` equals the input version when editing a draft in\nplace; it is a new version when forking from a published template, in\nwhich case :attr:`forked_from` is populated with the source's\n:class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is\n``None``.\n\n:attr:`status` is normally ``\"draft\"`` (both the in-place edit and the\nfork mint/keep a draft). The one exception is the **no-op fork skip**\n(#144): editing a published/deprecated version with a body byte-identical\nto the source creates no draft and returns the *unchanged source* \u2014 so\n``version`` is the source version, ``forked_from`` is ``None``, and\n``status`` is the source's own ``\"published\"`` / ``\"deprecated\"``. The\nnon-``\"draft\"`` status is the signal that no new draft was created."
       },
+      "EffectAuditRecord": {
+        "properties": {
+          "runner_id": {
+            "type": "string",
+            "title": "Runner Id"
+          },
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/EffectPhase"
+          },
+          "command_id": {
+            "type": "string",
+            "title": "Command Id"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "params_hash": {
+            "type": "string",
+            "title": "Params Hash"
+          },
+          "signature": {
+            "type": "string",
+            "nullable": true,
+            "title": "Signature"
+          },
+          "target_scope": {
+            "type": "string",
+            "title": "Target Scope"
+          },
+          "outcome": {
+            "type": "string",
+            "nullable": true,
+            "title": "Outcome"
+          },
+          "recorded_at": {
+            "type": "string",
+            "title": "Recorded At"
+          },
+          "prev_hash": {
+            "type": "string",
+            "title": "Prev Hash"
+          },
+          "record_hash": {
+            "type": "string",
+            "title": "Record Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "runner_id",
+          "seq",
+          "phase",
+          "command_id",
+          "op_id",
+          "params_hash",
+          "target_scope",
+          "recorded_at",
+          "prev_hash",
+          "record_hash"
+        ],
+        "title": "EffectAuditRecord",
+        "description": "One tamper-evident link in a runner's effect-audit chain.\n\nFrozen wire model shared verbatim with the central ingest verifier. The\nhashed body is every field **except** ``record_hash`` (see\n:func:`canonical_record_body`); ``record_hash`` folds in ``prev_hash`` so the\nrecords form a chain the centre re-derives link by link."
+      },
+      "EffectPhase": {
+        "type": "string",
+        "enum": [
+          "intent",
+          "outcome"
+        ],
+        "title": "EffectPhase",
+        "description": "The two records the runner writes per executed write item.\n\n* :attr:`INTENT` \u2014 written **before** the mutation is attempted (the runner\n  is about to execute a centrally-authorised write). Its presence without a\n  matching :attr:`OUTCOME` is itself evidence (the runner crashed or was\n  cut off mid-write).\n* :attr:`OUTCOME` \u2014 written **after** the handler returns, carrying the\n  runner-level result status."
+      },
       "EnableReadsResponse": {
         "properties": {
           "connector_id": {
@@ -27267,6 +27344,14 @@
             "nullable": true,
             "title": "Error",
             "description": "Failure summary (for a 'failed' outcome)."
+          },
+          "effect_records": {
+            "items": {
+              "$ref": "#/components/schemas/EffectAuditRecord"
+            },
+            "type": "array",
+            "title": "Effect Records",
+            "description": "Tamper-evident store-and-forward effect audit records to ingest."
           }
         },
         "additionalProperties": false,

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -242,6 +242,12 @@ const (
 	EditTemplateResponseStatusPublished  EditTemplateResponseStatus = "published"
 )
 
+// Defines values for EffectPhase.
+const (
+	EffectPhaseIntent  EffectPhase = "intent"
+	EffectPhaseOutcome EffectPhase = "outcome"
+)
+
 // Defines values for EvalRequestSurface.
 const (
 	EvalRequestSurfaceAll        EvalRequestSurface = "all"
@@ -4281,6 +4287,46 @@ type EditTemplateResponse struct {
 // EditTemplateResponseStatus defines model for EditTemplateResponse.Status.
 type EditTemplateResponseStatus string
 
+// EffectAuditRecord One tamper-evident link in a runner's effect-audit chain.
+//
+// Frozen wire model shared verbatim with the central ingest verifier. The
+// hashed body is every field **except** “record_hash“ (see
+// :func:`canonical_record_body`); “record_hash“ folds in “prev_hash“ so the
+// records form a chain the centre re-derives link by link.
+type EffectAuditRecord struct {
+	CommandId  string  `json:"command_id"`
+	OpId       string  `json:"op_id"`
+	Outcome    *string `json:"outcome"`
+	ParamsHash string  `json:"params_hash"`
+
+	// Phase The two records the runner writes per executed write item.
+	//
+	// * :attr:`INTENT` — written **before** the mutation is attempted (the runner
+	//   is about to execute a centrally-authorised write). Its presence without a
+	//   matching :attr:`OUTCOME` is itself evidence (the runner crashed or was
+	//   cut off mid-write).
+	// * :attr:`OUTCOME` — written **after** the handler returns, carrying the
+	//   runner-level result status.
+	Phase       EffectPhase `json:"phase"`
+	PrevHash    string      `json:"prev_hash"`
+	RecordHash  string      `json:"record_hash"`
+	RecordedAt  string      `json:"recorded_at"`
+	RunnerId    string      `json:"runner_id"`
+	Seq         int         `json:"seq"`
+	Signature   *string     `json:"signature"`
+	TargetScope string      `json:"target_scope"`
+}
+
+// EffectPhase The two records the runner writes per executed write item.
+//
+//   - :attr:`INTENT` — written **before** the mutation is attempted (the runner
+//     is about to execute a centrally-authorised write). Its presence without a
+//     matching :attr:`OUTCOME` is itself evidence (the runner crashed or was
+//     cut off mid-write).
+//   - :attr:`OUTCOME` — written **after** the handler returns, carrying the
+//     runner-level result status.
+type EffectPhase string
+
 // EnableReadsResponse Response body for “POST /api/v1/connectors/{id}/enable-reads“ (G0.25-T7 #1749).
 //
 // The bulk read-class enable path returns “200“ with a count
@@ -4642,6 +4688,9 @@ type GatewayResultAck struct {
 type GatewayResultBody struct {
 	// CommandId The delivered command's id.
 	CommandId openapi_types.UUID `json:"command_id"`
+
+	// EffectRecords Tamper-evident store-and-forward effect audit records to ingest.
+	EffectRecords *[]EffectAuditRecord `json:"effect_records,omitempty"`
 
 	// Error Failure summary (for a 'failed' outcome).
 	Error *string `json:"error"`

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -343,6 +343,85 @@ fails closed), plus optional `MEHO_RUNNER_VAULT_NAMESPACE` (Enterprise) and
 `MEHO_RUNNER_VAULT_TIMEOUT_SECONDS` (default 10). Wrapped brokering is a Vault
 feature; a Vault-free (`gsm`) deployment has no wrapped-brokering path yet.
 
+## Store-and-forward effect audit + un-reported-mint alarm — mechanism 4 (#3193)
+
+Mechanism 4 of the composed write-tier gate (decision
+`docs/decisions/satellite-write-path.md`, design
+`docs/research/2901-satellite-write-path.md` §3, threat T4) is the two
+compensating controls for a **consciously-recorded exception to v0.1-spec §6**.
+
+**Relationship to the §6 invariant (stated explicitly).** v0.1-spec §6 requires
+that an operation does not return success unless its audit row commits
+synchronously at the centre. For a satellite **write** that invariant *cannot*
+hold for the **effect**: the executing side (a runner) has no Postgres and the
+mutation is off-net, so there is no central transaction to commit the effect row
+in before the mutation happens. §6 **still holds for the mint** — the capability
+is minted only inside a synchronous central audit transaction
+(`gateway.command.mint`, `operations/gateway_commands.py`). What §6 cannot cover
+— the remote effect — is replaced by a *store-and-forward* record plus a
+*detector for its absence*, not by pretending the effect was synchronously
+audited. This is the recorded exception; the two mechanisms below make the edge's
+silence and tampering **observable**, they do not make a lying edge honest (that
+residual is bounded by the composition: allowlist × credential TTL).
+
+**Store-and-forward tamper-evident effect audit** (`runner/effect_audit.py`,
+DB-free — stdlib + pydantic, imported verbatim by the centre). For a
+`remote-write` item the runner appends a **hash-chained** record **before** the
+mutation (`intent`) and **after** it (`outcome`), keyed by a strictly-monotonic
+per-runner `seq`; each record's `record_hash = sha256(prev_hash + canonical_body)`
+folds in its predecessor's hash, and every record references the signed work
+item's Ed25519 `signature` (#3189) as the non-repudiation anchor. The chain head
+(`last_seq` / `last_hash`) persists on disk (`ResultSpool` mould) so a runner
+restart continues the chain rather than rewinding `seq` — a rewind would read as
+a gap. The executor brackets the mutation at the one seam that performs it:
+`execute_work_item` records `intent` after screening passes and `outcome` after
+the handler returns, only for a `REMOTE_WRITE` item with a chain provided (a
+`safe` read records nothing). Records forward with the result report on
+`POST /gateway/{runner}/result` (`GatewayResultBody.effect_records`), preserving
+the push-only boundary (#2877).
+
+**Central ingest + chain verification** (`gateway/effect_ingest.py`). The centre
+ingests each record into `audit_log` (`method='GATEWAY'`,
+`path='gateway.command.effect'`, `payload.provenance='store-and-forward'`) with
+`parent_audit_id = gateway_command.mint_audit_id`, so the effect joins the
+mint/result subtree the split lineage (#2500) already forms — **the existing
+`gateway.command.mint` / `gateway.command.result` lineage is preserved, not
+replaced.** Before writing anything it **verifies the chain** against the
+persisted per-runner head (`runner_effect_chain`, migration `0094`): a `seq` that
+is not `last_seq + 1` (a **gap** — a dropped/suppressed record), a `prev_hash`
+that misses the accepted head (a **broken link**), a `record_hash` that does not
+re-derive (a **tampered body**), or a record whose `runner_id` is not the
+authenticated runner (a **cross-runner forge**) each raises
+`EffectChainTamperError`. On a tamper the runner-facing endpoint rolls the whole
+result submission back — a tampered report is **not** accepted, so the capability
+stays unconsumed and the alarm below can still fire — and writes a durable
+`gateway.command.effect.quarantine` **security** audit row. The keying
+(`record.runner_id` bound to the token-authenticated runner) is why one runner
+cannot extend another's chain.
+
+**Un-reported-mint security alarm** (`gateway/unreported_mint.py`, the
+`gateway/deadman.py` mould). A central-clock, advisory-lock-elected,
+conditional-`UPDATE`-idempotent sweeper flags a minted `remote-write` capability
+past `expires_at` still `consumed_at IS NULL` (`safety_level IN` the remote-write
+set) — its effect was never reported (threat T4). Because the mint is audited
+synchronously, the centre always knows a write capability was granted and detects
+within the expiry window that its effect never came back. Each flip sets the
+one-way `gateway_command.unreported_alarm_at` latch (migration `0094`) under a
+`rowcount` gate and writes exactly one internal **security** audit row
+(`path='gateway.command.unreported_mint'`, `payload.event_class='security'`).
+This is a **security** monitor, deliberately **distinct** from the #2501 dead-man
+switch's **liveness** flip (`gateway.runner.stale`): a runner can be perfectly
+live and still execute-but-not-report one write — the exact gap the liveness
+monitor cannot see. Gated on `GATEWAY_UNREPORTED_MINT_ENABLED` (default on),
+cadence `GATEWAY_UNREPORTED_MINT_TICK_INTERVAL_SECONDS` (default 60), registered
+in `main.lifespan` alongside the dead-man sweeper.
+
+**Residual (bounded, not eliminated).** A fully compromised runner holds its own
+genesis and can fabricate a *self-consistent* alternate chain. Tamper evidence
+catches transit tampering and dropped records (chain gaps), **not** a lying edge;
+that residual is bounded only by the composition (allowlist × credential TTL) and
+by the un-reported-mint alarm, never by the effect record alone.
+
 ## Dead-man switch + mandatory heartbeat (#2501)
 
 A runner that dies, wedges, or loses its network path must not leave its


### PR DESCRIPTION
## Summary

- **Mechanism 4** of the composed satellite write-tier gate (Initiative #2901,
  decision `docs/decisions/satellite-write-path.md`, design
  `docs/research/2901-satellite-write-path.md` §3, threat T4): the two
  compensating controls for the **consciously-recorded v0.1-spec §6 exception**.
  A satellite write's *effect* cannot be synchronously audited at the centre (the
  runner has no DB, the mutation is off-net), so the **mint stays synchronously
  audited** and the **effect becomes store-and-forward with a detector for its
  absence**. The existing `gateway.command.mint` / `gateway.command.result`
  split lineage is **preserved**.
- **Tamper-evident store-and-forward effect audit** — runner (`runner/effect_audit.py`,
  DB-free) writes a **hash-chained** intent record *before* each remote-write
  mutation and an outcome record *after*, keyed by a monotonic per-runner `seq`,
  each referencing the signed work item (#3189) as the non-repudiation anchor;
  forwarded with the result on `POST /gateway/{runner}/result`. The centre
  (`gateway/effect_ingest.py`) verifies the chain against a persisted per-runner
  head and writes each record to `audit_log` with a `store-and-forward`
  provenance marker linked to the mint audit row (`parent_audit_id =
  mint_audit_id`). A **gap / broken link / tampered body / cross-runner forge**
  fails closed — the whole submission rolls back (capability stays unconsumed)
  and a `gateway.command.effect.quarantine` **security** row is written.
- **Un-reported-mint security alarm** — `gateway/unreported_mint.py` (the
  `gateway/deadman.py` mould) raises a **security** event
  (`path='gateway.command.unreported_mint'`, `event_class='security'`) **exactly
  once** for a minted `remote-write` past `expires_at` still `consumed_at IS
  NULL`. Deliberately **distinct** from the #2501 dead-man switch's *liveness*
  flip (`gateway.runner.stale`) — a live runner can still execute-but-not-report
  one write.

## Where the alarm surfaces

Both surfaces are the **audit plane** (`audit_log`), not a new notification
channel — reusing the established internal-audit-row precedent
(`write_internal_audit_row`, the same channel the dead-man switch and
`runner.principal.revoked` use, ready for the G8 audit-query consumers):

- Un-reported mint → one internal **security** audit row
  `path='gateway.command.unreported_mint'`.
- Tampered forward → one internal **security** audit row
  `path='gateway.command.effect.quarantine'`.
- Clean effect → `audit_log` rows `path='gateway.command.effect'`,
  `provenance='store-and-forward'`, linked into the mint's audit subtree.

## Migration

- **0094** `runner_effect_chain` head table + `gateway_command.unreported_alarm_at`
  latch. **`down_revision = "0092"`** — the single linear head on `origin/main`
  at push time (`0092_add_gateway_command_signature`). Sibling **#3190**
  (per-runner allowlist) runs concurrently under #2901 and owns **0093** if it
  needs a migration; this task **deliberately skips 0093** to avoid a
  revision-id clash. Only the `down_revision` pointer is load-bearing — **please
  re-point at merge if the race lands differently** (e.g. #3190 lands a 0093
  first → set `down_revision = "0093"`).

## Peer-owned decision-doc section

No change is required to the peer-owned `## Amendment (2026-08-31)` flight-recorder
section of `docs/decisions/satellite-write-path.md`. That text already correctly
states the store-and-forward **effect** audit "stays the permanent v0.1-spec §6
record" and is "distinct from … the flight recorder" — this PR implements exactly
that record and does not touch tracing, so the amendment's wording remains accurate
as written.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (changed files)
- [x] `mypy` — clean on changed files (the one full-package error, `icmp.py`
      `MSG_ERRQUEUE`, is a pre-existing macOS-only false positive, absent on CI Linux)
- [x] `alembic upgrade head` → `downgrade -1` → `upgrade head` — reversible; single head 0094
- [x] `pytest` — 203 passed across new + affected suites. New coverage:
  - chain gap detected on ingest; tampered body detected; broken link detected;
    cross-runner forge rejected; clean round-trip links mint-audit-row ↔ effect row
  - un-reported minted write past expiry alarms **exactly once**; a reported
    (consumed) write does not; a `safe` capability does not; an unexpired one does not
  - endpoint round-trip (`POST /gateway/{runner}/result` with `effect_records`)
    ingests + links; a tampered forward → `409` + rollback (command unconsumed) + quarantine row
  - runner chain: monotonic self-linking records, head persists across restart, drain
- [x] `code-quality.py --diff` — 0 blockers
- [x] `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated
      (`make snapshot-openapi && make generate`); `go build ./...` clean
- [x] Existing satellite / tier / dead-man / conformance suites stay green untouched

## Out of scope (per initiative slicing)

- The composed gate / per-runner allowlist (#3190), signing internals (#3246/#3189),
  and credential brokering (#3244/#3191) are untouched — additive only on shared
  files (`CHANGELOG`, `satellite-runner.md` unions expected with #3190 and the
  peer #3231/#3232 PRs).

Closes #3193
