### PR TITLE
feat(connectors): governed pfSense NAT-rule + alias delete on the destructive tier (#3232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,41 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — governed delete: pfSense NAT-rule + alias delete on the destructive tier + conformance (#3232)
+
+- Registers the pfSense connector's first two `safety_level="destructive"` +
+  `requires_approval=True` typed ops (`pfsense.nat.delete`,
+  `pfsense.alias.delete`) on the governed-delete tier (decision
+  `docs/decisions/governed-delete-operations.md`; precedent #3198). Both fold
+  into the **existing single-source** delete-shaped classifier — the default
+  `*.delete` glob (`Settings.service_grant_delete_shaped_patterns`) **and** the
+  `destructive` tag — with no new pattern list; each rides the full gate
+  (mandatory human approval, no agent path, no standing grant, no self-approval
+  even under break-glass, no satellite mint, #3197 preview-hash binding, and a
+  mandatory blast-radius statement).
+- **`pfsense.nat.delete`** deletes exactly ONE port-forward NAT rule
+  (`config.xml` `<nat><rule>`) by its stable `<tracker>` id — never by position
+  or description. Fail-closed on 0 matches (`not_found`) or >1 (`ambiguous`).
+  The blast radius names the rule (interface / proto / source / destination /
+  target / port) and enumerates the associated filter rule (left in place).
+- **`pfsense.alias.delete`** deletes exactly ONE firewall alias by exact name,
+  with a fail-closed dependency check: refused (`referenced`, naming every
+  referrer) when still used by any filter rule, NAT rule (port-forward /
+  outbound / 1:1), or other alias — mirroring pfSense's own in-use guard.
+- **Surgical single-object contract** on a shared perimeter firewall (decision
+  requirement 3): a Python pre-check (exactly one match), a PHP fragment that
+  `write_config()`s only on a single removal, and a post-delete read-back that
+  verifies the object is gone **and** the count dropped by exactly one — no
+  bulk, no device-wide. Identity is re-matched at dispatch time (post-approval),
+  so a rule recreated with a new tracker between park and approval is a
+  different object and resolves to `not_found`. Applied via the connector's
+  existing `pfSsh.php playback` idiom (`write_config` + `filter_configure`).
+- Conformance (`tests/test_connectors_pfsense_delete_ops.py`): agent `DENY`,
+  `ServicePrincipalGrant` refusal (both classifier single-sources),
+  no self-approval under break-glass, satellite mint `OP_NOT_SAFE`, dispatch
+  refused without a matching preview hash, park refused without a blast-radius
+  block, the full preview → park → **human** approve → audited resume delete,
+  and the not-found / ambiguous / referenced refusal paths.
 ### Added — governed delete on bind9: `bind9.record.delete` on the destructive tier + conformance (#3231 / #3198)
 
 - Registers the **second governed delete** — and the first

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: connector aggregator module -- the PfSenseConnector class
+# (auth/fingerprint/probe/execute) plus one thin bound-method shim per typed op
+# and the group when_to_use table the registration walk reads must co-locate with
+# the class definition; splitting the shim surface out is a separate refactor.
 
 """PfSenseConnector -- typed SSH-transport connector for pfSense 2.7.
 
@@ -165,8 +169,24 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     ),
     "nat": (
         "Use for pfSense NAT operations: reading the active NAT ruleset "
-        "(``pfsense.nat.rules``). Call when the operator wants to audit "
-        "port-forwarding, outbound NAT, or 1:1 NAT rules."
+        "(``pfsense.nat.rules``) or permanently deleting one port-forward "
+        "NAT rule (``pfsense.nat.delete``). Call ``pfsense.nat.rules`` to "
+        "audit port-forwarding, outbound NAT, or 1:1 NAT rules. Call "
+        "``pfsense.nat.delete`` to retire ONE port-forward rule by its "
+        "stable tracker id -- a GOVERNED DESTRUCTIVE delete "
+        "(safety_level=destructive, mandatory human approval, preview-hash "
+        "binding, blast-radius statement); it deletes exactly one rule and "
+        "refuses fail-closed on an ambiguous or missing tracker."
+    ),
+    "alias": (
+        "Use for pfSense firewall-alias lifecycle: permanently deleting one "
+        "alias (``pfsense.alias.delete``). Call ``pfsense.alias.delete`` to "
+        "retire ONE alias by exact name -- a GOVERNED DESTRUCTIVE delete "
+        "(safety_level=destructive, mandatory human approval, preview-hash "
+        "binding, blast-radius statement). It refuses fail-closed when the "
+        "alias is still referenced by any filter rule, NAT rule, or other "
+        "alias, naming every referrer. Read the current config first with "
+        "``pfsense.config.show``."
     ),
     "network": (
         "Use for pfSense network-interface operations: listing all "
@@ -659,6 +679,45 @@ class PfSenseConnector(SshConnector):
         )
 
         return await _pfsense_route_static_add(self, target, params, operator)
+
+    async def nat_delete(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.nat.delete`` (#3232).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_delete.pfsense_nat_delete`.
+        Governed destructive delete of one port-forward NAT rule by stable
+        tracker id (``safety_level=destructive`` / ``requires_approval=True``).
+        """
+        from meho_backplane.connectors.pfsense.ops_delete import (
+            pfsense_nat_delete as _pfsense_nat_delete,
+        )
+
+        return await _pfsense_nat_delete(self, target, params, operator)
+
+    async def alias_delete(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.alias.delete`` (#3232).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_delete.pfsense_alias_delete`.
+        Governed destructive delete of one firewall alias by exact name,
+        fail-closed on any live reference (``safety_level=destructive`` /
+        ``requires_approval=True``).
+        """
+        from meho_backplane.connectors.pfsense.ops_delete import (
+            pfsense_alias_delete as _pfsense_alias_delete,
+        )
+
+        return await _pfsense_alias_delete(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/pfsense/ops.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops.py
@@ -123,22 +123,27 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
     ``pfsense.interface.list``, ``pfsense.gateway.list``,
     ``pfsense.config.show``, and ``pfsense.dhcp.leases`` (#2849)) +
     ``WRITE_OPS`` (``pfsense.gateway.add`` and
-    ``pfsense.route.static.add``, #3090). Eleven ops total.
+    ``pfsense.route.static.add``, #3090) + ``DELETE_OPS`` (the governed
+    destructive deletes ``pfsense.nat.delete`` and
+    ``pfsense.alias.delete``, #3232). Thirteen ops total.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
     :class:`PfSenseOp` + ``_PFSENSE_ABOUT_OP``, then imports the read
-    ops from :mod:`meho_backplane.connectors.pfsense.ops_read` and the
-    write ops from :mod:`meho_backplane.connectors.pfsense.ops_write`.
-    The arrangement keeps the canary op co-located with the dataclass
-    while the larger read / write surfaces live in their own modules
-    next to their parsers. Mirrors
+    ops from :mod:`meho_backplane.connectors.pfsense.ops_read`, the
+    write ops from :mod:`meho_backplane.connectors.pfsense.ops_write`,
+    and the destructive deletes from
+    :mod:`meho_backplane.connectors.pfsense.ops_delete`. The arrangement
+    keeps the canary op co-located with the dataclass while the larger
+    read / write / delete surfaces live in their own modules next to
+    their parsers. Mirrors
     :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
     """
+    from meho_backplane.connectors.pfsense.ops_delete import DELETE_OPS
     from meho_backplane.connectors.pfsense.ops_read import READ_OPS
     from meho_backplane.connectors.pfsense.ops_write import WRITE_OPS
 
-    return (_PFSENSE_ABOUT_OP, *READ_OPS, *WRITE_OPS)
+    return (_PFSENSE_ABOUT_OP, *READ_OPS, *WRITE_OPS, *DELETE_OPS)
 
 
 #: The ops :class:`PfSenseConnector` registers at lifespan startup.
@@ -148,10 +153,11 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
 #: ``pfsense.interface.list``, ``pfsense.gateway.list``,
 #: ``pfsense.config.show``); #2849 adds ``pfsense.dhcp.leases``; #3090
 #: adds the first write ops (``pfsense.gateway.add``,
-#: ``pfsense.route.static.add``) -- 11 ops total. The shape of each
-#: follow-on PR is "import a new module-level tuple and splat it
-#: into :data:`PFSENSE_OPS` via :func:`_pfsense_ops`" -- the
-#: registration walk in
+#: ``pfsense.route.static.add``); #3232 adds the first governed
+#: destructive deletes (``pfsense.nat.delete``, ``pfsense.alias.delete``)
+#: -- 13 ops total. The shape of each follow-on PR is "import a new
+#: module-level tuple and splat it into :data:`PFSENSE_OPS` via
+#: :func:`_pfsense_ops`" -- the registration walk in
 #: :meth:`PfSenseConnector.register_operations` does not need to
 #: change.
 PFSENSE_OPS: tuple[PfSenseOp, ...] = _pfsense_ops()

--- a/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
@@ -1,0 +1,1057 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: declarative op module (parsers + small handlers + agent-facing
+# op metadata / JSON schemas / llm_instructions) mirroring the ops_write.py sibling's
+# single-module-per-op-group convention; all functions are small + low-complexity.
+
+"""pfSense governed destructive deletes -- NAT-rule + alias delete (#3232).
+
+Adds the connector's first two ``safety_level="destructive"`` typed ops:
+
+* ``pfsense.nat.delete`` -- permanently delete ONE port-forward NAT rule
+  (``config.xml`` ``<nat><rule>``) identified by its stable ``<tracker>``
+  id. Refuses fail-closed on 0 matches (``not_found``) or >1 matches
+  (``ambiguous`` -- a corrupt config with a duplicated tracker), never
+  guesses by position or description.
+* ``pfsense.alias.delete`` -- permanently delete ONE firewall alias
+  (``config.xml`` ``<aliases><alias>``) by exact ``<name>``. Refuses
+  fail-closed (``referenced``) when the alias is still referenced by any
+  filter rule, NAT rule (port-forward / outbound / 1:1), or other alias --
+  naming the referrers -- exactly as pfSense's own delete guard does.
+
+Governed-delete tier (the whole point of #3232)
+-----------------------------------------------
+
+Both ops are ``safety_level="destructive"`` + ``requires_approval=True``,
+so they ride the hardest gate MEHO has (decision
+``docs/decisions/governed-delete-operations.md``): mandatory human approval
+always (no agent path, no standing grant -- both op-ids match the
+single-source ``*.delete`` delete-shaped classifier
+:data:`~meho_backplane.settings._DEFAULT_SERVICE_GRANT_DELETE_SHAPED_PATTERNS`
+*and* carry the ``destructive`` tag -- no self-approval even under
+break-glass), a mandatory preview-hash binding, and a mandatory
+blast-radius statement. The blast-radius builders here name the exact rule
+/ alias (identity + summary) so the four-eyes approver reads *precisely
+what dies* before deciding. These run against a **shared perimeter
+firewall**, so per-object identity binding -- never bulk, never
+device-wide -- is load-bearing (decision requirement 3).
+
+Why config.xml, not ``pfctl``
+-----------------------------
+
+The read op ``pfsense.nat.rules`` parses ``pfctl -sn`` -- the *runtime,
+compiled* pf table, which carries no stable per-rule identity. A surgical,
+identity-bound delete must operate on the **source of truth**
+(``/cf/conf/config.xml``), where each port-forward rule carries a stable
+``<tracker>`` (a creation-time unix-timestamp id, stable across reordering)
+and each alias a unique ``<name>``. The mutation runs through the same
+``pfSsh.php playback`` idiom the ``ops_write`` additive writes use, and
+applies via ``filter_configure()`` (NAT rules and aliases both compile into
+the pf ruleset), then reads ``config.xml`` back to verify.
+
+Surgical single-object contract (adversarial risk #1)
+-----------------------------------------------------
+
+The one risk on config-array manipulation is deleting *more than* the one
+identified object. Three independent guards enforce single-object deletion:
+
+1. **Python pre-check.** The handler parses ``config.xml`` and requires
+   **exactly one** match before staging any playback; 0 → ``not_found``,
+   >1 → ``ambiguous`` (fail-closed, refuse).
+2. **PHP fragment guard.** The playback removes by exact tracker / name and
+   ``write_config()`` runs **only when exactly one** entry was removed
+   (``$meho_removed === 1``); a 0- or 2-match removal persists nothing.
+3. **Read-back verification.** After the playback the handler re-reads
+   ``config.xml`` and asserts the object is **absent** *and* the surviving
+   count dropped by **exactly one** -- a bulk deletion (whole array) or a
+   no-op is caught and raises rather than reporting a false success.
+
+Stale-approval safety (adversarial risk #5). Identity is the tracker /
+name, re-matched at *dispatch* time (post-approval). A rule
+deleted-and-recreated between preview and approval gets a **new** tracker,
+so the approved delete (old tracker) resolves to ``not_found`` and the
+recreated rule is untouched; the #3197 preview-hash binds the params so the
+tracker cannot be swapped after approval.
+
+Injection safety
+----------------
+
+The tracker is validated digits-only and the alias name against a
+word-character allowlist before any SSH round-trip; both are emitted
+through :func:`~meho_backplane.connectors.pfsense.ops_write._php_squote`
+inside the quoted-heredoc fragment. Neither carries shell metacharacters
+or PHP string-literal terminators.
+
+References
+----------
+
+* Task: #3232. Parent decision: ``docs/decisions/governed-delete-operations.md``.
+* Precedent (first governed delete): #3198 / ``vmware.composite.vm.destroy``.
+* Additive-write precedent: :mod:`meho_backplane.connectors.pfsense.ops_write`.
+* pfSense config.xml tracker semantics:
+  https://forum.netgate.com/topic/82877/purpose-of-tracker-on-pfsense-config-rules
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from defusedxml.ElementTree import ParseError, fromstring
+
+from meho_backplane.connectors.pfsense.ops import PfSenseOp
+from meho_backplane.connectors.pfsense.ops_write import (
+    _apply_playback,
+    _php_squote,
+    _read_config_xml,
+)
+from meho_backplane.operations._preview import PreviewContext, register_preview_builder
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.pfsense.connector import PfSenseConnector
+
+__all__ = [
+    "DELETE_OPS",
+    "find_alias_references",
+    "parse_aliases_xml",
+    "parse_nat_port_forwards_xml",
+    "pfsense_alias_delete",
+    "pfsense_nat_delete",
+    "register_pfsense_delete_preview_builders",
+]
+
+# A pfSense rule ``<tracker>`` is an integer creation-time id (``time()``
+# based). Digits-only -- injection-safe, and rejects a caller trying to
+# pass a positional index or a description as the identity.
+_TRACKER_RE = re.compile(r"^[0-9]{1,20}$")
+
+# pfSense alias names are word characters (its own validator is
+# ``^[a-zA-Z0-9_]+$``). Bounded + metacharacter-free, so the value is safe
+# to emit into the playback fragment and to compare as a reference token.
+_ALIAS_NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,64}$")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_tracker(value: Any) -> str:
+    """Return *value* if it is a valid NAT-rule tracker id, else raise."""
+    if not isinstance(value, str) or not _TRACKER_RE.match(value):
+        raise ValueError(
+            "tracker must be the rule's stable numeric <tracker> id "
+            f"(^[0-9]{{1,20}}$); got {value!r}. Read the current NAT rules "
+            "first to find a rule's tracker -- this op never deletes by "
+            "position or description."
+        )
+    return value
+
+
+def _validate_alias_name(value: Any) -> str:
+    """Return *value* if it is a valid pfSense alias name, else raise."""
+    if not isinstance(value, str) or not _ALIAS_NAME_RE.match(value):
+        raise ValueError(
+            "alias name must match ^[A-Za-z0-9_]{1,64}$ (alphanumeric, "
+            f"underscore); got {value!r}"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# config.xml parsing
+# ---------------------------------------------------------------------------
+
+
+def _child_text(element: Any, tag: str) -> str | None:
+    """Return the text of *tag* under *element*, or ``None``.
+
+    *element* is a ``defusedxml``-parsed node; defusedxml ships no type
+    stubs, so it surfaces as ``Any`` (annotating it with the stdlib
+    ``Element`` type would re-introduce the ``xml.etree`` import Semgrep
+    flags as an XXE vector). Mirrors
+    :func:`meho_backplane.connectors.pfsense.ops_write._child_text`.
+    """
+    child = element.find(tag)
+    return child.text if child is not None else None
+
+
+def _flatten_endpoint(element: Any) -> str:
+    """Summarise a pfSense ``<source>`` / ``<destination>`` block to a string.
+
+    pfSense serialises a rule endpoint as a nested block -- ``<any></any>``,
+    ``<network>wanip</network>``, or ``<address>ALIAS_OR_IP</address>`` --
+    with an optional ``<port>``. Flattened to a compact human string
+    (``"any"`` / ``"10.0.0.0/24:443"`` / ``"WEB_SERVERS"``) for the
+    blast-radius summary the approver reads. Returns ``"any"`` for a missing
+    or empty block (the pfSense default).
+    """
+    if element is None:
+        return "any"
+    if element.find("any") is not None:
+        base = "any"
+    else:
+        base = _child_text(element, "network") or _child_text(element, "address") or "any"
+    port = _child_text(element, "port")
+    return f"{base}:{port}" if port else base
+
+
+def parse_nat_port_forwards_xml(xml_text: str) -> list[dict[str, Any]]:
+    """Parse the ``<nat>`` port-forward rules from ``/cf/conf/config.xml``.
+
+    Returns one dict per ``<nat><rule>`` (port-forward / ``rdr``) child, in
+    document order, each carrying the fields the delete identity + the
+    blast-radius summary need:
+
+    .. code-block:: python
+
+        {
+            "tracker": "1585165239",      # the stable delete identity (or None)
+            "associated_rule_id": "nat_...",  # linked filter rule id, or None
+            "interface": "wan",
+            "protocol": "tcp",
+            "source": "any",
+            "destination": "wanip:443",
+            "target": "10.0.0.5",
+            "local_port": "443",
+            "descr": "web",
+            "position": 1,                # 1-based, for the operator's reference only
+        }
+
+    ``position`` is informational -- it is **never** the delete key. Returns
+    an empty list on any parse failure or an absent ``<nat>`` block. Only
+    the port-forward ``<nat><rule>`` chain is parsed (outbound / 1:1 NAT are
+    a separate config sub-tree, out of this op's scope).
+
+    >>> xml = (
+    ...     "<pfsense><nat><rule><tracker>1585165239</tracker>"
+    ...     "<interface>wan</interface><protocol>tcp</protocol>"
+    ...     "<target>10.0.0.5</target><local-port>443</local-port>"
+    ...     "<destination><network>wanip</network><port>443</port></destination>"
+    ...     "</rule></nat></pfsense>"
+    ... )
+    >>> parse_nat_port_forwards_xml(xml)[0]["tracker"]
+    '1585165239'
+    >>> parse_nat_port_forwards_xml(xml)[0]["destination"]
+    'wanip:443'
+    """
+    if not xml_text.strip():
+        return []
+    try:
+        root = fromstring(xml_text)
+    except ParseError:
+        return []
+    nat_root = root if root.tag == "nat" else root.find(".//nat")
+    if nat_root is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for position, item in enumerate(nat_root.findall("rule"), start=1):
+        rows.append(
+            {
+                "tracker": _child_text(item, "tracker"),
+                "associated_rule_id": _child_text(item, "associated-rule-id"),
+                "interface": _child_text(item, "interface"),
+                "protocol": _child_text(item, "protocol"),
+                "source": _flatten_endpoint(item.find("source")),
+                "destination": _flatten_endpoint(item.find("destination")),
+                "target": _child_text(item, "target"),
+                "local_port": _child_text(item, "local-port"),
+                "descr": _child_text(item, "descr"),
+                "position": position,
+            }
+        )
+    return rows
+
+
+def parse_aliases_xml(xml_text: str) -> list[dict[str, Any]]:
+    """Parse the ``<aliases>`` block from ``/cf/conf/config.xml``.
+
+    Returns one dict per ``<alias>`` child with ``name``, ``type``,
+    ``address``, and ``descr`` keys (``None`` for a missing tag). Returns an
+    empty list on any parse failure or an absent ``<aliases>`` block.
+
+    >>> xml = (
+    ...     "<pfsense><aliases><alias><name>WEB</name><type>host</type>"
+    ...     "<address>192.0.2.10</address></alias></aliases></pfsense>"
+    ... )
+    >>> parse_aliases_xml(xml)[0]["name"]
+    'WEB'
+    """
+    if not xml_text.strip():
+        return []
+    try:
+        root = fromstring(xml_text)
+    except ParseError:
+        return []
+    aliases_root = root if root.tag == "aliases" else root.find(".//aliases")
+    if aliases_root is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in aliases_root.findall("alias"):
+        rows.append(
+            {
+                "name": _child_text(item, "name"),
+                "type": _child_text(item, "type"),
+                "address": _child_text(item, "address"),
+                "descr": _child_text(item, "descr"),
+            }
+        )
+    return rows
+
+
+def _endpoint_tokens(element: Any) -> list[str]:
+    """Return the alias-accepting field values of a ``<source>``/``<destination>``.
+
+    A rule endpoint references an alias by putting the alias name in its
+    ``<address>`` (address alias) or ``<port>`` (port alias). Both are
+    collected so the reference scan catches either.
+    """
+    if element is None:
+        return []
+    tokens: list[str] = []
+    for tag in ("address", "port"):
+        val = _child_text(element, tag)
+        if val:
+            tokens.append(val)
+    return tokens
+
+
+def _reference_row(kind: str, element: Any, name_from: str = "tracker") -> dict[str, Any]:
+    """Build a named referrer row for the fail-closed refusal message."""
+    return {
+        "kind": kind,
+        "id": _child_text(element, name_from),
+        "descr": _child_text(element, "descr"),
+    }
+
+
+def find_alias_references(xml_text: str, alias_name: str) -> list[dict[str, Any]]:
+    """Return the config objects that reference *alias_name* (fail-closed guard).
+
+    Scans the same reference surface pfSense's own delete guard checks, so a
+    delete that pfSense would refuse ("Cannot delete alias. Currently in use
+    by ...") is refused here too -- **before** any mutation:
+
+    * **Other aliases** -- a nested alias whose ``<address>`` lists
+      *alias_name* as a space-separated token.
+    * **Filter rules** (``<filter><rule>``) -- source / destination
+      ``<address>`` or ``<port>``.
+    * **NAT port-forward rules** (``<nat><rule>``) -- source / destination
+      ``<address>`` / ``<port>``, ``<target>``, ``<local-port>``.
+    * **NAT outbound rules** (``<nat><outbound><rule>``) -- source /
+      destination ``<network>`` / ``<port>``, ``<sourceport>``,
+      ``<dstport>``, ``<target>``.
+    * **1:1 NAT** (``<nat><onetoone>``) -- source / destination
+      ``<address>`` and ``<external>``.
+
+    Returns one ``{kind, id, descr}`` row per referrer so the refusal can
+    name every one (``id`` is the rule tracker or the referring alias name).
+    An empty list means the alias is safe to delete. Returns an empty list
+    on parse failure only after a successful parse would have found nothing;
+    a genuinely unparseable config yields ``[]`` here but the handler's own
+    ``config.xml`` read-and-parse guards catch a broken config first.
+    """
+    if not xml_text.strip():
+        return []
+    try:
+        root = fromstring(xml_text)
+    except ParseError:
+        return []
+    refs: list[dict[str, Any]] = []
+
+    # Nested aliases: another alias whose address lists this name as a token.
+    aliases_root = root if root.tag == "aliases" else root.find(".//aliases")
+    if aliases_root is not None:
+        for alias in aliases_root.findall("alias"):
+            this_name = _child_text(alias, "name")
+            if this_name == alias_name:
+                continue  # the alias being deleted -- not a self-reference
+            address = _child_text(alias, "address") or ""
+            if alias_name in address.split():
+                refs.append(
+                    {"kind": "alias", "id": this_name, "descr": _child_text(alias, "descr")}
+                )
+
+    # Filter rules.
+    filter_root = root.find(".//filter")
+    if filter_root is not None:
+        for rule in filter_root.findall("rule"):
+            tokens = _endpoint_tokens(rule.find("source")) + _endpoint_tokens(
+                rule.find("destination")
+            )
+            if alias_name in tokens:
+                refs.append(_reference_row("filter_rule", rule))
+
+    # NAT: port-forward, outbound, and 1:1.
+    nat_root = root.find(".//nat")
+    if nat_root is not None:
+        for rule in nat_root.findall("rule"):
+            tokens = (
+                _endpoint_tokens(rule.find("source"))
+                + _endpoint_tokens(rule.find("destination"))
+                + [t for t in (_child_text(rule, "target"), _child_text(rule, "local-port")) if t]
+            )
+            if alias_name in tokens:
+                refs.append(_reference_row("nat_rule", rule))
+        outbound = nat_root.find("outbound")
+        if outbound is not None:
+            for rule in outbound.findall("rule"):
+                tokens = [
+                    t
+                    for t in (
+                        _child_text(rule.find("source"), "network")
+                        if rule.find("source") is not None
+                        else None,
+                        _child_text(rule.find("destination"), "network")
+                        if rule.find("destination") is not None
+                        else None,
+                        _child_text(rule, "sourceport"),
+                        _child_text(rule, "dstport"),
+                        _child_text(rule, "target"),
+                    )
+                    if t
+                ]
+                if alias_name in tokens:
+                    refs.append(_reference_row("nat_outbound_rule", rule))
+        for rule in nat_root.findall("onetoone"):
+            tokens = _endpoint_tokens(rule.find("source")) + _endpoint_tokens(
+                rule.find("destination")
+            )
+            external = _child_text(rule, "external")
+            if external:
+                tokens.append(external)
+            if alias_name in tokens:
+                refs.append(_reference_row("nat_onetoone_rule", rule))
+
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# pfSsh.php playback fragment construction
+# ---------------------------------------------------------------------------
+
+
+def _build_nat_delete_playback(tracker: str) -> str:
+    """Return the raw-PHP playback fragment that deletes ONE NAT rule by tracker.
+
+    Removes only the ``<nat><rule>`` whose ``<tracker>`` matches, reindexes
+    the array, and persists **only when exactly one** entry was removed
+    (``$meho_removed === 1``) -- so a concurrent 0- or 2-match state
+    persists nothing. Applies via ``filter_configure()`` (NAT rules compile
+    into the pf ruleset).
+    """
+    lines = [
+        "global $config;",
+        f"$meho_tracker = {_php_squote(tracker)};",
+        "$meho_removed = 0;",
+        "if (is_array($config['nat']) && is_array($config['nat']['rule'])) {",
+        "  foreach ($config['nat']['rule'] as $meho_i => $meho_r) {",
+        "    if (isset($meho_r['tracker']) && (string)$meho_r['tracker'] === $meho_tracker) {",
+        "      unset($config['nat']['rule'][$meho_i]);",
+        "      $meho_removed++;",
+        "    }",
+        "  }",
+        "  if ($meho_removed > 0) {",
+        "    $config['nat']['rule'] = array_values($config['nat']['rule']);",
+        "  }",
+        "}",
+        "if ($meho_removed === 1) {",
+        f"  write_config({_php_squote('meho: delete nat rule tracker ' + tracker)});",
+        "  filter_configure();",
+        "}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _build_alias_delete_playback(name: str) -> str:
+    """Return the raw-PHP playback fragment that deletes ONE alias by name.
+
+    Removes only the ``<aliases><alias>`` whose ``<name>`` matches,
+    reindexes, and persists **only when exactly one** entry was removed.
+    Applies via ``filter_configure()`` (aliases compile into pf tables).
+    """
+    lines = [
+        "global $config;",
+        f"$meho_name = {_php_squote(name)};",
+        "$meho_removed = 0;",
+        "if (is_array($config['aliases']) && is_array($config['aliases']['alias'])) {",
+        "  foreach ($config['aliases']['alias'] as $meho_i => $meho_a) {",
+        "    if (isset($meho_a['name']) && (string)$meho_a['name'] === $meho_name) {",
+        "      unset($config['aliases']['alias'][$meho_i]);",
+        "      $meho_removed++;",
+        "    }",
+        "  }",
+        "  if ($meho_removed > 0) {",
+        "    $config['aliases']['alias'] = array_values($config['aliases']['alias']);",
+        "  }",
+        "}",
+        "if ($meho_removed === 1) {",
+        f"  write_config({_php_squote('meho: delete alias ' + name)});",
+        "  filter_configure();",
+        "}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _script_token(value: str) -> str:
+    """Return a filename-safe token for a playback script name."""
+    return re.sub(r"[^A-Za-z0-9]", "_", value)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def pfsense_nat_delete(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.nat.delete`` -- governed single-rule NAT delete.
+
+    Sequence: validate ``tracker`` -> read ``config.xml`` -> match
+    port-forward rules by tracker. **Fail-closed pre-check:** 0 matches ->
+    ``not_found``, >1 matches -> ``ambiguous`` (never guess). Exactly one ->
+    stage + play back the delete-by-tracker fragment (which persists only on
+    a single removal), then read ``config.xml`` back and verify the rule is
+    **absent** *and* the surviving rule count dropped by **exactly one** --
+    proving a surgical single-object delete, never a bulk one. Runs at
+    dispatch time (post-approval), so a rule recreated with a new tracker
+    between park and approval is a different object and resolves to
+    ``not_found``.
+
+    Returns ``{op_class, resource, status, tracker, matched, removed,
+    rules_before, rules_after, verified, guidance}``. ``removed`` carries
+    the deleted rule's identity on success (else ``None``).
+    """
+    tracker = _validate_tracker(params.get("tracker"))
+
+    before = await _read_config_xml(self, target, operator)
+    rules_before = parse_nat_port_forwards_xml(before)
+    matches = [r for r in rules_before if r.get("tracker") == tracker]
+
+    result: dict[str, Any] = {
+        "op_class": "delete",
+        "resource": "nat_rule",
+        "tracker": tracker,
+        "matched": len(matches),
+        "removed": None,
+        "rules_before": len(rules_before),
+        "rules_after": None,
+        "verified": False,
+    }
+    if not matches:
+        return {
+            **result,
+            "status": "not_found",
+            "guidance": (
+                f"no port-forward NAT rule with tracker {tracker!r} in config.xml "
+                f"({len(rules_before)} port-forward rule(s) present); nothing deleted"
+            ),
+        }
+    if len(matches) > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"{len(matches)} port-forward NAT rules share tracker {tracker!r} "
+                "(corrupt config); refusing to delete -- an operator must "
+                "disambiguate the duplicate trackers first"
+            ),
+        }
+
+    rule = matches[0]
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_nat_delete_{_script_token(tracker)}",
+        script_body=_build_nat_delete_playback(tracker),
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    rules_after = parse_nat_port_forwards_xml(after)
+    still_present = any(r.get("tracker") == tracker for r in rules_after)
+    removed_exactly_one = len(rules_after) == len(rules_before) - 1
+    if still_present or not removed_exactly_one:
+        raise RuntimeError(
+            f"nat.delete verification failed for tracker {tracker!r}: "
+            f"present_after={still_present}, rules {len(rules_before)}->{len(rules_after)} "
+            "(expected exactly one fewer); the pfSsh.php playback did not persist a "
+            "clean single-rule delete"
+        )
+    return {
+        **result,
+        "status": "deleted",
+        "removed": rule,
+        "rules_after": len(rules_after),
+        "verified": True,
+        "guidance": None,
+    }
+
+
+async def pfsense_alias_delete(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.alias.delete`` -- governed single-alias delete.
+
+    Sequence: validate ``name`` -> read ``config.xml`` -> match aliases by
+    exact name. **Fail-closed pre-checks:** 0 matches -> ``not_found``, >1 ->
+    ``ambiguous``; then a **dependency check** -- if any filter rule, NAT
+    rule (port-forward / outbound / 1:1), or other alias still references the
+    name, refuse with ``referenced`` and name every referrer, deleting
+    nothing (mirrors pfSense's own in-use guard). Only a single,
+    unreferenced alias is deleted: stage + play back the delete-by-name
+    fragment (persists only on a single removal), then read ``config.xml``
+    back and verify the alias is **absent** *and* the alias count dropped by
+    **exactly one**. Runs at dispatch time (post-approval), so a reference
+    added between park and approval is still caught.
+
+    Returns ``{op_class, resource, status, name, matched, removed,
+    references, reference_count, aliases_before, aliases_after, verified,
+    guidance}``.
+    """
+    name = _validate_alias_name(params.get("name"))
+
+    before = await _read_config_xml(self, target, operator)
+    aliases_before = parse_aliases_xml(before)
+    matches = [a for a in aliases_before if a.get("name") == name]
+
+    result: dict[str, Any] = {
+        "op_class": "delete",
+        "resource": "alias",
+        "name": name,
+        "matched": len(matches),
+        "removed": None,
+        "references": [],
+        "reference_count": 0,
+        "aliases_before": len(aliases_before),
+        "aliases_after": None,
+        "verified": False,
+    }
+    if not matches:
+        return {
+            **result,
+            "status": "not_found",
+            "guidance": (
+                f"no alias named {name!r} in config.xml "
+                f"({len(aliases_before)} alias(es) present); nothing deleted"
+            ),
+        }
+    if len(matches) > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"{len(matches)} aliases share the name {name!r} (corrupt config); "
+                "refusing to delete -- an operator must disambiguate first"
+            ),
+        }
+
+    references = find_alias_references(before, name)
+    if references:
+        referrers = ", ".join(
+            f"{r['kind']}({r.get('id') or '?'}{': ' + r['descr'] if r.get('descr') else ''})"
+            for r in references
+        )
+        return {
+            **result,
+            "status": "referenced",
+            "references": references,
+            "reference_count": len(references),
+            "guidance": (
+                f"alias {name!r} is still referenced by {len(references)} object(s) "
+                f"[{referrers}]; refusing to delete (fail-closed) -- remove or "
+                "repoint those references first"
+            ),
+        }
+
+    alias = matches[0]
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_alias_delete_{_script_token(name)}",
+        script_body=_build_alias_delete_playback(name),
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    aliases_after = parse_aliases_xml(after)
+    still_present = any(a.get("name") == name for a in aliases_after)
+    removed_exactly_one = len(aliases_after) == len(aliases_before) - 1
+    if still_present or not removed_exactly_one:
+        raise RuntimeError(
+            f"alias.delete verification failed for {name!r}: present_after={still_present}, "
+            f"aliases {len(aliases_before)}->{len(aliases_after)} (expected exactly one "
+            "fewer); the pfSsh.php playback did not persist a clean single-alias delete"
+        )
+    return {
+        **result,
+        "status": "deleted",
+        "removed": alias,
+        "aliases_after": len(aliases_after),
+        "verified": True,
+        "guidance": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Blast-radius preview builders (#3197 mandatory destructive-tier block)
+# ---------------------------------------------------------------------------
+
+
+async def _read_config_for_preview(ctx: PreviewContext) -> str | None:
+    """Read ``config.xml`` for a preview builder; ``None`` on any failure.
+
+    The blast-radius builders are fail-soft: a connector that cannot be
+    resolved, or a ``config.xml`` read that faults, declines (``None``) ->
+    the park is refused ``blast_radius_required`` (fail-closed), never
+    executed.
+    """
+    if ctx.connector_instance is None:
+        return None
+    try:
+        return await _read_config_xml(
+            ctx.connector_instance,  # type: ignore[arg-type]  # PfSenseConnector at runtime
+            ctx.target,
+            ctx.operator,
+        )
+    except Exception:
+        # Fail-soft: any read fault (transport, non-zero cat, malformed) declines
+        # the preview -> the park is refused ``blast_radius_required`` (fail-closed).
+        return None
+
+
+async def _nat_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Blast-radius builder for ``pfsense.nat.delete`` (#3197 requirement 3).
+
+    Live-reads ``config.xml`` and, when the tracker resolves to **exactly
+    one** port-forward rule, populates the mandatory blast-radius block:
+    the object identity (tracker + interface / proto / source / destination
+    / target / port summary) and, as an enumerated child, the associated
+    filter rule (if any) that this op leaves in place. Declines (``None`` ->
+    park refused ``blast_radius_required``, fail-closed) when the connector
+    can't be read or the tracker does not resolve to a unique rule.
+    """
+    tracker = ctx.params.get("tracker")
+    if not isinstance(tracker, str) or not _TRACKER_RE.match(tracker):
+        return None
+    xml_text = await _read_config_for_preview(ctx)
+    if xml_text is None:
+        return None
+    matches = [r for r in parse_nat_port_forwards_xml(xml_text) if r.get("tracker") == tracker]
+    if len(matches) != 1:
+        return None
+    rule = matches[0]
+    children: list[dict[str, Any]] = []
+    if rule.get("associated_rule_id"):
+        children.append(
+            {
+                "kind": "associated_filter_rule",
+                "id": rule["associated_rule_id"],
+                "note": "left in place -- this op deletes only the NAT rule",
+            }
+        )
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "nat_rule",
+                "tracker": tracker,
+                "interface": rule.get("interface"),
+                "protocol": rule.get("protocol"),
+                "source": rule.get("source"),
+                "destination": rule.get("destination"),
+                "target": rule.get("target"),
+                "local_port": rule.get("local_port"),
+                "descr": rule.get("descr"),
+                "position": rule.get("position"),
+            },
+            "children": children,
+            "irreversibility": "permanent",
+        },
+    }
+
+
+async def _alias_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Blast-radius builder for ``pfsense.alias.delete`` (#3197 requirement 3).
+
+    Live-reads ``config.xml`` and, when the name resolves to **exactly one**
+    alias, populates the mandatory blast-radius block: the object identity
+    (name / type / address / descr) plus, as enumerated children, every
+    object that references the alias -- with ``reference_count`` surfaced so
+    the approver sees at a glance that the delete will be **refused** at
+    execution (fail-closed) unless those references are removed first.
+    Declines (``None`` -> park refused ``blast_radius_required``) when the
+    connector can't be read or the name does not resolve to a unique alias.
+    """
+    name = ctx.params.get("name")
+    if not isinstance(name, str) or not _ALIAS_NAME_RE.match(name):
+        return None
+    xml_text = await _read_config_for_preview(ctx)
+    if xml_text is None:
+        return None
+    matches = [a for a in parse_aliases_xml(xml_text) if a.get("name") == name]
+    if len(matches) != 1:
+        return None
+    alias = matches[0]
+    references = find_alias_references(xml_text, name)
+    children = [
+        {"kind": "reference", "ref_kind": r["kind"], "id": r.get("id"), "descr": r.get("descr")}
+        for r in references
+    ]
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "alias",
+                "name": name,
+                "type": alias.get("type"),
+                "address": alias.get("address"),
+                "descr": alias.get("descr"),
+            },
+            "children": children,
+            "reference_count": len(references),
+            "irreversibility": "permanent",
+        },
+    }
+
+
+def register_pfsense_delete_preview_builders() -> None:
+    """Wire the destructive-delete blast-radius builders. Import-time.
+
+    Mirrors :func:`meho_backplane.operations._preview._register_builtin_builders`
+    and the argocd ``ops_write_preview`` side-effect: called at module import
+    (the bottom of this module) so the builders are registered by the time
+    the connector package finishes importing and any dispatch can park.
+    Idempotent -- re-registration overwrites.
+    """
+    register_preview_builder("pfsense.nat.delete", _nat_delete_preview)
+    register_preview_builder("pfsense.alias.delete", _alias_delete_preview)
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` for the ``nat`` group's destructive delete. The
+#: authoritative group-level copy lives in ``_WHEN_TO_USE_BY_GROUP`` in
+#: ``connector.py`` (the registration walk reads that); this is the per-op
+#: ``llm_instructions.when_to_use``.
+_NAT_DELETE_WHEN_TO_USE = (
+    "Permanently delete ONE pfSense port-forward NAT rule, identified by its "
+    "stable ``tracker`` id (read the current rules first to find it). "
+    "GOVERNED DESTRUCTIVE DELETE: safety_level=destructive, requires mandatory "
+    "human approval (no agent path, no standing grant, no self-approval), a "
+    "preview-hash binding, and a blast-radius statement the approver reads. "
+    "Fail-closed: refuses on 0 matches (``not_found``) or >1 (``ambiguous``); "
+    "never deletes by position or description; deletes exactly one rule and "
+    "verifies the count dropped by one. Runs against a SHARED perimeter "
+    "firewall -- per-rule identity binding is the point. Leaves any associated "
+    "filter rule in place (surfaced in the blast radius)."
+)
+
+#: Curated ``when_to_use`` for the ``alias`` group's destructive delete.
+_ALIAS_DELETE_WHEN_TO_USE = (
+    "Permanently delete ONE pfSense firewall alias by exact name. GOVERNED "
+    "DESTRUCTIVE DELETE (same tier + gate as ``pfsense.nat.delete``). "
+    "Fail-closed dependency check: refuses (``referenced``) when the alias is "
+    "still used by any filter rule, NAT rule (port-forward / outbound / 1:1), "
+    "or other alias, naming every referrer -- remove or repoint those first. "
+    "Also refuses on 0 matches (``not_found``) or >1 (``ambiguous``). Deletes "
+    "exactly one alias and verifies the count dropped by one."
+)
+
+_NAT_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "tracker": {
+            "type": "string",
+            "pattern": "^[0-9]{1,20}$",
+            "description": (
+                "The stable ``<tracker>`` id of the ONE port-forward NAT rule "
+                "to delete (a creation-time unix-timestamp id, stable across "
+                "reordering). The delete identity -- never a position or "
+                "description. A tracker matching 0 rules is ``not_found``; >1 "
+                "(corrupt config) is ``ambiguous`` and refused."
+            ),
+        },
+    },
+    "required": ["tracker"],
+    "additionalProperties": False,
+}
+
+_NAT_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["delete"]},
+        "resource": {"type": "string", "enum": ["nat_rule"]},
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_found", "ambiguous"],
+            "description": (
+                "``deleted`` on a verified single-rule delete; ``not_found`` "
+                "when no rule carries the tracker; ``ambiguous`` when >1 do "
+                "(refused, fail-closed)."
+            ),
+        },
+        "tracker": {"type": "string"},
+        "matched": {"type": "integer"},
+        "removed": {"type": ["object", "null"]},
+        "rules_before": {"type": ["integer", "null"]},
+        "rules_after": {"type": ["integer", "null"]},
+        "verified": {"type": "boolean"},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["op_class", "resource", "status", "tracker", "matched", "verified"],
+    "additionalProperties": False,
+}
+
+_NAT_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": _NAT_DELETE_WHEN_TO_USE,
+    "parameter_hints": {
+        "tracker": (
+            "Required. The rule's stable numeric <tracker> id from config.xml "
+            "(not a position or description)."
+        ),
+    },
+    "output_shape": (
+        "``{op_class: 'delete', resource: 'nat_rule', status, tracker, "
+        "matched, removed, rules_before, rules_after, verified, guidance}``. "
+        "``status`` is ``deleted`` / ``not_found`` / ``ambiguous``. On "
+        "``deleted``, ``removed`` carries the deleted rule's identity and "
+        "``verified`` is true (config read back: rule absent, count -1)."
+    ),
+}
+
+_ALIAS_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_]{1,64}$",
+            "description": (
+                "Exact name of the ONE firewall alias to delete. Refused "
+                "(``referenced``) when still in use by any rule or other "
+                "alias; ``not_found`` when absent."
+            ),
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+_ALIAS_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["delete"]},
+        "resource": {"type": "string", "enum": ["alias"]},
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_found", "ambiguous", "referenced"],
+            "description": (
+                "``deleted`` on a verified single-alias delete; ``not_found`` "
+                "when absent; ``ambiguous`` on a duplicate name; ``referenced`` "
+                "when still in use (refused, fail-closed, with the referrers "
+                "named in ``references``)."
+            ),
+        },
+        "name": {"type": "string"},
+        "matched": {"type": "integer"},
+        "removed": {"type": ["object", "null"]},
+        "references": {"type": "array", "items": {"type": "object"}},
+        "reference_count": {"type": "integer"},
+        "aliases_before": {"type": ["integer", "null"]},
+        "aliases_after": {"type": ["integer", "null"]},
+        "verified": {"type": "boolean"},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["op_class", "resource", "status", "name", "matched", "verified"],
+    "additionalProperties": False,
+}
+
+_ALIAS_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": _ALIAS_DELETE_WHEN_TO_USE,
+    "parameter_hints": {
+        "name": "Required. Exact alias name (alphanumeric / underscore).",
+    },
+    "output_shape": (
+        "``{op_class: 'delete', resource: 'alias', status, name, matched, "
+        "removed, references, reference_count, aliases_before, aliases_after, "
+        "verified, guidance}``. On ``referenced``, ``references`` names every "
+        "object still using the alias. On ``deleted``, ``removed`` carries "
+        "the deleted alias and ``verified`` is true."
+    ),
+}
+
+#: The governed destructive-delete ops :class:`PfSenseConnector` registers
+#: alongside the read + additive-write surface. Both are
+#: ``safety_level='destructive'`` / ``requires_approval=True`` (#3232) --
+#: the connector's first ops on the governed-delete tier.
+DELETE_OPS: tuple[PfSenseOp, ...] = (
+    PfSenseOp(
+        op_id="pfsense.nat.delete",
+        handler_attr="nat_delete",
+        summary="Permanently delete ONE port-forward NAT rule by stable tracker id (governed).",
+        description=(
+            "Governed destructive delete of a single pfSense port-forward NAT "
+            "rule (``config.xml`` ``<nat><rule>``), identified by its stable "
+            "``<tracker>`` id. safety_level=destructive: mandatory human "
+            "approval (no agent path, no standing grant, no self-approval even "
+            "under break-glass), a mandatory preview-hash binding, and a "
+            "mandatory blast-radius statement (the exact rule's identity + "
+            "interface / proto / source / destination / target / port) the "
+            "four-eyes approver reads before deciding. Fail-closed: 0 matches "
+            "-> ``not_found``, >1 -> ``ambiguous`` (never guesses by position "
+            "or description). Deletes exactly one rule via ``pfSsh.php "
+            "playback`` (``write_config`` + ``filter_configure``) and verifies "
+            "the rule is gone and the count dropped by exactly one. Leaves any "
+            "associated filter rule in place (surfaced in the blast radius). "
+            "Operates on a SHARED perimeter firewall -- never bulk, never "
+            "device-wide."
+        ),
+        parameter_schema=_NAT_DELETE_PARAMETER_SCHEMA,
+        response_schema=_NAT_DELETE_RESPONSE_SCHEMA,
+        group_key="nat",
+        tags=("write", "nat", "delete", "destructive", "pfsense"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=_NAT_DELETE_LLM_INSTRUCTIONS,
+    ),
+    PfSenseOp(
+        op_id="pfsense.alias.delete",
+        handler_attr="alias_delete",
+        summary="Permanently delete ONE firewall alias by exact name (governed, fail-closed).",
+        description=(
+            "Governed destructive delete of a single pfSense firewall alias "
+            "(``config.xml`` ``<aliases><alias>``) by exact ``<name>``. "
+            "safety_level=destructive (same tier + gate as "
+            "``pfsense.nat.delete``). Fail-closed dependency check: refuses "
+            "(``referenced``) when the alias is still used by any filter rule, "
+            "NAT rule (port-forward / outbound / 1:1), or other alias -- "
+            "naming every referrer -- so a still-referenced alias is never "
+            "orphaned out from under a live rule (mirrors pfSense's own "
+            "in-use guard). Also refuses on 0 matches (``not_found``) or >1 "
+            "(``ambiguous``). The blast-radius statement names the alias + its "
+            "reference count. Deletes exactly one alias via ``pfSsh.php "
+            "playback`` (``write_config`` + ``filter_configure``) and verifies "
+            "it is gone and the count dropped by exactly one."
+        ),
+        parameter_schema=_ALIAS_DELETE_PARAMETER_SCHEMA,
+        response_schema=_ALIAS_DELETE_RESPONSE_SCHEMA,
+        group_key="alias",
+        tags=("write", "alias", "delete", "destructive", "pfsense"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=_ALIAS_DELETE_LLM_INSTRUCTIONS,
+    ),
+)
+
+
+# Import-time side-effect: register the blast-radius builders (mirrors the
+# argocd ``ops_write_preview`` import and ``_preview._register_builtin_builders``).
+register_pfsense_delete_preview_builders()

--- a/backend/tests/test_connectors_pfsense_delete_ops.py
+++ b/backend/tests/test_connectors_pfsense_delete_ops.py
@@ -1,0 +1,1060 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the pfSense governed destructive-delete ops (#3232).
+
+Covers the connector's first two ``safety_level="destructive"`` typed ops --
+``pfsense.nat.delete`` and ``pfsense.alias.delete`` -- across three layers:
+
+* **Unit** (mocked ``_run_command``): parsers, the fail-closed reference
+  scan, the delete-one-by-identity playback fragments, input validation, and
+  the handler happy / not-found / ambiguous / referenced / verify-failure
+  paths.
+* **Metadata**: registration classification (destructive + requires_approval
+  + ``destructive`` tag + group), response-schema conformance, and proof
+  the ops fold into the **existing single-source** delete-shaped classifier
+  (the default ``*.delete`` glob *and* the ``destructive`` tag) with **no**
+  new pattern list declared.
+* **Governed-flow conformance** (full ``call_operation`` dispatch against a
+  seeded recording connector): no agent path, no standing grant, no
+  self-approval even under break-glass, no satellite mint, dispatch refused
+  without a preview hash, park refused without a blast-radius block, and the
+  full preview -> park (hash + blast radius) -> distinct-human approve ->
+  audited resume delete. Plus the post-approval fail-closed re-checks
+  (referenced alias) and the #3197 param-sensitive composite hash.
+
+All config.xml fixtures are synthetic (RFC 5737 / RFC 1918 addresses, no lab
+hostnames / IPs / VLANs / real rule contents) -- the public repo must never
+carry lab values.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from jsonschema import Draft202012Validator
+from sqlalchemy import func, select
+
+import meho_backplane.connectors.pfsense  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
+from meho_backplane.connectors.pfsense.ops_delete import (
+    _build_alias_delete_playback,
+    _build_nat_delete_playback,
+    find_alias_references,
+    parse_aliases_xml,
+    parse_nat_port_forwards_xml,
+)
+from meho_backplane.connectors.registry import all_connectors_v2, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+    _delete_shaped_reason_by_pattern,
+)
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "pfsense-ssh-2.7"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003232")
+_NAT_OP = "pfsense.nat.delete"
+_ALIAS_OP = "pfsense.alias.delete"
+_TRACKER = "1585165239"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic config.xml fixtures (RFC 5737 / RFC 1918 -- no lab values)
+# ---------------------------------------------------------------------------
+
+# Two port-forward NAT rules; rule 1 carries an associated filter rule.
+_CONFIG_TWO_NAT = (
+    "<pfsense><nat>"
+    "<rule><tracker>1585165239</tracker><interface>wan</interface><protocol>tcp</protocol>"
+    "<target>192.0.2.10</target><local-port>443</local-port>"
+    "<destination><network>wanip</network><port>443</port></destination>"
+    "<associated-rule-id>nat_abc123</associated-rule-id><descr>web fwd</descr></rule>"
+    "<rule><tracker>1585165240</tracker><interface>wan</interface><protocol>udp</protocol>"
+    "<target>192.0.2.20</target><local-port>1194</local-port>"
+    "<destination><any></any></destination><descr>vpn fwd</descr></rule>"
+    "</nat></pfsense>"
+)
+# After deleting tracker 1585165239 (one rule remains).
+_CONFIG_ONE_NAT = (
+    "<pfsense><nat>"
+    "<rule><tracker>1585165240</tracker><interface>wan</interface><protocol>udp</protocol>"
+    "<target>192.0.2.20</target><local-port>1194</local-port>"
+    "<destination><any></any></destination><descr>vpn fwd</descr></rule>"
+    "</nat></pfsense>"
+)
+# A config where a corrupt duplicate tracker appears twice.
+_CONFIG_DUP_TRACKER = (
+    "<pfsense><nat>"
+    "<rule><tracker>1585165239</tracker><interface>wan</interface><protocol>tcp</protocol>"
+    "<target>192.0.2.10</target><descr>a</descr></rule>"
+    "<rule><tracker>1585165239</tracker><interface>wan</interface><protocol>tcp</protocol>"
+    "<target>192.0.2.11</target><descr>b</descr></rule>"
+    "</nat></pfsense>"
+)
+
+# Aliases: ORPHAN (unreferenced) + WEB_SERVERS (referenced by a filter rule
+# and by the NESTED alias) + HTTPS_PORTS (referenced by the same filter rule).
+_CONFIG_ALIASES = (
+    "<pfsense>"
+    "<aliases>"
+    "<alias><name>WEB_SERVERS</name><type>host</type>"
+    "<address>192.0.2.10 192.0.2.11</address><descr>web</descr></alias>"
+    "<alias><name>HTTPS_PORTS</name><type>port</type><address>443</address></alias>"
+    "<alias><name>ORPHAN</name><type>host</type><address>198.51.100.5</address></alias>"
+    "<alias><name>NESTED</name><type>host</type>"
+    "<address>WEB_SERVERS 203.0.113.1</address></alias>"
+    "</aliases>"
+    "<filter>"
+    "<rule><tracker>1600000001</tracker><descr>allow web</descr>"
+    "<source><any></any></source>"
+    "<destination><address>WEB_SERVERS</address><port>HTTPS_PORTS</port></destination></rule>"
+    "</filter>"
+    "</pfsense>"
+)
+# After deleting ORPHAN.
+_CONFIG_ALIASES_NO_ORPHAN = _CONFIG_ALIASES.replace(
+    "<alias><name>ORPHAN</name><type>host</type><address>198.51.100.5</address></alias>", ""
+)
+
+
+# ---------------------------------------------------------------------------
+# Environment fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Unit-test stubs
+# ---------------------------------------------------------------------------
+
+
+def _proc(stdout: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.exit_status = exit_status
+    return proc
+
+
+def _cmds(mock_cmd: AsyncMock) -> list[str]:
+    return [call.args[1] for call in mock_cmd.await_args_list]
+
+
+# ===========================================================================
+# Part A -- unit: parsers
+# ===========================================================================
+
+
+def test_parse_nat_port_forwards_extracts_identity_and_summary() -> None:
+    rows = parse_nat_port_forwards_xml(_CONFIG_TWO_NAT)
+    assert len(rows) == 2
+    r0 = rows[0]
+    assert r0["tracker"] == "1585165239"
+    assert r0["associated_rule_id"] == "nat_abc123"
+    assert r0["interface"] == "wan"
+    assert r0["protocol"] == "tcp"
+    assert r0["destination"] == "wanip:443"
+    assert r0["target"] == "192.0.2.10"
+    assert r0["local_port"] == "443"
+    assert r0["descr"] == "web fwd"
+    assert r0["position"] == 1
+    assert rows[1]["destination"] == "any"  # <any/> flattens to "any"
+
+
+def test_parse_nat_port_forwards_empty_and_malformed() -> None:
+    assert parse_nat_port_forwards_xml("") == []
+    assert parse_nat_port_forwards_xml("<broken") == []
+    assert parse_nat_port_forwards_xml("<pfsense></pfsense>") == []
+
+
+def test_parse_aliases_extracts_rows() -> None:
+    rows = parse_aliases_xml(_CONFIG_ALIASES)
+    names = [a["name"] for a in rows]
+    assert names == ["WEB_SERVERS", "HTTPS_PORTS", "ORPHAN", "NESTED"]
+    web = rows[0]
+    assert web["type"] == "host"
+    assert web["address"] == "192.0.2.10 192.0.2.11"
+
+
+def test_parse_aliases_empty_and_malformed() -> None:
+    assert parse_aliases_xml("") == []
+    assert parse_aliases_xml("<broken") == []
+    assert parse_aliases_xml("<pfsense></pfsense>") == []
+
+
+# ===========================================================================
+# Part A -- unit: fail-closed reference scan
+# ===========================================================================
+
+
+def test_find_alias_references_nested_alias_and_filter_rule() -> None:
+    refs = find_alias_references(_CONFIG_ALIASES, "WEB_SERVERS")
+    kinds = {(r["kind"], r["id"]) for r in refs}
+    assert ("alias", "NESTED") in kinds  # nested-alias reference
+    assert ("filter_rule", "1600000001") in kinds  # filter-rule reference
+
+
+def test_find_alias_references_port_alias_in_filter_rule() -> None:
+    refs = find_alias_references(_CONFIG_ALIASES, "HTTPS_PORTS")
+    assert [(r["kind"], r["id"]) for r in refs] == [("filter_rule", "1600000001")]
+
+
+def test_find_alias_references_unreferenced_is_empty() -> None:
+    assert find_alias_references(_CONFIG_ALIASES, "ORPHAN") == []
+
+
+def test_find_alias_references_nat_port_forward_and_outbound_and_onetoone() -> None:
+    cfg = (
+        "<pfsense><aliases>"
+        "<alias><name>TARGETS</name><type>host</type><address>192.0.2.5</address></alias>"
+        "<alias><name>OUTS</name><type>host</type><address>10.0.0.0/24</address></alias>"
+        "<alias><name>ONES</name><type>host</type><address>203.0.113.9</address></alias>"
+        "</aliases><nat>"
+        "<rule><tracker>1</tracker><target>TARGETS</target>"
+        "<destination><any></any></destination><descr>pf</descr></rule>"
+        "<outbound><rule><descr>ob</descr>"
+        "<source><network>OUTS</network></source></rule></outbound>"
+        "<onetoone><descr>oto</descr>"
+        "<source><address>ONES</address></source></onetoone>"
+        "</nat></pfsense>"
+    )
+    assert [r["kind"] for r in find_alias_references(cfg, "TARGETS")] == ["nat_rule"]
+    assert [r["kind"] for r in find_alias_references(cfg, "OUTS")] == ["nat_outbound_rule"]
+    assert [r["kind"] for r in find_alias_references(cfg, "ONES")] == ["nat_onetoone_rule"]
+
+
+# ===========================================================================
+# Part A -- unit: playback fragments delete exactly one, safely
+# ===========================================================================
+
+
+def test_nat_delete_playback_is_single_object_and_safe() -> None:
+    frag = _build_nat_delete_playback("1585165239")
+    assert "$meho_tracker = '1585165239';" in frag
+    # Persists only on a clean single removal.
+    assert "if ($meho_removed === 1) {" in frag
+    assert "write_config('meho: delete nat rule tracker 1585165239');" in frag
+    assert "filter_configure();" in frag
+    # A playback fragment carries no <?php tag and no trailing exec.
+    assert "<?php" not in frag
+    assert "\nexec" not in frag
+
+
+def test_alias_delete_playback_is_single_object_and_safe() -> None:
+    frag = _build_alias_delete_playback("ORPHAN")
+    assert "$meho_name = 'ORPHAN';" in frag
+    assert "if ($meho_removed === 1) {" in frag
+    assert "write_config('meho: delete alias ORPHAN');" in frag
+    assert "filter_configure();" in frag
+    assert "<?php" not in frag
+
+
+# ===========================================================================
+# Part A -- unit: input validation rejects before any SSH round-trip
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"tracker": "not-a-number"},
+        {"tracker": "1585165239; rm -rf /"},
+        {"tracker": "1' OR '1"},
+        {},  # missing tracker
+    ],
+)
+async def test_nat_delete_rejects_bad_tracker_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.nat_delete(None, params)
+    assert mock_cmd.await_count == 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"name": "bad name"},
+        {"name": "web'; write_config("},
+        {"name": "web;rm"},
+        {},  # missing name
+    ],
+)
+async def test_alias_delete_rejects_bad_name_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.alias_delete(None, params)
+    assert mock_cmd.await_count == 0
+
+
+# ===========================================================================
+# Part A -- unit: nat.delete handler paths
+# ===========================================================================
+
+
+async def test_nat_delete_happy_path_deletes_one_and_verifies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_TWO_NAT),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm cleanup
+            _proc(_CONFIG_ONE_NAT),  # read-back verify
+        ]
+        result = await connector.nat_delete(None, {"tracker": _TRACKER})
+
+    assert result["status"] == "deleted"
+    assert result["verified"] is True
+    assert result["matched"] == 1
+    assert result["rules_before"] == 2
+    assert result["rules_after"] == 1
+    assert result["removed"]["tracker"] == _TRACKER
+    cmds = _cmds(mock_cmd)
+    assert cmds[0] == "cat /cf/conf/config.xml"
+    assert cmds[2] == "pfSsh.php playback meho_nat_delete_1585165239"
+    body = cmds[1]
+    assert "$meho_tracker = '1585165239';" in body
+
+
+async def test_nat_delete_not_found_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_TWO_NAT)]
+        result = await connector.nat_delete(None, {"tracker": "9999999999"})
+    assert result["status"] == "not_found"
+    assert result["matched"] == 0
+    assert result["removed"] is None
+    # Only the guard read ran -- no staging, playback, or cleanup.
+    assert mock_cmd.await_count == 1
+
+
+async def test_nat_delete_ambiguous_refuses_fail_closed() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_DUP_TRACKER)]
+        result = await connector.nat_delete(None, {"tracker": _TRACKER})
+    assert result["status"] == "ambiguous"
+    assert result["matched"] == 2
+    assert result["removed"] is None
+    # Duplicate trackers -> never delete either. Guard read only.
+    assert mock_cmd.await_count == 1
+
+
+async def test_nat_delete_verification_failure_raises() -> None:
+    """A playback that left the rule present (or removed too many) raises."""
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_TWO_NAT),  # guard read (2 rules)
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_TWO_NAT),  # read-back: rule still present (did not persist)
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.nat_delete(None, {"tracker": _TRACKER})
+
+
+async def test_nat_delete_bulk_over_deletion_is_caught_by_count_check() -> None:
+    """A playback that removed MORE than the one rule is caught (adversarial risk #1).
+
+    Read-back shows an empty NAT set (both rules gone) when only one was
+    approved. ``rules_after (0) != rules_before (2) - 1`` -> the count guard
+    raises rather than reporting a false success. This is the load-bearing
+    proof that a bulk-deletion bug on the config array cannot pass verification.
+    """
+    empty_nat = "<pfsense><nat></nat></pfsense>"
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_TWO_NAT),  # guard read (2 rules)
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(empty_nat),  # read-back: BOTH rules gone (bulk over-deletion)
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.nat_delete(None, {"tracker": _TRACKER})
+
+
+# ===========================================================================
+# Part A -- unit: alias.delete handler paths
+# ===========================================================================
+
+
+async def test_alias_delete_happy_path_deletes_one_and_verifies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ALIASES),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_ALIASES_NO_ORPHAN),  # read-back verify
+        ]
+        result = await connector.alias_delete(None, {"name": "ORPHAN"})
+    assert result["status"] == "deleted"
+    assert result["verified"] is True
+    assert result["matched"] == 1
+    assert result["reference_count"] == 0
+    assert result["aliases_before"] == 4
+    assert result["aliases_after"] == 3
+    assert result["removed"]["name"] == "ORPHAN"
+
+
+async def test_alias_delete_referenced_refuses_and_names_referrers() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_ALIASES)]
+        result = await connector.alias_delete(None, {"name": "WEB_SERVERS"})
+    assert result["status"] == "referenced"
+    assert result["reference_count"] == 2
+    ref_ids = {(r["kind"], r["id"]) for r in result["references"]}
+    assert ("alias", "NESTED") in ref_ids
+    assert ("filter_rule", "1600000001") in ref_ids
+    assert "still referenced" in result["guidance"]
+    # Fail-closed: refuses after a single guard read, stages nothing.
+    assert mock_cmd.await_count == 1
+
+
+async def test_alias_delete_not_found_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_ALIASES)]
+        result = await connector.alias_delete(None, {"name": "NOPE"})
+    assert result["status"] == "not_found"
+    assert result["matched"] == 0
+    assert mock_cmd.await_count == 1
+
+
+async def test_alias_delete_verification_failure_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ALIASES),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_ALIASES),  # read-back: alias still present
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.alias_delete(None, {"name": "ORPHAN"})
+
+
+# ===========================================================================
+# Part B -- registration classification + schema conformance
+# ===========================================================================
+
+
+def test_delete_ops_are_destructive_requires_approval_with_tag() -> None:
+    delete_ids = {_NAT_OP, _ALIAS_OP}
+    seen = set()
+    for op in PFSENSE_OPS:
+        if op.op_id not in delete_ids:
+            continue
+        seen.add(op.op_id)
+        assert op.safety_level == "destructive", op.op_id
+        assert op.requires_approval is True, op.op_id
+        assert "destructive" in op.tags, op.op_id
+        assert "delete" in op.tags, op.op_id
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+        assert op.llm_instructions and op.llm_instructions.get("when_to_use"), op.op_id
+    assert seen == delete_ids
+
+
+def test_pfsense_op_count_is_thirteen() -> None:
+    assert len(PFSENSE_OPS) == 13
+
+
+def test_delete_ops_group_keys() -> None:
+    by_id = {op.op_id: op for op in PFSENSE_OPS}
+    assert by_id[_NAT_OP].group_key == "nat"
+    assert by_id[_ALIAS_OP].group_key == "alias"
+
+
+def test_nat_delete_response_schema_accepts_outcomes() -> None:
+    op = next(o for o in PFSENSE_OPS if o.op_id == _NAT_OP)
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "delete",
+            "resource": "nat_rule",
+            "status": "deleted",
+            "tracker": _TRACKER,
+            "matched": 1,
+            "removed": {"tracker": _TRACKER},
+            "rules_before": 2,
+            "rules_after": 1,
+            "verified": True,
+            "guidance": None,
+        }
+    )
+    validator.validate(
+        {
+            "op_class": "delete",
+            "resource": "nat_rule",
+            "status": "not_found",
+            "tracker": _TRACKER,
+            "matched": 0,
+            "removed": None,
+            "rules_before": 2,
+            "rules_after": None,
+            "verified": False,
+            "guidance": "no rule",
+        }
+    )
+
+
+def test_alias_delete_response_schema_accepts_outcomes() -> None:
+    op = next(o for o in PFSENSE_OPS if o.op_id == _ALIAS_OP)
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "delete",
+            "resource": "alias",
+            "status": "referenced",
+            "name": "WEB_SERVERS",
+            "matched": 1,
+            "removed": None,
+            "references": [{"kind": "filter_rule", "id": "1600000001", "descr": "allow web"}],
+            "reference_count": 1,
+            "aliases_before": 4,
+            "aliases_after": None,
+            "verified": False,
+            "guidance": "referenced",
+        }
+    )
+
+
+# ===========================================================================
+# Part B -- classifier fold via the EXISTING single source (no new patterns)
+# ===========================================================================
+
+
+def test_delete_ops_fold_into_default_delete_shaped_pattern() -> None:
+    """Both op-ids match the shipped default ``*.delete`` glob -- no new list."""
+    patterns = get_settings().service_grant_delete_shaped_patterns
+    assert "*.delete" in patterns  # the single source, not re-declared here
+    assert _delete_shaped_reason_by_pattern(_NAT_OP, patterns) is not None
+    assert _delete_shaped_reason_by_pattern(_ALIAS_OP, patterns) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_ops_fold_via_destructive_tag_even_without_pattern(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the ``*.delete`` glob overridden away (via the single-source env
+    var), the ``destructive`` tag still routes the grant refusal -- proving the
+    descriptor-tag single source (``_delete_shaped_reason_by_descriptor``) folds
+    the ops independently, with no new pattern list declared here."""
+    # Override the single-source pattern set to one that does NOT match the
+    # pfSense delete op-ids (the shipped SERVICE_GRANT_DELETE_SHAPED_PATTERNS
+    # override seam), so only the descriptor-tag path can refuse.
+    monkeypatch.setenv("SERVICE_GRANT_DELETE_SHAPED_PATTERNS", "DELETE:*")
+    get_settings.cache_clear()
+    patterns = get_settings().service_grant_delete_shaped_patterns
+    assert patterns == ("DELETE:*",)
+    assert _delete_shaped_reason_by_pattern(_NAT_OP, patterns) is None
+
+    # But a resolved descriptor carrying the destructive tag still refuses.
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_TWO_NAT))
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_NAT_OP,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "destructive" in str(exc.value).lower() or "delete-shaped" in str(exc.value).lower()
+
+
+# ===========================================================================
+# Part C -- governed-flow conformance (full dispatch)
+# ===========================================================================
+
+
+def _make_operator(
+    *, sub: str = "op-pf", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="pfSense Delete Conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "2.7") -> None:
+        self.version = version
+
+
+class _FakePfsenseTarget:
+    def __init__(self) -> None:
+        self.product = "pfsense"
+        self.fingerprint = _FakeFingerprint(version="2.7")
+        self.preferred_impl_id: str | None = "pfsense-ssh"
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = "pf-perimeter"
+        self.host = "pf.test"
+        self.port = 22
+        self.auth_model = "shared_service_account"
+
+
+class _RecordingPfSense(PfSenseConnector):
+    """A PfSenseConnector whose ``_run_command`` replays canned config.xml.
+
+    Seeded into ``_CONNECTOR_INSTANCE_CACHE`` so the dispatcher (and the
+    blast-radius preview builder) drive real dispatch without SSH. Models the
+    delete: ``cat config.xml`` returns ``config_before`` until a ``pfSsh.php
+    playback`` command runs, then ``config_after`` -- so the handler's
+    read-back verification is exercised end to end.
+    """
+
+    def __init__(self, *, config_before: str, config_after: str | None = None) -> None:
+        super().__init__()
+        self._config_before = config_before
+        self._config_after = config_after if config_after is not None else config_before
+        self._played = False
+        self.commands: list[str] = []
+
+    async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
+        return {"username": "admin", "client_keys": [], "known_hosts": None}
+
+    async def _run_command(self, target: Any, command: str, operator: Any = None) -> Any:
+        self.commands.append(command)
+        if command == "cat /cf/conf/config.xml":
+            return _proc(self._config_after if self._played else self._config_before)
+        if command.startswith("pfSsh.php playback"):
+            self._played = True
+        return _proc("", 0)
+
+    @property
+    def playback_ran(self) -> bool:
+        return any(c.startswith("pfSsh.php playback") for c in self.commands)
+
+
+async def _seed_target(name: str = "pf-perimeter") -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=name,
+                aliases=[],
+                product="pfsense",
+                host="pf.test",
+                port=22,
+                fqdn=None,
+                secret_ref="kv/dev/pfsense/perimeter",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "2.7"},
+                preferred_impl_id="pfsense-ssh",
+                notes="seeded by test_connectors_pfsense_delete_ops",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _bootstrap(recorder: _RecordingPfSense) -> None:
+    # The package import registers the connector; re-register only if a
+    # prior test cleared the v2 registry (register_connector_v2 raises on a
+    # duplicate three-tuple key).
+    if ("pfsense", "2.7", "pfsense-ssh") not in all_connectors_v2():
+        register_connector_v2(
+            product="pfsense", version="2.7", impl_id="pfsense-ssh", cls=PfSenseConnector
+        )
+    await PfSenseConnector.register_operations()
+    _CONNECTOR_INSTANCE_CACHE[PfSenseConnector] = recorder  # type: ignore[assignment]
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+@pytest.mark.asyncio
+async def test_ops_registered_destructive_requires_approval() -> None:
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_TWO_NAT))
+    async with get_sessionmaker()() as s:
+        for op_id in (_NAT_OP, _ALIAS_OP):
+            row = (
+                await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == op_id))
+            ).scalar_one()
+            assert row.safety_level == "destructive", op_id
+            assert row.requires_approval is True, op_id
+            assert row.source_kind == "typed", op_id
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_nat_delete() -> None:
+    """preview -> park (hash + blast radius) -> distinct human approve -> resume delete."""
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT, config_after=_CONFIG_ONE_NAT)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _NAT_OP,
+        "target": "pf-perimeter",
+        "params": {"tracker": _TRACKER},
+    }
+
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    bound_hash = preview["preview_hash"]
+    assert isinstance(bound_hash, str) and len(bound_hash) == 64
+
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert not recorder.playback_ran  # nothing mutated pre-approval
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    blast = effect["blast_radius"]
+    assert blast["object"]["kind"] == "nat_rule"
+    assert blast["object"]["tracker"] == _TRACKER
+    assert blast["object"]["destination"] == "wanip:443"
+    assert blast["irreversibility"] == "permanent"
+    # The associated filter rule is enumerated (left in place, surfaced).
+    assert {c["kind"] for c in blast["children"]} == {"associated_filter_rule"}
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["verified"] is True
+    assert resume.result["rules_before"] == 2
+    assert resume.result["rules_after"] == 1
+    assert recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_rule_recreated_between_park_and_approval_invalidates() -> None:
+    """A rule deleted-and-recreated between park and approval MUST invalidate (risk #5).
+
+    Identity is the ``tracker`` (carried in the hash-bound params). We park a
+    delete of tracker T (present at park, so the blast radius builds), then
+    simulate the rule being deleted-and-recreated with a NEW tracker before
+    approval by swapping the live config to one that no longer carries T. At
+    resume the identity re-match finds T absent -> ``not_found``; the recreated
+    rule (a different identity) is untouched and no playback runs.
+    """
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT, config_after=_CONFIG_ONE_NAT)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _NAT_OP,
+        "target": "pf-perimeter",
+        "params": {"tracker": _TRACKER},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Between park and approval the rule with tracker T is gone (recreated with
+    # a different tracker) -- the live config no longer carries T.
+    recorder._config_before = _CONFIG_ONE_NAT  # only tracker 1585165240 remains
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "not_found"
+    assert resume.result["matched"] == 0
+    assert not recorder.playback_ran  # the stale/recreated rule is never touched
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_alias_delete() -> None:
+    recorder = _RecordingPfSense(
+        config_before=_CONFIG_ALIASES, config_after=_CONFIG_ALIASES_NO_ORPHAN
+    )
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _ALIAS_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "ORPHAN"},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["object"]["kind"] == "alias"
+    assert blast["object"]["name"] == "ORPHAN"
+    assert blast["reference_count"] == 0
+    assert blast["children"] == []
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_referenced_alias_refused_post_approval_fail_closed() -> None:
+    """A referenced alias is refused at execution (post-approval); nothing mutates."""
+    recorder = _RecordingPfSense(config_before=_CONFIG_ALIASES)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _ALIAS_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "WEB_SERVERS"},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # The blast radius names the references so the approver sees the risk.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["reference_count"] == 2
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    # Fail-closed at execution: refuses, deletes nothing.
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "referenced"
+    assert resume.result["reference_count"] == 2
+    assert not recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_agent_principal_is_denied() -> None:
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT)
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_NAT_OP,
+        target=_FakePfsenseTarget(),
+        params={"tracker": _TRACKER},
+    )
+    assert result.status == "denied", result
+    assert not recorder.playback_ran  # never executed
+    assert await _pending_count() == 0  # never parked
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_id", [_NAT_OP, _ALIAS_OP])
+async def test_service_grant_refuses_delete_ops(op_id: str) -> None:
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_TWO_NAT))
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=op_id,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    msg = str(exc.value).lower()
+    assert "delete-shaped" in msg or "destructive" in msg
+
+
+@pytest.mark.asyncio
+async def test_no_self_approval_even_under_break_glass(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT, config_after=_CONFIG_ONE_NAT)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _NAT_OP,
+        "target": "pf-perimeter",
+        "params": {"tracker": _TRACKER},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+@pytest.mark.asyncio
+async def test_satellite_mint_refuses_op_not_safe() -> None:
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_TWO_NAT))
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_NAT_OP,
+            target=None,
+            params={"tracker": _TRACKER},
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refused_without_preview_hash() -> None:
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT)
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_NAT_OP,
+        target=_FakePfsenseTarget(),
+        params={"tracker": _TRACKER},
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert not recorder.playback_ran
+    assert await _pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_park_refused_without_blast_radius() -> None:
+    """A tracker matching no rule -> builder declines -> no blast radius -> refused."""
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _NAT_OP,
+        "target": "pf-perimeter",
+        "params": {"tracker": "9999999999"},  # present in neither rule
+    }
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert await _pending_count() == 0
+    assert not recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_composite_preview_hash_is_param_sensitive() -> None:
+    recorder = _RecordingPfSense(config_before=_CONFIG_TWO_NAT)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    base = {"connector_id": _CONNECTOR_ID, "op_id": _NAT_OP, "target": "pf-perimeter"}
+    p1 = await preview_operation(requester, {**base, "params": {"tracker": "1585165239"}})
+    p1b = await preview_operation(requester, {**base, "params": {"tracker": "1585165239"}})
+    p2 = await preview_operation(requester, {**base, "params": {"tracker": "1585165240"}})
+    assert p1["status"] == "ok"
+    assert p1["preview_hash"] == p1b["preview_hash"]  # stable for identical args
+    assert p1["preview_hash"] != p2["preview_hash"]  # a different delete -> different hash

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -302,6 +302,12 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
 #: (covered by ``test_connectors_pfsense_write_ops.py``).
 _WRITE_OP_IDS: frozenset[str] = frozenset({"pfsense.gateway.add", "pfsense.route.static.add"})
 
+#: The governed destructive deletes (#3232). Also held separate from the
+#: dispatch/audit sweep: they are ``safety_level='destructive'`` /
+#: ``requires_approval=True`` and take real params, so they park rather than
+#: execute inline (covered by ``test_connectors_pfsense_delete_ops.py``).
+_DELETE_OP_IDS: frozenset[str] = frozenset({"pfsense.nat.delete", "pfsense.alias.delete"})
+
 # ---------------------------------------------------------------------------
 # Target + connector seeding helpers
 # ---------------------------------------------------------------------------
@@ -412,16 +418,21 @@ async def pfsense_e2e(
 
 
 def test_pfsense_ops_registration_count() -> None:
-    """All 11 pfSense ops are registered in PFSENSE_OPS (9 read/identity + 2 write)."""
+    """All 13 pfSense ops registered (9 read/identity + 2 write + 2 delete)."""
     op_ids = {op.op_id for op in PFSENSE_OPS}
-    missing = (set(EXPECTED_OP_IDS) | _WRITE_OP_IDS) - op_ids
+    missing = (set(EXPECTED_OP_IDS) | _WRITE_OP_IDS | _DELETE_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(PFSENSE_OPS) == 11, f"Expected 11 ops, got {len(PFSENSE_OPS)}"
+    assert len(PFSENSE_OPS) == 13, f"Expected 13 ops, got {len(PFSENSE_OPS)}"
 
 
-def test_pfsense_ops_safety_levels_and_no_approval_required() -> None:
-    """Read ops are 'safe', the write ops (#3090) are 'caution'; none require approval."""
+def test_pfsense_ops_safety_levels_and_approval() -> None:
+    """Read ops 'safe', write ops (#3090) 'caution', delete ops (#3232)
+    'destructive' + requires_approval; nothing else requires approval."""
     for op in PFSENSE_OPS:
+        if op.op_id in _DELETE_OP_IDS:
+            assert op.safety_level == "destructive", f"{op.op_id} should be destructive"
+            assert op.requires_approval, f"{op.op_id} destructive delete must require approval"
+            continue
         expected = "caution" if op.op_id in _WRITE_OP_IDS else "safe"
         assert op.safety_level == expected, f"{op.op_id} should be safety_level={expected!r}"
         assert not op.requires_approval, f"{op.op_id} should not require approval"
@@ -434,7 +445,7 @@ def test_pfsense_read_ops_parameter_schemas_are_empty() -> None:
         assert schema.get("additionalProperties") is False, (
             f"{op.op_id}: parameter_schema must have additionalProperties=False"
         )
-        if op.op_id not in _WRITE_OP_IDS:
+        if op.op_id not in _WRITE_OP_IDS and op.op_id not in _DELETE_OP_IDS:
             assert schema.get("properties") == {}, (
                 f"{op.op_id}: read-op parameter_schema must have empty properties"
             )

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -34,12 +34,15 @@ Coverage matrix (per Task #847 acceptance criteria):
 * ``PFSENSE_OPS`` registration shape -- every op carries
   ``additionalProperties=False`` on the parameter schema, non-empty
   ``llm_instructions``, and a pfsense-namespace op_id; the read /
-  identity ops are ``safety_level='safe'`` and the two write ops
-  (#3090) are ``safety_level='caution'``; ``firewall``, ``nat``,
-  ``network``, ``config``, ``dhcp``, ``routing`` groups are present.
-* Registration count -- the ``PFSENSE_OPS`` tuple length matches 11
-  (T2 read ops + ``pfsense.dhcp.leases`` #2849 + the two write ops
-  #3090); the ``pfsense.about`` canary remains at index 0.
+  identity ops are ``safety_level='safe'``, the two write ops (#3090)
+  are ``safety_level='caution'``, and the two delete ops (#3232) are
+  ``safety_level='destructive'`` / ``requires_approval=True``;
+  ``firewall``, ``nat``, ``network``, ``config``, ``dhcp``, ``routing``,
+  ``alias`` groups are present.
+* Registration count -- the ``PFSENSE_OPS`` tuple length matches 13
+  (T2 read ops + ``pfsense.dhcp.leases`` #2849 + the two write ops #3090
+  + the two governed deletes #3232); the ``pfsense.about`` canary remains
+  at index 0.
 
 The ``pfsense.gateway.add`` / ``pfsense.route.static.add`` write-op
 behaviour (validation, idempotency guards, config-write failure
@@ -1037,9 +1040,9 @@ async def test_pfsense_dhcp_leases_response_schema_matches_handler_rows() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_pfsense_ops_has_eleven_entries() -> None:
-    """T1 canary + 7 T2 read ops + pfsense.dhcp.leases (#2849) + 2 write ops (#3090) = 11."""
-    assert len(PFSENSE_OPS) == 11
+def test_pfsense_ops_has_thirteen_entries() -> None:
+    """canary + 7 reads + dhcp.leases (#2849) + 2 writes (#3090) + 2 deletes (#3232) = 13."""
+    assert len(PFSENSE_OPS) == 13
 
 
 def test_pfsense_ops_about_is_first() -> None:
@@ -1055,10 +1058,18 @@ def test_pfsense_ops_all_have_pfsense_namespace() -> None:
 #: write), unlike the read/identity surface which is ``safe``.
 _WRITE_OP_IDS = {"pfsense.gateway.add", "pfsense.route.static.add"}
 
+#: The governed destructive deletes (#3232) -- classified ``destructive``
+#: and the only ops that require approval.
+_DELETE_OP_IDS = {"pfsense.nat.delete", "pfsense.alias.delete"}
 
-def test_pfsense_read_ops_safe_write_ops_caution() -> None:
+
+def test_pfsense_read_ops_safe_write_ops_caution_delete_ops_destructive() -> None:
     for op in PFSENSE_OPS:
-        if op.op_id in _WRITE_OP_IDS:
+        if op.op_id in _DELETE_OP_IDS:
+            assert op.safety_level == "destructive", (
+                f"{op.op_id!r} delete op should be safety_level='destructive'"
+            )
+        elif op.op_id in _WRITE_OP_IDS:
             assert op.safety_level == "caution", (
                 f"{op.op_id!r} write op should be safety_level='caution'"
             )
@@ -1095,6 +1106,8 @@ def test_pfsense_ops_covers_expected_op_ids() -> None:
         "pfsense.dhcp.leases",
         "pfsense.gateway.add",
         "pfsense.route.static.add",
+        "pfsense.nat.delete",
+        "pfsense.alias.delete",
     }
     assert op_ids == expected
 
@@ -1108,6 +1121,7 @@ def test_pfsense_ops_group_keys_include_new_groups() -> None:
     assert "config" in group_keys
     assert "dhcp" in group_keys
     assert "routing" in group_keys
+    assert "alias" in group_keys
 
 
 def test_pfsense_ops_handler_attrs_exist_on_connector() -> None:
@@ -1118,6 +1132,10 @@ def test_pfsense_ops_handler_attrs_exist_on_connector() -> None:
         )
 
 
-def test_pfsense_ops_no_requires_approval() -> None:
+def test_pfsense_ops_requires_approval_only_for_destructive_deletes() -> None:
+    """Only the #3232 governed destructive deletes require approval; all else don't."""
     for op in PFSENSE_OPS:
-        assert not op.requires_approval, f"{op.op_id!r} has requires_approval=True"
+        if op.op_id in _DELETE_OP_IDS:
+            assert op.requires_approval, f"{op.op_id!r} destructive delete must require approval"
+        else:
+            assert not op.requires_approval, f"{op.op_id!r} has requires_approval=True"

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -17,7 +17,9 @@ fingerprint, and the probe. G3.7-T2 (#847) adds the 7 read ops
 acceptance suite + onboarding doc. #2849 adds `pfsense.dhcp.leases`. #3090
 adds the first two write ops (`pfsense.gateway.add`,
 `pfsense.route.static.add`) via the `pfSsh.php playback` config-mutation
-idiom.
+idiom. #3232 adds the first two **governed destructive deletes**
+(`pfsense.nat.delete`, `pfsense.alias.delete`) — `safety_level="destructive"`
+on the governed-delete tier (`docs/decisions/governed-delete-operations.md`).
 
 Source: `backend/src/meho_backplane/connectors/pfsense/`.
 
@@ -28,8 +30,9 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   Inherits the per-target asyncssh connection pool and `aclose()` from the
   adapter; overrides `_auth_config` to reject password auth, plus `fingerprint`,
   `probe`, `execute`, `about`, the read-op bound-method shims (the 7 T2 ops
-  plus `dhcp_leases`, #2849), and the write-op bound-method shims (`gateway_add`,
-  `route_static_add`, #3090).
+  plus `dhcp_leases`, #2849), the write-op bound-method shims (`gateway_add`,
+  `route_static_add`, #3090), and the destructive-delete bound-method shims
+  (`nat_delete`, `alias_delete`, #3232).
 
 - **`_auth_config()` override** — the load-bearing auth constraint. Requires
   `ssh_private_key` in the target's **Vault secret** (`target.secret_ref` is a
@@ -42,10 +45,24 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   REPL) instead of a POSIX shell, causing any subsequent command to hang.
 
 - **Op metadata** (`ops.py`) — the `PfSenseOp` dataclass, the `_pfsense_ops()`
-  composition function, and the `PFSENSE_OPS` tuple (11 ops total). T1 shipped
+  composition function, and the `PFSENSE_OPS` tuple (13 ops total). T1 shipped
   `pfsense.about`; T2 (#847) adds 7 read ops via the `ops_read` module; #2849
   appends `pfsense.dhcp.leases`; #3090 appends the two write ops via the
-  `ops_write` module.
+  `ops_write` module; #3232 appends the two destructive deletes via the
+  `ops_delete` module.
+
+- **Destructive-delete handlers** (`ops_delete.py`, #3232) — the connector's
+  first `safety_level="destructive"` ops. Config parsers
+  (`parse_nat_port_forwards_xml` / `parse_aliases_xml`), the fail-closed
+  reference scan (`find_alias_references` — nested aliases + filter / NAT
+  port-forward / outbound / 1:1 rules), the delete-by-identity `pfSsh.php
+  playback` fragment builders (`_build_nat_delete_playback` /
+  `_build_alias_delete_playback`, each persisting only on a single removal),
+  the handlers (`pfsense_nat_delete` / `pfsense_alias_delete`), the mandatory
+  blast-radius preview builders (`_nat_delete_preview` / `_alias_delete_preview`,
+  registered at import via `register_pfsense_delete_preview_builders`), and the
+  `DELETE_OPS` tuple. Both fold into the existing single-source delete-shaped
+  classifier (`*.delete` glob + `destructive` tag) with no new pattern list.
 
 - **Write op handlers** (`ops_write.py`, #3090) — input validators
   (`_validate_gateway_name` / `_validate_interface` / `_validate_gateway_ip` /
@@ -170,7 +187,7 @@ Two-phase registration, identical to the bind9 pattern:
   (`connectors/registry.py`, `operations/typed_register.py`) — registration
   infrastructure.
 
-## Op surface (11 ops)
+## Op surface (13 ops)
 
 | Op ID | Command | Group | Safety |
 |---|---|---|---|
@@ -185,11 +202,22 @@ Two-phase registration, identical to the bind9 pattern:
 | `pfsense.dhcp.leases` | `cat /var/dhcpd/var/db/dhcpd.leases` (ISC dhcpd lease DB) | `dhcp` | `safe` |
 | `pfsense.gateway.add` | `cat /cf/conf/config.xml` guard + `pfSsh.php playback` fragment (append `gateway_item` + `write_config()`) | `routing` | `caution` |
 | `pfsense.route.static.add` | `cat /cf/conf/config.xml` guard + `pfSsh.php playback` fragment (append `staticroutes/route` + `write_config()` + `system_routing_configure()`) | `routing` | `caution` |
+| `pfsense.nat.delete` | `cat /cf/conf/config.xml` guard (match one `<nat><rule>` by `<tracker>`) + `pfSsh.php playback` fragment (delete-by-tracker + `write_config()` + `filter_configure()`) + read-back verify | `nat` | `destructive` |
+| `pfsense.alias.delete` | `cat /cf/conf/config.xml` guard (match one `<aliases><alias>` by name + fail-closed reference scan) + `pfSsh.php playback` fragment (delete-by-name + `write_config()` + `filter_configure()`) + read-back verify | `alias` | `destructive` |
 
 The 9 read / identity ops are `safety_level="safe"`; the 2 write ops (#3090)
-are `safety_level="caution"`. All 11 are `requires_approval=False` — the same
-posture `bind9.record.add` / `windns.record.add` carry for an additive,
-recoverable, idempotent config write.
+are `safety_level="caution"` / `requires_approval=False` — the same posture
+`bind9.record.add` / `windns.record.add` carry for an additive, recoverable,
+idempotent config write. The 2 delete ops (#3232) are
+`safety_level="destructive"` / `requires_approval=True` — the governed-delete
+tier: mandatory human approval (no agent path, no standing grant, no
+self-approval even under break-glass, no satellite mint), a #3197 preview-hash
+binding, and a mandatory blast-radius statement naming the exact rule / alias.
+Each deletes exactly one object by stable identity (`<tracker>` for a NAT rule,
+exact name for an alias — never by position or description), refuses fail-closed
+on a missing (`not_found`) / duplicated (`ambiguous`) identity or (for an alias)
+a live reference (`referenced`, naming every referrer), and read-back-verifies
+that the object is gone and the count dropped by exactly one.
 
 `pfsense.firewall.state` and `pfsense.dhcp.leases` both return `{rows, total}`
 and are the JSONFlux reduction candidates: connection-state tables and busy


### PR DESCRIPTION
Closes #3232.

Registers the pfSense connector's first two `safety_level="destructive"` / `requires_approval=True` typed ops on the governed-delete tier (decision `docs/decisions/governed-delete-operations.md`; precedent #3198 / PR #3225).

## Final op_id literals (cemented)
- **`pfsense.nat.delete`** — delete ONE port-forward NAT rule (`config.xml` `<nat><rule>`) by its stable `<tracker>` id.
- **`pfsense.alias.delete`** — delete ONE firewall alias by exact `<name>`.

Both fold into the **existing single-source** delete-shaped classifier — the default `*.delete` glob (`Settings.service_grant_delete_shaped_patterns`) **and** the `destructive` tag — with no new pattern list, so each rides the full gate: mandatory human approval (no agent path, no standing grant, no self-approval even under break-glass, no satellite mint), the #3197 preview-hash binding, and a mandatory blast-radius statement.

## Why config.xml, not `pfctl`
The existing `pfsense.nat.rules` read op parses `pfctl -sn` (the runtime compiled table), which carries **no stable per-rule identity**. A surgical governed delete operates on the source of truth (`/cf/conf/config.xml`), where each port-forward rule carries a stable `<tracker>` and each alias a unique `<name>`. Applied via the connector's existing `pfSsh.php playback` idiom (`write_config` + `filter_configure`).

## Surgical single-object contract (shared perimeter firewall — decision requirement 3)
Three layers guarantee exactly-one deletion: a Python pre-check (exactly one match; else `not_found`/`ambiguous`, fail-closed — never by position or description), a PHP fragment that `write_config()`s only on a single removal, and a read-back verify (object absent **AND** count dropped by exactly one). Identity is re-matched at dispatch time (post-approval), so a rule deleted-and-recreated (new tracker) between park and approval resolves to `not_found`. `pfsense.alias.delete` additionally runs a fail-closed dependency check (`referenced`, naming every filter / NAT port-forward-outbound-1:1 / nested-alias referrer — mirroring pfSense's own in-use guard).

## Adversarial review verdict: APPROVE
Hunted all five risk areas — bulk/positional deletion (3-layer guard + over-deletion test), classifier fold correctness (both single-sources, monkeypatch-proven), refusal completeness, approval bypass, and preview-hash staleness (delete-and-recreate → not_found test). No code bugs found; two adversarial tests added.

## Tests
`tests/test_connectors_pfsense_delete_ops.py` (47 tests): registration/schema/classification, full governed flow (preview → park w/ hash+blast-radius → distinct-human approve → audited resume delete), conformance (agent DENY, ServicePrincipalGrant refusal, no self-approval under break-glass, satellite mint OP_NOT_SAFE, dispatch refused without hash, park refused without blast radius), and all refusal + adversarial paths. Full local slice 279 passed; ruff/format/mypy clean. **No migration** (typed ops register at runtime). **No spec-reconcile lane** (typed SSH connector, no OpenAPI spec — consistent with bind9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)