### PR TITLE
feat(approvals): surface an approved dispatch's result to the originating consumer (#3209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — surface an approved dispatch's result to the originating consumer (#3209)
+
+- A paired, out-of-process consumer that parks a **non-idempotent** governed op
+  for approval (the concrete case: VCF `installer.sddc.bringup.start`) can now,
+  after a human approves, retrieve the result the backplane produced when it
+  re-dispatched the approved op — so it resumes in place by *polling the
+  returned task id* instead of a second submit that would start a second
+  bring-up. New principal-scoped `GET /api/v1/approvals/{id}/result`: only the
+  request owner (`principal_sub`) reads it (any other principal, operator role
+  or not, gets 403 `not_request_owner`), it writes a synchronous
+  `approval.result` audit row, and the payload is the same reduced /
+  handle-shaped `OperationResult` envelope the approver sees inline (a
+  set-shaped response rides a JSONFlux handle, never a raw body). The
+  re-dispatch result is captured onto `approval_request.resume_result`
+  (migration `0096`, `down_revision 0095`) on the exactly-one-resumer winning
+  path, so it composes with the existing resume claim rather than duplicating
+  it. Unblocks `meho-automation`#76's resume-in-place for `bringup`-class ops.
+
 ### Added — governed delete on bind9: `bind9.record.delete` on the destructive tier + conformance (#3231 / #3198)
 
 - Registers the **second governed delete** — and the first

--- a/backend/alembic/versions/0096_add_approval_request_resume_result.py
+++ b/backend/alembic/versions/0096_add_approval_request_resume_result.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``approval_request.resume_result`` — the approved dispatch's result.
+
+Revision ID: 0096
+Revises: 0095
+Create Date: 2026-09-01
+
+Task #3209. A paired, out-of-process consumer that parks a **non-idempotent**
+governed op for approval (the concrete case: VCF
+``installer.sddc.bringup.start``) cannot resume it in place after a human
+approves, because it has no way to retrieve the result the backplane produced
+when it re-dispatched the approved op. Two surface facts made the result
+unretrievable: :class:`ApprovalRequestView` carries no execution result, and
+``GET /api/v1/audit/by-work-ref`` reduces params to a hash and exposes no raw
+response body. So the consumer could only *re-submit*, which for a
+non-idempotent op starts a second bring-up.
+
+This migration adds the durable landing spot for that result:
+
+* ``resume_result`` -- JSON (JSONB on PG), nullable. The **reduced /
+  handle-shaped** :class:`~meho_backplane.connectors.schemas.OperationResult`
+  envelope (``OperationResult.model_dump(mode="json")``) of the approved
+  re-dispatch, captured on the exactly-one-resumer winning path
+  (:func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`).
+  It is the *same* reduced envelope the approver already sees inline — for a
+  set-shaped response the payload rides a JSONFlux ``handle`` (v0.1-spec §4),
+  never a raw body — so this is not a new raw-payload surface. NULL until the
+  winning resumer captures it: a pending / rejected / expired row, an agent-run
+  request resumed in-process (which does not route through the shared operator
+  resume path), and every pre-0096 row all keep NULL. Internal to the
+  principal-scoped ``GET /api/v1/approvals/{id}/result`` read surface only;
+  like ``params`` it is never projected onto the default read view or a
+  broadcast frame.
+
+Soft-column discipline mirrors ``0036`` / ``0040`` / ``0053`` / ``0055``:
+nullable, no server default (Python-side ``None`` / capture-set), reversible,
+no indexes (the column is only ever read/written off a row already loaded by
+primary key).
+
+Migration-chain note (single linear head)
+-----------------------------------------
+
+Numbered ``0096`` with ``down_revision = "0095"`` — the head on
+``origin/main`` after the satellite write-path chain landed
+(``0092 -> 0094 -> 0095``; the ``0093`` gap is a renumbered sibling, see
+``0095``). Additive-only: one nullable column on an existing table, no ALTER of
+an existing column.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column. SQLite's ALTER TABLE drop-column has been
+supported since 3.35.0 (we're on 3.45+); Alembic's batch-mode fallback is not
+required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0096"
+down_revision: str | None = "0095"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``resume_result`` column to ``approval_request``."""
+    op.add_column(
+        "approval_request",
+        sa.Column(
+            "resume_result",
+            sa.JSON(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``resume_result`` column added in :func:`upgrade`."""
+    op.drop_column("approval_request", "resume_result")

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -65,16 +65,19 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
+from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
     ParamsMismatchError,
     PreviewBindingMissingError,
+    ResultAccessForbiddenError,
     SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
     get_request,
     publish_approval_event,
+    read_approval_result,
     reject_request,
     resume_dispatch_after_approval,
 )
@@ -118,6 +121,31 @@ class ApprovalRequestView(BaseModel):
     created_at: str
     expires_at: str | None
     work_ref: str | None
+
+
+class ApprovalResultView(BaseModel):
+    """Principal-scoped view of an approved dispatch's result (#3209).
+
+    The response body of ``GET /api/v1/approvals/{id}/result``. Surfaces the
+    reduced / handle-shaped :class:`~meho_backplane.connectors.schemas.OperationResult`
+    envelope the backplane produced when it re-dispatched the approved op, so
+    the **originating** consumer that parked a non-idempotent op (VCF
+    ``bringup.start``) can resume by poll instead of a second submit. ``result``
+    is ``None`` until the winning resumer captures it — a ``pending`` /
+    ``rejected`` / ``expired`` request, or an ``approved`` one whose resume has
+    not landed yet — so a consumer polls until ``status == "approved"`` and
+    ``result`` is populated. A set-shaped payload rides a JSONFlux ``handle``
+    inside ``result`` (v0.1-spec §4), never a raw body.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    approval_request_id: uuid.UUID
+    status: ApprovalRequestStatus
+    resumed: bool
+    reviewed_by: str | None
+    decided_at: str | None
+    result: dict[str, Any] | None
 
 
 class ApproveRequestBody(BaseModel):
@@ -390,6 +418,67 @@ async def get_approval_request(
                 detail="approval_request_not_found",
             ) from exc
     return _view(row)
+
+
+@router.get("/{request_id}/result", response_model=ApprovalResultView)
+async def get_approval_result(
+    request_id: Annotated[uuid.UUID, Path()],
+    operator: Operator = Depends(verify_jwt_and_bind),
+) -> ApprovalResultView:
+    """Read the approved dispatch's result — originating-principal only (#3209).
+
+    Surfaces the reduced / handle-shaped ``OperationResult`` envelope the
+    backplane produced when it re-dispatched the approved op, so the consumer
+    that parked a **non-idempotent** op (VCF ``installer.sddc.bringup.start``)
+    can resume in place by poll — read back the resulting task id and continue
+    polling it — instead of a second submit that would start a second
+    bring-up.
+
+    Scope is deliberately narrow (this route is **not** ``operator``-gated like
+    the rest of the approvals surface): any authenticated principal may call
+    it, but :func:`~meho_backplane.operations.approval_queue.read_approval_result`
+    then enforces that only the request's **owner**
+    (``operator.sub == principal_sub``, the party that parked the op) reads the
+    result. This lets a non-operator service/agent principal — the paired
+    add-on that dispatched the op — retrieve its own result, while no other
+    principal (operator role or not) can. The read writes one synchronous
+    ``approval.result`` audit row (v0.1-spec §6).
+
+    HTTP status codes:
+
+    * 200 — the request exists and the caller owns it. ``result`` is the
+      captured envelope when the resume has landed, else ``null`` (poll again).
+    * 403 — the caller is authenticated but is not the request owner.
+    * 404 — request not found (or belongs to another tenant).
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="approval.result",
+        audit_op_class="read",
+        audit_approval_request_id=str(request_id),
+    )
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            row = await read_approval_result(session, operator=operator, request_id=request_id)
+            await session.commit()
+    except ApprovalNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="approval_request_not_found",
+        ) from exc
+    except ResultAccessForbiddenError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="not_request_owner",
+        ) from exc
+    return ApprovalResultView(
+        approval_request_id=row.id,
+        status=ApprovalRequestStatus(row.status),
+        resumed=row.resumed_at is not None,
+        reviewed_by=row.reviewed_by,
+        decided_at=row.decided_at.isoformat() if row.decided_at else None,
+        result=row.resume_result,
+    )
 
 
 async def _record_approval_decision(

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5937,6 +5937,23 @@ class ApprovalRequest(Base):
       resumed" -- the same claimable starting state a freshly-parked
       request has. No FK, no index. Added by migration ``0055``.
 
+    * ``resume_result`` -- JSON nullable (JSONB on PG). The reduced /
+      handle-shaped :class:`~meho_backplane.connectors.schemas.OperationResult`
+      envelope of the approved re-dispatch (#3209), captured on the
+      exactly-one-resumer winning path
+      (:func:`resume_dispatch_after_approval`). The paired consumer that
+      parked a **non-idempotent** op (VCF ``bringup.start``) reads it back —
+      principal-scoped to the request owner — via
+      ``GET /api/v1/approvals/{id}/result`` to resume by poll instead of a
+      second submit. It is the same reduced envelope the approver already
+      sees inline: a set-shaped response rides a JSONFlux ``handle``
+      (v0.1-spec §4), never a raw body. NULL until captured — a pending /
+      rejected / expired row, an agent-run request resumed in-process (which
+      does not route through the shared operator resume path), and every
+      pre-0096 row keep NULL. Internal to the ``/result`` surface only; like
+      ``params`` it is never projected onto the default read view or a
+      broadcast frame. Added by migration ``0096``.
+
     Indexes
     -------
 
@@ -6070,6 +6087,24 @@ class ApprovalRequest(Base):
     # primary-key-scoped conditional UPDATE). Added by migration 0055.
     resumed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    # Result of the approved re-dispatch (#3209). The reduced / handle-shaped
+    # OperationResult envelope (OperationResult.model_dump(mode="json")) the
+    # backplane produced when it re-executed the approved op, captured on the
+    # exactly-one-resumer winning path (resume_dispatch_after_approval). It is
+    # the same reduced envelope the approver sees inline -- a set-shaped
+    # response rides a JSONFlux handle (v0.1-spec §4), never a raw body -- so
+    # this is not a new raw-payload surface. NULL until the winning resumer
+    # captures it: pending / rejected / expired rows, an agent-run request
+    # resumed in-process (which does not route through the shared operator
+    # resume path), and every pre-0096 row keep NULL. Read only by the
+    # principal-scoped GET /api/v1/approvals/{id}/result surface -- like
+    # ``params`` it is never projected onto the default read view or a
+    # broadcast frame. Added by migration 0096.
+    resume_result: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
         nullable=True,
         default=None,
     )

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -104,6 +104,7 @@ __all__ = [
     "ApprovalRequestAlreadyDecidedError",
     "ParamsMismatchError",
     "PreviewBindingMissingError",
+    "ResultAccessForbiddenError",
     "SelfApprovalForbiddenError",
     "UnauthorizedApprovalError",
     "approve_request",
@@ -115,6 +116,7 @@ __all__ = [
     "get_request",
     "list_pending",
     "publish_approval_event",
+    "read_approval_result",
     "reject_request",
     "resume_dispatch_after_approval",
 ]
@@ -243,6 +245,28 @@ class UnauthorizedApprovalError(ApprovalError):
         super().__init__(
             f"operator {operator_sub!r} with role {role!r} may not approve/reject "
             "an approval request (requires at least 'operator')"
+        )
+
+
+class ResultAccessForbiddenError(ApprovalError):
+    """A principal other than the request owner tried to read its result.
+
+    Raised by :func:`read_approval_result` when
+    ``operator.sub != request.principal_sub``. The approved re-dispatch's
+    result is surfaced only to the **originating** principal — the consumer
+    that parked the op (#3209) — so it can resume a non-idempotent parked op
+    (VCF ``bringup.start``) by poll instead of a second submit. Any other
+    principal, including an operator who could approve the request, is refused;
+    the route layer maps this to 403. Tenant isolation is handled upstream by
+    :func:`get_request` (a cross-tenant id is a 404, never reaching this guard).
+    """
+
+    def __init__(self, *, request_id: uuid.UUID, principal_sub: str) -> None:
+        self.request_id = request_id
+        self.principal_sub = principal_sub
+        super().__init__(
+            f"principal {principal_sub!r} is not the owner of approval_request "
+            f"{request_id}; its result is readable only by the originating principal"
         )
 
 
@@ -969,6 +993,67 @@ async def resume_dispatch_after_approval(
     )
 
 
+def _dump_result_envelope(result: Any) -> dict[str, Any] | None:
+    """Project a re-dispatch result into a JSON dict for durable storage (#3209).
+
+    The winning resume path returns an
+    :class:`~meho_backplane.connectors.schemas.OperationResult` (a Pydantic
+    model). ``model_dump(mode="json")`` yields the reduced / handle-shaped
+    envelope — the same one the approver sees inline, so a set-shaped response
+    is already a JSONFlux ``handle`` (v0.1-spec §4), never a raw body. Returns
+    ``None`` when the value is not a dumpable model (defence-in-depth; a
+    non-model result is simply not captured rather than raising).
+    """
+    dump = getattr(result, "model_dump", None)
+    if dump is None:
+        return None
+    projection = dump(mode="json")
+    return projection if isinstance(projection, dict) else None
+
+
+async def _persist_resume_result(request_id: uuid.UUID, result: Any) -> None:
+    """Store the approved re-dispatch's reduced result envelope on the row (#3209).
+
+    Called on the exactly-one-resumer winning path only, so it runs at most
+    once per approved request. The stored value is the reduced /
+    handle-shaped ``OperationResult`` envelope; the originating consumer reads
+    it back — principal-scoped — via ``GET /api/v1/approvals/{id}/result`` to
+    resume a non-idempotent parked op (VCF ``bringup.start``) by poll.
+
+    Fail-soft: the dispatch's own synchronous audit row already committed
+    inside :func:`~meho_backplane.operations.dispatcher.dispatch` (the
+    v0.1-spec §6 record of what executed), so this convenience-durability write
+    must never break the approve path. A failure is logged and swallowed; the
+    approver still receives the result inline and the consumer can re-poll. Runs
+    in its own committed transaction — the decision and the dispatch already
+    committed in separate sessions.
+    """
+    dumped = _dump_result_envelope(result)
+    if dumped is None:
+        return
+    from meho_backplane.db.engine import get_sessionmaker
+
+    try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            await session.execute(
+                update(ApprovalRequest)
+                .where(ApprovalRequest.id == request_id)
+                .values(resume_result=dumped)
+                .execution_options(synchronize_session=False)
+            )
+            await session.commit()
+    except Exception:
+        # Fail-soft convenience write (see docstring): the dispatch's own
+        # synchronous audit row already committed, so a capture failure must
+        # not break the approve path.
+        _log.warning(
+            "approval_resume_result_persist_failed",
+            approval_request_id=str(request_id),
+            exc_info=True,
+        )
+
+
 def _resume_pre0036_denied(operator: Operator, request: ApprovalRequest) -> Any:
     """Fail-closed result for a pre-0036 row with no stored params to re-dispatch.
 
@@ -1021,7 +1106,7 @@ async def _dispatch_resume_with_bound_context(
     session_token = agent_session_id_var.set(request.agent_session_id)
     parent_token = parent_audit_id_var.set(request.request_audit_id)
     try:
-        return await dispatch(
+        result = await dispatch(
             operator=operator,
             connector_id=request.connector_id,
             op_id=request.op_id,
@@ -1033,6 +1118,13 @@ async def _dispatch_resume_with_bound_context(
         parent_audit_id_var.reset(parent_token)
         agent_session_id_var.reset(session_token)
         work_ref_var.reset(work_ref_token)
+    # Persist the reduced result envelope so the originating consumer can read it
+    # back (principal-scoped) and resume a non-idempotent parked op by poll
+    # instead of a second submit (#3209). Reached only by the exactly-one-resumer
+    # winner, so the capture runs at most once; fail-soft, never breaks the
+    # approve path.
+    await _persist_resume_result(request.id, result)
+    return result
 
 
 async def _rehydrate_resume_target(
@@ -1383,6 +1475,55 @@ async def get_request(
     access (indistinguishable to the caller).
     """
     return await _load_for_tenant(session, request_id, tenant_id)
+
+
+async def read_approval_result(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    request_id: uuid.UUID,
+) -> ApprovalRequest:
+    """Load a request for its owner + write the ``approval.result`` audit row (#3209).
+
+    The principal-scoped result-retrieval surface behind
+    ``GET /api/v1/approvals/{id}/result``. Two gates, in order:
+
+    1. **Tenant isolation** via :func:`get_request` — a cross-tenant or
+       missing id both raise :class:`ApprovalNotFoundError` (→ 404), so the
+       existence of another tenant's request never leaks.
+    2. **Principal scope** — only the request's owner
+       (``operator.sub == request.principal_sub``, the party that parked the
+       op) may read the re-dispatch result. Any other principal, operator role
+       or not, gets :class:`ResultAccessForbiddenError` (→ 403). The result is
+       otherwise visible only in the approver's inline response, so this is the
+       surface that lets the *originating* consumer retrieve it.
+
+    Writes one synchronous ``approval.result`` audit row (``method='APPROVAL'``,
+    ``status_code=200``) in the caller's transaction before returning — the
+    result surfacing is an auditable data egress (v0.1-spec §6), so the read
+    leaves a ledger row like every other governed access, anchored in the
+    request's replay subtree (#2086). The row records the request ``status``
+    and whether a result was present (``resume_result_present``) so a
+    poll-until-ready read pattern is visible on the ledger without the payload
+    ever landing on it. The caller owns the commit.
+    """
+    request = await get_request(session, tenant_id=operator.tenant_id, request_id=request_id)
+    if operator.sub != request.principal_sub:
+        raise ResultAccessForbiddenError(request_id=request_id, principal_sub=operator.sub)
+    await _write_audit_row(
+        session,
+        audit_id=uuid.uuid4(),
+        operator=operator,
+        request=request,
+        path="approval.result",
+        status_code=_DECISION_STATUS_CODE_APPROVED,
+        duration_ms=0.0,
+        extra_payload={
+            "status": request.status,
+            "resume_result_present": request.resume_result is not None,
+        },
+    )
+    return request
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/migrations/test_migration_0096_add_approval_request_resume_result.py
+++ b/backend/tests/migrations/test_migration_0096_add_approval_request_resume_result.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0096_add_approval_request_resume_result``.
+
+Task #3209. Adds the nullable ``resume_result`` column to ``approval_request``:
+
+* ``resume_result`` -- the reduced / handle-shaped ``OperationResult`` envelope
+  of the approved re-dispatch, captured on the exactly-one-resumer winning
+  path. The originating consumer reads it back (principal-scoped) to resume a
+  non-idempotent parked op by poll. NULL until captured; NULL on every pre-0096
+  row.
+
+Soft-column discipline mirrors ``0036`` / ``0040`` / ``0053`` / ``0055``:
+nullable, no server default, reversible, no indexes.
+
+**Idempotency pinning (0049/0050/0053 footgun).** Every forward/round-trip
+step targets this migration's **own** revision (``0096``) and its
+``down_revision`` (``0095``), never ``head`` -- so a future head migration that
+adds another column cannot make ``upgrade("head")`` re-run this ``add_column``
+on a row that already has it (the duplicate-column stamp-replay footgun).
+SQLite is the test driver and the migration uses only generic DDL, so PG
+parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0096"
+_DOWN_REVISION = "0095"
+_RESULT_COLUMN = "resume_result"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0096.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _approval_request_table_info(sync_url: str) -> list[tuple[str, bool]]:
+    """Return ``(column_name, is_nullable)`` pairs for ``approval_request``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(approval_request)")).all()
+    finally:
+        sync_eng.dispose()
+    return [(str(row[1]), int(row[3]) == 0) for row in rows]
+
+
+def _approval_request_columns(sync_url: str) -> set[str]:
+    return {name for name, _ in _approval_request_table_info(sync_url)}
+
+
+def _column_is_nullable(sync_url: str, column: str) -> bool:
+    for name, nullable in _approval_request_table_info(sync_url):
+        if name == column:
+            return nullable
+    raise AssertionError(f"column {column!r} not present on approval_request")
+
+
+def test_upgrade_adds_nullable_resume_result(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0096`` lands the nullable ``resume_result`` column."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    columns = _approval_request_columns(sync_url)
+    assert _RESULT_COLUMN in columns, f"migration 0096 must add approval_request.{_RESULT_COLUMN}"
+    assert _column_is_nullable(sync_url, _RESULT_COLUMN), (
+        f"{_RESULT_COLUMN} must be nullable -- NULL means 'not yet captured' "
+        "(pre-0096 rows, a pending/rejected/expired request, or an approved "
+        "request whose resume has not landed)"
+    )
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0095"`` drops the column; ``upgrade "0096"`` restores it.
+
+    Pinned to this migration's own revision on both legs (never ``head``)
+    so a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _RESULT_COLUMN in _approval_request_columns(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _RESULT_COLUMN not in _approval_request_columns(sync_url), (
+        f"downgrade must drop {_RESULT_COLUMN}"
+    )
+
+    command.upgrade(cfg, _REVISION)
+    assert _RESULT_COLUMN in _approval_request_columns(sync_url)

--- a/backend/tests/test_approval_result_surface.py
+++ b/backend/tests/test_approval_result_surface.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approved-dispatch result surface — capture + principal-scoped read (#3209).
+
+Task #3209. A paired, out-of-process consumer that parks a **non-idempotent**
+governed op for approval (the concrete case: VCF
+``installer.sddc.bringup.start``) cannot resume it in place after a human
+approves unless it can retrieve the result the backplane produced when it
+re-dispatched the approved op — otherwise its only option is a second submit,
+which starts a second bring-up.
+
+This suite pins the two halves of the fix:
+
+* **Capture** — the exactly-one-resumer winning path
+  (:func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`)
+  persists the reduced / handle-shaped result envelope onto
+  ``approval_request.resume_result``.
+* **Read** — :func:`~meho_backplane.operations.approval_queue.read_approval_result`
+  and ``GET /api/v1/approvals/{id}/result`` surface it **only** to the
+  originating principal (the request owner), write a synchronous
+  ``approval.result`` audit row, and refuse every other principal (operator
+  role or not) with 403.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from httpx import ASGITransport
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequestStatus, AuditLog
+from meho_backplane.main import app
+from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.operations.approval_queue import (
+    ApprovalNotFoundError,
+    ResultAccessForbiddenError,
+    create_pending_request,
+    get_request,
+    read_approval_result,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000039a9")
+_OTHER_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000039b9")
+_OWNER_SUB = "addon:vcf-bringup"
+
+_BRINGUP_OP = "installer.sddc.bringup.start"
+_BRINGUP_CONNECTOR = "vcf-installer-9.x"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires + silence the broadcast."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Open a session against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(
+    *,
+    sub: str = _OWNER_SUB,
+    role: TenantRole = TenantRole.OPERATOR,
+    tenant_id: uuid.UUID = _TENANT_ID,
+    principal_kind: PrincipalKind = PrincipalKind.SERVICE,
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Test Principal",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=tenant_id,
+        tenant_role=role,
+        principal_kind=principal_kind,
+    )
+
+
+async def _park_approved(
+    *,
+    sub: str = _OWNER_SUB,
+    tenant_id: uuid.UUID = _TENANT_ID,
+    resume_result: dict[str, Any] | None = None,
+) -> uuid.UUID:
+    """Insert a parked → approved request row; return its id.
+
+    ``resume_result`` seeds the captured envelope directly for read-side
+    tests; the capture-side test leaves it ``None`` and drives the real
+    resume path instead.
+    """
+    operator = _make_operator(sub=sub, tenant_id=tenant_id)
+    params = {"sddc_spec_ref": "spec-42"}
+    async with get_sessionmaker()() as s:
+        request = await create_pending_request(
+            s,
+            operator=operator,
+            connector_id=_BRINGUP_CONNECTOR,
+            op_id=_BRINGUP_OP,
+            target=None,
+            params=params,
+            params_hash=compute_params_hash(params),
+        )
+        request.status = ApprovalRequestStatus.APPROVED.value
+        if resume_result is not None:
+            request.resume_result = resume_result
+        await s.commit()
+        return request.id
+
+
+# ---------------------------------------------------------------------------
+# Capture: the winning resume path persists the reduced envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_capture_persists_reduced_result_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The winning resumer stores the re-dispatch's reduced envelope on the row.
+
+    Non-idempotent bring-up case: the consumer needs the resulting task id back,
+    not a re-submit. The captured envelope carries it, and ``resumed_at`` is
+    stamped (the exactly-one-resumer claim was won).
+    """
+    request_id = await _park_approved()
+
+    fake = OperationResult(
+        status="ok",
+        op_id=_BRINGUP_OP,
+        result={"task_id": "sddc-bringup-42", "state": "IN_PROGRESS"},
+        duration_ms=12.0,
+    )
+
+    import meho_backplane.operations.dispatcher as dispatcher_module
+
+    async def _fake_dispatch(**_kwargs: object) -> OperationResult:
+        return fake
+
+    monkeypatch.setattr(dispatcher_module, "dispatch", _fake_dispatch)
+
+    async with get_sessionmaker()() as s:
+        row = await get_request(s, tenant_id=_TENANT_ID, request_id=request_id)
+    operator = _make_operator()
+    result = await resume_dispatch_after_approval(operator=operator, request=row)
+    assert result.status == "ok"
+
+    async with get_sessionmaker()() as s:
+        stored = await get_request(s, tenant_id=_TENANT_ID, request_id=request_id)
+    assert stored.resume_result is not None, "resume result must be captured on the row"
+    assert stored.resume_result["status"] == "ok"
+    assert stored.resume_result["result"]["task_id"] == "sddc-bringup-42"
+    assert stored.resumed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_resume_capture_skipped_when_claim_already_taken(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resumer that loses the claim does not overwrite the captured result.
+
+    Only the exactly-one-resumer winner reaches the capture point, so a benign
+    ``already_resumed`` no-op leaves ``resume_result`` untouched (the winner
+    owns it).
+    """
+    seeded = {"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "winner-task"}}
+    request_id = await _park_approved(resume_result=seeded)
+
+    # Pre-claim the row so this resumer loses (resumed_at already set).
+    from meho_backplane.operations.approval_queue import claim_resume
+
+    assert await claim_resume(request_id) is True
+
+    import meho_backplane.operations.dispatcher as dispatcher_module
+
+    async def _fail_dispatch(**_kwargs: object) -> OperationResult:  # pragma: no cover
+        raise AssertionError("a losing resumer must not re-dispatch")
+
+    monkeypatch.setattr(dispatcher_module, "dispatch", _fail_dispatch)
+
+    async with get_sessionmaker()() as s:
+        row = await get_request(s, tenant_id=_TENANT_ID, request_id=request_id)
+    result = await resume_dispatch_after_approval(operator=_make_operator(), request=row)
+    assert result.status == "already_resumed"
+
+    async with get_sessionmaker()() as s:
+        stored = await get_request(s, tenant_id=_TENANT_ID, request_id=request_id)
+    assert stored.resume_result == seeded, "loser must not clobber the winner's result"
+
+
+# ---------------------------------------------------------------------------
+# Read: principal scope + audit row (service layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_approval_result_returns_row_for_owner(session: AsyncSession) -> None:
+    """The originating principal reads its result back."""
+    seeded = {"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "t-1"}}
+    request_id = await _park_approved(resume_result=seeded)
+
+    row = await read_approval_result(
+        session, operator=_make_operator(sub=_OWNER_SUB), request_id=request_id
+    )
+    await session.commit()
+    assert row.resume_result == seeded
+    assert row.principal_sub == _OWNER_SUB
+
+
+@pytest.mark.asyncio
+async def test_read_approval_result_writes_synchronous_audit_row(
+    session: AsyncSession,
+) -> None:
+    """A result read leaves one ``approval.result`` audit row (v0.1-spec §6)."""
+    request_id = await _park_approved(
+        resume_result={"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "t-2"}}
+    )
+    await read_approval_result(
+        session, operator=_make_operator(sub=_OWNER_SUB), request_id=request_id
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "approval.result")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    audit = rows[0]
+    assert audit.method == "APPROVAL"
+    assert audit.status_code == 200
+    assert audit.operator_sub == _OWNER_SUB
+    assert audit.payload["approval_request_id"] == str(request_id)
+    assert audit.payload["resume_result_present"] is True
+
+
+@pytest.mark.asyncio
+async def test_read_approval_result_forbidden_for_non_owner(session: AsyncSession) -> None:
+    """A principal that is not the request owner is refused (→ 403)."""
+    request_id = await _park_approved(
+        resume_result={"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "t-3"}}
+    )
+    # Same tenant, operator role, but a different sub — must still be refused.
+    with pytest.raises(ResultAccessForbiddenError):
+        await read_approval_result(
+            session,
+            operator=_make_operator(sub="operator:someone-else", role=TenantRole.OPERATOR),
+            request_id=request_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_approval_result_forbidden_write_leaves_no_audit_row(
+    session: AsyncSession,
+) -> None:
+    """A refused (non-owner) read writes no ``approval.result`` audit row."""
+    request_id = await _park_approved(
+        resume_result={"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "t-4"}}
+    )
+    with pytest.raises(ResultAccessForbiddenError):
+        await read_approval_result(
+            session,
+            operator=_make_operator(sub="operator:intruder"),
+            request_id=request_id,
+        )
+    await session.rollback()
+
+    async with get_sessionmaker()() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "approval.result")))
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_read_approval_result_cross_tenant_is_not_found(session: AsyncSession) -> None:
+    """A request in another tenant is a 404, never reaching the owner guard."""
+    request_id = await _park_approved(tenant_id=_OTHER_TENANT_ID, sub=_OWNER_SUB)
+    with pytest.raises(ApprovalNotFoundError):
+        await read_approval_result(
+            session,
+            operator=_make_operator(sub=_OWNER_SUB, tenant_id=_TENANT_ID),
+            request_id=request_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read: REST surface (route wiring + auth dependency)
+# ---------------------------------------------------------------------------
+
+
+def _token(key: Any, *, role: TenantRole, sub: str) -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(_TENANT_ID))
+
+
+@pytest.mark.asyncio
+async def test_result_endpoint_owner_reads_result_non_operator_role() -> None:
+    """The owner reads its result at 200 — even with a non-operator role.
+
+    Proves the ``/result`` route is **principal-scoped**, not operator-gated:
+    a ``read_only`` owner (a paired add-on's service principal) reads its own
+    result; the payload rides through unchanged.
+    """
+    seeded = {"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "sddc-99"}}
+    request_id = await _park_approved(resume_result=seeded)
+
+    key = make_rsa_keypair("kid-owner")
+    headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY, sub=_OWNER_SUB)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="https://testserver",
+        ) as ac:
+            response = await ac.get(f"/api/v1/approvals/{request_id}/result", headers=headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["approval_request_id"] == str(request_id)
+    assert body["status"] == "approved"
+    assert body["result"] == seeded
+
+
+@pytest.mark.asyncio
+async def test_result_endpoint_non_owner_is_forbidden() -> None:
+    """A non-owner principal (even operator role) gets 403 ``not_request_owner``."""
+    request_id = await _park_approved(
+        resume_result={"status": "ok", "op_id": _BRINGUP_OP, "result": {"task_id": "x"}}
+    )
+    key = make_rsa_keypair("kid-intruder")
+    headers = {
+        "Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR, sub='op:intruder')}"
+    }
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="https://testserver",
+        ) as ac:
+            response = await ac.get(f"/api/v1/approvals/{request_id}/result", headers=headers)
+
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "not_request_owner"}

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9457,6 +9457,60 @@
         }
       }
     },
+    "/api/v1/approvals/{request_id}/result": {
+      "get": {
+        "tags": [
+          "approvals"
+        ],
+        "summary": "Get Approval Result",
+        "description": "Read the approved dispatch's result \u2014 originating-principal only (#3209).\n\nSurfaces the reduced / handle-shaped ``OperationResult`` envelope the\nbackplane produced when it re-dispatched the approved op, so the consumer\nthat parked a **non-idempotent** op (VCF ``installer.sddc.bringup.start``)\ncan resume in place by poll \u2014 read back the resulting task id and continue\npolling it \u2014 instead of a second submit that would start a second\nbring-up.\n\nScope is deliberately narrow (this route is **not** ``operator``-gated like\nthe rest of the approvals surface): any authenticated principal may call\nit, but :func:`~meho_backplane.operations.approval_queue.read_approval_result`\nthen enforces that only the request's **owner**\n(``operator.sub == principal_sub``, the party that parked the op) reads the\nresult. This lets a non-operator service/agent principal \u2014 the paired\nadd-on that dispatched the op \u2014 retrieve its own result, while no other\nprincipal (operator role or not) can. The read writes one synchronous\n``approval.result`` audit row (v0.1-spec \u00a76).\n\nHTTP status codes:\n\n* 200 \u2014 the request exists and the caller owns it. ``result`` is the\n  captured envelope when the resume has landed, else ``null`` (poll again).\n* 403 \u2014 the caller is authenticated but is not the request owner.\n* 404 \u2014 request not found (or belongs to another tenant).",
+        "operationId": "get_approval_result_api_v1_approvals__request_id__result_get",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Request Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalResultView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/approvals/{request_id}/approve": {
       "post": {
         "tags": [
@@ -21907,6 +21961,49 @@
         ],
         "title": "ApprovalRequestView",
         "description": "Read-only view of an :class:`~meho_backplane.db.models.ApprovalRequest`."
+      },
+      "ApprovalResultView": {
+        "properties": {
+          "approval_request_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Approval Request Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ApprovalRequestStatus"
+          },
+          "resumed": {
+            "type": "boolean",
+            "title": "Resumed"
+          },
+          "reviewed_by": {
+            "type": "string",
+            "nullable": true,
+            "title": "Reviewed By"
+          },
+          "decided_at": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decided At"
+          },
+          "result": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "approval_request_id",
+          "status",
+          "resumed",
+          "reviewed_by",
+          "decided_at",
+          "result"
+        ],
+        "title": "ApprovalResultView",
+        "description": "Principal-scoped view of an approved dispatch's result (#3209).\n\nThe response body of ``GET /api/v1/approvals/{id}/result``. Surfaces the\nreduced / handle-shaped :class:`~meho_backplane.connectors.schemas.OperationResult`\nenvelope the backplane produced when it re-dispatched the approved op, so\nthe **originating** consumer that parked a non-idempotent op (VCF\n``bringup.start``) can resume by poll instead of a second submit. ``result``\nis ``None`` until the winning resumer captures it \u2014 a ``pending`` /\n``rejected`` / ``expired`` request, or an ``approved`` one whose resume has\nnot landed yet \u2014 so a consumer polls until ``status == \"approved\"`` and\n``result`` is populated. A set-shaped payload rides a JSONFlux ``handle``\ninside ``result`` (v0.1-spec \u00a74), never a raw body."
       },
       "ApproveRequestBody": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1242,6 +1242,52 @@ type ApprovalRequestView struct {
 	WorkRef  *string               `json:"work_ref"`
 }
 
+// ApprovalResultView Principal-scoped view of an approved dispatch's result (#3209).
+//
+// The response body of “GET /api/v1/approvals/{id}/result“. Surfaces the
+// reduced / handle-shaped :class:`~meho_backplane.connectors.schemas.OperationResult`
+// envelope the backplane produced when it re-dispatched the approved op, so
+// the **originating** consumer that parked a non-idempotent op (VCF
+// “bringup.start“) can resume by poll instead of a second submit. “result“
+// is “None“ until the winning resumer captures it — a “pending“ /
+// “rejected“ / “expired“ request, or an “approved“ one whose resume has
+// not landed yet — so a consumer polls until “status == "approved"“ and
+// “result“ is populated. A set-shaped payload rides a JSONFlux “handle“
+// inside “result“ (v0.1-spec §4), never a raw body.
+type ApprovalResultView struct {
+	ApprovalRequestId openapi_types.UUID      `json:"approval_request_id"`
+	DecidedAt         *string                 `json:"decided_at"`
+	Result            *map[string]interface{} `json:"result"`
+	Resumed           bool                    `json:"resumed"`
+	ReviewedBy        *string                 `json:"reviewed_by"`
+
+	// Status Closed lifecycle status of an :class:`ApprovalRequest`.
+	//
+	// Initiative #803 (G11.2 Agent permission model), Task #817 (T4). The
+	// approval queue parks a ``requires_approval`` dispatch durably; the
+	// row walks a simple four-state lifecycle enforced by the service
+	// (:mod:`meho_backplane.operations.approval_queue`).
+	//
+	// Members:
+	//
+	// * :attr:`PENDING` -- the request was written but no decision has
+	//   been made (initial state on insert). The associated agent run (if
+	//   any) is in ``awaiting_approval``.
+	// * :attr:`APPROVED` -- an authorized operator approved the request;
+	//   the dispatcher has re-executed the original call. Terminal.
+	// * :attr:`REJECTED` -- an authorized operator rejected the request;
+	//   the original call was not executed. Terminal.
+	// * :attr:`EXPIRED` -- the ``expires_at`` deadline passed without a
+	//   decision; the expiry sweep transitioned the row and wrote the
+	//   decision audit row. Terminal.
+	//
+	// The enum and the ``CHECK (status IN (...))`` constraint on the DB
+	// table move in lock-step (migration ``0023``); the drift guard
+	// :func:`tests.test_migration_0023_approval_request.test_status_check_matches_enum`
+	// asserts equality at unit-test time.
+	Status ApprovalRequestStatus `json:"status"`
+}
+
 // ApproveRequestBody POST body for “…/approve“.
 type ApproveRequestBody struct {
 	// Async Async governed dispatch (#3079). When true, the decision is still recorded synchronously, but the resumed op is dispatched on a background task and the route returns HTTP 202 + a durable run handle immediately instead of blocking for the resumed op's full duration. Poll / cancel via ``/api/v1/operations/runs/{handle}``. Default false — the response is byte-identical to the pre-#3079 inline resume.
@@ -8964,6 +9010,11 @@ type RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// GetApprovalResultApiV1ApprovalsRequestIdResultGetParams defines parameters for GetApprovalResultApiV1ApprovalsRequestIdResultGet.
+type GetApprovalResultApiV1ApprovalsRequestIdResultGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // AskDocsEndpointApiV1AskDocsPostParams defines parameters for AskDocsEndpointApiV1AskDocsPost.
 type AskDocsEndpointApiV1AskDocsPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -12071,6 +12122,9 @@ type ClientInterface interface {
 
 	RejectApprovalRequestApiV1ApprovalsRequestIdRejectPost(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetApprovalResultApiV1ApprovalsRequestIdResultGet request
+	GetApprovalResultApiV1ApprovalsRequestIdResultGet(ctx context.Context, requestId openapi_types.UUID, params *GetApprovalResultApiV1ApprovalsRequestIdResultGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AskDocsEndpointApiV1AskDocsPostWithBody request with any body
 	AskDocsEndpointApiV1AskDocsPostWithBody(ctx context.Context, params *AskDocsEndpointApiV1AskDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13969,6 +14023,18 @@ func (c *Client) RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostWithBody(
 
 func (c *Client) RejectApprovalRequestApiV1ApprovalsRequestIdRejectPost(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostRequest(c.Server, requestId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetApprovalResultApiV1ApprovalsRequestIdResultGet(ctx context.Context, requestId openapi_types.UUID, params *GetApprovalResultApiV1ApprovalsRequestIdResultGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApprovalResultApiV1ApprovalsRequestIdResultGetRequest(c.Server, requestId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -22103,6 +22169,55 @@ func NewRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostRequestWithBody(se
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGetApprovalResultApiV1ApprovalsRequestIdResultGetRequest generates requests for GetApprovalResultApiV1ApprovalsRequestIdResultGet
+func NewGetApprovalResultApiV1ApprovalsRequestIdResultGetRequest(server string, requestId openapi_types.UUID, params *GetApprovalResultApiV1ApprovalsRequestIdResultGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "request_id", runtime.ParamLocationPath, requestId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/approvals/%s/result", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -41532,6 +41647,9 @@ type ClientWithResponsesInterface interface {
 
 	RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostWithResponse(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse, error)
 
+	// GetApprovalResultApiV1ApprovalsRequestIdResultGetWithResponse request
+	GetApprovalResultApiV1ApprovalsRequestIdResultGetWithResponse(ctx context.Context, requestId openapi_types.UUID, params *GetApprovalResultApiV1ApprovalsRequestIdResultGetParams, reqEditors ...RequestEditorFn) (*GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse, error)
+
 	// AskDocsEndpointApiV1AskDocsPostWithBodyWithResponse request with any body
 	AskDocsEndpointApiV1AskDocsPostWithBodyWithResponse(ctx context.Context, params *AskDocsEndpointApiV1AskDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskDocsEndpointApiV1AskDocsPostResponse, error)
 
@@ -43659,6 +43777,29 @@ func (r RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse) Status()
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ApprovalResultView
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -51722,6 +51863,15 @@ func (c *ClientWithResponses) RejectApprovalRequestApiV1ApprovalsRequestIdReject
 	return ParseRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse(rsp)
 }
 
+// GetApprovalResultApiV1ApprovalsRequestIdResultGetWithResponse request returning *GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse
+func (c *ClientWithResponses) GetApprovalResultApiV1ApprovalsRequestIdResultGetWithResponse(ctx context.Context, requestId openapi_types.UUID, params *GetApprovalResultApiV1ApprovalsRequestIdResultGetParams, reqEditors ...RequestEditorFn) (*GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse, error) {
+	rsp, err := c.GetApprovalResultApiV1ApprovalsRequestIdResultGet(ctx, requestId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetApprovalResultApiV1ApprovalsRequestIdResultGetResponse(rsp)
+}
+
 // AskDocsEndpointApiV1AskDocsPostWithBodyWithResponse request with arbitrary body returning *AskDocsEndpointApiV1AskDocsPostResponse
 func (c *ClientWithResponses) AskDocsEndpointApiV1AskDocsPostWithBodyWithResponse(ctx context.Context, params *AskDocsEndpointApiV1AskDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskDocsEndpointApiV1AskDocsPostResponse, error) {
 	rsp, err := c.AskDocsEndpointApiV1AskDocsPostWithBody(ctx, params, contentType, body, reqEditors...)
@@ -57195,6 +57345,39 @@ func ParseRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse(rsp *ht
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest RejectResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetApprovalResultApiV1ApprovalsRequestIdResultGetResponse parses an HTTP response from a GetApprovalResultApiV1ApprovalsRequestIdResultGetWithResponse call
+func ParseGetApprovalResultApiV1ApprovalsRequestIdResultGetResponse(rsp *http.Response) (*GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetApprovalResultApiV1ApprovalsRequestIdResultGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ApprovalResultView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -395,6 +395,75 @@ to re-dispatch, so `resume_dispatch_after_approval` **fails closed** with
 a structured `denied` result naming the gap — the operator resumes it via
 REST `/approve` + params, exactly as before 0036.
 
+## Surfacing the approved dispatch's result to the originating consumer (#3209)
+
+Before #3209 the result of the approved re-dispatch was visible **only** in
+the approver's inline HTTP response (the `dispatch_*` fields on `/approve` /
+`/decide`). A paired, out-of-process consumer that parks an op for approval
+and then *waits* on the decision could not retrieve it: `ApprovalRequestView`
+carries no execution result, and `GET /api/v1/audit/by-work-ref` reduces
+params to a hash and exposes no response body. For a **non-idempotent** op
+that is a hard block — the concrete case is VCF
+`installer.sddc.bringup.start`, where resuming in place means *polling the
+SDDC task id the re-dispatch returned*, not re-submitting (a second submit
+starts a second bring-up). So `meho-automation`'s resume-in-place engine
+(#76) had to **re-park** non-idempotent ops instead of resuming them.
+
+The fix is a durable capture + a principal-scoped read, both composing with
+the existing exactly-one-resumer substrate rather than duplicating it:
+
+1. **Capture at the winning resume path.** `resume_dispatch_after_approval`
+   — the single execute-after-approve entry point shared by REST `/approve`
+   \+ `/decide`, MCP by-id approve, and the async approve background task
+   (#3079) — persists the re-dispatch's reduced result envelope onto
+   `approval_request.resume_result` (nullable JSON, migration `0096`) right
+   after the dispatch returns. Only the resumer that **won**
+   `claim_resume` (#2293) reaches the capture (`_persist_resume_result`), so
+   it runs at most once per approved request; a loser that no-ops
+   `already_resumed` leaves the winner's result untouched. The stored value
+   is `OperationResult.model_dump(mode="json")` — the **same** reduced /
+   handle-shaped envelope the approver sees inline, so a set-shaped response
+   rides a JSONFlux `handle` (v0.1-spec §4), never a raw body. The capture is
+   **fail-soft**: the dispatch's own synchronous audit row already committed
+   inside `dispatch()` (the v0.1-spec §6 record of what executed), so a
+   capture-write failure logs `approval_resume_result_persist_failed` and is
+   swallowed rather than breaking the approve path. NULL until captured: a
+   `pending` / `rejected` / `expired` row, an **agent-run** request resumed
+   in-process (the in-process waiter re-dispatches on the agent's own task and
+   does not route through this helper — the agent already consumes the result
+   in-loop, so it needs no surfacing), and every pre-0096 row all keep NULL.
+
+2. **Principal-scoped read.** `GET /api/v1/approvals/{id}/result`
+   (`read_approval_result`) returns the captured envelope, but — unlike the
+   rest of the approvals surface — it is **not** `operator`-gated. Any
+   authenticated principal may call it, and the service then enforces that
+   only the request's **owner** (`operator.sub == principal_sub`, the party
+   that parked the op) reads it; every other principal, operator role or not,
+   gets `ResultAccessForbiddenError` → 403 `not_request_owner`. This is what
+   lets a non-operator service/agent principal — the paired add-on that
+   dispatched the op — retrieve *its own* result while no one else can.
+   Tenant isolation is upstream (`get_request` → 404 on a cross-tenant id,
+   never reaching the owner guard). The read writes one synchronous
+   `approval.result` audit row (`method='APPROVAL'`, `status_code=200`,
+   parent-linked into the request's replay subtree #2086), recording the
+   request `status` and `resume_result_present` so a poll-until-ready pattern
+   is visible on the ledger without the payload ever landing on it.
+
+The response (`ApprovalResultView`) carries `status`, `resumed`
+(`resumed_at is not None`), `reviewed_by` / `decided_at`, and `result` (the
+captured envelope, or `null` while unready). A consumer polls until
+`status == "approved"` and `result` is populated, then resumes by poll on the
+returned task id. `resume_result` is **internal to this surface** — like
+`params` it is never projected onto the default read view (`_view`) or a
+broadcast frame.
+
+**Relation to the #3027 add-on step event.** `publish_approval_event`
+already durably records the *decision* (`approval.approved` / `.rejected`)
+for the paired add-on that requested the approval
+(`AddonStepEventService.record_if_owned_committed`). That answers "was it
+approved?"; the `/result` surface answers "what did the approved re-dispatch
+produce?" — complementary, not a duplicate.
+
 ## `proposed_effect` builder hook (#1437)
 
 `ApprovalRequest.proposed_effect` holds what the reviewer sees in the
@@ -774,6 +843,7 @@ the same grant.
 |---|---|---|---|
 | `GET` | `/api/v1/approvals` | operator | List, filtered by `status` (default: `pending`). |
 | `GET` | `/api/v1/approvals/{id}` | operator | **Inspect one request** (T5). 404 on cross-tenant. |
+| `GET` | `/api/v1/approvals/{id}/result` | **request owner** (any role) | **Read the approved dispatch's result** (#3209). Principal-scoped: only `principal_sub` reads it; any other principal gets 403 `not_request_owner`. Writes an `approval.result` audit row. |
 | `POST` | `/api/v1/approvals/{id}/approve` | operator | Approve. Requires `params` (hash-verified). Re-hydrates the target by id, then re-dispatches with `dispatch(..., _approved=True)`. 403 `self_approval_forbidden` when the approver is the requester and break-glass is off (G11.7-T1). |
 | `POST` | `/api/v1/approvals/{id}/decide` | operator | Decide (`approved` / `rejected`) by id alone. For an approved **direct** op (`run_id IS NULL`) re-dispatches with the **stored** params (#1503) and returns the outcome in `dispatch_*`; for an agent-run request records the decision only (the agent runtime resumes). |
 | `POST` | `/api/v1/approvals/{id}/reject` | operator | Reject. The op never executes. |
@@ -1011,6 +1081,9 @@ Full design: [`service-principal-grants.md`](service-principal-grants.md).
 - `backend/alembic/versions/0023_create_approval_request.py` — schema.
 - `backend/alembic/versions/0036_add_approval_request_params.py` — `params` column for direct-op approve re-dispatch (#1503).
 - `backend/alembic/versions/0053_add_approval_request_session_lineage.py` — `agent_session_id` + `request_audit_id` lineage columns for session replay (#2086).
+- `backend/alembic/versions/0096_add_approval_request_resume_result.py` — `resume_result` column: the reduced result envelope of the approved re-dispatch, surfaced to the originating consumer (#3209).
+- `backend/src/meho_backplane/operations/approval_queue.py::read_approval_result` — principal-scoped result read + `approval.result` audit row (#3209).
+- `backend/src/meho_backplane/api/v1/approvals.py::get_approval_result` — `GET /api/v1/approvals/{id}/result` (#3209).
 - `backend/src/meho_backplane/operations/approval_queue.py::resume_dispatch_after_approval` — the single execute-after-approve entry point shared by every operator surface (#1503).
 - `backend/src/meho_backplane/agent/approval_wait.py` — agent-runtime resume substrate (T9 #1117): broadcast subscription + re-dispatch on approval.
 - `backend/src/meho_backplane/operations/meta_tools.py` — `call_operation_with_approval` (the gate-bypass re-dispatch entry point).


### PR DESCRIPTION
## Summary

- A paired, out-of-process consumer that parks a **non-idempotent** governed op for approval (the concrete case: VCF `installer.sddc.bringup.start`) can now, after a human approves, retrieve the result the backplane produced when it re-dispatched the approved op — so it resumes in place by *polling the returned SDDC task id* instead of a second submit that would start a second bring-up. Unblocks `meho-automation`#76's resume-in-place for `bringup`-class ops.
- **Capture**: the re-dispatch's reduced result envelope lands on a new nullable `approval_request.resume_result` column (**migration `0096`**) on the exactly-one-resumer *winning* path (`_dispatch_resume_with_bound_context`), so it composes with the `claim_resume` substrate (#2293) rather than duplicating it. Fail-soft — the dispatch's own synchronous audit row already committed, so a capture-write failure never breaks the approve path.
- **Read**: new principal-scoped `GET /api/v1/approvals/{id}/result`. Unlike the rest of the approvals surface it is **not** `operator`-gated — any authenticated principal may call it, but only the request **owner** (`principal_sub`, the party that parked the op) reads the result; every other principal (operator role or not) gets 403 `not_request_owner`. The read writes a synchronous `approval.result` audit row (v0.1-spec §6).
- The stored/served value is the **same reduced / handle-shaped** `OperationResult` envelope the approver sees inline — a set-shaped response rides a JSONFlux `handle` (v0.1-spec §4), never a raw body. `resume_result` is internal to this surface: like `params` it is never projected onto the default read view or a broadcast frame.

## Postulate notes (flagged per task instruction)

- **Postulate 5 — no new agent-surface tool.** The result surface is **REST-only** (the driving consumer is `meho-automation` over the generated typed client). No MCP tool was added, so the **25-tool working surface** and the **78-tool inventory** (pinned by `test_mcp_surface_conformance.py`) are untouched. Surfacing the result via the operator queue-view (`meho_approvals_get`) would have leaked it to any operator — the opposite of the principal-scoping the issue requires — so it stays off that surface deliberately.
- **Postulate 6 — JSONFlux.** The surfaced result is the reduced envelope; set-shaped payloads ride a result `handle`, never a raw body.
- **Audit (v0.1-spec §6).** The new read path leaves a synchronous `approval.result` row, parent-linked into the request's replay subtree (#2086).

## Migration reservation

**Reserves migration `0096`** (`down_revision 0095`; single head → `0096`). One nullable column on `approval_request`; no new table (so no conftest TRUNCATE-list change). Additive-only, reversible.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` on changed modules — clean (the pre-existing darwin-only `icmp.py MSG_ERRQUEUE` note is unrelated; Linux CI passes it)
- [x] `code-quality.py --diff` — 0 blockers
- [x] New `tests/test_approval_result_surface.py` (9) — capture persists the reduced envelope + `resumed_at` stamped; loser-of-claim does not clobber; owner reads back; synchronous `approval.result` audit row written; non-owner 403 (service layer + REST); refused read leaves no audit row; cross-tenant 404; REST owner-reads-with-non-operator-role + non-owner-403
- [x] New `tests/migrations/test_migration_0096_*` (2) — nullable add + downgrade/upgrade round-trip
- [x] Existing approval suites green (134): `test_approval_queue` / `test_api_v1_approvals` / `test_agent_approval_resume` / `test_ui_approvals` / `test_mcp_tool_approvals`
- [x] Model + operation-run + **full migration** suites green (475), single migration head = `0096`
- [x] `cli/api/openapi.json` re-snapshotted + `client.gen.go` regenerated (additive: only the `/result` route + `ApprovalResultView`); `go build ./...` clean

## Out of scope

- Agent-run (`run_id`-bearing) resumes: the in-process waiter re-dispatches on the agent's own task and does not route through the shared operator resume helper — the agent already consumes the result in-loop, so `resume_result` stays NULL there by design.
- `#3243` (approve-only RBAC role) is deliberately sequenced *after* this PR; no part of it is implemented here.

Closes #3209
