### PR TITLE
feat(gateway): satellite write path — per-runner capability allowlist (#3190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,39 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — satellite write path: per-runner capability allowlist (#3190)
+
+- Mechanism 2 of the composed write-tier gate: a per-runner-principal
+  **capability allowlist** (`op_pattern` glob + `target_scope` cap, tenant-scoped)
+  that **is** the definition of a runner's write blast radius (design §3, threats
+  T1/T8). New `runner_write_allowlist` table (migration `0093`, `down_revision
+  0092`) hung off the runner principal, plus `RunnerWriteAllowlistService`.
+- **Composed, not weakened:** a `remote-write` op mints only when its op-class +
+  target is on the runner's allowlist **and** the #3189 approval binds it — the
+  gate is satisfiable only when **both** halves pass, fail-closed when either is
+  absent. An off-allowlist op refuses with the distinct
+  `MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED`, before the single-use latch
+  (no rows written, no approval consumed). Destructive/dangerous stay `EXCLUDED`
+  and unmintable; the safe read path is untouched.
+- **Checked twice (defence in depth):** the shared, DB-free
+  `evaluate_remote_write_gate` matcher runs at the **mint** (against the DB rows,
+  `load_runner_allowlist`) and is re-run at the **edge** (`executor._screen_item`)
+  against the runner's **own** provisioning config
+  (`SATELLITE_WRITE_ALLOWLIST` / `satellite_write_allowlist`) — never the mint's,
+  so an item allowlisted centrally is still refused if the edge config disagrees.
+  The assignment materialiser needs no third mirror (only `safe` ops materialise
+  into recurring assignments; `remote-write` rides the one-shot mint path).
+- **Not self-widenable (T7):** enrollment grants **no** write capability at
+  birth; a capability requires the separate human step
+  `POST /api/v1/runner-principals/{name}/write-allowlist` (`tenant_admin`,
+  bound at issuance via `created_by_sub`, idempotent), with a `GET` read-back.
+  A runner's read-only, route-caged token cannot reach the grant path.
+- Composes with the peer-owned "Amendment (2026-08-31)" in
+  `docs/decisions/satellite-write-path.md`: satellite dispatches (any tier)
+  remain untraced by the flight recorder; wiring the allowlist does not change
+  that (the `remote-write` item still executes through the
+  `dispatcher.dispatch`-bypassing edge path).
+
 ### Added — satellite write path: revocation hardening for write-capable runners (#3192)
 
 - Closes the T8 already-minted-write gap: a **revoked** runner can no longer

--- a/backend/alembic/versions/0093_create_runner_write_allowlist.py
+++ b/backend/alembic/versions/0093_create_runner_write_allowlist.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create ``runner_write_allowlist`` — the per-runner remote-write capability set.
+
+Revision ID: 0093
+Revises: 0092
+Create Date: 2026-09-01
+
+Task #3190 under Initiative #2901 (satellite write path), design
+``docs/research/2901-satellite-write-path.md`` §3 mechanism 2, decision
+``docs/decisions/satellite-write-path.md``. The per-runner-principal
+**capability allowlist**: each row grants one ``(op_pattern, target_scope)``
+remote-write capability to one runner principal, and the set of rows for a
+runner **is** the definition of its write blast radius (threats T1/T8). A
+``remote-write`` (``caution``) op mints to a runner only when its op-class +
+target is on this allowlist (checked at the central mint, ANDed with the
+approval binding of #3189) **and** the runner's own provisioning-config
+mirror agrees at the edge — defence in depth, exactly like the safe wall.
+
+What this migration adds
+------------------------
+
+* ``runner_write_allowlist`` table:
+  ``id`` (uuid PK), ``tenant_id`` (FK ``tenant.id``),
+  ``runner_principal_id`` (FK ``runner_principal.id`` — the capability is hung
+  off the runner principal), ``op_pattern`` (glob over ``op_id``),
+  ``target_scope`` (``*`` or a concrete ``str(target.id)`` cap),
+  ``created_by_sub`` (the granting human — the issuance binding), and
+  ``created_at``.
+* ``runner_write_allowlist_lookup_idx`` on ``(tenant_id,
+  runner_principal_id)`` — the dominant mint-time read ("every capability for
+  runner R in tenant T").
+* ``uq_runner_write_allowlist_capability`` unique on ``(runner_principal_id,
+  op_pattern, target_scope)`` — a re-grant of the same capability is
+  idempotent, not a duplicate.
+
+Not-at-birth (T7)
+-----------------
+
+Enrollment (``runner_principal`` register) writes **no** rows here: a write
+capability requires a separate human step
+(``RunnerWriteAllowlistService.grant`` over the operator-gated route), so a
+runner cannot self-widen its allowlist (decision recommendation 2).
+
+Migration-chain note (single linear head)
+-----------------------------------------
+
+Numbered ``0093`` with ``down_revision = "0092"`` — the head on ``origin/main``
+(``0092_add_gateway_command_signature``, #3189). Sibling #3193 (effect audit +
+alarm) runs concurrently and owns ``0094`` if it needs one; this task owns
+``0093`` only. Additive-only: a fresh table, no ALTER of an existing object.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the indexes then the table. Fresh table, no data
+dependency, so the downgrade is clean.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0093"
+down_revision: str | None = "0092"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``runner_write_allowlist`` table + its two indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "runner_write_allowlist",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), sa.ForeignKey("tenant.id"), nullable=False),
+        sa.Column(
+            "runner_principal_id",
+            sa.Uuid(),
+            sa.ForeignKey("runner_principal.id"),
+            nullable=False,
+        ),
+        sa.Column("op_pattern", sa.Text(), nullable=False),
+        sa.Column("target_scope", sa.Text(), nullable=False),
+        sa.Column("created_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+    # Dominant mint-time read: every capability for a runner in a tenant.
+    op.create_index(
+        "runner_write_allowlist_lookup_idx",
+        "runner_write_allowlist",
+        ["tenant_id", "runner_principal_id"],
+        postgresql_using="btree",
+    )
+    # At most one row per fully-scoped capability (idempotent re-grant).
+    op.create_index(
+        "uq_runner_write_allowlist_capability",
+        "runner_write_allowlist",
+        ["runner_principal_id", "op_pattern", "target_scope"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes and the table created in :func:`upgrade`."""
+    op.drop_index(
+        "uq_runner_write_allowlist_capability",
+        table_name="runner_write_allowlist",
+    )
+    op.drop_index(
+        "runner_write_allowlist_lookup_idx",
+        table_name="runner_write_allowlist",
+    )
+    op.drop_table("runner_write_allowlist")

--- a/backend/src/meho_backplane/api/v1/runner_principals.py
+++ b/backend/src/meho_backplane/api/v1/runner_principals.py
@@ -24,6 +24,12 @@ Route inventory
 * ``DELETE /api/v1/runner-principals/{name}/revoke`` — revoke a runner
   (kill switch: disables Keycloak client + marks row revoked). Returns the
   updated row. Role: ``tenant_admin``.
+* ``GET /api/v1/runner-principals/{name}/write-allowlist`` — list the
+  runner's granted ``remote-write`` capabilities (#3190). Role: ``operator``.
+* ``POST /api/v1/runner-principals/{name}/write-allowlist`` — grant one
+  ``remote-write`` capability (op-pattern + target-scope). The separate human
+  step a write capability requires after enrollment (a runner is never
+  granted write capability at birth). Returns 201. Role: ``tenant_admin``.
 
 Enforcement scope (the #2489 lesson, stated explicitly)
 -------------------------------------------------------
@@ -71,6 +77,11 @@ from meho_backplane.auth.runner_principals import (
     RunnerPrincipalRead,
     RunnerPrincipalService,
 )
+from meho_backplane.auth.runner_write_allowlist import (
+    RemoteWriteCapabilityGrant,
+    RunnerWriteAllowlistEntryRead,
+    RunnerWriteAllowlistService,
+)
 from meho_backplane.scheduler.vault_credentials import (
     SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
     SchedulerVaultBrokerError,
@@ -88,6 +99,8 @@ _OP_IDS: Final[dict[str, str]] = {
     "show": "runner_principal.show",
     "register": "runner_principal.register",
     "revoke": "runner_principal.revoke",
+    "write_allowlist_list": "runner_principal.write_allowlist.list",
+    "write_allowlist_grant": "runner_principal.write_allowlist.grant",
 }
 
 
@@ -97,6 +110,14 @@ class RunnerPrincipalListResponse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     principals: list[RunnerPrincipalRead]
+
+
+class RunnerWriteAllowlistResponse(BaseModel):
+    """Response envelope for ``GET .../{name}/write-allowlist``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    entries: list[RunnerWriteAllowlistEntryRead]
 
 
 def _handle_admin_error(exc: Exception) -> HTTPException:
@@ -247,3 +268,70 @@ async def revoke_runner_principal(
         ) from exc
     except KeycloakAdminError as exc:
         raise _handle_admin_error(exc) from exc
+
+
+@router.get("/{name}/write-allowlist", response_model=RunnerWriteAllowlistResponse)
+async def list_runner_write_allowlist(
+    name: Annotated[str, Path(max_length=NAME_MAX_LENGTH)],
+    operator: Operator = _require_operator,
+) -> RunnerWriteAllowlistResponse:
+    """List a runner's granted ``remote-write`` capabilities (#3190).
+
+    Read-back of the per-runner capability allowlist (mechanism 2 of the
+    satellite write path). 404 when the runner is unknown or revoked.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["write_allowlist_list"],
+        audit_op_class="read",
+        audit_runner_principal_name=name,
+    )
+    service = RunnerWriteAllowlistService()
+    try:
+        entries = await service.list_(operator.tenant_id, name)
+    except RunnerPrincipalNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="runner_principal_not_found",
+        ) from exc
+    return RunnerWriteAllowlistResponse(entries=entries)
+
+
+@router.post(
+    "/{name}/write-allowlist",
+    response_model=RunnerWriteAllowlistEntryRead,
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def grant_runner_write_capability(
+    name: Annotated[str, Path(max_length=NAME_MAX_LENGTH)],
+    body: RemoteWriteCapabilityGrant,
+    operator: Operator = _require_admin,
+) -> RunnerWriteAllowlistEntryRead:
+    """Grant one ``remote-write`` capability to a runner (#3190).
+
+    The **separate human step** a write capability requires after enrollment:
+    ``tenant_admin`` only, and never reachable by a runner's own read-only,
+    route-caged token — so a runner cannot widen its own allowlist (threat T7,
+    decision recommendation 2). Programmatic enrollment grants no write
+    capability at birth; this route is the only path that adds one. The grant
+    is bound at issuance (``created_by_sub`` records the operator) and
+    idempotent on ``(op_pattern, target_scope)``. 404 when the runner is
+    unknown or revoked.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_IDS["write_allowlist_grant"],
+        audit_op_class="write",
+        audit_runner_principal_name=name,
+    )
+    service = RunnerWriteAllowlistService()
+    try:
+        return await service.grant(
+            tenant_id=operator.tenant_id,
+            runner_name=name,
+            created_by_sub=operator.sub,
+            payload=body,
+        )
+    except RunnerPrincipalNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="runner_principal_not_found",
+        ) from exc

--- a/backend/src/meho_backplane/auth/runner_write_allowlist.py
+++ b/backend/src/meho_backplane/auth/runner_write_allowlist.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-runner remote-write capability allowlist — grant / list / load (#3190).
+
+Mechanism 2 of the satellite write-path composed gate (Initiative #2901,
+design ``docs/research/2901-satellite-write-path.md`` §3, decision
+``docs/decisions/satellite-write-path.md``). The companion of the runner
+principal (:mod:`meho_backplane.auth.runner_principals`): a runner principal is
+an *identity*; the rows this service manages are that identity's **write blast
+radius** — the enumerated ``(op_pattern, target_scope)`` capabilities it may
+ride as remote writes.
+
+Two provisioning methods (operator-facing, over the ``tenant_admin``-gated
+REST route) plus one mint-side reader:
+
+* :meth:`RunnerWriteAllowlistService.grant` — the **separate human step** a
+  write capability requires. Enrollment (``RunnerPrincipalService.register``)
+  grants **nothing**; a write capability is added only here, by a human
+  operator, recording ``created_by_sub`` as the issuance binding (decision
+  recommendation 2 / threat T7: programmatic enrollment can never grant write
+  capability at birth, and a runner's read-only, route-caged token cannot reach
+  this path — so the runner cannot widen its own allowlist).
+* :meth:`RunnerWriteAllowlistService.list_` — the operator read-back.
+* :func:`load_runner_allowlist` — the central mint reads a runner's rows into
+  the shared, DB-free :class:`~meho_backplane.runner.satellite_tier.RemoteWriteAllowEntry`
+  matcher input.
+
+Idempotent grant: the unique ``(runner_principal_id, op_pattern,
+target_scope)`` index makes a re-grant of the same capability return the
+existing row rather than duplicate or error.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.runner_principals import RunnerPrincipalNotFoundError
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import RunnerPrincipal, RunnerWriteAllowlistEntry
+from meho_backplane.runner.satellite_tier import RemoteWriteAllowEntry
+
+__all__ = [
+    "RemoteWriteCapabilityGrant",
+    "RunnerWriteAllowlistEntryRead",
+    "RunnerWriteAllowlistService",
+    "load_runner_allowlist",
+]
+
+#: Bounds on a granted pattern/scope. An ``op_pattern`` is a dotted op-glob and
+#: a ``target_scope`` is ``*`` or a uuid string; neither is ever near this cap,
+#: which exists only to reject pathological input at the API boundary.
+_FIELD_MAX_LENGTH = 512
+
+
+def _is_unique_violation(exc: IntegrityError) -> bool:
+    """Return whether *exc* is a unique-constraint violation (Postgres / SQLite)."""
+    orig = getattr(exc, "orig", None)
+    sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    return sqlstate == "23505" or "UNIQUE constraint failed" in str(orig or exc)
+
+
+class RemoteWriteCapabilityGrant(BaseModel):
+    """Input shape for :meth:`RunnerWriteAllowlistService.grant`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    #: A glob over ``op_id`` (``fnmatch``): an exact op-class for a minimal
+    #: Stage-1 allowlist, or a ``*`` prefix.
+    op_pattern: str = Field(min_length=1, max_length=_FIELD_MAX_LENGTH)
+    #: The target-scope cap: ``*`` (any target in the tenant) or a concrete
+    #: ``str(target.id)``. Defaults to ``*`` for ergonomics; the operator
+    #: narrows it to bound the blast radius.
+    target_scope: str = Field(default="*", min_length=1, max_length=_FIELD_MAX_LENGTH)
+
+
+class RunnerWriteAllowlistEntryRead(BaseModel):
+    """One granted remote-write capability, as returned by the accessors."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    runner_principal_id: uuid.UUID
+    op_pattern: str
+    target_scope: str
+    created_by_sub: str
+    created_at: datetime
+
+
+class RunnerWriteAllowlistService:
+    """Tenant-scoped grant / list of a runner principal's write capabilities.
+
+    Stateless; instantiate per request and call freely.
+    """
+
+    def __init__(self) -> None:
+        self._log = structlog.get_logger()
+
+    async def _resolve_runner_id(
+        self, session: AsyncSession, *, tenant_id: uuid.UUID, runner_name: str
+    ) -> uuid.UUID:
+        """Return the (non-revoked) runner principal id for ``(tenant, name)``.
+
+        Raises :class:`RunnerPrincipalNotFoundError` when no live principal
+        matches — a revoked or unknown runner gets no new write capability, and
+        the lookup adds no existence oracle beyond the name the operator already
+        supplied.
+        """
+        runner_pk = await session.scalar(
+            select(RunnerPrincipal.id).where(
+                RunnerPrincipal.tenant_id == tenant_id,
+                RunnerPrincipal.name == runner_name,
+                RunnerPrincipal.revoked.is_(False),
+            )
+        )
+        if runner_pk is None:
+            raise RunnerPrincipalNotFoundError(runner_name)
+        return runner_pk
+
+    async def grant(
+        self,
+        tenant_id: uuid.UUID,
+        runner_name: str,
+        created_by_sub: str,
+        payload: RemoteWriteCapabilityGrant,
+    ) -> RunnerWriteAllowlistEntryRead:
+        """Grant one remote-write capability to a runner (the human step).
+
+        Resolves the live runner principal, inserts one
+        ``runner_write_allowlist`` row, and returns it. Idempotent: a re-grant
+        of the same ``(op_pattern, target_scope)`` returns the existing row
+        (the unique index absorbs the duplicate) rather than erroring.
+
+        Raises
+        ------
+        RunnerPrincipalNotFoundError
+            No live runner principal matches ``(tenant_id, runner_name)``.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            runner_principal_id = await self._resolve_runner_id(
+                session, tenant_id=tenant_id, runner_name=runner_name
+            )
+            row = RunnerWriteAllowlistEntry(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                runner_principal_id=runner_principal_id,
+                op_pattern=payload.op_pattern,
+                target_scope=payload.target_scope,
+                created_by_sub=created_by_sub,
+            )
+            session.add(row)
+            try:
+                await session.flush()
+            except IntegrityError as exc:
+                await session.rollback()
+                if not _is_unique_violation(exc):
+                    raise
+                existing = await self._get_entry(
+                    session,
+                    runner_principal_id=runner_principal_id,
+                    op_pattern=payload.op_pattern,
+                    target_scope=payload.target_scope,
+                )
+                self._log.info(
+                    "runner_write_allowlist_grant_idempotent",
+                    tenant_id=str(tenant_id),
+                    runner=runner_name,
+                    op_pattern=payload.op_pattern,
+                    target_scope=payload.target_scope,
+                )
+                return existing
+            await session.refresh(row)
+            entry = RunnerWriteAllowlistEntryRead.model_validate(row)
+            await session.commit()
+        self._log.info(
+            "runner_write_allowlist_granted",
+            tenant_id=str(tenant_id),
+            runner=runner_name,
+            op_pattern=payload.op_pattern,
+            target_scope=payload.target_scope,
+            created_by_sub=created_by_sub,
+        )
+        return entry
+
+    async def _get_entry(
+        self,
+        session: AsyncSession,
+        *,
+        runner_principal_id: uuid.UUID,
+        op_pattern: str,
+        target_scope: str,
+    ) -> RunnerWriteAllowlistEntryRead:
+        """Fetch the single row for a fully-scoped capability (idempotent-grant path)."""
+        row = (
+            await session.execute(
+                select(RunnerWriteAllowlistEntry).where(
+                    RunnerWriteAllowlistEntry.runner_principal_id == runner_principal_id,
+                    RunnerWriteAllowlistEntry.op_pattern == op_pattern,
+                    RunnerWriteAllowlistEntry.target_scope == target_scope,
+                )
+            )
+        ).scalar_one()
+        return RunnerWriteAllowlistEntryRead.model_validate(row)
+
+    async def list_(
+        self,
+        tenant_id: uuid.UUID,
+        runner_name: str,
+    ) -> list[RunnerWriteAllowlistEntryRead]:
+        """Return a runner's granted capabilities, op-sorted.
+
+        Raises :class:`RunnerPrincipalNotFoundError` when the runner is unknown
+        or revoked in this tenant (so listing and granting agree on existence).
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            runner_principal_id = await self._resolve_runner_id(
+                session, tenant_id=tenant_id, runner_name=runner_name
+            )
+            rows = (
+                (
+                    await session.execute(
+                        select(RunnerWriteAllowlistEntry)
+                        .where(RunnerWriteAllowlistEntry.runner_principal_id == runner_principal_id)
+                        .order_by(
+                            RunnerWriteAllowlistEntry.op_pattern,
+                            RunnerWriteAllowlistEntry.target_scope,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        return [RunnerWriteAllowlistEntryRead.model_validate(row) for row in rows]
+
+
+async def load_runner_allowlist(
+    session: AsyncSession, *, tenant_id: uuid.UUID, runner_name: str
+) -> tuple[RemoteWriteAllowEntry, ...]:
+    """Read a runner's remote-write allowlist for the central mint (#3190).
+
+    One indexed join on the ``(tenant_id, name)`` runner row → its capability
+    rows, projected into the shared, DB-free
+    :class:`~meho_backplane.runner.satellite_tier.RemoteWriteAllowEntry` the mint
+    feeds to :func:`~meho_backplane.runner.satellite_tier.evaluate_remote_write_gate`
+    — the *same* matcher the edge re-runs against its own config mirror. Runs in
+    the caller's open mint session. An unknown runner (no row) yields the empty
+    tuple, so the gate fails closed (unprovisioned) exactly as for a runner with
+    no granted capability.
+    """
+    rows = (
+        await session.execute(
+            select(
+                RunnerWriteAllowlistEntry.op_pattern,
+                RunnerWriteAllowlistEntry.target_scope,
+            )
+            .join(
+                RunnerPrincipal,
+                RunnerWriteAllowlistEntry.runner_principal_id == RunnerPrincipal.id,
+            )
+            .where(
+                RunnerPrincipal.tenant_id == tenant_id,
+                RunnerPrincipal.name == runner_name,
+                RunnerWriteAllowlistEntry.tenant_id == tenant_id,
+            )
+        )
+    ).all()
+    return tuple(
+        RemoteWriteAllowEntry(op_pattern=op_pattern, target_scope=target_scope)
+        for op_pattern, target_scope in rows
+    )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4260,6 +4260,97 @@ class RunnerPrincipal(Base):
     )
 
 
+class RunnerWriteAllowlistEntry(Base):
+    """One ``remote-write`` capability a runner principal is allowed to execute (#3190).
+
+    Mechanism 2 of the satellite write-path composed gate (Initiative #2901,
+    design ``docs/research/2901-satellite-write-path.md`` §3, decision
+    ``docs/decisions/satellite-write-path.md``). Each row grants one
+    ``(op_pattern, target_scope)`` capability to one runner principal; the set
+    of rows for a runner **is** the definition of that runner's write blast
+    radius (threats T1/T8). A ``remote-write`` (``caution``) op is minted to a
+    runner **only** when its ``op_id`` + target matches one of these rows
+    (checked at the central mint,
+    :func:`~meho_backplane.operations.gateway_commands.mint_gateway_command`)
+    **and** an approval binds it (#3189); the runner independently re-checks
+    its own provisioning-config mirror at the edge
+    (:func:`~meho_backplane.runner.executor._screen_item`), defence in depth.
+
+    **Not granted at enrollment.** Registering a runner principal
+    (:meth:`~meho_backplane.auth.runner_principals.RunnerPrincipalService.register`)
+    writes **no** rows here: programmatic enrollment can never grant write
+    capability at birth (decision recommendation 2, threat T7). A write
+    capability requires a separate human step —
+    :meth:`~meho_backplane.auth.runner_write_allowlist.RunnerWriteAllowlistService.grant`,
+    reachable only over the operator-gated REST route — so the runner cannot
+    widen its own allowlist (its read-only, route-caged token cannot reach the
+    grant path). ``created_by_sub`` records the granting human for the audit
+    trail, binding the capability at issuance.
+
+    Additive-only (migration-compat contract): a fresh table plus its indexes,
+    no ALTER of an existing object (migration ``0093``).
+    """
+
+    __tablename__ = "runner_write_allowlist"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    # The runner principal this capability is hung off. FK to the row's id
+    # (the same value the token's unforgeable ``runner_id`` claim carries).
+    runner_principal_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("runner_principal.id"),
+        nullable=False,
+    )
+    # A glob over ``op_id`` (``fnmatch`` semantics): an exact op-class for a
+    # minimal Stage-1 allowlist (``vmware.vm.tag_set``) or a prefix
+    # (``vmware.vm.*``). Matched by the shared, DB-free gate
+    # (:func:`~meho_backplane.runner.satellite_tier.evaluate_remote_write_gate`).
+    op_pattern: Mapped[str] = mapped_column(Text, nullable=False)
+    # A target-scope cap: ``*`` (any target in the tenant), or a concrete
+    # ``str(target.id)`` binding the capability to one target. Matched by the
+    # same gate against the work item's resolved target scope.
+    target_scope: Mapped[str] = mapped_column(Text, nullable=False)
+    # The human operator who granted this capability (never a runner) — the
+    # issuance binding that makes the grant a deliberate, auditable human step.
+    created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        # The mint reads "every allowlist row for runner R in tenant T"; the
+        # edge never touches this table (it reads its own config mirror).
+        Index(
+            "runner_write_allowlist_lookup_idx",
+            "tenant_id",
+            "runner_principal_id",
+            postgresql_using="btree",
+        ),
+        # At most one row per fully-scoped capability, so a re-grant of the
+        # same ``(op_pattern, target_scope)`` is idempotent rather than
+        # accumulating duplicates.
+        Index(
+            "uq_runner_write_allowlist_capability",
+            "runner_principal_id",
+            "op_pattern",
+            "target_scope",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
 class AddonPairing(Base):
     """A paired add-on product — a Keycloak service principal + a versioned contract.
 

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -63,6 +63,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.runner_write_allowlist import load_runner_allowlist
 from meho_backplane.db.models import (
     AuditLog,
     EndpointDescriptor,
@@ -91,6 +92,7 @@ from meho_backplane.operations.approval_queue import (
 from meho_backplane.runner.satellite_tier import (
     SatelliteMintTier,
     classify_satellite_tier,
+    evaluate_remote_write_gate,
 )
 from meho_backplane.runner.work_item_signing import (
     TARGETLESS_SCOPE,
@@ -161,8 +163,10 @@ class MintRefusalCode(StrEnum):
     tier (``dangerous`` / ``destructive`` — never minted to a satellite);
     ``REMOTE_WRITE_GATE_UNSATISFIED`` is the fail-closed refusal of the
     additive ``remote-write`` tier when no committed, single-use approval
-    binds the mint (mechanism 1, #3189 — and, once #3190 lands, when the
-    op-class is off the runner's allowlist); ``REMOTE_WRITE_SIGNING_UNAVAILABLE``
+    binds the mint (mechanism 1, #3189); ``REMOTE_WRITE_NOT_ALLOWLISTED`` is the
+    mechanism-2 refusal (#3190) — the op-class + target is not on the runner's
+    per-runner capability allowlist, ANDed with the approval binding so the tier
+    is satisfiable only when both pass; ``REMOTE_WRITE_SIGNING_UNAVAILABLE``
     refuses a remote-write mint that cannot be signed because the central
     signing key is not provisioned (#3189); ``RUNNER_REVOKED`` is the
     write-tier revocation refusal (#3192, the Stage-3 gate) — a revoked runner
@@ -177,6 +181,7 @@ class MintRefusalCode(StrEnum):
     INVALID_OP_SCHEMA = "invalid_op_schema"
     OP_NOT_SAFE = "op_not_safe"
     REMOTE_WRITE_GATE_UNSATISFIED = "remote_write_gate_unsatisfied"
+    REMOTE_WRITE_NOT_ALLOWLISTED = "remote_write_not_allowlisted"
     REMOTE_WRITE_SIGNING_UNAVAILABLE = "remote_write_signing_unavailable"
     RUNNER_REVOKED = "runner_revoked"
     POLICY_DENIED = "policy_denied"
@@ -555,6 +560,102 @@ async def mint_gateway_command(
     )
 
 
+async def _screen_remote_write(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    op_id: str,
+    target: Any,
+    params_hash: str,
+    runner_id: str,
+) -> tuple[Any, Any, MintResult | None]:
+    """Run the three read-only remote-write pre-checks, in fail-closed order.
+
+    Returns ``(approval, signing_key, refusal)``. On any fail-closed check
+    ``refusal`` is a :class:`MintResult` (the mint aborts **before** the
+    single-use latch); when it is ``None`` both ``approval`` and ``signing_key``
+    are bound. None of these three checks writes a row or consumes the approval:
+
+    1. **Approval binding** (mechanism 1, #3189) — a committed, un-consumed,
+       param-bound ``ApprovalRequest`` for ``(op, target, params_hash)``; none →
+       :attr:`MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED`.
+    2. **Signing key** (#3189) — the central Ed25519 key must be provisioned to
+       sign the capability; unavailable →
+       :attr:`MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE`.
+    3. **Per-runner allowlist** (mechanism 2, #3190) — the op-class + target must
+       be on the runner's ``runner_write_allowlist``, screened through the shared
+       :func:`~meho_backplane.runner.satellite_tier.evaluate_remote_write_gate`
+       matcher the DB-free edge re-runs (defence in depth); off-allowlist (or no
+       allowlist at all) → :attr:`MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED`.
+    """
+    from meho_backplane.settings import get_settings
+
+    raw_target_id = getattr(target, "id", None) if target is not None else None
+    target_id = raw_target_id if isinstance(raw_target_id, uuid.UUID) else None
+
+    approval = await find_remote_write_approval(
+        session,
+        tenant_id=operator.tenant_id,
+        op_id=op_id,
+        target_id=target_id,
+        params_hash=params_hash,
+    )
+    if approval is None:
+        return (
+            None,
+            None,
+            _refuse_remote_write(
+                MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED,
+                f"remote-write op {op_id!r} refused: no committed, unconsumed approval "
+                "binding for this (op, target, params); the caution tier mints only "
+                "against a human-approved ApprovalRequest (mechanism 1)",
+                op_id=op_id,
+                operator=operator,
+                runner_id=runner_id,
+            ),
+        )
+
+    try:
+        signing_key = load_signing_key(get_settings().satellite_write_signing_key)
+    except SigningKeyUnavailableError as exc:
+        return (
+            None,
+            None,
+            _refuse_remote_write(
+                MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE,
+                f"remote-write op {op_id!r} refused: {exc}",
+                op_id=op_id,
+                operator=operator,
+                runner_id=runner_id,
+            ),
+        )
+
+    # Mechanism 2 (#3190): the per-runner capability allowlist, ANDed with the
+    # approval binding above. The runner's rows are screened through the same
+    # shared matcher the edge re-runs -- an op-class/target outside the allowlist
+    # (or no allowlist at all) fails closed here.
+    allowlist = await load_runner_allowlist(
+        session, tenant_id=operator.tenant_id, runner_name=runner_id
+    )
+    gate = evaluate_remote_write_gate(
+        op_id=op_id, allowlist=allowlist, target_scope=_target_scope(target), runner_id=runner_id
+    )
+    if not gate.permitted:
+        return (
+            None,
+            None,
+            _refuse_remote_write(
+                MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED,
+                gate.reason,
+                op_id=op_id,
+                operator=operator,
+                runner_id=runner_id,
+            ),
+        )
+
+    return approval, signing_key, None
+
+
 async def _mint_remote_write(
     session: AsyncSession,
     *,
@@ -570,64 +671,32 @@ async def _mint_remote_write(
     started: float,
     safety_level: str,
 ) -> MintResult:
-    """Mint a signed remote-write capability against a committed approval (#3189).
+    """Mint a signed, allowlisted remote-write capability (#3189 + #3190).
 
-    Mechanism 1 of the composed write-path gate: the caution tier mints
-    **only** against a committed, single-use, param-bound ``ApprovalRequest``
-    for the identical ``(op, target, params_hash)`` — the human approval
-    decision is the authorization (policy gate bypassed for this tier, the
-    mould of ``approve_request``'s ``_approved=True`` re-dispatch). On a win
-    the capability is **signed** for offline edge verification.
-
-    **Composition point for #3190** (mechanism 2, the per-runner allowlist):
-    the allowlist check slots in below, ANDed with this approval binding.
-    Until #3190 wires it at the mint, the edge allowlist re-check
-    (``executor._screen_item`` → ``evaluate_remote_write_gate``, still
-    fail-closed) keeps the tier closed end-to-end.
-
-    Order matters: the approval is located read-only and the signing key
-    checked **before** the single-use latch is claimed, so a fail-closed
-    refusal never consumes an approval (the "a refusal writes no rows"
-    invariant holds).
+    The caution tier's authorization is the **composition** of two halves,
+    resolved read-only by :func:`_screen_remote_write` (approval binding + signing
+    key + the per-runner allowlist) **before** the single-use latch: the tier is
+    satisfiable only when **both** the committed approval **and** the allowlist
+    pass, and either absent fails closed. The human approval decision is the
+    authorization (policy gate bypassed for this tier, the mould of
+    ``approve_request``'s ``_approved=True`` re-dispatch); on a win the capability
+    is **signed** for offline edge verification, and the same allowlist matcher is
+    re-run at the DB-free edge (``executor._screen_item``), defence in depth.
     """
-    from meho_backplane.settings import get_settings
-
-    raw_target_id = getattr(target, "id", None) if target is not None else None
-    target_id = raw_target_id if isinstance(raw_target_id, uuid.UUID) else None
-
-    # #3190 allowlist check composes here, ANDed with the approval binding.
-    approval = await find_remote_write_approval(
+    approval, signing_key, refusal = await _screen_remote_write(
         session,
-        tenant_id=operator.tenant_id,
+        operator=operator,
         op_id=op_id,
-        target_id=target_id,
+        target=target,
         params_hash=params_hash,
+        runner_id=runner_id,
     )
-    if approval is None:
-        return _refuse_remote_write(
-            MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED,
-            f"remote-write op {op_id!r} refused: no committed, unconsumed approval "
-            "binding for this (op, target, params); the caution tier mints only "
-            "against a human-approved ApprovalRequest (mechanism 1)",
-            op_id=op_id,
-            operator=operator,
-            runner_id=runner_id,
-        )
-
-    try:
-        signing_key = load_signing_key(get_settings().satellite_write_signing_key)
-    except SigningKeyUnavailableError as exc:
-        return _refuse_remote_write(
-            MintRefusalCode.REMOTE_WRITE_SIGNING_UNAVAILABLE,
-            f"remote-write op {op_id!r} refused: {exc}",
-            op_id=op_id,
-            operator=operator,
-            runner_id=runner_id,
-        )
-
-    # Claim the single-use latch only now the mint is certain to proceed. A
-    # racing mint that already claimed this approval loses (touches zero rows),
-    # so an approval binds at most one capability.
+    if refusal is not None:
+        return refusal
+    # refusal is None ⇒ the approval + signing key are bound (invariant of
+    # _screen_remote_write); claim the single-use latch only now the mint is
+    # certain to proceed. A racing mint that already claimed this approval loses
+    # (touches zero rows), so an approval binds at most one capability.
     if not await consume_remote_write_approval(session, approval):
         return _refuse_remote_write(
             MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED,

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -20,7 +20,10 @@ owned by #2500):
   ``EXCLUDED`` (``dangerous`` / ``destructive``) item is refused outright;
   a ``REMOTE_WRITE`` (``caution``) item has its centre-issued Ed25519
   signature verified offline (integrity + freshness + target scope, #3189)
-  and is then re-screened through the allowlist gate, failing closed at
+  and is then re-screened through the per-runner allowlist gate (#3190)
+  against the runner's **own** provisioning config
+  (``satellite_write_allowlist``) — not the mint's, so an item allowlisted
+  centrally is still refused if the edge config disagrees — failing closed at
   every step until the runner is authorised for the tier; only a ``SAFE``
   item proceeds.
 * **connector-tree-only** — a ``handler_ref`` that does not resolve inside
@@ -53,6 +56,7 @@ from meho_backplane.runner.satellite_tier import (
     SatelliteMintTier,
     classify_satellite_tier,
     evaluate_remote_write_gate,
+    parse_runner_allowlist,
 )
 from meho_backplane.runner.spool import ExecutedCommandStore
 from meho_backplane.runner.wire import RunnerResult, RunnerWorkItem
@@ -97,6 +101,8 @@ def _screen_item(item: RunnerWorkItem) -> str | None:
     import so an out-of-tree ``handler_ref`` never triggers a module-load side
     effect.
     """
+    from meho_backplane.settings import get_settings
+
     tier = classify_satellite_tier(item.safety_level)
     if tier is SatelliteMintTier.EXCLUDED:
         return (
@@ -111,11 +117,22 @@ def _screen_item(item: RunnerWorkItem) -> str | None:
         signature_refusal = _verify_remote_write_signature(item)
         if signature_refusal is not None:
             return signature_refusal
-        # Mechanism 2 edge re-check (#3190): the per-runner allowlist. Still
-        # fail-closed until #3190 wires it, so a validly-signed remote-write
-        # item does not execute at the edge until the allowlist is provisioned
-        # — the tier stays closed end-to-end.
-        decision = evaluate_remote_write_gate(op_id=item.op_id)
+        # Mechanism 2 edge re-check (#3190): the per-runner allowlist. The
+        # DB-free runner screens the op against its **own** provisioning-config
+        # allowlist (never the mint's, and never a field on the work item) —
+        # defence in depth, so an item allowlisted at the mint is still refused
+        # if the runner's own config disagrees. Fed to the same shared matcher
+        # the mint ran; fail-closed when the config is unprovisioned.
+        target_scope = (
+            str(item.target_descriptor.id)
+            if item.target_descriptor is not None
+            else TARGETLESS_SCOPE
+        )
+        decision = evaluate_remote_write_gate(
+            op_id=item.op_id,
+            allowlist=parse_runner_allowlist(get_settings().satellite_write_allowlist),
+            target_scope=target_scope,
+        )
         if not decision.permitted:
             return decision.reason
         # Mechanism 3 (#3191) edge check, composed after the gate: a

--- a/backend/src/meho_backplane/runner/satellite_tier.py
+++ b/backend/src/meho_backplane/runner/satellite_tier.py
@@ -45,16 +45,28 @@ schema migration.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from fnmatch import fnmatchcase
 
 __all__ = [
     "REMOTE_WRITE_SAFETY_LEVELS",
+    "TARGETLESS_SCOPE",
+    "RemoteWriteAllowEntry",
     "RemoteWriteGateDecision",
     "SatelliteMintTier",
     "classify_satellite_tier",
     "evaluate_remote_write_gate",
+    "parse_runner_allowlist",
 ]
+
+#: The canonical ``target_scope`` token for a targetless op (no resolved
+#: target). Mirrors
+#: :data:`meho_backplane.runner.work_item_signing.TARGETLESS_SCOPE`; duplicated
+#: here (rather than imported) so this DB-free module keeps its stdlib-only
+#: import surface. A concrete op scopes to ``str(target.id)``.
+TARGETLESS_SCOPE = ""
 
 #: The ``safety_level`` values that classify into
 #: :attr:`SatelliteMintTier.REMOTE_WRITE`. The SQL-expressible companion of
@@ -113,7 +125,30 @@ class RemoteWriteGateDecision:
     reason: str
 
 
-#: The invariant part of every fail-closed remote-write refusal reason.
+@dataclass(frozen=True)
+class RemoteWriteAllowEntry:
+    """One entry of a runner's remote-write capability allowlist (#3190).
+
+    :attr:`op_pattern` is a glob over ``op_id`` (``fnmatch`` semantics: an
+    exact op-class, or a ``*`` prefix); :attr:`target_scope` is a cap on the
+    target — ``*`` for any target in the tenant, or a concrete
+    ``str(target.id)`` binding the capability to one target.
+
+    The **single source of truth** the two enforcement layers share: the
+    central mint builds these from the ``runner_write_allowlist`` rows and the
+    DB-free edge builds them from its own provisioning config
+    (:func:`parse_runner_allowlist`), so both feed the *same*
+    :func:`evaluate_remote_write_gate` matcher — the defence-in-depth mould the
+    safe wall uses with :func:`classify_satellite_tier`.
+    """
+
+    op_pattern: str
+    target_scope: str = "*"
+
+
+#: The invariant part of the fail-closed refusal reason when a runner has **no**
+#: remote-write allowlist at all (the unprovisioned Stage-0 state — every runner
+#: today). Kept verbatim so the #3188 fail-closed conformance assertions hold.
 _UNPROVISIONED_REASON = (
     "the composed write-path gate (per-runner allowlist + approval/policy "
     "binding) is not provisioned; no runner is authorised for the "
@@ -121,27 +156,80 @@ _UNPROVISIONED_REASON = (
 )
 
 
+def parse_runner_allowlist(raw: str) -> tuple[RemoteWriteAllowEntry, ...]:
+    """Parse a runner's own allowlist config string into allow-entries (edge side).
+
+    The runner is DB-free, so it learns its allowlist from its provisioning
+    config (:attr:`meho_backplane.settings.Settings.satellite_write_allowlist`,
+    provisioned at enrollment beside the verification key), not from the DB.
+    The format is a comma-separated list of ``op_pattern`` or
+    ``op_pattern@target_scope`` tokens (``@`` omitted ⇒ ``target_scope='*'``);
+    blank tokens are skipped. Deliberately trivial + stdlib-only so it never
+    pulls the central stack onto the edge. Example:
+    ``"vmware.vm.tag_set@*,vmware.vm.annotation_set"``.
+    """
+    entries: list[RemoteWriteAllowEntry] = []
+    for token in raw.split(","):
+        spec = token.strip()
+        if not spec:
+            continue
+        op_pattern, sep, target_scope = spec.partition("@")
+        op_pattern = op_pattern.strip()
+        if not op_pattern:
+            continue
+        scope = target_scope.strip() if sep else "*"
+        entries.append(RemoteWriteAllowEntry(op_pattern=op_pattern, target_scope=scope or "*"))
+    return tuple(entries)
+
+
+def _entry_admits(entry: RemoteWriteAllowEntry, *, op_id: str, target_scope: str) -> bool:
+    """Whether *entry* covers this ``op_id`` + resolved ``target_scope``.
+
+    Case-sensitive glob on both axes (``op_id`` is case-sensitive): the op must
+    match ``op_pattern`` and the concrete target must fall within the entry's
+    ``target_scope`` cap (``*`` admits any target, including the targetless
+    scope).
+    """
+    return fnmatchcase(op_id, entry.op_pattern) and fnmatchcase(target_scope, entry.target_scope)
+
+
 def evaluate_remote_write_gate(
-    *, op_id: str, runner_id: str | None = None
+    *,
+    op_id: str,
+    allowlist: Sequence[RemoteWriteAllowEntry] = (),
+    target_scope: str = TARGETLESS_SCOPE,
+    runner_id: str | None = None,
 ) -> RemoteWriteGateDecision:
-    """The composed remote-write gate — fail-closed until the siblings wire it.
+    """The composed remote-write gate's **allowlist half** — mechanism 2 (#3190).
 
-    A ``remote-write`` op mints (and executes at the edge) **only** when its
-    op-class is on the runner's enrollment allowlist **and** either policy
-    ``AUTO_EXECUTE`` (the idempotent subset) or a committed ``ApprovalRequest``
-    (the caution subset) authorises it — the four-mechanism composition of
-    design §3. That allowlist + approval/signing machinery is filed as sibling
-    tasks (#3189-#3193) and does not exist yet, so there is no way to authorise
-    a remote-write capability: this seam refuses **every** remote-write op.
+    A ``remote-write`` op is admitted **only** when its ``op_id`` + resolved
+    ``target_scope`` matches one entry of the runner's *allowlist*. That
+    allowlist is the runner's write blast radius (design §3, threats T1/T8): the
+    central mint passes the ``runner_write_allowlist`` rows; the DB-free edge
+    passes its own provisioning-config mirror (:func:`parse_runner_allowlist`).
+    Both call this same matcher — "checked at mint *and* re-checked at the edge"
+    — so a remote-write item is screened independently at each layer.
 
-    Both the central mint and the edge executor call this independently —
-    mechanism 2's "checked at mint *and* re-checked at the edge" — so a
-    remote-write item fails closed at each layer on its own.
+    This is one half of the tier's authorization: the caller ANDs it with the
+    approval binding (#3189/#3246) — at the mint a committed ``ApprovalRequest``,
+    at the edge the centre's Ed25519 signature — so the tier is satisfiable only
+    when **both** the allowlist and the approval binding pass. Fail-closed on
+    each side: an **empty** allowlist (no capability provisioned — every runner
+    today) keeps the invariant unprovisioned reason; a **non-empty** allowlist
+    with no matching entry refuses as off-allowlist. Neither writes a row.
     """
     subject = f"remote-write op {op_id!r}"
     if runner_id is not None:
         subject += f" for runner {runner_id!r}"
-    return RemoteWriteGateDecision(
-        permitted=False,
-        reason=f"{subject} refused: {_UNPROVISIONED_REASON}",
-    )
+
+    if any(_entry_admits(entry, op_id=op_id, target_scope=target_scope) for entry in allowlist):
+        return RemoteWriteGateDecision(permitted=True, reason="")
+
+    if not allowlist:
+        reason = f"{subject} refused: {_UNPROVISIONED_REASON}"
+    else:
+        reason = (
+            f"{subject} refused: op-class + target (scope {target_scope!r}) is not on "
+            "this runner's remote-write allowlist"
+        )
+    return RemoteWriteGateDecision(permitted=False, reason=reason)

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1351,6 +1351,18 @@ class Settings(BaseModel):
     # print(base64.b64encode(k.public_key().public_bytes_raw()).decode())'``.
     satellite_write_signing_key: str = ""
     satellite_write_verify_key: str = ""
+    # Initiative #2901 (#3190) -- the runner's OWN remote-write capability
+    # allowlist (mechanism 2), provisioned at enrollment beside the
+    # verification key. The DB-free edge cannot read the central
+    # ``runner_write_allowlist`` table, so it re-checks its own config mirror
+    # in ``executor._screen_item`` (defence in depth: an item allowlisted at
+    # the mint is still refused if this config disagrees). Format: a
+    # comma-separated list of ``op_pattern`` or ``op_pattern@target_scope``
+    # tokens (``@`` omitted => ``target_scope='*'``), e.g.
+    # ``"vmware.vm.tag_set@*,vmware.vm.annotation_set"``; default ``""`` is
+    # fail-closed (no remote-write executes at the edge until provisioned).
+    # Central-only deployments (no runner role) leave this unset.
+    satellite_write_allowlist: str = ""
     ui_keycloak_client_id: str = ""
     ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
@@ -2113,6 +2125,7 @@ def get_settings() -> Settings:
         ),
         satellite_write_signing_key=os.environ.get("SATELLITE_WRITE_SIGNING_KEY", "").strip(),
         satellite_write_verify_key=os.environ.get("SATELLITE_WRITE_VERIFY_KEY", "").strip(),
+        satellite_write_allowlist=os.environ.get("SATELLITE_WRITE_ALLOWLIST", "").strip(),
         ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", "").strip(),
         ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", "").strip(),
         ui_session_encryption_key=os.environ.get("UI_SESSION_ENCRYPTION_KEY", "").strip(),

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -278,6 +278,14 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # every PG-backed acceptance test errors at setup with ``cannot truncate
     # a table referenced in a foreign key constraint``.
     "runner_principal",
+    # ``runner_write_allowlist.tenant_id`` is a real ``REFERENCES tenant(id)``
+    # FK from migration ``0093`` (#3190 per-runner capability allowlist), and it
+    # also carries a real FK ``runner_principal(id)``. PG rejects truncating
+    # ``tenant`` / ``runner_principal`` unless every referencing table is listed
+    # in the same statement, so ``runner_write_allowlist`` must appear here or
+    # every PG-backed acceptance test errors at setup with ``cannot truncate a
+    # table referenced in a foreign key constraint``.
+    "runner_write_allowlist",
     # ``scheduled_trigger.tenant_id`` and ``.agent_definition_id`` are real
     # ``REFERENCES`` FKs from migration ``0020`` (G11.3-T1 #822); the table
     # must be listed so the non-cascading multi-table TRUNCATE can drop

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -473,7 +473,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
-                "agent_principal, runner_principal, "
+                "agent_principal, runner_principal, runner_write_allowlist, "
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "
@@ -547,7 +547,7 @@ async def pg_engine_empty_tenant(
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
-                "agent_principal, runner_principal, "
+                "agent_principal, runner_principal, runner_write_allowlist, "
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, "

--- a/backend/tests/test_api_v1_runner_principals.py
+++ b/backend/tests/test_api_v1_runner_principals.py
@@ -146,6 +146,27 @@ async def _seed_tenants() -> None:
         await session.commit()
 
 
+async def _seed_runner_row(name: str, *, tenant_id: uuid.UUID = _TENANT_A) -> uuid.UUID:
+    """Insert a runner principal row directly (no Keycloak) for allowlist tests."""
+    runner_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            RunnerPrincipal(
+                id=runner_id,
+                tenant_id=tenant_id,
+                name=name,
+                keycloak_client_id=f"runner:{name}",
+                keycloak_internal_id=f"kc-{name}",
+                owner_sub="owner-sub",
+                created_by_sub="creator-sub",
+                revoked=False,
+            )
+        )
+        await session.commit()
+    return runner_id
+
+
 async def _fetch_principals(tenant_id: uuid.UUID) -> list[RunnerPrincipal]:
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -800,6 +821,122 @@ async def test_runner_kind_token_caged_from_non_gateway_route(client: TestClient
         resp = client.get(
             "/api/v1/agent-principals",
             headers={"Authorization": f"Bearer {_runner_token(key)}"},
+        )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "runner_scope_violation"
+
+
+# ---------------------------------------------------------------------------
+# Write-allowlist provisioning (#3190, mechanism 2) — grant + list + cage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_allowlist_grant_and_list_round_trip(client: TestClient) -> None:
+    """POST grant (201) → GET list returns the granted capability.
+
+    The separate human step a write capability requires after enrollment: the
+    runner row exists (enrollment) but carries no capability until a
+    ``tenant_admin`` grants one here.
+    """
+    await _seed_tenants()
+    runner_id = await _seed_runner_row("edge-runner")
+    key = make_rsa_keypair("kid-wa-rt")
+
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        admin_headers = {"Authorization": f"Bearer {_token(key)}"}
+
+        # Enrollment granted nothing: the allowlist starts empty.
+        empty = client.get(
+            "/api/v1/runner-principals/edge-runner/write-allowlist", headers=admin_headers
+        )
+        assert empty.status_code == 200, empty.text
+        assert empty.json()["entries"] == []
+
+        granted = client.post(
+            "/api/v1/runner-principals/edge-runner/write-allowlist",
+            json={"op_pattern": "vmware.vm.tag_set", "target_scope": "*"},
+            headers=admin_headers,
+        )
+        assert granted.status_code == 201, granted.text
+        body = granted.json()
+        assert body["op_pattern"] == "vmware.vm.tag_set"
+        assert body["target_scope"] == "*"
+        assert body["runner_principal_id"] == str(runner_id)
+        assert body["created_by_sub"] == "op-admin"
+
+        listed = client.get(
+            "/api/v1/runner-principals/edge-runner/write-allowlist", headers=admin_headers
+        )
+        assert listed.status_code == 200
+        entries = listed.json()["entries"]
+        assert len(entries) == 1
+        assert entries[0]["op_pattern"] == "vmware.vm.tag_set"
+
+
+@pytest.mark.asyncio
+async def test_write_allowlist_grant_requires_admin(client: TestClient) -> None:
+    """``operator`` may read the allowlist but not grant (403) — a grant is a privilege."""
+    await _seed_tenants()
+    await _seed_runner_row("edge-runner")
+    key = make_rsa_keypair("kid-wa-rbac")
+
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        op_headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+
+        assert (
+            client.get(
+                "/api/v1/runner-principals/edge-runner/write-allowlist", headers=op_headers
+            ).status_code
+            == 200
+        )
+        assert (
+            client.post(
+                "/api/v1/runner-principals/edge-runner/write-allowlist",
+                json={"op_pattern": "vmware.vm.tag_set"},
+                headers=op_headers,
+            ).status_code
+            == 403
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_allowlist_grant_unknown_runner_404(client: TestClient) -> None:
+    """Granting to an unknown runner returns 404."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-wa-404")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/runner-principals/ghost/write-allowlist",
+            json={"op_pattern": "vmware.vm.tag_set"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "runner_principal_not_found"
+
+
+@pytest.mark.asyncio
+async def test_runner_cannot_widen_its_own_allowlist(client: TestClient) -> None:
+    """A runner-kind token is 403'd on the grant route — it cannot self-widen (T7).
+
+    The write-allowlist routes live under ``/api/v1/runner-principals/``, outside
+    :data:`~meho_backplane.middleware.RUNNER_ALLOWED_PATH_PREFIXES`, so the
+    negative cage fail-closed 403s a runner's own read-only token before the
+    route runs — the enrollment path can never be turned into self-service
+    write-capability widening.
+    """
+    await _seed_tenants()
+    runner_id = await _seed_runner_row("edge-runner")
+    key = make_rsa_keypair("kid-wa-cage")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/runner-principals/edge-runner/write-allowlist",
+            json={"op_pattern": "vmware.vm.tag_set"},
+            headers={"Authorization": f"Bearer {_runner_token(key, runner_id=runner_id)}"},
         )
     assert resp.status_code == 403
     assert resp.json()["detail"] == "runner_scope_violation"

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -38,6 +38,7 @@ from meho_backplane.db.models import (
     GatewayCommandStatus,
     PermissionVerdict,
     RunnerPrincipal,
+    RunnerWriteAllowlistEntry,
     Tenant,
 )
 from meho_backplane.gateway.queue import (
@@ -218,6 +219,49 @@ async def _seed_runner_principal(*, revoked: bool, name: str = _RUNNER) -> None:
         await session.commit()
 
 
+async def _seed_write_allowlist(*, op_pattern: str = _OP_ID, target_scope: str = "*") -> None:
+    """Seed a runner principal (idempotent) + one write-allowlist entry (#3190).
+
+    The mint's ``load_runner_allowlist`` joins the ``runner_write_allowlist``
+    rows to the ``(tenant, name)`` runner principal, so both must exist for the
+    op to be admitted. Idempotent on the principal so a test can seed several
+    capabilities.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        runner_pk = await session.scalar(
+            select(RunnerPrincipal.id).where(
+                RunnerPrincipal.tenant_id == _TENANT,
+                RunnerPrincipal.name == _RUNNER,
+            )
+        )
+        if runner_pk is None:
+            runner_pk = uuid.uuid4()
+            session.add(
+                RunnerPrincipal(
+                    id=runner_pk,
+                    tenant_id=_TENANT,
+                    name=_RUNNER,
+                    keycloak_client_id=f"runner:{_RUNNER}",
+                    keycloak_internal_id=f"kc-{_RUNNER}",
+                    owner_sub="owner-sub",
+                    created_by_sub="creator-sub",
+                    revoked=False,
+                )
+            )
+        session.add(
+            RunnerWriteAllowlistEntry(
+                id=uuid.uuid4(),
+                tenant_id=_TENANT,
+                runner_principal_id=runner_pk,
+                op_pattern=op_pattern,
+                target_scope=target_scope,
+                created_by_sub="operator-sub",
+            )
+        )
+        await session.commit()
+
+
 async def _claim() -> None:
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -348,6 +392,9 @@ async def test_mint_remote_write_binds_approval_and_signs(
     approval is consumed single-use.
     """
     approval_id = await _seed_committed_approval()
+    # #3190: the caution tier now also requires the op-class on the runner's
+    # allowlist (ANDed with the approval binding).
+    await _seed_write_allowlist()
 
     result = await _mint_caution(monkeypatch)
 
@@ -403,6 +450,7 @@ async def test_mint_remote_write_approval_is_single_use(
 ) -> None:
     """One committed approval mints at most one capability."""
     await _seed_committed_approval()
+    await _seed_write_allowlist()
 
     first = await _mint_caution(monkeypatch)
     second = await _mint_caution(monkeypatch)
@@ -463,6 +511,73 @@ async def test_mint_remote_write_ignores_non_approved_request(
     assert not result.minted
     assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_GATE_UNSATISFIED
     assert await _count(GatewayCommand) == 0
+
+
+# ---------------------------------------------------------------------------
+# Remote-write tier — per-runner capability allowlist (#3190, mechanism 2)
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_remote_write_refused_without_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caution op with a valid approval but NO allowlist is refused (fail-closed).
+
+    The composed gate is satisfiable only when **both** halves pass: even with a
+    committed, param-bound approval binding, an unprovisioned runner allowlist
+    refuses the mint with the tier's own ``REMOTE_WRITE_NOT_ALLOWLISTED`` code,
+    writes no command row, and leaves the approval **unconsumed** (the allowlist
+    gate is read-only, before the single-use latch).
+    """
+    approval_id = await _seed_committed_approval()
+
+    result = await _mint_caution(monkeypatch)
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED
+    assert "remote-write" in (result.refusal_reason or "")
+    assert await _count(GatewayCommand) == 0
+    assert await _approval_resumed_at(approval_id) is None
+
+
+async def test_mint_remote_write_refused_off_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caution op on an approval but off the runner's allowlist is refused.
+
+    The runner has a provisioned allowlist, but for a *different* op-class, so
+    the op-class outside the allowlist is refused with the distinct
+    ``REMOTE_WRITE_NOT_ALLOWLISTED`` code — the approval alone cannot punch an
+    off-allowlist op through, and the approval stays unconsumed.
+    """
+    approval_id = await _seed_committed_approval()
+    await _seed_write_allowlist(op_pattern="net.some_other_write")
+
+    result = await _mint_caution(monkeypatch)
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED
+    assert "not on this runner's remote-write allowlist" in (result.refusal_reason or "")
+    assert await _count(GatewayCommand) == 0
+    assert await _approval_resumed_at(approval_id) is None
+
+
+async def test_mint_remote_write_stage1_single_class_admits_exactly_that_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-class Stage-1 allowlist admits exactly that op-class at the mint.
+
+    The runner is granted exactly ``_OP_ID``; that op (with its approval) mints,
+    while a sibling caution op — approved but not on the allowlist — is refused.
+    Proves the allowlist, not the approval, is what bounds the blast radius.
+    """
+    await _seed_committed_approval()
+    await _seed_write_allowlist(op_pattern=_OP_ID)
+
+    admitted = await _mint_caution(monkeypatch)
+
+    assert admitted.minted
+    assert await _count(GatewayCommand) == 1
 
 
 async def test_mint_refuses_poisoned_parameter_schema(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_runner_executor.py
+++ b/backend/tests/test_runner_executor.py
@@ -280,3 +280,63 @@ async def test_tampered_signed_item_is_refused_end_to_end(monkeypatch: pytest.Mo
     assert result.status == "refused"
     assert result.result is None
     assert "remote-write" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Per-runner allowlist edge re-check (#3190, mechanism 2) — defence in depth
+# ---------------------------------------------------------------------------
+
+
+def _set_edge_allowlist(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    """Provision the runner's OWN allowlist config, then re-load settings."""
+    monkeypatch.setenv("SATELLITE_WRITE_ALLOWLIST", raw)
+    get_settings.cache_clear()
+
+
+async def test_edge_refuses_validly_signed_item_off_config_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Defence in depth: an item the centre validly signed (i.e. allowlisted at
+    # the mint) is STILL refused at the edge when the runner's own config
+    # allowlist disagrees — the runner never trusts the mint's allowlist.
+    signing_key = _provision_verify_key(monkeypatch)
+    _set_edge_allowlist(monkeypatch, "vmware.vm.some_other_op")  # not the signed op
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+
+    result = await execute_work_item(item)
+
+    assert result.status == "refused"
+    assert "not on this runner's remote-write allowlist" in (result.error or "")
+
+
+async def test_edge_refuses_when_config_allowlist_unprovisioned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No runner allowlist config at all → fail-closed (unprovisioned), even for
+    # a validly-signed item. This is every runner today (Stage 0).
+    signing_key = _provision_verify_key(monkeypatch)
+    _set_edge_allowlist(monkeypatch, "")
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+
+    result = await execute_work_item(item)
+
+    assert result.status == "refused"
+    assert "remote-write" in (result.error or "")
+
+
+async def test_edge_allowlist_gate_crossed_when_config_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A validly-signed item whose op-class is on the runner's own config
+    # allowlist crosses the allowlist gate — the remaining refusal is the
+    # *credential* screen (mechanism 3), not the allowlist, proving the gate
+    # was passed rather than short-circuited.
+    signing_key = _provision_verify_key(monkeypatch)
+    _set_edge_allowlist(monkeypatch, "vmware.vm.tag_set")  # the signed op
+    item = _signed_rw_item(signing_key, expires_at=datetime.now(UTC) + timedelta(minutes=5))
+
+    result = await execute_work_item(item)
+
+    assert result.status == "refused"
+    assert "allowlist" not in (result.error or "")
+    assert "wrapped credential" in (result.error or "")

--- a/backend/tests/test_runner_satellite_tier.py
+++ b/backend/tests/test_runner_satellite_tier.py
@@ -13,9 +13,11 @@ import pytest
 
 from meho_backplane.runner.satellite_tier import (
     REMOTE_WRITE_SAFETY_LEVELS,
+    RemoteWriteAllowEntry,
     SatelliteMintTier,
     classify_satellite_tier,
     evaluate_remote_write_gate,
+    parse_runner_allowlist,
 )
 
 # Every ``safety_level`` value the classifier recognises (the closed
@@ -76,3 +78,98 @@ def test_remote_write_safety_levels_match_classifier() -> None:
     assert classifier_remote_write == REMOTE_WRITE_SAFETY_LEVELS
     # Concretely, only ``caution`` today.
     assert frozenset({"caution"}) == REMOTE_WRITE_SAFETY_LEVELS
+
+
+# ---------------------------------------------------------------------------
+# Allowlist gate (mechanism 2, #3190) — the shared matcher both layers run
+# ---------------------------------------------------------------------------
+
+
+def test_gate_admits_op_on_allowlist() -> None:
+    # A provisioned allowlist that covers the op admits it (permitted, no reason).
+    allowlist = (RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),)
+    decision = evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set", allowlist=allowlist, target_scope="tgt-1"
+    )
+    assert decision.permitted is True
+    assert decision.reason == ""
+
+
+def test_gate_stage1_single_class_admits_exactly_that_class() -> None:
+    # A single-enumerated-class Stage-1 allowlist admits exactly that op-class
+    # and refuses every other — the minimal blast radius the rollout starts at.
+    allowlist = (RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),)
+
+    admitted = evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set", allowlist=allowlist, target_scope="tgt-1"
+    )
+    other = evaluate_remote_write_gate(
+        op_id="vmware.vm.power_off", allowlist=allowlist, target_scope="tgt-1"
+    )
+
+    assert admitted.permitted is True
+    assert other.permitted is False
+    assert "not on this runner's remote-write allowlist" in other.reason
+    assert "vmware.vm.power_off" in other.reason
+
+
+def test_gate_off_allowlist_is_distinct_from_unprovisioned() -> None:
+    # An empty allowlist is the *unprovisioned* fail-closed state (Stage 0);
+    # a non-empty allowlist with no match is the *off-allowlist* refusal. Both
+    # fail closed, but the reasons are distinct for observability.
+    unprovisioned = evaluate_remote_write_gate(op_id="vmware.vm.tag_set", allowlist=())
+    off_list = evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set",
+        allowlist=(RemoteWriteAllowEntry("vmware.vm.annotation_set", "*"),),
+    )
+    assert unprovisioned.permitted is False and "not provisioned" in unprovisioned.reason
+    assert off_list.permitted is False and "not on this runner's remote-write" in off_list.reason
+
+
+def test_gate_target_scope_cap_binds_to_one_target() -> None:
+    # A target-scoped cap admits only the bound target; a re-pointed target is
+    # refused even though the op-class matches.
+    allowlist = (RemoteWriteAllowEntry("vmware.vm.tag_set", "tgt-blessed"),)
+
+    on_target = evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set", allowlist=allowlist, target_scope="tgt-blessed"
+    )
+    wrong_target = evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set", allowlist=allowlist, target_scope="tgt-other"
+    )
+    assert on_target.permitted is True
+    assert wrong_target.permitted is False
+
+
+def test_gate_op_pattern_glob_matches_prefix() -> None:
+    # An ``op_pattern`` glob covers a family of ops.
+    allowlist = (RemoteWriteAllowEntry("vmware.vm.*", "*"),)
+    assert evaluate_remote_write_gate(
+        op_id="vmware.vm.tag_set", allowlist=allowlist, target_scope="t"
+    ).permitted
+    assert not evaluate_remote_write_gate(
+        op_id="vmware.host.reboot", allowlist=allowlist, target_scope="t"
+    ).permitted
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", ()),
+        ("   ", ()),
+        ("vmware.vm.tag_set", (RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),)),
+        ("vmware.vm.tag_set@*", (RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),)),
+        ("vmware.vm.tag_set@tgt-1", (RemoteWriteAllowEntry("vmware.vm.tag_set", "tgt-1"),)),
+        (
+            " vmware.vm.tag_set , vmware.vm.annotation_set@tgt-2 ",
+            (
+                RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),
+                RemoteWriteAllowEntry("vmware.vm.annotation_set", "tgt-2"),
+            ),
+        ),
+        # A blank token and a bare ``@`` (no op) are skipped, not crashed.
+        ("vmware.vm.tag_set,,@scope", (RemoteWriteAllowEntry("vmware.vm.tag_set", "*"),)),
+    ],
+)
+def test_parse_runner_allowlist(raw: str, expected: tuple[RemoteWriteAllowEntry, ...]) -> None:
+    assert parse_runner_allowlist(raw) == expected

--- a/backend/tests/test_runner_write_allowlist.py
+++ b/backend/tests/test_runner_write_allowlist.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-runner remote-write capability allowlist service (#3190, mechanism 2).
+
+Service-level (no HTTP): grant / list / the mint-side ``load_runner_allowlist``
+reader against the real ``runner_write_allowlist`` + ``runner_principal``
+tables. The security contracts the acceptance criteria pin: enrollment grants
+no write capability at birth, a write capability requires the separate human
+``grant`` step (recording the operator), and a revoked/unknown runner gets
+none.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from meho_backplane.auth.runner_principals import RunnerPrincipalNotFoundError
+from meho_backplane.auth.runner_write_allowlist import (
+    RemoteWriteCapabilityGrant,
+    RunnerWriteAllowlistService,
+    load_runner_allowlist,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import RunnerPrincipal, Tenant
+from meho_backplane.runner.satellite_tier import RemoteWriteAllowEntry
+from meho_backplane.settings import get_settings
+
+_TENANT = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+_RUNNER = "runner-edge-1"
+_OPERATOR = "operator-sub"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=_TENANT, slug="tenant-b", name="tenant-b"))
+        await session.commit()
+
+
+async def _seed_runner(*, name: str = _RUNNER, revoked: bool = False) -> uuid.UUID:
+    """Seed one runner principal (as enrollment would) and return its id."""
+    runner_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            RunnerPrincipal(
+                id=runner_id,
+                tenant_id=_TENANT,
+                name=name,
+                keycloak_client_id=f"runner:{name}",
+                keycloak_internal_id=f"kc-{name}",
+                owner_sub="owner-sub",
+                created_by_sub="creator-sub",
+                revoked=revoked,
+            )
+        )
+        await session.commit()
+    return runner_id
+
+
+def _grant(op_pattern: str, target_scope: str = "*") -> RemoteWriteCapabilityGrant:
+    return RemoteWriteCapabilityGrant(op_pattern=op_pattern, target_scope=target_scope)
+
+
+async def test_grant_creates_entry_bound_to_the_operator() -> None:
+    await _seed_tenant()
+    runner_id = await _seed_runner()
+
+    entry = await RunnerWriteAllowlistService().grant(
+        _TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.tag_set", "tgt-1")
+    )
+
+    assert entry.runner_principal_id == runner_id
+    assert entry.op_pattern == "vmware.vm.tag_set"
+    assert entry.target_scope == "tgt-1"
+    # Bound at issuance: the granting human is recorded (never a runner).
+    assert entry.created_by_sub == _OPERATOR
+
+
+async def test_enrollment_grants_no_write_capability_at_birth() -> None:
+    # A freshly-enrolled runner (principal seeded, no grant) has an EMPTY
+    # allowlist — programmatic enrollment can never grant write capability at
+    # birth (T7); a capability appears only after the separate human grant step.
+    await _seed_tenant()
+    await _seed_runner()
+
+    entries = await RunnerWriteAllowlistService().list_(_TENANT, _RUNNER)
+    assert entries == []
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        loaded = await load_runner_allowlist(session, tenant_id=_TENANT, runner_name=_RUNNER)
+    assert loaded == ()
+
+
+async def test_grant_is_idempotent_on_the_same_capability() -> None:
+    await _seed_tenant()
+    await _seed_runner()
+    service = RunnerWriteAllowlistService()
+
+    first = await service.grant(_TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.tag_set", "*"))
+    second = await service.grant(
+        _TENANT, _RUNNER, "other-operator", _grant("vmware.vm.tag_set", "*")
+    )
+
+    # Same fully-scoped capability → the existing row, not a duplicate.
+    assert second.id == first.id
+    entries = await service.list_(_TENANT, _RUNNER)
+    assert len(entries) == 1
+
+
+async def test_list_returns_granted_capabilities_sorted() -> None:
+    await _seed_tenant()
+    await _seed_runner()
+    service = RunnerWriteAllowlistService()
+    await service.grant(_TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.tag_set"))
+    await service.grant(_TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.annotation_set"))
+
+    entries = await service.list_(_TENANT, _RUNNER)
+
+    assert [e.op_pattern for e in entries] == [
+        "vmware.vm.annotation_set",
+        "vmware.vm.tag_set",
+    ]
+
+
+async def test_grant_unknown_runner_raises() -> None:
+    await _seed_tenant()
+    with pytest.raises(RunnerPrincipalNotFoundError):
+        await RunnerWriteAllowlistService().grant(
+            _TENANT, "no-such-runner", _OPERATOR, _grant("vmware.vm.tag_set")
+        )
+
+
+async def test_grant_revoked_runner_raises() -> None:
+    # A revoked runner gets no new write capability (the resolve step filters
+    # ``revoked=False``), so a granting attempt fails as not-found.
+    await _seed_tenant()
+    await _seed_runner(revoked=True)
+    with pytest.raises(RunnerPrincipalNotFoundError):
+        await RunnerWriteAllowlistService().grant(
+            _TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.tag_set")
+        )
+
+
+async def test_load_runner_allowlist_projects_entries_for_the_mint() -> None:
+    await _seed_tenant()
+    await _seed_runner()
+    service = RunnerWriteAllowlistService()
+    await service.grant(_TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.tag_set", "tgt-1"))
+    await service.grant(_TENANT, _RUNNER, _OPERATOR, _grant("vmware.vm.annotation_set", "*"))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        loaded = await load_runner_allowlist(session, tenant_id=_TENANT, runner_name=_RUNNER)
+
+    assert set(loaded) == {
+        RemoteWriteAllowEntry("vmware.vm.tag_set", "tgt-1"),
+        RemoteWriteAllowEntry("vmware.vm.annotation_set", "*"),
+    }
+
+
+async def test_load_runner_allowlist_unknown_runner_is_empty() -> None:
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        loaded = await load_runner_allowlist(session, tenant_id=_TENANT, runner_name="ghost")
+    assert loaded == ()

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -8090,6 +8090,122 @@
         }
       }
     },
+    "/api/v1/runner-principals/{name}/write-allowlist": {
+      "get": {
+        "tags": [
+          "runner-principals"
+        ],
+        "summary": "List Runner Write Allowlist",
+        "description": "List a runner's granted ``remote-write`` capabilities (#3190).\n\nRead-back of the per-runner capability allowlist (mechanism 2 of the\nsatellite write path). 404 when the runner is unknown or revoked.",
+        "operationId": "list_runner_write_allowlist_api_v1_runner_principals__name__write_allowlist_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerWriteAllowlistResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "runner-principals"
+        ],
+        "summary": "Grant Runner Write Capability",
+        "description": "Grant one ``remote-write`` capability to a runner (#3190).\n\nThe **separate human step** a write capability requires after enrollment:\n``tenant_admin`` only, and never reachable by a runner's own read-only,\nroute-caged token \u2014 so a runner cannot widen its own allowlist (threat T7,\ndecision recommendation 2). Programmatic enrollment grants no write\ncapability at birth; this route is the only path that adds one. The grant\nis bound at issuance (``created_by_sub`` records the operator) and\nidempotent on ``(op_pattern, target_scope)``. 404 when the runner is\nunknown or revoked.",
+        "operationId": "grant_runner_write_capability_api_v1_runner_principals__name__write_allowlist_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoteWriteCapabilityGrant"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerWriteAllowlistEntryRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/gateway/{runner}/next": {
       "get": {
         "tags": [
@@ -29238,6 +29354,30 @@
         "title": "RememberBody",
         "description": "POST body for ``/api/v1/memory`` -- create one memory.\n\n``slug`` is constrained to :data:`SLUG_PATTERN` at the model\nboundary; the service-layer\n:func:`~meho_backplane.memory.schemas.validate_slug` is the\nparallel gate for non-Pydantic callers. ``frozen=True`` matches\nthe rest of the memory + kb schemas (a handler accidentally\nmutating a parsed request body surfaces as a pydantic error\ninstead of a confused-deputy bug). ``extra=\"forbid\"`` rejects\nunknown fields at 422 so a typo (``\"bodytext\"``) doesn't\nsilently become a no-op. A ``mode=\"before\"`` validator runs *ahead*\nof that rejection to turn the two known cross-surface field names\n(``ttl`` / top-level ``tags``, the MCP ``add_to_memory`` shape) into\na targeted 422 that names the correct REST field rather than the\nopaque ``extra_forbidden`` (see :data:`_CROSS_SURFACE_FIELD_HINTS`).\n\n``target_name`` is required when ``scope`` is ``user-target`` or\n``target``; the service-level\n:meth:`MemoryService._require_target_name` raises ``ValueError``\nwhen missing, which this route maps to 422 (parity with\npydantic's own missing-field shape)."
       },
+      "RemoteWriteCapabilityGrant": {
+        "properties": {
+          "op_pattern": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Op Pattern"
+          },
+          "target_scope": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Target Scope",
+            "default": "*"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "op_pattern"
+        ],
+        "title": "RemoteWriteCapabilityGrant",
+        "description": "Input shape for :meth:`RunnerWriteAllowlistService.grant`."
+      },
       "ReplayNode": {
         "properties": {
           "id": {
@@ -30298,6 +30438,71 @@
         ],
         "title": "RunnerWorkItem",
         "description": "One centrally-authorized operation for the runner to execute.\n\nCarries the fields the runner needs to resolve and invoke a handler\nentirely locally: the dotted ``handler_ref`` (resolved via\n:func:`~meho_backplane.operations._handler_resolve.import_handler`),\nthe ``(product, version, impl_id)`` registry key used to rebind a\nbound-method handler against its connector instance, the validated\n``params``, the ``safety_level`` the runner re-checks (defence in\ndepth), the principal context, and the resolved target descriptor\n(``None`` for targetless synthetic ops such as ``net.*``).\n\nRemote-write signing (#3189): a ``caution`` / ``remote-write`` item\nadditionally carries the centre's Ed25519 ``signature`` over its\ncanonical payload and the ``expires_at`` freshness bound the signature\ncovers, both verified in\n:func:`~meho_backplane.runner.executor._screen_item` before execution.\nBoth are ``None`` for a ``safe`` read item (the recurring assignment\npath materialises only ``safe`` ops and never signs them) -- signing is\na write-tier property, so their absence on a ``safe`` item is correct,\nnot a missing field."
+      },
+      "RunnerWriteAllowlistEntryRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "runner_principal_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Runner Principal Id"
+          },
+          "op_pattern": {
+            "type": "string",
+            "title": "Op Pattern"
+          },
+          "target_scope": {
+            "type": "string",
+            "title": "Target Scope"
+          },
+          "created_by_sub": {
+            "type": "string",
+            "title": "Created By Sub"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "runner_principal_id",
+          "op_pattern",
+          "target_scope",
+          "created_by_sub",
+          "created_at"
+        ],
+        "title": "RunnerWriteAllowlistEntryRead",
+        "description": "One granted remote-write capability, as returned by the accessors."
+      },
+      "RunnerWriteAllowlistResponse": {
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerWriteAllowlistEntryRead"
+            },
+            "type": "array",
+            "title": "Entries"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entries"
+        ],
+        "title": "RunnerWriteAllowlistResponse",
+        "description": "Response envelope for ``GET .../{name}/write-allowlist``."
       },
       "SafetyChangeModel": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -6096,6 +6096,12 @@ type RememberBody struct {
 	TargetName *string     `json:"target_name"`
 }
 
+// RemoteWriteCapabilityGrant Input shape for :meth:`RunnerWriteAllowlistService.grant`.
+type RemoteWriteCapabilityGrant struct {
+	OpPattern   string  `json:"op_pattern"`
+	TargetScope *string `json:"target_scope,omitempty"`
+}
+
 // ReplayNode One node of a per-session audit-replay tree (G8.2-T3).
 //
 // Subclasses :class:`AuditEntry` so it carries every audit field verbatim —
@@ -6679,6 +6685,22 @@ type RunnerWorkItem struct {
 	// would durably persist — a locked no-durable-artifact violation).
 	TargetDescriptor *ResolvedTargetDescriptor `json:"target_descriptor,omitempty"`
 	Version          *string                   `json:"version,omitempty"`
+}
+
+// RunnerWriteAllowlistEntryRead One granted remote-write capability, as returned by the accessors.
+type RunnerWriteAllowlistEntryRead struct {
+	CreatedAt         time.Time          `json:"created_at"`
+	CreatedBySub      string             `json:"created_by_sub"`
+	Id                openapi_types.UUID `json:"id"`
+	OpPattern         string             `json:"op_pattern"`
+	RunnerPrincipalId openapi_types.UUID `json:"runner_principal_id"`
+	TargetScope       string             `json:"target_scope"`
+	TenantId          openapi_types.UUID `json:"tenant_id"`
+}
+
+// RunnerWriteAllowlistResponse Response envelope for “GET .../{name}/write-allowlist“.
+type RunnerWriteAllowlistResponse struct {
+	Entries []RunnerWriteAllowlistEntryRead `json:"entries"`
 }
 
 // SafetyChangeModel Pydantic projection of
@@ -9476,6 +9498,16 @@ type RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams defines parameters for ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet.
+type ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams defines parameters for GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost.
+type GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ListTriggersApiV1SchedulerTriggersGetParams defines parameters for ListTriggersApiV1SchedulerTriggersGet.
 type ListTriggersApiV1SchedulerTriggersGetParams struct {
 	Limit         *int                                               `form:"limit,omitempty" json:"limit,omitempty"`
@@ -10211,6 +10243,9 @@ type PublishTemplateApiV1RunbooksTemplatesSlugPublishPostJSONRequestBody = Under
 
 // RegisterRunnerPrincipalApiV1RunnerPrincipalsPostJSONRequestBody defines body for RegisterRunnerPrincipalApiV1RunnerPrincipalsPost for application/json ContentType.
 type RegisterRunnerPrincipalApiV1RunnerPrincipalsPostJSONRequestBody = RunnerPrincipalCreate
+
+// GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody defines body for GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost for application/json ContentType.
+type GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody = RemoteWriteCapabilityGrant
 
 // CreateTriggerApiV1SchedulerTriggersPostJSONRequestBody defines body for CreateTriggerApiV1SchedulerTriggersPost for application/json ContentType.
 type CreateTriggerApiV1SchedulerTriggersPostJSONRequestBody = ScheduledTriggerCreate
@@ -12338,6 +12373,14 @@ type ClientInterface interface {
 
 	// RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDelete request
 	RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDelete(ctx context.Context, name string, params *RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet request
+	ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet(ctx context.Context, name string, params *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBody request with any body
+	GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBody(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, body GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTriggersApiV1SchedulerTriggersGet request
 	ListTriggersApiV1SchedulerTriggersGet(ctx context.Context, params *ListTriggersApiV1SchedulerTriggersGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -15425,6 +15468,42 @@ func (c *Client) ShowRunnerPrincipalApiV1RunnerPrincipalsNameGet(ctx context.Con
 
 func (c *Client) RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDelete(ctx context.Context, name string, params *RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet(ctx context.Context, name string, params *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBody(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequestWithBody(c.Server, name, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, body GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequest(c.Server, name, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -28030,6 +28109,117 @@ func NewRevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteRequest(server
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetRequest generates requests for ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet
+func NewListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetRequest(server string, name string, params *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/runner-principals/%s/write-allowlist", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequest calls the generic GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost builder with application/json body
+func NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequest(server string, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, body GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequestWithBody(server, name, params, "application/json", bodyReader)
+}
+
+// NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequestWithBody generates requests for GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost with any type of body
+func NewGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostRequestWithBody(server string, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/runner-principals/%s/write-allowlist", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -41645,6 +41835,14 @@ type ClientWithResponsesInterface interface {
 	// RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteWithResponse request
 	RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteWithResponse(ctx context.Context, name string, params *RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteParams, reqEditors ...RequestEditorFn) (*RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteResponse, error)
 
+	// ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetWithResponse request
+	ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetWithResponse(ctx context.Context, name string, params *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams, reqEditors ...RequestEditorFn) (*ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse, error)
+
+	// GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBodyWithResponse request with any body
+	GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBodyWithResponse(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse, error)
+
+	GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithResponse(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, body GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody, reqEditors ...RequestEditorFn) (*GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse, error)
+
 	// ListTriggersApiV1SchedulerTriggersGetWithResponse request
 	ListTriggersApiV1SchedulerTriggersGetWithResponse(ctx context.Context, params *ListTriggersApiV1SchedulerTriggersGetParams, reqEditors ...RequestEditorFn) (*ListTriggersApiV1SchedulerTriggersGetResponse, error)
 
@@ -45581,6 +45779,52 @@ func (r RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteResponse) Stat
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RunnerWriteAllowlistResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *RunnerWriteAllowlistEntryRead
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -52553,6 +52797,32 @@ func (c *ClientWithResponses) RevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevo
 		return nil, err
 	}
 	return ParseRevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteResponse(rsp)
+}
+
+// ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetWithResponse request returning *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse
+func (c *ClientWithResponses) ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetWithResponse(ctx context.Context, name string, params *ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetParams, reqEditors ...RequestEditorFn) (*ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse, error) {
+	rsp, err := c.ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGet(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse(rsp)
+}
+
+// GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBodyWithResponse request with arbitrary body returning *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse
+func (c *ClientWithResponses) GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBodyWithResponse(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse, error) {
+	rsp, err := c.GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithBody(ctx, name, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithResponse(ctx context.Context, name string, params *GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostParams, body GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostJSONRequestBody, reqEditors ...RequestEditorFn) (*GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse, error) {
+	rsp, err := c.GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPost(ctx, name, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse(rsp)
 }
 
 // ListTriggersApiV1SchedulerTriggersGetWithResponse request returning *ListTriggersApiV1SchedulerTriggersGetResponse
@@ -59916,6 +60186,72 @@ func ParseRevokeRunnerPrincipalApiV1RunnerPrincipalsNameRevokeDeleteResponse(rsp
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse parses an HTTP response from a ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetWithResponse call
+func ParseListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse(rsp *http.Response) (*ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRunnerWriteAllowlistApiV1RunnerPrincipalsNameWriteAllowlistGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RunnerWriteAllowlistResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse parses an HTTP response from a GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostWithResponse call
+func ParseGrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse(rsp *http.Response) (*GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GrantRunnerWriteCapabilityApiV1RunnerPrincipalsNameWriteAllowlistPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest RunnerWriteAllowlistEntryRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -165,8 +165,9 @@ through):
 - **Edge executor** — `_screen_item` (`runner/executor.py`): re-screens the
   delivered item independently, refusing `EXCLUDED` outright, verifying a
   `REMOTE_WRITE` item's signature (mechanism 1, below) and re-checking it
-  through the allowlist gate seam (mechanism 2's "checked at mint *and*
-  re-checked at the edge").
+  through the per-runner allowlist gate against the runner's **own**
+  provisioning config (mechanism 2's "checked at mint *and* re-checked at the
+  edge", below).
 
 ### Mechanism 1 — signed work items + approval-bound minting (#3189)
 
@@ -206,15 +207,50 @@ work item, plus approval-bound minting.
   unsigned, tampered, out-of-scope, expired, or unverifiable-key item all fail
   closed **before** any handler import.
 
-**The allowlist gate is still a seam.** `evaluate_remote_write_gate` remains
-fail-closed by construction — mechanism 2 (the per-runner enrollment
-allowlist, #3190) is not yet wired, so it refuses at the edge. A remote-write
-op mints only when its op-class is on the runner's allowlist **and** the #3189
-approval binding authorises it — the composition of design §3. The mint's
-allowlist check is the marked composition point in `_mint_remote_write`; until
-#3190 wires it there, the edge allowlist re-check keeps the tier closed
-end-to-end. Credential brokering (#3191) and revocation hardening (#3192) are
-the remaining sibling mechanisms.
+### Mechanism 2 — per-runner capability allowlist (#3190)
+
+The allowlist **is** the definition of a runner's write blast radius (design
+§3, threats T1/T8): a `remote-write` op mints (and executes) **only** when its
+op-class + target is on the runner's allowlist. Composed with #3189 so the tier
+is satisfiable only when **both** halves pass — the approval binding **and** the
+allowlist — and fail-closed when either is absent.
+
+- **Storage — `runner_write_allowlist` (migration `0093`).** One row per
+  granted `(op_pattern, target_scope)` capability, hung off the runner principal
+  (`runner_principal_id` FK). `op_pattern` is an `fnmatch` glob over `op_id`
+  (an exact op-class for a minimal Stage-1 allowlist, or a `*` prefix);
+  `target_scope` is a cap — `*` (any target in the tenant) or a concrete
+  `str(target.id)`. `created_by_sub` records the granting human.
+- **Not at birth (T7).** Enrollment (`RunnerPrincipalService.register`) writes
+  **no** rows here: programmatic enrollment can never grant write capability at
+  birth. A capability requires the **separate human step**
+  `RunnerWriteAllowlistService.grant`, reachable only over the operator-gated
+  route `POST /api/v1/runner-principals/{name}/write-allowlist` (`tenant_admin`).
+  A runner's own read-only, route-caged token cannot reach that path, so a
+  runner cannot self-widen its allowlist. Read back with the `GET` sibling.
+- **Shared matcher (single source of truth).**
+  `evaluate_remote_write_gate(op_id, allowlist, target_scope)`
+  (`runner/satellite_tier.py`, stdlib-only, DB-free) is the one matcher both
+  layers run against a `RemoteWriteAllowEntry` sequence — the same
+  defence-in-depth mould `classify_satellite_tier` uses.
+- **At the mint** — `_mint_remote_write` reads the runner's rows
+  (`load_runner_allowlist`) and ANDs the gate with the approval binding; an
+  op-class/target off the allowlist (or no allowlist at all) →
+  `MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED`, before the single-use latch
+  (a refusal writes no rows / consumes no approval).
+- **At the edge** — `_screen_item` re-runs the same matcher against the
+  runner's **own** provisioning-config mirror (`satellite_write_allowlist`,
+  parsed by `parse_runner_allowlist`), never the mint's and never a field on
+  the work item. So an item allowlisted centrally is still refused if the edge
+  config disagrees — defence in depth, fail-closed when unprovisioned.
+
+The **assignment materialiser** needs no third mirror here: only `SAFE`-tier ops
+are ever materialised into recurring assignments (`_is_runnable_safe`), and
+`remote-write` work rides the one-shot capability-mint path exclusively, so it
+never reaches that layer.
+
+Credential brokering (#3191) and revocation hardening (#3192) are the remaining
+sibling mechanisms.
 
 **Composition with #3183.** The destructive tier is `EXCLUDED` by this ladder
 everywhere, so delete-shaped work stays central-or-break-glass and never


### PR DESCRIPTION
## Summary

- **Mechanism 2** of the composed satellite write-tier gate (parent #2901): a per-runner-principal **capability allowlist** — `op_pattern` glob + `target_scope` cap, tenant-scoped — that **is** the definition of a runner's remote-write blast radius (design §3, threats T1/T8). New `runner_write_allowlist` table hung off the runner principal + `RunnerWriteAllowlistService`.
- **Composed, not weakened.** `evaluate_remote_write_gate` (the shared, DB-free matcher, was unconditionally fail-closed) now admits an op only when its op-class + target is on the runner's allowlist. It is ANDed with the #3189 approval binding at the mint, so the `remote-write` tier is satisfiable **only when both halves pass** and fail-closed when either is absent. Off-allowlist → the distinct `MintRefusalCode.REMOTE_WRITE_NOT_ALLOWLISTED`, before the single-use latch (no rows written, no approval consumed).
- **Checked twice (defence in depth).** The mint reads the DB rows (`load_runner_allowlist`); the edge (`executor._screen_item`) re-runs the *same matcher* against the runner's **own** provisioning config (`SATELLITE_WRITE_ALLOWLIST`), never the mint's — so an item allowlisted centrally is still refused if the edge config disagrees.
- **Not self-widenable (T7).** Enrollment grants **no** write capability at birth; a capability requires the separate human step `POST /api/v1/runner-principals/{name}/write-allowlist` (`tenant_admin`, bound at issuance via `created_by_sub`, idempotent) with a `GET` read-back. A runner's read-only, route-caged token cannot reach the grant path.
- Destructive/dangerous stay `EXCLUDED` and unmintable; the `safe` read path is untouched.

## Composed-gate final shape (how the two halves AND together)

`_mint_remote_write` → `_screen_remote_write` runs three read-only pre-checks in fail-closed order, all **before** the single-use approval latch (so a refusal writes no rows / consumes no approval):

1. **approval binding** (#3189) — committed, param-bound `ApprovalRequest`; none → `REMOTE_WRITE_GATE_UNSATISFIED`
2. **signing key** (#3189) — none → `REMOTE_WRITE_SIGNING_UNAVAILABLE`
3. **allowlist** (#3190) — `evaluate_remote_write_gate(op_id, allowlist=<DB rows>, target_scope)`; off-list → `REMOTE_WRITE_NOT_ALLOWLISTED`

Only if all three pass does the latch claim + sign + finalize run. The **edge** ANDs the two halves as: signature verify (mechanism 1's proxy for the approval) **AND** `evaluate_remote_write_gate(op_id, allowlist=parse_runner_allowlist(config), target_scope)`.

## Migration

- **0095 → 0094** (0093 skipped, #3193's `0094` landed mid-flight). This task originally numbered `0093 → 0092`; sibling #3193 (#3249) merged `0094_satellite_effect_audit` (also off `0092`) first, which would have branched the head, so this migration was renumbered to **0095** and re-parented onto **0094**. The chain is a single linear head `0092 → 0094 → 0095`. Additive-only — a fresh table + two indexes, no ALTER. Integrated via a merge of `origin/main` (unioned CHANGELOG, `satellite-runner.md`, and both per-test TRUNCATE lists with #3193; regenerated the CLI OpenAPI snapshot + Go client).

## Third mirror (assignment materialiser) — deliberately not touched

The design's optional third mirror is **not required**: `_is_runnable_safe` only ever materialises `SAFE`-tier ops into recurring assignments; `remote-write` rides the one-shot capability-mint path exclusively and never reaches that layer (documented in `satellite-runner.md`).

## Decision-doc amendment interaction (surfaced per instructions; amendment text left unedited)

The peer-owned "## Amendment (2026-08-31)" (dispatch flight recorder cross-ref) states satellite dispatches of every tier remain **untraced** today, explicitly noting the `remote-write` tier is fail-closed at `evaluate_remote_write_gate` "until its per-runner allowlist + approval binding is wired (#3189–#3193)". This PR wires that allowlist half — and does **not** change the tracing statement: an admitted `remote-write` item still executes through the `dispatcher.dispatch`-bypassing edge path (`execute_work_item` → `_invoke`), so it still opens no capture scope. No amendment text was modified.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed modules) — clean (repo-wide: only the pre-existing darwin-only `MSG_ERRQUEUE` in `connectors/net/icmp.py`, green on Linux CI)
- [x] `code-quality.py --diff` — 0 blockers (refactored `_mint_remote_write` under the size gate by extracting `_screen_remote_write`)
- [x] migration upgrade → downgrade → upgrade round-trip — clean; passes the UUID-binding migration lint
- [x] `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated (`make snapshot-openapi && make generate`) — drift gate clean
- [x] Fail-closed conformance: mint refused for an op outside the allowlist **even with a valid approval** (`REMOTE_WRITE_NOT_ALLOWLISTED`, approval unconsumed); edge refuses a validly-signed item when the runner's own config disagrees (defence in depth); single-class Stage-1 allowlist admits exactly that class; a runner-kind token is 403'd on the grant route (cannot self-widen)
- [x] #3188 tier tests, #3189/#3246 signing tests, #3225 conformance, downstream gateway/runner suites — green (extended additively; the two happy-path signing tests seed the now-required allowlist, no signing assertion changed)
- [x] `pytest` touched + downstream suites — 634 passed

## Out of scope

- Sibling #3193 (store-and-forward effect audit + un-reported-mint alarm) — CHANGELOG / `satellite-runner.md` will union with it and with the peer #3231/#3232 delete-family PRs.

Closes #3190

