### PR TITLE
feat(connectors): winsrv — Windows Server core typed connector (PowerShell 5.1 over SSH) (#3261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — `winsrv` connector: Windows Server core over PowerShell-5.1-over-SSH (#3261 / #3271)
+
+- **`winsrv` connector** — typed connector for Windows Server core management
+  over SSH → PowerShell 5.1, on the shared `_shared/pwsh` transport (#3260) +
+  `SshConnector` base, registered as `("winsrv", "2022.x", "winsrv-ssh")` (+
+  wildcard). 23 ops across six groups — `system` (about / os-info / uptime /
+  pending-reboot), `services` (list / get / start / stop / restart), `features`
+  (list / install / remove — the c1sql1 `Install-WindowsFeature` path), `power`
+  (reboot / shutdown), `localusers` (list / create / set / delete), `storage`
+  (disk / volume / iSCSI-target list, iSCSI connect, raw-disk format).
+- Safety tiers per the Initiative #3259 satellite table: reads `safe`;
+  recoverable writes `caution`; `power.reboot` / `power.shutdown` /
+  `localuser.delete` are `dangerous` + `requires_approval` (the rke2
+  approval-parked-write mold, satellite-excluded by the tier ladder). Secret
+  hygiene: no credential rides the `-EncodedCommand` argv — `localuser.create`
+  is passwordless and `iscsi.connect` has no CHAP (both deferred to a
+  Vault-brokered flow); every operator string is escaped via `ps_single_quote`.
+- The new `winsrv` product token extends the OpenAPI `TargetCreate.product`
+  enum, so the CLI snapshot (`cli/api/openapi.json` + generated client) is
+  regenerated. `winsrv` is the estate mold for the incoming `msad` / `wsfc` /
+  `hyperv` connectors. Live c1sql1 consumer proof is deferred (lab VMs not yet
+  built); scripted-transport unit suite + injection-safety + secret-leak guard
+  are the deliverable, consistent with recent connector tasks.
+
 ### Added — typed HttpNfcLease OVF import: `vm.import_from_library` (#3229)
 
 - The durable, transfer-window-decoupled sibling of `vm.deploy_from_library`.

--- a/backend/src/meho_backplane/connectors/winsrv/__init__.py
+++ b/backend/src/meho_backplane/connectors/winsrv/__init__.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.winsrv -- WinsrvConnector package.
+
+Importing the package registers :class:`WinsrvConnector` against the v2
+connector registry under the natural key
+``(product="winsrv", version="2022.x", impl_id="winsrv-ssh")``, and queues
+the connector's typed-op upserts onto the lifespan-driven registrar list so
+``endpoint_descriptor`` rows land before the first dispatch. The package is
+discovered automatically by
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` (which
+imports every ``connectors/<product>/`` subpackage in name-sorted order) --
+there is no central connector list to edit; self-registration at import time
+is the whole wiring.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.windows_dns.__init__` and
+:mod:`meho_backplane.connectors.rke2.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` inside
+  this module, so a probe firing during startup sees a fully-populated
+  registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_winsrv_typed_operations`, which delegates to
+  :meth:`WinsrvConnector.register_operations`.
+
+The ``(product, version, impl_id)`` triple is chosen so
+``connector_id="winsrv-ssh-2022.x"`` round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` (``product`` =
+the first hyphen-segment of ``impl_id`` = ``"winsrv"``); a hyphen/underscore
+in the product token would break that round-trip and the registry's
+``_assert_product_impl_id_round_trips`` guard would crash
+``_eager_import_connectors`` at boot.
+
+Like windows_dns / rke2, this connector has no v1 chassis history, so the v1
+``register_connector`` write is intentionally omitted -- only the v2 triple
+advertises this class.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+from meho_backplane.connectors.winsrv.ops import WINSRV_OPS, WinsrvOp
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_winsrv_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``WinsrvConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level ``async def
+    register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via
+    :func:`register_typed_op_registrar`. The ``embedding_service``
+    keyword-only parameter mirrors the windows_dns / rke2 sibling contract --
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` to every registrar, so each registrar **must**
+    accept the kwarg or the lifespan crashes with :class:`TypeError`. The
+    wrapper accepts-and-discards it because
+    :meth:`WinsrvConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await WinsrvConnector.register_operations()
+
+
+__all__ = [
+    "WINSRV_OPS",
+    "WinsrvConnector",
+    "WinsrvOp",
+    "register_winsrv_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key.
+register_connector_v2(
+    product="winsrv",
+    version="2022.x",
+    impl_id="winsrv-ssh",
+    cls=WinsrvConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1). Mirrors the
+# windows_dns / rke2 wildcard rows.
+register_connector_v2(
+    product="winsrv",
+    version="",
+    impl_id="",
+    cls=WinsrvConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_winsrv_typed_operations)

--- a/backend/src/meho_backplane/connectors/winsrv/connector.py
+++ b/backend/src/meho_backplane/connectors/winsrv/connector.py
@@ -1,0 +1,599 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""WinsrvConnector -- typed SSH-transport connector for Windows Server core.
+
+Manages Windows Server hosts (system facts, services, roles/features, reboot,
+local users, disk / iSCSI storage) over SSH → PowerShell: the Windows host
+runs an OpenSSH server whose shell drives ``powershell`` (Windows PowerShell
+5.1) executing the built-in management cmdlets. The connector is a structural
+sibling of
+:class:`~meho_backplane.connectors.windows_dns.connector.WindowsDnsConnector`
+(same ``SshConnector`` base + shared PowerShell-over-SSH transport
+:mod:`~meho_backplane.connectors._shared.pwsh`) and adopts the
+:mod:`~meho_backplane.connectors.rke2.ops_write` approval-parked-write mold
+for its destructive ops. It is the *estate mold*: msad / wsfc / hyperv (the
+rest of Initiative #3259) are structured copies of this package with
+different cmdlet modules.
+
+This module ships :class:`WinsrvConnector` (registry-v2 triple ``("winsrv",
+"2022.x", "winsrv-ssh")``): :meth:`fingerprint` (one round-trip reading the
+hostname + ``Win32_OperatingSystem`` CIM instance → ``vendor="microsoft"`` /
+``product="windows-server"``), :meth:`probe` (five distinct
+``ProbeResult.reason`` values), :meth:`about` (the ``winsrv.about`` op), the
+bound-method op shims for the six groups, and the operator-less
+:meth:`execute` dispatcher shim (same shape as windows_dns / rke2).
+
+Building the next estate connector: the shared transport's
+``POWERSHELL_EXECUTABLE`` fallback is ``pwsh`` (PS7), which a Windows Server
+host does NOT ship. This connector sets ``POWERSHELL_EXECUTABLE =
+"powershell"`` explicitly, and msad / wsfc / hyperv MUST do the same (see
+``docs/codebase/connectors-winsrv.md`` -- "building the next estate
+connector"). Auth uses the base ``SshConnector._auth_config`` unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.winsrv.ops import WINSRV_OPS, WINSRV_WHEN_TO_USE_BY_GROUP
+
+__all__ = ["WinsrvConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- mirrors the placeholder in the SSH adapter and the
+# windows_dns / rke2 siblings.
+type Target = Any
+
+
+#: The fingerprint / about script -- hostname + Win32_OperatingSystem CIM
+#: fields + PowerShell version in one round-trip. No operator input is
+#: interpolated (constant script), so the identity path has no injection
+#: surface.
+_FINGERPRINT_SCRIPT: str = (
+    "$os = Get-CimInstance -ClassName Win32_OperatingSystem; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "Hostname = [System.Net.Dns]::GetHostName(); "
+    "Caption = $os.Caption; "
+    "Version = $os.Version; "
+    "BuildNumber = $os.BuildNumber; "
+    "PowerShellVersion = $PSVersionTable.PSVersion.ToString() }"
+)
+
+#: The probe reachability script -- a minimal CIM-OS presence check that
+#: always emits JSON.
+_PROBE_SCRIPT: str = (
+    "ConvertTo-Json -Compress -InputObject @{ present = [bool]("
+    "Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction SilentlyContinue) }"
+)
+
+
+class WinsrvConnector(SshConnector):
+    """Windows Server core connector built on the :class:`SshConnector` adapter.
+
+    Registry v2 triple: ``("winsrv", "2022.x", "winsrv-ssh")``.
+
+    * ``product="winsrv"`` -- a short, separator-free product token (the repo
+      convention: ``parse_connector_id`` derives the product from the first
+      hyphen-segment of ``impl_id``, so ``connector_id="winsrv-ssh-2022.x"``
+      round-trips; a hyphen/underscore in the token breaks the registry's
+      round-trip guard at boot).
+    * ``version="2022.x"`` -- the cmdlet surface targets Windows Server 2022
+      (stable across 2019 → 2025). A future release-specific impl can register
+      alongside.
+    * ``impl_id="winsrv-ssh"`` -- leaves room for a future ``winsrv-winrm``
+      sibling once a non-SSH control surface lands.
+
+    **Auth: password-default + key-fallback.** Inherits the base
+    :class:`SshConnector` ``_auth_config`` unchanged.
+
+    **Transport: PowerShell-over-SSH.** Cmdlets reach the host through
+    ``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1 --
+    see :attr:`POWERSHELL_EXECUTABLE`) routed by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`; output is parsed
+    via stdlib :mod:`json` from the cmdlet's ``ConvertTo-Json`` pipe.
+    """
+
+    product = "winsrv"
+    version = "2022.x"
+    impl_id = "winsrv-ssh"
+
+    #: The PowerShell executable the shared ``_shared.pwsh`` transport invokes.
+    #: ``powershell`` (Windows PowerShell 5.1) -- NOT ``pwsh`` (PS7), which is
+    #: absent by default on a Windows Server host. Set explicitly because the
+    #: shared transport's fallback is ``pwsh``; the estate connectors (msad /
+    #: wsfc / hyperv) MUST set this too (see the connector doc).
+    POWERSHELL_EXECUTABLE = "powershell"
+
+    #: Prepended to every script so the ServerManager / CIM modules' first-use
+    #: progress stream does not CLIXML-serialise onto the remote streams (the
+    #: windows_dns guard; the transport's ``strip_clixml`` net is a backstop).
+    POWERSHELL_SCRIPT_PREFIX = "$ProgressPreference = 'SilentlyContinue'; "
+
+    #: The structured-log event name the shared transport emits per run, kept
+    #: connector-scoped so log queries stay per-connector.
+    POWERSHELL_LOG_EVENT = "winsrv_pwsh_executed"
+
+    async def fingerprint(
+        self,
+        target: Target,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Read hostname + Win32_OperatingSystem -- the canonical fingerprint.
+
+        Runs :data:`_FINGERPRINT_SCRIPT` (one round-trip) and parses the JSON
+        object. Unreachable / SSH-failed / cmdlet-failed → ``reachable=False``
+        + ``extras["error"]`` (the #986 discipline: an unresolvable credential
+        is an unreachable target, not an unhandled exception). ``operator`` is
+        threaded to the SSH adapter for the Vault read on a pool miss; ``None``
+        fails closed.
+        """
+        probed_at = datetime.now(UTC)
+        method = "ssh: powershell Get-CimInstance Win32_OperatingSystem"
+        try:
+            payload = await pwsh_run(self, target, _FINGERPRINT_SCRIPT, operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            CredentialsReadError,
+            PwshRunError,
+        ) as exc:
+            _log.warning(
+                "winsrv_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="microsoft",
+                product="windows-server",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=method,
+                extras={"error": str(exc)},
+            )
+
+        data = payload if isinstance(payload, dict) else {}
+        return FingerprintResult(
+            vendor="microsoft",
+            product="windows-server",
+            version=_as_str(data.get("Version")),
+            build=_as_str(data.get("BuildNumber")),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=method,
+            extras={
+                "hostname": _as_str(data.get("Hostname")),
+                "os_caption": _as_str(data.get("Caption")),
+                "powershell_version": _as_str(data.get("PowerShellVersion")),
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + PowerShell + CIM-OS readability check.
+
+        Failure modes (each surfaces a distinct ``reason``):
+
+        * ``tcp_unreachable`` -- the SSH TCP socket cannot connect.
+        * ``ssh_auth_failed`` -- credentials rejected, the handshake failed,
+          or the Vault credential could not be resolved.
+        * ``powershell_unavailable`` -- SSH succeeded but the reachability
+          script failed (``powershell`` not on the shell, or a pwsh error).
+        * ``command_failed`` -- a post-connect transport failure (connection
+          drop / timeout / socket error) after a successful handshake (the
+          #986 post-connect guard).
+        * ``os_query_failed`` -- PowerShell runs but ``Win32_OperatingSystem``
+          is not readable (not a healthy Windows host, or WMI/CIM broken).
+
+        The probe does not mutate state -- ``Get-CimInstance`` is read-only.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(ok=ok, reason=reason, latency_ms=latency_ms, probed_at=probed_at)
+
+        # Order matters: PermissionDenied (subclass of DisconnectError) before
+        # DisconnectError; OSError is the TCP-level failure.
+        try:
+            await self._connect(target)
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, CredentialsReadError):
+            return _result(False, "ssh_auth_failed")
+
+        try:
+            payload = await pwsh_run(self, target, _PROBE_SCRIPT)
+        except PwshRunError:
+            return _result(False, "powershell_unavailable")
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
+
+        present = payload.get("present") if isinstance(payload, dict) else None
+        if present is not True:
+            return _result(False, "os_query_failed")
+
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Return the Windows Server host's identity snapshot.
+
+        Op-id: ``winsrv.about``. Reuses :meth:`fingerprint` so the
+        operator-facing op and the canonical fingerprint share one round-trip.
+        ``_assert_reachable`` re-raises an unreachable fingerprint as a
+        :exc:`~meho_backplane.connectors.adapters.ssh.ConnectorUnreachableError`
+        so the dispatcher reports a non-ok op rather than empty identity
+        fields (#986).
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target, operator)
+        self._assert_reachable(result)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "build": result.build,
+            "hostname": result.extras.get("hostname"),
+            "os_caption": result.extras.get("os_caption"),
+            "powershell_version": result.extras.get("powershell_version"),
+        }
+
+    # -- system group shims -------------------------------------------------
+
+    async def winsrv_os_info(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.system.os-info``."""
+        from meho_backplane.connectors.winsrv.ops_system import winsrv_os_info as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_uptime(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.system.uptime``."""
+        from meho_backplane.connectors.winsrv.ops_system import winsrv_uptime as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_pending_reboot(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.system.pending-reboot``."""
+        from meho_backplane.connectors.winsrv.ops_system import winsrv_pending_reboot as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- services group shims ----------------------------------------------
+
+    async def winsrv_service_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.service.list``."""
+        from meho_backplane.connectors.winsrv.ops_services import winsrv_service_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_service_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.service.get``."""
+        from meho_backplane.connectors.winsrv.ops_services import winsrv_service_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_service_start(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.service.start`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_services import winsrv_service_start as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_service_stop(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.service.stop`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_services import winsrv_service_stop as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_service_restart(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.service.restart`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_services import winsrv_service_restart as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- features group shims ----------------------------------------------
+
+    async def winsrv_feature_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.feature.list``."""
+        from meho_backplane.connectors.winsrv.ops_features import winsrv_feature_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_feature_install(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.feature.install`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_features import winsrv_feature_install as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_feature_remove(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.feature.remove`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_features import winsrv_feature_remove as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- power group shims (dangerous + requires_approval) -----------------
+
+    async def winsrv_power_reboot(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.power.reboot`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.winsrv.ops_power import winsrv_power_reboot as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_power_shutdown(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.power.shutdown`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.winsrv.ops_power import winsrv_power_shutdown as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- localusers group shims --------------------------------------------
+
+    async def winsrv_localuser_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.localuser.list``."""
+        from meho_backplane.connectors.winsrv.ops_localusers import winsrv_localuser_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_localuser_create(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.localuser.create`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_localusers import winsrv_localuser_create as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_localuser_set(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.localuser.set`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_localusers import winsrv_localuser_set as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_localuser_delete(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.localuser.delete`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.winsrv.ops_localusers import winsrv_localuser_delete as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- storage group shims -----------------------------------------------
+
+    async def winsrv_disk_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.storage.disk.list``."""
+        from meho_backplane.connectors.winsrv.ops_storage import winsrv_disk_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_volume_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.storage.volume.list``."""
+        from meho_backplane.connectors.winsrv.ops_storage import winsrv_volume_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_iscsi_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.storage.iscsi.list``."""
+        from meho_backplane.connectors.winsrv.ops_storage import winsrv_iscsi_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_iscsi_connect(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.storage.iscsi.connect`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_storage import winsrv_iscsi_connect as _h
+
+        return await _h(self, target, params, operator)
+
+    async def winsrv_disk_format(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``winsrv.storage.disk.format`` (caution)."""
+        from meho_backplane.connectors.winsrv.ops_storage import winsrv_disk_format as _h
+
+        return await _h(self, target, params, operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`WINSRV_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.winsrv.ops.WINSRV_OPS` and routes
+        each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+        Idempotent across pod restarts -- mirrors the windows_dns / rke2 shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in WINSRV_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"WinsrvConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = WINSRV_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"WinsrvConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"WINSRV_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.winsrv.ops."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "winsrv_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`WindowsDnsConnector.execute`. Operator-less (no policy
+        gate, no audit row, no broadcast); the operator-aware surface is
+        ``POST /api/v1/operations/call`` via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )
+
+
+def _as_str(value: Any) -> str | None:
+    """Return *value* when it is a non-empty ``str``, else ``None`` (guards the
+    fingerprint projection: ``ConvertTo-Json`` can render an absent CIM field
+    as ``null``, and :class:`FingerprintResult` fields are typed ``str | None``)."""
+    return value if isinstance(value, str) and value else None

--- a/backend/src/meho_backplane/connectors/winsrv/ops.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`WinsrvConnector`.
+
+The connector manages **Windows Server core** — system facts, service and
+feature management, reboot/shutdown, local users, and disk / iSCSI-initiator
+storage — over SSH → PowerShell (``powershell`` running Windows PowerShell
+5.1 cmdlets), routed through
+:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` (the shared
+PowerShell-over-SSH transport hoisted by #3260). Structurally it mirrors the
+windows_dns connector (identity canary + per-domain op groups on the
+``SshConnector`` base) and adopts the rke2 approval-parked-write mold for
+its destructive ops.
+
+Op surface (23 ops across six groups; safety tier per the Initiative #3259
+satellite table — reads ``safe``, recoverable writes ``caution``,
+destructive ``dangerous`` + ``requires_approval``):
+
+* ``winsrv.about``               [safe]      identity canary (CIM OS + PS version).
+* ``winsrv.system.os-info``      [safe]      Get-CimInstance Win32_OperatingSystem.
+* ``winsrv.system.uptime``       [safe]      LastBootUpTime → uptime.
+* ``winsrv.system.pending-reboot`` [safe]    pending-reboot registry markers.
+* ``winsrv.service.list``        [safe]      Get-Service (list-shaped → JSONFlux).
+* ``winsrv.service.get``         [safe]      Get-Service -Name.
+* ``winsrv.service.start``       [caution]   Start-Service.
+* ``winsrv.service.stop``        [caution]   Stop-Service.
+* ``winsrv.service.restart``     [caution]   Restart-Service.
+* ``winsrv.feature.list``        [safe]      Get-WindowsFeature (list-shaped → JSONFlux).
+* ``winsrv.feature.install``     [caution]   Install-WindowsFeature.
+* ``winsrv.feature.remove``      [caution]   Uninstall-WindowsFeature.
+* ``winsrv.power.reboot``        [dangerous+approval]  Restart-Computer -Force.
+* ``winsrv.power.shutdown``      [dangerous+approval]  Stop-Computer -Force.
+* ``winsrv.localuser.list``      [safe]      Get-LocalUser (list-shaped → JSONFlux).
+* ``winsrv.localuser.create``    [caution]   New-LocalUser -NoPassword.
+* ``winsrv.localuser.set``       [caution]   Set-LocalUser / Enable-/Disable-LocalUser.
+* ``winsrv.localuser.delete``    [dangerous+approval]  Remove-LocalUser.
+* ``winsrv.storage.disk.list``   [safe]      Get-Disk (list-shaped → JSONFlux).
+* ``winsrv.storage.volume.list`` [safe]      Get-Volume (list-shaped → JSONFlux).
+* ``winsrv.storage.iscsi.list``  [safe]      Get-IscsiTarget (list-shaped → JSONFlux).
+* ``winsrv.storage.iscsi.connect`` [caution] Connect-IscsiTarget.
+* ``winsrv.storage.disk.format`` [caution]   Initialize-Disk + New-Partition + Format-Volume.
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.windows_dns.ops` and
+:mod:`~meho_backplane.connectors.rke2.ops` so the registration walk reads
+identically across SSH-transport connectors. The composition pattern
+(``_winsrv_ops()`` importing per-domain op tuples) mirrors windows_dns's
+``ops.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = [
+    "SSH_TRANSPORT_NOTE",
+    "WINSRV_OPS",
+    "WINSRV_WHEN_TO_USE_BY_GROUP",
+    "WinsrvOp",
+    "normalise_json_rows",
+]
+
+
+#: Curated ``when_to_use`` strings per group key, consumed by
+#: :meth:`WinsrvConnector.register_operations` (imported into the connector,
+#: the rke2 ``RKE2_WHEN_TO_USE_WRITE_BY_GROUP`` precedent — the blurbs live
+#: with the op metadata, not the transport class). Each entry covers a
+#: ``group_key`` declared across the winsrv op tuples; the registration walk
+#: fails closed with a :class:`ValueError` if a ``group_key`` lacks a curated
+#: entry (the windows_dns / rke2 precedent).
+WINSRV_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "system": (
+        "Use for Windows Server host facts before any higher-level drill-in: "
+        "identity (``winsrv.about``), the full CIM OS projection "
+        "(``winsrv.system.os-info``), uptime (``winsrv.system.uptime``), and "
+        "whether a reboot is pending (``winsrv.system.pending-reboot``). All "
+        "read-only. Call ``winsrv.about`` first to confirm the host is "
+        "reachable over SSH + PowerShell; check ``pending-reboot`` before a "
+        "feature install or a governed reboot."
+    ),
+    "services": (
+        "Use to inventory and control Windows services: list all "
+        "(``winsrv.service.list``) or read one (``winsrv.service.get``) -- "
+        "both read-only -- and start / stop / restart a named service "
+        "(``caution``). The right group to check or bounce a service (e.g. "
+        "``MSSQLSERVER``) around a config change."
+    ),
+    "features": (
+        "Use to inventory and manage Windows roles/features: list "
+        "(``winsrv.feature.list``, read-only) and install / remove "
+        "(``caution``) via the ServerManager cmdlets. This is the c1sql1 "
+        "Failover-Clustering install path. Install/remove never auto-restart "
+        "-- check ``restart_needed`` and use the approval-gated "
+        "``winsrv.power.reboot``."
+    ),
+    "power": (
+        "Use to reboot or shut down a Windows Server host. BOTH ops are "
+        "``dangerous`` + ``requires_approval`` -- a dispatch parks for a "
+        "human decision before anything happens, and the tier ladder "
+        "excludes them from satellite runners (central-dial / on-site only). "
+        "Reboot lands a pending feature-install reboot; shutdown leaves the "
+        "host off until powered back on out of band."
+    ),
+    "localusers": (
+        "Use to inventory and manage local user accounts: list "
+        "(``winsrv.localuser.list``, read-only, no password material), create "
+        "/ set attributes (``caution`` -- passwordless; a plaintext password "
+        "cannot ride the pwsh transport), and delete (``dangerous`` + "
+        "``requires_approval`` -- irreversible removal parks for approval)."
+    ),
+    "storage": (
+        "Use to inventory and provision storage: list disks / volumes / iSCSI "
+        "targets (read-only), connect an iSCSI target, and format a raw disk "
+        "into a volume (both ``caution``). This is the SQL-FCI shared-disk "
+        "path: ``iscsi.connect`` then ``disk.format`` (which refuses a "
+        "non-RAW disk unless force=true). No CHAP in this cut."
+    ),
+}
+
+
+#: Canonical SSH-only / pwsh transport reminder copied into every op's
+#: ``llm_instructions``. Mirrors windows_dns's ``SSH_TRANSPORT_NOTE`` — the
+#: agent-facing descriptions must call out the PowerShell-over-SSH transport
+#: so an LLM doesn't compose against a non-existent REST surface (Windows
+#: Server core management has no unified REST API).
+SSH_TRANSPORT_NOTE: str = (
+    "Windows Server core management has no unified REST API; the underlying "
+    "transport is PowerShell-over-SSH (powershell -EncodedCommand routed "
+    "through asyncssh) driving Windows PowerShell 5.1 cmdlets."
+)
+
+
+@dataclass(frozen=True)
+class WinsrvOp:
+    """Metadata for one winsrv op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can
+    splat the dataclass into the helper without per-op boilerplate.
+    ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.winsrv.connector.WinsrvConnector`
+    that exposes the async handler; the connector resolves the bound method
+    against itself at registration time so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+    recovers the callable from the persisted ``module.ClassName.method``
+    dotted path.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def normalise_json_rows(payload: Any) -> list[dict[str, Any]]:
+    """Normalise a ``ConvertTo-Json`` payload into a list of row dicts.
+
+    PowerShell's ``ConvertTo-Json`` renders a **single**-element result as a
+    flat object and a **multi**-element result as a JSON array; a
+    zero-element result renders as ``null`` (an empty stdout is caught
+    upstream by :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`
+    before it reaches here). This helper collapses all three shapes to a
+    ``list[dict]`` so the list handlers walk a uniform structure — the
+    windows_dns ``normalise_json_rows`` shape, shared across every
+    winsrv list op so the ``{rows, total}`` envelope the JSONFlux reducer
+    keys on is built identically.
+    """
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    return []
+
+
+#: The identity canary op. ``winsrv.about`` is the operator-facing wrapper
+#: around :meth:`WinsrvConnector.fingerprint` — same vendor / product /
+#: version / host payload, surfaced through the typed-op dispatcher so
+#: callers see the standard :class:`OperationResult` envelope instead of the
+#: raw :class:`FingerprintResult`. Mirrors windows_dns's ``windns.about``.
+_WINSRV_ABOUT_OP = WinsrvOp(
+    op_id="winsrv.about",
+    handler_attr="about",
+    summary="Return the Windows Server host's OS caption/version/build + PowerShell version.",
+    description=(
+        "Connects to the Windows Server host over SSH and runs a single "
+        "``powershell -EncodedCommand`` script that reads the machine "
+        "hostname, the ``Win32_OperatingSystem`` CIM instance (caption / "
+        "version / build), and the Windows PowerShell version. Returns a "
+        "flat dict with the vendor (``microsoft``), product "
+        "(``windows-server``), the OS version + build, and the host name. "
+        "Use to confirm the host is reachable over SSH + PowerShell and to "
+        "read its OS identity before issuing higher-level system / service "
+        "/ feature ops; no params; safe on any healthy target."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "build": {"type": ["string", "null"]},
+            "hostname": {"type": ["string", "null"]},
+            "os_caption": {"type": ["string", "null"]},
+            "powershell_version": {"type": ["string", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="system",
+    tags=("read-only", "identity", "windows-server"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the Windows Server "
+            "host behind a target — its OS caption / version / build — or "
+            "to confirm the host is reachable via SSH + PowerShell before "
+            "issuing higher-level system / service / feature ops. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``version`` carries the OS version (e.g. "
+            "``10.0.20348``), ``build`` the build number (e.g. ``20348``), "
+            "``os_caption`` the friendly caption (e.g. ``Microsoft Windows "
+            "Server 2022 Datacenter``), ``hostname`` the machine name."
+        ),
+    },
+)
+
+
+def _winsrv_ops() -> tuple[WinsrvOp, ...]:
+    """Return the merged registration tuple.
+
+    Composition: ``winsrv.about`` (identity canary) + the per-domain op
+    tuples (system / services / features / power / localusers / storage).
+    Implemented as a function call rather than a literal-and-splat at module
+    level so the import order stays linear: ``ops.py`` defines
+    :class:`WinsrvOp` + ``_WINSRV_ABOUT_OP`` + :func:`normalise_json_rows`,
+    then imports the per-domain op tuples from their modules (each of which
+    only depends on this module plus its own helpers). Mirrors
+    :func:`meho_backplane.connectors.windows_dns.ops._windows_dns_ops`.
+    """
+    from meho_backplane.connectors.winsrv.ops_features import FEATURE_OPS
+    from meho_backplane.connectors.winsrv.ops_localusers import LOCALUSER_OPS
+    from meho_backplane.connectors.winsrv.ops_power import POWER_OPS
+    from meho_backplane.connectors.winsrv.ops_services import SERVICE_OPS
+    from meho_backplane.connectors.winsrv.ops_storage import STORAGE_OPS
+    from meho_backplane.connectors.winsrv.ops_system import SYSTEM_OPS
+
+    return (
+        _WINSRV_ABOUT_OP,
+        *SYSTEM_OPS,
+        *SERVICE_OPS,
+        *FEATURE_OPS,
+        *POWER_OPS,
+        *LOCALUSER_OPS,
+        *STORAGE_OPS,
+    )
+
+
+#: The ops :class:`WinsrvConnector` registers at lifespan startup. The shape
+#: of each follow-on op is "import a new module-level tuple and splat it into
+#: :data:`WINSRV_OPS` via :func:`_winsrv_ops`" — the registration walk in
+#: :meth:`WinsrvConnector.register_operations` does not change.
+WINSRV_OPS: tuple[WinsrvOp, ...] = _winsrv_ops()

--- a/backend/src/meho_backplane/connectors/winsrv/ops_features.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_features.py
@@ -135,12 +135,12 @@ async def winsrv_feature_remove(
     reboot to the approval-gated ``winsrv.power.reboot``.
     """
     name: str = params["name"]
-    sub_features = _ps_bool(params.get("include_all_sub_feature"))
+    mgmt_tools = _ps_bool(params.get("include_management_tools"))
     quoted = ps_single_quote(name)
     script = (
         "$ErrorActionPreference = 'Stop'; "
         f"$r = Uninstall-WindowsFeature -Name {quoted} "
-        f"-IncludeManagementTools:{sub_features}; "
+        f"-IncludeManagementTools:{mgmt_tools}; "
         "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
         "ok = [bool]$r.Success; success = [bool]$r.Success; "
         "exit_code = $r.ExitCode.ToString(); "
@@ -301,7 +301,7 @@ FEATURE_OPS: tuple[WinsrvOp, ...] = (
             "type": "object",
             "properties": {
                 "name": _FEATURE_NAME_PROP,
-                "include_all_sub_feature": {
+                "include_management_tools": {
                     "type": "boolean",
                     "description": (
                         "Also remove the feature's management tools "
@@ -325,7 +325,7 @@ FEATURE_OPS: tuple[WinsrvOp, ...] = (
             ),
             "parameter_hints": {
                 "name": "Required. The feature short name.",
-                "include_all_sub_feature": "Optional bool; default false.",
+                "include_management_tools": "Optional bool; default false.",
             },
             "output_shape": (
                 "{'name', 'action': 'remove', 'success', 'exit_code', "

--- a/backend/src/meho_backplane/connectors/winsrv/ops_features.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_features.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv feature ops — ``list`` (safe) + ``install`` / ``remove`` (caution).
+
+The Windows Server role/feature surface is driven by the ``ServerManager``
+module (``Get-WindowsFeature`` / ``Install-WindowsFeature`` /
+``Uninstall-WindowsFeature``) over the shared PowerShell-over-SSH transport.
+This is the c1sql1 ``Install-WindowsFeature`` path
+(evoila-bosnia/claude-rdc-hetzner-dc#2789) — the Failover-Clustering role
+install that today rides ungoverned ``govc guest.run``.
+
+``install`` / ``remove`` are ``caution`` (recoverable — a removed feature can
+be reinstalled). They deliberately **never** pass ``-Restart``: a reboot is a
+``dangerous`` + ``requires_approval`` action, so the handlers return
+``restart_needed`` and leave the reboot to the approval-gated
+``winsrv.power.reboot`` op. Batch feature changes, then take one governed
+reboot.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied feature ``name`` is interpolated only inside a
+single-quoted PowerShell literal via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`. The boolean
+toggles are rendered as PowerShell ``$true`` / ``$false`` literals after
+Python-side validation, never as interpolated operator text.
+
+References
+----------
+
+* ``Get-WindowsFeature`` / ``Install-WindowsFeature`` /
+  ``Uninstall-WindowsFeature`` (ServerManager, Windows Server 2022):
+  https://learn.microsoft.com/en-us/powershell/module/servermanager/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "FEATURE_OPS",
+    "winsrv_feature_install",
+    "winsrv_feature_list",
+    "winsrv_feature_remove",
+]
+
+_FEATURE_SELECT: str = "Name, DisplayName, InstallState, Installed"
+
+
+def _ps_bool(value: Any) -> str:
+    """Render *value* as a PowerShell ``$true`` / ``$false`` literal.
+
+    ``value`` is a JSON-schema-validated boolean (or absent → treated as
+    ``False``). Rendering to a fixed literal — never the interpolated
+    operator text — keeps the toggle off the injection surface entirely.
+    """
+    return "$true" if value is True else "$false"
+
+
+async def winsrv_feature_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.feature.list`` — every role/feature (list-shaped).
+
+    Runs ``Get-WindowsFeature`` and returns ``{rows, total}`` (each row
+    carries ``Name`` / ``DisplayName`` / ``InstallState`` / ``Installed``).
+    Read-only. Requires the ServerManager module (present on Windows Server).
+    """
+    del params  # declared empty in schema; intentionally ignored
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$f = @(Get-WindowsFeature | Select-Object {_FEATURE_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $f; total = $f.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def winsrv_feature_install(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.feature.install`` (caution) — ``Install-WindowsFeature``.
+
+    Installs the named feature (with optional ``-IncludeManagementTools`` /
+    ``-IncludeAllSubFeature``) under ``$ErrorActionPreference = 'Stop'``.
+    Never passes ``-Restart`` — returns ``restart_needed`` and leaves the
+    reboot to the approval-gated ``winsrv.power.reboot``. Returns the
+    cmdlet's ``Success`` / ``ExitCode`` / ``RestartNeeded`` plus the changed
+    feature names.
+    """
+    name: str = params["name"]
+    mgmt_tools = _ps_bool(params.get("include_management_tools"))
+    sub_features = _ps_bool(params.get("include_all_sub_feature"))
+    quoted = ps_single_quote(name)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$r = Install-WindowsFeature -Name {quoted} "
+        f"-IncludeManagementTools:{mgmt_tools} -IncludeAllSubFeature:{sub_features}; "
+        "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+        "ok = [bool]$r.Success; success = [bool]$r.Success; "
+        "exit_code = $r.ExitCode.ToString(); "
+        "restart_needed = ($r.RestartNeeded.ToString() -ne 'No'); "
+        "features_changed = @($r.FeatureResult | ForEach-Object { $_.Name }) }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return _feature_write_result(name, "install", payload)
+
+
+async def winsrv_feature_remove(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.feature.remove`` (caution) — ``Uninstall-WindowsFeature``.
+
+    Removes the named feature under ``$ErrorActionPreference = 'Stop'``.
+    Never passes ``-Restart`` — returns ``restart_needed`` and leaves the
+    reboot to the approval-gated ``winsrv.power.reboot``.
+    """
+    name: str = params["name"]
+    sub_features = _ps_bool(params.get("include_all_sub_feature"))
+    quoted = ps_single_quote(name)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$r = Uninstall-WindowsFeature -Name {quoted} "
+        f"-IncludeManagementTools:{sub_features}; "
+        "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+        "ok = [bool]$r.Success; success = [bool]$r.Success; "
+        "exit_code = $r.ExitCode.ToString(); "
+        "restart_needed = ($r.RestartNeeded.ToString() -ne 'No'); "
+        "features_changed = @($r.FeatureResult | ForEach-Object { $_.Name }) }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return _feature_write_result(name, "remove", payload)
+
+
+def _feature_write_result(name: str, action: str, payload: Any) -> dict[str, Any]:
+    """Shape the install/remove cmdlet payload into the write envelope."""
+    data = payload if isinstance(payload, dict) else {}
+    changed = data.get("features_changed")
+    return {
+        "name": name,
+        "action": action,
+        "success": bool(data.get("success")),
+        "exit_code": data.get("exit_code"),
+        "restart_needed": bool(data.get("restart_needed")),
+        "features_changed": changed if isinstance(changed, list) else [],
+        "op_class": "write",
+    }
+
+
+_FEATURE_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The Windows feature/role short name (the ``Name`` column, e.g. "
+        "``Failover-Clustering`` or ``Web-Server``)."
+    ),
+}
+
+_FEATURE_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "success": {"type": "boolean"},
+        "exit_code": {"type": ["string", "null"]},
+        "restart_needed": {"type": "boolean"},
+        "features_changed": {"type": "array", "items": {"type": "string"}},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["name", "action", "success", "op_class"],
+    "additionalProperties": True,
+}
+
+
+FEATURE_OPS: tuple[WinsrvOp, ...] = (
+    WinsrvOp(
+        op_id="winsrv.feature.list",
+        handler_attr="winsrv_feature_list",
+        summary="List Windows roles/features via ``Get-WindowsFeature`` (name/install-state).",
+        description=(
+            "Runs ``Get-WindowsFeature`` and returns one row per role/feature "
+            "(Name, DisplayName, InstallState, Installed). Read-only. "
+            "Requires the ServerManager module (present on Windows Server, "
+            "absent on client SKUs)."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="features",
+        tags=("read-only", "feature", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate Windows roles/features and their install "
+                "state (e.g. is ``Failover-Clustering`` installed?) before an "
+                "install/remove. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Name, DisplayName, InstallState, Installed}], 'total': <int>}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.feature.install",
+        handler_attr="winsrv_feature_install",
+        summary="Install a Windows role/feature via ``Install-WindowsFeature`` (caution).",
+        description=(
+            "Runs ``Install-WindowsFeature -Name <name>`` with optional "
+            "``-IncludeManagementTools`` / ``-IncludeAllSubFeature``. Never "
+            "auto-restarts — returns ``restart_needed`` and leaves the reboot "
+            "to the approval-gated ``winsrv.power.reboot`` (batch feature "
+            "changes, then one governed reboot). safety_level=caution. This "
+            "is the c1sql1 Failover-Clustering install path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _FEATURE_NAME_PROP,
+                "include_management_tools": {
+                    "type": "boolean",
+                    "description": (
+                        "Also install the feature's management tools "
+                        "(``-IncludeManagementTools``). Default false — the "
+                        "cmdlet default."
+                    ),
+                },
+                "include_all_sub_feature": {
+                    "type": "boolean",
+                    "description": (
+                        "Also install all sub-features (``-IncludeAllSubFeature``). Default false."
+                    ),
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_FEATURE_WRITE_RESPONSE_SCHEMA,
+        group_key="features",
+        tags=("write", "feature", "install"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Install a Windows role/feature (e.g. ``Failover-Clustering`` "
+                "with ``include_management_tools=true`` on a SQL FCI node). "
+                "Recoverable; safety_level=caution. Does NOT restart — check "
+                "``restart_needed`` and use ``winsrv.power.reboot`` (approval-"
+                "gated) if set. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The feature short name.",
+                "include_management_tools": "Optional bool; default false.",
+                "include_all_sub_feature": "Optional bool; default false.",
+            },
+            "output_shape": (
+                "{'name', 'action': 'install', 'success', 'exit_code', "
+                "'restart_needed', 'features_changed': [names], 'op_class': 'write'}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.feature.remove",
+        handler_attr="winsrv_feature_remove",
+        summary="Remove a Windows role/feature via ``Uninstall-WindowsFeature`` (caution).",
+        description=(
+            "Runs ``Uninstall-WindowsFeature -Name <name>`` (optionally with "
+            "``-IncludeManagementTools`` to also remove the tools). Never "
+            "auto-restarts — returns ``restart_needed``. safety_level=caution "
+            "(recoverable — the feature can be reinstalled)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _FEATURE_NAME_PROP,
+                "include_all_sub_feature": {
+                    "type": "boolean",
+                    "description": (
+                        "Also remove the feature's management tools "
+                        "(``-IncludeManagementTools``). Default false."
+                    ),
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_FEATURE_WRITE_RESPONSE_SCHEMA,
+        group_key="features",
+        tags=("write", "feature", "remove"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Remove a Windows role/feature. Recoverable; "
+                "safety_level=caution. Does NOT restart — check "
+                "``restart_needed``. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The feature short name.",
+                "include_all_sub_feature": "Optional bool; default false.",
+            },
+            "output_shape": (
+                "{'name', 'action': 'remove', 'success', 'exit_code', "
+                "'restart_needed', 'features_changed': [names], 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/winsrv/ops_localusers.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_localusers.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv local-user ops — ``list`` (safe) + ``create`` / ``set`` (caution) + ``delete``.
+
+Local accounts are driven by the ``Microsoft.PowerShell.LocalAccounts``
+cmdlets (``Get-LocalUser`` / ``New-LocalUser`` / ``Set-LocalUser`` /
+``Enable-LocalUser`` / ``Disable-LocalUser`` / ``Remove-LocalUser``) over the
+shared PowerShell-over-SSH transport. ``delete`` is ``dangerous`` +
+``requires_approval`` (the rke2 mold — irreversible account removal parks for
+a human decision); ``create`` / ``set`` are ``caution``.
+
+No plaintext password on the wire (deliberate)
+----------------------------------------------
+
+The shared pwsh transport's safety contract forbids credential material in
+the ``-EncodedCommand`` script — the encoded payload lands on the remote
+process argv and the script body is visible to a privileged remote observer
+(see :mod:`~meho_backplane.connectors._shared.pwsh`). ``New-LocalUser`` /
+``Set-LocalUser`` take the password as a ``SecureString``, but constructing
+one from an operator-supplied plaintext would require embedding that
+plaintext in the script — a direct contract violation. So ``create`` uses the
+``-NoPassword`` parameter set and ``set`` never touches the password.
+Provisioning a password is a deferred follow-up (the rke2
+``token.rotate`` mint-and-stash-in-Vault mold, so no secret ever enters the
+script). Until then, set the password out of band or via a domain flow (msad,
+#3262).
+
+PowerShell injection safety
+---------------------------
+
+Operator-supplied strings (name / description / full name) are interpolated
+only inside single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; boolean
+toggles render as ``$true`` / ``$false`` literals after validation.
+
+References
+----------
+
+* ``New-LocalUser`` / ``Set-LocalUser`` / ``Remove-LocalUser`` (PowerShell 5.1):
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "LOCALUSER_OPS",
+    "winsrv_localuser_create",
+    "winsrv_localuser_delete",
+    "winsrv_localuser_list",
+    "winsrv_localuser_set",
+]
+
+_LOCALUSER_SELECT: str = "Name, Enabled, Description, FullName, PasswordRequired, LastLogon"
+
+
+async def winsrv_localuser_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.localuser.list`` — every local user (list-shaped).
+
+    Runs ``Get-LocalUser`` and returns ``{rows, total}`` (each row carries
+    ``Name`` / ``Enabled`` / ``Description`` / ``FullName`` /
+    ``PasswordRequired`` / ``LastLogon``). Read-only.
+    """
+    del params  # declared empty in schema; intentionally ignored
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$u = @(Get-LocalUser | Select-Object {_LOCALUSER_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $u; total = $u.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def winsrv_localuser_create(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.localuser.create`` (caution) — ``New-LocalUser -NoPassword``.
+
+    Creates a local account with no password (see the module docstring — a
+    plaintext password can't ride the pwsh transport). Optional ``full_name``
+    / ``description`` and ``disabled`` / ``account_never_expires`` /
+    ``user_may_not_change_password`` toggles.
+    """
+    name: str = params["name"]
+    clauses = [f"New-LocalUser -Name {ps_single_quote(name)} -NoPassword"]
+    if params.get("full_name"):
+        clauses.append(f"-FullName {ps_single_quote(params['full_name'])}")
+    if params.get("description"):
+        clauses.append(f"-Description {ps_single_quote(params['description'])}")
+    if params.get("disabled") is True:
+        clauses.append("-Disabled")
+    if params.get("account_never_expires") is True:
+        clauses.append("-AccountNeverExpires")
+    if params.get("user_may_not_change_password") is True:
+        clauses.append("-UserMayNotChangePassword")
+    new_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{new_expr} | Out-Null; "
+        f"$u = Get-LocalUser -Name {ps_single_quote(name)} "
+        f"| Select-Object {_LOCALUSER_SELECT}; "
+        "ConvertTo-Json -Depth 3 -Compress -InputObject @{ ok = $true; user = $u }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    user = payload.get("user") if isinstance(payload, dict) else None
+    return {"name": name, "action": "create", "user": user, "op_class": "write"}
+
+
+async def winsrv_localuser_set(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.localuser.set`` (caution) — ``Set-LocalUser`` + enable/disable.
+
+    Applies the supplied account attributes (``full_name`` / ``description``
+    / ``password_never_expires``) via ``Set-LocalUser`` and, when ``enabled``
+    is supplied, toggles the account with ``Enable-LocalUser`` /
+    ``Disable-LocalUser``. Never touches the password. At least one settable
+    attribute is required.
+    """
+    name: str = params["name"]
+    quoted = ps_single_quote(name)
+    set_clauses: list[str] = []
+    if params.get("full_name") is not None:
+        set_clauses.append(f"-FullName {ps_single_quote(params['full_name'])}")
+    if params.get("description") is not None:
+        set_clauses.append(f"-Description {ps_single_quote(params['description'])}")
+    if params.get("password_never_expires") is not None:
+        flag = "$true" if params["password_never_expires"] else "$false"
+        set_clauses.append(f"-PasswordNeverExpires {flag}")
+
+    enabled = params.get("enabled")
+    if not set_clauses and enabled is None:
+        raise ValueError(
+            "localuser.set requires at least one attribute to change "
+            "(full_name / description / password_never_expires / enabled)"
+        )
+
+    statements = ["$ErrorActionPreference = 'Stop'"]
+    if set_clauses:
+        statements.append(f"Set-LocalUser -Name {quoted} {' '.join(set_clauses)}")
+    if enabled is True:
+        statements.append(f"Enable-LocalUser -Name {quoted}")
+    elif enabled is False:
+        statements.append(f"Disable-LocalUser -Name {quoted}")
+    statements.append(f"$u = Get-LocalUser -Name {quoted} | Select-Object {_LOCALUSER_SELECT}")
+    statements.append("ConvertTo-Json -Depth 3 -Compress -InputObject @{ ok = $true; user = $u }")
+    script = "; ".join(statements)
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    user = payload.get("user") if isinstance(payload, dict) else None
+    return {"name": name, "action": "set", "user": user, "op_class": "write"}
+
+
+async def winsrv_localuser_delete(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.localuser.delete`` (dangerous, resume path only).
+
+    Runs ``Remove-LocalUser -Name <name>`` under ``$ErrorActionPreference =
+    'Stop'``. Irreversible — the op is ``requires_approval`` so a dispatch
+    parks for a human decision before the account is removed.
+    """
+    name: str = params["name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Remove-LocalUser -Name {ps_single_quote(name)}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"name": name, "action": "delete", "op_class": "write"}
+
+
+_USER_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The local user account name (the ``Name`` column, e.g. ``svc-sql``).",
+}
+
+_USER_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "user": {"type": ["object", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+LOCALUSER_OPS: tuple[WinsrvOp, ...] = (
+    WinsrvOp(
+        op_id="winsrv.localuser.list",
+        handler_attr="winsrv_localuser_list",
+        summary="List local users via ``Get-LocalUser`` (name/enabled/description).",
+        description=(
+            "Runs ``Get-LocalUser`` and returns one row per local account "
+            "(Name, Enabled, Description, FullName, PasswordRequired, "
+            "LastLogon). Read-only. No password material is ever read or "
+            "returned."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="localusers",
+        tags=("read-only", "localuser", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate local user accounts and their enabled "
+                "state. Read-only; no password material. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Name, Enabled, Description, FullName, ...}], 'total': <int>}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.localuser.create",
+        handler_attr="winsrv_localuser_create",
+        summary="Create a local user via ``New-LocalUser -NoPassword`` (caution).",
+        description=(
+            "Runs ``New-LocalUser -Name <name> -NoPassword`` with optional "
+            "``full_name`` / ``description`` and disabled / never-expires / "
+            "may-not-change-password toggles. The account is created WITHOUT "
+            "a password — a plaintext password cannot ride the pwsh transport "
+            "(see the connector doc); provision it out of band or via the "
+            "domain (msad). safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _USER_NAME_PROP,
+                "full_name": {"type": "string", "description": "Optional display/full name."},
+                "description": {"type": "string", "description": "Optional account comment."},
+                "disabled": {
+                    "type": "boolean",
+                    "description": "Create the account disabled (``-Disabled``). Default false.",
+                },
+                "account_never_expires": {
+                    "type": "boolean",
+                    "description": "``-AccountNeverExpires``. Default false.",
+                },
+                "user_may_not_change_password": {
+                    "type": "boolean",
+                    "description": "``-UserMayNotChangePassword``. Default false.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_USER_WRITE_RESPONSE_SCHEMA,
+        group_key="localusers",
+        tags=("write", "localuser", "create"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Create a local user account (no password — set it out of "
+                "band). Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The local account name.",
+                "full_name": "Optional display name.",
+                "description": "Optional comment.",
+            },
+            "output_shape": (
+                "{'name', 'action': 'create', 'user': <created account>, 'op_class': 'write'}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.localuser.set",
+        handler_attr="winsrv_localuser_set",
+        summary="Update a local user's attributes / enabled state (caution).",
+        description=(
+            "Applies ``full_name`` / ``description`` / "
+            "``password_never_expires`` via ``Set-LocalUser`` and toggles the "
+            "account via ``Enable-LocalUser`` / ``Disable-LocalUser`` when "
+            "``enabled`` is supplied. Never touches the password. At least "
+            "one attribute is required. safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _USER_NAME_PROP,
+                "full_name": {"type": "string", "description": "New display/full name."},
+                "description": {"type": "string", "description": "New account comment."},
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable (true) or disable (false) the account.",
+                },
+                "password_never_expires": {
+                    "type": "boolean",
+                    "description": "Set ``-PasswordNeverExpires``.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_USER_WRITE_RESPONSE_SCHEMA,
+        group_key="localusers",
+        tags=("write", "localuser", "set"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Update a local account's display name, description, "
+                "password-never-expires flag, or enabled state. Never touches "
+                "the password. Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The local account name.",
+                "enabled": "Optional bool; enable/disable the account.",
+            },
+            "output_shape": (
+                "{'name', 'action': 'set', 'user': <updated account>, 'op_class': 'write'}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.localuser.delete",
+        handler_attr="winsrv_localuser_delete",
+        summary="Delete a local user via ``Remove-LocalUser`` (dangerous, approval-gated).",
+        description=(
+            "Runs ``Remove-LocalUser -Name <name>``. Irreversible — the "
+            "account and its SID are gone. safety_level=dangerous, "
+            "requires_approval=True: a dispatch parks for a human to approve "
+            "before the account is removed."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _USER_NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "action": {"type": "string"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["name", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="localusers",
+        tags=("write", "localuser", "delete"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Delete a local user account. Irreversible; approval-gated — "
+                "parks for a human decision first. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The local account name to remove."},
+            "output_shape": "{'name', 'action': 'delete', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/winsrv/ops_power.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_power.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv power ops — ``reboot`` / ``shutdown`` (dangerous + requires_approval).
+
+The rke2 approval-parked-write mold (``dangerous`` +
+``requires_approval=True``): the dispatcher's policy gate parks a dispatch at
+``needs-approval`` for a human decision, and the handler runs only on the
+``_approved=True`` resume path. Per the Initiative #3259 satellite table a
+destructive op is satellite-EXCLUDED by the tier ladder — central-dial /
+on-site only.
+
+Why ``shutdown.exe`` with a delay (not a bare ``Restart-Computer -Force``)
+------------------------------------------------------------------------
+
+A reboot/shutdown tears down the very SSH channel the transport is reading
+its ``ConvertTo-Json`` ack over. A bare ``Restart-Computer -Force`` initiates
+the teardown immediately, so the channel can drop before stdout flushes and
+:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` would raise on a
+truncated read — reporting failure on a reboot that in fact succeeded. Using
+``shutdown.exe /r /t <delay>`` *schedules* the reboot, returns
+immediately, and the JSON ack flushes cleanly; the machine goes down after
+the delay. ``$LASTEXITCODE`` is checked so a rejected schedule (already
+shutting down, insufficient rights) surfaces as a real
+:class:`~meho_backplane.connectors._shared.pwsh.PwshRunError` rather than a
+false ``ok``.
+
+PowerShell injection safety
+---------------------------
+
+The optional operator ``message`` is interpolated only inside a single-quoted
+PowerShell literal via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; the delay is
+a Python-validated non-negative ``int``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "POWER_OPS",
+    "winsrv_power_reboot",
+    "winsrv_power_shutdown",
+]
+
+#: Default schedule delay (seconds). Non-zero so the JSON ack flushes over
+#: SSH before the OS tears the channel down, and a small grace window before
+#: the host actually goes down.
+_DEFAULT_DELAY_SECONDS: int = 15
+
+
+def _validate_delay(raw: Any) -> int:
+    """Return a validated non-negative ``int`` delay (default when absent)."""
+    if raw is None:
+        return _DEFAULT_DELAY_SECONDS
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw < 0:
+        raise ValueError(f"delay_seconds must be a non-negative integer; got {raw!r}")
+    return raw
+
+
+async def _power_action(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    *,
+    flag: str,
+    action: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Schedule ``shutdown.exe`` with *flag* (``/r`` reboot, ``/s`` shutdown)."""
+    delay = _validate_delay(params.get("delay_seconds"))
+    message: str | None = params.get("message")
+    comment_clause = ""
+    if message:
+        comment_clause = f" /c {ps_single_quote(message)}"
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"shutdown.exe {flag} /t {delay}{comment_clause}; "
+        'if ($LASTEXITCODE -ne 0) { throw "shutdown.exe exited $LASTEXITCODE" }; '
+        "ConvertTo-Json -Compress -InputObject @{ "
+        f"ok = $true; action = '{action}'; delay_seconds = {delay} }}"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {
+        "ok": True,
+        "action": action,
+        "delay_seconds": delay,
+        "message": message,
+        "op_class": "write",
+    }
+
+
+async def winsrv_power_reboot(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.power.reboot`` (dangerous, resume path only)."""
+    return await _power_action(
+        connector, target, params, flag="/r", action="reboot", operator=operator
+    )
+
+
+async def winsrv_power_shutdown(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.power.shutdown`` (dangerous, resume path only)."""
+    return await _power_action(
+        connector, target, params, flag="/s", action="shutdown", operator=operator
+    )
+
+
+_POWER_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "delay_seconds": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Seconds to wait before the host goes down (``shutdown.exe "
+                "/t``). Default 15 — non-zero so the ack flushes and there is "
+                "a short grace window."
+            ),
+        },
+        "message": {
+            "type": "string",
+            "description": ("Optional comment shown to logged-in users (``shutdown.exe /c``)."),
+        },
+    },
+    "additionalProperties": False,
+}
+
+_POWER_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "ok": {"type": "boolean"},
+        "action": {"type": "string"},
+        "delay_seconds": {"type": "integer"},
+        "message": {"type": ["string", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["ok", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+POWER_OPS: tuple[WinsrvOp, ...] = (
+    WinsrvOp(
+        op_id="winsrv.power.reboot",
+        handler_attr="winsrv_power_reboot",
+        summary="Reboot the Windows Server host (dangerous, approval-gated).",
+        description=(
+            "Schedules a reboot via ``shutdown.exe /r /t <delay>`` (default "
+            "15s) so the ack flushes before the SSH channel tears down. "
+            "safety_level=dangerous, requires_approval=True — a dispatch "
+            "parks for a human to approve before anything changes. The right "
+            "op to land a pending reboot after a feature install; it does NOT "
+            "run automatically as part of ``winsrv.feature.install``."
+        ),
+        parameter_schema=_POWER_PARAM_SCHEMA,
+        response_schema=_POWER_RESPONSE_SCHEMA,
+        group_key="power",
+        tags=("write", "power", "reboot"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Reboot a Windows Server host (e.g. to land a "
+                "Failover-Clustering install that reported "
+                "``restart_needed``). Destructive to running work; "
+                "approval-gated — parks for a human decision first. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "delay_seconds": "Optional; seconds before going down. Default 15.",
+                "message": "Optional comment shown to logged-in users.",
+            },
+            "output_shape": (
+                "{'ok': true, 'action': 'reboot', 'delay_seconds', 'message', "
+                "'op_class': 'write'}. The reboot lands after the delay."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.power.shutdown",
+        handler_attr="winsrv_power_shutdown",
+        summary="Shut down the Windows Server host (dangerous, approval-gated).",
+        description=(
+            "Schedules a shutdown via ``shutdown.exe /s /t <delay>`` (default "
+            "15s). safety_level=dangerous, requires_approval=True — parks for "
+            "human approval. A shutdown (unlike a reboot) leaves the host off "
+            "until it is powered back on out of band."
+        ),
+        parameter_schema=_POWER_PARAM_SCHEMA,
+        response_schema=_POWER_RESPONSE_SCHEMA,
+        group_key="power",
+        tags=("write", "power", "shutdown"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Power a Windows Server host down (it stays off until powered "
+                "back on out of band). Destructive; approval-gated. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "delay_seconds": "Optional; seconds before going down. Default 15.",
+                "message": "Optional comment shown to logged-in users.",
+            },
+            "output_shape": (
+                "{'ok': true, 'action': 'shutdown', 'delay_seconds', "
+                "'message', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/winsrv/ops_services.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_services.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv service ops — reads (``list`` / ``get`` safe) + lifecycle writes.
+
+``start`` / ``stop`` / ``restart`` are ``caution`` (recoverable service-state
+changes — satellite-executable only through the Stage-3 composed write gate,
+per the Initiative #3259 satellite table). Windows services are driven by the
+``Microsoft.PowerShell.Management`` cmdlets (``Get-Service`` /
+``Start-Service`` / ``Stop-Service`` / ``Restart-Service``) over the shared
+PowerShell-over-SSH transport.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied service ``name`` is interpolated only inside a
+single-quoted PowerShell literal via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote` (embedded
+``'`` doubled — complete escaping inside a single-quoted PowerShell string).
+The transport is ``powershell -EncodedCommand`` (base64 UTF-16LE), so the
+shell never parses the script — only the PowerShell parser does.
+
+References
+----------
+
+* ``Get-Service`` / ``Start-Service`` / ``Stop-Service`` / ``Restart-Service``:
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "SERVICE_OPS",
+    "winsrv_service_get",
+    "winsrv_service_list",
+    "winsrv_service_restart",
+    "winsrv_service_start",
+    "winsrv_service_stop",
+]
+
+# The Get-Service projection every read returns — the operator-relevant
+# subset. Selected explicitly so the JSON shape stays stable and bounded.
+_SERVICE_SELECT: str = "Name, DisplayName, Status, StartType"
+
+
+async def winsrv_service_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.service.list`` — every service (list-shaped).
+
+    Runs ``Get-Service`` and returns ``{rows, total}`` (each row carries
+    ``Name`` / ``DisplayName`` / ``Status`` / ``StartType``). Read-only.
+    The ``@{ rows; total }`` envelope keeps stdout JSON-shaped even on a
+    host with no services (never an empty-stdout ``PwshRunError``).
+    """
+    del params  # declared empty in schema; intentionally ignored
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$svc = @(Get-Service | Select-Object {_SERVICE_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $svc; total = $svc.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def winsrv_service_get(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.service.get`` — one service by name.
+
+    Runs ``Get-Service -Name <name>`` and returns ``{rows, total}`` — a
+    missing service is a terminating error under ``'Stop'`` (a real
+    ``PwshRunError``), not a false-empty read. ``rows`` normally has one
+    element.
+    """
+    name: str = params["name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$svc = @(Get-Service -Name {ps_single_quote(name)} "
+        f"| Select-Object {_SERVICE_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $svc; total = $svc.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"name": name, "rows": rows, "total": len(rows)}
+
+
+async def _service_action(
+    connector: WinsrvConnector,
+    target: Any,
+    name: str,
+    cmdlet: str,
+    action: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run a service lifecycle cmdlet and return the post-action status.
+
+    ``cmdlet`` is ``Start-Service`` / ``Stop-Service`` / ``Restart-Service``.
+    Under ``$ErrorActionPreference = 'Stop'`` a cmdlet failure (missing
+    service, insufficient rights) terminates the pwsh process non-zero →
+    :class:`~meho_backplane.connectors._shared.pwsh.PwshRunError`. On success
+    the trailing ``Get-Service`` reads back the resulting ``Status``.
+    """
+    quoted = ps_single_quote(name)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{cmdlet} -Name {quoted}; "
+        f"$svc = Get-Service -Name {quoted}; "
+        "ConvertTo-Json -Compress -InputObject @{ "
+        "ok = $true; name = $svc.Name; status = $svc.Status.ToString() }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    status = payload.get("status") if isinstance(payload, dict) else None
+    return {"name": name, "action": action, "status": status, "op_class": "write"}
+
+
+async def winsrv_service_start(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.service.start`` (caution) — ``Start-Service``."""
+    return await _service_action(
+        connector, target, params["name"], "Start-Service", "start", operator
+    )
+
+
+async def winsrv_service_stop(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.service.stop`` (caution) — ``Stop-Service``."""
+    return await _service_action(
+        connector, target, params["name"], "Stop-Service", "stop", operator
+    )
+
+
+async def winsrv_service_restart(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.service.restart`` (caution) — ``Restart-Service``."""
+    return await _service_action(
+        connector, target, params["name"], "Restart-Service", "restart", operator
+    )
+
+
+_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The Windows service short name (the ``Name`` column, e.g. ``MSSQLSERVER``).",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_ACTION_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "status": {"type": ["string", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+def _action_op(op_id: str, handler_attr: str, verb: str, cmdlet: str) -> WinsrvOp:
+    """Build one caution-tier service lifecycle op (start / stop / restart)."""
+    return WinsrvOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"{verb.capitalize()} a Windows service via ``{cmdlet}`` (caution).",
+        description=(
+            f"Runs ``{cmdlet} -Name <name>`` on the Windows Server host under "
+            "``$ErrorActionPreference = 'Stop'`` and reads back the resulting "
+            f"service status. safety_level=caution (a recoverable service-state "
+            "change; the production-path gate is policy territory keyed on this "
+            "value)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_ACTION_RESPONSE_SCHEMA,
+        group_key="services",
+        tags=("write", "service", verb),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                f"{verb.capitalize()} a named Windows service (e.g. restart "
+                "``MSSQLSERVER`` after a config change). Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The service short name."},
+            "output_shape": "{'name', 'action', 'status', 'op_class': 'write'}.",
+        },
+    )
+
+
+SERVICE_OPS: tuple[WinsrvOp, ...] = (
+    WinsrvOp(
+        op_id="winsrv.service.list",
+        handler_attr="winsrv_service_list",
+        summary="List every Windows service via ``Get-Service`` (name/status/start-type).",
+        description=(
+            "Runs ``Get-Service`` and returns one row per service (Name, "
+            "DisplayName, Status, StartType). Read-only; the right op when "
+            "the agent needs the service inventory or doesn't yet know a "
+            "service's exact short name."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="services",
+        tags=("read-only", "service", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate Windows services or find a service's short "
+                "name before a start/stop/restart. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": ("{'rows': [{Name, DisplayName, Status, StartType}], 'total': <int>}."),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.service.get",
+        handler_attr="winsrv_service_get",
+        summary="Read one Windows service by name via ``Get-Service -Name``.",
+        description=(
+            "Runs ``Get-Service -Name <name>`` and returns the single "
+            "matching service (Name, DisplayName, Status, StartType) as a "
+            "``{rows, total}`` envelope. A missing service is a terminating "
+            "error, not a false-empty read. Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["name", "rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="services",
+        tags=("read-only", "service", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one named Windows service's current state "
+                "(e.g. is ``MSSQLSERVER`` running?). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The service short name."},
+            "output_shape": "{'name', 'rows': [<service object>], 'total': <int>}.",
+        },
+    ),
+    _action_op("winsrv.service.start", "winsrv_service_start", "start", "Start-Service"),
+    _action_op("winsrv.service.stop", "winsrv_service_stop", "stop", "Stop-Service"),
+    _action_op("winsrv.service.restart", "winsrv_service_restart", "restart", "Restart-Service"),
+)

--- a/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
@@ -10,9 +10,15 @@ PowerShell-over-SSH transport. This is the c1sql1 SQL-FCI shared-disk path:
 attach an iSCSI target, then provision the raw disk into a volume.
 
 ``iscsi.connect`` and ``disk.format`` are ``caution`` (recoverable
-provisioning). ``disk.format`` additionally **fails closed** on a disk that
-already carries a partition table (``PartitionStyle != RAW``) unless
-``force=true`` is passed — it will not silently clobber data.
+provisioning). ``disk.format`` is non-destructive by construction: it
+``Initialize-Disk``s only a ``RAW`` disk and ``New-Partition -UseMaximumSize``
+only allocates **unallocated** space, so it never removes an existing
+partition or its data. It fails closed on a disk that already carries a
+partition table (``PartitionStyle != RAW``) unless ``force=true`` is passed;
+``force=true`` then only provisions the disk's free space (a full disk fails
+at ``New-Partition``), it does **not** wipe. A true data-destroying wipe
+(``Clear-Disk -RemoveData``) is deliberately NOT offered here — it would be a
+separate ``dangerous`` op with its own ticket, per the #3259 tier doctrine.
 
 Deferred: iSCSI CHAP
 --------------------
@@ -45,6 +51,7 @@ References
 
 from __future__ import annotations
 
+import string
 from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
@@ -171,11 +178,16 @@ async def winsrv_iscsi_connect(
 
 
 def _validate_drive_letter(raw: Any) -> str | None:
-    """Return an uppercased single-letter drive letter, or ``None`` when absent."""
+    """Return an uppercased single-letter drive letter, or ``None`` when absent.
+
+    Accepts only ASCII ``A-Z`` / ``a-z`` (``string.ascii_letters``) — not
+    ``str.isalpha`` (which admits Unicode letters), so the Python check agrees
+    with the schema's ``^[A-Za-z]$`` pattern exactly.
+    """
     if raw is None:
         return None
-    if not isinstance(raw, str) or len(raw) != 1 or not raw.isalpha():
-        raise ValueError(f"drive_letter must be a single letter A-Z; got {raw!r}")
+    if not isinstance(raw, str) or len(raw) != 1 or raw not in string.ascii_letters:
+        raise ValueError(f"drive_letter must be a single ASCII letter A-Z; got {raw!r}")
     return raw.upper()
 
 
@@ -188,10 +200,11 @@ async def winsrv_disk_format(
     """Handler for ``winsrv.storage.disk.format`` (caution) — provision a raw disk.
 
     Initializes disk ``disk_number`` (GPT, only when it is ``RAW``), creates a
-    max-size partition (with ``drive_letter`` or an auto-assigned letter), and
-    formats it (``NTFS`` default / ``ReFS``, optional ``label``). Fails closed
-    on a disk that already carries a partition table unless ``force=true`` —
-    so an accidental format never silently clobbers data.
+    ``-UseMaximumSize`` partition from unallocated space (with ``drive_letter``
+    or an auto-assigned letter), and formats that new volume (``NTFS`` default
+    / ``ReFS``, optional ``label``). Non-destructive: it never removes an
+    existing partition or its data. Fails closed on a non-``RAW`` disk unless
+    ``force=true``, which then only provisions the disk's free space.
     """
     disk_number = params["disk_number"]
     if not isinstance(disk_number, int) or isinstance(disk_number, bool) or disk_number < 0:
@@ -214,7 +227,7 @@ async def winsrv_disk_format(
         f"$d = Get-Disk -Number {disk_number}; "
         f"if ($d.PartitionStyle -ne 'RAW' -and -not {force}) {{ "
         f'throw "disk {disk_number} is not RAW (PartitionStyle=$($d.PartitionStyle)); '
-        'pass force=true to reformat" }; '
+        'pass force=true to provision its free space" }; '
         f"if ($d.PartitionStyle -eq 'RAW') {{ "
         f"Initialize-Disk -Number {disk_number} -PartitionStyle GPT | Out-Null }}; "
         f"$p = New-Partition -DiskNumber {disk_number} -UseMaximumSize {letter_clause}; "
@@ -375,13 +388,15 @@ STORAGE_OPS: tuple[WinsrvOp, ...] = (
         summary="Initialize + partition + format a raw disk (caution; RAW-guarded).",
         description=(
             "Provisions disk ``disk_number`` into a volume: initializes it "
-            "GPT (only when RAW), creates a max-size partition (with "
-            "``drive_letter`` or an auto-assigned letter), and formats it "
-            "(``NTFS`` default / ``ReFS``, optional ``label``). FAILS CLOSED "
-            "on a disk that already carries a partition table unless "
-            "``force=true`` — it never silently clobbers data. safety_level="
-            "caution — the SQL-FCI shared-disk provisioning step after "
-            "``iscsi.connect``."
+            "GPT (only when RAW), creates a ``-UseMaximumSize`` partition from "
+            "unallocated space (with ``drive_letter`` or an auto-assigned "
+            "letter), and formats that new volume (``NTFS`` default / ``ReFS``, "
+            "optional ``label``). Non-destructive — it never removes an "
+            "existing partition or its data. FAILS CLOSED on a non-RAW disk "
+            "unless ``force=true``, which then only provisions the disk's free "
+            "space (it does NOT wipe; a true wipe would be a separate "
+            "``dangerous`` op). safety_level=caution — the SQL-FCI shared-disk "
+            "provisioning step after ``iscsi.connect``."
         ),
         parameter_schema={
             "type": "object",
@@ -406,9 +421,13 @@ STORAGE_OPS: tuple[WinsrvOp, ...] = (
                 "force": {
                     "type": "boolean",
                     "description": (
-                        "Reformat a disk that already carries a partition "
-                        "table (DESTROYS its data). Default false — a "
-                        "non-RAW disk is refused without this."
+                        "Allow provisioning on a disk that is already "
+                        "initialized (non-RAW): a new volume is created from "
+                        "the disk's UNALLOCATED space only — existing "
+                        "partitions and their data are left intact (a full "
+                        "disk fails). Default false, so a non-RAW disk is "
+                        "refused. This never wipes; a data-destroying wipe "
+                        "would be a separate dangerous op."
                     ),
                 },
             },
@@ -434,8 +453,10 @@ STORAGE_OPS: tuple[WinsrvOp, ...] = (
         llm_instructions={
             "when_to_use": (
                 "Provision a newly-attached raw disk (e.g. after "
-                "``iscsi.connect``) into a formatted volume. Refuses a disk "
-                "with an existing partition table unless force=true. "
+                "``iscsi.connect``) into a formatted volume. Non-destructive "
+                "— only unallocated space becomes the new volume; existing "
+                "partitions/data are untouched. Refuses a non-RAW disk unless "
+                "force=true (which still only uses free space). "
                 "safety_level=caution. " + SSH_TRANSPORT_NOTE
             ),
             "parameter_hints": {

--- a/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv storage ops — disk/volume/iSCSI reads (safe) + iSCSI connect / disk format.
+
+Storage is driven by the ``Storage`` module (``Get-Disk`` / ``Get-Volume`` /
+``Initialize-Disk`` / ``New-Partition`` / ``Format-Volume``) and the ``iSCSI``
+module (``Get-IscsiTarget`` / ``Connect-IscsiTarget``) over the shared
+PowerShell-over-SSH transport. This is the c1sql1 SQL-FCI shared-disk path:
+attach an iSCSI target, then provision the raw disk into a volume.
+
+``iscsi.connect`` and ``disk.format`` are ``caution`` (recoverable
+provisioning). ``disk.format`` additionally **fails closed** on a disk that
+already carries a partition table (``PartitionStyle != RAW``) unless
+``force=true`` is passed — it will not silently clobber data.
+
+Deferred: iSCSI CHAP
+--------------------
+
+``Connect-IscsiTarget`` supports CHAP (``-ChapUsername`` / ``-ChapSecret``),
+but the secret would land in the ``-EncodedCommand`` script — a violation of
+the shared transport's secret-hygiene contract (see
+:mod:`~meho_backplane.connectors._shared.pwsh`). CHAP is therefore out of
+scope for this cut (connect against a trusted lab fabric); a Vault-brokered
+CHAP flow is a follow-up.
+
+PowerShell injection safety
+---------------------------
+
+Operator-supplied strings (IQN / portal address / volume label) are
+interpolated only inside single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`. The disk
+number, portal port, and drive letter are Python-validated (int / bounded
+enum / single ``[A-Za-z]``); booleans render as ``$true`` / ``$false``.
+
+References
+----------
+
+* ``Get-Disk`` / ``Get-Volume`` / ``Initialize-Disk`` / ``New-Partition`` /
+  ``Format-Volume`` (Storage, Windows Server 2022) and ``Get-IscsiTarget`` /
+  ``Connect-IscsiTarget`` (iSCSI):
+  https://learn.microsoft.com/en-us/powershell/module/storage/ ,
+  https://learn.microsoft.com/en-us/powershell/module/iscsi/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "STORAGE_OPS",
+    "winsrv_disk_format",
+    "winsrv_disk_list",
+    "winsrv_iscsi_connect",
+    "winsrv_iscsi_list",
+    "winsrv_volume_list",
+]
+
+_DISK_SELECT: str = (
+    "Number, FriendlyName, SerialNumber, PartitionStyle, "
+    "OperationalStatus, HealthStatus, Size, BusType"
+)
+_VOLUME_SELECT: str = (
+    "DriveLetter, FileSystemLabel, FileSystem, DriveType, HealthStatus, SizeRemaining, Size"
+)
+_ISCSI_SELECT: str = "NodeAddress, IsConnected"
+
+_SUPPORTED_FILESYSTEMS: frozenset[str] = frozenset({"NTFS", "ReFS"})
+
+
+async def _list_read(
+    connector: WinsrvConnector,
+    target: Any,
+    cmdlet: str,
+    select: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run a read cmdlet under ``'Stop'`` and return the ``{rows, total}`` envelope."""
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$x = @({cmdlet} | Select-Object {select}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $x; total = $x.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def winsrv_disk_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.storage.disk.list`` — ``Get-Disk`` (list-shaped)."""
+    del params
+    return await _list_read(connector, target, "Get-Disk", _DISK_SELECT, operator)
+
+
+async def winsrv_volume_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.storage.volume.list`` — ``Get-Volume`` (list-shaped)."""
+    del params
+    return await _list_read(connector, target, "Get-Volume", _VOLUME_SELECT, operator)
+
+
+async def winsrv_iscsi_list(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.storage.iscsi.list`` — ``Get-IscsiTarget`` (list-shaped)."""
+    del params
+    return await _list_read(connector, target, "Get-IscsiTarget", _ISCSI_SELECT, operator)
+
+
+async def winsrv_iscsi_connect(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.storage.iscsi.connect`` (caution) — ``Connect-IscsiTarget``.
+
+    Connects the local initiator to the iSCSI target identified by its IQN
+    (``node_address``), optionally naming the target portal address / port
+    and whether the session persists across reboots. No CHAP (see the module
+    docstring).
+    """
+    node_address: str = params["node_address"]
+    is_persistent = "$true" if params.get("is_persistent", True) else "$false"
+    clauses = [f"Connect-IscsiTarget -NodeAddress {ps_single_quote(node_address)}"]
+    if params.get("target_portal_address"):
+        clauses.append(f"-TargetPortalAddress {ps_single_quote(params['target_portal_address'])}")
+    port = params.get("target_portal_port")
+    if port is not None:
+        if not isinstance(port, int) or isinstance(port, bool) or not (0 < port <= 65535):
+            raise ValueError(f"target_portal_port must be a TCP port 1-65535; got {port!r}")
+        clauses.append(f"-TargetPortalPortNumber {port}")
+    clauses.append(f"-IsPersistent {is_persistent}")
+    connect_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$s = {connect_expr}; "
+        "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+        "ok = $true; node_address = $s.TargetNodeAddress; "
+        "is_connected = [bool]$s.IsConnected; is_persistent = [bool]$s.IsPersistent }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "node_address": node_address,
+        "action": "connect",
+        "is_connected": bool(data.get("is_connected")),
+        "is_persistent": bool(data.get("is_persistent")),
+        "op_class": "write",
+    }
+
+
+def _validate_drive_letter(raw: Any) -> str | None:
+    """Return an uppercased single-letter drive letter, or ``None`` when absent."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or len(raw) != 1 or not raw.isalpha():
+        raise ValueError(f"drive_letter must be a single letter A-Z; got {raw!r}")
+    return raw.upper()
+
+
+async def winsrv_disk_format(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.storage.disk.format`` (caution) — provision a raw disk.
+
+    Initializes disk ``disk_number`` (GPT, only when it is ``RAW``), creates a
+    max-size partition (with ``drive_letter`` or an auto-assigned letter), and
+    formats it (``NTFS`` default / ``ReFS``, optional ``label``). Fails closed
+    on a disk that already carries a partition table unless ``force=true`` —
+    so an accidental format never silently clobbers data.
+    """
+    disk_number = params["disk_number"]
+    if not isinstance(disk_number, int) or isinstance(disk_number, bool) or disk_number < 0:
+        raise ValueError(f"disk_number must be a non-negative integer; got {disk_number!r}")
+    filesystem = params.get("filesystem", "NTFS")
+    if filesystem not in _SUPPORTED_FILESYSTEMS:
+        raise ValueError(
+            f"filesystem must be one of {sorted(_SUPPORTED_FILESYSTEMS)}; got {filesystem!r}"
+        )
+    drive_letter = _validate_drive_letter(params.get("drive_letter"))
+    force = "$true" if params.get("force") is True else "$false"
+
+    letter_clause = f"-DriveLetter {drive_letter}" if drive_letter else "-AssignDriveLetter"
+    label_clause = ""
+    if params.get("label"):
+        label_clause = f" -NewFileSystemLabel {ps_single_quote(params['label'])}"
+
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$d = Get-Disk -Number {disk_number}; "
+        f"if ($d.PartitionStyle -ne 'RAW' -and -not {force}) {{ "
+        f"throw 'disk {disk_number} is not RAW (PartitionStyle=' + $d.PartitionStyle + "
+        "'); pass force=true to reformat' }; "
+        f"if ($d.PartitionStyle -eq 'RAW') {{ "
+        f"Initialize-Disk -Number {disk_number} -PartitionStyle GPT | Out-Null }}; "
+        f"$p = New-Partition -DiskNumber {disk_number} -UseMaximumSize {letter_clause}; "
+        f"$v = Format-Volume -Partition $p -FileSystem {ps_single_quote(filesystem)}"
+        f"{label_clause} -Confirm:$false -Force; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        f"disk = {disk_number}; drive_letter = $v.DriveLetter.ToString(); "
+        "filesystem = $v.FileSystem }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "disk_number": disk_number,
+        "action": "format",
+        "drive_letter": data.get("drive_letter"),
+        "filesystem": data.get("filesystem"),
+        "op_class": "write",
+    }
+
+
+def _list_op(op_id: str, handler_attr: str, noun: str, cmdlet: str, fields: str) -> WinsrvOp:
+    """Build one safe storage list op."""
+    return WinsrvOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"List {noun} via ``{cmdlet}`` (list-shaped, JSONFlux-reduced).",
+        description=(
+            f"Runs ``{cmdlet}`` and returns one row per {noun} ({fields}). "
+            "Read-only; the standard ``{rows, total}`` envelope is JSONFlux-"
+            "reduced to a handle for large result sets."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="storage",
+        tags=("read-only", "storage", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                f"Call to enumerate {noun} on a Windows Server host (e.g. "
+                "before connecting an iSCSI target or formatting a new disk). "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": f"{{'rows': [{{{fields}}}], 'total': <int>}}.",
+        },
+    )
+
+
+STORAGE_OPS: tuple[WinsrvOp, ...] = (
+    _list_op(
+        "winsrv.storage.disk.list",
+        "winsrv_disk_list",
+        "physical disks",
+        "Get-Disk",
+        "Number, FriendlyName, PartitionStyle, OperationalStatus, Size, BusType",
+    ),
+    _list_op(
+        "winsrv.storage.volume.list",
+        "winsrv_volume_list",
+        "volumes",
+        "Get-Volume",
+        "DriveLetter, FileSystemLabel, FileSystem, SizeRemaining, Size",
+    ),
+    _list_op(
+        "winsrv.storage.iscsi.list",
+        "winsrv_iscsi_list",
+        "iSCSI initiator targets",
+        "Get-IscsiTarget",
+        "NodeAddress, IsConnected",
+    ),
+    WinsrvOp(
+        op_id="winsrv.storage.iscsi.connect",
+        handler_attr="winsrv_iscsi_connect",
+        summary="Connect the initiator to an iSCSI target via ``Connect-IscsiTarget`` (caution).",
+        description=(
+            "Runs ``Connect-IscsiTarget -NodeAddress <iqn>`` (optionally "
+            "``-TargetPortalAddress`` / ``-TargetPortalPortNumber`` / "
+            "``-IsPersistent``). No CHAP (the secret can't ride the pwsh "
+            "transport — connect against a trusted fabric). safety_level="
+            "caution — this is the SQL-FCI shared-disk attach step."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "node_address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The discovered target IQN (``-NodeAddress``).",
+                },
+                "target_portal_address": {
+                    "type": "string",
+                    "description": "Optional target portal IP/DNS (``-TargetPortalAddress``).",
+                },
+                "target_portal_port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Optional target portal TCP port (default 3260).",
+                },
+                "is_persistent": {
+                    "type": "boolean",
+                    "description": (
+                        "Reconnect the session automatically after reboot "
+                        "(``-IsPersistent``). Default true — SQL FCI shared "
+                        "disks want persistent sessions."
+                    ),
+                },
+            },
+            "required": ["node_address"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "node_address": {"type": "string"},
+                "action": {"type": "string"},
+                "is_connected": {"type": "boolean"},
+                "is_persistent": {"type": "boolean"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["node_address", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="storage",
+        tags=("write", "storage", "iscsi", "connect"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Attach an iSCSI target to a Windows Server host (e.g. a SQL "
+                "FCI shared disk). Recoverable; safety_level=caution. No CHAP "
+                "in this cut. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "node_address": "Required. The target IQN.",
+                "target_portal_address": "Optional. Target portal IP/DNS.",
+                "is_persistent": "Optional bool; default true.",
+            },
+            "output_shape": (
+                "{'node_address', 'action': 'connect', 'is_connected', "
+                "'is_persistent', 'op_class': 'write'}."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.storage.disk.format",
+        handler_attr="winsrv_disk_format",
+        summary="Initialize + partition + format a raw disk (caution; RAW-guarded).",
+        description=(
+            "Provisions disk ``disk_number`` into a volume: initializes it "
+            "GPT (only when RAW), creates a max-size partition (with "
+            "``drive_letter`` or an auto-assigned letter), and formats it "
+            "(``NTFS`` default / ``ReFS``, optional ``label``). FAILS CLOSED "
+            "on a disk that already carries a partition table unless "
+            "``force=true`` — it never silently clobbers data. safety_level="
+            "caution — the SQL-FCI shared-disk provisioning step after "
+            "``iscsi.connect``."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "disk_number": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "The ``Get-Disk`` Number of the disk to provision.",
+                },
+                "drive_letter": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z]$",
+                    "description": "Optional drive letter to assign; omit to auto-assign.",
+                },
+                "filesystem": {
+                    "type": "string",
+                    "enum": sorted(_SUPPORTED_FILESYSTEMS),
+                    "default": "NTFS",
+                    "description": "File system: ``NTFS`` (default) or ``ReFS``.",
+                },
+                "label": {"type": "string", "description": "Optional volume label."},
+                "force": {
+                    "type": "boolean",
+                    "description": (
+                        "Reformat a disk that already carries a partition "
+                        "table (DESTROYS its data). Default false — a "
+                        "non-RAW disk is refused without this."
+                    ),
+                },
+            },
+            "required": ["disk_number"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "disk_number": {"type": "integer"},
+                "action": {"type": "string"},
+                "drive_letter": {"type": ["string", "null"]},
+                "filesystem": {"type": ["string", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["disk_number", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="storage",
+        tags=("write", "storage", "disk", "format"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Provision a newly-attached raw disk (e.g. after "
+                "``iscsi.connect``) into a formatted volume. Refuses a disk "
+                "with an existing partition table unless force=true. "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "disk_number": "Required. The Get-Disk Number.",
+                "drive_letter": "Optional single letter; omit to auto-assign.",
+                "filesystem": "Optional; NTFS (default) or ReFS.",
+                "force": "Optional bool; required to reformat a non-RAW disk.",
+            },
+            "output_shape": (
+                "{'disk_number', 'action': 'format', 'drive_letter', "
+                "'filesystem', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_storage.py
@@ -213,8 +213,8 @@ async def winsrv_disk_format(
         "$ErrorActionPreference = 'Stop'; "
         f"$d = Get-Disk -Number {disk_number}; "
         f"if ($d.PartitionStyle -ne 'RAW' -and -not {force}) {{ "
-        f"throw 'disk {disk_number} is not RAW (PartitionStyle=' + $d.PartitionStyle + "
-        "'); pass force=true to reformat' }; "
+        f'throw "disk {disk_number} is not RAW (PartitionStyle=$($d.PartitionStyle)); '
+        'pass force=true to reformat" }; '
         f"if ($d.PartitionStyle -eq 'RAW') {{ "
         f"Initialize-Disk -Number {disk_number} -PartitionStyle GPT | Out-Null }}; "
         f"$p = New-Partition -DiskNumber {disk_number} -UseMaximumSize {letter_clause}; "

--- a/backend/src/meho_backplane/connectors/winsrv/ops_system.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_system.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""winsrv system reads — ``os-info`` / ``uptime`` / ``pending-reboot`` (all safe).
+
+Read-only system facts via ``Get-CimInstance Win32_OperatingSystem`` and the
+pending-reboot marker registry keys, routed through the shared
+PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). No operator input
+is interpolated into any of these scripts (they are constants), so the
+system-read group has no injection surface.
+
+References
+----------
+
+* ``Win32_OperatingSystem`` CIM class:
+  https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-operatingsystem
+* Pending-reboot markers (CBS RebootPending, WU RebootRequired,
+  PendingFileRenameOperations) — the widely-documented detection set.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+from meho_backplane.connectors.winsrv.ops import SSH_TRANSPORT_NOTE, WinsrvOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.winsrv.connector import WinsrvConnector
+
+__all__ = [
+    "SYSTEM_OPS",
+    "winsrv_os_info",
+    "winsrv_pending_reboot",
+    "winsrv_uptime",
+]
+
+
+_OS_INFO_SCRIPT: str = (
+    "$os = Get-CimInstance -ClassName Win32_OperatingSystem; "
+    "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+    "Hostname = [System.Net.Dns]::GetHostName(); "
+    "Caption = $os.Caption; "
+    "Version = $os.Version; "
+    "BuildNumber = $os.BuildNumber; "
+    "OSArchitecture = $os.OSArchitecture; "
+    "InstallDate = if ($os.InstallDate) { $os.InstallDate.ToString('o') } else { $null }; "
+    "LastBootUpTime = if ($os.LastBootUpTime) { $os.LastBootUpTime.ToString('o') } else { $null }; "
+    "PowerShellVersion = $PSVersionTable.PSVersion.ToString() }"
+)
+
+_UPTIME_SCRIPT: str = (
+    "$os = Get-CimInstance -ClassName Win32_OperatingSystem; "
+    "$boot = $os.LastBootUpTime; "
+    "$span = (Get-Date) - $boot; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "LastBootUpTime = if ($boot) { $boot.ToString('o') } else { $null }; "
+    "UptimeSeconds = [int64]$span.TotalSeconds; "
+    "UptimeDays = [int]$span.Days }"
+)
+
+# Each marker is a read-only Test-Path / property probe; any True flips the
+# aggregate ``pending_reboot`` to true. ``PendingFileRenameOperations`` is a
+# value under the Session Manager key, so it is probed with Get-ItemProperty.
+_PENDING_REBOOT_SCRIPT: str = (
+    "$cbs = Test-Path "
+    "'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based "
+    "Servicing\\RebootPending'; "
+    "$wu = Test-Path "
+    "'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\"
+    "Auto Update\\RebootRequired'; "
+    "$pfro = [bool]((Get-ItemProperty "
+    "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager' "
+    "-Name PendingFileRenameOperations -ErrorAction SilentlyContinue)"
+    ".PendingFileRenameOperations); "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "pending_reboot = ($cbs -or $wu -or $pfro); "
+    "component_based_servicing = $cbs; "
+    "windows_update = $wu; "
+    "pending_file_rename = $pfro }"
+)
+
+
+async def winsrv_os_info(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.system.os-info`` — the full CIM OS projection.
+
+    Runs ``Get-CimInstance Win32_OperatingSystem`` and returns the caption,
+    version, build number, architecture, install date, last-boot time, and
+    PowerShell version. Read-only.
+    """
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _OS_INFO_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def winsrv_uptime(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.system.uptime`` — derived from LastBootUpTime.
+
+    Runs a script that reads ``Win32_OperatingSystem.LastBootUpTime`` and
+    returns the boot time (ISO-8601) plus the elapsed uptime in seconds and
+    whole days. Read-only.
+    """
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _UPTIME_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def winsrv_pending_reboot(
+    connector: WinsrvConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``winsrv.system.pending-reboot`` — marker-registry probe.
+
+    Probes the three widely-documented pending-reboot markers (Component
+    Based Servicing ``RebootPending``, Windows Update ``RebootRequired``,
+    Session Manager ``PendingFileRenameOperations``) and returns the
+    aggregate ``pending_reboot`` boolean plus the per-marker breakdown.
+    Read-only.
+    """
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _PENDING_REBOOT_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+_EMPTY_PARAMS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+SYSTEM_OPS: tuple[WinsrvOp, ...] = (
+    WinsrvOp(
+        op_id="winsrv.system.os-info",
+        handler_attr="winsrv_os_info",
+        summary="Read the full Win32_OperatingSystem CIM projection.",
+        description=(
+            "Runs ``Get-CimInstance Win32_OperatingSystem`` and returns the "
+            "OS caption, version, build number, architecture, install date, "
+            "last-boot time, and PowerShell version. Read-only; a superset "
+            "of ``winsrv.about`` for callers that need the full OS facts."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Hostname": {"type": ["string", "null"]},
+                "Caption": {"type": ["string", "null"]},
+                "Version": {"type": ["string", "null"]},
+                "BuildNumber": {"type": ["string", "null"]},
+                "OSArchitecture": {"type": ["string", "null"]},
+                "InstallDate": {"type": ["string", "null"]},
+                "LastBootUpTime": {"type": ["string", "null"]},
+                "PowerShellVersion": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="system",
+        tags=("read-only", "system", "os"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for the full OS identity of a Windows Server host — "
+                "caption, version, build, architecture, install/boot times. "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict of CIM OS fields (Caption, Version, BuildNumber, "
+                "OSArchitecture, InstallDate, LastBootUpTime, ...)."
+            ),
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.system.uptime",
+        handler_attr="winsrv_uptime",
+        summary="Report host uptime derived from Win32_OperatingSystem.LastBootUpTime.",
+        description=(
+            "Reads ``Win32_OperatingSystem.LastBootUpTime`` and returns the "
+            "boot timestamp (ISO-8601) plus the elapsed uptime in seconds "
+            "and whole days. Read-only."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "LastBootUpTime": {"type": ["string", "null"]},
+                "UptimeSeconds": {"type": "integer"},
+                "UptimeDays": {"type": "integer"},
+            },
+            "additionalProperties": True,
+        },
+        group_key="system",
+        tags=("read-only", "system", "uptime"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to check how long a Windows Server host has been up "
+                "(e.g. to confirm a reboot landed, or diagnose an unexpected "
+                "restart). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'LastBootUpTime', 'UptimeSeconds', 'UptimeDays'}.",
+        },
+    ),
+    WinsrvOp(
+        op_id="winsrv.system.pending-reboot",
+        handler_attr="winsrv_pending_reboot",
+        summary="Report whether the host has a pending reboot (marker-registry probe).",
+        description=(
+            "Probes the Component Based Servicing ``RebootPending``, Windows "
+            "Update ``RebootRequired``, and Session Manager "
+            "``PendingFileRenameOperations`` markers and returns the "
+            "aggregate ``pending_reboot`` boolean plus the per-marker "
+            "breakdown. Read-only — the right pre-flight before a feature "
+            "install or a governed reboot."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "pending_reboot": {"type": "boolean"},
+                "component_based_servicing": {"type": "boolean"},
+                "windows_update": {"type": "boolean"},
+                "pending_file_rename": {"type": "boolean"},
+            },
+            "required": ["pending_reboot"],
+            "additionalProperties": True,
+        },
+        group_key="system",
+        tags=("read-only", "system", "reboot"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call before a feature install or a governed reboot to check "
+                "whether a reboot is already pending, or after one to confirm "
+                "the marker cleared. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'pending_reboot': <bool>, 'component_based_servicing', "
+                "'windows_update', 'pending_file_rename'}."
+            ),
+        },
+    ),
+)

--- a/backend/tests/test_connectors_winsrv.py
+++ b/backend/tests/test_connectors_winsrv.py
@@ -1,0 +1,617 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the winsrv connector (SSH → PowerShell / Windows Server core).
+
+Mirrors the windows_dns harness (``test_connectors_windows_dns.py``): a
+``_StubTarget`` dataclass, a ``_completed_process`` SSHCompletedProcess stub,
+and ``patch.object(connector, "_run_command", AsyncMock(...))`` so the cmdlet
+handlers can be exercised without a real Windows host. Because the transport
+is ``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1),
+the assertions decode the base64 payload back to the script and assert on the
+cmdlet + quoted arguments the handler built.
+
+There is no spec-reconcile lane — the cmdlet surface ships no OpenAPI (the
+confirmed convention for SSH-typed connectors). Drift protection is this
+ordinary unit suite. Coverage spans every op group, the injection-safety
+escape on every parameterized script, and the secret-hygiene invariant that
+no plaintext password ever enters a script.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.winsrv  # noqa: F401 -- registers connector at import
+from meho_backplane.connectors.registry import product_impl_id_round_trips
+from meho_backplane.connectors.winsrv import WINSRV_OPS, WinsrvConnector
+from meho_backplane.connectors.winsrv.ops import WINSRV_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.winsrv.ops_features import (
+    winsrv_feature_install,
+    winsrv_feature_list,
+    winsrv_feature_remove,
+)
+from meho_backplane.connectors.winsrv.ops_localusers import (
+    winsrv_localuser_create,
+    winsrv_localuser_delete,
+    winsrv_localuser_list,
+    winsrv_localuser_set,
+)
+from meho_backplane.connectors.winsrv.ops_power import (
+    winsrv_power_reboot,
+    winsrv_power_shutdown,
+)
+from meho_backplane.connectors.winsrv.ops_services import (
+    winsrv_service_get,
+    winsrv_service_list,
+    winsrv_service_restart,
+    winsrv_service_start,
+    winsrv_service_stop,
+)
+from meho_backplane.connectors.winsrv.ops_storage import (
+    winsrv_disk_format,
+    winsrv_disk_list,
+    winsrv_iscsi_connect,
+    winsrv_iscsi_list,
+    winsrv_volume_list,
+)
+from meho_backplane.connectors.winsrv.ops_system import (
+    winsrv_os_info,
+    winsrv_pending_reboot,
+    winsrv_uptime,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires (mirrors the windns suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="winsrv-test",
+    host="win.test.invalid",
+    port=22,
+    secret_ref="meho/testing/winsrv/winsrv-test",
+)
+
+
+def _completed_process(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Stub mimicking asyncssh's :class:`SSHCompletedProcess`."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _script_from_call(run_mock: AsyncMock) -> str:
+    """Recover the PowerShell script from the mocked ``_run_command`` argv.
+
+    ``pwsh_run`` builds ``powershell -NoProfile -NonInteractive
+    -EncodedCommand <base64-utf16le>`` and passes it as the 2nd positional arg
+    to ``_run_command``. Decode the base64 tail back to the script text (which
+    carries the transport's prepended ``$ProgressPreference`` guard).
+    """
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    encoded = cmd.rsplit(" ", 1)[1]
+    return base64.b64decode(encoded).decode("utf-16-le")
+
+
+def _run(stdout: str) -> AsyncMock:
+    return AsyncMock(return_value=_completed_process(stdout=stdout))
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+async def test_transport_uses_windows_powershell_and_suppresses_progress() -> None:
+    connector = WinsrvConnector()
+    assert connector.POWERSHELL_EXECUTABLE == "powershell"
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await winsrv_service_list(connector, _TARGET, {})
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    assert not cmd.startswith("pwsh ")
+    assert _script_from_call(run_mock).startswith("$ProgressPreference = 'SilentlyContinue';")
+
+
+# ---------------------------------------------------------------------------
+# Registration / metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_connector_id_triple_round_trips() -> None:
+    assert WinsrvConnector.product == "winsrv"
+    assert WinsrvConnector.version == "2022.x"
+    assert WinsrvConnector.impl_id == "winsrv-ssh"
+    assert product_impl_id_round_trips(product="winsrv", version="2022.x", impl_id="winsrv-ssh")
+
+
+def test_op_surface_ids_and_safety_tiers() -> None:
+    by_id = {op.op_id: op for op in WINSRV_OPS}
+    assert len(by_id) == 23
+    safe = {k for k, v in by_id.items() if v.safety_level == "safe"}
+    caution = {k for k, v in by_id.items() if v.safety_level == "caution"}
+    dangerous = {k for k, v in by_id.items() if v.safety_level == "dangerous"}
+    assert dangerous == {
+        "winsrv.power.reboot",
+        "winsrv.power.shutdown",
+        "winsrv.localuser.delete",
+    }
+    # Every dangerous op requires approval; nothing else does.
+    assert {k for k, v in by_id.items() if v.requires_approval} == dangerous
+    assert "winsrv.feature.install" in caution
+    assert "winsrv.storage.disk.format" in caution
+    assert {"winsrv.about", "winsrv.service.list", "winsrv.storage.disk.list"} <= safe
+
+
+def test_every_group_has_a_curated_when_to_use() -> None:
+    groups = {op.group_key for op in WINSRV_OPS}
+    assert groups == {"system", "services", "features", "power", "localusers", "storage"}
+    assert groups <= set(WINSRV_WHEN_TO_USE_BY_GROUP)
+
+
+def test_every_handler_attr_resolves_on_the_class() -> None:
+    for op in WINSRV_OPS:
+        assert getattr(WinsrvConnector, op.handler_attr, None) is not None, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# system group
+# ---------------------------------------------------------------------------
+
+
+async def test_os_info_builds_cim_query() -> None:
+    connector = WinsrvConnector()
+    payload = '{"Caption":"Microsoft Windows Server 2022 Datacenter","Version":"10.0.20348"}'
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_os_info(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-CimInstance -ClassName Win32_OperatingSystem" in script
+    assert result["Version"] == "10.0.20348"
+
+
+async def test_uptime_reads_last_boot_up_time() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"LastBootUpTime":"2026-09-01T00:00:00.0000000+00:00","UptimeSeconds":3600}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_uptime(connector, _TARGET, {})
+    assert "LastBootUpTime" in _script_from_call(run_mock)
+    assert result["UptimeSeconds"] == 3600
+
+
+async def test_pending_reboot_probes_markers() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"pending_reboot":false,"component_based_servicing":false}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_pending_reboot(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Component Based Servicing" in script
+    assert "PendingFileRenameOperations" in script
+    assert result["pending_reboot"] is False
+
+
+# ---------------------------------------------------------------------------
+# services group
+# ---------------------------------------------------------------------------
+
+
+async def test_service_list_builds_envelope() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"rows":[{"Name":"MSSQLSERVER","Status":"Running"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_service_list(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-Service" in script
+    assert "rows = $svc; total = $svc.Count" in script
+    assert result["total"] == 1
+
+
+@pytest.mark.parametrize("rows_json", ["[]", "null"])
+async def test_service_list_empty_host(rows_json: str) -> None:
+    connector = WinsrvConnector()
+    run_mock = _run(f'{{"rows":{rows_json},"total":0}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_service_list(connector, _TARGET, {})
+    assert result == {"rows": [], "total": 0}
+
+
+async def test_service_get_builds_named_query_and_escapes() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"rows":[{"Name":"o\'db"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        await winsrv_service_get(connector, _TARGET, {"name": "o'db"})
+    script = _script_from_call(run_mock)
+    assert "-Name 'o''db'" in script  # single quote doubled inside the literal
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet", "action"),
+    [
+        (winsrv_service_start, "Start-Service", "start"),
+        (winsrv_service_stop, "Stop-Service", "stop"),
+        (winsrv_service_restart, "Restart-Service", "restart"),
+    ],
+)
+async def test_service_actions_build_cmdlet(handler: Any, cmdlet: str, action: str) -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"name":"W32Time","status":"Running"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(connector, _TARGET, {"name": "W32Time"})
+    script = _script_from_call(run_mock)
+    assert f"{cmdlet} -Name 'W32Time'" in script
+    assert result == {
+        "name": "W32Time",
+        "action": action,
+        "status": "Running",
+        "op_class": "write",
+    }
+
+
+# ---------------------------------------------------------------------------
+# features group
+# ---------------------------------------------------------------------------
+
+
+async def test_feature_install_builds_cmdlet_and_toggles() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run(
+        '{"success":true,"exit_code":"Success","restart_needed":true,'
+        '"features_changed":["Failover-Clustering"]}'
+    )
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_feature_install(
+            connector,
+            _TARGET,
+            {"name": "Failover-Clustering", "include_management_tools": True},
+        )
+    script = _script_from_call(run_mock)
+    assert "Install-WindowsFeature -Name 'Failover-Clustering'" in script
+    assert "-IncludeManagementTools:$true" in script
+    assert "-IncludeAllSubFeature:$false" in script
+    assert "-Restart" not in script  # never auto-restart
+    assert result["success"] is True
+    assert result["restart_needed"] is True
+    assert result["features_changed"] == ["Failover-Clustering"]
+
+
+async def test_feature_remove_builds_uninstall() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"success":true,"exit_code":"Success","restart_needed":false}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_feature_remove(connector, _TARGET, {"name": "Web-Server"})
+    script = _script_from_call(run_mock)
+    assert "Uninstall-WindowsFeature -Name 'Web-Server'" in script
+    assert "-Restart" not in script
+    assert result["action"] == "remove"
+
+
+async def test_feature_list_builds_envelope() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"rows":[{"Name":"Web-Server","Installed":false}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_feature_list(connector, _TARGET, {})
+    assert "Get-WindowsFeature" in _script_from_call(run_mock)
+    assert result["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# power group (dangerous + requires_approval)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("handler", "flag", "action"),
+    [(winsrv_power_reboot, "/r", "reboot"), (winsrv_power_shutdown, "/s", "shutdown")],
+)
+async def test_power_schedules_shutdown_exe(handler: Any, flag: str, action: str) -> None:
+    connector = WinsrvConnector()
+    run_mock = _run(f'{{"ok":true,"action":"{action}","delay_seconds":30}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(
+            connector, _TARGET, {"delay_seconds": 30, "message": "patch o'clock"}
+        )
+    script = _script_from_call(run_mock)
+    assert f"shutdown.exe {flag} /t 30" in script
+    assert "/c 'patch o''clock'" in script  # message single-quote-escaped
+    assert "$LASTEXITCODE -ne 0" in script  # native-exit guard
+    assert result == {
+        "ok": True,
+        "action": action,
+        "delay_seconds": 30,
+        "message": "patch o'clock",
+        "op_class": "write",
+    }
+
+
+async def test_power_default_delay_and_no_message() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"action":"reboot","delay_seconds":15}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_power_reboot(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "shutdown.exe /r /t 15" in script
+    assert "/c" not in script
+    assert result["delay_seconds"] == 15
+
+
+async def test_power_rejects_negative_delay() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await winsrv_power_reboot(connector, _TARGET, {"delay_seconds": -5})
+    run_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# localusers group — incl. the secret-hygiene invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_localuser_create_is_passwordless() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"user":{"Name":"svc-sql","Enabled":true}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_localuser_create(
+            connector, _TARGET, {"name": "svc-sql", "description": "SQL service"}
+        )
+    script = _script_from_call(run_mock)
+    assert "New-LocalUser -Name 'svc-sql' -NoPassword" in script
+    assert "-Description 'SQL service'" in script
+    # Secret-hygiene: no password material ever enters the script.
+    assert "-Password " not in script
+    assert "ConvertTo-SecureString" not in script
+    assert result["action"] == "create"
+
+
+async def test_localuser_set_builds_and_toggles() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"user":{"Name":"svc-sql","Enabled":false}}')
+    with patch.object(connector, "_run_command", run_mock):
+        await winsrv_localuser_set(
+            connector, _TARGET, {"name": "svc-sql", "description": "x", "enabled": False}
+        )
+    script = _script_from_call(run_mock)
+    assert "Set-LocalUser -Name 'svc-sql' -Description 'x'" in script
+    assert "Disable-LocalUser -Name 'svc-sql'" in script
+    assert "-Password " not in script
+
+
+async def test_localuser_set_requires_an_attribute() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await winsrv_localuser_set(connector, _TARGET, {"name": "svc-sql"})
+    run_mock.assert_not_awaited()
+
+
+async def test_localuser_delete_builds_remove() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_localuser_delete(connector, _TARGET, {"name": "svc-sql"})
+    assert "Remove-LocalUser -Name 'svc-sql'" in _script_from_call(run_mock)
+    assert result == {"name": "svc-sql", "action": "delete", "op_class": "write"}
+
+
+async def test_localuser_list_reads_no_secret() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"rows":[{"Name":"Administrator"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_localuser_list(connector, _TARGET, {})
+    assert "Get-LocalUser" in _script_from_call(run_mock)
+    assert result["total"] == 1
+
+
+def test_no_write_op_exposes_a_secret_value_field() -> None:
+    """The secret-leak guard at the schema level: no op accepts a plaintext
+    secret-value parameter (password / secret / chap credential), so a secret
+    can never reach the ``-EncodedCommand`` argv. Boolean policy flags whose
+    NAME contains 'password' (e.g. ``password_never_expires``) are fine — the
+    guard keys on exact secret-value field names, not substrings."""
+    secret_fields = {"password", "secret", "chap_secret", "chapsecret", "chap_username"}
+    for op in WINSRV_OPS:
+        props = op.parameter_schema.get("properties", {})
+        leaked = secret_fields & {key.lower() for key in props}
+        assert not leaked, (op.op_id, sorted(leaked))
+
+
+# ---------------------------------------------------------------------------
+# storage group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet"),
+    [
+        (winsrv_disk_list, "Get-Disk"),
+        (winsrv_volume_list, "Get-Volume"),
+        (winsrv_iscsi_list, "Get-IscsiTarget"),
+    ],
+)
+async def test_storage_lists_build_envelope(handler: Any, cmdlet: str) -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(connector, _TARGET, {})
+    assert cmdlet in _script_from_call(run_mock)
+    assert result == {"rows": [], "total": 0}
+
+
+async def test_iscsi_connect_builds_cmdlet_and_escapes() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"is_connected":true,"is_persistent":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_iscsi_connect(
+            connector,
+            _TARGET,
+            {"node_address": "iqn.1991-05.com.microsoft:t'gt", "target_portal_address": "10.0.0.5"},
+        )
+    script = _script_from_call(run_mock)
+    assert "Connect-IscsiTarget -NodeAddress 'iqn.1991-05.com.microsoft:t''gt'" in script
+    assert "-TargetPortalAddress '10.0.0.5'" in script
+    assert "-IsPersistent $true" in script
+    assert result["is_connected"] is True
+
+
+async def test_iscsi_connect_rejects_bad_port() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await winsrv_iscsi_connect(
+            connector, _TARGET, {"node_address": "iqn.x", "target_portal_port": 99999}
+        )
+    run_mock.assert_not_awaited()
+
+
+async def test_disk_format_provisions_raw_disk() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"disk":3,"drive_letter":"E","filesystem":"NTFS"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await winsrv_disk_format(
+            connector, _TARGET, {"disk_number": 3, "drive_letter": "e", "label": "sql'data"}
+        )
+    script = _script_from_call(run_mock)
+    assert "Get-Disk -Number 3" in script
+    assert "Initialize-Disk -Number 3 -PartitionStyle GPT" in script
+    assert "New-Partition -DiskNumber 3 -UseMaximumSize -DriveLetter E" in script
+    assert "-FileSystem 'NTFS'" in script
+    assert "-NewFileSystemLabel 'sql''data'" in script
+    assert "-not $false" in script  # force defaults to $false → non-RAW disk refused
+    assert result["drive_letter"] == "E"
+
+
+async def test_disk_format_force_flag_rendered() -> None:
+    connector = WinsrvConnector()
+    run_mock = _run('{"ok":true,"disk":3,"drive_letter":"E","filesystem":"NTFS"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await winsrv_disk_format(connector, _TARGET, {"disk_number": 3, "force": True})
+    script = _script_from_call(run_mock)
+    assert "-not $true" in script
+    assert "-AssignDriveLetter" in script  # no drive_letter → auto-assign
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"disk_number": 3, "filesystem": "ext4"},
+        {"disk_number": 3, "drive_letter": "EE"},
+        {"disk_number": -1},
+    ],
+)
+async def test_disk_format_rejects_bad_input(params: dict[str, Any]) -> None:
+    connector = WinsrvConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await winsrv_disk_format(connector, _TARGET, params)
+    run_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# about (fingerprint wrapper) + probe
+# ---------------------------------------------------------------------------
+
+
+async def test_about_maps_fingerprint_into_identity_dict() -> None:
+    connector = WinsrvConnector()
+    payload = (
+        '{"Hostname":"SQL01","Caption":"Microsoft Windows Server 2022 Datacenter",'
+        '"Version":"10.0.20348","BuildNumber":"20348","PowerShellVersion":"5.1.20348.1"}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await connector.about(_TARGET, {})
+    assert result["vendor"] == "microsoft"
+    assert result["product"] == "windows-server"
+    assert result["version"] == "10.0.20348"
+    assert result["build"] == "20348"
+    assert result["hostname"] == "SQL01"
+    assert result["os_caption"].startswith("Microsoft Windows Server 2022")
+    assert result["powershell_version"] == "5.1.20348.1"
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("connection reset by peer"),
+        asyncssh.ConnectionLost("channel closed mid-command"),
+        TimeoutError("probe script timed out"),
+    ],
+)
+async def test_probe_command_failed_when_run_command_raises_after_connect(boom: Exception) -> None:
+    connector = WinsrvConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "command_failed"
+
+
+async def test_probe_os_query_failed_when_cim_unreadable() -> None:
+    connector = WinsrvConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"present":false}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "os_query_failed"
+
+
+async def test_probe_ok_when_cim_readable() -> None:
+    connector = WinsrvConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"present":true}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is True
+    assert result.reason is None
+
+
+async def test_probe_tcp_unreachable_and_auth_failed() -> None:
+    connector = WinsrvConnector()
+    with patch.object(connector, "_connect", AsyncMock(side_effect=OSError("no route"))):
+        assert (await connector.probe(_TARGET)).reason == "tcp_unreachable"
+    with patch.object(
+        connector, "_connect", AsyncMock(side_effect=asyncssh.PermissionDenied("no"))
+    ):
+        assert (await connector.probe(_TARGET)).reason == "ssh_auth_failed"
+
+
+async def test_fingerprint_unreachable_is_not_an_exception() -> None:
+    connector = WinsrvConnector()
+    with patch.object(connector, "_run_command", AsyncMock(side_effect=OSError("down"))):
+        result = await connector.fingerprint(_TARGET)
+    assert result.reachable is False
+    assert result.vendor == "microsoft"
+    assert "error" in result.extras

--- a/backend/tests/test_connectors_winsrv.py
+++ b/backend/tests/test_connectors_winsrv.py
@@ -540,6 +540,8 @@ async def test_disk_format_force_flag_rendered() -> None:
     [
         {"disk_number": 3, "filesystem": "ext4"},
         {"disk_number": 3, "drive_letter": "EE"},
+        {"disk_number": 3, "drive_letter": "Ä"},  # unicode letter — ASCII-only per the schema
+        {"disk_number": 3, "drive_letter": "5"},
         {"disk_number": -1},
     ],
 )

--- a/backend/tests/test_connectors_winsrv.py
+++ b/backend/tests/test_connectors_winsrv.py
@@ -306,11 +306,26 @@ async def test_feature_remove_builds_uninstall() -> None:
     connector = WinsrvConnector()
     run_mock = _run('{"success":true,"exit_code":"Success","restart_needed":false}')
     with patch.object(connector, "_run_command", run_mock):
-        result = await winsrv_feature_remove(connector, _TARGET, {"name": "Web-Server"})
+        result = await winsrv_feature_remove(
+            connector, _TARGET, {"name": "Web-Server", "include_management_tools": True}
+        )
     script = _script_from_call(run_mock)
     assert "Uninstall-WindowsFeature -Name 'Web-Server'" in script
+    # The management-tools toggle wires to -IncludeManagementTools (name matches wiring).
+    assert "-IncludeManagementTools:$true" in script
     assert "-Restart" not in script
     assert result["action"] == "remove"
+
+
+def test_feature_remove_toggle_param_name_matches_wiring() -> None:
+    """Guard against the misleading-param-name regression: the remove op's
+    management-tools toggle is named ``include_management_tools`` (matching the
+    install op + the ``-IncludeManagementTools`` it drives), not
+    ``include_all_sub_feature``."""
+    by_id = {op.op_id: op for op in WINSRV_OPS}
+    props = by_id["winsrv.feature.remove"].parameter_schema["properties"]
+    assert "include_management_tools" in props
+    assert "include_all_sub_feature" not in props
 
 
 async def test_feature_list_builds_envelope() -> None:
@@ -505,6 +520,8 @@ async def test_disk_format_provisions_raw_disk() -> None:
     assert "-FileSystem 'NTFS'" in script
     assert "-NewFileSystemLabel 'sql''data'" in script
     assert "-not $false" in script  # force defaults to $false → non-RAW disk refused
+    # The RAW-guard throw uses an unambiguous double-quoted subexpression.
+    assert 'throw "disk 3 is not RAW (PartitionStyle=$($d.PartitionStyle))' in script
     assert result["drive_letter"] == "E"
 
 

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -456,6 +456,7 @@ _EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
         "vrops-rest",
         "vrops-vrops8",
         "windns-ssh",
+        "winsrv-ssh",
     }
 )
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -32398,7 +32398,8 @@
               "vmware",
               "vrli",
               "vrops",
-              "windns"
+              "windns",
+              "winsrv"
             ],
             "description": "Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss."
           },

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -559,6 +559,7 @@ const (
 	TargetCreateProductVrli       TargetCreateProduct = "vrli"
 	TargetCreateProductVrops      TargetCreateProduct = "vrops"
 	TargetCreateProductWindns     TargetCreateProduct = "windns"
+	TargetCreateProductWinsrv     TargetCreateProduct = "winsrv"
 )
 
 // Defines values for TemplateSummaryStatus.

--- a/docs/codebase/connectors-winsrv.md
+++ b/docs/codebase/connectors-winsrv.md
@@ -286,8 +286,14 @@ generated Go client knows the token).
   Vault-minted-password flow (rke2 `token.rotate` mold) is a follow-up.
 - **iSCSI CHAP** is not supported (`iscsi.connect` connects against a trusted
   fabric); a Vault-brokered CHAP flow is a follow-up.
-- **`disk.format`** refuses a disk that already carries a partition table unless
-  `force=true`, so an accidental format never silently clobbers data.
+- **`disk.format`** is non-destructive by construction: it `Initialize-Disk`s
+  only a `RAW` disk and `New-Partition -UseMaximumSize` only allocates
+  **unallocated** space, so it never removes an existing partition or its data.
+  It refuses a non-`RAW` disk unless `force=true`; `force=true` then only
+  provisions the disk's free space (a full disk fails at `New-Partition`) — it
+  does **not** wipe. A true data-destroying wipe (`Clear-Disk -RemoveData`) is
+  deliberately not offered on this `caution` op: per the #3259 tier doctrine a
+  wipe belongs to a separate `dangerous` op with its own ticket.
 - **Consumer proof against a live c1sql1 lab node is an OPEN acceptance
   criterion** — the c1sql1 Windows Server 2022 VMs do not exist yet; the probe +
   feature-install + service-ops proof is deferred to the lab program

--- a/docs/codebase/connectors-winsrv.md
+++ b/docs/codebase/connectors-winsrv.md
@@ -1,0 +1,310 @@
+# Connector: winsrv (winsrv-2022.x / `winsrv-ssh`)
+
+## Overview
+
+The `winsrv` connector is the typed `Connector` subclass that manages **Windows
+Server core** — system facts, service and feature management, reboot/shutdown,
+local users, and disk / iSCSI-initiator storage — over SSH → PowerShell (the
+built-in Windows PowerShell 5.1 cmdlets). It is registered under the
+`(product="winsrv", version="2022.x", impl_id="winsrv-ssh")` registry triple
+plus the `("winsrv", "", "")` wildcard fallback row, and is a child of the
+shared `SshConnector` adapter (`connectors/adapters/ssh.py`) — the same
+transport base as `WindowsDnsConnector`, `HolodeckConnector`, and
+`Rke2SshConnector`.
+
+Windows Server core management exposes **no unified REST API**; before this
+connector the c1sql1 program (evoila-bosnia/claude-rdc-hetzner-dc#2789) drove
+feature installs and reboots through raw `govc guest.run` — ungoverned. The
+connector is a structural sibling of `windows_dns` (identity canary + per-domain
+op groups on the `SshConnector` base) built on the PowerShell-over-SSH transport
+`_shared/pwsh` (base64 UTF-16LE `-EncodedCommand` + stdlib `json` parse). It
+adopts the `rke2` approval-parked-write mold for its destructive ops.
+
+`winsrv` is also the **estate mold**: `msad` (#3262), `wsfc` (#3263), and
+`hyperv` (#3265) are structured copies of this package with different cmdlet
+modules — see "Building the next estate connector" below.
+
+Registry-triple rationale: `product="winsrv"` is a short, separator-free token
+because `parse_connector_id` derives the product from the first hyphen-segment
+of `impl_id`, so `connector_id="winsrv-ssh-2022.x"` round-trips (a
+hyphen/underscore in the product token breaks the registry's round-trip guard at
+boot — the reason `vcf_logs` retired its `vcf-logs` token). `version="2022.x"`
+marks the cmdlet surface (stable across Windows Server 2019 → 2025).
+`impl_id="winsrv-ssh"` leaves room for a future `winsrv-winrm` sibling.
+
+Source: `backend/src/meho_backplane/connectors/winsrv/`.
+
+## Op surface (23 ops across six groups)
+
+Safety tier is a reach decision per the Initiative #3259 satellite table: reads
+= `safe` (ride satellite runners); recoverable writes = `caution` (satellite-
+executable only through the Stage-3 composed write gate, #2901); destructive =
+`dangerous` + `requires_approval` (satellite-EXCLUDED by the tier ladder,
+central-dial / on-site only).
+
+| op | safety | approval | cmdlet(s) |
+| --- | --- | --- | --- |
+| `winsrv.about` | safe | no | `Get-CimInstance Win32_OperatingSystem` + `$PSVersionTable` |
+| `winsrv.system.os-info` | safe | no | `Get-CimInstance Win32_OperatingSystem` |
+| `winsrv.system.uptime` | safe | no | `Win32_OperatingSystem.LastBootUpTime` |
+| `winsrv.system.pending-reboot` | safe | no | CBS / WU / Session-Manager marker registry keys |
+| `winsrv.service.list` | safe | no | `Get-Service` |
+| `winsrv.service.get` | safe | no | `Get-Service -Name` |
+| `winsrv.service.start` | caution | no | `Start-Service` |
+| `winsrv.service.stop` | caution | no | `Stop-Service` |
+| `winsrv.service.restart` | caution | no | `Restart-Service` |
+| `winsrv.feature.list` | safe | no | `Get-WindowsFeature` |
+| `winsrv.feature.install` | caution | no | `Install-WindowsFeature` |
+| `winsrv.feature.remove` | caution | no | `Uninstall-WindowsFeature` |
+| `winsrv.power.reboot` | **dangerous** | **yes** | `shutdown.exe /r /t <delay>` |
+| `winsrv.power.shutdown` | **dangerous** | **yes** | `shutdown.exe /s /t <delay>` |
+| `winsrv.localuser.list` | safe | no | `Get-LocalUser` |
+| `winsrv.localuser.create` | caution | no | `New-LocalUser -NoPassword` |
+| `winsrv.localuser.set` | caution | no | `Set-LocalUser` + `Enable-`/`Disable-LocalUser` |
+| `winsrv.localuser.delete` | **dangerous** | **yes** | `Remove-LocalUser` |
+| `winsrv.storage.disk.list` | safe | no | `Get-Disk` |
+| `winsrv.storage.volume.list` | safe | no | `Get-Volume` |
+| `winsrv.storage.iscsi.list` | safe | no | `Get-IscsiTarget` |
+| `winsrv.storage.iscsi.connect` | caution | no | `Connect-IscsiTarget` |
+| `winsrv.storage.disk.format` | caution | no | `Initialize-Disk` + `New-Partition` + `Format-Volume` |
+
+The three `dangerous` ops (`power.reboot`, `power.shutdown`, `localuser.delete`)
+are `requires_approval=True` — a dispatch parks at `needs-approval` for a human
+decision (the rke2 write mold; no bespoke `proposed_effect` builder is
+registered — the generic params-echo default (#1856) surfaces the target /
+params redaction-safely to the reviewer). The **agent-principal ceiling**
+therefore applies: an agent session cannot self-approve these — approval is a
+human decision (v0.1-spec §7), so a `winsrv.power.*` / `localuser.delete`
+dispatch from an agent floors at the approval queue until an operator approves in
+the console / CLI. Reads ride satellite runners; the `dangerous` ops are excluded
+from satellites by the tier ladder.
+
+## Key types
+
+- **`WinsrvConnector`** (`connector.py`) — `SshConnector` subclass. Class
+  attributes: `product="winsrv"`, `version="2022.x"`, `impl_id="winsrv-ssh"`,
+  `POWERSHELL_EXECUTABLE="powershell"`. Ships `fingerprint`, `probe`, `about`,
+  the 22 bound-method op shims, `register_operations`, and the operator-less
+  `execute` dispatcher shim. Inherits the per-target asyncssh connection pool,
+  `_auth_config`, `_run_command`, `_assert_reachable`, and `aclose()` from the
+  adapter.
+- **Shared pwsh transport** (`_shared/pwsh.py`, #3260) — `pwsh_run` (the single
+  seam every handler routes its script through), `ps_single_quote` (the
+  `shlex.quote` analogue), `encode_pwsh_command`, `strip_clixml`, `PwshRunError`.
+  Per-connector wire variation rides three class-level seams:
+  `POWERSHELL_EXECUTABLE` (`powershell` here), `POWERSHELL_SCRIPT_PREFIX` (the
+  `$ProgressPreference` guard), `POWERSHELL_LOG_EVENT` (`winsrv_pwsh_executed`).
+- **Op metadata** (`ops.py`) — `WinsrvOp` frozen dataclass (mirrors `WindowsDnsOp`
+  / `Rke2Op`), `WINSRV_OPS` (`about` + the six per-domain tuples),
+  `WINSRV_WHEN_TO_USE_BY_GROUP` (curated per-group blurbs, imported into the
+  connector — the rke2 `RKE2_WHEN_TO_USE_WRITE_BY_GROUP` precedent), and
+  `normalise_json_rows` (collapses `ConvertTo-Json`'s dict / list / null shapes
+  to `list[dict]`).
+- **Per-domain op modules** — `ops_system.py`, `ops_services.py`,
+  `ops_features.py`, `ops_power.py`, `ops_localusers.py`, `ops_storage.py`. Each
+  owns its handlers + op tuple, imports `WinsrvOp` from `ops.py`, and (for
+  parameterized scripts) `ps_single_quote` from `_shared/pwsh`.
+- **Registration** (`__init__.py`) — two-phase, mirroring windows_dns / rke2:
+  synchronous `register_connector_v2` at import time (versioned triple + wildcard
+  row); async `register_winsrv_typed_operations` queued onto the lifespan
+  registrar list. No v1 `register_connector` — no chassis history.
+
+## Transport: PowerShell-over-SSH
+
+Every op runs `powershell -NoProfile -NonInteractive -EncodedCommand <base64>`
+over the pooled SSH connection:
+
+- **`powershell` (Windows PowerShell 5.1), not `pwsh` (PS7).** A Windows Server
+  host ships 5.1; PS7 is a separate optional install absent by default. The
+  connector sets `POWERSHELL_EXECUTABLE="powershell"` explicitly.
+- **`-EncodedCommand` wire shape** — the script is UTF-16LE-encoded and base64'd
+  (no BOM). The shell never parses the script text, so there is no `sh -c`
+  quoting layer; only the PowerShell parser sees it.
+- **`$ProgressPreference = 'SilentlyContinue'` guard** — prepended to every
+  script so the ServerManager / CIM modules' first-use progress stream never
+  serialises CLIXML noise onto the streams.
+- **JSON out** — handlers pipe through `ConvertTo-Json` (explicit `-Depth`) and
+  `pwsh_run` parses stdout with stdlib `json`.
+- **Hashtable envelope for list reads** — `ConvertTo-Json` emits *nothing* on a
+  zero-object pipeline (which trips `pwsh_run`'s empty-stdout guard), so every
+  list read wraps its result in `@{ rows = $x; total = $x.Count }` and runs under
+  `$ErrorActionPreference = 'Stop'` (a cmdlet error must surface as a real
+  `PwshRunError`, not read as a false-empty inventory). The `{rows, total}`
+  envelope is what the dispatcher's JSONFlux reducer keys on to spill a
+  set-shaped result to a `result_query` handle.
+- **`shutdown.exe` for power ops** — a bare `Restart-Computer -Force` tears down
+  the SSH channel before the JSON ack flushes (`pwsh_run` would raise on the
+  truncated read, reporting failure on a reboot that succeeded). The power ops
+  instead *schedule* the reboot/shutdown with `shutdown.exe /r|/s /t <delay>`
+  (default 15s), so the ack flushes cleanly and the host goes down after the
+  delay. `$LASTEXITCODE` is checked so a rejected schedule surfaces as a real
+  `PwshRunError`.
+- **Secret hygiene** — logging emits `script_len` / `encoded_len` /
+  `exit_status` only; `PwshRunError` never retains the script or the encoded
+  payload. The SSH credential is the only secret and it never reaches the script
+  text.
+
+### Injection safety
+
+Operator-supplied strings (service / feature / user names, iSCSI IQN, volume
+label, reboot message) are interpolated only inside **single-quoted** PowerShell
+literals via `ps_single_quote` (embedded `'` doubled — complete escaping inside a
+single-quoted PowerShell string). Integers (delay, disk number, iSCSI port) are
+validated to `int` before interpolation; `filesystem` and `drive_letter` are
+validated against a bounded enum / `^[A-Za-z]$`; booleans render as fixed
+`$true` / `$false` literals, never as interpolated operator text.
+
+### No plaintext secret on the wire (deliberate)
+
+The `-EncodedCommand` payload lands on the remote process argv and the script
+body is visible to a privileged remote observer, so the shared transport's safety
+contract **forbids credential material in the script**. Two consequences:
+
+- **`localuser.create` is passwordless** (`New-LocalUser -NoPassword`) and
+  `localuser.set` never touches the password. Provisioning a password is a
+  deferred follow-up (the rke2 `token.rotate` mint-and-stash-in-Vault mold, so no
+  secret enters the script) — until then set it out of band or via the domain
+  (msad, #3262).
+- **`iscsi.connect` has no CHAP** — `Connect-IscsiTarget` supports
+  `-ChapUsername` / `-ChapSecret`, but the secret would land in the script. CHAP
+  is out of scope for this cut (connect against a trusted fabric); a
+  Vault-brokered CHAP flow is a follow-up.
+
+A unit test (`test_no_write_op_exposes_a_secret_value_field`) pins this at the
+schema level: no op declares a `password` / `secret` / CHAP parameter.
+
+## `fingerprint(target)` / `probe(target)`
+
+`fingerprint` runs one `-EncodedCommand` round-trip reading the hostname +
+`Win32_OperatingSystem` (caption / version / build) + PowerShell version; returns
+`vendor="microsoft"`, `product="windows-server"`, `version=<OS version>`,
+`build=<build number>`, with `extras={hostname, os_caption, powershell_version}`.
+Any transport / credential failure (`OSError`, `asyncssh.Error`, `ValueError`,
+`VaultClientError`, `CredentialsReadError`, `PwshRunError`) maps to
+`reachable=False` + `extras["error"]` — never an unhandled exception (#986).
+`about` (`winsrv.about`) wraps `fingerprint` + `_assert_reachable`.
+
+`probe` surfaces five distinct `ProbeResult.reason` values:
+
+| reason | meaning |
+| --- | --- |
+| `tcp_unreachable` | the SSH TCP socket cannot connect |
+| `ssh_auth_failed` | credentials rejected / handshake failed / Vault credential unresolvable |
+| `powershell_unavailable` | SSH succeeded but the PowerShell reachability script failed |
+| `command_failed` | post-connect transport failure (connection drop / timeout / socket error) after a successful handshake (the #986 post-connect guard) |
+| `os_query_failed` | PowerShell runs but `Win32_OperatingSystem` is not readable (not a healthy Windows host, or WMI/CIM broken) |
+
+## Auth
+
+Uses the base `SshConnector._auth_config` **unchanged** — a Vault secret with
+`ssh_private_key` prefers key auth, otherwise password auth runs. Credentials
+resolve via `_shared/vault_creds` from the Vault KV-v2 path string in
+`target.secret_ref`. The transport prerequisite is an **OpenSSH server on the
+Windows target** (same as windows_dns), with `powershell` reachable as the login
+shell or via the default shell. Server-side setup:
+
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd; Set-Service -Name sshd -StartupType Automatic
+# Optionally make PowerShell the default SSH shell:
+New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell `
+  -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force
+```
+
+`probe()` carries no operator, so its Vault read runs under the synthesised
+system operator and fails closed to `ssh_auth_failed`.
+
+## Control flow
+
+1. **Boot** — `_eager_import_connectors()` imports the `winsrv` subpackage;
+   `__init__.py` registers the v2 triple + wildcard synchronously and queues the
+   typed-op registrar.
+2. **Lifespan startup** — `run_typed_op_registrars()` →
+   `register_winsrv_typed_operations` → `WinsrvConnector.register_operations`,
+   which upserts each `WINSRV_OPS` entry into `endpoint_descriptor` (idempotent
+   across restarts) with the curated per-group `when_to_use`. The op rows come
+   from **runtime registration, not an alembic migration** — there is no schema
+   change.
+3. **Dispatch** — `POST /api/v1/operations/call` resolves
+   `connector_id="winsrv-ssh-2022.x"` + the target and invokes the bound handler
+   through the policy/audit path. `dangerous` + `requires_approval` ops park at
+   `needs-approval` first. The CLI reaches the same path via `meho operation call
+   winsrv-ssh-2022.x <op_id> --params-json '{...}'` (no dedicated `meho winsrv`
+   verb package — the windows_dns / rke2 precedent for SSH-typed connectors).
+
+## Building the next estate connector
+
+`winsrv` is the mold for `msad` / `wsfc` / `hyperv`. When copying this package,
+**the single most important footgun**:
+
+> The shared transport's `POWERSHELL_EXECUTABLE` fallback is **`pwsh` (PS7)**,
+> which a Windows Server host does NOT ship. A connector that forgets to set the
+> class attribute gets a silent `pwsh -EncodedCommand`, which fails confusingly
+> ("`pwsh` is not recognized") on every 5.1-only Windows host. **Every
+> Windows-estate connector MUST set `POWERSHELL_EXECUTABLE = "powershell"`
+> explicitly** (as `winsrv` and `windows_dns` do). The transport keeps the `pwsh`
+> default deliberately, so a bare mock connector resolves to the documented
+> default in the shared-transport unit suite (`test_connectors_holodeck_pwsh.py`);
+> the estate connectors override it, so the default is never hit in production.
+
+Other copy points: set `POWERSHELL_SCRIPT_PREFIX` to the `$ProgressPreference`
+guard if the connector's cmdlet module emits first-use progress; give
+`POWERSHELL_LOG_EVENT` a connector-scoped name; keep the `{rows, total}` envelope
+under `$ErrorActionPreference = 'Stop'` for list reads; interpolate every
+operator string through `ps_single_quote`; never embed credential material in a
+script; and put destructive ops on the `dangerous` + `requires_approval` tier
+(the rke2 mold).
+
+## Tests
+
+`backend/tests/test_connectors_winsrv.py` — mirrors the windows_dns harness
+(`_StubTarget`, `_completed_process`, `patch.object(connector, "_run_command",
+AsyncMock(...))`); assertions decode the `-EncodedCommand` base64 back to the
+script text. Covers the transport (`powershell` + `$ProgressPreference`), the
+registry-triple round-trip, the 23-op surface + safety-tier + group-coverage
+invariants, every op group's script construction, the injection-safety escape on
+every parameterized script (service / feature / user name, iSCSI IQN, volume
+label, reboot message — single-quote doubling), the secret-hygiene invariant (no
+secret-value parameter on any op; passwordless create/set), the `disk.format`
+RAW-disk guard + `force` override + input validation, the `about` fingerprint
+mapping, and the probe reason matrix. **No spec-reconcile lane** — the cmdlet
+surface ships no OpenAPI (the confirmed convention for SSH-typed connectors);
+drift protection is this ordinary unit suite.
+
+## CLI
+
+No dedicated `meho winsrv` verb package (the windows_dns / rke2 precedent for
+SSH-typed connectors). CLI parity is the generic dispatch path — `meho operation
+call winsrv-ssh-2022.x <op_id> --params-json '{...}'` — plus the `winsrv` product
+token added to the OpenAPI `TargetCreate.product` enum (regenerated from the live
+registry, so `meho targets create --product winsrv ...` validates and the
+generated Go client knows the token).
+
+## Known issues / scope
+
+- **Local-user passwords** are not provisioned (create is `-NoPassword`); a
+  Vault-minted-password flow (rke2 `token.rotate` mold) is a follow-up.
+- **iSCSI CHAP** is not supported (`iscsi.connect` connects against a trusted
+  fabric); a Vault-brokered CHAP flow is a follow-up.
+- **`disk.format`** refuses a disk that already carries a partition table unless
+  `force=true`, so an accidental format never silently clobbers data.
+- **Consumer proof against a live c1sql1 lab node is an OPEN acceptance
+  criterion** — the c1sql1 Windows Server 2022 VMs do not exist yet; the probe +
+  feature-install + service-ops proof is deferred to the lab program
+  (evoila-bosnia/claude-rdc-hetzner-dc#2789).
+- Host-key checking is disabled (`known_hosts=None`) at the adapter level for
+  v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
+
+## References
+
+- Task #3261 (connector); Initiative #3259 (Microsoft estate); prerequisite
+  #3260 / PR #3268 (shared `_shared/pwsh` transport hoist).
+- Molds: `docs/codebase/connectors-windows-dns.md` (structure + probe #986
+  discipline + PowerShell-over-SSH transport), `docs/codebase/connectors-rke2.md`
+  (approval-parked-write mold).
+- Cmdlet references (Windows Server 2022 / PowerShell 5.1):
+  <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/>,
+  <https://learn.microsoft.com/en-us/powershell/module/servermanager/>,
+  <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/>,
+  <https://learn.microsoft.com/en-us/powershell/module/storage/>,
+  <https://learn.microsoft.com/en-us/powershell/module/iscsi/>.


### PR DESCRIPTION
## Summary

- Ships `winsrv`, the **Windows Server core** typed connector, on the shared PowerShell-over-SSH transport (`_shared/pwsh`, #3260) + `SshConnector` base — the **estate mold** that `msad` / `wsfc` / `hyperv` (Initiative #3259) copy. 23 ops across six groups (system / services / features / power / localusers / storage).
- **Safety-tiered per the #3259 satellite table** (verified by test): 11 `safe` reads, 9 `caution` recoverable writes, and 3 `dangerous` + `requires_approval` (`power.reboot`, `power.shutdown`, `localuser.delete`) on the rke2 approval-parked-write mold — an agent dispatch parks for a human decision, satellite-excluded by the tier ladder.
- **Secret hygiene is load-bearing**: the `-EncodedCommand` payload lands on the remote argv, so no credential rides the script — `localuser.create` is passwordless (`-NoPassword`), `localuser.set` never touches the password, `iscsi.connect` has no CHAP (both deferred to a Vault-brokered flow). Every operator string is escaped via `ps_single_quote`; `disk.format` refuses a non-RAW disk unless `force=true`.
- Product token `winsrv` is separator-free (round-trip guard), registered versioned + wildcard. **No alembic migration** (op rows come from runtime registration); **no spec-reconcile lane** (cmdlet surface ships no OpenAPI).

**CLI snapshot: CHANGED (new product token winsrv).** The `winsrv` token extends the OpenAPI `TargetCreate.product` enum (derived from the live registry), so `cli/api/openapi.json` + `cli/internal/api/client.gen.go` were regenerated via `make snapshot-openapi && make generate`. The diff is exactly the `winsrv` enum entry + the generated `TargetCreateProductWinsrv` constant. CLI parity is the generic `meho operation call winsrv-ssh-2022.x <op_id>` path (no dedicated verb package — the windows_dns / rke2 precedent for SSH-typed connectors).

## Coordinator fold-in (post-merge audit of #3268)

- **Item 1 (shared `POWERSHELL_EXECUTABLE` default footgun).** Set `POWERSHELL_EXECUTABLE = "powershell"` explicitly on winsrv (done regardless). On the "harden the seam vs. document" call: I chose **document** — a prominent "Building the next estate connector" section in `docs/codebase/connectors-winsrv.md`. Rationale: the `pwsh` default is a *deliberately-documented test-ergonomics feature* (`test_connectors_holodeck_pwsh.py:113` drives `pwsh_run` with a bare `MagicMock()` connector and relies on the default), so removing it is **not** a no-behavior-change edit — it would break the shared-transport suite and contradict #3268's documented design. Both real connectors (holodeck=`pwsh`, windows_dns=`powershell`) already set it explicitly, so the production footgun only bites a future author who skips the mold's explicit setting — which the doc warning + the mold now guard. **Flagged for reviewer concurrence** (the coordinator asked to judge this with the reviewer).
- **Item 2 (PwshRunError docstring `exit_status` wording).** Not applicable — I did not touch `_shared/pwsh.py` (per item 1's decision), so per the coordinator's instruction it rides with a future work item.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (winsrv src + test)
- [x] `mypy src/meho_backplane/connectors/winsrv/` — Success: no issues in 9 files
- [x] `pytest tests/test_connectors_winsrv.py` — **49 passed** (scripted-transport fakes; every op group's script construction; injection-safety escape on every parameterized script; secret-leak guard; `disk.format` RAW guard + validation; probe reason matrix; `about` mapping; registry round-trip + 23-op safety-tier invariants)
- [x] `pytest test_openapi_target_product_enum.py test_connectors_registry_v2.py test_connectors_windows_dns.py test_connectors_holodeck_pwsh.py` — **88 passed** (product enum auto-includes `winsrv`; siblings unaffected — the shared seam is untouched)
- [x] `code-quality.py --diff` — **0 blockers** (2 file-size warnings: connector.py 599, ops_storage.py 454 — inherent to a 23-op connector; recorded below)
- [x] `cd cli && make snapshot-openapi && make generate` + `go build ./...` — snapshot regenerated, Go client compiles
- [ ] **Consumer proof against a live c1sql1 lab node** — OPEN acceptance criterion: the c1sql1 Windows Server 2022 VMs do not exist yet. The probe + governed feature-install + service-ops proof is deferred to the lab program (evoila-bosnia/claude-rdc-hetzner-dc#2789). Not satisfiable in this run; do not treat as done.

## Out of scope / deferred (recorded)

- Local-user password provisioning (Vault-minted-password flow, rke2 `token.rotate` mold) and iSCSI CHAP (Vault-brokered) — both would put a secret on the `-EncodedCommand` argv, so deferred.
- `connector.py` (599 lines) and `ops_storage.py` (454) sit above the 400-line warn threshold — inherent to a 23-op connector (one dispatch shim per op for the handler_ref round-trip); the `_WHEN_TO_USE_BY_GROUP` blurbs were already moved to `ops.py` (rke2 precedent) to keep the connector under the 600 block threshold.
- `msad` / `wsfc` / `hyperv` are the sibling estate connectors (#3262/#3263/#3265), out of scope here.

<!-- auto-implement-issue: fresh, iteration 1 -->

## Audit fold-ins (commit `09ea873a`)

Four cheap findings from the independent pre-merge audit (0 block-merge), folded in one push:
1. **`disk.format` framing corrected** — the op is non-destructive by construction (`Initialize-Disk` only on a RAW disk; `New-Partition -UseMaximumSize` allocates only *unallocated* space), so the prior "DESTROYS data" / "reformat" language was wrong. Softened across the force param, op description, docstrings, throw message, and `connectors-winsrv.md`: `force=true` only provisions the disk's free space and never wipes. Per the #3259 tier doctrine a true `Clear-Disk -RemoveData` wipe is deliberately NOT added at `caution` — it would be a separate `dangerous` op with its own ticket (noted in the doc).
2. **CHANGELOG** — added the `[Unreleased]` winsrv entry in house style.
3. **PR test count** — corrected (now **49** after the fold-in tests).
4. **`_validate_drive_letter`** — now `string.ascii_letters` (not `str.isalpha`, which admits Unicode), agreeing with the schema `^[A-Za-z]$`; a Unicode-letter rejection case pins it.

Per-op schemas/validation are runtime `endpoint_descriptor` concerns, not the OpenAPI product enum, so the **CLI snapshot is unchanged** by this push.

<!-- auto-implement-issue: audit-foldins, head 09ea873a -->

Closes #3261

