### PR TITLE
ci(merge-queue): make chart.yml merge_group-compatible + document operator toggle (#3253)

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -68,6 +68,18 @@ on:
     # mirrors the same decision documented in image.yml.
     branches: [main]
     tags: ['v*']
+  # Fires when a PR enters the GitHub merge queue. Required so the
+  # `helm install + helm test (pgvector preflight)` status context — a
+  # required check in branch protection (#349) — reports against the
+  # synthesised merge commit, not just the PR head. Without this, the
+  # merge queue would hang forever on the missing required context.
+  # The `changes` job emits `chart=true` on any non-`pull_request`
+  # event, so a queue admission runs the full kind-based helm-test (same
+  # depth as a push to `main`) — validating the actual merge result.
+  # `publish` + `verify-anonymous-pull` are guarded to `push` only, so a
+  # queue entry never packages or pushes a chart to GHCR. Same rationale
+  # as ci.yml's merge_group trigger (#769).
+  merge_group:
 
 permissions:
   contents: read
@@ -80,17 +92,27 @@ permissions:
 concurrency:
   # On main/tag pushes: keep one in-flight publish per ref so a fast follow-up
   # commit cancels its predecessor. On PRs: scoped by PR ref the same way.
-  group: chart-${{ github.ref }}
-  cancel-in-progress: true
+  # The `${{ github.event_name }}` suffix keeps pull_request / push /
+  # merge_group runs in distinct cancellation domains (mirrors ci.yml,
+  # security-scan.yml, secret-scan.yml, dependency-license-check.yml).
+  #
+  # IMPORTANT: already-running merge_group jobs must NEVER be cancelled — a
+  # cancelled queue check fails the merge attempt and drops the PR out of the
+  # queue, defeating the queue's purpose (#769). cancel-in-progress is
+  # therefore scoped OFF for merge_group and stays ON for pull_request / push.
+  group: chart-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
     name: Detect chart-relevant changes
     # Gate-keeper for the required `helm-test` check (see the `on:` note above).
     # Runs on every PR; the expensive jobs read `outputs.chart` in their `if:`.
-    # On push (main / v* tags) the chart jobs always run — their `if:`
+    # On any non-`pull_request` event (push to main / v* tags, or a
+    # `merge_group` queue admission) the chart jobs always run — their `if:`
     # short-circuits on `github.event_name != 'pull_request'` before reading
-    # this output — so we just emit `true` to satisfy their `needs`.
+    # this output — so we just emit `true` to satisfy their `needs`. That
+    # makes a queue admission validate the merge result at full depth.
     permissions:
       contents: read
       pull-requests: read
@@ -1131,10 +1153,13 @@ jobs:
 
   publish:
     name: Package + push + sign chart
-    # Skip on pull_request entirely — PRs don't push. The same fork-PR guard
-    # would never fire here because the trigger above already filters PRs,
-    # but the explicit `if` makes intent visible.
-    if: github.event_name != 'pull_request'
+    # Push events only (main / v* tags). PRs don't push, and a `merge_group`
+    # queue entry must NOT package/push/sign a chart to GHCR — the merge has
+    # not happened yet and the PR may still fall out of the queue. `== 'push'`
+    # is behaviour-preserving for the pre-merge_group trigger set (where
+    # `!= 'pull_request'` meant exactly `push`) while cleanly excluding the
+    # new `merge_group` event.
+    if: github.event_name == 'push'
     needs: validate
     runs-on: meho-runners-ci
     timeout-minutes: 15
@@ -1358,7 +1383,9 @@ jobs:
     # state from the push step cannot accidentally satisfy the pull. A fresh
     # job ships a clean filesystem with no GHCR credentials anywhere — a
     # successful `helm pull` here can only mean the GHCR package is public.
-    if: github.event_name != 'pull_request'
+    # Push events only — same rationale as `publish` above: a `merge_group`
+    # queue entry never publishes, so there is nothing for it to pull.
+    if: github.event_name == 'push'
     needs: publish
     runs-on: meho-runners-ci
     timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — merge-queue readiness: every required check now reports on `merge_group` refs (#3253)
+
+- `chart.yml` — the last required-check workflow without a `merge_group`
+  trigger — now subscribes to `merge_group`, closing the gap #769 left
+  after landing the trigger in `ci.yml`, `security-scan.yml`,
+  `secret-scan.yml`, and `dependency-license-check.yml`. Its required
+  context `helm install + helm test (pgvector preflight)` (the
+  `always()` `helm-test-gate` aggregator) now reports against the
+  synthesised merge commit, so a future merge queue does not hang
+  forever on a missing required status.
+- `chart.yml` concurrency is scoped like the sibling workflows —
+  `group` suffixed with `${{ github.event_name }}` and
+  `cancel-in-progress: ${{ github.event_name != 'merge_group' }}` — so a
+  queued check is never cancelled (a cancelled queue check drops the PR
+  out of the queue). Its `publish` and `verify-anonymous-pull` jobs are
+  guarded to `push` events only, so a queue admission validates the
+  merge result at full depth without packaging or pushing a chart to
+  GHCR.
+- `docs/codebase/devops.md` merge-queue section rewritten: the full
+  required-context → workflow map (all 11 contexts across five workflows
+  plus the external DCO App), the changelog-churn / full-relap win the
+  queue buys, and the **operator** steps to enable it — enabling the
+  `merge_queue` rule on the `protect main` ruleset is an operator action;
+  no repo setting is changed by this PR. Includes the DCO-App and
+  approval-ratchet caveats to verify before enabling.
+
 ### Added — approve-only RBAC capability: decouple the approvals plane from the dispatch gate (#3243)
 
 - A principal can now be granted the ability to **decide** approvals

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -818,49 +818,127 @@ to a **fan-in** (`python-unit-lane`) over a lint job (`python-lint`) and a
 _string_ is unchanged, so branch protection / the ruleset are untouched —
 see [Sharded unit lane (#3251)](#sharded-unit-lane-3251) below.
 
-### Merge queue (#769)
+### Merge queue (#769, #3253)
 
-`ci.yml` triggers on `merge_group` in addition to `pull_request` and
-`push`. The `merge_group` event fires when a PR is admitted to the
-GitHub merge queue and runs the full check matrix against the
-**synthesised merge commit** — PR head + current `main` tip + any
-PRs ahead in the queue. A merge that would break `main` fails in the
-queue and never reaches `main`, ending the inherited-red episodes from
-2026-05-20/21 where cancelled post-merge CI allowed broken combinations
-to land silently.
+Every workflow that owns a required status check triggers on
+`merge_group` in addition to `pull_request` and `push`: `ci.yml`,
+`security-scan.yml`, `secret-scan.yml`, `dependency-license-check.yml`
+(all landed with #769) and `chart.yml` (the last gap, closed by #3253).
+The `merge_group` event fires when a PR is admitted to the GitHub merge
+queue and runs the full check matrix against the **synthesised merge
+commit** — PR head + current `main` tip + any PRs ahead in the queue. A
+merge that would break `main` fails in the queue and never reaches
+`main`, ending the inherited-red episodes from 2026-05-20/21 where
+cancelled post-merge CI allowed broken combinations to land silently.
 
-Merge-queue setup (admin action, separate from this code change):
+**Why the queue is worth enabling — two distinct wins:**
 
-1. Enable "Require merge queue" in the repository's branch-protection
-   ruleset for `main` (Settings → Rules → Branches → protect main →
-   add "Require merge queue" rule, or via
-   `gh api -X PUT repos/evoila/meho/rulesets/14556458 ...`).
-2. Configure merge-queue required checks. The full set required by
-   branch protection on `main` spans four workflows; mirror the same
-   set in the merge-queue ruleset so the queue enforces the same bar
-   against the actual merge result, not just the PR's own head:
-   - From `ci.yml`: `Python (ruff + mypy + pytest)`,
-     `Python (integration testcontainers)`,
-     `Go (golangci-lint + go test)`,
-     `Helm (lint + template + kubeconform)`.
-   - From `security-scan.yml`: `Semgrep SAST`.
-   - From `secret-scan.yml`: `TruffleHog Secret Scan`.
-   - From `dependency-license-check.yml`: `Python License Check`,
-     `NPM License Check`. Both jobs no-op via `hashFiles()` when the
-     PR doesn't touch a manifest, so they report cheap green on
-     unrelated PRs — but they MUST run on every queue admission so
-     branch protection's required-context list stays satisfiable.
-3. The `merge_group` triggers in `ci.yml`, `security-scan.yml`,
-   `secret-scan.yml`, and `dependency-license-check.yml` are the
-   code-side prerequisite for step 2 — without each sibling workflow
-   subscribing to `merge_group`, its required context would never
-   report on queue runs and the queue would hang on missing checks.
+- *Inherited-red race.* Without the queue, two independently-green PRs
+  can merge in sequence and produce a broken `main` (each was tested
+  against an older tip). The queue tests the **actual** merge result of
+  each admission, so a semantically-broken combination is caught before
+  it lands.
+- *Changelog-churn / full-relap cost.* Today every force-push to a PR —
+  including the mechanical rebases that resolve `[Unreleased]`
+  CHANGELOG-union conflicts when a sibling PR merges first — reruns the
+  **entire** check matrix on that PR. On a busy day the same PR pays for
+  many full laps it did not semantically change. The queue replaces that
+  with a single batched rebase-test-merge against the queued tip: one
+  authoritative lap per batch instead of N redundant laps per PR. This
+  is the code-side lever the lab-capacity Initiative
+  (claude-rdc-hetzner-dc#2777) leans on.
 
-Concurrency note: `cancel-in-progress` is conditional on
-`github.event_name != 'merge_group'`. A cancelled queue check causes
-the merge attempt to fail and the PR falls out of the queue — so
-merge-queue runs are never cancelled. PR force-pushes and rapid main
-commits still cancel their own prior runs as before.
+**Required-check → workflow map** (branch protection on `main`,
+`branches/main/protection.required_status_checks.contexts`, 11
+contexts). Enabling the queue means every one of these must report on
+`merge_group` refs — a required check that never reports on a queue ref
+hangs the queue forever:
+
+| Required context | Owning workflow | Reports on `merge_group`? |
+| --- | --- | --- |
+| `Python (ruff + mypy + pytest)` | `ci.yml` | yes (#769) |
+| `Python (integration testcontainers)` | `ci.yml` | yes (#769) |
+| `Python (database migrations)` | `ci.yml` | yes (#769) — `changes` job emits `true` on non-PR events |
+| `Go (golangci-lint + go test)` | `ci.yml` | yes (#769) |
+| `Helm (lint + template + kubeconform)` | `ci.yml` | yes (#769) |
+| `Semgrep SAST` | `security-scan.yml` | yes (#769) |
+| `TruffleHog Secret Scan` | `secret-scan.yml` | yes (#769) |
+| `Python License Check` | `dependency-license-check.yml` | yes — `changes` + job-level `if:` |
+| `NPM License Check` | `dependency-license-check.yml` | yes — same shape |
+| `helm install + helm test (pgvector preflight)` | `chart.yml` | **yes (#3253)** — the `helm-test-gate` aggregator (`if: always()`) is the required context and fails closed |
+| `DCO` | **external GitHub App** (`app_id 1861`), not a workflow | **operator must verify** — see caveat below |
+
+Two shapes are load-bearing for queue compatibility and appear across
+these workflows:
+
+- **No `on.*.paths` filter on a required-check workflow.** A workflow
+  skipped by a path filter leaves its required context stuck at
+  "Expected — waiting for status" and blocks the merge (the #2140
+  skipped-vs-pending trap). Instead each conditional workflow always
+  triggers, a lightweight `changes` job detects relevance, and the
+  expensive jobs are gated by a job-level `if:` — a job skipped via `if:`
+  reports **Success** and satisfies the required check. `chart.yml` adds
+  one more layer: an `always()` `helm-test-gate` aggregator carries the
+  required-context *name* and explicitly re-checks the upstream job
+  results so a skipped-because-a-dependency-failed run cannot masquerade
+  as green.
+- **Concurrency scoped so a queue run is never cancelled.** Each
+  workflow's `concurrency` group is suffixed with
+  `${{ github.event_name }}` and sets
+  `cancel-in-progress: ${{ github.event_name != 'merge_group' }}`. A
+  cancelled queue check fails the merge attempt and drops the PR out of
+  the queue, so `merge_group` runs are never cancelled; `pull_request` /
+  `push` runs still cancel their own predecessors as before.
+
+`chart.yml` additionally guards its `publish` and `verify-anonymous-pull`
+jobs to `github.event_name == 'push'` (was `!= 'pull_request'`), so a
+queue admission validates the merge result at full depth **without**
+packaging or pushing a chart to GHCR — the merge has not happened yet.
+
+**Enabling the queue is an operator action — a session never flips it.**
+Repo-settings / ruleset mutations are outside a session's remit (the
+park note on #769; restated in #3253). The code side is now complete;
+the operator performs:
+
+1. **Add a `merge_queue` rule to the `protect main` ruleset**
+   (id `14556458`). UI path: *Settings → Rules → Rulesets → protect
+   main → Add rule → Require merge queue*. API path — fetch the ruleset,
+   append the rule, and PUT it back (the endpoint replaces the whole
+   `rules` array, so a blind PUT would drop the existing
+   `pull_request` / `deletion` / `non_fast_forward` rules):
+
+   ```bash
+   gh api repos/evoila/meho/rulesets/14556458 > ruleset.json
+   # add {"type":"merge_queue","parameters":{ ...grouping/merge_method... }}
+   # to .rules, then:
+   gh api -X PUT repos/evoila/meho/rulesets/14556458 --input ruleset.json
+   ```
+
+2. **Verify the queue enforces the same 11 required contexts.** The
+   required checks currently live in *classic* branch protection
+   (`branches/main/protection`), not in the ruleset. Confirm the merge
+   queue waits on the same set against the merge ref — mirror the
+   contexts into a `required_status_checks` rule on the ruleset if the
+   queue does not pick up the classic set.
+
+3. **Verify the `DCO` context reports on `merge_group` refs before
+   enabling.** DCO is provided by an external GitHub App, not a workflow
+   in this repo — nothing in #3253 can make it report on queue refs. If
+   the DCO App does not post a status on the synthesised merge commit,
+   the required `DCO` context will hang the queue. Confirm on a canary
+   queue entry, or remove `DCO` from the queue's required set and keep it
+   as a PR-only gate, before turning the queue on for everyone.
+
+4. **DCO / `require_last_push_approval` /
+   `require_extra_approval_for_unattributed_changes` interplay.** The
+   `protect main` ruleset's `pull_request` rule has both approval
+   ratchets on. The merge queue rebases the PR onto the queued tip, which
+   can re-touch attribution; verify a queued PR still satisfies these on
+   the merge ref, or document the admin-merge fallback. (This is the
+   #769 AC item that was never closed out.)
+
+No repo setting is changed by the session that lands #3253 — only
+workflow files, this doc, and the changelog.
 
 ### Matrix
 


### PR DESCRIPTION
Closes #3253

## What

Finishes merge-queue readiness. The issue's premise ("only `ci.yml`
carries the trigger today") was **stale**: #769 actually landed the
`merge_group` trigger in four workflows (ci.yml, security-scan.yml,
secret-scan.yml, dependency-license-check.yml). Auditing the ~11
required contexts against their owning workflows found **`chart.yml` was
the sole remaining gap** — its required context `helm install + helm
test (pgvector preflight)` never triggered on `merge_group`, so a future
merge queue would hang forever on the missing status.

Note: the ~11 required contexts live in **classic branch protection**
(`branches/main/protection.required_status_checks`), *not* the `protect
main` ruleset (which holds only pull_request / deletion /
non_fast_forward).

## Per-context compatibility table

| Required context | Owning workflow | Before | After | Operator-verify caveat |
|---|---|---|---|---|
| Python (ruff + mypy + pytest) | ci.yml | reports (#769) | reports | — |
| Python (integration testcontainers) | ci.yml | reports (#769) | reports | — |
| Python (database migrations) | ci.yml | reports (#769) | reports | — |
| Go (golangci-lint + go test) | ci.yml | reports (#769) | reports | — |
| Helm (lint + template + kubeconform) | ci.yml | reports (#769) | reports | — |
| Semgrep SAST | security-scan.yml | reports (#769) | reports | — |
| TruffleHog Secret Scan | secret-scan.yml | reports (#769) | reports | — |
| Python License Check | dependency-license-check.yml | reports (#769) | reports | — |
| NPM License Check | dependency-license-check.yml | reports (#769) | reports | — |
| **helm install + helm test (pgvector preflight)** | **chart.yml** | **HANGS (no merge_group)** | **reports (#3253)** | — |
| **DCO** | **external GitHub App (`app_id 1861`)** | unknown on queue refs | **unchanged — not fixable in a workflow** | **Operator must verify the DCO App posts a status on `merge_group` refs before enabling — else the queue hangs. Confirm on a canary queue entry, or drop DCO from the queue's required set and keep it PR-only.** |

## Changes (`chart.yml`)

- Added the `merge_group:` trigger.
- Scoped concurrency to the #769 pattern: `group` suffixed with
  `${{ github.event_name }}`, `cancel-in-progress:
  ${{ github.event_name != 'merge_group' }}` (was unconditional `true`)
  — a queued check is never cancelled.
- Guarded `publish` + `verify-anonymous-pull` to
  `github.event_name == 'push'` (was `!= 'pull_request'`), so a queue
  admission validates the merge result at full depth **without**
  packaging/pushing a chart to GHCR. The required-context gate
  (`helm-test-gate`, `if: always()`) is unaffected and reports correctly.

## Docs

Rewrote the `docs/codebase/devops.md` "Merge queue" section (the old
copy was factually incomplete — claimed "four workflows"/8 contexts).
Now carries the full 11-context → workflow map, the changelog-churn /
full-relap win the queue buys, the two load-bearing shapes (no
`on.*.paths` on a required workflow; scoped concurrency), and the
**operator** enable steps (exact `gh api` fetch-modify-PUT on ruleset
`14556458` + UI path), with the DCO-App and
`require_last_push_approval` / `require_extra_approval_for_unattributed_changes`
approval-ratchet caveats to verify first. **No repo setting is changed
by this PR** — enabling the `merge_queue` rule is an operator action.

## Adversarial review — verdict: APPROVE

- **queue-hang:** all 10 workflow-owned contexts report on `merge_group`;
  DCO (external App) is the only unfixable-in-workflow context, listed
  with explicit remediation.
- **double-run:** pull_request vs merge_group run on distinct SHAs/refs;
  event-suffixed concurrency key prevents cross-cancellation; no GHCR
  publish on queue entries.
- **#2140 skipped-vs-pending:** chart.yml uses changes-job + job-level
  `if:` + `always()` gate (no `on.paths`); all sibling required
  workflows verified to use the same clean-skip shape.
- **docs accuracy:** verified against the live ruleset, classic
  protection, `app_id 1861`, and #769 provenance.

ci.yml was not touched (the #3251 unit-lane shard owns it); confirmed the
restructured `python-unit-lane` fan-in still carries the exact required
context and reports on `merge_group`, so the doc rows stay accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)