### PR TITLE
ci(unit-lane): shard the required Python unit lane 3 ways via #3177 stride + fan-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,19 @@
 # Locked matrix (Goal #11 DoD bullet 4 — every PR runs lint + tests on
 # every toolchain that has source code in the repo):
 #
-#   python-lint-test  : ruff check + ruff format --check + mypy + pytest on backend/
+#   Python (ruff + mypy + pytest) on backend/ — SHARDED (#3251) into:
+#     python-lint       : ruff check + ruff format --check + mypy (once)
+#     python-unit-shard : the pytest unit sweep as a 3-way file-stride matrix
+#     python-unit-lane  : fan-in carrying the branch-protection required
+#                         context `Python (ruff + mypy + pytest)`
 #   go-lint-test      : golangci-lint + go build + go test on cli/
 #   helm-lint-template: helm lint + helm template + kubeconform on deploy/charts/meho/
 #
-# Each job runs on its own meho-runners-ci runner in parallel; total wall
-# clock for a green PR is well below the 10-minute Goal #11 budget
-# because the three jobs never block each other. Per-job
-# `timeout-minutes` caps a runaway gate at twice its observed cost.
+# Each job runs on its own runner in parallel; total wall clock for a green PR
+# is the slowest job's elapsed time because the jobs never block each other.
+# Sharding the unit lane (#3251) turned its ~19-min serial pytest wall into
+# ~6-8-min parallel shards, cutting the dominant PR-wall contributor. Per-job
+# `timeout-minutes` caps a runaway gate at roughly twice its observed cost.
 #
 # Out of scope (deliberately delegated to existing workflows; do not
 # duplicate here):
@@ -45,9 +50,10 @@
 # main only) uploads `coverage.xml` as a `python-coverage` artifact so
 # the downstream SonarCloud scan can ingest it — quality-gate.yml's
 # `actions/download-artifact` step references that exact name. The
-# required unit lane (`python-lint-test`) is intentionally NO-cov: see
-# that job and #1982 — running the unit suite under coverage OOM-kills
-# the memory-limited heavy runner, so coverage was split into its own
+# required unit lane (the `python-unit-shard` matrix behind the
+# `python-unit-lane` fan-in) is intentionally NO-cov: see those jobs and
+# #1982 — running the unit suite under coverage OOM-kills the
+# memory-limited heavy runner, so coverage was split into its own
 # push-only, non-required, continue-on-error job (#1987).
 #
 # Fail-loud posture (per Goal #11 + devops_best_practices "no
@@ -162,38 +168,117 @@ jobs:
             echo "migrations=false" >> "$GITHUB_OUTPUT"
           fi
 
-  python-lint-test:
-    name: Python (ruff + mypy + pytest)
-    # Fork-PR guard: never execute project code from a fork on the
-    # self-hosted runner pool. Mirrors image.yml + chart.yml's stance —
-    # `runs-on: meho-runners-ci` is internal infra, so fork PRs skip
-    # entirely. Push events (main) short-circuit the OR via
-    # github.event_name != 'pull_request'. Job-level (not step-level)
-    # so no step ever starts on a fork PR.
+  # ---------------------------------------------------------------------------
+  # Required unit lane, sharded (#3251). The pre-#3251 monolithic
+  # `python-lint-test` job (ruff + ruff format + mypy + the whole ~13k-test
+  # unit sweep, serial, ~19-min wall) was the single biggest contributor to
+  # PR wall-time. It is now three cooperating jobs, mirroring the #3172/#3177
+  # coverage-sweep shape (deterministic file-stride matrix + fan-in):
+  #
+  #   python-lint       — ruff check + ruff format --check + mypy. Whole-tree,
+  #                       unshardable-by-file, ~1-2 min; runs ONCE on the light
+  #                       pool. Non-required check.
+  #   python-unit-shard — the pytest unit sweep as a 3-way stride matrix over
+  #                       the sorted test-file list (heavy pool, in parallel).
+  #                       Non-required checks (`Python unit shard N/3`).
+  #   python-unit-lane  — FAN-IN carrying the EXACT branch-protection required
+  #                       context `Python (ruff + mypy + pytest)`; fails iff
+  #                       python-lint or ANY shard did not pass. Branch
+  #                       protection / the ruleset are UNTOUCHED — the required
+  #                       name simply moved from the old monolithic job to this
+  #                       fan-in (the `python-coverage-combine` shape #3177 used
+  #                       to keep quality-gate.yml's contract byte-identical).
+  #
+  # Only pytest fans out: ruff + ruff format + mypy are whole-tree checks that
+  # cannot be split by test file and cost ~1-2 min, so duplicating them per
+  # shard would be pure waste — they run exactly once in python-lint.
+  # ---------------------------------------------------------------------------
+  python-lint:
+    name: Python lint + typecheck (ruff + mypy)
+    # Non-required check — the branch-protection required context lives on the
+    # python-unit-lane fan-in below. Whole-tree ruff + ruff format + mypy: none
+    # of it is shardable by test file, none of it needs testcontainers / the
+    # vendor spec-shelf / the embedding or spaCy models, and it is CPU-cheap
+    # (~1-2 min), so it runs ONCE here on the dense light pool rather than N
+    # times inside every pytest shard. Same fork-PR guard as every other job.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # Dedicated heavy ARC scale set (6000m requests=limits, max 5 pods)
-    # for the unit suite only — #761. The other jobs (Go, Helm,
-    # integration) stay on the 4-core `meho-runners-ci` pool; only the
-    # pytest sweep is CPU-bound enough to want the extra cores. Heavy
-    # pool scales from 0, so an idle period costs one cold-start on the
-    # next run. Provisioned RDC-side in rdc-gitops#55.
+    runs-on: meho-runners-ci
+    # Twice the ~1-2 min observed cost, per the file's per-job cap convention.
+    timeout-minutes: 10
+    defaults:
+      run:
+        # backend/ is the only Python project today; pyproject.toml
+        # and uv.lock both live here.
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install uv
+        # uv is the project's canonical Python toolchain (pyproject.toml locks
+        # a uv.lock). enable-cache keys the uv download cache on uv.lock, shared
+        # with every sibling Python job.
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Sync Python environment (locked)
+        # --locked refuses to update uv.lock; if pyproject.toml drifted from the
+        # lock, CI fails here rather than silently bumping deps. --all-groups
+        # pulls the dev tools (ruff, mypy) declared in [dependency-groups.dev].
+        run: uv sync --locked --all-groups
+
+      - name: Ruff check (lint)
+        # ruff config lives in backend/pyproject.toml [tool.ruff.lint].
+        # Targets the src/ + tests/ trees the project ships.
+        run: uv run ruff check src/ tests/
+
+      - name: Ruff format --check
+        # Format gate — non-zero exit if any file would be reformatted.
+        # Authors run `uv run ruff format` locally before pushing.
+        run: uv run ruff format --check src/ tests/
+
+      - name: Mypy (strict)
+        # [tool.mypy] in pyproject.toml is `strict = true` against
+        # files = ["src"]. Per-dep ignores (authlib, hvac, requests)
+        # are already declared there.
+        run: uv run mypy src/
+
+  python-unit-shard:
+    name: Python unit shard ${{ matrix.shard }}/3
+    # Non-required checks (one per matrix leg: `Python unit shard 1/3`,
+    # `.../2/3`, `.../3/3`) — the required context is carried by the
+    # python-unit-lane fan-in below. This is the pytest half of the old
+    # required lane, split into a deterministic 3-way file-stride matrix
+    # (#3251) so its ~15-18-min serial wall runs as ~6-min parallel shards.
+    #
+    # Fork-PR guard: never execute project code from a fork on the self-hosted
+    # runner pool. Same stance as the old lane — job-level so no step ever
+    # starts on a fork PR. On a fork PR all three legs skip (→ reported
+    # Success), which the fan-in's own fork guard mirrors.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Dedicated heavy ARC scale set (6000m requests=limits, max 5 pods) — #761.
+    # Three shards fit inside the 5-pod ceiling. Only the pytest sweep is
+    # CPU/memory-bound enough to want the extra cores; ruff/mypy stayed on the
+    # light pool in python-lint.
     runs-on: meho-runners-ci-heavy
-    # 25-min cap (raised from 20): the unit lane was OOM-killed on the heavy
-    # runner near end-of-run (null Pytest step, no log, `failure`, ~17-21 min,
-    # NOT reproducible locally, worker-count-independent). Root cause + fix are
-    # detailed in the perf-budget `run:` block: coverage's combine peaked the
-    # pytest tree at 13.67 GiB (vs 7.86 GiB without), over the pod's memory
-    # limit; the fix drops `--cov` from this gate and keeps -n 3 (lower base
-    # memory). No-cov -n 3 wall is ~13-18 min, so 25 min keeps a hang-backstop
-    # margin above the budget_s early-warning gate. ~8m33s with --cov+sysmon was
-    # the pre-growth -n 4 wall (run 26245676016).
-    # History: the combined serial sweep once blew the 10→20→40→50-min caps
-    # (runs 25910787068, 25970564527, 25972807988, 25987329377,
-    # 25992737115) before the integration split (#570), xdist
-    # (#585/#603), and the #799 re-embed fix landed; the 50-min cap was
-    # generous headroom from that era. Job name is intentionally unchanged so
-    # the existing branch-protection required check stays satisfied.
-    timeout-minutes: 25
+    strategy:
+      # 3 stride shards (#3251), sized off the pre-shard ~19-min lane so each
+      # shard lands ~6-8 min. fail-fast: false — one shard's red tests must NOT
+      # cancel the others, so a broad breakage surfaces every failing shard in
+      # one run (the fan-in still fails if ANY leg fails). To rebalance, change
+      # the shard count in BOTH the matrix and the `TOTAL` in the pytest step,
+      # in lockstep.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    # 20-min cap: hang backstop only. Expected job wall is ~8 min (setup ~2 min
+    # + pytest ~6 min); the perf-budget step below is the PR-level early-warning
+    # gate that fires well before this cap. The pre-shard lane's 25-min cap
+    # covered a ~18-min serial pytest wall; a ~6-min shard needs far less. The
+    # old lane's OOM/heartbeat history (why the whole-suite lane dropped --cov
+    # and pinned -n 3) is preserved verbatim in the pytest step comment below.
+    timeout-minutes: 20
     env:
       # Surfaced as a job-level env var purely so the Docker Hub login
       # step can test it in an `if:`. The `secrets` context is NOT
@@ -288,6 +373,13 @@ jobs:
         # runs). Dependabot runs read the Dependabot secret store,
         # where this secret is deliberately not mirrored, so they skip
         # too.
+        #
+        # Sharded (#3251): every shard runs this checkout, because each
+        # shard's stride slice may include the spec-backed reconcile
+        # lanes; the cone-mode sparse + blob:none filter keeps it cheap
+        # (~0.4 MB argocd-3.3 + … a few tens of MB total), and the
+        # SPEC_SHELF_TOKEN PAT is read-only, so the parallel fetches are
+        # safe.
         if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -413,9 +505,10 @@ jobs:
         # locks a uv.lock, not a requirements.txt). enable-cache: true
         # opts into the action's built-in cache for the uv download
         # cache directory, keyed by uv.lock — repeat installs on the
-        # same lockfile are near-instant. version unset -> latest, which
-        # is fine because uv ships a strict resolver and the lockfile
-        # pins every transitive dep.
+        # same lockfile are near-instant, so the three shards share one
+        # warm uv cache. version unset -> latest, which is fine because
+        # uv ships a strict resolver and the lockfile pins every
+        # transitive dep.
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           enable-cache: true
@@ -427,22 +520,6 @@ jobs:
         # declared in [dependency-groups.dev].
         run: uv sync --locked --all-groups
 
-      - name: Ruff check (lint)
-        # ruff config lives in backend/pyproject.toml [tool.ruff.lint].
-        # Targets the src/ + tests/ trees the project ships.
-        run: uv run ruff check src/ tests/
-
-      - name: Ruff format --check
-        # Format gate — non-zero exit if any file would be reformatted.
-        # Authors run `uv run ruff format` locally before pushing.
-        run: uv run ruff format --check src/ tests/
-
-      - name: Mypy (strict)
-        # [tool.mypy] in pyproject.toml is `strict = true` against
-        # files = ["src"]. Per-dep ignores (authlib, hvac, requests)
-        # are already declared there.
-        run: uv run mypy src/
-
       - name: Cache fastembed model (drift-guard + slow-lane)
         # The drift-guard below downloads the ~67 MB default ONNX model
         # from HuggingFace. Without this cache every run re-fetches it
@@ -452,7 +529,9 @@ jobs:
         # pinned there, so a fastembed bump (which can remap the HF
         # source/filename) misses the cache and the model re-downloads
         # exactly once, then re-saves. restore-keys lets an unrelated
-        # lock change still reuse the prior model blob.
+        # lock change still reuse the prior model blob. All three shards
+        # share this one cache entry (same key), so steady-state only the
+        # first cold run pays the download.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ${{ github.workspace }}/.fastembed-cache
@@ -493,7 +572,9 @@ jobs:
         # middleware test gate on ``spacy.util.is_package(...)``,
         # accepting either model -- so this step suffices for the
         # unit lane's correctness signal without paying the ``lg``
-        # download wall every run.
+        # download wall every run. Each shard provisions the sm model
+        # (its stride slice may include the Tier-2 lanes); the ~12 MB
+        # download is cheap enough to not warrant caching.
         #
         # ``MEHO_REDACTION_SPACY_MODEL`` is the runtime override the
         # presidio.py adapter reads; setting it here pins the unit
@@ -507,7 +588,12 @@ jobs:
           MEHO_REDACTION_SPACY_MODEL=en_core_web_sm \
             uv run python -c "from meho_backplane.redaction import get_engines; get_engines('en')"
 
-      - name: Pytest (unit + coverage)
+      - name: Pytest (unit shard ${{ matrix.shard }}/3)
+        # `shell: bash` for `mapfile` + arrays (and the pipefail/-e the
+        # default self-hosted shell does not enable — #2865). Under -e a
+        # failing `uv run pytest` exits the step immediately, so the
+        # perf-budget check below can never mask a red suite.
+        shell: bash
         env:
           # Pin Tier-2's spaCy model to the unit-lane choice so the
           # acceptance tests in test_redaction_presidio.py + the
@@ -523,9 +609,7 @@ jobs:
           # ingest (~3,470 ops through parse + register + embedding +
           # grouping — the fixture is function-scoped by design), which
           # took the whole sweep from 478 s (2026-08-17 16:57Z, canary
-          # still erroring fast) past this job's 25-min cap (four
-          # consecutive timeout kills on head eaccb895, the last on a
-          # quiet cluster with pytest at 81% and progressing). Per this
+          # still erroring fast) past this job's cap. Per this
           # workflow's perf-budget discipline (#898/#793/#827): the slow
           # path is relocated, not the cap raised. The canary's
           # full-ingest tests run armed in the python-integration job
@@ -535,127 +619,156 @@ jobs:
           # collection-time skipif marker in tests/acceptance/
           # test_g07_vsphere_canary.py (fixture-level backstop in
           # vcenter_spec_path); rule of record in
-          # docs/decisions/spec-reconcile-guards-standard.md.
+          # docs/decisions/spec-reconcile-guards-standard.md. The
+          # canary module lands in exactly one shard's stride slice, so
+          # this opt-out must stay on every shard.
           MEHO_SKIP_SPEC_INGEST_TESTS: "1"
-        # PARALLELIZED via pytest-xdist (#585 unblocked this). The
-        # serial sweep was the job's dominant cost (~49 min in CI vs
-        # ~5 min local). #585 added process-wide global-registry
-        # snapshot/restore + deterministic MCP-module import in
-        # tests/conftest.py, eliminating the cross-module isolation
-        # leaks that previously made `-n auto` red on
-        # test_mcp_registry / test_audit_middleware. Controlled
-        # same-commit proof (acceptance of #585): serial 2007/0/0 and
-        # `-n auto --dist loadscope` 2007/0/0 — identical, empty
-        # failure set; local wall-clock serial 10:18 → xdist 6:14
-        # (limited by core count; CI multi-core gets the ~49→~10 min).
+        # PARALLELIZED two ways now (#3251): file-STRIDE across shards
+        # (this matrix) AND pytest-xdist WITHIN each shard. #585 unblocked
+        # xdist by adding process-wide global-registry snapshot/restore +
+        # deterministic MCP-module import in tests/conftest.py, eliminating
+        # the cross-module isolation leaks that made `-n auto` red.
+        # File-level sharding is strictly COARSER than what xdist
+        # --dist loadscope already does across workers (whole modules stay
+        # together, conftest semantics are identical to a full run), so a
+        # suite that is xdist-safe is shard-safe — proven live by the
+        # #3172/#3177 python-coverage sweep, which runs the identical
+        # file-stride split (over a superset of these files) green.
         # Worker count is -n 3 (lowered -n 6 → -n 4 per #1901 for CPU starvation,
-        # then -n 4 → -n 3 for MEMORY headroom when the lane OOM-killed the pod —
-        # see the root-cause analysis in the perf-budget `run:` block below; fewer
-        # workers => lower base memory). The original -n 6 reasoning, kept
-        # for context: pinned, matched to the dedicated `meho-runners-ci-heavy`
-        # scale set's 6000m guaranteed cores (#761). History: -n auto
-        # was inconsistent on the shared 4-core pool (run 26164020459
-        # reported 4 workers, a later same-day push reported 8 — cgroup
-        # detection drift), so #726 pinned -n 3 (N-1, leaving a core for
-        # the coordinator + DinD on the burstable 4-core pool). The heavy
-        # pool is QoS Guaranteed (requests=limits=6000m), so the
-        # host-core-detection ambiguity is gone and the headroom math
-        # changes: 6 workers fully subscribe the pod. The xdist
-        # coordinator is mostly IPC-blocked and DinD is near-idle during
-        # pure-CPU test execution (testcontainers pgvector/valkey only
-        # burst at spin-up — see MEHO_TEST_PGVECTOR_IMAGE env above), so
-        # full subscription is the intended trade. If the #761 wall/
-        # variance measurement shows oversubscription symptoms (high
-        # variance, wall not improving vs -n 3), drop to -n 5 (N-1) as
-        # the fallback.
+        # then -n 4 → -n 3 for MEMORY headroom when the whole-suite lane OOM-killed
+        # the pod — see #1982). Kept at -n 3 per shard: a shard runs ~1/3 the
+        # tests so its base memory is well under the pod limit even without --cov,
+        # and -n 3 stays inside the #1983 heartbeat-safe worker count on the
+        # 6-core cap. History: -n auto was inconsistent on the shared 4-core pool
+        # (cgroup detection drift), so #726 pinned -n 3.
         # RULE — pytest-xdist -n vs runner CPU (#1983): -n must stay BELOW
         # the runner container's usable cores, leaving at least one core for
         # the GHA agent + xdist coordinator. The fix for "runner lost
         # communication" / heartbeat starvation is burst headroom on the
         # pod's CPU *limit* (rke2-ci heavy pool target: request 4000m /
         # limit 7000m, pending evoila-bosnia/rdc-gitops#70 — currently
-        # 6000m requests=limits), not a smaller -n. That is why
-        # -n 6 → 4 → 3 never fixed the heartbeat failures against the hard
-        # 6-core cap: the pod had no burst slack, and with requests=limits
-        # the kernel enforces the cap via cgroup CPU quota (100% throttle),
-        # so the GHA agent misses its heartbeat and GitHub kills the job
-        # even though the nodes were at ~0% CPU. Until rdc-gitops#70 lands,
-        # do not raise -n above the current value to chase wall-clock
-        # improvements — the symptom will return. Raise the CPU *limit*
-        # instead.
-        # --dist loadscope: a module's
-        # tests stay on one worker so module-/session-scoped fixtures
-        # (testcontainers PG, embedding service) instantiate per
-        # worker, not per test. --maxfail=1 preserves the old `-x`
-        # fast-fail (xdist ignores `-x`). --ignore=tests/integration →
-        # the container-heavy subtree runs in the sibling
-        # `python-integration` job.
-        # COVERAGE REMOVED from this required gate (was `COVERAGE_CORE=sysmon
-        # ... --cov=meho_backplane --cov-report=xml`). The xdist coverage combine
-        # peaked the pytest tree at 13.67 GiB (vs 7.86 GiB without — measured via
-        # cgroup memory.peak at -n 3, 8243 passed), OOM-killing the heavy runner
-        # pod near end-of-run and leaving the lane red on main for every PR. The
-        # +5.8 GiB is coverage's session-end merge (all workers' data + the
-        # controller's combine, co-resident); the coverage config has no
-        # per-test contexts to trim (only `[tool.coverage.run] relative_files`).
-        # Coverage was non-blocking anyway — quality-gate.yml is whole-job
-        # continue-on-error and a missing/late artifact never blocks merge — so
-        # dropping it to keep this gate GREEN is the right priority over the
-        # SonarCloud Clean-as-You-Code decoration it fed. FOLLOW-UP: restore that
-        # decoration memory-safely (offline `coverage combine`+`xml` after the
-        # xdist workers exit; a push-only serial-cov job; or a larger-memory
-        # pool). History (for whoever restores it): cov on PR+push came from
-        # #726/#771/#793/#799 after the #799 re-embed fix made --cov ~+1 min, and
-        # COVERAGE_CORE=sysmon (PEP 669, coverage.py 7.4+, lock 7.14) halved the
-        # tracer tax with line counts matching the C tracer (2913/11832).
+        # 6000m requests=limits), not a smaller -n. Do not raise -n above
+        # the current value to chase wall-clock; raise the CPU *limit* instead.
+        # --dist loadscope: a module's tests stay on one worker so
+        # module-/session-scoped fixtures (testcontainers PG, embedding
+        # service) instantiate per worker, not per test. --maxfail=1
+        # preserves the old `-x` fast-fail per shard (xdist ignores `-x`);
+        # with fail-fast: false one red shard still lets the others run,
+        # so a broad breakage surfaces every failing shard at once.
+        # COVERAGE stays OUT of this required gate (was `COVERAGE_CORE=sysmon
+        # ... --cov=meho_backplane --cov-report=xml`): the xdist coverage combine
+        # peaked the whole-suite pytest tree at 13.67 GiB (vs 7.86 GiB without),
+        # OOM-killing the heavy runner. Coverage is produced by the dedicated,
+        # non-blocking, sharded `python-coverage` + `python-coverage-combine`
+        # jobs below (#1982/#1987/#3172).
         run: |
-          # Perf-budget guard — early warning for CI-perf creep (the #898 / G3.6
-          # timeout class). The Goal #11 unit budget is 10 min, but it was
-          # aspirational (comment-only): the G3.6 batch crept 9.3 -> 19 min and
-          # nothing failed until the 20-min `timeout-minutes` cliff, blocking a
-          # release. This step measures the pytest wall, always prints it (trend
-          # visibility), and FAILS at the budget — well below the hard cap, so a
-          # regression is caught at the PR that causes it, not at release time.
-          # `timeout-minutes` stays as the hang backstop.
+          # Deterministic stride shard (#3251, mirrors the #3172/#3177
+          # python-coverage split): the sorted test-file list, every
+          # TOTAL-th file to this shard. File-level split keeps conftest /
+          # loadscope semantics identical to a full run; stride (vs
+          # contiguous blocks) spreads the heavyweight suites across shards.
+          # The three shards partition the full set exactly (NR mod 3 hits
+          # each residue once). tests/integration stays out (→ python-
+          # integration) and tests/migrations stays out (→ python-migration-
+          # tests), matching the pre-shard lane's `--ignore` of both.
+          TOTAL=3
+          SHARD="${{ matrix.shard }}"
+          mapfile -t SHARD_FILES < <(find tests -name 'test_*.py' -not -path 'tests/integration/*' -not -path 'tests/migrations/*' | sort | awk -v s="${SHARD}" -v t="${TOTAL}" 'NR % t == s - 1')
+          echo "shard ${SHARD}/${TOTAL}: ${#SHARD_FILES[@]} test files"
+          if [ "${#SHARD_FILES[@]}" -eq 0 ]; then
+            echo "::error::shard ${SHARD} selected 0 test files — stride selection broken"
+            exit 1
+          fi
+          # Per-shard perf-budget guard — early warning for CI-perf creep (the
+          # #898 / G3.6 timeout class), scaled from the pre-shard 1320 s
+          # whole-suite budget to a per-shard wall (~1/3 the suite). 660 s
+          # leaves generous headroom over the expected ~6-min (~360 s) shard
+          # wall + the heaviest stride slice, while still firing well below the
+          # 20-min job `timeout-minutes` hang backstop. This step measures the
+          # pytest wall, always prints it (trend visibility), and FAILS at the
+          # budget so a regression is caught at the PR that causes it.
           # MEASURE before raising budget_s (see #793/#827/#898): re-run with
           #   MEHO_FIXTURE_TIMING_FILE=/tmp/fixt MEHO_LIFESPAN_TIMING=/tmp/lifespan
           # then `uv run python tests/_perf_timing_report.py` to attribute the wall.
-          # ROOT CAUSE (corrected): the unit lane died with a null Pytest step,
-          # no log, `failure`, at ~17-21min on the heavy runner — NOT reproducible
-          # locally and worker-count-INDEPENDENT (it recurred identically after
-          # -n 4 → -n 3, just ~3min later in wall-clock). That rules out the #1901
-          # CPU-starvation class and points at an OOM kill of the runner pod near
-          # end-of-run. Measured peak memory of the pytest tree (cgroup memory.peak,
-          # -n 3, 8243 passed): 13.67 GiB WITH `--cov`+sysmon vs 7.86 GiB WITHOUT —
-          # coverage's combine (all xdist workers' data + the controller's merge,
-          # co-resident at session end) adds ~5.8 GiB and tips the pod over its
-          # memory limit (<13.67 GiB; the lane passes on a 62 GiB dev box). The
-          # alembic migration round-trip cluster (schema 0048+, each reversibility
-          # test replays the whole upgrade→downgrade chain — ~45 of the slowest 60
-          # tests) plus the new /ui console wave grew both wall AND peak until cov
-          # pushed it over. FIX: drop `--cov` from this required gate (peak 13.67 →
-          # 7.86 GiB) and keep -n 3 (fewer workers => lower base memory: ~7.86 GiB
-          # vs ~10 GiB at -n 4) for headroom. Coverage is non-blocking by design
-          # (quality-gate.yml is whole-job continue-on-error; a missing artifact only
-          # degrades the SonarCloud signal, never blocks merge) — so dropping it to
-          # keep the gate GREEN is the right priority. FOLLOW-UP: restore SonarCloud
-          # coverage memory-safely (offline `coverage combine`+`xml` after workers
-          # exit, a push-only serial-cov job, or a larger-memory pool). budget_s set
-          # to 1320 for the no-cov -n 3 wall (local 816s/13:34; runner expected
-          # ~15-18min) with creep-detection headroom, under the 25-min timeout.
-          budget_s=1320
+          # If ONE shard consistently trips while the others are comfortable, the
+          # stride is unbalanced by a heavy module — rebalance (raise the shard
+          # count in the matrix + TOTAL) rather than bumping only this budget.
+          budget_s=660
           start=$(date +%s)
-          uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration --ignore=tests/migrations tests/
+          uv run pytest -n 3 --dist loadscope --maxfail=1 "${SHARD_FILES[@]}"
           dur=$(( $(date +%s) - start ))
-          echo "::notice title=Unit pytest wall::${dur}s (budget ${budget_s}s = no-cov -n 3 wall; hard cap = job timeout-minutes)"
+          echo "::notice title=Unit pytest wall (shard ${SHARD}/${TOTAL})::${dur}s (budget ${budget_s}s per shard; hard cap = job timeout-minutes)"
           if [ "$dur" -gt "$budget_s" ]; then
-            echo "::error title=Unit perf budget exceeded::unit pytest ${dur}s > budget ${budget_s}s. Early-warning gate for CI-perf creep (#898 / G3.6 class). MEASURE the slow path before raising budget_s: MEHO_FIXTURE_TIMING_FILE + MEHO_LIFESPAN_TIMING + tests/_perf_timing_report.py (#793/#827). Amortize the cost; do not just bump the budget."
+            echo "::error title=Unit perf budget exceeded (shard ${SHARD}/${TOTAL})::shard pytest ${dur}s > per-shard budget ${budget_s}s. Early-warning gate for CI-perf creep (#898 / G3.6 class). MEASURE the slow path before raising budget_s (MEHO_FIXTURE_TIMING_FILE + MEHO_LIFESPAN_TIMING + tests/_perf_timing_report.py — #793/#827). Amortize the cost or rebalance the shards; do not just bump the budget."
             exit 1
           fi
-        # NOTE: this required lane no longer uploads a coverage artifact —
-        # #1982 dropped `--cov` here (OOM) and the dead `hashFiles(coverage.xml)`-
-        # guarded upload step was removed in #1987. The SonarCloud coverage
-        # artifact is now produced by the dedicated `python-coverage` job below.
+
+  python-unit-lane:
+    name: Python (ruff + mypy + pytest)
+    # FAN-IN carrying the branch-protection required context (#3251). This job
+    # name is the EXACT string pinned in the `main` ruleset's
+    # required_status_checks, so branch protection / the ruleset are UNTOUCHED
+    # by this change — the required name simply moved off the old monolithic
+    # `python-lint-test` job onto this fan-in (the `python-coverage-combine`
+    # shape #3172/#3177 used to keep the downstream contract byte-identical).
+    #
+    # It depends on python-lint (ruff + ruff format + mypy) and every
+    # python-unit-shard leg, and PASSES iff all of them passed. Two correctness
+    # properties this shape must have:
+    #
+    #  1. NOT fail-open. A required aggregation gate that just `needs:` the
+    #     shards would be SKIPPED when a shard fails (GitHub's default
+    #     skip-on-needs-failure), and a skipped required check counts as
+    #     Success (#2140) — i.e. a red shard would let the PR merge. `always()`
+    #     forces this job to RUN regardless of upstream results, and the step
+    #     below inspects `needs.*.result` and FAILS on anything that is not
+    #     `success`/`skipped`. A shard that hangs → its own timeout-minutes →
+    #     `cancelled` leg → aggregate result `cancelled`/`failure` → this gate
+    #     FAILS (not open). Verified reasoning, not luck.
+    #  2. Clean fork-PR + skip behaviour. The fork guard is AND-ed in, so on a
+    #     fork PR (and only then) this job — like python-lint / python-unit-
+    #     shard — is skipped by its own `if:`, which reports the required
+    #     context as Success exactly as the old single job did (#2140). On
+    #     same-repo PRs / push / merge_group the guard is true and the gate
+    #     evaluates the real results.
+    #
+    # Concurrency: the shards, python-lint and this fan-in all share the
+    # workflow-level concurrency group, so a PR force-push cancels the whole
+    # in-flight run as a SET and a fresh run supersedes it — there is no
+    # partial-cancel path that could leave this gate green on stale shards.
+    # Light pool: this job does no setup and runs one bash step.
+    needs: [python-lint, python-unit-shard]
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: meho-runners-ci
+    timeout-minutes: 5
+    steps:
+      - name: Assert lint + typecheck + every pytest shard passed
+        # needs.<job>.result is one of success / failure / cancelled / skipped.
+        # For the matrix job, needs.python-unit-shard.result is the AGGREGATE:
+        # success only if every leg succeeded, otherwise failure/cancelled.
+        # Pass iff both upstreams are success or skipped (skipped == the
+        # fork-PR path, where this job is itself skipped and never runs this
+        # step); anything else FAILS the required gate.
+        run: |
+          lint='${{ needs.python-lint.result }}'
+          shards='${{ needs.python-unit-shard.result }}'
+          echo "python-lint (ruff + ruff format + mypy): ${lint}"
+          echo "python-unit-shard (aggregate of all 3 stride legs): ${shards}"
+          fail=0
+          for r in "${lint}" "${shards}"; do
+            case "${r}" in
+              success|skipped) ;;
+              *) fail=1 ;;
+            esac
+          done
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error title=Python unit lane red::ruff / ruff format / mypy or one or more pytest stride shards did not pass. This fan-in carries the branch-protection required context 'Python (ruff + mypy + pytest)'; open the 'Python lint + typecheck (ruff + mypy)' / 'Python unit shard N/3' jobs above for the failing detail."
+            exit 1
+          fi
+          echo "Unit lane GREEN — ruff + ruff format + mypy + all 3 pytest stride shards passed."
 
   python-coverage:
     name: Python coverage (SonarCloud, shard ${{ matrix.shard }}/3)
@@ -1123,10 +1236,10 @@ jobs:
 
   python-integration:
     name: Python (integration testcontainers)
-    # Sibling of python-lint-test. Holds the container-heavy
-    # tests/integration/ subtree (pgvector/valkey/k3d/vcsim
+    # Sibling of the sharded unit lane (python-unit-shard). Holds the
+    # container-heavy tests/integration/ subtree (pgvector/valkey/k3d/vcsim
     # testcontainers) that made the combined serial sweep blow every
-    # timeout cap (see python-lint-test comment). Separated so the
+    # timeout cap (see the python-unit-shard comment). Separated so the
     # required lint+mypy+unit gate stays fast and deterministic while
     # integration runs on every PR.
     # **Required merge gate as of 2026-05-20 (#698).** This job's
@@ -1180,7 +1293,7 @@ jobs:
       # #2949 — vendor vCenter spec-shelf wiring; this job runs the
       # tests/integration real-spec ingest lanes
       # (test_operations_ingest_vcenter.py / _vi_json.py). See the
-      # comment on the python-lint-test job's occurrence of these two
+      # comment on the python-unit-shard job's occurrence of these two
       # rows for the full rationale (presence-flag gating; the
       # unconditional docs-root that degrades to lane-skip when the
       # shelf checkout was skipped).
@@ -1194,7 +1307,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Checkout vendor spec-shelf (secret-gated, #2949; nsx #2981)
-        # Same secret-gated sparse checkout as the python-lint-test
+        # Same secret-gated sparse checkout as the python-unit-shard
         # job's spec-shelf step — see that step's comment for the
         # licensing pointer (docs/decisions/vendor-spec-ci-
         # provisioning.md), the secret scope, and the fork/Dependabot
@@ -1224,7 +1337,7 @@ jobs:
 
       - name: Verify spec-shelf provisioned the pinned specs
         # Fail-loud layout guard — same rationale as the
-        # python-lint-test job's occurrence.
+        # python-unit-shard job's occurrence.
         if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
         working-directory: ${{ github.workspace }}
         run: |
@@ -1255,7 +1368,7 @@ jobs:
           echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
-        # Same rationale as python-lint-test's login step — the
+        # Same rationale as python-unit-shard's login step — the
         # integration subtree is the heaviest testcontainers consumer
         # (pgvector/valkey/k3d/vcsim), so authenticated pulls are
         # load-bearing here in particular.
@@ -1310,8 +1423,9 @@ jobs:
     # Runs the relocated backend/tests/migrations/ suite: per-migration
     # data-transform assertions, the alembic upgrade/downgrade round-trip,
     # and the 3 pgvector-container forward-compat rollback tests. The
-    # required unit lane (python-lint-test) now --ignore=tests/migrations,
-    # so this job carries the deep per-migration coverage — but only on
+    # required unit lane (the python-unit-shard stride matrix) excludes
+    # tests/migrations from its find, so this job carries the deep
+    # per-migration coverage — but only on
     # migration-touching PRs, gated by the `changes` job.
     #
     # Safety net: the unit lane's session-scoped `_schema_template_db`

--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Sync Python environment (locked)
         # --locked refuses to update uv.lock; if pyproject.toml drifted
         # from the lock, CI fails here rather than silently bumping
-        # deps. Same pattern as ci.yml's python-lint-test job.
+        # deps. Same pattern as ci.yml's python-lint job.
         run: uv sync --locked --all-groups
 
       - name: Run retrieval-eval gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — required PR unit lane sharded 3 ways (#3251)
+
+- The required unit lane (branch-protection context `Python (ruff + mypy +
+  pytest)`) was one monolithic job running ruff + ruff format + mypy + the
+  whole ~13k-test unit sweep serially (~19-min wall) — the single biggest
+  contributor to PR wall-time. It is now three cooperating jobs mirroring the
+  #3177 coverage-sweep shape (deterministic file-stride matrix + fan-in):
+  `python-lint` (ruff + ruff format + mypy, once), `python-unit-shard` (the
+  pytest sweep as a 3-way stride matrix over the sorted test-file list), and
+  `python-unit-lane` (the fan-in). Expected wall drops from ~19 min to
+  ~6-8 min per shard in parallel — roughly a 3x cut to the dominant lane.
+- **Branch protection is untouched.** The fan-in job carries the *exact*
+  required-context string `Python (ruff + mypy + pytest)`, so the `main`
+  ruleset and the merge-queue required-check list need no edit — the required
+  name simply moved from the old monolithic job onto the fan-in. The fan-in
+  uses `if: always()` + explicit `needs.*.result` inspection so a failed or
+  hung shard FAILS the gate rather than being silently skipped-as-Success.
+- Only pytest fans out: ruff/ruff-format/mypy are whole-tree, unshardable by
+  test file, and cost ~1-2 min, so they run once in `python-lint` instead of
+  N times per shard. The `tests/integration` / `tests/migrations` exclusions
+  and the G0.7 canary `MEHO_SKIP_SPEC_INGEST_TESTS` opt-out (#2980) are
+  preserved on every shard; coverage stays in the separate non-blocking
+  `python-coverage` jobs. No new escape-hatch label is needed — unlike the
+  push-only coverage lane, the unit lane runs on every PR, so a sharding PR
+  self-validates through its own `pull_request` run.
+
 ### Added — governed delete: pfSense NAT-rule + alias delete on the destructive tier + conformance (#3232)
 
 - Registers the pfSense connector's first two `safety_level="destructive"` +

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -803,13 +803,20 @@ into `GITHUB_STEP_SUMMARY` on every successful publish.
 ## PR-level CI (`.github/workflows/ci.yml`)
 
 `ci.yml` is the central per-PR test harness. Every PR targeting `main`
-runs four jobs in parallel and every push to `main` re-runs the same
-matrix as a regression catch. Branch protection consumes each job's
-status as a required check (per
+runs the toolchain jobs in parallel and every push to `main` re-runs the
+same matrix as a regression catch. Branch protection consumes the
+required jobs' status per
 `branches/main/protection.required_status_checks.contexts` —
 re-verified after the 2026-05-20 #698 promotion of the integration
 lane, the structural corrective to the v0.2 / G3.4 green-but-hollow
-incidents #634 / #697).
+incidents #634 / #697.
+
+Since #3251 the required unit lane is **sharded**: the required context
+`Python (ruff + mypy + pytest)` no longer maps to one monolithic job but
+to a **fan-in** (`python-unit-lane`) over a lint job (`python-lint`) and a
+3-way pytest stride matrix (`python-unit-shard`). The required-context
+_string_ is unchanged, so branch protection / the ruleset are untouched —
+see [Sharded unit lane (#3251)](#sharded-unit-lane-3251) below.
 
 ### Merge queue (#769)
 
@@ -859,26 +866,80 @@ commits still cancel their own prior runs as before.
 
 | Job | Surface | Steps |
 | --- | --- | --- |
-| `python-lint-test` (`Python (ruff + mypy + pytest)`) | `backend/` unit + acceptance subtree | `uv sync --locked --all-groups` -> `ruff check` -> `ruff format --check` -> `mypy --strict` -> `pytest -n 3 --dist loadscope` (excludes `tests/integration/`; `-n 3` reduced from 6 → 4 → 3 for CPU/memory headroom — see [runner-CPU rule](#runner-cpu-rule) below) |
+| `python-lint` (`Python lint + typecheck (ruff + mypy)`) | `backend/src/` + `backend/tests/` | `uv sync --locked --all-groups` -> `ruff check` -> `ruff format --check` -> `mypy --strict`. Non-required; whole-tree, unshardable-by-file, runs once on the light pool (#3251). |
+| `python-unit-shard` (`Python unit shard N/3`) | `backend/` unit + acceptance subtree, split 3 ways | `pytest -n 3 --dist loadscope --maxfail=1` over a deterministic file-stride slice (excludes `tests/integration/` and `tests/migrations/`; `-n 3` per shard for CPU/memory headroom — see [runner-CPU rule](#runner-cpu-rule)). Non-required matrix (#3251). |
+| `python-unit-lane` (`Python (ruff + mypy + pytest)`) | fan-in | `needs: [python-lint, python-unit-shard]`; **required check** — fails iff lint or any shard failed. Carries the exact branch-protection required context so the ruleset is untouched (#3251). |
 | `python-integration` (`Python (integration testcontainers)`) | `backend/tests/integration/` | `uv sync --locked --all-groups` -> `pytest tests/integration/` against pgvector / valkey / k3d / vcsim / vault testcontainers via DinD. **Required merge gate (#698)** so the lane that exercises real connector dispatch can no longer ship red. |
 | `go-lint-test` (`Go (golangci-lint + go test)`) | `cli/` | `golangci-lint` (v6 action) -> `go build ./...` -> `go test -race -cover ./...` |
 | `helm-lint-template` (`Helm (lint + template + kubeconform)`) | `deploy/charts/meho/` | `helm lint` -> `helm template` -> `kubeconform --strict --kubernetes-version 1.28.0` |
 
-`python-lint-test` runs on `meho-runners-ci-heavy` (dedicated ARC scale
-set, 6000m requests=limits, max 5 pods — #761 / rdc-gitops#55). The
-other three jobs (`python-integration`, `go-lint-test`,
-`helm-lint-template`) run on the dense `meho-runners-ci` pool (4-core).
-`python-lint-test` carries a 25-minute `timeout-minutes` (raised from
-20 min after #1982 dropped `--cov` and the no-cov `-n 3` wall is
-~15-18 min; the hard cap stays above the observed wall for hang
-detection while the perf-budget-guard step enforces the budget at the
-PR level). `go-lint-test` and `helm-lint-template` carry 10 minutes;
+The three `python-unit-shard` legs run on `meho-runners-ci-heavy`
+(dedicated ARC scale set, 6000m requests=limits, max 5 pods — #761 /
+rdc-gitops#55; three shards fit the 5-pod ceiling). `python-lint`, the
+`python-unit-lane` fan-in, and the other jobs (`python-integration`,
+`go-lint-test`, `helm-lint-template`) run on the dense `meho-runners-ci`
+pool (4-core). Each `python-unit-shard` carries a 20-minute
+`timeout-minutes` (hang backstop only — the expected shard job wall is
+~8 min: ~2 min setup + ~6 min pytest, down from the pre-#3251
+monolithic lane's ~15-18 min serial pytest wall); a per-shard
+perf-budget-guard step (`budget_s=660`, scaled from the old 1320 s
+whole-suite budget) is the PR-level early-warning gate that fires well
+below the cap. `python-lint` and the fan-in carry 10 and 5 minutes.
+`go-lint-test` and `helm-lint-template` carry 10 minutes;
 `python-integration` carries 60 minutes for the container-pull + DinD
 spin-up + testcontainers sweep (xdist loadgroup parallelisation tracked
 in #564). Wall-clock for a green PR is the slowest job's elapsed time
-because the four jobs never block each other — `python-integration`
-typically dominates and is the dispatch surface for the Goal #11 budget
-conversation.
+because the jobs never block each other — since #3251 sharded the unit
+lane, `python-integration` is typically the dominant lane and the
+dispatch surface for the Goal #11 budget conversation.
+
+### Sharded unit lane (#3251)
+
+The required unit lane was a single `python-lint-test` job running ruff +
+ruff format + mypy + the whole ~13k-test unit sweep serially (~19-min
+wall) — the biggest single contributor to PR wall-time. #3251 split it
+into three cooperating jobs, mirroring the #3172/#3177 coverage-sweep
+shape (deterministic file-stride matrix + fan-in):
+
+- **`python-lint`** — ruff check + ruff format --check + mypy. Whole-tree
+  checks that cannot be split by test file and cost ~1-2 min, so they run
+  **once** on the light pool rather than N times per shard. Only pytest
+  fans out.
+- **`python-unit-shard`** — the pytest sweep as a **3-way stride matrix**.
+  Each shard runs `find tests -name 'test_*.py' -not -path
+  'tests/integration/*' -not -path 'tests/migrations/*' | sort | awk 'NR %
+  3 == shard - 1'` — the sorted test-file list, every third file. The
+  stride (not contiguous blocks) spreads heavyweight suites across shards,
+  and the three residues partition the file set **exactly** (union == full,
+  pairwise disjoint). File-level sharding is strictly coarser than what
+  xdist `--dist loadscope` already does across workers (whole modules stay
+  together, conftest semantics identical to a full run), so an xdist-safe
+  suite is shard-safe — proven live by the `python-coverage` sweep, which
+  runs the identical split over a superset of these files. `fail-fast:
+  false` so one red shard does not cancel the others; each shard keeps
+  `--maxfail=1` for fast per-shard feedback. The `tests/integration` /
+  `tests/migrations` exclusions and the `MEHO_SKIP_SPEC_INGEST_TESTS` G0.7
+  canary opt-out (#2980) are preserved on **every** shard.
+- **`python-unit-lane`** — the **fan-in** carrying the exact
+  branch-protection required context `Python (ruff + mypy + pytest)`. It
+  `needs: [python-lint, python-unit-shard]` and, via `if: always() && <fork
+  guard>`, runs regardless of upstream results, then FAILS unless both are
+  `success`/`skipped`. `always()` is load-bearing: a plain `needs:` gate
+  would be *skipped* when a shard fails, and a skipped required check
+  counts as Success (#2140) — i.e. a red shard would let the PR merge. A
+  hung shard hits its own `timeout-minutes` → `cancelled` leg → aggregate
+  `cancelled`/`failure` → the gate FAILS (not open). On a fork PR the fork
+  guard skips this job (and the shards), reporting the required context as
+  Success exactly as the old single job did.
+
+Because the required context string is unchanged and stays on a job, the
+**branch-protection ruleset and merge-queue required-check list need no
+edit** — the required name simply moved from the monolithic job onto the
+fan-in (the `python-coverage-combine` technique that kept quality-gate.yml
+byte-identical). No escape-hatch label (the coverage lane's
+`ci-coverage-validate`) is needed: the coverage lane is push-only and must
+be *forced* onto a PR, whereas the unit lane runs on every PR by default,
+so a sharding PR self-validates through its own `pull_request` run.
 
 ### Runner-CPU rule
 
@@ -912,7 +973,8 @@ ingest + op_id reconciliation against the **real** Broadcom/VMware-licensed
 `vcenter.yaml` / `vi-json.yaml`, which are deliberately not in this public
 repo. `ci.yml` provisions them at runtime, gated on a secret:
 
-- Both Python test jobs (`python-lint-test`, `python-integration`) carry a
+- Both Python test jobs (`python-unit-shard` — every shard — and
+  `python-integration`) carry a
   secret-gated "Checkout vendor vCenter spec-shelf" step: a cone-mode sparse
   checkout of `docs/vcenter-9.0/` from the private
   `evoila-bosnia/claude-rdc-hetzner-dc` shelf repo into

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -421,11 +421,13 @@ comparator fires `AssertionError`. The meta-tests exist because
 as "the gate is broken" -- the meta-tests rule out the second case.
 
 **Where the gate runs.** The harness is a standard pytest file
-under `backend/tests/`, so it is picked up by the existing
-`python-lint-test` job in `.github/workflows/ci.yml`. That job
-is in the branch-protection required-status-checks set, so a
-round-trip mismatch blocks merge by configuration -- no new
-workflow step needed. Adding new fixture pairs only requires
+under `backend/tests/`, so it is picked up by the required unit
+sweep in `.github/workflows/ci.yml` — since #3251 the
+`python-unit-shard` matrix (whichever stride slice its file lands
+in), reported through the `python-unit-lane` fan-in that carries
+the branch-protection required context. That check is in the
+required-status-checks set, so a round-trip mismatch blocks merge
+by configuration -- no new workflow step needed. Adding new fixture pairs only requires
 dropping them into the fixtures directory; the harness
 auto-discovers them.
 


### PR DESCRIPTION
Closes #3251.

## What

Shards the required PR unit lane (`Python (ruff + mypy + pytest)`) using the exact stride + fan-in shape proven by #3177 (`python-coverage` / `python-coverage-combine`). The one monolithic `python-lint-test` job becomes three cooperating jobs:

| Job | Name (check context) | Required? | Pool |
|---|---|---|---|
| `python-lint` | `Python lint + typecheck (ruff + mypy)` | no | `meho-runners-ci` |
| `python-unit-shard` | `Python unit shard 1/3` … `3/3` | no | `meho-runners-ci-heavy` |
| `python-unit-lane` | **`Python (ruff + mypy + pytest)`** | **yes (fan-in)** | `meho-runners-ci` |

Each shard runs `find tests -name 'test_*.py' -not -path 'tests/integration/*' -not -path 'tests/migrations/*' | sort | awk 'NR % 3 == shard-1'` then `pytest -n 3 --dist loadscope --maxfail=1` over its slice — the identical stride mechanism #3177 used, extended only to also exclude `tests/migrations` (the pre-shard lane's second `--ignore`).

## Required-check contract path (AC item 2): **fan-in, ruleset UNTOUCHED**

I chose the **fan-in** path, not the ruleset-edit path. `python-unit-lane`'s `name:` is the exact string `Python (ruff + mypy + pytest)` already pinned in the `main` ruleset and the merge-queue required-check list, so **no operator/ruleset action is required** — the required name simply moved from the old monolithic job onto the fan-in (the `python-coverage-combine` technique). Verified: that exact name occurs exactly once in `ci.yml`, on the fan-in.

The fan-in `needs: [python-lint, python-unit-shard]` and uses `if: always() && <fork-guard>` + explicit `needs.*.result` inspection, failing on anything not `success`/`skipped`. `always()` is load-bearing: a plain `needs:` gate would be *skipped* on shard failure, and a skipped required check counts as Success (#2140) — a red shard would merge. A hung shard hits its own `timeout-minutes` → `cancelled` leg → aggregate `cancelled`/`failure` → the gate **fails, not open**.

## Lint/type not duplicated (AC item 3)

ruff + ruff format + mypy are whole-tree, unshardable by test file, and cost ~1-2 min, so they run **once** in `python-lint`. Only pytest fans out.

## Live validation (AC item 4): the PR self-validates — no escape-hatch label

The `ci-coverage-validate` label exists because the coverage lane is **push-only** and must be *forced* onto a PR. The unit lane runs on **every** PR by default, so this PR's own `pull_request` run exercises the sharded path directly — **this PR is the live validation**. Adding a label would be redundant apparatus, so none is added.

## Partition-completeness proof (adversarial hunt (a))

Ran the stride split locally over the real base (701 unit test files):

```
full=701  union=701
UNION == FULL (no file missing, no extra): PASS
duplicates across shards: 0 (DISJOINT: PASS)
every shard non-empty: PASS
--- balance ---
shard 1/3: 233 files, ~3615 test funcs
shard 2/3: 234 files, ~3561 test funcs
shard 3/3: 234 files, ~3975 test funcs
```

The awk residues {0,1,2} of `NR % 3` cover the sorted list exactly once each; belt-and-suspenders, the shard step hard-fails (`exit 1`) if it ever selects 0 files. `pytest`'s collection glob is `test_*.py` (`python_files` unoverridden) and there are 0 `*_test.py` files under `tests/`, so `find -name 'test_*.py'` captures the identical set the pre-shard `pytest tests/` collected; `addopts=["-m","not load"]` still applies to an explicit file list, so the `load` marker stays excluded exactly as before.

## Wall-time before/after (AC item 5)

- **Before:** ~19 min, serial (setup + ruff/mypy ~1-2 min + pytest ~15-18 min) — the biggest single contributor to PR wall-time.
- **After:** slowest shard ≈ ~2 min setup + ~6 min pytest (18/3) ≈ **~8 min**, three in parallel; fan-in ~1 min; `python-lint` ~4 min in parallel. Lane critical path ≈ **~8-9 min**. The pytest execution itself is cut ~3×; the lane wall improves ~2-2.4× because per-shard setup + the fan-in are fixed overhead that does not shard. Actual per-shard walls are recorded from this PR's own run.

## Preserved invariants

- `tests/integration` → `python-integration`; `tests/migrations` → `python-migration-tests` (both `--ignore`s replaced by the `find` exclusions).
- G0.7 canary opt-out `MEHO_SKIP_SPEC_INGEST_TESTS=1` (#2980) on **every** shard; the spec-shelf checkout + fail-loud verify (#2949) on every shard; `-n 3` per shard for the #1983 heartbeat/memory reasoning; coverage stays in the separate non-blocking `python-coverage` jobs (#1982/#1987/#3172).
- Per-shard perf-budget guard (`budget_s=660`, scaled from the old 1320 s whole-suite budget) preserves the #898 CI-perf-creep early-warning below the 20-min hang backstop.

## Adversarial review (all addressed)

- **(b) required-context drift** — fan-in name is the exact pinned string (unique); shards/lint get new non-required names.
- **(c) fail-open fan-in** — `always()` + `needs.*.result` check; cancelled/failed/hung shard → gate fails; fork PR → job skipped → Success (matches old job).
- **(d) setup tripling** — uv + fastembed caches share keys (warm steady-state); spaCy ~12 MB; parallel, no wall tripling.
- **(e) concurrency** — workflow-level `concurrency` group covers all jobs, so a force-push cancels the run as a set; `merge_group` never cancelled.

Validated with `actionlint` (repo config) + `shellcheck` — clean except the pre-existing `meho-runners-ci-heavy` custom-label warning (also present on the untouched `python-coverage` job).

Docs updated (`docs/codebase/devops.md` matrix + new "Sharded unit lane" section, `redaction.md`) and dangling `python-lint-test` comment refs in sibling jobs + `eval-gate.yml` fixed. CHANGELOG `### Changed` on top of `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)