### PR TITLE
feat(connectors): wsfc — Windows Server Failover Clustering typed connector (#3263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,37 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — `wsfc` connector: Windows Server Failover Clustering over PowerShell-5.1-over-SSH (#3263)
+
+- **`wsfc` connector** — typed connector for Windows Server Failover Clustering
+  (the `FailoverClusters` PowerShell module) over SSH → PowerShell 5.1, on the
+  shared `_shared/pwsh` transport (#3260) + `SshConnector` base, registered as
+  `("wsfc", "2022.x", "wsfc-ssh")` (+ wildcard). A structured copy of the
+  `winsrv` estate mold (#3261). 19 ops across five groups — `cluster` (about /
+  get health-rollup / quorum / validation-report / long-running `Test-Cluster`),
+  `nodes` (list / state / pause-drain / resume / evict), `groups` (list / state /
+  move / offline / online), `resources` (list / dependency-report), `witness`
+  (get / set). The target is any single cluster node — the cmdlets fan out
+  cluster-wide from one node.
+- Safety tiers per the Initiative #3259 satellite table: reads `safe`;
+  recoverable writes (`cluster.test` / `nodes.pause` / `nodes.resume` /
+  `groups.move` / `witness.set`) `caution`; `nodes.evict` / `groups.offline` /
+  `groups.online` are `dangerous` + `requires_approval` (the rke2
+  approval-parked-write mold, satellite-excluded by the tier ladder — a
+  production-role state change is an outage / data-risk event). Secret hygiene:
+  no credential rides the `-EncodedCommand` argv — `witness.set` has no cloud
+  witness (its access key can't ride the transport; deferred to a Vault-brokered
+  flow); every operator string is escaped via `ps_single_quote`.
+- Ships **ready-made Sensor pin recipes** for the checks plane in
+  `docs/codebase/connectors-wsfc.md` (cluster node count, SQL FCI role online,
+  quorum witness online, failed-role / failed-resource) — `wsfc.cluster.get`
+  exposes flat scalar health counts precisely so a bounded assertion can pin
+  them. The new `wsfc` product token extends the OpenAPI `TargetCreate.product`
+  enum, so the CLI snapshot (`cli/api/openapi.json` + generated client) is
+  regenerated. Live c1sql1 consumer proof (probe + governed failover + live
+  Sensor) is deferred (lab cluster not yet built); scripted-transport unit suite
+  + injection-safety + secret-leak guard are the deliverable.
+
 ### Changed — docs-only CI fast path (#3252)
 
 - A PR whose diff is **purely documentation** — every changed path under

--- a/backend/src/meho_backplane/connectors/wsfc/__init__.py
+++ b/backend/src/meho_backplane/connectors/wsfc/__init__.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.wsfc -- WsfcConnector package.
+
+Importing the package registers :class:`WsfcConnector` against the v2 connector
+registry under the natural key ``(product="wsfc", version="2022.x",
+impl_id="wsfc-ssh")``, and queues the connector's typed-op upserts onto the
+lifespan-driven registrar list so ``endpoint_descriptor`` rows land before the
+first dispatch. The package is discovered automatically by
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` (which
+imports every ``connectors/<product>/`` subpackage in name-sorted order) --
+there is no central connector list to edit; self-registration at import time is
+the whole wiring.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.winsrv.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` inside this
+  module, so a probe firing during startup sees a fully-populated registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_wsfc_typed_operations`, which delegates to
+  :meth:`WsfcConnector.register_operations`.
+
+The ``(product, version, impl_id)`` triple is chosen so
+``connector_id="wsfc-ssh-2022.x"`` round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` (``product`` =
+the first hyphen-segment of ``impl_id`` = ``"wsfc"``); a hyphen/underscore in
+the product token would break that round-trip and the registry's
+``_assert_product_impl_id_round_trips`` guard would crash
+``_eager_import_connectors`` at boot.
+
+Like winsrv / rke2, this connector has no v1 chassis history, so the v1
+``register_connector`` write is intentionally omitted -- only the v2 triple
+advertises this class.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.wsfc.connector import WsfcConnector
+from meho_backplane.connectors.wsfc.ops import WSFC_OPS, WsfcOp
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_wsfc_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``WsfcConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level ``async def
+    register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via :func:`register_typed_op_registrar`. The
+    ``embedding_service`` keyword-only parameter mirrors the winsrv / rke2
+    sibling contract -- :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` to every registrar, so each registrar **must**
+    accept the kwarg or the lifespan crashes with :class:`TypeError`. The
+    wrapper accepts-and-discards it because
+    :meth:`WsfcConnector.register_operations` resolves the embedding service via
+    ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await WsfcConnector.register_operations()
+
+
+__all__ = [
+    "WSFC_OPS",
+    "WsfcConnector",
+    "WsfcOp",
+    "register_wsfc_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key.
+register_connector_v2(
+    product="wsfc",
+    version="2022.x",
+    impl_id="wsfc-ssh",
+    cls=WsfcConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1). Mirrors the
+# winsrv / rke2 wildcard rows.
+register_connector_v2(
+    product="wsfc",
+    version="",
+    impl_id="",
+    cls=WsfcConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_wsfc_typed_operations)

--- a/backend/src/meho_backplane/connectors/wsfc/connector.py
+++ b/backend/src/meho_backplane/connectors/wsfc/connector.py
@@ -1,0 +1,596 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""WsfcConnector -- typed SSH-transport connector for Windows Server Failover Clustering.
+
+Manages a Windows Server Failover Cluster (cluster / node / group / resource /
+quorum state, validation, guarded role-move / failover) over SSH → PowerShell:
+the target cluster node runs an OpenSSH server whose shell drives
+``powershell`` (Windows PowerShell 5.1) executing the built-in
+``FailoverClusters`` module cmdlets. The connector is a structured copy of
+:class:`~meho_backplane.connectors.winsrv.connector.WinsrvConnector` (the
+estate mold — same ``SshConnector`` base + shared PowerShell-over-SSH transport
+:mod:`~meho_backplane.connectors._shared.pwsh`) and adopts the
+:mod:`~meho_backplane.connectors.rke2.ops_write` approval-parked-write mold for
+its destructive ops.
+
+The **target is any single cluster node**: the ``FailoverClusters`` cmdlets
+talk to the local Cluster Service (the cluster-wide database), so they fan out
+cluster-wide from whichever node runs them — one node is a sufficient control
+point for the whole cluster.
+
+This module ships :class:`WsfcConnector` (registry-v2 triple ``("wsfc",
+"2022.x", "wsfc-ssh")``): :meth:`fingerprint` (one round-trip reading the
+hostname + OS + ``FailoverClusters`` module presence + cluster membership),
+:meth:`probe` (six distinct ``ProbeResult.reason`` values, two of them
+cluster-membership specific), :meth:`about` (the ``wsfc.about`` op), the
+bound-method op shims for the five groups, and the operator-less
+:meth:`execute` dispatcher shim (same shape as winsrv / windows_dns / rke2).
+
+Like winsrv, this connector sets ``POWERSHELL_EXECUTABLE = "powershell"``
+explicitly: the shared transport's fallback is ``pwsh`` (PS7), which a Windows
+Server host does NOT ship (see ``docs/codebase/connectors-winsrv.md`` --
+"building the next estate connector").
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.wsfc.ops import WSFC_OPS, WSFC_WHEN_TO_USE_BY_GROUP
+
+__all__ = ["WsfcConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- mirrors the placeholder in the SSH adapter and the
+# winsrv / windows_dns / rke2 siblings.
+type Target = Any
+
+
+#: The fingerprint / about script -- hostname + OS version/build + PowerShell
+#: version + FailoverClusters module presence + cluster membership in one
+#: round-trip. No operator input is interpolated (constant script), so the
+#: identity path has no injection surface. ``Get-Cluster`` is wrapped in
+#: try/catch so a non-clustered node reports ``ClusterName = $null`` instead of
+#: failing the whole fingerprint.
+_FINGERPRINT_SCRIPT: str = (
+    "$os = Get-CimInstance -ClassName Win32_OperatingSystem; "
+    "$mod = [bool](Get-Module -ListAvailable -Name FailoverClusters); "
+    "$cn = $null; $cfl = $null; "
+    'if ($mod) { try { $cl = Get-Cluster -ErrorAction Stop; $cn = "$($cl.Name)"; '
+    "$cfl = [int]$cl.ClusterFunctionalLevel } catch { $cn = $null } }; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "Hostname = [System.Net.Dns]::GetHostName(); "
+    "OsVersion = $os.Version; "
+    "BuildNumber = $os.BuildNumber; "
+    "PowerShellVersion = $PSVersionTable.PSVersion.ToString(); "
+    "FailoverClustersModule = $mod; "
+    "ClusterName = $cn; "
+    "ClusterFunctionalLevel = $cfl }"
+)
+
+#: The probe script -- FailoverClusters module presence + cluster membership.
+#: Always emits JSON. ``Get-Cluster`` is only attempted when the module is
+#: present (it is the module's cmdlet), and a non-membership failure is caught.
+_PROBE_SCRIPT: str = (
+    "$mod = [bool](Get-Module -ListAvailable -Name FailoverClusters); "
+    "$cn = $null; "
+    'if ($mod) { try { $cn = "$((Get-Cluster -ErrorAction Stop).Name)" } catch { $cn = $null } }; '
+    "ConvertTo-Json -Compress -InputObject @{ module = $mod; cluster = $cn }"
+)
+
+
+class WsfcConnector(SshConnector):
+    """Windows Server Failover Clustering connector on the :class:`SshConnector` adapter.
+
+    Registry v2 triple: ``("wsfc", "2022.x", "wsfc-ssh")``.
+
+    * ``product="wsfc"`` -- a short, separator-free product token (the repo
+      convention: ``parse_connector_id`` derives the product from the first
+      hyphen-segment of ``impl_id``, so ``connector_id="wsfc-ssh-2022.x"``
+      round-trips; a hyphen/underscore in the token breaks the registry's
+      round-trip guard at boot).
+    * ``version="2022.x"`` -- the ``FailoverClusters`` cmdlet surface targets
+      Windows Server 2022 (stable across 2019 → 2025).
+    * ``impl_id="wsfc-ssh"`` -- leaves room for a future ``wsfc-winrm`` sibling.
+
+    **Auth: password-default + key-fallback.** Inherits the base
+    :class:`SshConnector` ``_auth_config`` unchanged.
+
+    **Transport: PowerShell-over-SSH.** Cmdlets reach the node through
+    ``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1 --
+    see :attr:`POWERSHELL_EXECUTABLE`) routed by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`; output is parsed
+    via stdlib :mod:`json` from the cmdlet's ``ConvertTo-Json`` pipe.
+    """
+
+    product = "wsfc"
+    version = "2022.x"
+    impl_id = "wsfc-ssh"
+
+    #: The PowerShell executable the shared transport invokes. ``powershell``
+    #: (Windows PowerShell 5.1) -- NOT ``pwsh`` (PS7). Set explicitly because
+    #: the shared transport's fallback is ``pwsh``; every Windows-estate
+    #: connector MUST set this (see the connectors-winsrv doc).
+    POWERSHELL_EXECUTABLE = "powershell"
+
+    #: Prepended to every script so the FailoverClusters module's first-use
+    #: progress stream does not CLIXML-serialise onto the remote streams.
+    POWERSHELL_SCRIPT_PREFIX = "$ProgressPreference = 'SilentlyContinue'; "
+
+    #: The structured-log event name the shared transport emits per run, kept
+    #: connector-scoped so log queries stay per-connector.
+    POWERSHELL_LOG_EVENT = "wsfc_pwsh_executed"
+
+    async def fingerprint(
+        self,
+        target: Target,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Read the node OS + FailoverClusters module + cluster membership.
+
+        Runs :data:`_FINGERPRINT_SCRIPT` (one round-trip) and parses the JSON
+        object. Unreachable / SSH-failed / cmdlet-failed → ``reachable=False``
+        + ``extras["error"]`` (the #986 discipline). ``operator`` is threaded to
+        the SSH adapter for the Vault read on a pool miss; ``None`` fails
+        closed. Whether the node is *clustered* is metadata (``cluster_name``),
+        not a reachability signal — an unclustered but reachable node is
+        ``reachable=True`` here; :meth:`probe` is where non-membership becomes a
+        distinct reason.
+        """
+        probed_at = datetime.now(UTC)
+        method = "ssh: powershell Get-Cluster / Win32_OperatingSystem"
+        try:
+            payload = await pwsh_run(self, target, _FINGERPRINT_SCRIPT, operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            CredentialsReadError,
+            PwshRunError,
+        ) as exc:
+            _log.warning(
+                "wsfc_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="microsoft",
+                product="windows-failover-cluster",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=method,
+                extras={"error": str(exc)},
+            )
+
+        data = payload if isinstance(payload, dict) else {}
+        return FingerprintResult(
+            vendor="microsoft",
+            product="windows-failover-cluster",
+            version=_as_str(data.get("OsVersion")),
+            build=_as_str(data.get("BuildNumber")),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=method,
+            extras={
+                "hostname": _as_str(data.get("Hostname")),
+                "cluster_name": _as_str(data.get("ClusterName")),
+                "cluster_functional_level": _as_int(data.get("ClusterFunctionalLevel")),
+                "failover_clusters_module": _as_bool(data.get("FailoverClustersModule")),
+                "powershell_version": _as_str(data.get("PowerShellVersion")),
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + PowerShell + cluster-membership check.
+
+        Failure modes (each surfaces a distinct ``reason``):
+
+        * ``tcp_unreachable`` -- the SSH TCP socket cannot connect.
+        * ``ssh_auth_failed`` -- credentials rejected, the handshake failed,
+          or the Vault credential could not be resolved.
+        * ``powershell_unavailable`` -- SSH succeeded but the reachability
+          script failed (``powershell`` not on the shell, or a pwsh error).
+        * ``command_failed`` -- a post-connect transport failure (connection
+          drop / timeout / socket error) after a successful handshake.
+        * ``failover_module_absent`` -- PowerShell runs but the
+          ``FailoverClusters`` module is not installed (not a cluster node).
+        * ``not_cluster_member`` -- the module is present but the node is not a
+          member of a running cluster (``Get-Cluster`` failed).
+
+        The probe does not mutate state -- ``Get-Cluster`` is read-only.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(ok=ok, reason=reason, latency_ms=latency_ms, probed_at=probed_at)
+
+        # Order matters: PermissionDenied (subclass of DisconnectError) before
+        # DisconnectError; OSError is the TCP-level failure.
+        try:
+            await self._connect(target)
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, CredentialsReadError):
+            return _result(False, "ssh_auth_failed")
+
+        try:
+            payload = await pwsh_run(self, target, _PROBE_SCRIPT)
+        except PwshRunError:
+            return _result(False, "powershell_unavailable")
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
+
+        data = payload if isinstance(payload, dict) else {}
+        if data.get("module") is not True:
+            return _result(False, "failover_module_absent")
+        if not _as_str(data.get("cluster")):
+            return _result(False, "not_cluster_member")
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Return the cluster node's identity + membership snapshot.
+
+        Op-id: ``wsfc.about``. Reuses :meth:`fingerprint` so the operator-facing
+        op and the canonical fingerprint share one round-trip.
+        ``_assert_reachable`` re-raises an unreachable fingerprint as a
+        :exc:`~meho_backplane.connectors.adapters.ssh.ConnectorUnreachableError`
+        so the dispatcher reports a non-ok op rather than empty identity fields
+        (#986).
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target, operator)
+        self._assert_reachable(result)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "build": result.build,
+            "hostname": result.extras.get("hostname"),
+            "cluster_name": result.extras.get("cluster_name"),
+            "cluster_functional_level": result.extras.get("cluster_functional_level"),
+            "failover_clusters_module": result.extras.get("failover_clusters_module"),
+            "powershell_version": result.extras.get("powershell_version"),
+        }
+
+    # -- cluster group shims -----------------------------------------------
+
+    async def wsfc_cluster_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.cluster.get``."""
+        from meho_backplane.connectors.wsfc.ops_cluster import wsfc_cluster_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_cluster_quorum(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.cluster.quorum``."""
+        from meho_backplane.connectors.wsfc.ops_cluster import wsfc_cluster_quorum as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_cluster_validation_report(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.cluster.validation-report``."""
+        from meho_backplane.connectors.wsfc.ops_cluster import wsfc_cluster_validation_report as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_cluster_test(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.cluster.test`` (caution, long-running)."""
+        from meho_backplane.connectors.wsfc.ops_cluster import wsfc_cluster_test as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- nodes group shims -------------------------------------------------
+
+    async def wsfc_node_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.nodes.list``."""
+        from meho_backplane.connectors.wsfc.ops_nodes import wsfc_node_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_node_state(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.nodes.state``."""
+        from meho_backplane.connectors.wsfc.ops_nodes import wsfc_node_state as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_node_pause(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.nodes.pause`` (caution)."""
+        from meho_backplane.connectors.wsfc.ops_nodes import wsfc_node_pause as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_node_resume(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.nodes.resume`` (caution)."""
+        from meho_backplane.connectors.wsfc.ops_nodes import wsfc_node_resume as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_node_evict(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.nodes.evict`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.wsfc.ops_nodes import wsfc_node_evict as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- groups group shims ------------------------------------------------
+
+    async def wsfc_group_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.groups.list``."""
+        from meho_backplane.connectors.wsfc.ops_groups import wsfc_group_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_group_state(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.groups.state``."""
+        from meho_backplane.connectors.wsfc.ops_groups import wsfc_group_state as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_group_move(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.groups.move`` (caution)."""
+        from meho_backplane.connectors.wsfc.ops_groups import wsfc_group_move as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_group_offline(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.groups.offline`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.wsfc.ops_groups import wsfc_group_offline as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_group_online(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.groups.online`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.wsfc.ops_groups import wsfc_group_online as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- resources group shims ---------------------------------------------
+
+    async def wsfc_resource_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.resources.list``."""
+        from meho_backplane.connectors.wsfc.ops_resources import wsfc_resource_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_resource_dependency_report(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.resources.dependency-report``."""
+        from meho_backplane.connectors.wsfc.ops_resources import (
+            wsfc_resource_dependency_report as _h,
+        )
+
+        return await _h(self, target, params, operator)
+
+    # -- witness group shims -----------------------------------------------
+
+    async def wsfc_witness_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.witness.get``."""
+        from meho_backplane.connectors.wsfc.ops_witness import wsfc_witness_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def wsfc_witness_set(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``wsfc.witness.set`` (caution)."""
+        from meho_backplane.connectors.wsfc.ops_witness import wsfc_witness_set as _h
+
+        return await _h(self, target, params, operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`WSFC_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.wsfc.ops.WSFC_OPS` and routes each row
+        through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+        Idempotent across pod restarts -- mirrors the winsrv / rke2 shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in WSFC_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"WsfcConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = WSFC_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"WsfcConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"WSFC_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.wsfc.ops."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "wsfc_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`WinsrvConnector.execute`. Operator-less (no policy gate,
+        no audit row, no broadcast); the operator-aware surface is
+        ``POST /api/v1/operations/call`` via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )
+
+
+def _as_str(value: Any) -> str | None:
+    """Return *value* when it is a non-empty ``str``, else ``None``.
+
+    Guards the fingerprint projection: ``ConvertTo-Json`` can render an absent
+    field as ``null``, and :class:`FingerprintResult` fields are typed
+    ``str | None``.
+    """
+    return value if isinstance(value, str) and value else None
+
+
+def _as_int(value: Any) -> int | None:
+    """Return *value* as an ``int`` (excluding ``bool``), else ``None``."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_bool(value: Any) -> bool | None:
+    """Return *value* when it is a ``bool``, else ``None``."""
+    return value if isinstance(value, bool) else None

--- a/backend/src/meho_backplane/connectors/wsfc/ops.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`WsfcConnector`.
+
+The connector manages **Windows Server Failover Clustering** — cluster / node /
+group (clustered-role) / resource / quorum state, cluster validation, and
+guarded role-move / failover writes — over SSH → PowerShell (``powershell``
+running the Windows PowerShell 5.1 ``FailoverClusters`` module cmdlets), routed
+through :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` (the shared
+PowerShell-over-SSH transport hoisted by #3260). Structurally it is a copy of
+the winsrv estate mold (identity canary + per-domain op groups on the
+``SshConnector`` base) and adopts the rke2 approval-parked-write mold for its
+destructive ops.
+
+The **target is any single cluster node**: the ``FailoverClusters`` cmdlets
+fan out cluster-wide from whichever node runs them (they talk to the local
+Cluster Service, which is the cluster-wide database), so one node is a
+sufficient control point for the whole cluster. There is no per-node target
+fan-out to arrange.
+
+Op surface (19 ops across five groups; safety tier per the Initiative #3259
+satellite table — reads ``safe``, recoverable writes ``caution``, destructive
+``dangerous`` + ``requires_approval``):
+
+* ``wsfc.about``                     [safe]      identity canary (node OS + cluster membership).
+* ``wsfc.cluster.get``               [safe]      cluster health rollup (node/group counts).
+* ``wsfc.cluster.quorum``            [safe]      Get-ClusterQuorum (quorum model + witness).
+* ``wsfc.cluster.validation-report`` [safe]      list stored validation reports (→ JSONFlux).
+* ``wsfc.cluster.test``              [caution]   Test-Cluster (LONG-running validation).
+* ``wsfc.nodes.list``                [safe]      Get-ClusterNode (list-shaped → JSONFlux).
+* ``wsfc.nodes.state``               [safe]      Get-ClusterNode -Name (one node).
+* ``wsfc.nodes.pause``               [caution]   Suspend-ClusterNode (drain).
+* ``wsfc.nodes.resume``              [caution]   Resume-ClusterNode.
+* ``wsfc.nodes.evict``               [dangerous+approval]  Remove-ClusterNode -Force.
+* ``wsfc.groups.list``               [safe]      Get-ClusterGroup (list-shaped → JSONFlux).
+* ``wsfc.groups.state``              [safe]      Get-ClusterGroup -Name (one role).
+* ``wsfc.groups.move``               [caution]   Move-ClusterGroup (governed failover).
+* ``wsfc.groups.offline``            [dangerous+approval]  Stop-ClusterGroup.
+* ``wsfc.groups.online``             [dangerous+approval]  Start-ClusterGroup.
+* ``wsfc.resources.list``            [safe]      Get-ClusterResource (list-shaped → JSONFlux).
+* ``wsfc.resources.dependency-report`` [safe]    per-resource dependency expressions (→ JSONFlux).
+* ``wsfc.witness.get``               [safe]      quorum witness resource + online state.
+* ``wsfc.witness.set``               [caution]   Set-ClusterQuorum (reconfigure the witness).
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.winsrv.ops` so the registration walk reads
+identically across SSH-transport connectors. The composition pattern
+(``_wsfc_ops()`` importing per-domain op tuples) mirrors winsrv's ``ops.py``.
+
+Grounding note — enum strings and output property names
+-------------------------------------------------------
+
+The ``FailoverClusters`` cmdlet reference pages on Microsoft Learn document
+parameters and the output *.NET type name* but do **not** tabulate the output
+objects' property names or the enum member values. The property names this
+module reads (``State`` / ``OwnerNode`` / ``OwnerGroup`` / ``NodeWeight`` /
+``DynamicWeight`` / ``Id``) and the state strings the health rollup compares
+against (``Up`` / ``Down`` / ``Online`` / ``Offline`` / ``Failed``) are the
+canonical ``Microsoft.FailoverClusters.PowerShell.ClusterNodeState`` /
+``ClusterGroupState`` / ``ClusterResourceState`` members. To keep the rollup
+robust against a rendering / casing difference, the count scripts compare the
+**stringified** state (``"$($_.State)" -eq 'Up'`` — case-insensitive in
+PowerShell) rather than the raw enum, and ``wsfc.cluster.get`` additionally
+returns the raw per-state count maps, so a state the hardcoded scalars don't
+name still surfaces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = [
+    "SSH_TRANSPORT_NOTE",
+    "WSFC_OPS",
+    "WSFC_WHEN_TO_USE_BY_GROUP",
+    "WsfcOp",
+    "normalise_json_rows",
+]
+
+
+#: Curated ``when_to_use`` strings per group key, consumed by
+#: :meth:`WsfcConnector.register_operations` (imported into the connector, the
+#: rke2 / winsrv precedent — the blurbs live with the op metadata, not the
+#: transport class). Each entry covers a ``group_key`` declared across the wsfc
+#: op tuples; the registration walk fails closed with a :class:`ValueError` if
+#: a ``group_key`` lacks a curated entry.
+WSFC_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "cluster": (
+        "Use for cluster-wide facts and health before drilling into nodes / "
+        "roles / resources: identity (``wsfc.about``), the health rollup "
+        "(``wsfc.cluster.get`` — node/group/resource up-counts, the sensor "
+        "workhorse), the quorum model (``wsfc.cluster.quorum``), and the "
+        "stored validation reports (``wsfc.cluster.validation-report``). All "
+        "read-only. ``wsfc.cluster.test`` RUNS a validation pass "
+        "(``caution`` — LONG-running, minutes). Call ``wsfc.about`` first to "
+        "confirm the target node is a live cluster member."
+    ),
+    "nodes": (
+        "Use to inventory and control cluster nodes: list all "
+        "(``wsfc.nodes.list``) or read one (``wsfc.nodes.state``) — both "
+        "read-only — pause/drain (``wsfc.nodes.pause``) and resume "
+        "(``wsfc.nodes.resume``) a node for maintenance (``caution``), and "
+        "evict a node from cluster membership (``wsfc.nodes.evict`` — "
+        "``dangerous`` + approval, irreversible). Pause drains roles off a "
+        "node before patching; resume brings it back into rotation."
+    ),
+    "groups": (
+        "Use to inventory and control clustered roles / groups (a SQL FCI "
+        "instance is a group): list all (``wsfc.groups.list``) or read one "
+        "(``wsfc.groups.state`` — the op a Sensor pins to watch a role's "
+        "``Online`` state) — both read-only — move / fail a role over to "
+        "another node (``wsfc.groups.move`` — ``caution``, the governed "
+        "planned-failover path), and take a role offline / bring it online "
+        "(``wsfc.groups.offline`` / ``wsfc.groups.online`` — ``dangerous`` + "
+        "approval: a production-role state change is an outage / data-risk "
+        "event)."
+    ),
+    "resources": (
+        "Use to inventory cluster resources and their dependency wiring: list "
+        "all resources with their state / owning group / type "
+        "(``wsfc.resources.list``) and read the per-resource dependency "
+        "expressions (``wsfc.resources.dependency-report``). Both read-only. "
+        "The dependency report is how you see what must come online before a "
+        "SQL FCI's network name / IP / disk resources."
+    ),
+    "witness": (
+        "Use to read or reconfigure the cluster quorum witness: read the "
+        "witness resource and its online state (``wsfc.witness.get`` — the op "
+        "a Sensor pins to watch witness reachability, load-bearing on a "
+        "2-node cluster) and reconfigure it (``wsfc.witness.set`` — "
+        "``caution``: a disk or file-share witness, via ``Set-ClusterQuorum``; "
+        "no cloud witness because its access key cannot ride the pwsh "
+        "transport)."
+    ),
+}
+
+
+#: Canonical SSH-only / pwsh transport reminder copied into every op's
+#: ``llm_instructions``. Mirrors winsrv's ``SSH_TRANSPORT_NOTE`` — the
+#: agent-facing descriptions must call out the PowerShell-over-SSH transport so
+#: an LLM doesn't compose against a non-existent REST surface (Windows Server
+#: Failover Clustering has no unified REST API).
+SSH_TRANSPORT_NOTE: str = (
+    "Windows Server Failover Clustering has no unified REST API; the "
+    "underlying transport is PowerShell-over-SSH (powershell -EncodedCommand "
+    "routed through asyncssh) driving the FailoverClusters module cmdlets on "
+    "a cluster node, which operate cluster-wide from that one node."
+)
+
+
+@dataclass(frozen=True)
+class WsfcOp:
+    """Metadata for one wsfc op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can splat
+    the dataclass into the helper without per-op boilerplate. ``handler_attr``
+    is the attribute name on
+    :class:`~meho_backplane.connectors.wsfc.connector.WsfcConnector` that
+    exposes the async handler; the connector resolves the bound method against
+    itself at registration time so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+    recovers the callable from the persisted ``module.ClassName.method`` path.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def normalise_json_rows(payload: Any) -> list[dict[str, Any]]:
+    """Normalise a ``ConvertTo-Json`` payload into a list of row dicts.
+
+    PowerShell's ``ConvertTo-Json`` renders a **single**-element result as a
+    flat object and a **multi**-element result as a JSON array; a zero-element
+    result renders as ``null`` (an empty stdout is caught upstream by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` before it reaches
+    here). This helper collapses all three shapes to a ``list[dict]`` so the
+    list handlers walk a uniform structure — the winsrv ``normalise_json_rows``
+    shape, shared across every wsfc list op so the ``{rows, total}`` envelope
+    the JSONFlux reducer keys on is built identically.
+    """
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    return []
+
+
+#: The identity canary op. ``wsfc.about`` is the operator-facing wrapper around
+#: :meth:`WsfcConnector.fingerprint` — same vendor / product / node / cluster
+#: payload, surfaced through the typed-op dispatcher so callers see the standard
+#: :class:`OperationResult` envelope instead of the raw
+#: :class:`FingerprintResult`. Mirrors winsrv's ``winsrv.about``.
+_WSFC_ABOUT_OP = WsfcOp(
+    op_id="wsfc.about",
+    handler_attr="about",
+    summary="Identify the cluster node + its cluster membership (OS + cluster name).",
+    description=(
+        "Connects to the cluster node over SSH and runs a single "
+        "``powershell -EncodedCommand`` script that reads the machine "
+        "hostname, the OS version / build, the Windows PowerShell version, "
+        "whether the ``FailoverClusters`` module is present, and — when the "
+        "node is a cluster member — the cluster name and functional level. "
+        "Returns a flat dict with the vendor (``microsoft``), product "
+        "(``windows-failover-cluster``), the OS version + build, the host "
+        "name, and the cluster membership. Use to confirm the target is a "
+        "reachable, clustered node before issuing higher-level cluster / node "
+        "/ group ops; no params; safe on any healthy target."
+    ),
+    parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "build": {"type": ["string", "null"]},
+            "hostname": {"type": ["string", "null"]},
+            "cluster_name": {"type": ["string", "null"]},
+            "cluster_functional_level": {"type": ["integer", "null"]},
+            "failover_clusters_module": {"type": ["boolean", "null"]},
+            "powershell_version": {"type": ["string", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="cluster",
+    tags=("read-only", "identity", "wsfc"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the cluster node behind "
+            "a target — its OS + whether it is a live cluster member and which "
+            "cluster — or to confirm the node is reachable via SSH + "
+            "PowerShell before issuing higher-level cluster ops. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``cluster_name`` is the cluster the node belongs to "
+            "(``null`` when the node is not clustered), "
+            "``failover_clusters_module`` whether the module is installed, "
+            "``version`` / ``build`` the node OS."
+        ),
+    },
+)
+
+
+def _wsfc_ops() -> tuple[WsfcOp, ...]:
+    """Return the merged registration tuple.
+
+    Composition: ``wsfc.about`` (identity canary) + the per-domain op tuples
+    (cluster / nodes / groups / resources / witness). Implemented as a function
+    call rather than a literal-and-splat at module level so the import order
+    stays linear: ``ops.py`` defines :class:`WsfcOp` + ``_WSFC_ABOUT_OP`` +
+    :func:`normalise_json_rows`, then imports the per-domain op tuples from
+    their modules (each depends only on this module plus its own helpers).
+    Mirrors :func:`meho_backplane.connectors.winsrv.ops._winsrv_ops`.
+    """
+    from meho_backplane.connectors.wsfc.ops_cluster import CLUSTER_OPS
+    from meho_backplane.connectors.wsfc.ops_groups import GROUP_OPS
+    from meho_backplane.connectors.wsfc.ops_nodes import NODE_OPS
+    from meho_backplane.connectors.wsfc.ops_resources import RESOURCE_OPS
+    from meho_backplane.connectors.wsfc.ops_witness import WITNESS_OPS
+
+    return (
+        _WSFC_ABOUT_OP,
+        *CLUSTER_OPS,
+        *NODE_OPS,
+        *GROUP_OPS,
+        *RESOURCE_OPS,
+        *WITNESS_OPS,
+    )
+
+
+#: The ops :class:`WsfcConnector` registers at lifespan startup. The shape of
+#: each follow-on op is "import a new module-level tuple and splat it into
+#: :data:`WSFC_OPS` via :func:`_wsfc_ops`" — the registration walk in
+#: :meth:`WsfcConnector.register_operations` does not change.
+WSFC_OPS: tuple[WsfcOp, ...] = _wsfc_ops()

--- a/backend/src/meho_backplane/connectors/wsfc/ops_cluster.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_cluster.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""wsfc cluster ops — ``get`` / ``quorum`` / ``validation-report`` (safe) + ``test`` (caution).
+
+The cluster group is driven by ``Get-Cluster`` / ``Get-ClusterNode`` /
+``Get-ClusterGroup`` / ``Get-ClusterResource`` / ``Get-ClusterQuorum`` and the
+long-running ``Test-Cluster`` over the shared PowerShell-over-SSH transport.
+
+* ``wsfc.cluster.get`` — the health rollup (node / group / resource up-counts
+  in one round-trip). This is the **sensor workhorse**: it returns flat scalar
+  fields (``nodes_up`` / ``groups_failed`` / ...) a bounded assertion can pin,
+  plus the raw per-state count maps for observability.
+* ``wsfc.cluster.quorum`` — the quorum *model* (``Get-ClusterQuorum``).
+* ``wsfc.cluster.validation-report`` — enumerate the stored validation reports
+  ``Test-Cluster`` has written (list-shaped → JSONFlux). Reading a specific
+  report's per-test pass/fail is a follow-up (the report is an ``.mht`` on
+  disk); this op lists what is available and when it was run.
+* ``wsfc.cluster.test`` — RUN ``Test-Cluster`` (``caution``). See the
+  duration note below.
+
+Duration semantics for ``wsfc.cluster.test``
+--------------------------------------------
+
+``Test-Cluster`` runs the full validation suite and can take **minutes** on a
+real cluster, so the handler forwards a raised ``timeout`` (:data:`_TEST_TIMEOUT`)
+to :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` — far above the
+transport's 30 s default. On a running cluster the disruptive storage tests
+(which need the disks offline) are skipped automatically for online disks;
+scope the run with ``include`` to keep it short. The op is ``caution``, not
+``safe``, precisely because it is a real, resource-touching validation run (and
+because a full run is long enough to be worth an explicit operator decision).
+
+PowerShell injection safety
+---------------------------
+
+``wsfc.cluster.test``'s optional ``include`` / ``report_name`` are the only
+operator strings in this module; each is interpolated only inside a
+single-quoted PowerShell literal via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`. Every other
+script here is a constant (no injection surface).
+
+References
+----------
+
+* ``Get-Cluster`` / ``Get-ClusterNode`` / ``Get-ClusterGroup`` /
+  ``Get-ClusterResource`` / ``Get-ClusterQuorum`` / ``Test-Cluster``
+  (FailoverClusters, Windows Server 2022 / PowerShell 5.1):
+  https://learn.microsoft.com/en-us/powershell/module/failoverclusters/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.wsfc.ops import SSH_TRANSPORT_NOTE, WsfcOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.wsfc.connector import WsfcConnector
+
+__all__ = [
+    "CLUSTER_OPS",
+    "wsfc_cluster_get",
+    "wsfc_cluster_quorum",
+    "wsfc_cluster_test",
+    "wsfc_cluster_validation_report",
+]
+
+
+#: Test-Cluster wall-clock budget (seconds). Test-Cluster runs the full
+#: validation suite and can take minutes; the transport default (30 s) would
+#: truncate the read and report a false failure on a validation that in fact
+#: completed. 15 minutes is a generous ceiling for a small cluster.
+_TEST_TIMEOUT: float = 900.0
+
+#: The cluster health rollup script. One round-trip: reads the cluster, its
+#: nodes, groups, and resources, and computes per-state count maps plus the
+#: common health scalars. The ``"$($_.State)" -eq 'Up'`` form compares the
+#: stringified state (case-insensitive in PowerShell), so a rendering / casing
+#: difference in the ``ClusterNodeState`` / ``ClusterGroupState`` /
+#: ``ClusterResourceState`` enum cannot silently zero a count.
+_CLUSTER_GET_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$c = Get-Cluster; "
+    "$nodes = @(Get-ClusterNode); "
+    "$groups = @(Get-ClusterGroup); "
+    "$res = @(Get-ClusterResource); "
+    "function _bystate($items) { $m = @{}; foreach ($i in $items) { "
+    '$k = "$($i.State)"; if ($m.ContainsKey($k)) { $m[$k]++ } else { $m[$k] = 1 } }; return $m }; '
+    "function _count($items, $state) { return @($items | "
+    'Where-Object { "$($_.State)" -eq $state }).Count }; '
+    "ConvertTo-Json -Depth 4 -Compress -InputObject @{ "
+    'name = "$($c.Name)"; '
+    "nodes_total = $nodes.Count; "
+    "nodes_up = _count $nodes 'Up'; "
+    "nodes_down = _count $nodes 'Down'; "
+    "nodes_paused = _count $nodes 'Paused'; "
+    "nodes_by_state = _bystate $nodes; "
+    "groups_total = $groups.Count; "
+    "groups_online = _count $groups 'Online'; "
+    "groups_offline = _count $groups 'Offline'; "
+    "groups_failed = _count $groups 'Failed'; "
+    "groups_by_state = _bystate $groups; "
+    "resources_total = $res.Count; "
+    "resources_online = _count $res 'Online'; "
+    "resources_failed = _count $res 'Failed'; "
+    "resources_by_state = _bystate $res }"
+)
+
+#: Get-ClusterQuorum → the quorum model + witness resource name. Constant.
+_CLUSTER_QUORUM_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$q = Get-ClusterQuorum; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    'cluster = "$($q.Cluster)"; '
+    'quorum_type = "$($q.QuorumType)"; '
+    'quorum_resource = if ($q.QuorumResource) { "$($q.QuorumResource)" } else { $null } }'
+)
+
+#: Enumerate the validation reports Test-Cluster has written. The report
+#: directory is the well-known ``%SystemRoot%\Cluster\Reports``; the script
+#: builds the path from ``$env:SystemRoot`` so it is not hardcoded, and returns
+#: the ``{rows, total}`` envelope (JSONFlux-reduced) even when the directory is
+#: absent. Constant script (no operator input).
+_VALIDATION_REPORT_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$dir = Join-Path $env:SystemRoot 'Cluster\\Reports'; "
+    "$rows = @(); "
+    "if (Test-Path $dir) { $rows = @(Get-ChildItem -Path $dir -File -ErrorAction SilentlyContinue "
+    "| Where-Object { $_.Extension -in '.mht','.htm','.html' } "
+    "| Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 50 "
+    "| ForEach-Object { [pscustomobject]@{ name = $_.Name; path = $_.FullName; "
+    "created = $_.LastWriteTimeUtc.ToString('o'); size_bytes = [int64]$_.Length } }) }; "
+    "ConvertTo-Json -Depth 3 -InputObject @{ rows = $rows; total = $rows.Count }"
+)
+
+
+async def wsfc_cluster_get(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.cluster.get`` — the cluster health rollup.
+
+    Returns flat scalar health fields (``nodes_up`` / ``groups_online`` /
+    ``resources_failed`` / ...) plus the raw per-state count maps. Small flat
+    dict, so it is never JSONFlux-reduced — the shape a Sensor can pin a
+    bounded assertion on (e.g. ``$.nodes_up``).
+    """
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _CLUSTER_GET_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def wsfc_cluster_quorum(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.cluster.quorum`` — the quorum model + witness resource."""
+    del params
+    payload = await pwsh_run(connector, target, _CLUSTER_QUORUM_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def wsfc_cluster_validation_report(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.cluster.validation-report`` — list the stored reports.
+
+    Returns ``{rows, total}`` (each row: ``name`` / ``path`` / ``created`` /
+    ``size_bytes``), most-recent first. List-shaped, so the dispatcher's
+    JSONFlux reducer spills a large set to a ``result_query`` handle.
+    """
+    del params
+    payload = await pwsh_run(connector, target, _VALIDATION_REPORT_SCRIPT, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def wsfc_cluster_test(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.cluster.test`` (caution) — RUN ``Test-Cluster``.
+
+    Long-running (minutes); the handler forwards a raised
+    :data:`_TEST_TIMEOUT`. Optional ``include`` scopes the run to named test
+    categories; ``report_name`` names the generated report. Returns the
+    generated report path (from the ``Test-Cluster`` FileInfo output).
+    """
+    include = params.get("include")
+    include_clause = ""
+    if include:
+        if not isinstance(include, list) or not all(isinstance(i, str) and i for i in include):
+            raise ValueError("include must be a list of non-empty test-category strings")
+        quoted = ", ".join(ps_single_quote(i) for i in include)
+        include_clause = f" -Include {quoted}"
+    report_name = params.get("report_name")
+    report_clause = ""
+    if report_name:
+        if not isinstance(report_name, str):
+            raise ValueError("report_name must be a string")
+        report_clause = f" -ReportName {ps_single_quote(report_name)}"
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$r = Test-Cluster{include_clause}{report_clause} -Confirm:$false; "
+        "$fi = $r | Where-Object { $_ -is [System.IO.FileInfo] } | Select-Object -First 1; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        "report_path = if ($fi) { $fi.FullName } else { $null } }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator, timeout=_TEST_TIMEOUT)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "action": "test",
+        "report_path": data.get("report_path"),
+        "op_class": "write",
+    }
+
+
+_EMPTY_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+_ROLLUP_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "nodes_total": {"type": "integer"},
+        "nodes_up": {"type": "integer"},
+        "nodes_down": {"type": "integer"},
+        "nodes_paused": {"type": "integer"},
+        "nodes_by_state": {"type": "object"},
+        "groups_total": {"type": "integer"},
+        "groups_online": {"type": "integer"},
+        "groups_offline": {"type": "integer"},
+        "groups_failed": {"type": "integer"},
+        "groups_by_state": {"type": "object"},
+        "resources_total": {"type": "integer"},
+        "resources_online": {"type": "integer"},
+        "resources_failed": {"type": "integer"},
+        "resources_by_state": {"type": "object"},
+    },
+    "additionalProperties": True,
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+CLUSTER_OPS: tuple[WsfcOp, ...] = (
+    WsfcOp(
+        op_id="wsfc.cluster.get",
+        handler_attr="wsfc_cluster_get",
+        summary="Cluster health rollup: node/group/resource up-counts in one round-trip.",
+        description=(
+            "Reads ``Get-Cluster`` + ``Get-ClusterNode`` + ``Get-ClusterGroup`` "
+            "+ ``Get-ClusterResource`` and returns the cluster name plus the "
+            "per-state counts: ``nodes_up`` / ``nodes_down`` / ``nodes_total`` "
+            "(and ``nodes_by_state``), the same for groups (roles) and "
+            "resources. Read-only. A small flat dict — the right op for a "
+            "Sensor to pin a bounded assertion on (e.g. ``$.nodes_up`` or "
+            "``$.groups_failed``)."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema=_ROLLUP_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=("read-only", "cluster", "health"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for a one-shot cluster health snapshot — how many nodes "
+                "are Up, how many roles are Online, whether any group / "
+                "resource is Failed. Read-only; the sensor workhorse op. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict: {name, nodes_total, nodes_up, nodes_down, "
+                "nodes_paused, nodes_by_state, groups_*, resources_*}."
+            ),
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.cluster.quorum",
+        handler_attr="wsfc_cluster_quorum",
+        summary="Read the cluster quorum model via ``Get-ClusterQuorum``.",
+        description=(
+            "Runs ``Get-ClusterQuorum`` and returns the quorum ``quorum_type`` "
+            "(``NodeMajority`` / ``NodeAndDiskMajority`` / "
+            "``NodeAndFileShareMajority`` / ``DiskOnly``) and the witness "
+            "``quorum_resource`` name (``null`` for node-majority). Read-only. "
+            "For the witness resource's *online state*, use ``wsfc.witness.get``."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "cluster": {"type": ["string", "null"]},
+                "quorum_type": {"type": ["string", "null"]},
+                "quorum_resource": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="cluster",
+        tags=("read-only", "cluster", "quorum"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read the cluster's quorum configuration — which "
+                "quorum model is in effect and which resource is the witness. "
+                "Read-only. For witness online state use ``wsfc.witness.get``. "
+                + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'cluster', 'quorum_type', 'quorum_resource'}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.cluster.validation-report",
+        handler_attr="wsfc_cluster_validation_report",
+        summary="List the stored cluster validation reports (list-shaped, JSONFlux-reduced).",
+        description=(
+            "Enumerates the validation reports ``Test-Cluster`` has written "
+            "under ``%SystemRoot%\\Cluster\\Reports`` and returns one row per "
+            "report (``name`` / ``path`` / ``created`` / ``size_bytes``), "
+            "most-recent first. Read-only; the ``{rows, total}`` envelope is "
+            "JSONFlux-reduced to a handle for a large set. Reading a specific "
+            "report's per-test pass/fail is a follow-up (the report is an "
+            "``.mht`` on disk)."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=("read-only", "cluster", "validation"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to see which cluster validation reports exist and when "
+                "each was run (e.g. after ``wsfc.cluster.test``). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'rows': [{name, path, created, size_bytes}], 'total': <int>}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.cluster.test",
+        handler_attr="wsfc_cluster_test",
+        summary="Run cluster validation via ``Test-Cluster`` (caution; LONG-running).",
+        description=(
+            "Runs ``Test-Cluster`` against the current cluster and returns the "
+            "generated report path. safety_level=caution — this is a real "
+            "validation RUN, and it is LONG-running (minutes): the handler "
+            "raises the transport timeout to 15 minutes. On a running cluster "
+            "the disruptive storage tests (which need the disks offline) are "
+            "skipped automatically for online disks. Scope the run with "
+            "``include`` (a list of test categories) to keep it short."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "include": {
+                    "type": "array",
+                    "items": {"type": "string", "minLength": 1},
+                    "description": (
+                        "Optional list of ``Test-Cluster -Include`` test "
+                        "categories (e.g. ``Inventory`` / ``Network`` / "
+                        "``System Configuration``). Omit to run the full suite."
+                    ),
+                },
+                "report_name": {
+                    "type": "string",
+                    "description": "Optional ``-ReportName`` for the generated report.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "report_path": {"type": ["string", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="cluster",
+        tags=("write", "cluster", "validation", "long-running"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Run cluster validation (e.g. before adding a node or after a "
+                "config change). LONG-running (minutes); safety_level=caution. "
+                "Scope with ``include`` to shorten it. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "include": "Optional list of test categories to scope the run.",
+                "report_name": "Optional report name.",
+            },
+            "output_shape": "{'action': 'test', 'report_path', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/wsfc/ops_cluster.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_cluster.py
@@ -77,36 +77,43 @@ _TEST_TIMEOUT: float = 900.0
 
 #: The cluster health rollup script. One round-trip: reads the cluster, its
 #: nodes, groups, and resources, and computes per-state count maps plus the
-#: common health scalars. The ``"$($_.State)" -eq 'Up'`` form compares the
-#: stringified state (case-insensitive in PowerShell), so a rendering / casing
-#: difference in the ``ClusterNodeState`` / ``ClusterGroupState`` /
-#: ``ClusterResourceState`` enum cannot silently zero a count.
+#: common health scalars. Every hashtable value is a plain PowerShell
+#: *expression* (a ``@(... | Where-Object {...}).Count`` array-count or a
+#: precomputed ``$*bs`` map variable) — no inline function calls as hashtable
+#: values, which keeps the one-liner unambiguous to parse (the whole script is
+#: assembled and executed remotely, never run through a local interpreter, so
+#: the construct must be plainly correct by inspection). The
+#: ``"$($_.State)" -eq 'Up'`` form compares the stringified state
+#: (case-insensitive in PowerShell), so a rendering / casing difference in the
+#: ``ClusterNodeState`` / ``ClusterGroupState`` / ``ClusterResourceState`` enum
+#: cannot silently zero a count; the ``$*bs`` maps carry every state verbatim so
+#: a state the scalars don't name still surfaces. ``$m[$k] = 1 + $m[$k]``
+#: relies on ``1 + $null == 1`` for a first-seen key.
 _CLUSTER_GET_SCRIPT: str = (
     "$ErrorActionPreference = 'Stop'; "
     "$c = Get-Cluster; "
     "$nodes = @(Get-ClusterNode); "
     "$groups = @(Get-ClusterGroup); "
     "$res = @(Get-ClusterResource); "
-    "function _bystate($items) { $m = @{}; foreach ($i in $items) { "
-    '$k = "$($i.State)"; if ($m.ContainsKey($k)) { $m[$k]++ } else { $m[$k] = 1 } }; return $m }; '
-    "function _count($items, $state) { return @($items | "
-    'Where-Object { "$($_.State)" -eq $state }).Count }; '
+    '$nbs = @{}; foreach ($i in $nodes) { $k = "$($i.State)"; $nbs[$k] = 1 + $nbs[$k] }; '
+    '$gbs = @{}; foreach ($i in $groups) { $k = "$($i.State)"; $gbs[$k] = 1 + $gbs[$k] }; '
+    '$rbs = @{}; foreach ($i in $res) { $k = "$($i.State)"; $rbs[$k] = 1 + $rbs[$k] }; '
     "ConvertTo-Json -Depth 4 -Compress -InputObject @{ "
     'name = "$($c.Name)"; '
     "nodes_total = $nodes.Count; "
-    "nodes_up = _count $nodes 'Up'; "
-    "nodes_down = _count $nodes 'Down'; "
-    "nodes_paused = _count $nodes 'Paused'; "
-    "nodes_by_state = _bystate $nodes; "
+    "nodes_up = @($nodes | Where-Object { \"$($_.State)\" -eq 'Up' }).Count; "
+    "nodes_down = @($nodes | Where-Object { \"$($_.State)\" -eq 'Down' }).Count; "
+    "nodes_paused = @($nodes | Where-Object { \"$($_.State)\" -eq 'Paused' }).Count; "
+    "nodes_by_state = $nbs; "
     "groups_total = $groups.Count; "
-    "groups_online = _count $groups 'Online'; "
-    "groups_offline = _count $groups 'Offline'; "
-    "groups_failed = _count $groups 'Failed'; "
-    "groups_by_state = _bystate $groups; "
+    "groups_online = @($groups | Where-Object { \"$($_.State)\" -eq 'Online' }).Count; "
+    "groups_offline = @($groups | Where-Object { \"$($_.State)\" -eq 'Offline' }).Count; "
+    "groups_failed = @($groups | Where-Object { \"$($_.State)\" -eq 'Failed' }).Count; "
+    "groups_by_state = $gbs; "
     "resources_total = $res.Count; "
-    "resources_online = _count $res 'Online'; "
-    "resources_failed = _count $res 'Failed'; "
-    "resources_by_state = _bystate $res }"
+    "resources_online = @($res | Where-Object { \"$($_.State)\" -eq 'Online' }).Count; "
+    "resources_failed = @($res | Where-Object { \"$($_.State)\" -eq 'Failed' }).Count; "
+    "resources_by_state = $rbs }"
 )
 
 #: Get-ClusterQuorum → the quorum model + witness resource name. Constant.

--- a/backend/src/meho_backplane/connectors/wsfc/ops_groups.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_groups.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""wsfc group (clustered-role) ops — list/state (safe) + move/offline/online writes.
+
+A cluster *group* is a clustered role (a SQL Server FCI instance is one group).
+Driven by ``Get-ClusterGroup`` / ``Move-ClusterGroup`` / ``Stop-ClusterGroup`` /
+``Start-ClusterGroup`` over the shared PowerShell-over-SSH transport.
+
+* ``move`` (``Move-ClusterGroup``) is ``caution`` — a recoverable planned
+  failover of a role to another node (the governed failover the acceptance
+  criteria want proven on the lab cluster).
+* ``offline`` (``Stop-ClusterGroup``) and ``online`` (``Start-ClusterGroup``)
+  are ``dangerous`` + ``requires_approval`` (the rke2 mold). Per the #3259
+  initiative table, a production-role state change is an outage / data-risk
+  event: taking a SQL FCI role offline is a service outage, and forcing one
+  online (e.g. to the wrong node, or while it should stay down) can cause
+  split-brain / data issues. Both park for a human decision; both are
+  satellite-EXCLUDED by the tier ladder.
+
+PowerShell injection safety
+---------------------------
+
+Operator-supplied strings (group name / target node) are interpolated only
+inside single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`.
+
+References
+----------
+
+* ``Get-ClusterGroup`` / ``Move-ClusterGroup`` / ``Stop-ClusterGroup`` /
+  ``Start-ClusterGroup`` (FailoverClusters):
+  https://learn.microsoft.com/en-us/powershell/module/failoverclusters/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.wsfc.ops import SSH_TRANSPORT_NOTE, WsfcOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.wsfc.connector import WsfcConnector
+
+__all__ = [
+    "GROUP_OPS",
+    "wsfc_group_list",
+    "wsfc_group_move",
+    "wsfc_group_offline",
+    "wsfc_group_online",
+    "wsfc_group_state",
+]
+
+_GROUP_SELECT: str = "Name, State, OwnerNode"
+
+
+async def wsfc_group_list(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.groups.list`` — every clustered role (list-shaped)."""
+    del params
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$g = @(Get-ClusterGroup | Select-Object {_GROUP_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $g; total = $g.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def wsfc_group_state(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.groups.state`` — one role's state + owner by name.
+
+    Returns a flat dict with the stringified ``state`` (``Online`` / ``Offline``
+    / ``Failed`` / ``PartialOnline`` / ``Pending``) and ``owner_node`` — the op
+    a Sensor pins to watch a SQL FCI role's ``Online`` state (``$.state``).
+    """
+    name: str = params["name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$g = Get-ClusterGroup -Name {ps_single_quote(name)}; "
+        'ConvertTo-Json -Compress -InputObject @{ name = "$($g.Name)"; '
+        'state = "$($g.State)"; owner_node = "$($g.OwnerNode)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def wsfc_group_move(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.groups.move`` (caution) — ``Move-ClusterGroup``.
+
+    Fails a role over to another node. Optional ``node`` names the destination
+    (omit to let the cluster pick). safety_level=caution — a recoverable
+    planned failover.
+    """
+    name: str = params["name"]
+    quoted = ps_single_quote(name)
+    clauses = [f"Move-ClusterGroup -Name {quoted}"]
+    if params.get("node"):
+        clauses.append(f"-Node {ps_single_quote(params['node'])}")
+    move_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{move_expr} | Out-Null; "
+        f"$g = Get-ClusterGroup -Name {quoted}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        'name = "$($g.Name)"; state = "$($g.State)"; owner_node = "$($g.OwnerNode)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "name": name,
+        "action": "move",
+        "state": data.get("state"),
+        "owner_node": data.get("owner_node"),
+        "op_class": "write",
+    }
+
+
+async def _group_power(
+    connector: WsfcConnector,
+    target: Any,
+    name: str,
+    cmdlet: str,
+    action: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run ``Stop-ClusterGroup`` / ``Start-ClusterGroup`` and read back the state."""
+    quoted = ps_single_quote(name)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{cmdlet} -Name {quoted} | Out-Null; "
+        f"$g = Get-ClusterGroup -Name {quoted}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        'name = "$($g.Name)"; state = "$($g.State)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {"name": name, "action": action, "state": data.get("state"), "op_class": "write"}
+
+
+async def wsfc_group_offline(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.groups.offline`` (dangerous, resume path only) — ``Stop-ClusterGroup``."""
+    return await _group_power(
+        connector, target, params["name"], "Stop-ClusterGroup", "offline", operator
+    )
+
+
+async def wsfc_group_online(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.groups.online`` (dangerous, resume path only) — ``Start-ClusterGroup``."""
+    return await _group_power(
+        connector, target, params["name"], "Start-ClusterGroup", "online", operator
+    )
+
+
+_GROUP_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The clustered role / group name (e.g. ``SQL Server (MSSQLSERVER)``).",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_GROUP_ACTION_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "state": {"type": ["string", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+def _power_op(op_id: str, handler_attr: str, verb: str, cmdlet: str) -> WsfcOp:
+    """Build one dangerous+approval group power op (offline / online)."""
+    return WsfcOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"Take a clustered role {verb} via ``{cmdlet}`` (dangerous, approval-gated).",
+        description=(
+            f"Runs ``{cmdlet} -Name <name>`` and reads back the role's state. "
+            "safety_level=dangerous, requires_approval=True — a production-role "
+            "state change is an outage / data-risk event (offline is a service "
+            "outage; forcing online can cause split-brain), so a dispatch parks "
+            "for a human decision. For a planned node-to-node failover use the "
+            "``caution`` ``wsfc.groups.move`` instead."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _GROUP_NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_GROUP_ACTION_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("write", "group", verb),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                f"Take a clustered role {verb}. Destructive to the running "
+                "service; approval-gated — parks for a human decision first. "
+                "For a planned failover use ``wsfc.groups.move``. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The clustered role / group name."},
+            "output_shape": f"{{'name', 'action': '{verb}', 'state', 'op_class': 'write'}}.",
+        },
+    )
+
+
+GROUP_OPS: tuple[WsfcOp, ...] = (
+    WsfcOp(
+        op_id="wsfc.groups.list",
+        handler_attr="wsfc_group_list",
+        summary="List clustered roles / groups via ``Get-ClusterGroup`` (name/state/owner).",
+        description=(
+            "Runs ``Get-ClusterGroup`` and returns one row per clustered role "
+            "(Name, State, OwnerNode). Read-only; the ``{rows, total}`` "
+            "envelope is JSONFlux-reduced for a large cluster."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("read-only", "group", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the cluster's roles and their Online/Offline "
+                "state and current owner node (e.g. find the SQL FCI role's "
+                "exact name). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'rows': [{Name, State, OwnerNode}], 'total': <int>}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.groups.state",
+        handler_attr="wsfc_group_state",
+        summary="Read one clustered role's state + owner via ``Get-ClusterGroup -Name``.",
+        description=(
+            "Runs ``Get-ClusterGroup -Name <name>`` and returns a flat dict "
+            "with the stringified ``state`` (``Online`` / ``Offline`` / "
+            "``Failed`` / ``PartialOnline`` / ``Pending``) and ``owner_node``. "
+            "Read-only — the op a Sensor pins to watch a SQL FCI role's "
+            "``Online`` state (``$.state``)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _GROUP_NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": ["string", "null"]},
+                "state": {"type": ["string", "null"]},
+                "owner_node": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="groups",
+        tags=("read-only", "group", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one named role's state and owner (e.g. is the "
+                "SQL FCI role Online and on which node?). Read-only; the "
+                "sensor op for role health. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The clustered role / group name."},
+            "output_shape": "{'name', 'state', 'owner_node'}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.groups.move",
+        handler_attr="wsfc_group_move",
+        summary="Fail a clustered role over to another node via ``Move-ClusterGroup`` (caution).",
+        description=(
+            "Runs ``Move-ClusterGroup -Name <name>`` (optionally ``-Node "
+            "<target>``) to fail a role over to another node, then reads back "
+            "the resulting state + owner. safety_level=caution — a recoverable "
+            "planned failover (the governed failover path). For a hard "
+            "offline/online use the dangerous ``wsfc.groups.offline`` / "
+            "``wsfc.groups.online``."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _GROUP_NAME_PROP,
+                "node": {
+                    "type": "string",
+                    "description": "Optional destination node; omit to let the cluster pick.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "action": {"type": "string"},
+                "state": {"type": ["string", "null"]},
+                "owner_node": {"type": ["string", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["name", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="groups",
+        tags=("write", "group", "move"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Fail a clustered role over to another node (planned "
+                "failover / rebalance). Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The role / group to move.",
+                "node": "Optional destination node.",
+            },
+            "output_shape": "{'name', 'action': 'move', 'state', 'owner_node', 'op_class'}.",
+        },
+    ),
+    _power_op("wsfc.groups.offline", "wsfc_group_offline", "offline", "Stop-ClusterGroup"),
+    _power_op("wsfc.groups.online", "wsfc_group_online", "online", "Start-ClusterGroup"),
+)

--- a/backend/src/meho_backplane/connectors/wsfc/ops_nodes.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_nodes.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""wsfc node ops — ``list`` / ``state`` (safe) + ``pause`` / ``resume`` (caution) + ``evict``.
+
+Nodes are driven by the ``FailoverClusters`` cmdlets ``Get-ClusterNode`` /
+``Suspend-ClusterNode`` / ``Resume-ClusterNode`` / ``Remove-ClusterNode`` over
+the shared PowerShell-over-SSH transport.
+
+* ``pause`` (``Suspend-ClusterNode``) and ``resume`` (``Resume-ClusterNode``)
+  are ``caution`` — a recoverable maintenance action (drain roles off a node,
+  then bring it back). ``pause -Drain`` moves the node's roles to other nodes
+  first, so it is safe on a running cluster.
+* ``evict`` (``Remove-ClusterNode -Force``) is ``dangerous`` +
+  ``requires_approval`` (the rke2 mold): removing a node from cluster
+  membership is irreversible (re-joining is a full add-node flow), so a
+  dispatch parks for a human decision. Per the #3259 satellite table a
+  destructive op is satellite-EXCLUDED by the tier ladder.
+
+PowerShell injection safety
+---------------------------
+
+Operator-supplied strings (node name / target node) are interpolated only
+inside single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; the
+``-Failback`` value is validated against a bounded enum before interpolation.
+
+References
+----------
+
+* ``Get-ClusterNode`` / ``Suspend-ClusterNode`` / ``Resume-ClusterNode`` /
+  ``Remove-ClusterNode`` (FailoverClusters):
+  https://learn.microsoft.com/en-us/powershell/module/failoverclusters/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.wsfc.ops import SSH_TRANSPORT_NOTE, WsfcOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.wsfc.connector import WsfcConnector
+
+__all__ = [
+    "NODE_OPS",
+    "wsfc_node_evict",
+    "wsfc_node_list",
+    "wsfc_node_pause",
+    "wsfc_node_resume",
+    "wsfc_node_state",
+]
+
+#: The Get-ClusterNode projection. ``State`` is rendered as a string via the
+#: ``ConvertTo-Json`` of the enum; the count-level rollup in ops_cluster keys
+#: on the same stringified value.
+_NODE_SELECT: str = "Name, State, NodeWeight, DynamicWeight, Id"
+
+#: ``Resume-ClusterNode -Failback`` accepted values (confirmed from the Learn
+#: "Accepted values" table): ``NoFailback`` / ``Immediate`` / ``Policy``.
+_FAILBACK_VALUES: frozenset[str] = frozenset({"NoFailback", "Immediate", "Policy"})
+
+
+async def wsfc_node_list(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.nodes.list`` — every cluster node (list-shaped)."""
+    del params
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$n = @(Get-ClusterNode | Select-Object {_NODE_SELECT}); "
+        "ConvertTo-Json -Depth 3 -InputObject @{ rows = $n; total = $n.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def wsfc_node_state(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.nodes.state`` — one node's state by name.
+
+    Returns a flat dict with the stringified ``state`` so a Sensor can pin a
+    per-node assertion (e.g. ``$.state`` equals ``Up``).
+    """
+    name: str = params["name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$n = Get-ClusterNode -Name {ps_single_quote(name)}; "
+        'ConvertTo-Json -Compress -InputObject @{ name = "$($n.Name)"; '
+        'state = "$($n.State)"; node_weight = $n.NodeWeight; '
+        'dynamic_weight = $n.DynamicWeight; id = "$($n.Id)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def wsfc_node_pause(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.nodes.pause`` (caution) — ``Suspend-ClusterNode``.
+
+    Suspends (pauses) the node; ``drain=true`` (the default) moves its roles to
+    other nodes first (``-Drain``), the safe maintenance path on a running
+    cluster. An optional ``target_node`` names where to drain the roles.
+    """
+    name: str = params["name"]
+    quoted = ps_single_quote(name)
+    clauses = [f"Suspend-ClusterNode -Name {quoted}"]
+    if params.get("drain", True):
+        clauses.append("-Drain")
+        if params.get("target_node"):
+            clauses.append(f"-TargetNode {ps_single_quote(params['target_node'])}")
+    suspend_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{suspend_expr} | Out-Null; "
+        f"$n = Get-ClusterNode -Name {quoted}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        'name = "$($n.Name)"; state = "$($n.State)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {"name": name, "action": "pause", "state": data.get("state"), "op_class": "write"}
+
+
+async def wsfc_node_resume(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.nodes.resume`` (caution) — ``Resume-ClusterNode``.
+
+    Resumes a paused node. Optional ``failback`` (``NoFailback`` / ``Immediate``
+    / ``Policy``) controls whether roles drained off at pause come back.
+    """
+    name: str = params["name"]
+    quoted = ps_single_quote(name)
+    clauses = [f"Resume-ClusterNode -Name {quoted}"]
+    failback = params.get("failback")
+    if failback is not None:
+        if failback not in _FAILBACK_VALUES:
+            raise ValueError(
+                f"failback must be one of {sorted(_FAILBACK_VALUES)}; got {failback!r}"
+            )
+        clauses.append(f"-Failback {failback}")
+    resume_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{resume_expr} | Out-Null; "
+        f"$n = Get-ClusterNode -Name {quoted}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        'name = "$($n.Name)"; state = "$($n.State)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {"name": name, "action": "resume", "state": data.get("state"), "op_class": "write"}
+
+
+async def wsfc_node_evict(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.nodes.evict`` (dangerous, resume path only) — ``Remove-ClusterNode``.
+
+    Runs ``Remove-ClusterNode -Name <name> -Force``. Irreversible (re-joining
+    is a full add-node flow) — the op is ``requires_approval`` so a dispatch
+    parks for a human decision before the node is evicted.
+    """
+    name: str = params["name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Remove-ClusterNode -Name {ps_single_quote(name)} -Force; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"name": name, "action": "evict", "op_class": "write"}
+
+
+_NODE_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The cluster node name (the ``Name`` column, e.g. ``SQL01``).",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_NODE_ACTION_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "state": {"type": ["string", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+NODE_OPS: tuple[WsfcOp, ...] = (
+    WsfcOp(
+        op_id="wsfc.nodes.list",
+        handler_attr="wsfc_node_list",
+        summary="List cluster nodes via ``Get-ClusterNode`` (name/state/weight).",
+        description=(
+            "Runs ``Get-ClusterNode`` and returns one row per node (Name, "
+            "State, NodeWeight, DynamicWeight, Id). Read-only; the "
+            "``{rows, total}`` envelope is JSONFlux-reduced for a large "
+            "cluster."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="nodes",
+        tags=("read-only", "node", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the cluster's nodes and their Up/Down state "
+                "and quorum weight. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'rows': [{Name, State, NodeWeight, ...}], 'total': <int>}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.nodes.state",
+        handler_attr="wsfc_node_state",
+        summary="Read one cluster node's state via ``Get-ClusterNode -Name``.",
+        description=(
+            "Runs ``Get-ClusterNode -Name <name>`` and returns a flat dict "
+            "with the node's stringified ``state`` (``Up`` / ``Down`` / "
+            "``Paused`` / ``Joining``), quorum weight, and id. Read-only — a "
+            "Sensor can pin a per-node ``$.state`` assertion."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _NODE_NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": ["string", "null"]},
+                "state": {"type": ["string", "null"]},
+                "node_weight": {"type": ["integer", "null"]},
+                "dynamic_weight": {"type": ["integer", "null"]},
+                "id": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="nodes",
+        tags=("read-only", "node", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one named node's current state (e.g. is ``SQL02`` "
+                "Up?). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The cluster node name."},
+            "output_shape": "{'name', 'state', 'node_weight', 'dynamic_weight', 'id'}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.nodes.pause",
+        handler_attr="wsfc_node_pause",
+        summary="Pause/drain a cluster node via ``Suspend-ClusterNode`` (caution).",
+        description=(
+            "Runs ``Suspend-ClusterNode -Name <name>``; ``drain`` (default "
+            "true) adds ``-Drain`` so the node's roles move to other nodes "
+            "first (the safe maintenance path), optionally to ``target_node``. "
+            "safety_level=caution — a recoverable maintenance state change "
+            "(resume brings the node back)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _NODE_NAME_PROP,
+                "drain": {
+                    "type": "boolean",
+                    "description": "Drain roles off the node first (``-Drain``). Default true.",
+                },
+                "target_node": {
+                    "type": "string",
+                    "description": "Optional node to drain the roles to (``-TargetNode``).",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_NODE_ACTION_RESPONSE_SCHEMA,
+        group_key="nodes",
+        tags=("write", "node", "pause"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Pause a node for maintenance (e.g. before patching). Drains "
+                "roles to other nodes by default. Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The node to pause.",
+                "drain": "Optional bool; default true (move roles off first).",
+            },
+            "output_shape": "{'name', 'action': 'pause', 'state', 'op_class': 'write'}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.nodes.resume",
+        handler_attr="wsfc_node_resume",
+        summary="Resume a paused cluster node via ``Resume-ClusterNode`` (caution).",
+        description=(
+            "Runs ``Resume-ClusterNode -Name <name>``. Optional ``failback`` "
+            "(``NoFailback`` / ``Immediate`` / ``Policy``) controls whether "
+            "roles drained off at pause return. safety_level=caution — a "
+            "recoverable state change."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _NODE_NAME_PROP,
+                "failback": {
+                    "type": "string",
+                    "enum": sorted(_FAILBACK_VALUES),
+                    "description": "Optional ``-Failback`` mode for drained roles.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_NODE_ACTION_RESPONSE_SCHEMA,
+        group_key="nodes",
+        tags=("write", "node", "resume"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Bring a paused node back into the cluster (e.g. after "
+                "patching). Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The paused node to resume.",
+                "failback": "Optional; NoFailback / Immediate / Policy.",
+            },
+            "output_shape": "{'name', 'action': 'resume', 'state', 'op_class': 'write'}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.nodes.evict",
+        handler_attr="wsfc_node_evict",
+        summary="Evict a node from the cluster via ``Remove-ClusterNode`` (dangerous).",
+        description=(
+            "Runs ``Remove-ClusterNode -Name <name> -Force``. Irreversible — "
+            "the node leaves cluster membership and re-joining is a full "
+            "add-node flow. safety_level=dangerous, requires_approval=True: a "
+            "dispatch parks for a human to approve before the node is evicted."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"name": _NODE_NAME_PROP},
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "action": {"type": "string"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["name", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="nodes",
+        tags=("write", "node", "evict"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Remove a node from cluster membership. Irreversible; "
+                "approval-gated — parks for a human decision first. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"name": "Required. The node to evict."},
+            "output_shape": "{'name', 'action': 'evict', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/wsfc/ops_nodes.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_nodes.py
@@ -115,15 +115,25 @@ async def wsfc_node_pause(
 
     Suspends (pauses) the node; ``drain=true`` (the default) moves its roles to
     other nodes first (``-Drain``), the safe maintenance path on a running
-    cluster. An optional ``target_node`` names where to drain the roles.
+    cluster. An optional ``target_node`` names where to drain the roles — it
+    requires ``drain=true`` because ``Suspend-ClusterNode`` only honours
+    ``-TargetNode`` alongside ``-Drain``, so a ``target_node`` supplied with
+    ``drain=false`` is rejected fail-closed rather than silently dropped.
     """
     name: str = params["name"]
     quoted = ps_single_quote(name)
+    drain = params.get("drain", True)
+    target_node = params.get("target_node")
+    if target_node and not drain:
+        raise ValueError(
+            "target_node requires drain=true; Suspend-ClusterNode only honors "
+            "-TargetNode with -Drain"
+        )
     clauses = [f"Suspend-ClusterNode -Name {quoted}"]
-    if params.get("drain", True):
+    if drain:
         clauses.append("-Drain")
-        if params.get("target_node"):
-            clauses.append(f"-TargetNode {ps_single_quote(params['target_node'])}")
+        if target_node:
+            clauses.append(f"-TargetNode {ps_single_quote(target_node)}")
     suspend_expr = " ".join(clauses)
     script = (
         "$ErrorActionPreference = 'Stop'; "
@@ -310,7 +320,10 @@ NODE_OPS: tuple[WsfcOp, ...] = (
                 },
                 "target_node": {
                     "type": "string",
-                    "description": "Optional node to drain the roles to (``-TargetNode``).",
+                    "description": (
+                        "Optional node to drain the roles to (``-TargetNode``); "
+                        "requires ``drain=true`` (rejected otherwise)."
+                    ),
                 },
             },
             "required": ["name"],

--- a/backend/src/meho_backplane/connectors/wsfc/ops_resources.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_resources.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""wsfc resource ops — ``list`` / ``dependency-report`` (both safe, list-shaped).
+
+Cluster resources are driven by ``Get-ClusterResource`` and
+``Get-ClusterResourceDependency`` over the shared PowerShell-over-SSH
+transport. Both ops are read-only and list-shaped, so the dispatcher's JSONFlux
+reducer spills a large set (a busy cluster can carry dozens of resources) to a
+``result_query`` handle.
+
+Both scripts are constants (no operator input), so there is no injection
+surface. ``State`` / ``OwnerGroup`` / ``ResourceType`` are projected through
+``"$( ... )"`` string interpolation rather than a bare ``Select-Object`` so the
+JSON carries flat strings, not the nested ``Microsoft.FailoverClusters``
+objects those properties otherwise serialise to.
+
+References
+----------
+
+* ``Get-ClusterResource`` / ``Get-ClusterResourceDependency``
+  (FailoverClusters):
+  https://learn.microsoft.com/en-us/powershell/module/failoverclusters/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+from meho_backplane.connectors.wsfc.ops import SSH_TRANSPORT_NOTE, WsfcOp, normalise_json_rows
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.wsfc.connector import WsfcConnector
+
+__all__ = [
+    "RESOURCE_OPS",
+    "wsfc_resource_dependency_report",
+    "wsfc_resource_list",
+]
+
+_RESOURCE_LIST_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$r = @(Get-ClusterResource | ForEach-Object { [pscustomobject]@{ "
+    'Name = "$($_.Name)"; State = "$($_.State)"; '
+    'OwnerGroup = "$($_.OwnerGroup)"; ResourceType = "$($_.ResourceType)" } }); '
+    "ConvertTo-Json -Depth 3 -InputObject @{ rows = $r; total = $r.Count }"
+)
+
+_DEPENDENCY_REPORT_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$r = @(Get-ClusterResource | ForEach-Object { "
+    "$dep = Get-ClusterResourceDependency -Resource $_.Name; "
+    '[pscustomobject]@{ resource = "$($_.Name)"; owner_group = "$($_.OwnerGroup)"; '
+    'dependency_expression = "$($dep.DependencyExpression)" } }); '
+    "ConvertTo-Json -Depth 3 -InputObject @{ rows = $r; total = $r.Count }"
+)
+
+
+async def wsfc_resource_list(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.resources.list`` — every cluster resource (list-shaped)."""
+    del params
+    payload = await pwsh_run(connector, target, _RESOURCE_LIST_SCRIPT, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def wsfc_resource_dependency_report(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.resources.dependency-report`` — per-resource dependency expressions.
+
+    Runs ``Get-ClusterResourceDependency`` per resource and returns
+    ``{rows, total}`` (each row: ``resource`` / ``owner_group`` /
+    ``dependency_expression``). List-shaped → JSONFlux-reduced.
+    """
+    del params
+    payload = await pwsh_run(connector, target, _DEPENDENCY_REPORT_SCRIPT, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+RESOURCE_OPS: tuple[WsfcOp, ...] = (
+    WsfcOp(
+        op_id="wsfc.resources.list",
+        handler_attr="wsfc_resource_list",
+        summary="List cluster resources via ``Get-ClusterResource`` (name/state/owner/type).",
+        description=(
+            "Runs ``Get-ClusterResource`` and returns one row per resource "
+            "(Name, State, OwnerGroup, ResourceType). Read-only; the "
+            "``{rows, total}`` envelope is JSONFlux-reduced for a large "
+            "cluster."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="resources",
+        tags=("read-only", "resource", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the cluster's resources and their state / "
+                "owning group / type (IP address, network name, disk, SQL "
+                "Server, ...). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{'rows': [{Name, State, OwnerGroup, ResourceType}], 'total': <int>}.",
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.resources.dependency-report",
+        handler_attr="wsfc_resource_dependency_report",
+        summary="Per-resource dependency expressions via ``Get-ClusterResourceDependency``.",
+        description=(
+            "Runs ``Get-ClusterResourceDependency`` for every cluster resource "
+            "and returns one row per resource (``resource`` / ``owner_group`` / "
+            "``dependency_expression``). Read-only; the ``{rows, total}`` "
+            "envelope is JSONFlux-reduced. The dependency expression shows what "
+            "must come online before a resource (e.g. a SQL FCI's network name "
+            "depends on its IP and disk resources)."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="resources",
+        tags=("read-only", "resource", "dependency"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to see the cluster resources' dependency wiring — what "
+                "must be online before each resource. Read-only; the right op "
+                "to understand a SQL FCI's resource ordering. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{resource, owner_group, dependency_expression}], 'total': <int>}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/wsfc/ops_witness.py
+++ b/backend/src/meho_backplane/connectors/wsfc/ops_witness.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""wsfc witness ops — ``get`` (safe) + ``set`` (caution).
+
+The quorum witness is driven by ``Get-ClusterQuorum`` (read) and
+``Set-ClusterQuorum`` (reconfigure) over the shared PowerShell-over-SSH
+transport.
+
+* ``wsfc.witness.get`` resolves the witness *resource* from
+  ``Get-ClusterQuorum.QuorumResource`` and reads its online state via
+  ``Get-ClusterResource`` — the dynamic signal a Sensor pins (``$.online``),
+  load-bearing on a 2-node cluster where a downed witness is one node failure
+  from quorum loss. A node-majority cluster has no witness, so ``online`` reads
+  ``false`` there — pin this recipe only where a witness is expected.
+* ``wsfc.witness.set`` reconfigures the witness (``caution``): a **disk**
+  witness (``Set-ClusterQuorum -DiskWitness <resource>``), a **file-share**
+  witness (``-FileShareWitness <UNC path>``), or **node majority / no witness**
+  (``-NoWitness``).
+
+No cloud witness (deliberate)
+-----------------------------
+
+``Set-ClusterQuorum -CloudWitness`` needs ``-AccessKey`` (an Azure storage
+account key). That secret would land in the ``-EncodedCommand`` script — a
+violation of the shared transport's secret-hygiene contract (see
+:mod:`~meho_backplane.connectors._shared.pwsh`, the same reason winsrv's
+``iscsi.connect`` has no CHAP). A cloud witness is therefore out of scope for
+this cut; a Vault-brokered flow (mint-and-stash, so no secret enters the
+script) is a follow-up.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied disk-resource name / file-share path is interpolated only
+inside a single-quoted PowerShell literal via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; ``witness_type``
+is validated against a bounded enum before it selects a fixed cmdlet flag.
+
+References
+----------
+
+* ``Get-ClusterQuorum`` / ``Set-ClusterQuorum`` / ``Get-ClusterResource``
+  (FailoverClusters):
+  https://learn.microsoft.com/en-us/powershell/module/failoverclusters/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.wsfc.ops import SSH_TRANSPORT_NOTE, WsfcOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.wsfc.connector import WsfcConnector
+
+__all__ = [
+    "WITNESS_OPS",
+    "wsfc_witness_get",
+    "wsfc_witness_set",
+]
+
+#: Resolve the witness resource from Get-ClusterQuorum and read its online
+#: state. Constant script (no operator input). ``QuorumResource`` stringifies
+#: to the resource name; ``Get-ClusterResource -Name`` then reads the state.
+_WITNESS_GET_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$q = Get-ClusterQuorum; "
+    '$wname = if ($q.QuorumResource) { "$($q.QuorumResource)" } else { $null }; '
+    "$wstate = $null; $wtype = $null; $online = $false; "
+    "if ($wname) { $r = Get-ClusterResource -Name $wname -ErrorAction SilentlyContinue; "
+    'if ($r) { $wstate = "$($r.State)"; $wtype = "$($r.ResourceType)"; '
+    "$online = (\"$($r.State)\" -eq 'Online') } }; "
+    'ConvertTo-Json -Compress -InputObject @{ cluster = "$($q.Cluster)"; '
+    'quorum_type = "$($q.QuorumType)"; witness_resource = $wname; '
+    "witness_type = $wtype; witness_state = $wstate; online = $online }"
+)
+
+#: witness_type → the Set-ClusterQuorum flag it selects. ``disk`` /
+#: ``file_share`` also consume an operator string (resource / path);
+#: ``node_majority`` is a bare switch. Cloud witness is intentionally absent
+#: (its access key cannot ride the transport — see the module docstring).
+_WITNESS_TYPES: frozenset[str] = frozenset({"node_majority", "disk", "file_share"})
+
+
+async def wsfc_witness_get(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.witness.get`` — the witness resource + its online state.
+
+    Returns ``{cluster, quorum_type, witness_resource, witness_type,
+    witness_state, online}``. ``online`` is the boolean a Sensor pins
+    (``$.online``); it is ``false`` when the cluster has no witness
+    (node-majority).
+    """
+    del params
+    payload = await pwsh_run(connector, target, _WITNESS_GET_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+def _witness_clause(params: dict[str, Any]) -> str:
+    """Return the validated ``Set-ClusterQuorum`` witness clause from *params*."""
+    witness_type = params.get("witness_type")
+    if witness_type not in _WITNESS_TYPES:
+        raise ValueError(
+            f"witness_type must be one of {sorted(_WITNESS_TYPES)}; got {witness_type!r}"
+        )
+    if witness_type == "node_majority":
+        return "-NoWitness"
+    if witness_type == "disk":
+        resource = params.get("resource")
+        if not isinstance(resource, str) or not resource.strip():
+            raise ValueError(
+                "witness_type='disk' requires a non-empty 'resource' (disk resource name)"
+            )
+        return f"-DiskWitness {ps_single_quote(resource)}"
+    # file_share
+    path = params.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("witness_type='file_share' requires a non-empty 'path' (UNC share path)")
+    return f"-FileShareWitness {ps_single_quote(path)}"
+
+
+async def wsfc_witness_set(
+    connector: WsfcConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``wsfc.witness.set`` (caution) — reconfigure the quorum witness.
+
+    ``witness_type`` selects the witness model: ``disk`` (needs ``resource``),
+    ``file_share`` (needs ``path``), or ``node_majority`` (no witness). Reads
+    back the resulting quorum model. No cloud witness (see the module
+    docstring).
+    """
+    clause = _witness_clause(params)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Set-ClusterQuorum {clause} | Out-Null; "
+        "$q = Get-ClusterQuorum; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; "
+        'quorum_type = "$($q.QuorumType)"; '
+        'quorum_resource = if ($q.QuorumResource) { "$($q.QuorumResource)" } else { $null } }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "action": "set",
+        "witness_type": params["witness_type"],
+        "quorum_type": data.get("quorum_type"),
+        "quorum_resource": data.get("quorum_resource"),
+        "op_class": "write",
+    }
+
+
+WITNESS_OPS: tuple[WsfcOp, ...] = (
+    WsfcOp(
+        op_id="wsfc.witness.get",
+        handler_attr="wsfc_witness_get",
+        summary="Read the quorum witness resource + its online state.",
+        description=(
+            "Resolves the witness resource from ``Get-ClusterQuorum`` and reads "
+            "its online state via ``Get-ClusterResource``. Returns "
+            "``{cluster, quorum_type, witness_resource, witness_type, "
+            "witness_state, online}``. Read-only — the ``online`` boolean is "
+            "the op a Sensor pins to watch witness reachability (load-bearing "
+            "on a 2-node cluster). A node-majority cluster has no witness, so "
+            "``online`` reads ``false`` there."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema={
+            "type": "object",
+            "properties": {
+                "cluster": {"type": ["string", "null"]},
+                "quorum_type": {"type": ["string", "null"]},
+                "witness_resource": {"type": ["string", "null"]},
+                "witness_type": {"type": ["string", "null"]},
+                "witness_state": {"type": ["string", "null"]},
+                "online": {"type": "boolean"},
+            },
+            "additionalProperties": True,
+        },
+        group_key="witness",
+        tags=("read-only", "witness", "quorum"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to check the quorum witness — which resource is the "
+                "witness and whether it is Online. Read-only; the sensor op "
+                "for witness reachability. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'cluster', 'quorum_type', 'witness_resource', 'witness_type', "
+                "'witness_state', 'online': <bool>}."
+            ),
+        },
+    ),
+    WsfcOp(
+        op_id="wsfc.witness.set",
+        handler_attr="wsfc_witness_set",
+        summary="Reconfigure the quorum witness via ``Set-ClusterQuorum`` (caution).",
+        description=(
+            "Reconfigures the cluster quorum witness. ``witness_type`` selects "
+            "the model: ``disk`` (``-DiskWitness <resource>``, needs "
+            "``resource``), ``file_share`` (``-FileShareWitness <UNC path>``, "
+            "needs ``path``), or ``node_majority`` (``-NoWitness``). No cloud "
+            "witness — its access key cannot ride the pwsh transport (a "
+            "Vault-brokered flow is a follow-up). safety_level=caution — a "
+            "recoverable quorum reconfiguration."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "witness_type": {
+                    "type": "string",
+                    "enum": sorted(_WITNESS_TYPES),
+                    "description": "The witness model: disk / file_share / node_majority.",
+                },
+                "resource": {
+                    "type": "string",
+                    "description": "Disk resource name (required for ``witness_type='disk'``).",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "UNC share path (required for ``witness_type='file_share'``).",
+                },
+            },
+            "required": ["witness_type"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "witness_type": {"type": "string"},
+                "quorum_type": {"type": ["string", "null"]},
+                "quorum_resource": {"type": ["string", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["action", "witness_type", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="witness",
+        tags=("write", "witness", "quorum"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Reconfigure the quorum witness (disk / file-share / node "
+                "majority). Recoverable; safety_level=caution. No cloud "
+                "witness in this cut. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "witness_type": "Required. disk / file_share / node_majority.",
+                "resource": "Disk resource name (for witness_type=disk).",
+                "path": "UNC share path (for witness_type=file_share).",
+            },
+            "output_shape": (
+                "{'action': 'set', 'witness_type', 'quorum_type', "
+                "'quorum_resource', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/tests/test_connectors_wsfc.py
+++ b/backend/tests/test_connectors_wsfc.py
@@ -207,7 +207,10 @@ async def test_cluster_get_builds_health_rollup() -> None:
     assert "Get-ClusterNode" in script
     assert "Get-ClusterGroup" in script
     assert "Get-ClusterResource" in script
-    assert "nodes_up = _count $nodes 'Up'" in script
+    # Hashtable values are plain expressions (no inline-function calls), and the
+    # per-state maps are precomputed variables.
+    assert "nodes_up = @($nodes | Where-Object { \"$($_.State)\" -eq 'Up' }).Count" in script
+    assert "nodes_by_state = $nbs" in script
     assert result["nodes_up"] == 2
     assert result["groups_failed"] == 0
 

--- a/backend/tests/test_connectors_wsfc.py
+++ b/backend/tests/test_connectors_wsfc.py
@@ -255,6 +255,16 @@ async def test_cluster_test_rejects_bad_include() -> None:
     run_mock.assert_not_awaited()
 
 
+async def test_cluster_test_escapes_report_name() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"report_path":"C:\\\\r.mht"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_cluster_test(connector, _TARGET, {"report_name": "run o'clock"})
+    # EncodedCommand-decode injection check: the operator report name is escaped
+    # inside a single-quoted literal (embedded quote doubled).
+    assert "-ReportName 'run o''clock'" in _script_from_call(run_mock)
+
+
 # ---------------------------------------------------------------------------
 # nodes group
 # ---------------------------------------------------------------------------
@@ -305,6 +315,18 @@ async def test_node_pause_no_drain_omits_flag() -> None:
     script = _script_from_call(run_mock)
     assert "Suspend-ClusterNode -Name 'SQL01'" in script
     assert "-Drain" not in script
+
+
+async def test_node_pause_rejects_target_node_without_drain() -> None:
+    """``-TargetNode`` is only valid with ``-Drain``; the contradictory combo is
+    rejected fail-closed, never silently dropped."""
+    connector = WsfcConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await wsfc_node_pause(
+            connector, _TARGET, {"name": "SQL01", "target_node": "SQL02", "drain": False}
+        )
+    run_mock.assert_not_awaited()
 
 
 async def test_node_resume_validates_failback() -> None:

--- a/backend/tests/test_connectors_wsfc.py
+++ b/backend/tests/test_connectors_wsfc.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the wsfc connector (SSH → PowerShell / FailoverClusters).
+
+Mirrors the winsrv harness (``test_connectors_winsrv.py``): a ``_StubTarget``
+dataclass, a ``_completed_process`` SSHCompletedProcess stub, and
+``patch.object(connector, "_run_command", AsyncMock(...))`` so the cmdlet
+handlers can be exercised without a real cluster. Because the transport is
+``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1), the
+assertions decode the base64 payload back to the script and assert on the
+cmdlet + quoted arguments the handler built — that decode is the injection-
+safety check (an operator string must appear only inside a doubled
+single-quoted literal).
+
+There is no spec-reconcile lane — the cmdlet surface ships no OpenAPI (the
+confirmed convention for SSH-typed connectors). Drift protection is this
+ordinary unit suite.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.wsfc  # noqa: F401 -- registers connector at import
+from meho_backplane.connectors.registry import product_impl_id_round_trips
+from meho_backplane.connectors.wsfc import WSFC_OPS, WsfcConnector
+from meho_backplane.connectors.wsfc.ops import WSFC_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.wsfc.ops_cluster import (
+    wsfc_cluster_get,
+    wsfc_cluster_quorum,
+    wsfc_cluster_test,
+    wsfc_cluster_validation_report,
+)
+from meho_backplane.connectors.wsfc.ops_groups import (
+    wsfc_group_list,
+    wsfc_group_move,
+    wsfc_group_offline,
+    wsfc_group_online,
+    wsfc_group_state,
+)
+from meho_backplane.connectors.wsfc.ops_nodes import (
+    wsfc_node_evict,
+    wsfc_node_list,
+    wsfc_node_pause,
+    wsfc_node_resume,
+    wsfc_node_state,
+)
+from meho_backplane.connectors.wsfc.ops_resources import (
+    wsfc_resource_dependency_report,
+    wsfc_resource_list,
+)
+from meho_backplane.connectors.wsfc.ops_witness import wsfc_witness_get, wsfc_witness_set
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires (mirrors the winsrv suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="wsfc-test",
+    host="node1.test.invalid",
+    port=22,
+    secret_ref="meho/testing/wsfc/wsfc-test",
+)
+
+
+def _completed_process(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Stub mimicking asyncssh's :class:`SSHCompletedProcess`."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _script_from_call(run_mock: AsyncMock) -> str:
+    """Recover the PowerShell script from the mocked ``_run_command`` argv.
+
+    ``pwsh_run`` builds ``powershell -NoProfile -NonInteractive -EncodedCommand
+    <base64-utf16le>`` and passes it as the 2nd positional arg to
+    ``_run_command``. Decode the base64 tail back to the script text (which
+    carries the transport's prepended ``$ProgressPreference`` guard).
+    """
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    encoded = cmd.rsplit(" ", 1)[1]
+    return base64.b64decode(encoded).decode("utf-16-le")
+
+
+def _run(stdout: str) -> AsyncMock:
+    return AsyncMock(return_value=_completed_process(stdout=stdout))
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+async def test_transport_uses_windows_powershell_and_suppresses_progress() -> None:
+    connector = WsfcConnector()
+    assert connector.POWERSHELL_EXECUTABLE == "powershell"
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_node_list(connector, _TARGET, {})
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    assert not cmd.startswith("pwsh ")
+    assert _script_from_call(run_mock).startswith("$ProgressPreference = 'SilentlyContinue';")
+
+
+# ---------------------------------------------------------------------------
+# Registration / metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_connector_id_triple_round_trips() -> None:
+    assert WsfcConnector.product == "wsfc"
+    assert WsfcConnector.version == "2022.x"
+    assert WsfcConnector.impl_id == "wsfc-ssh"
+    assert product_impl_id_round_trips(product="wsfc", version="2022.x", impl_id="wsfc-ssh")
+
+
+def test_op_surface_ids_and_safety_tiers() -> None:
+    by_id = {op.op_id: op for op in WSFC_OPS}
+    assert len(by_id) == 19
+    safe = {k for k, v in by_id.items() if v.safety_level == "safe"}
+    caution = {k for k, v in by_id.items() if v.safety_level == "caution"}
+    dangerous = {k for k, v in by_id.items() if v.safety_level == "dangerous"}
+    assert dangerous == {
+        "wsfc.nodes.evict",
+        "wsfc.groups.offline",
+        "wsfc.groups.online",
+    }
+    # Every dangerous op requires approval; nothing else does.
+    assert {k for k, v in by_id.items() if v.requires_approval} == dangerous
+    assert caution == {
+        "wsfc.cluster.test",
+        "wsfc.nodes.pause",
+        "wsfc.nodes.resume",
+        "wsfc.groups.move",
+        "wsfc.witness.set",
+    }
+    assert {
+        "wsfc.about",
+        "wsfc.cluster.get",
+        "wsfc.cluster.quorum",
+        "wsfc.cluster.validation-report",
+        "wsfc.nodes.list",
+        "wsfc.groups.state",
+        "wsfc.resources.dependency-report",
+        "wsfc.witness.get",
+    } <= safe
+
+
+def test_every_group_has_a_curated_when_to_use() -> None:
+    groups = {op.group_key for op in WSFC_OPS}
+    assert groups == {"cluster", "nodes", "groups", "resources", "witness"}
+    assert groups <= set(WSFC_WHEN_TO_USE_BY_GROUP)
+
+
+def test_every_handler_attr_resolves_on_the_class() -> None:
+    for op in WSFC_OPS:
+        assert getattr(WsfcConnector, op.handler_attr, None) is not None, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# cluster group
+# ---------------------------------------------------------------------------
+
+
+async def test_cluster_get_builds_health_rollup() -> None:
+    connector = WsfcConnector()
+    payload = (
+        '{"name":"c1sql1","nodes_total":2,"nodes_up":2,"nodes_down":0,'
+        '"groups_total":3,"groups_online":3,"groups_failed":0,'
+        '"resources_total":8,"resources_online":8,"resources_failed":0}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_cluster_get(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-Cluster" in script
+    assert "Get-ClusterNode" in script
+    assert "Get-ClusterGroup" in script
+    assert "Get-ClusterResource" in script
+    assert "nodes_up = _count $nodes 'Up'" in script
+    assert result["nodes_up"] == 2
+    assert result["groups_failed"] == 0
+
+
+async def test_cluster_quorum_builds_query() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"cluster":"c1sql1","quorum_type":"NodeAndFileShareMajority"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_cluster_quorum(connector, _TARGET, {})
+    assert "Get-ClusterQuorum" in _script_from_call(run_mock)
+    assert result["quorum_type"] == "NodeAndFileShareMajority"
+
+
+@pytest.mark.parametrize("rows_json", ["[]", "null"])
+async def test_validation_report_empty(rows_json: str) -> None:
+    connector = WsfcConnector()
+    run_mock = _run(f'{{"rows":{rows_json},"total":0}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_cluster_validation_report(connector, _TARGET, {})
+    assert "Cluster\\Reports" in _script_from_call(run_mock)
+    assert result == {"rows": [], "total": 0}
+
+
+async def test_cluster_test_runs_with_raised_timeout_and_escapes_include() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"report_path":"C:\\\\x.mht"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_cluster_test(connector, _TARGET, {"include": ["Inventory", "Net'work"]})
+    script = _script_from_call(run_mock)
+    assert "Test-Cluster -Include 'Inventory', 'Net''work'" in script
+    assert "-Confirm:$false" in script
+    # LONG-running: the handler forwards a raised timeout to _run_command.
+    assert run_mock.await_args.kwargs["timeout"] == 900.0
+    assert result == {"action": "test", "report_path": "C:\\x.mht", "op_class": "write"}
+
+
+async def test_cluster_test_rejects_bad_include() -> None:
+    connector = WsfcConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await wsfc_cluster_test(connector, _TARGET, {"include": ["ok", ""]})
+    run_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# nodes group
+# ---------------------------------------------------------------------------
+
+
+async def test_node_list_builds_envelope() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"rows":[{"Name":"SQL01","State":"Up"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_node_list(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ClusterNode" in script
+    assert "rows = $n; total = $n.Count" in script
+    assert result["total"] == 1
+
+
+async def test_node_state_escapes_name() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"name":"o\'db","state":"Up"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_node_state(connector, _TARGET, {"name": "o'db"})
+    assert "Get-ClusterNode -Name 'o''db'" in _script_from_call(run_mock)
+    assert result["state"] == "Up"
+
+
+async def test_node_pause_drains_and_escapes_target() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"name":"SQL01","state":"Paused"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_node_pause(
+            connector, _TARGET, {"name": "SQL01", "target_node": "SQL0'2"}
+        )
+    script = _script_from_call(run_mock)
+    assert "Suspend-ClusterNode -Name 'SQL01' -Drain -TargetNode 'SQL0''2'" in script
+    assert result == {
+        "name": "SQL01",
+        "action": "pause",
+        "state": "Paused",
+        "op_class": "write",
+    }
+
+
+async def test_node_pause_no_drain_omits_flag() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"name":"SQL01","state":"Paused"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_node_pause(connector, _TARGET, {"name": "SQL01", "drain": False})
+    script = _script_from_call(run_mock)
+    assert "Suspend-ClusterNode -Name 'SQL01'" in script
+    assert "-Drain" not in script
+
+
+async def test_node_resume_validates_failback() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"name":"SQL01","state":"Up"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_node_resume(connector, _TARGET, {"name": "SQL01", "failback": "Immediate"})
+    assert "Resume-ClusterNode -Name 'SQL01' -Failback Immediate" in _script_from_call(run_mock)
+
+
+async def test_node_resume_rejects_bad_failback() -> None:
+    connector = WsfcConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await wsfc_node_resume(connector, _TARGET, {"name": "SQL01", "failback": "later"})
+    run_mock.assert_not_awaited()
+
+
+async def test_node_evict_builds_remove_force() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_node_evict(connector, _TARGET, {"name": "SQL0'2"})
+    assert "Remove-ClusterNode -Name 'SQL0''2' -Force" in _script_from_call(run_mock)
+    assert result == {"name": "SQL0'2", "action": "evict", "op_class": "write"}
+
+
+# ---------------------------------------------------------------------------
+# groups group
+# ---------------------------------------------------------------------------
+
+
+async def test_group_list_builds_envelope() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"rows":[{"Name":"SQL Server (MSSQLSERVER)","State":"Online"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_group_list(connector, _TARGET, {})
+    assert "Get-ClusterGroup" in _script_from_call(run_mock)
+    assert result["total"] == 1
+
+
+async def test_group_state_escapes_and_reads_owner() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"name":"SQL Server (MSSQLSERVER)","state":"Online","owner_node":"SQL01"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_group_state(connector, _TARGET, {"name": "SQL Server (MSSQLSERVER)"})
+    assert "Get-ClusterGroup -Name 'SQL Server (MSSQLSERVER)'" in _script_from_call(run_mock)
+    assert result["state"] == "Online"
+    assert result["owner_node"] == "SQL01"
+
+
+async def test_group_move_builds_and_escapes_node() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"name":"role","state":"Online","owner_node":"SQL02"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_group_move(connector, _TARGET, {"name": "role", "node": "SQL0'2"})
+    script = _script_from_call(run_mock)
+    assert "Move-ClusterGroup -Name 'role' -Node 'SQL0''2'" in script
+    assert result["action"] == "move"
+    assert result["owner_node"] == "SQL02"
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet", "action"),
+    [
+        (wsfc_group_offline, "Stop-ClusterGroup", "offline"),
+        (wsfc_group_online, "Start-ClusterGroup", "online"),
+    ],
+)
+async def test_group_power_builds_cmdlet(handler: Any, cmdlet: str, action: str) -> None:
+    connector = WsfcConnector()
+    run_mock = _run(f'{{"ok":true,"name":"role","state":"{action}"}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(connector, _TARGET, {"name": "ro'le"})
+    assert f"{cmdlet} -Name 'ro''le'" in _script_from_call(run_mock)
+    assert result["action"] == action
+    assert result["op_class"] == "write"
+
+
+# ---------------------------------------------------------------------------
+# resources group
+# ---------------------------------------------------------------------------
+
+
+async def test_resource_list_builds_projection() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"rows":[{"Name":"IP","State":"Online"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_resource_list(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ClusterResource" in script
+    assert "ResourceType" in script
+    assert result["total"] == 1
+
+
+async def test_dependency_report_builds_per_resource_query() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"rows":[{"resource":"Name","dependency_expression":"([IP])"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_resource_dependency_report(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ClusterResourceDependency -Resource $_.Name" in script
+    assert result["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# witness group — incl. the secret-hygiene invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_witness_get_resolves_resource_state() -> None:
+    connector = WsfcConnector()
+    run_mock = _run(
+        '{"cluster":"c1sql1","quorum_type":"NodeAndFileShareMajority",'
+        '"witness_resource":"File Share Witness","witness_state":"Online","online":true}'
+    )
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_witness_get(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ClusterQuorum" in script
+    assert "Get-ClusterResource -Name $wname" in script
+    assert result["online"] is True
+
+
+async def test_witness_set_disk_escapes_resource() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"quorum_type":"NodeAndDiskMajority","quorum_resource":"Disk"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await wsfc_witness_set(
+            connector, _TARGET, {"witness_type": "disk", "resource": "Cluster Disk 'W'"}
+        )
+    script = _script_from_call(run_mock)
+    assert "Set-ClusterQuorum -DiskWitness 'Cluster Disk ''W'''" in script
+    assert result == {
+        "action": "set",
+        "witness_type": "disk",
+        "quorum_type": "NodeAndDiskMajority",
+        "quorum_resource": "Disk",
+        "op_class": "write",
+    }
+
+
+async def test_witness_set_file_share_escapes_path() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"quorum_type":"NodeAndFileShareMajority","quorum_resource":"FSW"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_witness_set(
+            connector, _TARGET, {"witness_type": "file_share", "path": "\\\\fs\\w'x"}
+        )
+    assert "Set-ClusterQuorum -FileShareWitness '\\\\fs\\w''x'" in _script_from_call(run_mock)
+
+
+async def test_witness_set_node_majority_uses_no_witness() -> None:
+    connector = WsfcConnector()
+    run_mock = _run('{"ok":true,"quorum_type":"NodeMajority","quorum_resource":null}')
+    with patch.object(connector, "_run_command", run_mock):
+        await wsfc_witness_set(connector, _TARGET, {"witness_type": "node_majority"})
+    assert "Set-ClusterQuorum -NoWitness" in _script_from_call(run_mock)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"witness_type": "cloud"},  # cloud witness excluded (secret can't ride the transport)
+        {"witness_type": "disk"},  # missing resource
+        {"witness_type": "file_share"},  # missing path
+    ],
+)
+async def test_witness_set_rejects_bad_params(params: dict[str, Any]) -> None:
+    connector = WsfcConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await wsfc_witness_set(connector, _TARGET, params)
+    run_mock.assert_not_awaited()
+
+
+def test_no_write_op_exposes_a_secret_value_field() -> None:
+    """The secret-leak guard at the schema level: no op accepts a plaintext
+    secret-value parameter (password / secret / cloud-witness access key), so a
+    secret can never reach the ``-EncodedCommand`` argv. (The cloud witness,
+    whose ``-AccessKey`` is a secret, is deliberately not offered.)"""
+    secret_fields = {"password", "secret", "access_key", "accesskey", "accountkey"}
+    for op in WSFC_OPS:
+        props = op.parameter_schema.get("properties", {})
+        leaked = secret_fields & {key.lower() for key in props}
+        assert not leaked, (op.op_id, sorted(leaked))
+
+
+# ---------------------------------------------------------------------------
+# about (fingerprint wrapper) + probe
+# ---------------------------------------------------------------------------
+
+
+async def test_about_maps_fingerprint_into_identity_dict() -> None:
+    connector = WsfcConnector()
+    payload = (
+        '{"Hostname":"SQL01","OsVersion":"10.0.20348","BuildNumber":"20348",'
+        '"PowerShellVersion":"5.1.20348.1","FailoverClustersModule":true,'
+        '"ClusterName":"c1sql1","ClusterFunctionalLevel":11}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await connector.about(_TARGET, {})
+    assert "Get-Module -ListAvailable -Name FailoverClusters" in _script_from_call(run_mock)
+    assert result["vendor"] == "microsoft"
+    assert result["product"] == "windows-failover-cluster"
+    assert result["version"] == "10.0.20348"
+    assert result["build"] == "20348"
+    assert result["hostname"] == "SQL01"
+    assert result["cluster_name"] == "c1sql1"
+    assert result["cluster_functional_level"] == 11
+    assert result["failover_clusters_module"] is True
+    assert result["powershell_version"] == "5.1.20348.1"
+
+
+async def test_probe_failover_module_absent() -> None:
+    connector = WsfcConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":false,"cluster":null}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "failover_module_absent"
+
+
+async def test_probe_not_cluster_member() -> None:
+    connector = WsfcConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":true,"cluster":null}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "not_cluster_member"
+
+
+async def test_probe_ok_when_member() -> None:
+    connector = WsfcConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":true,"cluster":"c1sql1"}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is True
+    assert result.reason is None
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("connection reset by peer"),
+        asyncssh.ConnectionLost("channel closed mid-command"),
+        TimeoutError("probe script timed out"),
+    ],
+)
+async def test_probe_command_failed_when_run_command_raises_after_connect(boom: Exception) -> None:
+    connector = WsfcConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "command_failed"
+
+
+async def test_probe_tcp_unreachable_and_auth_failed() -> None:
+    connector = WsfcConnector()
+    with patch.object(connector, "_connect", AsyncMock(side_effect=OSError("no route"))):
+        assert (await connector.probe(_TARGET)).reason == "tcp_unreachable"
+    with patch.object(
+        connector, "_connect", AsyncMock(side_effect=asyncssh.PermissionDenied("no"))
+    ):
+        assert (await connector.probe(_TARGET)).reason == "ssh_auth_failed"
+
+
+async def test_fingerprint_unreachable_is_not_an_exception() -> None:
+    connector = WsfcConnector()
+    with patch.object(connector, "_run_command", AsyncMock(side_effect=OSError("down"))):
+        result = await connector.fingerprint(_TARGET)
+    assert result.reachable is False
+    assert result.vendor == "microsoft"
+    assert result.product == "windows-failover-cluster"
+    assert "error" in result.extras

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -457,6 +457,7 @@ _EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
         "vrops-vrops8",
         "windns-ssh",
         "winsrv-ssh",
+        "wsfc-ssh",
     }
 )
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -32399,7 +32399,8 @@
               "vrli",
               "vrops",
               "windns",
-              "winsrv"
+              "winsrv",
+              "wsfc"
             ],
             "description": "Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss."
           },

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -560,6 +560,7 @@ const (
 	TargetCreateProductVrops      TargetCreateProduct = "vrops"
 	TargetCreateProductWindns     TargetCreateProduct = "windns"
 	TargetCreateProductWinsrv     TargetCreateProduct = "winsrv"
+	TargetCreateProductWsfc       TargetCreateProduct = "wsfc"
 )
 
 // Defines values for TemplateSummaryStatus.

--- a/docs/codebase/connectors-wsfc.md
+++ b/docs/codebase/connectors-wsfc.md
@@ -1,0 +1,440 @@
+# Connector: wsfc (wsfc-2022.x / `wsfc-ssh`)
+
+## Overview
+
+The `wsfc` connector is the typed `Connector` subclass that manages a **Windows
+Server Failover Cluster** — cluster / node / group (clustered-role) / resource /
+quorum state, cluster validation, and guarded role-move / failover writes — over
+SSH → PowerShell (the built-in Windows PowerShell 5.1 `FailoverClusters` module
+cmdlets). It is registered under the `(product="wsfc", version="2022.x",
+impl_id="wsfc-ssh")` registry triple plus the `("wsfc", "", "")` wildcard
+fallback row, and is a child of the shared `SshConnector` adapter — the same
+transport base as `WinsrvConnector`, `WindowsDnsConnector`, and
+`Rke2SshConnector`.
+
+The `wsfc` connector is a **structured copy of the winsrv estate mold**
+(`docs/codebase/connectors-winsrv.md`): identity canary + per-domain op groups
+on the `SshConnector` base, built on the PowerShell-over-SSH transport
+`_shared/pwsh` (base64 UTF-16LE `-EncodedCommand` + stdlib `json` parse), with
+the `rke2` approval-parked-write mold for its destructive ops. It complements
+evoila/meho#3256 (the vSphere shared-disk layer *beneath* the guest cluster);
+this connector is the cluster layer *inside* it. Its named consumer is the
+c1sql1 SQL Server FCI (evoila-bosnia/claude-rdc-hetzner-dc#2794 / #2795), whose
+cluster state today is only visible by hand inside the guest.
+
+**The target is any single cluster node.** The `FailoverClusters` cmdlets talk
+to the local Cluster Service, which is the cluster-wide database, so they fan
+out cluster-wide from whichever node runs them. One node is a sufficient control
+point for the whole cluster — there is no per-node target fan-out to arrange.
+Pick a stable node (or a node the satellite can reach) as the target.
+
+Registry-triple rationale: `product="wsfc"` is a short, separator-free token
+because `parse_connector_id` derives the product from the first hyphen-segment
+of `impl_id`, so `connector_id="wsfc-ssh-2022.x"` round-trips (a
+hyphen/underscore in the product token breaks the registry's round-trip guard at
+boot). `version="2022.x"` marks the cmdlet surface (stable across Windows Server
+2019 → 2025). `impl_id="wsfc-ssh"` leaves room for a future `wsfc-winrm` sibling.
+
+Source: `backend/src/meho_backplane/connectors/wsfc/`.
+
+## Op surface (19 ops across five groups)
+
+Safety tier is a reach decision per the Initiative #3259 satellite table: reads
+= `safe` (ride satellite runners); recoverable writes = `caution` (satellite-
+executable only through the Stage-3 composed write gate, #2901); destructive =
+`dangerous` + `requires_approval` (satellite-EXCLUDED by the tier ladder,
+central-dial / on-site only).
+
+| op | safety | approval | cmdlet(s) |
+| --- | --- | --- | --- |
+| `wsfc.about` | safe | no | `Get-Module FailoverClusters` + `Get-Cluster` + `Win32_OperatingSystem` |
+| `wsfc.cluster.get` | safe | no | `Get-Cluster` + `Get-ClusterNode` + `Get-ClusterGroup` + `Get-ClusterResource` |
+| `wsfc.cluster.quorum` | safe | no | `Get-ClusterQuorum` |
+| `wsfc.cluster.validation-report` | safe | no | `Get-ChildItem %SystemRoot%\Cluster\Reports` |
+| `wsfc.cluster.test` | caution | no | `Test-Cluster` (**long-running**) |
+| `wsfc.nodes.list` | safe | no | `Get-ClusterNode` |
+| `wsfc.nodes.state` | safe | no | `Get-ClusterNode -Name` |
+| `wsfc.nodes.pause` | caution | no | `Suspend-ClusterNode -Drain` |
+| `wsfc.nodes.resume` | caution | no | `Resume-ClusterNode` |
+| `wsfc.nodes.evict` | **dangerous** | **yes** | `Remove-ClusterNode -Force` |
+| `wsfc.groups.list` | safe | no | `Get-ClusterGroup` |
+| `wsfc.groups.state` | safe | no | `Get-ClusterGroup -Name` |
+| `wsfc.groups.move` | caution | no | `Move-ClusterGroup` |
+| `wsfc.groups.offline` | **dangerous** | **yes** | `Stop-ClusterGroup` |
+| `wsfc.groups.online` | **dangerous** | **yes** | `Start-ClusterGroup` |
+| `wsfc.resources.list` | safe | no | `Get-ClusterResource` |
+| `wsfc.resources.dependency-report` | safe | no | `Get-ClusterResourceDependency` |
+| `wsfc.witness.get` | safe | no | `Get-ClusterQuorum` + `Get-ClusterResource` |
+| `wsfc.witness.set` | caution | no | `Set-ClusterQuorum` |
+
+The three `dangerous` ops (`nodes.evict`, `groups.offline`, `groups.online`) are
+`requires_approval=True` — a dispatch parks at `needs-approval` for a human
+decision (the rke2 write mold; no bespoke `proposed_effect` builder is
+registered — the generic params-echo default (#1856) surfaces the target /
+params redaction-safely to the reviewer). The **agent-principal ceiling**
+therefore applies: an agent session cannot self-approve these — approval is a
+human decision (v0.1-spec §7), so a dispatch from an agent floors at the approval
+queue until an operator approves in the console / CLI. Reads ride satellite
+runners; the `dangerous` ops are excluded from satellites by the tier ladder.
+
+**Why `offline`/`online` are dangerous but `move` is caution.** A planned
+node-to-node failover (`Move-ClusterGroup`) is a recoverable rebalance — the role
+stays online, just on another node — so it is `caution` (the governed-failover
+path the acceptance criteria want proven). Taking a production role *offline*
+(`Stop-ClusterGroup`) is a service outage, and forcing one *online*
+(`Start-ClusterGroup`) — e.g. to the wrong node, or while it should stay down —
+can cause split-brain / data issues. Both are `dangerous` + approval per the
+#3259 initiative table.
+
+## Key types
+
+- **`WsfcConnector`** (`connector.py`) — `SshConnector` subclass. Class
+  attributes: `product="wsfc"`, `version="2022.x"`, `impl_id="wsfc-ssh"`,
+  `POWERSHELL_EXECUTABLE="powershell"`. Ships `fingerprint`, `probe`, `about`,
+  the 18 bound-method op shims, `register_operations`, and the operator-less
+  `execute` dispatcher shim. Inherits the per-target asyncssh connection pool,
+  `_auth_config`, `_run_command`, `_assert_reachable`, and `aclose()` from the
+  adapter.
+- **Shared pwsh transport** (`_shared/pwsh.py`, #3260) — `pwsh_run` (the single
+  seam every handler routes its script through), `ps_single_quote` (the
+  `shlex.quote` analogue), `encode_pwsh_command`, `strip_clixml`, `PwshRunError`.
+  Per-connector wire variation rides three class-level seams:
+  `POWERSHELL_EXECUTABLE` (`powershell` here), `POWERSHELL_SCRIPT_PREFIX` (the
+  `$ProgressPreference` guard), `POWERSHELL_LOG_EVENT` (`wsfc_pwsh_executed`).
+- **Op metadata** (`ops.py`) — `WsfcOp` frozen dataclass (mirrors `WinsrvOp`),
+  `WSFC_OPS` (`about` + the five per-domain tuples),
+  `WSFC_WHEN_TO_USE_BY_GROUP` (curated per-group blurbs, imported into the
+  connector — the rke2 / winsrv precedent), and `normalise_json_rows` (collapses
+  `ConvertTo-Json`'s dict / list / null shapes to `list[dict]`).
+- **Per-domain op modules** — `ops_cluster.py`, `ops_nodes.py`, `ops_groups.py`,
+  `ops_resources.py`, `ops_witness.py`. Each owns its handlers + op tuple,
+  imports `WsfcOp` from `ops.py`, and (for parameterized scripts)
+  `ps_single_quote` from `_shared/pwsh`.
+- **Registration** (`__init__.py`) — two-phase, mirroring winsrv / rke2:
+  synchronous `register_connector_v2` at import time (versioned triple + wildcard
+  row); async `register_wsfc_typed_operations` queued onto the lifespan registrar
+  list. No v1 `register_connector` — no chassis history.
+
+## Transport: PowerShell-over-SSH
+
+Every op runs `powershell -NoProfile -NonInteractive -EncodedCommand <base64>`
+over the pooled SSH connection — identical to winsrv (see
+`docs/codebase/connectors-winsrv.md` for the full transport rationale). The
+wsfc-specific points:
+
+- **`powershell` (Windows PowerShell 5.1), not `pwsh` (PS7).** The connector sets
+  `POWERSHELL_EXECUTABLE="powershell"` explicitly. The shared transport's
+  fallback is `pwsh` (PS7), which a Windows Server host does NOT ship — the
+  single most important footgun when copying the estate mold (see the winsrv doc,
+  "building the next estate connector").
+- **`$ProgressPreference = 'SilentlyContinue'` guard** — prepended to every
+  script so the `FailoverClusters` module's first-use progress stream never
+  serialises CLIXML noise onto the streams.
+- **Hashtable envelope for list reads** — every list op wraps its result in
+  `@{ rows = $x; total = $x.Count }` under `$ErrorActionPreference = 'Stop'`, so a
+  zero-object pipeline is still JSON-shaped (never an empty-stdout `PwshRunError`)
+  and a cmdlet error is a real failure, not a false-empty read. The `{rows, total}`
+  envelope is what the dispatcher's JSONFlux reducer keys on to spill a set-shaped
+  result (> 50 rows or > 4 KB) to a `result_query` handle. `nodes.list` /
+  `groups.list` / `resources.list` / `resources.dependency-report` /
+  `cluster.validation-report` are the list ops.
+- **`Test-Cluster` is long-running** — `wsfc.cluster.test` forwards a raised
+  15-minute `timeout` to `pwsh_run` (the transport default is 30 s). See
+  *`cluster.test` duration semantics* below.
+
+### Enum strings and output property names (grounding note)
+
+The `FailoverClusters` cmdlet reference pages on Microsoft Learn document
+parameters and the output *.NET type name* but do **not** tabulate the output
+objects' property names or the enum member values. The property names this
+connector reads (`State` / `OwnerNode` / `OwnerGroup` / `NodeWeight` /
+`DynamicWeight` / `Id`) and the state strings the health rollup compares against
+(`Up` / `Down` / `Online` / `Offline` / `Failed`) are the canonical
+`Microsoft.FailoverClusters.PowerShell.ClusterNodeState` / `ClusterGroupState` /
+`ClusterResourceState` members. To keep the rollup robust against a rendering /
+casing difference, the count scripts compare the **stringified** state
+(`"$($_.State)" -eq 'Up'` — case-insensitive in PowerShell) rather than the raw
+enum, and `wsfc.cluster.get` additionally returns the raw per-state count maps
+(`nodes_by_state` / `groups_by_state` / `resources_by_state`), so a state the
+hardcoded scalars don't name still surfaces. The live c1sql1 probe (an OPEN
+acceptance criterion) is where the exact strings get confirmed against a real
+cluster.
+
+### Injection safety
+
+Operator-supplied strings (node / group name, target node, disk-resource name,
+file-share path, `Test-Cluster -Include` categories) are interpolated only
+inside **single-quoted** PowerShell literals via `ps_single_quote` (embedded `'`
+doubled — complete escaping inside a single-quoted PowerShell string). The
+`Resume-ClusterNode -Failback` value and the `witness_type` are validated against
+bounded enums before they select a fixed cmdlet flag. Every non-parameterized
+script (`cluster.get`, `cluster.quorum`, `validation-report`, the two `list`
+reads, `dependency-report`, `witness.get`, the fingerprint / probe) is a constant
+with no injection surface. A unit test decodes the `-EncodedCommand` base64 back
+to the script and asserts the single-quote doubling on every parameterized op.
+
+### No plaintext secret on the wire (deliberate)
+
+The shared transport forbids credential material in the script (it lands on the
+remote process argv). One consequence for wsfc: **`witness.set` has no cloud
+witness.** `Set-ClusterQuorum -CloudWitness` needs `-AccessKey` (an Azure storage
+account key) — a secret that would enter the script. Cloud witness is therefore
+out of scope for this cut (`witness_type` is `disk` / `file_share` /
+`node_majority` only); a Vault-brokered mint-and-stash flow is a follow-up, the
+same pattern by which winsrv's `iscsi.connect` defers CHAP. A unit test
+(`test_no_write_op_exposes_a_secret_value_field`) pins this at the schema level:
+no op declares a `password` / `secret` / `access_key` parameter.
+
+## `fingerprint(target)` / `probe(target)`
+
+`fingerprint` runs one `-EncodedCommand` round-trip reading the node OS version /
+build, the PowerShell version, whether the `FailoverClusters` module is present,
+and — when the node is a cluster member — the cluster name and functional level;
+returns `vendor="microsoft"`, `product="windows-failover-cluster"`,
+`version=<OS version>`, `build=<build number>`, with `extras={hostname,
+cluster_name, cluster_functional_level, failover_clusters_module,
+powershell_version}`. Whether the node is *clustered* is metadata
+(`cluster_name`), not a reachability signal — an unclustered but reachable node
+is `reachable=True`. Any transport / credential failure maps to `reachable=False`
++ `extras["error"]` (#986). `about` (`wsfc.about`) wraps `fingerprint` +
+`_assert_reachable`.
+
+`probe` surfaces six distinct `ProbeResult.reason` values — the last two are the
+cluster-membership reasons the issue asks for:
+
+| reason | meaning |
+| --- | --- |
+| `tcp_unreachable` | the SSH TCP socket cannot connect |
+| `ssh_auth_failed` | credentials rejected / handshake failed / Vault credential unresolvable |
+| `powershell_unavailable` | SSH succeeded but the PowerShell reachability script failed |
+| `command_failed` | post-connect transport failure (drop / timeout / socket error) after a successful handshake (#986) |
+| `failover_module_absent` | PowerShell runs but the `FailoverClusters` module is not installed (not a cluster node) |
+| `not_cluster_member` | the module is present but the node is not a member of a running cluster (`Get-Cluster` failed) |
+
+## Auth
+
+Uses the base `SshConnector._auth_config` **unchanged** (see the winsrv doc). The
+transport prerequisite is an **OpenSSH server on the cluster node** with
+`powershell` reachable, and the SSH principal must have cluster-administrative
+rights (the `FailoverClusters` cmdlets require it). `probe()` carries no operator,
+so its Vault read runs under the synthesised system operator and fails closed to
+`ssh_auth_failed`.
+
+## Control flow
+
+1. **Boot** — `_eager_import_connectors()` imports the `wsfc` subpackage;
+   `__init__.py` registers the v2 triple + wildcard synchronously and queues the
+   typed-op registrar.
+2. **Lifespan startup** — `run_typed_op_registrars()` →
+   `register_wsfc_typed_operations` → `WsfcConnector.register_operations`, which
+   upserts each `WSFC_OPS` entry into `endpoint_descriptor` (idempotent across
+   restarts) with the curated per-group `when_to_use`. The op rows come from
+   **runtime registration, not an alembic migration** — there is no schema change.
+3. **Dispatch** — `POST /api/v1/operations/call` resolves
+   `connector_id="wsfc-ssh-2022.x"` + the target and invokes the bound handler
+   through the policy/audit path. `dangerous` + `requires_approval` ops park at
+   `needs-approval` first. The CLI reaches the same path via `meho operation call
+   wsfc-ssh-2022.x <op_id> --params-json '{...}'` (no dedicated `meho wsfc` verb
+   package — the winsrv / rke2 precedent for SSH-typed connectors).
+
+### `cluster.test` duration semantics
+
+`wsfc.cluster.test` RUNS `Test-Cluster`, which executes the full validation suite
+and can take **minutes** on a real cluster. The handler forwards a raised
+15-minute `timeout` to `pwsh_run` — far above the transport's 30 s default — so
+the JSON ack is not truncated into a false failure on a validation that in fact
+completed. On a running cluster the disruptive storage tests (which need the
+disks offline) are skipped automatically for online disks; scope the run with the
+`include` param (a list of `Test-Cluster -Include` categories, e.g. `Inventory` /
+`Network` / `System Configuration`) to keep it short. The op is `caution`, not
+`safe`, precisely because it is a real, resource-touching validation RUN. It
+writes reports under `%SystemRoot%\Cluster\Reports`; enumerate them with the
+safe `wsfc.cluster.validation-report`.
+
+## Sensor pin recipes (checks plane)
+
+Cluster state is a first-class **checks/sensors** feed (`docs/codebase/sensor.md`):
+node up, role online, witness reachable — deterministic assertions the monitoring
+plane can pin. A Sensor stores an `(op + params + assertion + cadence + severity)`
+tuple; the runner dispatches the op on a schedule and feeds the reduced op result
+into #2504's bounded assertion evaluator (`AssertionSpec` — one dotted-path
+select feeding one typed comparator).
+
+Two constraints shape these recipes:
+
+- **The safe-only guard** (`SensorAdminService.create`): a Sensor may pin only a
+  `safety_level="safe"` op. All five recipes below use safe reads.
+- **Pin *scalar* reads, not list reads.** A list op (`nodes.list`,
+  `groups.list`, ...) returns `{rows, total}` that the JSONFlux reducer spills to
+  a handle, so the assertion would see the reduced envelope, not the rows. That
+  is exactly why `wsfc.cluster.get` exposes flat scalar counts (`nodes_up`,
+  `groups_failed`, ...) and `wsfc.groups.state` / `wsfc.witness.get` return flat
+  dicts — those are the sensor-shaped ops.
+
+The five recipes (`c1sql1` is the named 2-node SQL FCI consumer; substitute your
+own target name). Each shows the op + params + the `assertion` JSON and a runnable
+`meho sensor create` invocation. The `--target` names the cluster-node target the
+runner dispatches against.
+
+### 1. Cluster node count (all nodes up)
+
+`wsfc.cluster.get` → `$.nodes_up`. For a 2-node cluster, fewer than 2 up is
+`degraded`, fewer than 1 (i.e. the last node down / cluster service unreachable)
+is `critical`.
+
+```json
+{"select": {"path": "$.nodes_up"},
+ "compare": {"type": "threshold", "op": "lt", "degraded": 2, "critical": 1}}
+```
+
+```bash
+meho sensor create --name c1sql1-nodes-up \
+  --connector-id wsfc-ssh-2022.x --op-id wsfc.cluster.get \
+  --target '{"name": "c1sql1"}' \
+  --assertion '{"select":{"path":"$.nodes_up"},"compare":{"type":"threshold","op":"lt","degraded":2,"critical":1}}' \
+  --cadence-kind interval --interval-seconds 60 --severity critical
+```
+
+### 2. SQL Server FCI role online
+
+`wsfc.groups.state` (params name the clustered role) → `$.state`. Anything other
+than `Online` is `critical` (the equals comparator emits `ok` on match,
+`critical` otherwise).
+
+```json
+{"select": {"path": "$.state"},
+ "compare": {"type": "equals", "value": "Online"}}
+```
+
+```bash
+meho sensor create --name c1sql1-fci-online \
+  --connector-id wsfc-ssh-2022.x --op-id wsfc.groups.state \
+  --target '{"name": "c1sql1"}' \
+  --params '{"name": "SQL Server (MSSQLSERVER)"}' \
+  --assertion '{"select":{"path":"$.state"},"compare":{"type":"equals","value":"Online"}}' \
+  --cadence-kind interval --interval-seconds 30 --severity critical
+```
+
+### 3. Quorum witness online
+
+`wsfc.witness.get` → `$.online`. On a 2-node cluster a downed witness is one node
+failure from quorum loss, so a witness that is not `Online` is `critical`. (Pin
+this only where a witness is expected — a node-majority cluster reads
+`online=false`.)
+
+```json
+{"select": {"path": "$.online"},
+ "compare": {"type": "bool", "expect": true}}
+```
+
+```bash
+meho sensor create --name c1sql1-witness-online \
+  --connector-id wsfc-ssh-2022.x --op-id wsfc.witness.get \
+  --target '{"name": "c1sql1"}' \
+  --assertion '{"select":{"path":"$.online"},"compare":{"type":"bool","expect":true}}' \
+  --cadence-kind interval --interval-seconds 60 --severity critical
+```
+
+### 4. No failed cluster roles
+
+`wsfc.cluster.get` → `$.groups_failed`. Any role in the `Failed` state is
+`degraded`; more than one is `critical`.
+
+```json
+{"select": {"path": "$.groups_failed"},
+ "compare": {"type": "threshold", "op": "gt", "degraded": 0, "critical": 1}}
+```
+
+```bash
+meho sensor create --name c1sql1-groups-failed \
+  --connector-id wsfc-ssh-2022.x --op-id wsfc.cluster.get \
+  --target '{"name": "c1sql1"}' \
+  --assertion '{"select":{"path":"$.groups_failed"},"compare":{"type":"threshold","op":"gt","degraded":0,"critical":1}}' \
+  --cadence-kind interval --interval-seconds 60 --severity degraded
+```
+
+### 5. No failed cluster resources
+
+`wsfc.cluster.get` → `$.resources_failed`. Same shape as recipe 4 at the resource
+grain (an IP / network-name / disk resource in `Failed`).
+
+```json
+{"select": {"path": "$.resources_failed"},
+ "compare": {"type": "threshold", "op": "gt", "degraded": 0, "critical": 1}}
+```
+
+```bash
+meho sensor create --name c1sql1-resources-failed \
+  --connector-id wsfc-ssh-2022.x --op-id wsfc.cluster.get \
+  --target '{"name": "c1sql1"}' \
+  --assertion '{"select":{"path":"$.resources_failed"},"compare":{"type":"threshold","op":"gt","degraded":0,"critical":1}}' \
+  --cadence-kind interval --interval-seconds 60 --severity degraded
+```
+
+Pinning at least one of these on a live c1sql1 read is the consumer proof for the
+checks plane (an OPEN acceptance criterion — the cluster does not exist yet; see
+*Known issues / scope*).
+
+## Tests
+
+`backend/tests/test_connectors_wsfc.py` — mirrors the winsrv / windows_dns
+harness (`_StubTarget`, `_completed_process`, `patch.object(connector,
+"_run_command", AsyncMock(...))`); assertions decode the `-EncodedCommand` base64
+back to the script text. Covers the transport (`powershell` +
+`$ProgressPreference`), the registry-triple round-trip, the 19-op surface +
+safety-tier + group-coverage invariants, every op group's script construction,
+the injection-safety escape on every parameterized script (node / group name,
+target node, disk resource, file-share path, `Test-Cluster` include —
+single-quote doubling), the raised `Test-Cluster` timeout, the witness
+`witness_type` validation (incl. cloud-witness rejection), the secret-hygiene
+invariant (no secret-value parameter on any op), the `about` fingerprint mapping,
+and the probe reason matrix (incl. `failover_module_absent` / `not_cluster_member`).
+The connector is also covered by the registry-driven flight-recorder conformance
+sweep (`test_flight_recorder_typed_spans.py` — `wsfc-ssh` in
+`_EXPECTED_TYPED_IMPLS`). **No spec-reconcile lane** — the cmdlet surface ships no
+OpenAPI (the confirmed convention for SSH-typed connectors); drift protection is
+this ordinary unit suite.
+
+## CLI
+
+No dedicated `meho wsfc` verb package (the winsrv / rke2 precedent for SSH-typed
+connectors). CLI parity is the generic dispatch path — `meho operation call
+wsfc-ssh-2022.x <op_id> --params-json '{...}'` — plus the `wsfc` product token
+added to the OpenAPI `TargetCreate.product` enum (regenerated from the live
+registry, so `meho targets create --product wsfc ...` validates and the generated
+Go client knows the token). The CLI OpenAPI snapshot (`cli/api/openapi.json` +
+the generated `cli/internal/api/client.gen.go`) is regenerated in this PR.
+
+## Known issues / scope
+
+- **Consumer proof against a live c1sql1 cluster is an OPEN acceptance
+  criterion** — the c1sql1 Windows Server 2022 SQL FCI does not exist yet (it is
+  built by evoila-bosnia/claude-rdc-hetzner-dc#2794 / #2795). The green probe, the
+  governed `groups.move` failover, the approval-parked `evict` / `offline` /
+  `online`, and the live Sensor pin are all deferred to that lab program; the exact
+  `ClusterNodeState` / `ClusterGroupState` / `QuorumType` strings get confirmed
+  against the real cluster there.
+- **No cloud witness** — `witness.set` supports `disk` / `file_share` /
+  `node_majority` only; the cloud witness's `-AccessKey` is a secret that cannot
+  ride the pwsh transport (a Vault-brokered flow is a follow-up).
+- **`validation-report` lists reports, it does not parse them** — reading a
+  specific validation report's per-test pass/fail is a follow-up (the report is an
+  `.mht` on disk; a robust machine-readable parse is out of scope for this cut).
+- **`cluster.test` is long-running** — a full `Test-Cluster` can take minutes (the
+  handler raises the transport timeout to 15 minutes). Scope it with `include` on
+  a busy cluster.
+- Host-key checking is disabled (`known_hosts=None`) at the adapter level for
+  v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
+
+## References
+
+- Task #3263 (connector); Initiative #3259 (Microsoft estate); mold #3261
+  (`winsrv`) + prerequisite #3260 (shared `_shared/pwsh` transport hoist);
+  evoila/meho#3256 (the vSphere shared-disk layer beneath the guest cluster).
+- Molds: `docs/codebase/connectors-winsrv.md` (the estate mold — structure,
+  transport, "building the next estate connector"),
+  `docs/codebase/connectors-rke2.md` (approval-parked-write mold),
+  `docs/codebase/sensor.md` (the checks-plane conventions the recipes follow).
+- Consumer: evoila-bosnia/claude-rdc-hetzner-dc#2794 / #2795 (the c1sql1 SQL FCI).
+- Cmdlet references (Windows Server 2022 / PowerShell 5.1):
+  <https://learn.microsoft.com/en-us/powershell/module/failoverclusters/>.

--- a/docs/codebase/connectors-wsfc.md
+++ b/docs/codebase/connectors-wsfc.md
@@ -84,7 +84,15 @@ path the acceptance criteria want proven). Taking a production role *offline*
 (`Stop-ClusterGroup`) is a service outage, and forcing one *online*
 (`Start-ClusterGroup`) — e.g. to the wrong node, or while it should stay down —
 can cause split-brain / data issues. Both are `dangerous` + approval per the
-#3259 initiative table.
+#3259 initiative table. This tier is **unconditional for every group**, not
+only "production" roles: `safety_level` is a per-op property, not per-role, so
+MEHO cannot scope "dangerous only for production roles" — the op is one row in
+`endpoint_descriptor` shared by all groups. The conservative blanket (every
+`offline` / `online` parks for approval, even on a scratch role) is deliberate:
+the alternative — trusting a caller-supplied "is this production?" hint — would
+be a trivially-bypassable flag, not a safety boundary. An operator who wants a
+non-parked offline/online on a throwaway role uses the same approval path
+(a human still decides).
 
 ## Key types
 


### PR DESCRIPTION
## Summary

- Add the **`wsfc`** typed connector — Windows Server Failover Clustering over SSH → PowerShell 5.1 (the `FailoverClusters` module), a structured copy of the `winsrv` estate mold (#3261) on the shared `_shared/pwsh` transport (#3260) + `SshConnector` base. Registered as `("wsfc", "2022.x", "wsfc-ssh")` + wildcard; the product token round-trips through `parse_connector_id`.
- **19 ops across five groups** — `cluster` (about / get health-rollup / quorum / validation-report / long-running `Test-Cluster`), `nodes` (list / state / pause-drain / resume / evict), `groups` (list / state / move / offline / online), `resources` (list / dependency-report), `witness` (get / set). The target is **any single cluster node** — the cmdlets fan out cluster-wide from one node.
- **Safety tiers per the #3259 satellite table**: reads `safe`; recoverable writes (`cluster.test`, `nodes.pause`, `nodes.resume`, `groups.move`, `witness.set`) `caution`; `nodes.evict` / `groups.offline` / `groups.online` are `dangerous` + `requires_approval` (the rke2 approval-parked-write mold — a production-role state change is an outage / data-risk event; a planned `groups.move` failover stays `caution`).
- **Checks-plane deliverable**: `wsfc.cluster.get` exposes flat scalar health counts precisely so a bounded assertion can pin them; `docs/codebase/connectors-wsfc.md` ships **5 ready-made Sensor pin recipes** (cluster node count, SQL FCI role online, quorum witness online, failed-role, failed-resource) grounded in the real `AssertionSpec` + `meho sensor create` shape.

## Test plan

- [x] `ruff check` — clean; `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/wsfc/` — clean
- [x] `pytest tests/test_connectors_wsfc.py` — **41 passed** (transport, round-trip, 19-op surface + tiers + group coverage, every group's script construction, injection-safety EncodedCommand-decode on every parameterized op, raised `Test-Cluster` timeout, witness `witness_type` validation incl. cloud rejection, secret-hygiene guard, `about` fingerprint mapping, 6-reason probe matrix incl. `failover_module_absent` / `not_cluster_member`)
- [x] `pytest tests/test_flight_recorder_typed_spans.py` — passed (`wsfc-ssh` added to `_EXPECTED_TYPED_IMPLS`; registry-driven conformance sweep registers all 19 ops end-to-end)
- [x] `pytest test_openapi_target_product_enum.py test_connectors_registry_v2.py test_retrieval_eval_corpus.py` — passed (product-enum test is dynamic against `registered_product_tokens()`)
- [x] `python3 .claude/hooks/code-quality.py --diff` — **0 blockers** (3 file-size warnings >400 on ops_cluster/ops_nodes/connector, consistent with the winsrv op-module sizes; recorded)
- [x] `go build ./...` in `cli/` — clean against the regenerated client

## CLI snapshot: CHANGED (new product token `wsfc`)

`make snapshot-openapi && make generate` regenerated both artifacts, committed: `cli/api/openapi.json` (`wsfc` inserted into the `TargetCreate.product` enum, after `winsrv`) and `cli/internal/api/client.gen.go` (one new enum constant). Minimal diff (+2/-1 and +1).

## Acceptance criteria status

| AC | Status |
|---|---|
| Registers + boots green | ✅ proven (registrar conformance sweep + import + op invariants) |
| Evict/offline park for approval | ✅ proven (`dangerous` + `requires_approval` tier asserted in unit tests) |
| Suite green; doc (incl. sensor recipes) + CLI snapshot committed | ✅ done |
| **Probe green against a live c1sql1 cluster node** | ⚠️ **OPEN** — the c1sql1 SQL FCI is not built yet (lab#2794/#2795) |
| **`move` proven governed on the lab cluster** | ⚠️ **OPEN** — deferred to the lab program |
| **≥1 live Sensor pinned on a wsfc read against c1sql1** | ⚠️ **OPEN** — 5 recipes documented; live pin deferred to the lab |

The live-consumer ACs are honestly OPEN: the c1sql1 cluster does not exist yet, so the green probe, governed failover, and live Sensor pin are deferred to the lab program (evoila-bosnia/claude-rdc-hetzner-dc#2794 / #2795). The exact `ClusterNodeState` / `ClusterGroupState` / `QuorumType` strings get confirmed against a real cluster there; the connector uses stringify-and-compare (`"$($_.State)" -eq 'Up'`) + raw per-state maps so a casing difference can't silently zero a health count.

## Notes / out of scope

- **No alembic migration** — op rows come from runtime registration (peer lanes own heads 0096/0097). **No spec-reconcile lane** — the cmdlet surface ships no OpenAPI (the SSH-typed convention).
- **No cloud witness** — `witness.set` is `disk` / `file_share` / `node_majority` only; the cloud witness's `-AccessKey` is a secret that can't ride the pwsh transport (Vault-brokered flow is a follow-up, mirroring winsrv's deferred CHAP).
- **Serialization**: a sibling worker is building `msad` (#3262) on the same CLI snapshot artifacts; per the initiative these merge serially (msad first by default). This PR does not merge; on a rebase after msad lands, the snapshot is re-generated (`make snapshot-openapi && make generate`), never hand-merged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3263
