### PR TITLE
feat(connectors): typed HttpNfcLease OVF import (#3229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,36 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — typed HttpNfcLease OVF import: `vm.import_from_library` (#3229)
+
+- The durable, transfer-window-decoupled sibling of `vm.deploy_from_library`.
+  The REST deploy holds one POST open for the whole server-side copy, so
+  completion is bounded by the client read-timeout — a 4.7 GB installer OVA
+  outran even the 3 h mitigation ceiling live (#3176 / stopgap PR #3234). The
+  new composite drives the disk transfer itself over a typed vim `HttpNfcLease`
+  import (`ServiceContent` resolve → `OvfManager.CreateImportSpec` → the governed
+  `ResourcePool.ImportVApp` write → lease-ready poll → stream each disk from the
+  content library straight to the lease device URLs with an
+  `HttpNfcLeaseProgress` heartbeat → `HttpNfcLeaseComplete`), so completion is
+  bounded only by the transfer's own duration and there is no single blocking
+  read to outrun. Any failure after the lease exists aborts it, so vCenter
+  removes the half-created VM.
+- Version-agnostic (core vim25 `OvfManager` / `HttpNfcLease`; only pre-9.0
+  device-URL fields read — never the 9.0-only `sslCertificate`), so it covers
+  the pre-9.0 VCF 5.x migration-source fleet (#3056) as well as 9.0+. Item
+  resolution reuses `deploy_from_library`'s name-find; the outcome maps onto the
+  same `deployed` / `deploy_failed` / `deploy_error` envelope family (#3071) plus
+  a per-disk `transfer` manifest. `datastore` is required (the vim import spec is
+  built against an explicit placement datastore).
+- New modules `ovf_import.py` / `ovf_import_control.py` / `ovf_transfer.py`
+  (the lease engine) + `library_download.py` (the content-library
+  download-session byte source). The vim methods, download-session REST paths,
+  and every emitted `_typeName` are grounded against the pinned `vcenter.yaml` /
+  `vi-json.yaml` by the reconcile lanes; the mechanics are proven by
+  mock-transport unit tests. Live-appliance verification is deferred (no lab
+  access) — implementation + full conformance/unit coverage is the deliverable,
+  consistent with recent connector tasks.
+
 ### Added — governed delete: pfSense NAT-rule + alias delete on the destructive tier + conformance (#3232)
 
 - Registers the pfSense connector's first two `safety_level="destructive"` +
@@ -163,7 +193,6 @@ connector-related release-notes line.
   blast-radius block, the fail-closed refusal paths, and the full
   preview → parked approval (hash + blast radius) → **distinct human**
   approve → audited resume flow deleting exactly one record.
-
 ### Added — satellite write path: per-runner capability allowlist (#3190)
 
 - Mechanism 2 of the composed write-tier gate: a per-runner-principal

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -91,6 +91,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_destroy_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
+    vm_import_from_library_composite,
     vm_migrate_composite,
     vm_nic_repoint_composite,
     vm_power_bulk_composite,
@@ -153,6 +154,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_DEVICE_CDROM_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
     VM_DISK_GROW_RESPONSE_SCHEMA,
+    VM_IMPORT_FROM_LIBRARY_PARAMETER_SCHEMA,
+    VM_IMPORT_FROM_LIBRARY_RESPONSE_SCHEMA,
     VM_MIGRATE_PARAMETER_SCHEMA,
     VM_MIGRATE_RESPONSE_SCHEMA,
     VM_NIC_REPOINT_PARAMETER_SCHEMA,
@@ -535,6 +538,41 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         ),
         parameter_schema=VM_DEPLOY_FROM_LIBRARY_PARAMETER_SCHEMA,
         response_schema=VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle", "ovf"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.import_from_library",
+        handler=vm_import_from_library_composite,
+        summary="Import an OVF/OVA content-library item to a new VM via a typed HttpNfcLease.",
+        description=(
+            "The durable, transfer-window-decoupled counterpart to "
+            "vm.deploy_from_library (#3229). deploy_from_library's synchronous REST "
+            "deploy holds one POST open for the whole server-side copy, so completion "
+            "is bounded by the client read-timeout — a multi-GB installer OVA outran "
+            "even the 3h mitigation ceiling live (#3176). This composite drives the "
+            "transfer itself over a typed vim HttpNfcLease import: ServiceContent "
+            "resolve → OvfManager.CreateImportSpec (validates the descriptor) → the "
+            "governed ResourcePool.ImportVApp write → poll the lease to ready → stream "
+            "each disk from the content library (client-side download-session) straight "
+            "to the lease device URLs with an HttpNfcLeaseProgress heartbeat → "
+            "HttpNfcLeaseComplete. Completion is bounded only by the transfer's own "
+            "duration, not any single HTTP read, and under async governed dispatch "
+            "(#3079) a dropped caller no longer aborts it. Version-agnostic (core "
+            "vim25 OvfManager / HttpNfcLease; no 9.0-only fields), so it also covers "
+            "the pre-9.0 VCF 5.x migration-source fleet (#3056). The library item is "
+            "referenced by id (passthrough) or name (resolved via "
+            "POST:/content/library/item?action=find, ambiguity-refused before any "
+            "mutation); resource_pool and datastore are required. Any failure after "
+            "the lease exists aborts it, so vCenter removes the half-created VM. Maps "
+            "to the same deployed / deploy_failed / deploy_error envelope (#3071) as "
+            "the deploy composite, plus a per-disk transfer manifest. Equivalent of a "
+            "task-polled 'govc library.deploy' for large OVAs."
+        ),
+        parameter_schema=VM_IMPORT_FROM_LIBRARY_PARAMETER_SCHEMA,
+        response_schema=VM_IMPORT_FROM_LIBRARY_RESPONSE_SCHEMA,
         group_key="vm",
         tags=["composite", "write", "vm", "lifecycle", "ovf"],
         safety_level="dangerous",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 19 protocol-driven composite handlers for the
+# code-quality-allow: 21 protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
@@ -9,10 +9,10 @@
 # from #2893, the folder-template clone from #2894, the vim cluster /
 # inventory writes — DRS-rule + folder create — from #2895, the #2891
 # hardware writes — vm.resize / vm.nic.repoint / vm.device.cdrom, the
-# GOSC create/apply from #2892, and the OVF/OVA content-library deploy
-# from #2909).
+# GOSC create/apply from #2892, the OVF/OVA content-library deploy
+# from #2909, and the typed HttpNfcLease OVF import from #3229).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (19 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (21 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -96,6 +96,12 @@ import httpx
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest import library_download, ovf_import_control
+from meho_backplane.connectors.vmware_rest.ovf_import import (
+    ImportPlacement,
+    LeaseImportResult,
+    import_ovf_from_source,
+)
 from meho_backplane.connectors.vmware_rest.vim_body import (
     VIM_TYPE_NAME_KEY,
     retrieve_properties_body,
@@ -106,6 +112,8 @@ from meho_backplane.connectors.vmware_rest.vim_task import TASK_STATE_ERROR, pol
 from meho_backplane.operations.composite import DispatchChild, enforce_subop_policy
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
 
 __all__ = [
@@ -122,6 +130,7 @@ __all__ = [
     "vm_deploy_from_library_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
+    "vm_import_from_library_composite",
     "vm_migrate_composite",
     "vm_nic_repoint_composite",
     "vm_power_bulk_composite",
@@ -835,6 +844,36 @@ _SUB_OPS_VM_DEPLOY_FROM_LIBRARY: tuple[str, ...] = (
     _OP_FIND_LIBRARY_ITEM,
     _OP_DEPLOY_OVF_LIBRARY_ITEM,
     _power_vm_op_id("start"),
+)
+# vm.import_from_library (#3229) REST sub-ops: the shared name-resolution find
+# actions, the optional power-on, and the content-library download-session flow
+# the typed HttpNfcLease source reads the OVF descriptor + disks through (all
+# vcenter.yaml-served REST paths, so they reconcile through the generic
+# ``_SUB_OPS_*`` sweep). The vim control-plane sub-ops are the separate
+# ``_VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY`` manifest below.
+_SUB_OPS_VM_IMPORT_FROM_LIBRARY: tuple[str, ...] = (
+    _OP_FIND_LIBRARY,
+    _OP_FIND_LIBRARY_ITEM,
+    library_download.OP_DOWNLOAD_SESSION_CREATE,
+    library_download.OP_DOWNLOAD_SESSION_LIST_FILES,
+    library_download.OP_DOWNLOAD_SESSION_PREPARE_FILE,
+    library_download.OP_DOWNLOAD_SESSION_KEEP_ALIVE,
+    library_download.OP_DOWNLOAD_SESSION_CANCEL,
+    _power_vm_op_id("start"),
+)
+# vm.import_from_library (#3229) vim (VI-JSON) sub-ops: the ServiceContent
+# resolve, the OVF CreateImportSpec read, the governed ImportVApp write, the
+# lease-state poll, and the lease progress/complete/abort lifecycle. Declared
+# out of the ``_SUB_OPS_*`` namespace (uppercase MoType path roots) so the
+# vcenter.yaml sweep skips them; reconciled against vi-json.yaml below.
+_VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY: tuple[str, ...] = (
+    ovf_import_control.OP_RETRIEVE_SERVICE_CONTENT,
+    ovf_import_control.OP_CREATE_IMPORT_SPEC,
+    ovf_import_control.OP_IMPORT_VAPP,
+    ovf_import_control.OP_RETRIEVE_PROPERTIES,
+    ovf_import_control.OP_LEASE_PROGRESS,
+    ovf_import_control.OP_LEASE_COMPLETE,
+    ovf_import_control.OP_LEASE_ABORT,
 )
 _SUB_OPS_VM_MIGRATE: tuple[str, ...] = (_OP_RELOCATE_VM,)
 _SUB_OPS_VM_POWER_BULK: tuple[str, ...] = (
@@ -2682,6 +2721,184 @@ async def vm_deploy_from_library_composite(
         "issues": issues,
         "candidates": None,
     }
+
+
+# ===========================================================================
+# vm.import_from_library (typed HttpNfcLease OVF import -- #3229)
+# ===========================================================================
+#
+# The durable, transfer-window-decoupled sibling of vm.deploy_from_library.
+# That composite's synchronous REST deploy holds one POST open for the whole
+# server-side copy, so completion is bounded by the client read-timeout, not
+# the operation's real duration -- a multi-GB installer OVA outran even the 3 h
+# mitigation ceiling live (#3176 / stopgap PR #3234). This composite drives the
+# transfer itself via a typed vim HttpNfcLease import: it reads the OVF
+# descriptor + disks from the content library client-side (the download-session
+# source, :mod:`..library_download`) and streams each disk straight to the
+# lease's device URLs with a progress heartbeat (:mod:`..ovf_import`), so
+# completion is bounded only by the transfer's own duration and, under async
+# governed dispatch (#3079), a dropped caller no longer aborts it. Version-
+# agnostic (core vim25 OvfManager / HttpNfcLease; no 9.0-only fields), so it
+# also covers the pre-9.0 VCF 5.x migration-source fleet (#3056).
+#
+# Item resolution (id passthrough or name find, ambiguity-refusing) reuses
+# ``_resolve_deploy_library_item``; the outcome maps onto the same
+# ``deployed`` / ``deploy_failed`` / ``deploy_error`` envelope family (#3071)
+# the deploy composite uses, plus a per-disk ``transfer`` manifest.
+
+# The vim ImportVApp governance op_id + shared write posture the ImportVApp
+# gate evaluates (the one governed write in the import flow; the lease
+# lifecycle + reads ride the already-approved composite).
+_OP_IMPORT_VAPP_GOVERNANCE = ovf_import_control.OP_IMPORT_VAPP
+
+
+def _import_vapp_gate(
+    connector: VmwareRestConnector, target: Any, operator: Operator
+) -> Callable[[dict[str, Any]], Awaitable[OperationResult | None]]:
+    """Build the ImportVApp gate closure the engine calls before the write.
+
+    Runs the same :func:`enforce_subop_policy` seam every composite write uses,
+    under the shared ``dangerous`` / ``requires_approval=False`` posture (the
+    top-level composite is the single approval gate). Returns an
+    ``OperationResult`` when the gate parks / denies -- the engine returns it
+    verbatim so a policy-denied import never reaches ``ImportVApp``.
+    """
+
+    async def _gate(params: dict[str, Any]) -> OperationResult | None:
+        return await enforce_subop_policy(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_IMPORT_VAPP_GOVERNANCE,
+            safety_level=_WRITE_SAFETY_LEVEL,
+            requires_approval=_WRITE_REQUIRES_APPROVAL,
+            target=target,
+            params=params,
+        )
+
+    return _gate
+
+
+#: ``LeaseImportResult.status`` -> the deploy-envelope status family (#3071).
+_IMPORT_STATUS_TO_ENVELOPE = {
+    "imported": "deployed",
+    "import_failed": "deploy_failed",
+    "import_error": "deploy_error",
+    "lease_error": "deploy_error",
+    "lease_timeout": "deploy_error",
+}
+
+
+def _import_placement(item_name: str, params: dict[str, Any]) -> ImportPlacement:
+    """Build the :class:`ImportPlacement` from the composite params."""
+    network_mappings = params.get("network_mappings")
+    ovf_properties = params.get("ovf_properties")
+    return ImportPlacement(
+        resource_pool=params["resource_pool"],
+        datastore=params["datastore"],
+        entity_name=params.get("name") or "",
+        host=params.get("host"),
+        folder=params.get("folder"),
+        network_mappings=(
+            {str(k): str(v) for k, v in network_mappings.items()}
+            if isinstance(network_mappings, dict)
+            else {}
+        ),
+        ovf_properties=(
+            {str(k): str(v) for k, v in ovf_properties.items()}
+            if isinstance(ovf_properties, dict)
+            else {}
+        ),
+        disk_provisioning=params.get("storage_provisioning"),
+    )
+
+
+def _import_envelope(result: LeaseImportResult, item_id: str) -> dict[str, Any]:
+    """Map a :class:`LeaseImportResult` onto the deploy-envelope response shape."""
+    return {
+        "status": _IMPORT_STATUS_TO_ENVELOPE.get(result.status, "deploy_error"),
+        "vm_id": result.vm_id,
+        "resource_type": result.resource_type,
+        "library_item_id": item_id,
+        "powered_on": False,
+        "issues": list(result.issues),
+        "transfer": list(result.transfer),
+        "candidates": None,
+    }
+
+
+async def vm_import_from_library_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Import an OVF/OVA content-library item to a new VM via a typed HttpNfcLease.
+
+    Op-id: ``vmware.composite.vm.import_from_library``. The durable counterpart
+    to ``vm.deploy_from_library`` for items whose transfer outruns a single
+    HTTP read-timeout (#3176): MEHO drives the disk transfer itself over an
+    ``HttpNfcLease`` rather than blocking on one server-side-copy POST, so
+    completion is bounded only by the transfer's real duration. Resolves the
+    library item (id passthrough or name lookup, ambiguity-refusing), streams
+    the OVF from the content library to the lease, and maps the outcome to the
+    structured ``deployed`` / ``deploy_failed`` / ``deploy_error`` envelope
+    (#3071) plus a per-disk ``transfer`` manifest. With ``power_on`` the
+    imported VM is started best-effort.
+
+    **Calling convention.** Multi-GB imports should be dispatched in async mode
+    (``call_operation`` with ``async=true`` -> HTTP 202 + a durable run handle,
+    #3079): the import then runs on a background task, so a caller that
+    disconnects mid-transfer no longer cancels it -- and, unlike the sync REST
+    deploy, there is no single blocking read to bound completion at all.
+    """
+    try:
+        item_id, resolution_error = await _resolve_deploy_library_item(
+            connector=connector, target=target, operator=operator, params=params
+        )
+    except httpx.HTTPError as exc:
+        return _deploy_failure(
+            "resolve_error",
+            issues=[
+                _deploy_issue(
+                    "resolve",
+                    "error",
+                    f"content-library lookup faulted: {_vsphere_fault_detail(exc)}",
+                )
+            ],
+        )
+    if resolution_error is not None:
+        return resolution_error
+    assert item_id is not None  # resolution_error is None => item_id resolved
+
+    placement = _import_placement(item_id, params)
+    source = library_download.LibraryDownloadSource(
+        connector=connector, target=target, operator=operator, library_item_id=item_id
+    )
+    try:
+        result = await import_ovf_from_source(
+            connector=connector,
+            target=target,
+            operator=operator,
+            source=source,
+            placement=placement,
+            gate=_import_vapp_gate(connector, target, operator),
+        )
+    finally:
+        await source.aclose()
+
+    if isinstance(result, OperationResult):  # ImportVApp gate parked / denied
+        return result
+
+    envelope = _import_envelope(result, item_id)
+    if result.status == "imported" and result.vm_id and bool(params.get("power_on", False)):
+        powered_on, power_issue = await _power_on_deployed_vm(
+            connector, target, operator, result.vm_id
+        )
+        envelope["powered_on"] = powered_on
+        if power_issue is not None:
+            envelope["issues"].append(power_issue)
+    return envelope
 
 
 # ===========================================================================

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -2958,6 +2958,224 @@ VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
 }
 
 
+#: ``vmware.composite.vm.import_from_library`` parameter schema.
+#:
+#: The typed ``HttpNfcLease`` OVF import (#3229): the durable counterpart to
+#: ``deploy_from_library`` for items whose transfer outruns a single HTTP
+#: read-timeout (#3176). Same name-resolution surface as the deploy composite,
+#: but ``datastore`` is **required** (the vim ``OvfManager.CreateImportSpec``
+#: request requires the inventory-placement datastore MoRef, unlike the REST
+#: deploy which can derive it) and ``accept_all_eula`` / ``storage_profile`` are
+#: dropped (the ``OvfCreateImportSpecParams`` cisp does not carry them).
+VM_IMPORT_FROM_LIBRARY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "library_item": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Content-library OVF/OVA item id (passthrough). Supply this **or** "
+                "``library_item_name``; ``library_item`` wins when both are present."
+            ),
+        },
+        "library_item_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "OVF/OVA item display name, resolved to an id via "
+                "``POST:/content/library/item?action=find`` (filtered to "
+                "``type='ovf'``). No match returns ``status='item_not_found'``, more "
+                "than one ``status='ambiguous_item'`` with candidate ids — no import "
+                "fires. Ignored when ``library_item`` is given."
+            ),
+        },
+        "library_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional library display name scoping the ``library_item_name`` "
+                "lookup to one library (via ``POST:/content/library?action=find``); "
+                "an unknown name returns ``status='library_not_found'`` and an "
+                "ambiguous one ``status='ambiguous_library'``."
+            ),
+        },
+        "resource_pool": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Target ``ResourcePool`` moid the entity is imported into "
+                "(``ResourcePool.ImportVApp`` receiver + ``CreateImportSpec`` "
+                "resourcePool)."
+            ),
+        },
+        "datastore": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Target ``Datastore`` moid for the imported inventory objects "
+                "(``CreateImportSpec.datastore``). Required for the lease import — "
+                "the vim import spec is built against an explicit datastore."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional target ``HostSystem`` moid (``ImportVApp.host``). For a "
+                "stand-alone host or a DRS cluster it may be omitted."
+            ),
+        },
+        "folder": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional destination VM ``Folder`` moid (``ImportVApp.folder``); the "
+                "datacenter's VM root folder is used when omitted."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional display name for the imported VM "
+                "(``OvfCreateImportSpecParams.entityName``); the OVF descriptor's "
+                "product name is used when omitted."
+            ),
+        },
+        "network_mappings": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Map of OVF NetworkSection identifier → target ``Network`` moid "
+                "(portgroup). Folded into ``OvfCreateImportSpecParams.networkMapping``. "
+                "A key the OVF descriptor does not declare comes back as a structured "
+                "``deploy_failed`` issue, not a raw fault."
+            ),
+        },
+        "storage_provisioning": {
+            "type": "string",
+            "enum": ["thin", "thick"],
+            "description": (
+                "Optional disk provisioning applied to all disks "
+                "(``OvfCreateImportSpecParams.diskProvisioning``)."
+            ),
+        },
+        "ovf_properties": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Optional OVF product-section properties as ``{property_id: value}``, "
+                "folded into ``OvfCreateImportSpecParams.propertyMapping``. Values may "
+                "be secret (appliance passwords), so the park-time preview echoes only "
+                "the property **ids**, never the values."
+            ),
+        },
+        "power_on": {
+            "type": "boolean",
+            "description": (
+                "Power the imported VM on afterward via "
+                "``POST:/vcenter/vm/{vm}/power?action=start`` (the import itself never "
+                "powers on). Best-effort: a power-on fault leaves ``status='deployed'`` "
+                "with ``powered_on=false`` and an issue."
+            ),
+        },
+    },
+    "required": ["resource_pool", "datastore"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.import_from_library`` response schema.
+VM_IMPORT_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "deployed",
+                "deploy_failed",
+                "deploy_error",
+                "invalid_reference",
+                "library_not_found",
+                "ambiguous_library",
+                "item_not_found",
+                "ambiguous_item",
+                "resolve_error",
+            ],
+            "description": (
+                "The ``deploy_from_library`` envelope family (#3071), reused so the "
+                "import and deploy paths share one contract: ``'deployed'`` — the "
+                "lease import completed and the VM was created; ``'deploy_failed'`` — "
+                "``OvfManager.CreateImportSpec`` rejected the descriptor (bad network "
+                "mapping / property / placement), with per-issue messages under "
+                "``issues``; ``'deploy_error'`` — a vim control-plane call, the lease "
+                "state, or a disk upload faulted (surfaced as a structured message, "
+                "never a raw vendor fault); the resolution statuses "
+                "(``'invalid_reference'`` / ``'library_not_found'`` / "
+                "``'ambiguous_library'`` / ``'item_not_found'`` / ``'ambiguous_item'`` "
+                "/ ``'resolve_error'``) are reached before any mutation, identical to "
+                "the deploy composite."
+            ),
+        },
+        "vm_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Imported VM moid (``HttpNfcLeaseInfo.entity``); ``null`` unless "
+                "``status='deployed'``."
+            ),
+        },
+        "resource_type": {
+            "type": ["string", "null"],
+            "description": (
+                "``'VirtualMachine'`` or ``'VirtualApp'`` "
+                "(``HttpNfcLeaseInfo.entity`` type); ``null`` unless imported."
+            ),
+        },
+        "library_item_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The library-item id the import used — the passthrough id, or the id "
+                "resolved from ``library_item_name``. ``null`` when resolution failed "
+                "before import."
+            ),
+        },
+        "powered_on": {
+            "type": "boolean",
+            "description": (
+                "Whether the follow-on power-on succeeded. Always ``false`` when "
+                "``power_on`` was not requested or the import did not succeed."
+            ),
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Per-issue projections ``{category, severity, message}`` from the OVF "
+                "descriptor validation, lease fault, disk-upload fault, resolution, or "
+                "power-on. Empty on a clean import with no descriptor warnings."
+            ),
+        },
+        "transfer": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Per-disk transfer manifest ``{path, device_id, size_bytes}`` for the "
+                "files streamed to the lease. Empty unless ``status='deployed'``."
+            ),
+        },
+        "candidates": {
+            "type": ["array", "null"],
+            "items": {"type": "string"},
+            "description": (
+                "Candidate ids on ``ambiguous_item`` (library-item ids) or "
+                "``ambiguous_library`` (library ids); ``null`` otherwise."
+            ),
+        },
+    },
+    "required": ["status", "vm_id", "powered_on", "issues", "transfer"],
+}
+
+
 # ===========================================================================
 # Host-domain write composites (#3182) -- dangerous / requires approval
 # ===========================================================================

--- a/backend/src/meho_backplane/connectors/vmware_rest/library_download.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/library_download.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Content-library download-session OVF byte source for the lease import (#3229).
+
+Implements :class:`.ovf_transfer.OvfSource` over the content-library
+download-session REST flow, so the typed ``HttpNfcLease`` import
+(:mod:`.ovf_import`) can read a library item's OVF descriptor + disk files
+client-side and stream them to the lease. The flow (all served by the pinned
+``vcenter.yaml``):
+
+1. ``POST /content/library/item/download-session`` -- create a session for
+   the library item (``{library_item_id}``); the 201 body is the session id.
+2. ``GET .../download-session/{id}/file`` -- list the item's files
+   (descriptor + disks) with their prepare status.
+3. ``POST .../file?action=prepare`` (``{file_name}``) -- request a file, then
+   poll the file list until its status is ``PREPARED`` and its
+   ``download_endpoint.uri`` is set.
+4. GET that URI -- the descriptor is buffered whole (small); each disk is
+   streamed, its byte count taken from the response ``Content-Length`` (the
+   ``File.Info.size`` is not guaranteed set until the download completes).
+5. ``POST .../download-session/{id}?action=keep-alive`` -- refresh the session
+   during a long transfer (folded into the lease heartbeat).
+6. ``POST .../download-session/{id}?action=cancel`` on close.
+
+The find-action resolution that turns a name into the item id stays in
+:mod:`.composites._write` (shared with ``deploy_from_library``); this source
+takes the resolved item id. The download endpoints are HTTPS links on the
+authenticated vCenter, so the byte GETs carry the connector's session auth
+headers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.vmware_rest.typed_ops import _unwrap_value
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import httpx
+
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+# Canonical ``METHOD:/path`` op_ids (what the ingest parser emits from
+# vcenter.yaml). ``_write`` re-exports these in its
+# ``_SUB_OPS_VM_IMPORT_FROM_LIBRARY`` manifest; the write-body reconcile lane
+# also introspects this module for its POST ops.
+OP_DOWNLOAD_SESSION_CREATE = "POST:/content/library/item/download-session"
+OP_DOWNLOAD_SESSION_LIST_FILES = (
+    "GET:/content/library/item/download-session/{downloadSessionId}/file"
+)
+OP_DOWNLOAD_SESSION_PREPARE_FILE = (
+    "POST:/content/library/item/download-session/{downloadSessionId}/file?action=prepare"
+)
+OP_DOWNLOAD_SESSION_KEEP_ALIVE = (
+    "POST:/content/library/item/download-session/{downloadSessionId}?action=keep-alive"
+)
+OP_DOWNLOAD_SESSION_CANCEL = (
+    "POST:/content/library/item/download-session/{downloadSessionId}?action=cancel"
+)
+
+# ``Content.Library.Item.Downloadsession.File.PrepareStatus`` enum values.
+_PREPARE_STATUS_PREPARED = "PREPARED"
+_PREPARE_STATUS_ERROR = "ERROR"
+
+# OVF descriptor file extension (the item carries exactly one).
+_OVF_DESCRIPTOR_SUFFIX = ".ovf"
+
+# Default file-prepare wall-clock bound + cadence (module-global so tests zero
+# them).
+_PREPARE_TIMEOUT_SECONDS = 300.0
+_PREPARE_POLL_INTERVAL = 2.0
+# Streaming read chunk for the download GET -> lease PUT hop.
+_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+
+
+class LibraryDownloadError(RuntimeError):
+    """A download-session step failed in a way the import cannot recover from."""
+
+
+class _DiskStream:
+    """One in-flight disk download exposing ``size`` + ``aiter_bytes`` (OvfSourceFile).
+
+    Wraps the connector client's streaming GET so the bytes flow straight into
+    the lease PUT without buffering. The download URI is resolved on
+    ``__aenter__`` (just-in-time, so an earlier disk can still be uploading);
+    ``size`` is the download response's ``Content-Length`` -- authoritative for
+    the lease PUT's own ``Content-Length``, since ``File.Info.size`` is not
+    guaranteed set before the download completes.
+    """
+
+    def __init__(self, source: LibraryDownloadSource, name: str) -> None:
+        self._source = source
+        self._name = name
+        self._stream_cm: Any = None
+        self._response: httpx.Response | None = None
+        self.size = 0
+
+    async def __aenter__(self) -> _DiskStream:
+        source = self._source
+        uri = await source._resolve_download_uri(self._name)
+        client = await source._connector._http_client(source._target)
+        headers = await source._connector.auth_headers(source._target, source._operator)
+        self._stream_cm = client.stream("GET", uri, headers=headers)
+        self._response = await self._stream_cm.__aenter__()
+        self._response.raise_for_status()
+        length = self._response.headers.get("content-length")
+        self.size = int(length) if length is not None and length.isdigit() else 0
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._stream_cm is not None:
+            await self._stream_cm.__aexit__(*exc)
+
+    def aiter_bytes(self) -> AsyncIterator[bytes]:
+        assert self._response is not None  # entered
+        return self._response.aiter_bytes(_DOWNLOAD_CHUNK_BYTES)
+
+
+class LibraryDownloadSource:
+    """Content-library download-session implementation of :class:`.ovf_transfer.OvfSource`.
+
+    Lazily creates the download session on first use; :meth:`aclose` cancels
+    it. Every REST call rides the connector's own authenticated session
+    (``_post_json`` / ``_get_json``) -- these are content reads, so, like the
+    ``?action=find`` resolution, they run un-gated (the governed write is the
+    ``ImportVApp`` inside the engine).
+    """
+
+    def __init__(
+        self,
+        *,
+        connector: VmwareRestConnector,
+        target: VsphereTargetLike,
+        operator: Operator,
+        library_item_id: str,
+    ) -> None:
+        self._connector = connector
+        self._target = target
+        self._operator = operator
+        self._item_id = library_item_id
+        self._session_id: str | None = None
+
+    async def _ensure_session(self) -> str:
+        """Create the download session on first use; return its id."""
+        if self._session_id is not None:
+            return self._session_id
+        _, _, path = OP_DOWNLOAD_SESSION_CREATE.partition(":")
+        mounted = await self._connector.mount_op_path(self._target, path, self._operator)
+        payload = await self._connector._post_json(
+            self._target, mounted, operator=self._operator, json={"library_item_id": self._item_id}
+        )
+        session_id = _unwrap_value(payload)
+        if not isinstance(session_id, str) or not session_id:
+            raise LibraryDownloadError(f"download-session create returned no id (got {payload!r})")
+        self._session_id = session_id
+        return session_id
+
+    async def _list_files(self) -> list[dict[str, Any]]:
+        """List the session's files (name / status / download_endpoint)."""
+        session_id = await self._ensure_session()
+        path = OP_DOWNLOAD_SESSION_LIST_FILES.partition(":")[2].format(downloadSessionId=session_id)
+        mounted = await self._connector.mount_op_path(self._target, path, self._operator)
+        payload = await self._connector._get_json(self._target, mounted, operator=self._operator)
+        files = _unwrap_value(payload)
+        return [f for f in files if isinstance(f, dict)] if isinstance(files, list) else []
+
+    async def _prepare(self, file_name: str) -> None:
+        """POST ``?action=prepare`` for one file (idempotent server-side)."""
+        session_id = await self._ensure_session()
+        path = OP_DOWNLOAD_SESSION_PREPARE_FILE.partition(":")[2].format(
+            downloadSessionId=session_id
+        )
+        mounted = await self._connector.mount_op_path(self._target, path, self._operator)
+        await self._connector._post_json(
+            self._target, mounted, operator=self._operator, json={"file_name": file_name}
+        )
+
+    async def _resolve_download_uri(self, file_name: str) -> str:
+        """Prepare *file_name* and poll to ``PREPARED``; return its download URI."""
+        await self._prepare(file_name)
+        deadline = time.monotonic() + _PREPARE_TIMEOUT_SECONDS
+        while True:
+            info = _match_file(await self._list_files(), file_name)
+            status = info.get("status") if info else None
+            if status == _PREPARE_STATUS_PREPARED and info is not None:
+                uri = _download_uri(info)
+                if uri:
+                    return uri
+            if status == _PREPARE_STATUS_ERROR:
+                raise LibraryDownloadError(
+                    f"download-session file {file_name!r} failed to prepare (status=ERROR)"
+                )
+            if time.monotonic() >= deadline:
+                raise LibraryDownloadError(
+                    f"download-session file {file_name!r} not PREPARED within "
+                    f"{int(_PREPARE_TIMEOUT_SECONDS)}s"
+                )
+            await asyncio.sleep(_PREPARE_POLL_INTERVAL)
+
+    async def read_descriptor(self) -> str:
+        """Buffer and return the item's OVF descriptor XML text."""
+        files = await self._list_files()
+        descriptor_name = _descriptor_name(files)
+        if descriptor_name is None:
+            raise LibraryDownloadError(
+                f"library item {self._item_id!r} has no .ovf descriptor file"
+            )
+        uri = await self._resolve_download_uri(descriptor_name)
+        client = await self._connector._http_client(self._target)
+        headers = await self._connector.auth_headers(self._target, self._operator)
+        resp = await client.get(uri, headers=headers)
+        resp.raise_for_status()
+        return resp.text
+
+    def open_disk(self, name: str) -> _DiskStream:
+        """Open the named disk for streaming (an async context manager)."""
+        return _DiskStream(self, name)
+
+    async def keep_alive(self) -> None:
+        """Best-effort ``?action=keep-alive`` -- extends the active session."""
+        if self._session_id is None:
+            return
+        path = OP_DOWNLOAD_SESSION_KEEP_ALIVE.partition(":")[2].format(
+            downloadSessionId=self._session_id
+        )
+        with contextlib.suppress(Exception):
+            mounted = await self._connector.mount_op_path(self._target, path, self._operator)
+            await self._connector._post_json(
+                self._target, mounted, operator=self._operator, json={}
+            )
+
+    async def aclose(self) -> None:
+        """Best-effort ``?action=cancel`` -- releases the download session."""
+        if self._session_id is None:
+            return
+        path = OP_DOWNLOAD_SESSION_CANCEL.partition(":")[2].format(
+            downloadSessionId=self._session_id
+        )
+        with contextlib.suppress(Exception):
+            mounted = await self._connector.mount_op_path(self._target, path, self._operator)
+            await self._connector._post_json(
+                self._target, mounted, operator=self._operator, json={}
+            )
+        self._session_id = None
+
+
+def _match_file(files: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Return the file info whose ``name`` matches (exact, then basename)."""
+    for info in files:
+        if info.get("name") == name:
+            return info
+    base = name.rsplit("/", 1)[-1]
+    for info in files:
+        file_name = info.get("name")
+        if isinstance(file_name, str) and file_name.rsplit("/", 1)[-1] == base:
+            return info
+    return None
+
+
+def _descriptor_name(files: list[dict[str, Any]]) -> str | None:
+    """Return the name of the item's ``.ovf`` descriptor file, if present."""
+    for info in files:
+        name = info.get("name")
+        if isinstance(name, str) and name.lower().endswith(_OVF_DESCRIPTOR_SUFFIX):
+            return name
+    return None
+
+
+def _download_uri(info: dict[str, Any]) -> str | None:
+    """Pull ``download_endpoint.uri`` off a PREPARED file info."""
+    endpoint = info.get("download_endpoint")
+    if isinstance(endpoint, dict):
+        uri = endpoint.get("uri")
+        return uri if isinstance(uri, str) and uri else None
+    return None

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_import.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_import.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed ``HttpNfcLease`` OVF import orchestrator (#3229).
+
+The durable, transfer-window-decoupled counterpart to the synchronous
+``vmware.composite.vm.deploy_from_library`` REST deploy. That deploy holds
+one HTTP POST open for the whole server-side disk copy, so completion is
+bounded by the client read-timeout rather than the operation's real
+duration; a multi-GB installer OVA to an NFS datastore outran even the 3 h
+mitigation ceiling live (#3176). The stopgap PR #3234 raised that ceiling +
+established the async-dispatch convention; this is the durable fix it
+deferred.
+
+This module ties the pieces together; the mechanics live beside it:
+
+* :mod:`.ovf_import_control` -- the vim25 control-plane calls (over the
+  VI-JSON seam ``_post_vmomi_json`` / #2466): ``RetrieveServiceContent`` ->
+  ``CreateImportSpec`` -> the governed ``ImportVApp`` write -> lease-ready
+  poll -> ``Complete`` / ``Abort``.
+* :mod:`.ovf_transfer` -- the net-new streaming machinery: each disk streams
+  from the source straight to its lease device URL with a background
+  ``HttpNfcLeaseProgress`` heartbeat, so the transfer is bounded only by its
+  own duration (AC1) and reports percent (AC2).
+
+The flow: resolve the ``OvfManager`` + ``rootFolder`` morefs, read the OVF
+descriptor from the source, ``CreateImportSpec`` (a descriptor error short-
+circuits to ``import_failed`` before any mutation), gate + ``ImportVApp``
+(the one governed write; a parked / denied gate returns the
+``OperationResult`` verbatim), poll the lease to ``ready``, stream every disk
+matched to its device URL, then ``Complete``. Any failure after the lease
+exists aborts it, so vCenter removes the half-created inventory objects and a
+failed import never leaves a partial VM behind.
+
+The engine is governance-agnostic: the ``ImportVApp`` gate is injected, so
+the composite layer owns the ``enforce_subop_policy`` posture and the engine
+stays a pure mechanism (unit-testable with a fake source + recording
+connector). The byte source is abstracted behind :class:`.ovf_transfer.OvfSource`;
+:mod:`.library_download` supplies the content-library implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from meho_backplane.connectors.vmware_rest import ovf_import_control as control
+from meho_backplane.connectors.vmware_rest import ovf_transfer as transfer
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors import OperationResult
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.connectors.vmware_rest.ovf_transfer import OvfSource
+    from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+__all__ = [
+    "ImportPlacement",
+    "LeaseImportResult",
+    "import_ovf_from_source",
+]
+
+# Default heartbeat cadence forwarded to the transfer (module-global so a test
+# can shrink it without reaching into the transfer module).
+_PROGRESS_HEARTBEAT_INTERVAL = 30.0
+
+
+@dataclass(frozen=True)
+class ImportPlacement:
+    """Resolved placement + descriptor-mapping inputs for one import."""
+
+    resource_pool: str
+    datastore: str
+    entity_name: str
+    host: str | None = None
+    folder: str | None = None
+    network_mappings: dict[str, str] = field(default_factory=dict)
+    ovf_properties: dict[str, str] = field(default_factory=dict)
+    disk_provisioning: str | None = None
+
+
+@dataclass(frozen=True)
+class LeaseImportResult:
+    """Terminal outcome of a lease import, mapped to the deploy envelope family.
+
+    ``status`` is one of ``imported`` / ``import_failed`` (the OVF descriptor
+    was rejected by ``CreateImportSpec``) / ``import_error`` (a vim control-
+    plane or disk-upload call faulted) / ``lease_error`` (the lease reached the
+    ``error`` state) / ``lease_timeout`` (the lease never reached ``ready``).
+    ``vm_id`` / ``resource_type`` are set only on ``imported``. ``issues``
+    carries the ``{category, severity, message}`` projections; ``transfer`` the
+    per-disk manifest.
+    """
+
+    status: str
+    vm_id: str | None = None
+    resource_type: str | None = None
+    issues: list[dict[str, Any]] = field(default_factory=list)
+    transfer: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ImportSpec:
+    """The CreateImportSpec output the rest of the import needs."""
+
+    root_folder_moid: str
+    import_spec: Any
+    warnings: list[dict[str, Any]]
+    file_items: list[dict[str, Any]]
+
+
+async def _create_import_spec(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    source: OvfSource,
+    placement: ImportPlacement,
+) -> _ImportSpec | LeaseImportResult:
+    """Resolve ServiceContent + descriptor + CreateImportSpec.
+
+    Returns the :class:`_ImportSpec` to proceed with, or an ``import_failed``
+    :class:`LeaseImportResult` when the descriptor is rejected (no mutation yet).
+    """
+    ovf_manager_moid, root_folder_moid = await control.retrieve_service_content(
+        connector, target, operator
+    )
+    descriptor = await source.read_descriptor()
+    spec_result = await control.create_import_spec(
+        connector,
+        target,
+        operator,
+        ovf_manager_moid=ovf_manager_moid,
+        descriptor=descriptor,
+        placement=placement,
+    )
+    errors = control.spec_errors(spec_result)
+    if errors:
+        return LeaseImportResult(status="import_failed", issues=errors)
+    return _ImportSpec(
+        root_folder_moid=root_folder_moid,
+        import_spec=spec_result.get("importSpec"),
+        warnings=control.spec_warnings(spec_result),
+        file_items=control.file_items(spec_result),
+    )
+
+
+async def import_ovf_from_source(
+    *,
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    source: OvfSource,
+    placement: ImportPlacement,
+    gate: Callable[[dict[str, Any]], Awaitable[OperationResult | None]],
+    lease_ready_timeout: float | None = None,
+    heartbeat_interval: float = _PROGRESS_HEARTBEAT_INTERVAL,
+) -> LeaseImportResult | OperationResult:
+    """Drive a full ``HttpNfcLease`` OVF import from *source* to a new VM.
+
+    Returns a :class:`LeaseImportResult` (the composite maps it to the deploy
+    envelope) or, when the ``ImportVApp`` gate parks / denies, the
+    :class:`OperationResult` verbatim.
+    """
+    spec = await _create_import_spec(
+        connector, target, operator, source=source, placement=placement
+    )
+    if isinstance(spec, LeaseImportResult):
+        return spec
+
+    parked, lease = await control.import_vapp(
+        connector,
+        target,
+        operator,
+        resource_pool=placement.resource_pool,
+        folder_moid=placement.folder or spec.root_folder_moid,
+        host=placement.host,
+        import_spec=spec.import_spec,
+        gate=gate,
+    )
+    if parked is not None:
+        return parked
+    lease_moid = control.lease_moid(lease)
+    if lease_moid is None:
+        return LeaseImportResult(
+            status="import_error",
+            issues=[
+                *spec.warnings,
+                control.issue("lease", "error", "ImportVApp returned no lease"),
+            ],
+        )
+
+    ready_kwargs = {} if lease_ready_timeout is None else {"timeout_seconds": lease_ready_timeout}
+    outcome, info = await control.poll_lease_ready(
+        connector, target, operator, lease_moid=lease_moid, **ready_kwargs
+    )
+    if outcome != control.LEASE_STATE_READY:
+        return await _finalize_non_ready(
+            connector,
+            target,
+            operator,
+            lease_moid=lease_moid,
+            outcome=outcome,
+            info=info,
+            warnings=spec.warnings,
+        )
+    return await _run_transfer(
+        connector,
+        target,
+        operator,
+        lease_moid=lease_moid,
+        info=info,
+        file_items=spec.file_items,
+        source=source,
+        warnings=spec.warnings,
+        heartbeat_interval=heartbeat_interval,
+    )
+
+
+async def _finalize_non_ready(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    outcome: str,
+    info: dict[str, Any],
+    warnings: list[dict[str, Any]],
+) -> LeaseImportResult:
+    """Map a lease that reached ``error`` / timed out to a structured result."""
+    if outcome == control.LEASE_STATE_ERROR:
+        message = control.fault_text(info.get("error"))
+        return LeaseImportResult(
+            status="lease_error", issues=[*warnings, control.issue("lease", "error", message)]
+        )
+    await control.abort_lease(connector, target, operator, lease_moid=lease_moid)
+    return LeaseImportResult(
+        status="lease_timeout",
+        issues=[*warnings, control.issue("lease", "error", "lease never reached the ready state")],
+    )
+
+
+async def _run_transfer(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    info: dict[str, Any],
+    file_items: list[dict[str, Any]],
+    source: OvfSource,
+    warnings: list[dict[str, Any]],
+    heartbeat_interval: float,
+) -> LeaseImportResult:
+    """Stream the disks, complete the lease, and build the ``imported`` result.
+
+    The disk plan matches ``CreateImportSpec``'s ``fileItem`` list to the
+    lease ``deviceUrl`` map (by import key). Any upload / control-plane fault
+    aborts the lease and returns a structured ``import_error`` -- vCenter then
+    removes the half-created VM, so a failed transfer never leaves a partial
+    import behind.
+    """
+    raw_device_urls = info.get("deviceUrl")
+    device_urls: list[dict[str, Any]] = raw_device_urls if isinstance(raw_device_urls, list) else []
+    connect_host = str(getattr(target, "host", "") or "")
+    plan = transfer.plan_transfers(file_items, device_urls, connect_host)
+    try:
+        manifest = await transfer.transfer_all(
+            connector,
+            target,
+            operator,
+            lease_moid=lease_moid,
+            plan=plan,
+            source=source,
+            heartbeat_interval=heartbeat_interval,
+        )
+        await control.lease_complete(connector, target, operator, lease_moid=lease_moid)
+    except httpx.HTTPError as exc:
+        await control.abort_lease(connector, target, operator, lease_moid=lease_moid)
+        return LeaseImportResult(
+            status="import_error",
+            issues=[*warnings, control.issue("transfer", "error", f"disk upload faulted: {exc}")],
+        )
+    vm_id, resource_type = control.entity_from_info(info)
+    return LeaseImportResult(
+        status="imported",
+        vm_id=vm_id,
+        resource_type=resource_type,
+        issues=warnings,
+        transfer=manifest,
+    )

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_import_control.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_import_control.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vim control-plane calls for the ``HttpNfcLease`` OVF import (#3229).
+
+The vim25 methods the import orchestrator (:mod:`.ovf_import`) drives over
+the VI-JSON seam ``_post_vmomi_json`` (#2466): resolve the ``OvfManager`` +
+``rootFolder`` off ``ServiceContent``, ``CreateImportSpec`` (a read that
+validates the descriptor and returns the ``importSpec`` + disk ``fileItem``
+list), the governed ``ImportVApp`` write (returns the ``HttpNfcLease``), the
+lease-state ready-poll, and the ``Complete`` / ``Abort`` lifecycle.
+
+Every request DataObject carries its ``_typeName`` discriminator (#3103).
+The ``importSpec`` from ``CreateImportSpec`` is round-tripped **verbatim**
+into ``ImportVApp`` -- it is a server-issued ``Any``-typed DataObject that
+already carries its annotations, so it is never passed through
+:func:`unwrap_vim_value` (which would strip the tags an ``Any`` request
+field needs). Only pre-9.0 fields are read, so the surface is version-
+agnostic across the VCF 5.x migration-source fleet (#3056) and 9.0+.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    VIM_TYPE_NAME_KEY,
+    retrieve_properties_body,
+    unwrap_vim_value,
+    vim_moref,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors import OperationResult
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.connectors.vmware_rest.ovf_import import ImportPlacement
+    from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+# Governance op_ids (canonical ``METHOD:/{moId}`` keys the ingest parser emits
+# from vi-json.yaml). ``_write`` re-exports these in its
+# ``_VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY`` manifest for the l2 reconcile lane.
+OP_RETRIEVE_SERVICE_CONTENT = "POST:/ServiceInstance/{moId}/RetrieveServiceContent"
+OP_CREATE_IMPORT_SPEC = "POST:/OvfManager/{moId}/CreateImportSpec"
+OP_IMPORT_VAPP = "POST:/ResourcePool/{moId}/ImportVApp"
+OP_LEASE_PROGRESS = "POST:/HttpNfcLease/{moId}/HttpNfcLeaseProgress"
+OP_LEASE_COMPLETE = "POST:/HttpNfcLease/{moId}/HttpNfcLeaseComplete"
+OP_LEASE_ABORT = "POST:/HttpNfcLease/{moId}/HttpNfcLeaseAbort"
+OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+
+# vim ``_typeName`` discriminators the engine emits in request bodies. Every
+# value names a component schema in the pinned vi-json.yaml (grounded by the
+# ``_EMITTED_VIM_TYPE_NAMES`` reconcile lane).
+OVF_CREATE_IMPORT_SPEC_PARAMS_TYPE = "OvfCreateImportSpecParams"
+OVF_NETWORK_MAPPING_TYPE = "OvfNetworkMapping"
+KEY_VALUE_TYPE = "KeyValue"
+
+# Well-known bootstrap moid: the ServiceInstance singleton every vim client
+# starts from (govmomi's ``vim25.ServiceInstance``). The OvfManager +
+# rootFolder morefs are read off its ServiceContent, not guessed.
+_SERVICE_INSTANCE_MOID = "ServiceInstance"
+# The PropertyCollector singleton moid the lease-state poll reads through.
+_PROPERTY_COLLECTOR_MOID = "propertyCollector"
+
+_MO_TYPE_HTTP_NFC_LEASE = "HttpNfcLease"
+_MO_TYPE_NETWORK = "Network"
+_MO_TYPE_RESOURCE_POOL = "ResourcePool"
+_MO_TYPE_FOLDER = "Folder"
+_MO_TYPE_HOST_SYSTEM = "HostSystem"
+_MO_TYPE_DATASTORE = "Datastore"
+
+# ``HttpNfcLeaseState_enum`` values. ``initializing`` is the non-terminal state
+# the ready-poll waits through; ``ready`` unblocks the transfer.
+LEASE_STATE_READY = "ready"
+LEASE_STATE_ERROR = "error"
+
+# Default lease-ready wall-clock bound + cadence (module-global so tests zero
+# them), mirroring the ``poll_vim_task`` 600s / 2s convention.
+_LEASE_READY_TIMEOUT_SECONDS = 600.0
+_LEASE_READY_POLL_INTERVAL = 2.0
+
+
+def issue(category: str, severity: str, message: str) -> dict[str, Any]:
+    """Build one ``{category, severity, message}`` issue projection."""
+    return {"category": category, "severity": severity, "message": message}
+
+
+def fault_text(fault: Any) -> str:
+    """Best human-readable text from a vim ``MethodFault`` / ``LocalizedMethodFault``.
+
+    Mirrors :func:`vim_task._fault_message`'s fallback order:
+    ``localizedMessage`` -> joined ``faultMessage[*].message`` -> the fault's
+    ``_typeName`` concrete class -- so a genuine placement / OVF fault reaches
+    the operator as text, never a bare ``<no message>``.
+    """
+    if not isinstance(fault, dict):
+        return "<no fault reported>"
+    localized = fault.get("localizedMessage")
+    if isinstance(localized, str) and localized.strip():
+        return localized
+    body = fault.get("fault") if isinstance(fault.get("fault"), dict) else fault
+    messages = body.get("faultMessage") if isinstance(body, dict) else None
+    if isinstance(messages, list):
+        texts = [
+            m
+            for entry in messages
+            if isinstance(entry, dict) and isinstance(m := entry.get("message"), str) and m.strip()
+        ]
+        if texts:
+            return "; ".join(texts)
+    type_name = body.get("_typeName") if isinstance(body, dict) else None
+    return type_name if isinstance(type_name, str) and type_name.strip() else "<no fault reported>"
+
+
+def _cisp_body(placement: ImportPlacement) -> dict[str, Any]:
+    """Build the annotated ``OvfCreateImportSpecParams`` (``cisp``) DataObject.
+
+    ``entityName`` is the one required field (empty string lets vCenter fall
+    back to the descriptor's product name). ``networkMapping`` /
+    ``propertyMapping`` fold the operator's OVF-key maps into annotated
+    ``OvfNetworkMapping`` / ``KeyValue`` DataObjects; ``diskProvisioning`` is
+    passed through only when set.
+    """
+    cisp: dict[str, Any] = {
+        VIM_TYPE_NAME_KEY: OVF_CREATE_IMPORT_SPEC_PARAMS_TYPE,
+        "entityName": placement.entity_name,
+    }
+    if placement.network_mappings:
+        cisp["networkMapping"] = [
+            {
+                VIM_TYPE_NAME_KEY: OVF_NETWORK_MAPPING_TYPE,
+                "name": str(ovf_key),
+                "network": vim_moref(_MO_TYPE_NETWORK, str(moid)),
+            }
+            for ovf_key, moid in placement.network_mappings.items()
+        ]
+    if placement.ovf_properties:
+        cisp["propertyMapping"] = [
+            {VIM_TYPE_NAME_KEY: KEY_VALUE_TYPE, "key": str(k), "value": str(v)}
+            for k, v in placement.ovf_properties.items()
+        ]
+    if placement.disk_provisioning:
+        cisp["diskProvisioning"] = placement.disk_provisioning
+    return cisp
+
+
+async def retrieve_service_content(
+    connector: VmwareRestConnector, target: VsphereTargetLike, operator: Operator
+) -> tuple[str, str]:
+    """Return ``(ovf_manager_moid, root_folder_moid)`` off the ServiceContent.
+
+    Reads ``ServiceInstance.RetrieveServiceContent`` -- the documented way to
+    resolve the singleton managed objects (their moids are not guessed). The
+    boxed ``Any`` values normalise through :func:`unwrap_vim_value`.
+    """
+    path = f"/ServiceInstance/{_SERVICE_INSTANCE_MOID}/RetrieveServiceContent"
+    raw = await connector._post_vmomi_json(target, path, operator=operator, json={})
+    content = unwrap_vim_value(raw)
+    if not isinstance(content, dict):
+        raise RuntimeError(f"RetrieveServiceContent returned no ServiceContent ({type(raw)})")
+    ovf_ref = content.get("ovfManager")
+    folder_ref = content.get("rootFolder")
+    ovf_moid = ovf_ref.get("value") if isinstance(ovf_ref, dict) else None
+    folder_moid = folder_ref.get("value") if isinstance(folder_ref, dict) else None
+    if not isinstance(ovf_moid, str) or not isinstance(folder_moid, str):
+        raise RuntimeError("ServiceContent missing ovfManager / rootFolder MoRef")
+    return ovf_moid, folder_moid
+
+
+async def create_import_spec(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    ovf_manager_moid: str,
+    descriptor: str,
+    placement: ImportPlacement,
+) -> dict[str, Any]:
+    """Call ``OvfManager.CreateImportSpec`` and return the raw result dict.
+
+    A read (``System.View``) -- validates the descriptor and returns the
+    ``importSpec`` (round-tripped verbatim into ``ImportVApp``) plus the
+    ``fileItem`` upload list. The result is **not** wholesale-unwrapped:
+    ``importSpec`` must keep its ``_typeName`` tags for the round-trip; the
+    ``fileItem`` / ``error`` fields are read box-tolerantly at their own sites.
+    """
+    body = {
+        "ovfDescriptor": descriptor,
+        "resourcePool": vim_moref(_MO_TYPE_RESOURCE_POOL, placement.resource_pool),
+        "datastore": vim_moref(_MO_TYPE_DATASTORE, placement.datastore),
+        "cisp": _cisp_body(placement),
+    }
+    path = f"/OvfManager/{ovf_manager_moid}/CreateImportSpec"
+    result = await connector._post_vmomi_json(target, path, operator=operator, json=body)
+    if not isinstance(result, dict):
+        raise RuntimeError(
+            f"CreateImportSpec returned no OvfCreateImportSpecResult ({type(result)})"
+        )
+    return result
+
+
+def spec_errors(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten ``OvfCreateImportSpecResult.error`` into issue projections."""
+    errors = unwrap_vim_value(result.get("error"))
+    if not isinstance(errors, list):
+        return []
+    return [issue("descriptor", "error", fault_text(e)) for e in errors if isinstance(e, dict)]
+
+
+def spec_warnings(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten ``OvfCreateImportSpecResult.warning`` into issue projections."""
+    warnings = unwrap_vim_value(result.get("warning"))
+    if not isinstance(warnings, list):
+        return []
+    return [issue("descriptor", "warning", fault_text(w)) for w in warnings if isinstance(w, dict)]
+
+
+def file_items(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the ``OvfFileItem`` list (box-tolerant) from a CreateImportSpec result."""
+    items = unwrap_vim_value(result.get("fileItem"))
+    if not isinstance(items, list):
+        return []
+    return [i for i in items if isinstance(i, dict)]
+
+
+async def import_vapp(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    resource_pool: str,
+    folder_moid: str,
+    host: str | None,
+    import_spec: Any,
+    gate: Callable[[dict[str, Any]], Awaitable[OperationResult | None]],
+) -> tuple[OperationResult | None, Any]:
+    """Gate then call ``ResourcePool.ImportVApp``; return ``(gate, lease_moref)``.
+
+    The one governed *write* -- it creates the inventory objects. The gate
+    parks / denies for an agent principal like every other composite write;
+    when it clears, ``ImportVApp`` returns the ``HttpNfcLease`` MoRef the
+    transfer drives. ``import_spec`` is passed **verbatim** (never unwrapped)
+    so its server-issued ``_typeName`` annotations survive the round-trip.
+    """
+    params = {"resource_pool": resource_pool, "folder": folder_moid, "spec": "<import-spec>"}
+    parked = await gate(params)
+    if parked is not None:
+        return parked, None
+    body: dict[str, Any] = {
+        "spec": import_spec,
+        "folder": vim_moref(_MO_TYPE_FOLDER, folder_moid),
+    }
+    if host:
+        body["host"] = vim_moref(_MO_TYPE_HOST_SYSTEM, host)
+    path = f"/ResourcePool/{resource_pool}/ImportVApp"
+    lease = await connector._post_vmomi_json(target, path, operator=operator, json=body)
+    return None, unwrap_vim_value(lease)
+
+
+async def _read_lease_props(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    props: list[str],
+) -> dict[str, Any]:
+    """Read named ``HttpNfcLease`` properties via RetrievePropertiesEx.
+
+    Returns ``{prop_name: value}`` (box-normalised). Absent properties are
+    simply missing from the map -- the poll treats that as "not ready yet".
+    """
+    body = retrieve_properties_body(_MO_TYPE_HTTP_NFC_LEASE, [lease_moid], props)
+    path = f"/PropertyCollector/{_PROPERTY_COLLECTOR_MOID}/RetrievePropertiesEx"
+    raw = await connector._post_vmomi_json(target, path, operator=operator, json=body)
+    payload = unwrap_vim_value(raw)
+    objects = payload.get("objects") if isinstance(payload, dict) else None
+    if not isinstance(objects, list):
+        return {}
+    out: dict[str, Any] = {}
+    for obj in objects:
+        prop_set = obj.get("propSet", []) if isinstance(obj, dict) else []
+        for prop in prop_set or []:
+            if isinstance(prop, dict) and isinstance(prop.get("name"), str):
+                out[prop["name"]] = prop.get("val")
+    return out
+
+
+async def poll_lease_ready(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    timeout_seconds: float = _LEASE_READY_TIMEOUT_SECONDS,
+    poll_interval: float = _LEASE_READY_POLL_INTERVAL,
+) -> tuple[str, dict[str, Any]]:
+    """Poll ``HttpNfcLease.state`` to ``ready`` / ``error`` / timeout.
+
+    Returns ``(outcome, info)`` where outcome is ``"ready"`` (``info`` is the
+    ``HttpNfcLeaseInfo`` carrying ``deviceUrl`` + ``entity``), ``"error"``
+    (``info`` carries the lease fault under ``"error"``), or ``"timeout"``
+    (``info`` empty). Wall-clock bound, mirroring ``poll_vim_task``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        props = await _read_lease_props(
+            connector, target, operator, lease_moid=lease_moid, props=["state", "info", "error"]
+        )
+        state = props.get("state")
+        if state == LEASE_STATE_READY:
+            info = props.get("info")
+            return LEASE_STATE_READY, info if isinstance(info, dict) else {}
+        if state == LEASE_STATE_ERROR:
+            return LEASE_STATE_ERROR, {"error": props.get("error")}
+        if time.monotonic() >= deadline:
+            return "timeout", {}
+        await asyncio.sleep(poll_interval)
+
+
+async def lease_complete(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+) -> None:
+    """``HttpNfcLeaseComplete`` -- releases the lease + marks the import a success."""
+    path = f"/HttpNfcLease/{lease_moid}/HttpNfcLeaseComplete"
+    await connector._post_vmomi_json(target, path, operator=operator, json={})
+
+
+async def abort_lease(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+) -> None:
+    """Best-effort ``HttpNfcLeaseAbort`` -- vCenter then removes the half-import.
+
+    Swallows every fault: abort runs on the failure path and must never mask
+    the original error with a secondary one.
+    """
+    with contextlib.suppress(Exception):
+        path = f"/HttpNfcLease/{lease_moid}/HttpNfcLeaseAbort"
+        await connector._post_vmomi_json(target, path, operator=operator, json={})
+
+
+def lease_moid(lease: Any) -> str | None:
+    """Pull the moid out of the ``HttpNfcLease`` MoRef ``ImportVApp`` returned."""
+    if isinstance(lease, dict):
+        value = lease.get("value")
+        return value if isinstance(value, str) else None
+    return lease if isinstance(lease, str) else None
+
+
+def entity_from_info(info: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(vm_moid, resource_type)`` from ``HttpNfcLeaseInfo.entity``."""
+    entity = info.get("entity")
+    if not isinstance(entity, dict):
+        return None, None
+    value = entity.get("value")
+    kind = entity.get("type")
+    return (
+        value if isinstance(value, str) else None,
+        kind if isinstance(kind, str) else None,
+    )

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Streaming disk transfer for the ``HttpNfcLease`` OVF import (#3229).
+
+The net-new machinery the deploy-window-decoupling fix is built on: given a
+lease's per-device upload URLs and an :class:`OvfSource`, stream each disk
+straight from the source to its device URL with a background
+``HttpNfcLeaseProgress`` heartbeat. Nothing here buffers a whole disk -- the
+source's ``aiter_bytes`` chunks flow directly into the ``httpx`` PUT body, so
+a multi-GB transfer is bounded only by its own duration, never by a single
+HTTP read-timeout (the #3176 failure mode). The heartbeat both keeps the
+lease + source session alive and surfaces percent progress.
+
+The control-plane vim calls (``CreateImportSpec`` / ``ImportVApp`` / lease
+poll / ``Complete`` / ``Abort``) live in :mod:`.ovf_import_control`; the
+orchestration in :mod:`.ovf_import`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+__all__ = [
+    "OvfSource",
+    "OvfSourceFile",
+    "ProgressTracker",
+    "TransferEntry",
+    "lease_progress",
+    "plan_transfers",
+    "substitute_wildcard_host",
+    "transfer_all",
+]
+
+# Content-Type the ESXi NFC endpoint expects for a stream-optimized VMDK PUT;
+# non-disk file backings (ISO, nvram) upload as opaque octets.
+_STREAM_VMDK_CONTENT_TYPE = "application/x-vnd.vmware-streamVmdk"
+_OCTET_STREAM_CONTENT_TYPE = "application/octet-stream"
+
+# The lease PUT legitimately outlasts the connector's 30s client default (a
+# multi-GB disk copy), so read/write are uncapped; connect/pool stay fast so a
+# dead ESXi host still fails fast.
+_DISK_UPLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=None, pool=10.0)
+
+# Default heartbeat cadence (module-global so tests can shrink it).
+_PROGRESS_HEARTBEAT_INTERVAL = 30.0
+
+
+class OvfSourceFile(Protocol):
+    """One openable source file (a disk) with its total byte size."""
+
+    size: int
+
+    def aiter_bytes(self) -> AsyncIterator[bytes]:
+        """Yield the file's bytes in transfer-sized chunks."""
+        ...
+
+
+class OvfSource(Protocol):
+    """The OVF byte source the import engine streams from.
+
+    :mod:`.library_download` implements this over the content-library
+    download-session REST flow; tests supply an in-memory fake. ``open_disk``
+    is an async context manager so the streaming read is torn down
+    deterministically after each disk uploads.
+    """
+
+    async def read_descriptor(self) -> str:
+        """Return the OVF descriptor XML text (small; buffered whole)."""
+        ...
+
+    def open_disk(self, name: str) -> contextlib.AbstractAsyncContextManager[OvfSourceFile]:
+        """Open the named disk file for streaming (async context manager)."""
+        ...
+
+    async def keep_alive(self) -> None:
+        """Refresh the source-side session so a long transfer does not expire it."""
+        ...
+
+    async def aclose(self) -> None:
+        """Release the source (cancel/delete the download session)."""
+        ...
+
+
+@dataclass
+class TransferEntry:
+    """One planned disk upload: source file path -> lease device URL."""
+
+    device_id: str
+    path: str
+    url: str
+    size: int
+    is_disk: bool
+
+
+def substitute_wildcard_host(url: str, connect_host: str) -> str:
+    """Replace a ``*`` device-URL host with the host the client connected to.
+
+    A ``HttpNfcLeaseDeviceUrl.url`` may return ``*`` for the host when vCenter
+    cannot determine a reachable name (NAT / proxy / multihomed); the client
+    substitutes the host it used to reach the server (the
+    ``HttpNfcLeaseDeviceUrl.url`` spec contract). A concrete host is untouched.
+    """
+    parts = urlsplit(url)
+    if parts.hostname != "*":
+        return url
+    userinfo = f"{parts.username}@" if parts.username else ""
+    port = f":{parts.port}" if parts.port else ""
+    netloc = f"{userinfo}{connect_host}{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def plan_transfers(
+    file_items: list[dict[str, Any]], device_urls: list[dict[str, Any]], connect_host: str
+) -> list[TransferEntry]:
+    """Match each ``OvfFileItem`` to its lease ``deviceUrl`` by import key.
+
+    ``HttpNfcLeaseDeviceUrl.importKey`` equals the ``OvfFileItem.deviceId``
+    (the name-based device id from the ImportSpec); a ``*`` URL host is
+    substituted with *connect_host*. A file with no matching device URL is
+    skipped (the lease did not request its upload, e.g. a shared parent disk).
+    """
+    by_key: dict[str, dict[str, Any]] = {}
+    for durl in device_urls:
+        if not isinstance(durl, dict):
+            continue
+        key = durl.get("importKey") or durl.get("key")
+        if isinstance(key, str):
+            by_key[key] = durl
+    plan: list[TransferEntry] = []
+    for item in file_items:
+        device_id = item.get("deviceId") if isinstance(item, dict) else None
+        matched = by_key.get(device_id) if isinstance(device_id, str) else None
+        url = matched.get("url") if isinstance(matched, dict) else None
+        if not isinstance(device_id, str) or not isinstance(url, str) or matched is None:
+            continue
+        size = item.get("size")
+        plan.append(
+            TransferEntry(
+                device_id=device_id,
+                path=str(item.get("path", device_id)),
+                url=substitute_wildcard_host(url, connect_host),
+                size=int(size) if isinstance(size, int) and not isinstance(size, bool) else 0,
+                is_disk=bool(matched.get("disk")),
+            )
+        )
+    return plan
+
+
+class ProgressTracker:
+    """Shared byte counter -> lease percent, updated as disks stream."""
+
+    def __init__(self, total_bytes: int) -> None:
+        self._total = max(total_bytes, 0)
+        self.sent = 0
+
+    def add(self, chunk: int) -> None:
+        """Advance the sent-byte counter as a chunk flows to the wire."""
+        self.sent += chunk
+
+    def percent(self) -> int:
+        """Completion as an integer 0-100 (0 when the total size is unknown)."""
+        if self._total <= 0:
+            return 0
+        return min(100, int(self.sent * 100 / self._total))
+
+
+async def lease_progress(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    percent: int,
+) -> None:
+    """Send one ``HttpNfcLeaseProgress`` (keeps the lease alive + reports percent)."""
+    path = f"/HttpNfcLease/{lease_moid}/HttpNfcLeaseProgress"
+    await connector._post_vmomi_json(target, path, operator=operator, json={"percent": percent})
+
+
+async def _heartbeat(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    tracker: ProgressTracker,
+    source: OvfSource,
+    interval: float,
+) -> None:
+    """Background loop: refresh the lease + source session on a fixed cadence.
+
+    Runs concurrently with the disk stream so a transfer that outlasts the
+    lease / download-session timeout keeps both alive (AC1) and reports
+    percent (AC2). Cancelled by :func:`transfer_all` once every disk uploads.
+    A transient progress/keep-alive fault is swallowed -- the heartbeat is
+    best-effort; a real upload fault surfaces on the transfer path itself.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        with contextlib.suppress(httpx.HTTPError):
+            await lease_progress(
+                connector, target, operator, lease_moid=lease_moid, percent=tracker.percent()
+            )
+        with contextlib.suppress(Exception):
+            await source.keep_alive()
+
+
+async def _upload_one(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    *,
+    entry: TransferEntry,
+    source: OvfSource,
+    tracker: ProgressTracker,
+) -> int:
+    """Stream one disk from the source straight to its lease device URL.
+
+    Returns the byte count uploaded. The stream is wrapped so the shared
+    :class:`ProgressTracker` advances as bytes flow -- that is what the
+    heartbeat reports. Uses the connector's pooled client (its TLS trust
+    config) with the ESXi NFC device URL as an absolute URL; the lease token
+    embedded in the URL authorizes the PUT. ``Content-Length`` is the source
+    file's own size (not the descriptor's declared size), sent explicitly so
+    the NFC endpoint gets a sized -- not chunked -- body.
+    """
+    client = await connector._http_client(target)
+    content_type = _STREAM_VMDK_CONTENT_TYPE if entry.is_disk else _OCTET_STREAM_CONTENT_TYPE
+    async with source.open_disk(entry.path) as handle:
+        size = handle.size
+
+        async def _counted() -> AsyncIterator[bytes]:
+            async for chunk in handle.aiter_bytes():
+                tracker.add(len(chunk))
+                yield chunk
+
+        headers = {"Content-Type": content_type, "Content-Length": str(size)}
+        resp = await client.put(
+            entry.url, content=_counted(), headers=headers, timeout=_DISK_UPLOAD_TIMEOUT
+        )
+        resp.raise_for_status()
+    return size
+
+
+async def transfer_all(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    plan: list[TransferEntry],
+    source: OvfSource,
+    heartbeat_interval: float = _PROGRESS_HEARTBEAT_INTERVAL,
+) -> list[dict[str, Any]]:
+    """Upload every planned disk with a concurrent progress heartbeat.
+
+    Files upload **in order** (a later file may patch an earlier one per the
+    OVF spec). Returns the per-disk manifest. Any upload failure propagates to
+    the caller, which aborts the lease so vCenter tears down the half-import.
+    The heartbeat task is always cancelled + awaited on exit.
+    """
+    total = sum(e.size for e in plan)
+    tracker = ProgressTracker(total)
+    manifest: list[dict[str, Any]] = []
+    hb = asyncio.create_task(
+        _heartbeat(
+            connector,
+            target,
+            operator,
+            lease_moid=lease_moid,
+            tracker=tracker,
+            source=source,
+            interval=heartbeat_interval,
+        )
+    )
+    try:
+        for entry in plan:
+            sent = await _upload_one(connector, target, entry=entry, source=source, tracker=tracker)
+            manifest.append({"path": entry.path, "device_id": entry.device_id, "size_bytes": sent})
+        # Final 100% progress so the server records completion before Complete.
+        await lease_progress(connector, target, operator, lease_moid=lease_moid, percent=100)
+    finally:
+        hb.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await hb
+    return manifest

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -134,10 +134,11 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Fourteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
-    writes, the #2891 hardware trio, the two GOSC composites / #2892, plus
-    the OVF/OVA content-library deploy / #2909 — whose reads ride the
-    content-library find actions, both served by the pinned vcenter.yaml).
+    Fifteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
+    writes, the #2891 hardware trio, the two GOSC composites / #2892, the
+    OVF/OVA content-library deploy / #2909, plus the typed HttpNfcLease import
+    / #3229 — whose REST sub-ops ride the content-library find + download-session
+    actions, all served by the pinned vcenter.yaml).
     ``vm.snapshot.revert`` no longer appears: both of its sub-ops moved to
     the vim surface in #2970 (the pinned vcenter.yaml serves no snapshot
     REST resource), so its manifest lives in
@@ -157,6 +158,7 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_VM_CUSTOMIZE",
         "_SUB_OPS_VM_DEPLOY_FROM_LIBRARY",
         "_SUB_OPS_VM_DEVICE_CDROM",
+        "_SUB_OPS_VM_IMPORT_FROM_LIBRARY",
         "_SUB_OPS_VM_MIGRATE",
         "_SUB_OPS_VM_NIC_REPOINT",
         "_SUB_OPS_VM_POWER",
@@ -177,6 +179,27 @@ def test_vm_deploy_from_library_sub_op_manifest_is_expected() -> None:
         "POST:/content/library?action=find",
         "POST:/content/library/item?action=find",
         "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy",
+        "POST:/vcenter/vm/{vm}/power?action=start",
+    }
+
+
+def test_vm_import_from_library_sub_op_manifest_is_expected() -> None:
+    """Pin the import_from_library REST manifest so a drift can't shrink the reconcile.
+
+    All eight REST sub-ops are ``vcenter.yaml``-served paths (the two shared
+    content-library find actions, the five download-session steps the typed
+    HttpNfcLease source reads the OVF through, and the power-on), so they
+    reconcile through the generic ``_SUB_OPS_*`` sweep. The vim control-plane
+    sub-ops are the separate ``_VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY`` lane below.
+    """
+    assert set(_write._SUB_OPS_VM_IMPORT_FROM_LIBRARY) == {
+        "POST:/content/library?action=find",
+        "POST:/content/library/item?action=find",
+        "POST:/content/library/item/download-session",
+        "GET:/content/library/item/download-session/{downloadSessionId}/file",
+        "POST:/content/library/item/download-session/{downloadSessionId}/file?action=prepare",
+        "POST:/content/library/item/download-session/{downloadSessionId}?action=keep-alive",
+        "POST:/content/library/item/download-session/{downloadSessionId}?action=cancel",
         "POST:/vcenter/vm/{vm}/power?action=start",
     }
 
@@ -529,6 +552,75 @@ def test_vm_destroy_vi_json_paths_exist_in_the_pinned_spec() -> None:
         assert _vi_json_path_item_has_post(spec_text, path), (
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
             "destroy vi-json sub-op targets a path the spec does not serve"
+        )
+
+
+# ---------------------------------------------------------------------------
+# vm.import_from_library VI-JSON sub-op reconciliation (#3229)
+# ---------------------------------------------------------------------------
+#
+# The typed HttpNfcLease import's control plane is vi-json, not vcenter REST:
+# ``ServiceInstance.RetrieveServiceContent`` (resolve OvfManager/rootFolder),
+# ``OvfManager.CreateImportSpec`` (validate descriptor), the governed
+# ``ResourcePool.ImportVApp`` write, ``PropertyCollector.RetrievePropertiesEx``
+# (lease-state poll), and the ``HttpNfcLease`` progress / complete / abort
+# lifecycle. Declared in ``_write._VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY``
+# (deliberately NOT in the ``_SUB_OPS_*`` namespace, so the vcenter.yaml sweep
+# above skips them). Same ``METHOD:/path`` keying as the other vim writes — the
+# moId rides the path as ``{moId}`` — so the same reconciliation proof applies,
+# and it is additionally checked against the pinned ``vi-json.yaml`` when the
+# spec-shelf is configured.
+
+
+def test_vm_import_from_library_vi_json_sub_op_manifest_is_expected() -> None:
+    """Pin the import vim manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY) == {
+        "POST:/ServiceInstance/{moId}/RetrieveServiceContent",
+        "POST:/OvfManager/{moId}/CreateImportSpec",
+        "POST:/ResourcePool/{moId}/ImportVApp",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HttpNfcLease/{moId}/HttpNfcLeaseProgress",
+        "POST:/HttpNfcLease/{moId}/HttpNfcLeaseComplete",
+        "POST:/HttpNfcLease/{moId}/HttpNfcLeaseAbort",
+    }
+
+
+def test_vm_import_from_library_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The import vim op_ids are byte-for-byte what the parser emits."""
+    required = set(_write._VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_vm_import_from_library_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each import vim sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The #3229 grounding: the typed HttpNfcLease import's OvfManager /
+    ResourcePool.ImportVApp / HttpNfcLease control-plane methods are core vim25
+    (version-agnostic), so the pinned spec must serve every one. Skips when the
+    spec-shelf is not configured, so CI — where the env vars are wired — is the
+    operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_VM_IMPORT_FROM_LIBRARY:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "import vi-json sub-op targets a path the spec does not serve"
         )
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -196,7 +196,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 33 total: 9 reads
+    # Embedding service called once per composite -- 34 total: 9 reads
     # (T5 #508's 5 + the 4 guest-ops reads #3100) + 24 writes (T6 #509 +
     # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     # folder-template vm.clone_from_template #2894 + vim cluster/inventory
@@ -209,7 +209,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # destructive-tier vm.destroy #3198). (The former
     # host.network_uplinks / host.vsan_health reads were re-shipped as typed
     # ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 33
+    assert stub_embedding_service.encode_one.call_count == 34
 
 
 @pytest.mark.asyncio
@@ -456,7 +456,7 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> read rows persist; embedding stays at 33.
+    """Running the registrar twice -> read rows persist; embedding stays at 34.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
@@ -472,7 +472,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 33
+    assert first_count == 34
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
@@ -35,6 +35,7 @@ re-wrapped.
 
 from __future__ import annotations
 
+from meho_backplane.connectors.vmware_rest import library_download
 from meho_backplane.connectors.vmware_rest.composites import _write
 from tests._spec_shelf import openapi_request_body_props, require_shelf_spec
 
@@ -51,6 +52,13 @@ _EXPECTED_REST_WRITE_OP_IDS = {
     "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy",
     "POST:/content/library?action=find",
     "POST:/content/library/item?action=find",
+    # Content-library download-session flow the typed HttpNfcLease import source
+    # reads the OVF descriptor + disks through (#3229; POST ops declared in
+    # ``library_download``).
+    "POST:/content/library/item/download-session",
+    "POST:/content/library/item/download-session/{downloadSessionId}/file?action=prepare",
+    "POST:/content/library/item/download-session/{downloadSessionId}?action=keep-alive",
+    "POST:/content/library/item/download-session/{downloadSessionId}?action=cancel",
     "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true",
     "POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect",
     "PATCH:/vcenter/vm/{vm}/hardware/cpu",
@@ -80,30 +88,34 @@ _FLATTENED_WRITE_OP_IDS = {
 
 
 def _rest_write_op_ids() -> set[str]:
-    """Every REST-Automation write op_id in ``_write``, introspected live.
+    """Every REST-Automation write op_id the connector emits, introspected live.
 
-    A REST write op is a ``POST`` / ``PATCH`` / ``PUT`` ``_OP_*`` constant whose
-    path root is a lowercase Automation family (``/vcenter``, ``/esx``,
-    ``/content``, ...). The vmomi VI-JSON methods (``ReconfigVM_Task``,
-    ``CloneVM_Task``, ...) dispatch through ``_post_vmomi_json`` onto the
-    ``/sdk/vim25`` mount and are keyed by an **uppercase** managed-object type
-    (``/VirtualMachine/{moId}/...``); their request types genuinely carry a
-    ``spec`` field, so they are correctly excluded from the flat-body contract.
+    A REST write op is a ``POST`` / ``PATCH`` / ``PUT`` op_id constant whose path
+    root is a lowercase Automation family (``/vcenter``, ``/esx``, ``/content``,
+    ...). Scans the ``_OP_*`` constants in ``_write`` plus the public ``OP_*``
+    constants in ``library_download`` (the #3229 download-session source module),
+    so a new REST write op in either forces a body-shape review. The vmomi
+    VI-JSON methods (``ReconfigVM_Task``, ``CloneVM_Task``, ...) dispatch through
+    ``_post_vmomi_json`` onto the ``/sdk/vim25`` mount and are keyed by an
+    **uppercase** managed-object type (``/VirtualMachine/{moId}/...``); their
+    request types genuinely carry a ``spec`` field, so they are correctly
+    excluded from the flat-body contract.
     """
     ops: set[str] = set()
-    for name in dir(_write):
-        if not name.startswith("_OP_"):
-            continue
-        value = getattr(_write, name)
-        if not isinstance(value, str) or ":" not in value:
-            continue
-        method, _, path = value.partition(":")
-        if method not in {"POST", "PATCH", "PUT"}:
-            continue
-        first = path.lstrip("/").split("/", 1)[0].split("?", 1)[0]
-        if not first or first[0].isupper():  # vmomi VI-JSON method, not the /api surface
-            continue
-        ops.add(value)
+    for module, prefix in ((_write, "_OP_"), (library_download, "OP_")):
+        for name in dir(module):
+            if not name.startswith(prefix):
+                continue
+            value = getattr(module, name)
+            if not isinstance(value, str) or ":" not in value:
+                continue
+            method, _, path = value.partition(":")
+            if method not in {"POST", "PATCH", "PUT"}:
+                continue
+            first = path.lstrip("/").split("/", 1)[0].split("?", 1)[0]
+            if not first or first[0].isupper():  # vmomi VI-JSON method, not the /api surface
+                continue
+            ops.add(value)
     return ops
 
 
@@ -189,6 +201,7 @@ def test_flattened_2973_bodies_are_served_flat_by_the_pinned_spec() -> None:
 # literal the substrate can emit must name a real component schema in the
 # pinned ``vi-json.yaml``.
 
+from meho_backplane.connectors.vmware_rest import ovf_import_control  # noqa: E402
 from meho_backplane.connectors.vmware_rest.vim_body import (  # noqa: E402
     MOREF_TYPE_NAME,
     retrieve_properties_body,
@@ -218,6 +231,11 @@ _EMITTED_VIM_TYPE_NAMES: set[str] = {
     _write._CLUSTER_RULE_SPEC_TYPE,
     _write._CLUSTER_AFFINITY_RULE_TYPE,
     _write._CLUSTER_ANTI_AFFINITY_RULE_TYPE,
+    # Typed HttpNfcLease OVF import (#3229) -- the CreateImportSpec cisp +
+    # its network / property mapping DataObjects.
+    ovf_import_control.OVF_CREATE_IMPORT_SPEC_PARAMS_TYPE,
+    ovf_import_control.OVF_NETWORK_MAPPING_TYPE,
+    ovf_import_control.KEY_VALUE_TYPE,
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 22 vmware-rest write composites.
+"""Registration tests for the 25 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -10,7 +10,7 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 24 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 25 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``requires_approval=True``, and
   ``safety_level="dangerous"`` (T4's defaults intentionally inherited) —
   except the destructive-tier ``vm.destroy`` / #3198, which is
@@ -20,7 +20,7 @@ and the GOSC composites ``guest.customization_spec.create`` /
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` per the canary's stub-LLM taxonomy.
 * Combined with the 9 read composites (#508's 5 + the 4 guest-ops
-  reads / #3100), the registrar produces **33 rows** total. (The former
+  reads / #3100), the registrar produces **34 rows** total. (The former
   host.network_uplinks / host.vsan_health reads were re-shipped as typed
   ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
@@ -71,7 +71,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 24 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 25 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
@@ -82,6 +82,7 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
     "vmware.composite.vm.deploy_from_library",
+    "vmware.composite.vm.import_from_library",
     "vmware.composite.vm.clone_from_template",
     "vmware.composite.vm.snapshot.revert",
     "vmware.composite.vm.destroy",
@@ -123,7 +124,7 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
 )
 
-# 33 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 24 write
+# 34 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 25 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -141,6 +142,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.vm.deploy_from_library": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_deploy_from_library_composite"
+    ),
+    "vmware.composite.vm.import_from_library": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_import_from_library_composite"
     ),
     "vmware.composite.vm.clone_from_template": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_from_template_composite"
@@ -213,6 +217,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.create": "vm",
     "vmware.composite.vm.clone": "vm",
     "vmware.composite.vm.deploy_from_library": "vm",
+    "vmware.composite.vm.import_from_library": "vm",
     "vmware.composite.vm.clone_from_template": "vm",
     "vmware.composite.vm.snapshot.revert": "vm",
     "vmware.composite.vm.destroy": "vm",
@@ -277,7 +282,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 24 write composites land alongside the 9 reads (33 total)
+# 25 write composites land alongside the 9 reads (34 total)
 # ---------------------------------------------------------------------------
 
 
@@ -285,7 +290,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_all_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 24 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 25 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -305,12 +310,12 @@ async def test_register_vmware_composite_operations_inserts_all_write_rows(
 async def test_full_registration_produces_thirty_three_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """9 reads (#508 + guest-ops reads #3100) + 24 writes (#509 + vm.power #2301 +
+    """9 reads (#508 + guest-ops reads #3100) + 25 writes (#509 + vm.power #2301 +
     vm.disk.grow #2893 + vm.clone_from_template #2894 + cluster.drs_rule.create +
     folder.create #2895 + #2891 hardware writes vm.resize / vm.nic.repoint /
     vm.device.cdrom + GOSC create/apply #2892 + OVF deploy #2909 + host-domain
     writes #3182 + guest-ops write vm.guest.file.write #3100 + destructive-tier
-    vm.destroy #3198) = 33 rows. DoD bar."""
+    vm.destroy #3198) = 34 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -324,7 +329,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 33
+    assert len(rows) == 34
 
 
 @pytest.mark.asyncio
@@ -354,7 +359,7 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 24 write rows before iterating —
+    # Prove the query actually returned all 25 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
@@ -633,10 +638,10 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 33 rows total, embedding called 33x once."""
+    """Running the registrar twice -> 34 rows total, embedding called 34x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 33
+    assert first_count == 34
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
@@ -654,7 +659,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 33
+    assert len(rows) == 34
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_library_download.py
+++ b/backend/tests/test_connectors_vmware_rest_library_download.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the content-library download-session OVF source (#3229).
+
+Exercises :class:`LibraryDownloadSource` against a stateful fake connector
+(no live vCenter): create the session, list files, prepare + poll to
+``PREPARED``, buffer the OVF descriptor, stream a disk with its size taken
+from the download ``Content-Length``, keep-alive, and cancel on close.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.vmware_rest.library_download import (
+    LibraryDownloadError,
+    LibraryDownloadSource,
+)
+
+
+class _Target:
+    host = "vcenter.lab"
+    name = "vc-1"
+
+
+class _Operator:
+    raw_jwt = "jwt"
+
+
+class _GetResp:
+    def __init__(self, *, text: str = "", data: bytes = b"", headers: dict[str, str] | None = None):
+        self.text = text
+        self._data = data
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self, chunk: int | None = None) -> Any:
+        yield self._data
+
+
+class _StreamCtx:
+    def __init__(self, resp: _GetResp) -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> _GetResp:
+        return self._resp
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _SourceClient:
+    def __init__(self, descriptor: str, disk: bytes) -> None:
+        self._descriptor = descriptor
+        self._disk = disk
+
+    async def get(self, uri: str, *, headers: dict[str, str]) -> _GetResp:
+        return _GetResp(text=self._descriptor)
+
+    def stream(self, method: str, uri: str, *, headers: dict[str, str]) -> _StreamCtx:
+        return _StreamCtx(
+            _GetResp(data=self._disk, headers={"content-length": str(len(self._disk))})
+        )
+
+
+class _SourceConnector:
+    """Stateful fake: a file becomes PREPARED once ``?action=prepare`` is posted."""
+
+    def __init__(
+        self,
+        *,
+        files: list[str],
+        descriptor: str = "<Envelope/>",
+        disk: bytes = b"DISKDATA",
+        prepare_status: dict[str, str] | None = None,
+    ) -> None:
+        self._files = files
+        self._prepared: set[str] = set()
+        self._client = _SourceClient(descriptor, disk)
+        self._prepare_status = prepare_status or {}
+        self.session_created = False
+        self.canceled = False
+        self.keep_alives = 0
+        self.posts: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Any) -> str:
+        return path
+
+    async def _post_json(self, target: Any, path: str, *, operator: Any, json: Any = None) -> Any:
+        self.posts.append(path)
+        if path == "/content/library/item/download-session":
+            self.session_created = True
+            return "dl-1"
+        if path.endswith("/file?action=prepare"):
+            self._prepared.add(json["file_name"])
+            return {"name": json["file_name"], "status": "PREPARE_REQUESTED"}
+        if path.endswith("?action=keep-alive"):
+            self.keep_alives += 1
+            return {}
+        if path.endswith("?action=cancel"):
+            self.canceled = True
+            return {}
+        return {}
+
+    async def _get_json(self, target: Any, path: str, *, operator: Any, params: Any = None) -> Any:
+        out: list[dict[str, Any]] = []
+        for name in self._files:
+            forced = self._prepare_status.get(name)
+            if forced:
+                out.append({"name": name, "status": forced})
+            elif name in self._prepared:
+                out.append(
+                    {
+                        "name": name,
+                        "status": "PREPARED",
+                        "download_endpoint": {"uri": f"https://vcenter.lab/dl/{name}"},
+                    }
+                )
+            else:
+                out.append({"name": name, "status": "UNPREPARED"})
+        return out
+
+    async def _http_client(self, target: Any) -> _SourceClient:
+        return self._client
+
+    async def auth_headers(self, target: Any, operator: Any) -> dict[str, str]:
+        return {}
+
+
+def _source(conn: _SourceConnector) -> LibraryDownloadSource:
+    return LibraryDownloadSource(
+        connector=conn,  # type: ignore[arg-type]
+        target=_Target(),
+        operator=_Operator(),  # type: ignore[arg-type]
+        library_item_id="item-1",
+    )
+
+
+async def test_read_descriptor_creates_session_prepares_and_buffers() -> None:
+    conn = _SourceConnector(
+        files=["app.ovf", "app-disk1.vmdk"], descriptor="<Envelope>ovf</Envelope>"
+    )
+    source = _source(conn)
+    text = await source.read_descriptor()
+    assert text == "<Envelope>ovf</Envelope>"
+    assert conn.session_created
+    assert "/content/library/item/download-session/dl-1/file?action=prepare" in conn.posts
+
+
+async def test_open_disk_streams_bytes_with_content_length_size() -> None:
+    conn = _SourceConnector(files=["app.ovf", "app-disk1.vmdk"], disk=b"0123456789")
+    source = _source(conn)
+    async with source.open_disk("app-disk1.vmdk") as handle:
+        assert handle.size == 10  # from the download Content-Length
+        collected = b"".join([chunk async for chunk in handle.aiter_bytes()])
+    assert collected == b"0123456789"
+
+
+async def test_missing_descriptor_raises() -> None:
+    conn = _SourceConnector(files=["only-a-disk.vmdk"])
+    source = _source(conn)
+    with pytest.raises(LibraryDownloadError, match=r"no \.ovf descriptor"):
+        await source.read_descriptor()
+
+
+async def test_prepare_error_status_raises() -> None:
+    conn = _SourceConnector(files=["app.ovf"], prepare_status={"app.ovf": "ERROR"})
+    source = _source(conn)
+    with pytest.raises(LibraryDownloadError, match="failed to prepare"):
+        await source.read_descriptor()
+
+
+async def test_keep_alive_and_aclose_are_session_scoped() -> None:
+    conn = _SourceConnector(files=["app.ovf"])
+    source = _source(conn)
+    # No session yet: keep_alive / aclose are no-ops (nothing to refresh/cancel).
+    await source.keep_alive()
+    await source.aclose()
+    assert conn.keep_alives == 0
+    assert not conn.canceled
+    # Establish a session, then keep-alive + cancel act on it.
+    await source.read_descriptor()
+    await source.keep_alive()
+    await source.aclose()
+    assert conn.keep_alives == 1
+    assert conn.canceled
+
+
+async def test_create_returning_no_id_raises() -> None:
+    class _NoIdConnector(_SourceConnector):
+        async def _post_json(
+            self, target: Any, path: str, *, operator: Any, json: Any = None
+        ) -> Any:
+            if path == "/content/library/item/download-session":
+                return ""
+            return await super()._post_json(target, path, operator=operator, json=json)
+
+    source = _source(_NoIdConnector(files=["app.ovf"]))
+    with pytest.raises(LibraryDownloadError, match="no id"):
+        await source.read_descriptor()

--- a/backend/tests/test_connectors_vmware_rest_ovf_import.py
+++ b/backend/tests/test_connectors_vmware_rest_ovf_import.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the typed HttpNfcLease OVF import engine (#3229).
+
+Proves the acceptance criteria with a recording connector + an in-memory
+fake source (no live vCenter): a lease import completes regardless of any
+single-request window (AC1), progress is surfaced via the lease heartbeat
+(AC2), the deploy-envelope error family is preserved (AC4), and only
+version-agnostic vim fields are read (AC5). Composite-handler wiring
+(resolution reuse, envelope mapping, source cleanup, power-on) is tested
+against ``_write.vm_import_from_library_composite``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, ClassVar
+
+import httpx
+import pytest
+
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest import ovf_import
+from meho_backplane.connectors.vmware_rest.composites import _write
+from meho_backplane.connectors.vmware_rest.ovf_import import ImportPlacement, LeaseImportResult
+
+
+class _Target:
+    def __init__(self, host: str = "vcenter.lab", name: str = "vc-1") -> None:
+        self.host = host
+        self.name = name
+
+
+class _Operator:
+    raw_jwt = "jwt"
+
+
+class _Resp:
+    def __init__(self, status: int = 200) -> None:
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("boom", request=None, response=None)  # type: ignore[arg-type]
+
+
+class _PutClient:
+    """Fake pooled client: records PUTs and drains the streamed body."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.puts: list[dict[str, Any]] = []
+        self._fail = fail
+
+    async def put(self, url: str, *, content: Any, headers: dict[str, str], timeout: Any) -> _Resp:
+        drained = 0
+        async for chunk in content:
+            drained += len(chunk)
+        self.puts.append({"url": url, "headers": headers, "drained": drained})
+        return _Resp(500 if self._fail else 200)
+
+
+class _EngineConnector:
+    """Recording stand-in for VmwareRestConnector on the engine path."""
+
+    def __init__(
+        self,
+        *,
+        service_content: dict[str, Any],
+        import_spec_result: dict[str, Any],
+        lease_ref: Any,
+        lease_polls: list[dict[str, Any]],
+        put_client: _PutClient | None = None,
+    ) -> None:
+        self._service_content = service_content
+        self._import_spec_result = import_spec_result
+        self._lease_ref = lease_ref
+        self._lease_polls = list(lease_polls)
+        self._client = put_client or _PutClient()
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Any, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/RetrieveServiceContent"):
+            return self._service_content
+        if path.endswith("/CreateImportSpec"):
+            return self._import_spec_result
+        if path.endswith("/ImportVApp"):
+            return self._lease_ref
+        if path.endswith("/RetrievePropertiesEx"):
+            poll = self._lease_polls.pop(0) if len(self._lease_polls) > 1 else self._lease_polls[0]
+            return poll
+        return {}
+
+    async def _http_client(self, target: Any) -> _PutClient:
+        return self._client
+
+
+class _FakeDisk:
+    def __init__(self, data: bytes, *, chunk_sleep: float = 0.0, chunks: int = 1) -> None:
+        self._data = data
+        self.size = len(data)
+        self._chunk_sleep = chunk_sleep
+        self._chunks = chunks
+
+    async def __aenter__(self) -> _FakeDisk:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    def aiter_bytes(self) -> Any:
+        return self._gen()
+
+    async def _gen(self) -> Any:
+        step = max(1, len(self._data) // max(self._chunks, 1))
+        for i in range(0, len(self._data), step):
+            if self._chunk_sleep:
+                await asyncio.sleep(self._chunk_sleep)
+            yield self._data[i : i + step]
+
+
+class _FakeSource:
+    def __init__(self, descriptor: str, disks: dict[str, _FakeDisk]) -> None:
+        self._descriptor = descriptor
+        self._disks = disks
+        self.keep_alives = 0
+        self.closed = False
+
+    async def read_descriptor(self) -> str:
+        return self._descriptor
+
+    def open_disk(self, name: str) -> _FakeDisk:
+        return self._disks[name]
+
+    async def keep_alive(self) -> None:
+        self.keep_alives += 1
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _service_content() -> dict[str, Any]:
+    return {
+        "ovfManager": {"type": "OvfManager", "value": "OvfManager"},
+        "rootFolder": {"type": "Folder", "value": "group-d1"},
+    }
+
+
+def _import_spec_result(
+    *, errors: list[Any] | None = None, warnings: list[Any] | None = None
+) -> dict[str, Any]:
+    return {
+        "importSpec": {
+            "_typeName": "VirtualMachineImportSpec",
+            "configSpec": {"_typeName": "VirtualMachineConfigSpec", "name": "app"},
+        },
+        "fileItem": [
+            {
+                "_typeName": "OvfFileItem",
+                "deviceId": "disk1",
+                "path": "app-disk1.vmdk",
+                "size": 8,
+                "cimType": 17,
+                "create": True,
+            }
+        ],
+        "error": errors or [],
+        "warning": warnings or [],
+    }
+
+
+def _ready_poll(*, with_ssl_cert: bool = False) -> dict[str, Any]:
+    device_url: dict[str, Any] = {
+        "_typeName": "HttpNfcLeaseDeviceUrl",
+        "key": "/vm-9/disk-0",
+        "importKey": "disk1",
+        "url": "https://*/nfc/lease-1/disk-0.vmdk",
+        "disk": True,
+    }
+    if with_ssl_cert:  # 9.0-only field the engine must ignore
+        device_url["sslCertificate"] = "-----BEGIN CERTIFICATE-----"
+    info = {
+        "_typeName": "HttpNfcLeaseInfo",
+        "lease": {"type": "HttpNfcLease", "value": "lease-1"},
+        "entity": {"type": "VirtualMachine", "value": "vm-9"},
+        "deviceUrl": [device_url],
+        "totalDiskCapacityInKB": 8,
+        "leaseTimeout": 300,
+    }
+    prop_set = [{"name": "state", "val": "ready"}, {"name": "info", "val": info}]
+    return {"objects": [{"propSet": prop_set}]}
+
+
+def _lease_ref() -> dict[str, Any]:
+    return {"type": "HttpNfcLease", "value": "lease-1"}
+
+
+async def _run(connector: _EngineConnector, source: _FakeSource, **kw: Any) -> Any:
+    async def _gate(_params: dict[str, Any]) -> None:
+        return None
+
+    return await ovf_import.import_ovf_from_source(
+        connector=connector,  # type: ignore[arg-type]
+        target=_Target(),
+        operator=_Operator(),  # type: ignore[arg-type]
+        source=source,  # type: ignore[arg-type]
+        placement=ImportPlacement(resource_pool="rp-1", datastore="ds-1", entity_name="app"),
+        gate=kw.pop("gate", _gate),
+        lease_ready_timeout=kw.pop("lease_ready_timeout", None),
+        heartbeat_interval=kw.pop("heartbeat_interval", 30.0),
+    )
+
+
+async def test_import_success_streams_disk_and_completes() -> None:
+    """Full happy path: descriptor -> import -> lease-ready -> disk PUT -> Complete."""
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    assert result.vm_id == "vm-9"
+    assert result.resource_type == "VirtualMachine"
+    assert result.transfer == [{"path": "app-disk1.vmdk", "device_id": "disk1", "size_bytes": 8}]
+    # The disk was PUT to the substituted (concrete-host) device URL and Complete ran.
+    assert conn._client.puts[0]["url"] == "https://vcenter.lab/nfc/lease-1/disk-0.vmdk"
+    assert conn._client.puts[0]["headers"]["Content-Type"] == "application/x-vnd.vmware-streamVmdk"
+    methods = [p.rsplit("/", 1)[-1] for p, _ in conn.vmomi_calls]
+    assert methods[-1] == "HttpNfcLeaseComplete"
+
+
+async def test_import_spec_round_trips_verbatim_into_import_vapp() -> None:
+    """The server-issued importSpec is passed to ImportVApp with its _typeName intact."""
+    spec_result = _import_spec_result()
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=spec_result,
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    await _run(conn, source)
+    import_vapp_body = next(body for path, body in conn.vmomi_calls if path.endswith("/ImportVApp"))
+    assert import_vapp_body["spec"] == spec_result["importSpec"]
+    assert import_vapp_body["spec"]["_typeName"] == "VirtualMachineImportSpec"
+
+
+async def test_descriptor_errors_short_circuit_to_import_failed() -> None:
+    """A CreateImportSpec error maps to deploy_failed-family import_failed, no lease."""
+    errors = [{"_typeName": "OvfNetworkMappingNotSupported", "localizedMessage": "bad network"}]
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(errors=errors),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+    )
+    result = await _run(conn, _FakeSource("<Envelope/>", {}))
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "import_failed"
+    assert result.issues[0]["message"] == "bad network"
+    assert not any(p.endswith("/ImportVApp") for p, _ in conn.vmomi_calls)
+
+
+async def test_import_vapp_gate_park_returns_operation_result() -> None:
+    """A parked ImportVApp gate returns the OperationResult verbatim; no write fires."""
+    parked = OperationResult(
+        status="pending", op_id="vmware.composite.vm.import_from_library", duration_ms=0.0
+    )
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+    )
+
+    async def _gate(_params: dict[str, Any]) -> OperationResult:
+        return parked
+
+    result = await _run(conn, _FakeSource("<Envelope/>", {}), gate=_gate)
+    assert result is parked
+    assert not any(p.endswith("/ImportVApp") for p, _ in conn.vmomi_calls)
+
+
+async def test_lease_error_state_maps_to_lease_error() -> None:
+    """A lease that reaches the error state surfaces the fault as lease_error."""
+    error_poll = {
+        "objects": [
+            {
+                "propSet": [
+                    {"name": "state", "val": "error"},
+                    {"name": "error", "val": {"localizedMessage": "datastore full"}},
+                ]
+            }
+        ]
+    }
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[error_poll],
+    )
+    result = await _run(conn, _FakeSource("<Envelope/>", {}))
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "lease_error"
+    assert result.issues[0]["message"] == "datastore full"
+
+
+async def test_lease_timeout_aborts_and_maps_to_lease_timeout() -> None:
+    """A lease that never reaches ready times out, aborts, and maps to lease_timeout."""
+    initializing = {"objects": [{"propSet": [{"name": "state", "val": "initializing"}]}]}
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[initializing],
+    )
+    result = await _run(conn, _FakeSource("<Envelope/>", {}), lease_ready_timeout=0.0)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "lease_timeout"
+    assert any(p.endswith("/HttpNfcLeaseAbort") for p, _ in conn.vmomi_calls)
+
+
+async def test_upload_fault_aborts_and_maps_to_import_error() -> None:
+    """A disk-upload transport fault aborts the lease and maps to import_error."""
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+        put_client=_PutClient(fail=True),
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "import_error"
+    assert any(p.endswith("/HttpNfcLeaseAbort") for p, _ in conn.vmomi_calls)
+    assert not any(p.endswith("/HttpNfcLeaseComplete") for p, _ in conn.vmomi_calls)
+
+
+async def test_progress_heartbeat_fires_during_a_slow_upload() -> None:
+    """AC1/AC2: the lease heartbeat runs concurrently with a slow transfer.
+
+    A disk whose stream sleeps between chunks makes the upload outlast several
+    heartbeat intervals; the engine keeps sending HttpNfcLeaseProgress (keeping
+    the lease alive) and refreshing the source, then sends a final 100%.
+    """
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll()],
+    )
+    disk = _FakeDisk(b"0123456789abcdef", chunk_sleep=0.02, chunks=8)
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": disk})
+    result = await _run(conn, source, heartbeat_interval=0.01)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    progress = [
+        body["percent"] for path, body in conn.vmomi_calls if path.endswith("/HttpNfcLeaseProgress")
+    ]
+    assert progress, "no HttpNfcLeaseProgress heartbeat fired"
+    assert progress[-1] == 100  # final progress before Complete
+    assert source.keep_alives >= 1  # the source session was refreshed too
+
+
+async def test_import_is_version_agnostic_ignoring_9_0_only_device_fields() -> None:
+    """AC5: a device URL carrying the 9.0-only sslCertificate still imports cleanly.
+
+    The engine reads only the pre-9.0 key / importKey / url fields, so a lease
+    from a pre-9.0 (VCF 5.x migration-source) target and a 9.0+ target both work.
+    """
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll(with_ssl_cert=True)],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+
+
+# ---------------------------------------------------------------------------
+# Composite handler wiring (vm.import_from_library)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSource:
+    instances: ClassVar[list[_RecordingSource]] = []
+
+    def __init__(self, **_kw: Any) -> None:
+        self.closed = False
+        _RecordingSource.instances.append(self)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def _call_handler(
+    monkeypatch: pytest.MonkeyPatch, *, resolved: Any, engine_result: Any, params: dict[str, Any]
+) -> Any:
+    _RecordingSource.instances = []
+    monkeypatch.setattr(
+        _write.library_download, "LibraryDownloadSource", _RecordingSource, raising=True
+    )
+
+    async def _fake_resolve(**_kw: Any) -> Any:
+        return resolved
+
+    async def _fake_engine(**_kw: Any) -> Any:
+        return engine_result
+
+    monkeypatch.setattr(_write, "_resolve_deploy_library_item", _fake_resolve)
+    monkeypatch.setattr(_write, "import_ovf_from_source", _fake_engine)
+    return await _write.vm_import_from_library_composite(
+        operator=_Operator(),
+        target=_Target(),
+        params=params,
+        connector=object(),  # type: ignore[arg-type]
+    )
+
+
+async def test_handler_maps_imported_to_deployed_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine_result = LeaseImportResult(
+        status="imported",
+        vm_id="vm-9",
+        resource_type="VirtualMachine",
+        transfer=[{"path": "d.vmdk", "device_id": "disk1", "size_bytes": 8}],
+    )
+    envelope = await _call_handler(
+        monkeypatch,
+        resolved=("item-1", None),
+        engine_result=engine_result,
+        params={"resource_pool": "rp-1", "datastore": "ds-1"},
+    )
+    assert envelope["status"] == "deployed"
+    assert envelope["vm_id"] == "vm-9"
+    assert envelope["library_item_id"] == "item-1"
+    assert envelope["transfer"][0]["device_id"] == "disk1"
+    assert _RecordingSource.instances[0].closed is True  # source cleaned up
+
+
+async def test_handler_maps_import_failed_to_deploy_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine_result = LeaseImportResult(
+        status="import_failed",
+        issues=[{"category": "descriptor", "severity": "error", "message": "x"}],
+    )
+    envelope = await _call_handler(
+        monkeypatch,
+        resolved=("item-1", None),
+        engine_result=engine_result,
+        params={"resource_pool": "rp-1", "datastore": "ds-1"},
+    )
+    assert envelope["status"] == "deploy_failed"
+    assert envelope["vm_id"] is None
+
+
+async def test_handler_returns_gate_operation_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    parked = OperationResult(
+        status="pending", op_id="vmware.composite.vm.import_from_library", duration_ms=0.0
+    )
+    result = await _call_handler(
+        monkeypatch,
+        resolved=("item-1", None),
+        engine_result=parked,
+        params={"resource_pool": "rp-1", "datastore": "ds-1"},
+    )
+    assert result is parked
+    assert _RecordingSource.instances[0].closed is True
+
+
+async def test_handler_returns_resolution_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolution_error = {"status": "ambiguous_item", "candidates": ["a", "b"]}
+    envelope = await _call_handler(
+        monkeypatch,
+        resolved=(None, resolution_error),
+        engine_result=None,
+        params={"resource_pool": "rp-1", "datastore": "ds-1", "library_item_name": "app"},
+    )
+    assert envelope["status"] == "ambiguous_item"

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -80,9 +80,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   cluster-wide `overall_health` colour plus the health-test `groups`
   list. It is likewise best-effort (a failed health-service read nulls
   `groups` / `overall_health` with a `read_note`).
-- **Write composites** (`composites/_write.py`) — fifteen module-level
+- **Write composites** (`composites/_write.py`) — sixteen module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
-  `vm_deploy_from_library_composite`,
+  `vm_deploy_from_library_composite`, `vm_import_from_library_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
   `vm_power_composite`, `vm_power_bulk_composite`,
   `vm_resize_composite`, `vm_nic_repoint_composite`,
@@ -641,6 +641,7 @@ enum) are:
 | `vm.create` | `created`, `rolled_back` (the optional `nested_hv` VHV leg (#3093) is a vim `ReconfigVM_Task` through the governed vmomi seam, task-polled, applied after NIC attach and before any power-on; a leg failure — transport fault, task fault, or poll timeout — rolls back like the other post-create steps. The `created` envelope echoes the applied `nested_hv` state only when the param was supplied, so a param-absent call keeps the pre-#3093 envelope byte-identical. Optional placement pins — `resource_pool` / `datastore` / `host` moids, #3096 — thread into the CreateSpec `placement` alongside the resolved folder moid; absent pins keep the create body byte-identical and never echo into the envelope. **Data disks (#3117):** the optional `disks` param (`[{capacity_gb}]`) lands data disks in the one create — REST arm threads each into the CreateSpec `disks` as a SCSI `new_vmdk` (vCenter fabricates the controller), pre-9.0 vim arm ALWAYS folds a `VirtualLsiLogicSASController` (so a fresh VM is disk-add-ready even with no `disks`, closing the `500 UNABLE_TO_ALLOCATE_RESOURCE` on the documented governed disk-add) plus one `VirtualDisk` (`fileOperation: create`) per entry bound to it; `disk_attach` rides `steps_succeeded` when disks were requested, an invalid `capacity_gb` fails closed with `disk_spec`, and empty `disks` keeps the REST create byte-identical. **Folder resolution (#3115, both arms):** an explicit `folder` moid pin skips the display-name lookup entirely (`folder_lookup` omitted from the ledger; one of `folder`/`folder_name` required via `anyOf`); a `folder_name` matching more than one folder — every datacenter ships a default VM folder named `vm`, so multi-DC collisions are the norm — reverse-maps a placement pin to its datacenter (datacenter listing + one identity∩`datacenters` intersection probe per DC, host → resource-pool → datastore priority) and re-issues the lookup scoped via `filter.datacenters`; residual ambiguity refuses with a `rolled_back` carrying `candidate_folders` instead of silently taking the first row (which created VMs in the wrong datacenter, proven live). Unique-name lookups stay byte-identical (zero extra reads). **Version-conditional create transport (#3099):** on a live pre-9.0 `about.version` major the whole create rides vim `Folder.CreateVM_Task` through the governed vmomi seam, task-polled — bare REST `POST /api/vcenter/vm` is vendor-defective on vCenter 8.0.x (opaque `500 UNABLE_TO_ALLOCATE_RESOURCE` for every spec shape/placement, proven live) — with the always-folded SCSI controller + disks (#3117), NICs (vmxnet3; DVPG backing resolved via portgroup-key + switch-uuid vmomi reads, standard-portgroup backing via the network display name) and `nested_hv` folded into the one ConfigSpec; `resource_pool`/`datastore` are required there (`placement_params` fail-closed), the `guest_os` enum maps through a curated spec-grounded guestId table (`guest_id_mapping` fail-closed), and 9.0+/unresolved keep the REST path byte-identical) |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
 | `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item`, `resolve_error` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error`, and a faulted content-library `find` during name resolution → `resolve_error` (#3071), both with a structured message carrying the vCenter status — so a placement/mapping/resolution error is a structured status, never a raw vendor fault) |
+| `vm.import_from_library` | `deployed`, `deploy_failed`, `deploy_error`, plus the same resolution statuses as `vm.deploy_from_library` (typed HttpNfcLease OVF import, #3229; the deploy-envelope family is reused — `CreateImportSpec` descriptor rejection → `deploy_failed`, a vim control-plane / lease / disk-upload fault → `deploy_error` — plus a per-disk `transfer` manifest; see the dedicated section) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
 | `vm.migrate` | `migrated`, `no_recommendation` |
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
@@ -1074,9 +1075,11 @@ handle (`GET /api/v1/operations/runs/{handle}` polls it, and the completed
 is spawned via `asyncio.create_task` — independent of the request handler
 task — a dropped caller no longer propagates cancellation into the in-flight
 copy. The synchronous path stays the default for small items but is bounded by
-the ceiling above; an item large enough to outrun even 3 h needs the durable
-typed `HttpNfcLease` import (#2890), which streams disks against a lease with
-progress instead of coupling completion to one blocking read.
+the ceiling above; an item large enough to outrun even 3 h uses the durable
+typed `HttpNfcLease` import `vm.import_from_library` (#3229; shipped, see the
+next section) — MEHO drives the disk transfer itself, so completion is bounded
+only by the transfer's own duration and there is no single blocking read to
+outrun at all.
 
 **204 / empty-body write acks (#3082).** Several vCenter write endpoints
 acknowledge success with **204 No Content** and no body — the power actions
@@ -1101,6 +1104,79 @@ payloads) are byte-identical. Every `_write_sub_op` call site inherits the
 guard because `vmware_rest` does not override the transport helpers; the
 `vcf_automation` connector *does* override them and applies the same guard
 for contract parity.
+
+### Typed HttpNfcLease OVF import (`vm.import_from_library`, #3229)
+
+The durable, transfer-window-decoupled sibling of `vm.deploy_from_library`.
+The deploy composite's REST deploy is *synchronous* — one POST is held open
+for the whole server-side copy, so completion is bounded by the client
+read-timeout, not the operation's real duration; a 4.7 GB installer OVA to an
+NFS datastore outran even the 3 h mitigation ceiling live (#3176). Rather than
+widen a fixed window further, `vm.import_from_library` **drives the disk
+transfer itself** over a typed vim `HttpNfcLease` import, so completion is
+bounded only by the transfer's own duration and there is no single blocking
+read to outrun. Per postulate 1 a typed path is the sanctioned durable fix
+when the REST spec is inadequate — the pinned `vcenter.yaml` serves no `$Task`
+variant of the library-item deploy (#2970), and the only async REST OVF deploy
+(`Vcenter.Ovfs_deploy$Task`) is URL-sourced + 9.0-only.
+
+**Mechanism** (vim25 over the VI-JSON `_post_vmomi_json` seam / #2466, split
+across `ovf_import.py` / `ovf_import_control.py` / `ovf_transfer.py`, with the
+content-library byte source in `library_download.py`):
+
+1. `ServiceInstance.RetrieveServiceContent` → the `OvfManager` + `rootFolder`
+   MoRefs (resolved off ServiceContent, never a guessed singleton moid).
+2. `OvfManager.CreateImportSpec` (a read: `System.View`) validates the OVF
+   descriptor against the target and returns an `importSpec` + the `fileItem`
+   disk list. A descriptor error short-circuits to `deploy_failed` before any
+   mutation.
+3. `ResourcePool.ImportVApp` — the one governed *write* (gated through the same
+   `enforce_subop_policy` seam as every composite write) — creates the
+   inventory objects and returns an `HttpNfcLease`. The `importSpec` is
+   round-tripped **verbatim** into `ImportVApp` (never funnelled through
+   `unwrap_vim_value`, which would strip the `_typeName` tags an `Any` request
+   field needs — the response-consumption-only contract of that helper).
+4. Poll `HttpNfcLease.state` to `ready`; `ready` carries the per-device upload
+   URLs in `HttpNfcLease.info.deviceUrl`.
+5. Stream each disk from the content library (client-side download-session:
+   create → prepare → poll `PREPARED` → GET the `download_endpoint.uri`)
+   straight to its device URL, matched by `deviceUrl.importKey ==
+   fileItem.deviceId`, with a background `HttpNfcLeaseProgress` heartbeat that
+   both keeps the lease + download session alive and surfaces percent. Nothing
+   buffers a whole disk — the download stream feeds the lease PUT directly, and
+   the PUT's `Content-Length` is the download response's own `Content-Length`
+   (the `File.Info.size` is not guaranteed set before the download completes).
+   A `*` device-URL host is substituted with the host the client connected to
+   (the `HttpNfcLeaseDeviceUrl.url` spec contract).
+6. `HttpNfcLeaseComplete` on success; `HttpNfcLeaseAbort` on any failure after
+   the lease exists — vCenter then removes the half-created inventory objects,
+   so a failed import never leaves a partial VM behind.
+
+**Version-agnostic (AC5).** Every schema + method is core vim25 (`OvfManager`
+/ `HttpNfcLease` predate 9.0), and the engine reads only the pre-9.0
+`HttpNfcLeaseDeviceUrl` fields (`key` / `importKey` / `url`) — never the
+9.0-only `sslCertificate` — so it works on the VCF 5.x migration-source fleet
+(#3056) as well as 9.0+.
+
+**Envelope.** Item resolution (id passthrough or name find, ambiguity-refusing)
+reuses `_resolve_deploy_library_item`, and the outcome maps onto the **same**
+`deployed` / `deploy_failed` / `deploy_error` family (#3071) as the deploy
+composite, plus a per-disk `transfer` manifest (`{path, device_id,
+size_bytes}`). `datastore` is **required** (the vim `CreateImportSpec` request
+takes an explicit placement datastore, unlike the REST deploy which derives
+it). As with the deploy composite, multi-GB imports should ride **async
+governed dispatch** (#3079) so a dropped caller cannot cancel the in-flight
+transfer.
+
+**Live-appliance verification is deferred** (no lab access at implementation
+time): the deliverable is the implementation + full conformance/unit coverage,
+consistent with how every recent connector task shipped. The vim methods,
+content-library download-session paths, and every emitted `_typeName` are
+grounded against the pinned `vcenter.yaml` / `vi-json.yaml` by the reconcile
+lanes (`..._l2_ingest_reconcile` + `..._write_body_reconcile`); the engine +
+source mechanics are proven by mock-transport unit tests
+(`test_connectors_vmware_rest_ovf_import.py` /
+`test_connectors_vmware_rest_library_download.py`).
 
 ### vim cluster / inventory writes (`cluster.drs_rule.create` + `folder.create`, #2895)
 


### PR DESCRIPTION
## Summary

- Adds **`vmware.composite.vm.import_from_library`** — the durable,
  transfer-window-decoupled sibling of `vm.deploy_from_library`. The REST
  deploy holds one POST open for the whole server-side copy, so completion is
  bounded by the client read-timeout; a 4.7 GB installer OVA outran even the
  3 h mitigation ceiling live (#3176 / stopgap PR #3234). This composite drives
  the disk transfer itself over a typed vim `HttpNfcLease` import, so completion
  is bounded only by the transfer's own duration — there is no single blocking
  read to outrun at all.
- **Mechanism** (vim25 over the VI-JSON `_post_vmomi_json` seam / #2466):
  `ServiceInstance.RetrieveServiceContent` → `OvfManager.CreateImportSpec`
  (validates the descriptor) → the governed `ResourcePool.ImportVApp` write →
  poll the lease to `ready` → stream each disk from the content library
  (client-side download-session) straight to the lease device URLs with an
  `HttpNfcLeaseProgress` heartbeat → `HttpNfcLeaseComplete`. Any failure after
  the lease exists aborts it, so vCenter removes the half-created VM.
- **Version-agnostic** — core vim25 `OvfManager` / `HttpNfcLease`, and only the
  pre-9.0 `HttpNfcLeaseDeviceUrl` fields are read (never the 9.0-only
  `sslCertificate`), so it covers the pre-9.0 VCF 5.x migration-source fleet
  (#3056) as well as 9.0+. Item resolution reuses `deploy_from_library`'s
  name-find; the outcome maps onto the **same** `deployed` / `deploy_failed` /
  `deploy_error` envelope family (#3071) plus a per-disk `transfer` manifest.
  The one governed write (`ImportVApp`) rides the shared `enforce_subop_policy`
  seam under the `dangerous` / `requires_approval=True` composite posture.

**Design note — sibling op, not an in-op arm.** The task framed a
"version-conditional dual-arm" shape, but the HttpNfcLease path is
version-agnostic and strictly heavier, so gating it *inside* the working REST
`deploy_from_library` would risk its byte-identical dispatch (which many tests
pin) for no selection benefit. A separate composite op is the surgical, lower-
risk choice — squarely within the existing composite dispatch model (the same
precedent as `vm.clone` vs `vm.deploy_from_library` being distinct deploy ops)
— and the "op counts updated" acceptance criterion anticipates a new op. The
deploy composite's docstring + the connector doc cross-reference it for
multi-GB items.

**No migration** reserved — this task needs none (single head stays `0095`).

## Live verification deferred

Live-appliance verification is **deferred** (no lab access at implementation
time). The deliverable is the implementation + full conformance/unit coverage,
consistent with how every recent connector task shipped. Grounding:

- The vim methods, content-library download-session REST paths, and every
  emitted `_typeName` are reconciled against the pinned `vcenter.yaml` /
  `vi-json.yaml` by the reconcile lanes (verified locally against the real
  spec shelf: all reconcile tests green).
- The engine + source mechanics are proven by mock-transport unit tests
  covering the acceptance criteria (see below).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (new modules + touched tests)
- [x] `mypy src/meho_backplane/connectors/vmware_rest/` — clean (24 files)
- [x] `code-quality.py --diff` — 0 blockers (1 warning: the orchestrator is
      70 lines, a linear delegation flow — recorded, not blocking)
- [x] `test_connectors_vmware_rest_ovf_import.py` — engine + handler: happy
      path streams the disk & completes; **AC1/AC2** the progress heartbeat
      fires during a slow upload and a final 100% precedes Complete; **AC4**
      descriptor error → `import_failed`, lease error → `lease_error`, lease
      timeout → `lease_timeout` (+ abort), upload fault → `import_error` (+
      abort), gate park → `OperationResult` verbatim; **AC5** a 9.0-only
      `sslCertificate` device field is ignored; the `importSpec` round-trips
      verbatim into `ImportVApp`
- [x] `test_connectors_vmware_rest_library_download.py` — source: create
      session, prepare→`PREPARED` poll, buffer descriptor, stream a disk with
      its size from `Content-Length`, keep-alive/cancel, error paths
- [x] reconcile lanes (with the spec shelf wired) — `..._l2_ingest_reconcile`
      (new REST + vim sub-op manifests) + `..._write_body_reconcile` (new
      download-session write ops + vim `_typeName` vocabulary) green against
      the real pinned spec
- [x] register/count lanes — `..._composites_register` / `..._write_register`
      (op count 33→34, group_key, handler_ref) green
- [x] broader `..._composites_write` / `_write_gate` / `_write_preview` /
      surface-drift / mcp-conformance — **302 + 19 passed, no regressions**

## Out of scope

- Live-appliance validation of the actual byte transfer to a real ESXi NFC
  endpoint (deferred — needs lab redeploy).
- SSL-thumbprint pinning of the lease device URLs (uses the connector's TLS
  trust config; noted as a future hardening in the module docstring).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3229
