### PR TITLE
feat(connectors): msad — Active Directory typed connector (PowerShell 5.1 over SSH) (#3262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,40 @@ connector-related release-notes line.
   human-only (console / CLI / REST), and the 25-tool working surface + 78-tool
   inventory are unchanged. No schema change / no migration.
 
+### Added — `msad` connector: Active Directory over PowerShell-5.1-over-SSH (#3262)
+
+- **`msad` connector** — typed connector for Active Directory day-2 management
+  over SSH → PowerShell 5.1 (the `ActiveDirectory` module on a domain
+  controller), on the shared `_shared/pwsh` transport (#3260) + `SshConnector`
+  base, registered as `("msad", "2022.x", "msad-ssh")` (+ wildcard). 27 ops
+  across five groups — `domain` (about / info / forest / controllers /
+  replication — FSMO holders + functional level + inbound-replication summary),
+  `users` (list / get / search / create / set / enable / disable / delete),
+  `groups` (list / get / members / add-member / remove-member / delete),
+  `computers` (list / get / join-prestage / unjoin / delete), `ou` (list /
+  create / move). Complements `windows_dns` on the same DC; copies the `winsrv`
+  estate mold (#3261).
+- Safety tiers per the Initiative #3259 satellite table: reads `safe`;
+  recoverable writes `caution`; `user.delete` / `group.delete` /
+  `computer.delete` are `dangerous` + `requires_approval` (the rke2
+  approval-parked-write mold, satellite-excluded by the tier ladder).
+  `computer.unjoin` disables the account (recoverable), distinct from the
+  destructive `computer.delete`.
+- Secret hygiene: no credential rides the `-EncodedCommand` argv — `user.create`
+  is passwordless (created disabled until a password is set out of band) and
+  there is **no `password-reset` op** (a Vault-brokered follow-up); a schema-level
+  test proves no op exposes a secret-value parameter. Every operator string is
+  escaped via `ps_single_quote`; the `user.search` query is bound through a
+  script-block `-Filter` (the AD injection-safe form). In-task decision:
+  DC-targeting assumes the SSH host IS a domain controller (`-Server`/jump-host
+  with a second credential deferred).
+- The new `msad` product token extends the OpenAPI `TargetCreate.product` enum,
+  so the CLI snapshot (`cli/api/openapi.json` + generated client) is regenerated.
+  Live `c1sql-dc1` consumer proof is deferred (lab DC not yet reachable from this
+  build); scripted-transport unit suite + injection-safety + secret-leak guard +
+  six-reason probe matrix are the deliverable, consistent with recent connector
+  tasks.
+
 ### Added — `winsrv` connector: Windows Server core over PowerShell-5.1-over-SSH (#3261 / #3271)
 
 - **`winsrv` connector** — typed connector for Windows Server core management

--- a/backend/src/meho_backplane/connectors/msad/__init__.py
+++ b/backend/src/meho_backplane/connectors/msad/__init__.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.msad -- MsadConnector package.
+
+Importing the package registers :class:`MsadConnector` against the v2 connector
+registry under the natural key
+``(product="msad", version="2022.x", impl_id="msad-ssh")`` (+ the ``("msad", "",
+"")`` wildcard row), and queues the connector's typed-op upserts onto the
+lifespan-driven registrar list so ``endpoint_descriptor`` rows land before the
+first dispatch. The package is discovered automatically by
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` -- there is
+no central connector list to edit; self-registration at import time is the whole
+wiring.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.winsrv.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entries land via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2`.
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_msad_typed_operations`, delegating to
+  :meth:`MsadConnector.register_operations`.
+
+The ``(product, version, impl_id)`` triple is chosen so
+``connector_id="msad-ssh-2022.x"`` round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` (``product`` = the
+first hyphen-segment of ``impl_id`` = ``"msad"``); a hyphen/underscore in the
+product token would break that round-trip and the registry's
+``_assert_product_impl_id_round_trips`` guard would crash
+``_eager_import_connectors`` at boot. Like winsrv, this connector has no v1
+chassis history, so the v1 ``register_connector`` write is intentionally omitted.
+"""
+
+from meho_backplane.connectors.msad.connector import MsadConnector
+from meho_backplane.connectors.msad.ops import MSAD_OPS, MsadOp
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_msad_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``MsadConnector.register_operations``.
+
+    The ``embedding_service`` keyword-only parameter mirrors the winsrv / rke2
+    sibling contract -- :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` to every registrar, so each **must** accept the
+    kwarg or the lifespan crashes with :class:`TypeError`. The wrapper
+    accepts-and-discards it because :meth:`MsadConnector.register_operations`
+    resolves the embedding service via ``register_typed_operation``'s
+    process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await MsadConnector.register_operations()
+
+
+__all__ = [
+    "MSAD_OPS",
+    "MsadConnector",
+    "MsadOp",
+    "register_msad_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key.
+register_connector_v2(
+    product="msad",
+    version="2022.x",
+    impl_id="msad-ssh",
+    cls=MsadConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present. Mirrors the winsrv / windows_dns wildcard
+# rows.
+register_connector_v2(
+    product="msad",
+    version="",
+    impl_id="",
+    cls=MsadConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_msad_typed_operations)

--- a/backend/src/meho_backplane/connectors/msad/connector.py
+++ b/backend/src/meho_backplane/connectors/msad/connector.py
@@ -1,0 +1,596 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""MsadConnector -- typed SSH-transport connector for Active Directory.
+
+Manages an AD domain (domain / forest / DC facts, and day-2 reads + guarded
+writes over users, groups, computers, OUs) through the ``ActiveDirectory``
+PowerShell module (Windows PowerShell 5.1) run on a **domain controller** over
+SSH, routed through the shared transport
+:mod:`~meho_backplane.connectors._shared.pwsh`. It is a structured copy of the
+``winsrv`` estate mold (#3261): same ``SshConnector`` base, the ``{rows, total}``
+JSONFlux envelope for list reads, and the rke2 approval-parked-write mold for
+destructive ops. Registry-v2 triple ``("msad", "2022.x", "msad-ssh")`` (+
+wildcard); the separator-free product token round-trips through
+``parse_connector_id``.
+
+**DC-targeting decision (in-task):** every AD cmdlet runs on the SSH target
+**without** an explicit ``-Server`` -- the only supported topology is "the SSH
+target host IS a domain controller". A jump-host pattern (``-Server`` + a second
+``-Credential`` secret) is deferred; see ``docs/codebase/connectors-msad.md``.
+``POWERSHELL_EXECUTABLE`` is set to ``powershell`` explicitly (the load-bearing
+winsrv trap -- the shared transport's ``pwsh`` fallback is absent on a DC).
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.msad.ops import MSAD_OPS, MSAD_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["MsadConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- mirrors the SSH adapter + winsrv / windows_dns siblings.
+type Target = Any
+
+
+#: The fingerprint / about script -- Get-ADDomain identity + AD module version
+#: in one round-trip. No operator input is interpolated (constant script), so
+#: the identity path has no injection surface.
+_FINGERPRINT_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$d = Get-ADDomain; "
+    "$m = (Get-Module -ListAvailable -Name ActiveDirectory | Select-Object -First 1).Version; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "DNSRoot = $d.DNSRoot; "
+    "NetBIOSName = $d.NetBIOSName; "
+    "Forest = $d.Forest; "
+    "DomainMode = $d.DomainMode.ToString(); "
+    "PDCEmulator = $d.PDCEmulator; "
+    "ADModuleVersion = if ($m) { $m.ToString() } else { $null } }"
+)
+
+#: The probe script -- AD module presence + domain readability, always emitting
+#: JSON (the Get-ADDomain failure is caught so a missing module / dead domain
+#: does not raise, letting the probe distinguish those two reasons).
+_PROBE_SCRIPT: str = (
+    "$m = [bool](Get-Module -ListAvailable -Name ActiveDirectory); "
+    "$dom = $false; "
+    "if ($m) { try { $null = Get-ADDomain -ErrorAction Stop; $dom = $true } "
+    "catch { $dom = $false } }; "
+    "ConvertTo-Json -Compress -InputObject @{ ad_module = $m; domain = $dom }"
+)
+
+
+class MsadConnector(SshConnector):
+    """Active Directory connector on the :class:`SshConnector` adapter.
+
+    ``version="2022.x"`` marks the cmdlet surface (stable across Windows Server
+    2019 -> 2025 DCs); ``impl_id="msad-ssh"`` leaves room for a future
+    ``msad-winrm`` sibling. Transport is ``powershell -EncodedCommand`` (PS 5.1)
+    via ``pwsh_run``; output parses with stdlib :mod:`json`.
+    """
+
+    product = "msad"
+    version = "2022.x"
+    impl_id = "msad-ssh"
+
+    #: Windows PowerShell 5.1 -- NOT ``pwsh`` (PS7), absent on a Windows DC. Set
+    #: explicitly because the shared transport's fallback is ``pwsh`` (the
+    #: load-bearing estate-connector trap; see the connector doc).
+    POWERSHELL_EXECUTABLE = "powershell"
+
+    #: Prepended to every script so the ActiveDirectory module's first-use
+    #: progress / import warning does not CLIXML-serialise onto the streams.
+    POWERSHELL_SCRIPT_PREFIX = "$ProgressPreference = 'SilentlyContinue'; "
+
+    #: Connector-scoped structured-log event name for the shared transport.
+    POWERSHELL_LOG_EVENT = "msad_pwsh_executed"
+
+    async def fingerprint(
+        self,
+        target: Target,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Read ``Get-ADDomain`` -- the canonical AD fingerprint.
+
+        Runs :data:`_FINGERPRINT_SCRIPT` (one round-trip) and parses the JSON.
+        Unreachable / SSH-failed / cmdlet-failed -> ``reachable=False`` +
+        ``extras["error"]`` (the #986 discipline: an unresolvable credential or
+        a non-DC target is an unreachable target, not an unhandled exception).
+        """
+        probed_at = datetime.now(UTC)
+        method = "ssh: powershell Get-ADDomain"
+        try:
+            payload = await pwsh_run(self, target, _FINGERPRINT_SCRIPT, operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            CredentialsReadError,
+            PwshRunError,
+        ) as exc:
+            _log.warning(
+                "msad_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="microsoft",
+                product="active-directory",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=method,
+                extras={"error": str(exc)},
+            )
+
+        data = payload if isinstance(payload, dict) else {}
+        return FingerprintResult(
+            vendor="microsoft",
+            product="active-directory",
+            version=_as_str(data.get("DomainMode")),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=method,
+            extras={
+                "dns_root": _as_str(data.get("DNSRoot")),
+                "netbios_name": _as_str(data.get("NetBIOSName")),
+                "forest": _as_str(data.get("Forest")),
+                "pdc_emulator": _as_str(data.get("PDCEmulator")),
+                "ad_module_version": _as_str(data.get("ADModuleVersion")),
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + PowerShell + AD-module + domain-readability check.
+
+        Failure modes (each a distinct ``reason``): ``tcp_unreachable`` (socket),
+        ``ssh_auth_failed`` (creds / handshake / Vault), ``powershell_unavailable``
+        (SSH ok but the reachability script failed), ``command_failed`` (a
+        post-connect transport failure -- the #986 guard), ``ad_module_unavailable``
+        (PowerShell runs but the ActiveDirectory module is absent -- not a DC), and
+        ``domain_unreachable`` (module present but ``Get-ADDomain`` fails).
+
+        The probe does not mutate state -- both cmdlets are read-only.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(ok=ok, reason=reason, latency_ms=latency_ms, probed_at=probed_at)
+
+        # Order matters: PermissionDenied (subclass of DisconnectError) before
+        # DisconnectError; OSError is the TCP-level failure.
+        try:
+            await self._connect(target)
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, CredentialsReadError):
+            return _result(False, "ssh_auth_failed")
+
+        try:
+            payload = await pwsh_run(self, target, _PROBE_SCRIPT)
+        except PwshRunError:
+            return _result(False, "powershell_unavailable")
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
+
+        data = payload if isinstance(payload, dict) else {}
+        if data.get("ad_module") is not True:
+            return _result(False, "ad_module_unavailable")
+        if data.get("domain") is not True:
+            return _result(False, "domain_unreachable")
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Return the AD domain identity snapshot (op-id ``msad.about``).
+
+        Reuses :meth:`fingerprint` so the op and the canonical fingerprint share
+        one round-trip. ``_assert_reachable`` re-raises an unreachable
+        fingerprint as a ``ConnectorUnreachableError`` so the dispatcher reports
+        a non-ok op rather than empty identity fields.
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target, operator)
+        self._assert_reachable(result)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "dns_root": result.extras.get("dns_root"),
+            "netbios_name": result.extras.get("netbios_name"),
+            "forest": result.extras.get("forest"),
+            "pdc_emulator": result.extras.get("pdc_emulator"),
+            "ad_module_version": result.extras.get("ad_module_version"),
+        }
+
+    # -- domain group shims -------------------------------------------------
+
+    async def msad_domain_info(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.domain.info``."""
+        from meho_backplane.connectors.msad.ops_domain import msad_domain_info as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_domain_forest(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.domain.forest``."""
+        from meho_backplane.connectors.msad.ops_domain import msad_domain_forest as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_domain_controllers(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.domain.controllers``."""
+        from meho_backplane.connectors.msad.ops_domain import msad_domain_controllers as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_domain_replication(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.domain.replication``."""
+        from meho_backplane.connectors.msad.ops_domain import msad_domain_replication as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- users group shims --------------------------------------------------
+
+    async def msad_user_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.list``."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.get``."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_search(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.search``."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_search as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_create(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.create`` (caution)."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_create as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_set(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.set`` (caution)."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_set as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_enable(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.enable`` (caution)."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_enable as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_disable(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.disable`` (caution)."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_disable as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_user_delete(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.user.delete`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.msad.ops_users import msad_user_delete as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- groups group shims -------------------------------------------------
+
+    async def msad_group_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.list``."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_group_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.get``."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_group_members(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.members``."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_members as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_group_add_member(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.add-member`` (caution)."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_add_member as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_group_remove_member(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.remove-member`` (caution)."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_remove_member as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_group_delete(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.group.delete`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.msad.ops_groups import msad_group_delete as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- computers group shims ----------------------------------------------
+
+    async def msad_computer_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.computer.list``."""
+        from meho_backplane.connectors.msad.ops_computers import msad_computer_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_computer_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.computer.get``."""
+        from meho_backplane.connectors.msad.ops_computers import msad_computer_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_computer_join_prestage(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.computer.join-prestage`` (caution)."""
+        from meho_backplane.connectors.msad.ops_computers import msad_computer_join_prestage as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_computer_unjoin(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.computer.unjoin`` (caution)."""
+        from meho_backplane.connectors.msad.ops_computers import msad_computer_unjoin as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_computer_delete(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.computer.delete`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.msad.ops_computers import msad_computer_delete as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- ou group shims -----------------------------------------------------
+
+    async def msad_ou_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.ou.list``."""
+        from meho_backplane.connectors.msad.ops_ou import msad_ou_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_ou_create(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.ou.create`` (caution)."""
+        from meho_backplane.connectors.msad.ops_ou import msad_ou_create as _h
+
+        return await _h(self, target, params, operator)
+
+    async def msad_ou_move(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``msad.ou.move`` (caution)."""
+        from meho_backplane.connectors.msad.ops_ou import msad_ou_move as _h
+
+        return await _h(self, target, params, operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`MSAD_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Idempotent across pod restarts;
+        mirrors the winsrv / windows_dns / rke2 shape. Fails closed if an op
+        declares a ``group_key`` with no curated ``when_to_use``.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in MSAD_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"MsadConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = MSAD_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"MsadConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"MSAD_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.msad.ops."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "msad_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`WinsrvConnector.execute`. Operator-less (no policy gate,
+        no audit row, no broadcast); the operator-aware surface is
+        ``POST /api/v1/operations/call`` via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )
+
+
+def _as_str(value: Any) -> str | None:
+    """Return *value* when it is a non-empty ``str``, else ``None``.
+
+    Guards the fingerprint projection: ``ConvertTo-Json`` can render an absent
+    field as ``null``, and :class:`FingerprintResult` fields are ``str | None``.
+    """
+    return value if isinstance(value, str) and value else None

--- a/backend/src/meho_backplane/connectors/msad/ops.py
+++ b/backend/src/meho_backplane/connectors/msad/ops.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`MsadConnector`.
+
+The connector manages **Active Directory** — domain / forest / DC facts, and
+day-2 reads + guarded writes over users, groups, computers, and organizational
+units — through the ``ActiveDirectory`` PowerShell module (Windows PowerShell
+5.1) run on a **domain controller** over SSH, routed through the shared
+PowerShell-over-SSH transport
+:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` (hoisted by #3260).
+Structurally it is a copy of the ``winsrv`` estate mold (#3261): identity canary
++ per-domain op groups on the ``SshConnector`` base, the ``{rows, total}``
+JSONFlux envelope for list reads, and the ``rke2`` approval-parked-write mold
+for its destructive ops.
+
+Op surface (27 ops across five groups; safety tier per the Initiative #3259
+satellite table — reads ``safe``, recoverable writes ``caution``, destructive
+``dangerous`` + ``requires_approval``):
+
+* ``msad.about``                  [safe]      identity canary (Get-ADDomain minimal).
+* ``msad.domain.info``            [safe]      Get-ADDomain (FSMO PDC/RID/Infra, mode).
+* ``msad.domain.forest``          [safe]      Get-ADForest (FSMO schema/naming, mode).
+* ``msad.domain.controllers``     [safe]      Get-ADDomainController -Filter * (list).
+* ``msad.domain.replication``     [safe]      Get-ADReplicationPartnerMetadata (list).
+* ``msad.user.list``              [safe]      Get-ADUser -Filter * (list).
+* ``msad.user.get``               [safe]      Get-ADUser -Identity.
+* ``msad.user.search``            [safe]      Get-ADUser -Filter {name/sam -like} (list).
+* ``msad.user.create``            [caution]   New-ADUser (created disabled, no password).
+* ``msad.user.set``               [caution]   Set-ADUser (attributes; never a password).
+* ``msad.user.enable``            [caution]   Enable-ADAccount.
+* ``msad.user.disable``           [caution]   Disable-ADAccount.
+* ``msad.user.delete``            [dangerous+approval]  Remove-ADUser.
+* ``msad.group.list``             [safe]      Get-ADGroup -Filter * (list).
+* ``msad.group.get``              [safe]      Get-ADGroup -Identity.
+* ``msad.group.members``          [safe]      Get-ADGroupMember (list).
+* ``msad.group.add-member``       [caution]   Add-ADGroupMember.
+* ``msad.group.remove-member``    [caution]   Remove-ADGroupMember.
+* ``msad.group.delete``           [dangerous+approval]  Remove-ADGroup.
+* ``msad.computer.list``          [safe]      Get-ADComputer -Filter * (list).
+* ``msad.computer.get``           [safe]      Get-ADComputer -Identity.
+* ``msad.computer.join-prestage`` [caution]   New-ADComputer.
+* ``msad.computer.unjoin``        [caution]   Disable-ADAccount (recoverable).
+* ``msad.computer.delete``        [dangerous+approval]  Remove-ADComputer.
+* ``msad.ou.list``                [safe]      Get-ADOrganizationalUnit -Filter * (list).
+* ``msad.ou.create``              [caution]   New-ADOrganizationalUnit.
+* ``msad.ou.move``                [caution]   Move-ADObject.
+
+**Password-reset is deferred, not shipped** (in-task decision; see
+``docs/codebase/connectors-msad.md``): a plaintext AD password cannot ride the
+``-EncodedCommand`` argv (the shared transport's secret-hygiene contract), so —
+mirroring winsrv's passwordless-create — ``user.create`` creates a **disabled,
+passwordless** account and no op carries a secret-value parameter. Provisioning
+/ resetting a password is a Vault-brokered follow-up (the rke2 ``token.rotate``
+mold).
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.winsrv.ops`; the composition pattern
+(``_msad_ops()`` importing per-domain op tuples) mirrors it too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "DEFAULT_RESULT_LIMIT",
+    "MSAD_OPS",
+    "MSAD_WHEN_TO_USE_BY_GROUP",
+    "SSH_TRANSPORT_NOTE",
+    "MsadOp",
+    "ad_list_read",
+    "normalise_json_rows",
+    "validate_limit",
+]
+
+
+#: Default cap on rows returned by a ``-Filter *`` list / search read. A real
+#: AD domain can hold tens of thousands of objects; an unbounded pull would
+#: blow the JSON payload and the pwsh timeout. Operators override per call via
+#: the ``limit`` param; the value maps to the cmdlet's ``-ResultSetSize``.
+DEFAULT_RESULT_LIMIT: int = 500
+
+
+#: Curated ``when_to_use`` strings per group key, consumed by
+#: :meth:`MsadConnector.register_operations` (the winsrv / rke2 precedent — the
+#: blurbs live with the op metadata, not the transport class). The registration
+#: walk fails closed with a :class:`ValueError` if a ``group_key`` lacks a
+#: curated entry here.
+MSAD_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "domain": (
+        "Use for domain / forest topology facts before any object drill-in: "
+        "identity (``msad.about``), the full domain projection with FSMO role "
+        "holders (``msad.domain.info`` — PDC emulator / RID / infrastructure "
+        "master), the forest projection (``msad.domain.forest`` — schema / "
+        "domain-naming master, functional level), the DC inventory "
+        "(``msad.domain.controllers``), and the inbound replication summary "
+        "(``msad.domain.replication``). All read-only. Call ``msad.about`` "
+        "first to confirm the target is a reachable domain controller."
+    ),
+    "users": (
+        "Use to inventory and manage AD user accounts: list / get / search "
+        "(read-only, ``safe``); create / set-attributes / enable / disable "
+        "(``caution`` — recoverable); delete (``dangerous`` + "
+        "``requires_approval`` — parks for a human). ``create`` makes a "
+        "**disabled, passwordless** account — a plaintext password cannot ride "
+        "the pwsh transport, so provision it out of band (password-reset is a "
+        "Vault-brokered follow-up)."
+    ),
+    "groups": (
+        "Use to inventory and manage AD groups and their membership: list / "
+        "get / members (read-only, ``safe``); add-member / remove-member "
+        "(``caution`` — recoverable); delete the group (``dangerous`` + "
+        "``requires_approval``). The right group to grant a service account "
+        "into a role group (e.g. add ``svc-sql`` to a SQL admins group)."
+    ),
+    "computers": (
+        "Use to inventory and manage AD computer accounts: list / get "
+        "(read-only, ``safe``); prestage a computer account so a machine can "
+        "join the domain (``join-prestage``) and disable a computer account so "
+        "it can no longer authenticate while the object is retained "
+        "(``unjoin``) — both ``caution`` / recoverable; delete the account "
+        "(``dangerous`` + ``requires_approval`` — irreversible)."
+    ),
+    "ou": (
+        "Use to inventory and shape the OU tree: list OUs (read-only, "
+        "``safe``); create a new OU (``create``) and move an object / OU to a "
+        "new parent (``move``) — both ``caution``. Deleting an OU is out of "
+        "scope for this connector cut."
+    ),
+}
+
+
+#: Canonical SSH-only / pwsh transport reminder copied into every op's
+#: ``llm_instructions`` (the winsrv ``SSH_TRANSPORT_NOTE`` precedent) so an LLM
+#: does not compose against a non-existent AD REST surface.
+SSH_TRANSPORT_NOTE: str = (
+    "Active Directory exposes no unified REST API for these operations; the "
+    "underlying transport is PowerShell-over-SSH (powershell -EncodedCommand "
+    "routed through asyncssh) driving the Windows PowerShell 5.1 "
+    "ActiveDirectory module cmdlets on a domain controller."
+)
+
+
+@dataclass(frozen=True)
+class MsadOp:
+    """Metadata for one msad op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can splat
+    the dataclass into the helper. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.msad.connector.MsadConnector` exposing
+    the async handler; the connector resolves the bound method against itself
+    at registration time (identical shape to
+    :class:`~meho_backplane.connectors.winsrv.ops.WinsrvOp`).
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def normalise_json_rows(payload: Any) -> list[dict[str, Any]]:
+    """Normalise a ``ConvertTo-Json`` payload into a list of row dicts.
+
+    ``ConvertTo-Json`` renders a **single**-element result as a flat object and
+    a **multi**-element result as a JSON array; a zero-element result renders as
+    ``null`` (an empty stdout is caught upstream by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). This collapses
+    all three shapes to a ``list[dict]`` — the winsrv ``normalise_json_rows``
+    shape, shared across every list op so the ``{rows, total}`` envelope the
+    JSONFlux reducer keys on is built identically.
+    """
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    return []
+
+
+def validate_limit(raw: Any, default: int = DEFAULT_RESULT_LIMIT) -> int:
+    """Return a validated positive ``int`` result-set cap (default when absent).
+
+    A non-int / bool / non-positive value raises :class:`ValueError` before any
+    interpolation, so the ``-ResultSetSize`` operand is always a safe integer.
+    """
+    if raw is None:
+        return default
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        raise ValueError(f"limit must be a positive integer; got {raw!r}")
+    return raw
+
+
+async def ad_list_read(
+    connector: MsadConnector,
+    target: Any,
+    *,
+    pipeline: str,
+    operator: Operator | None,
+    prelude: str = "",
+) -> dict[str, Any]:
+    """Run a read *pipeline* under ``'Stop'`` and return the ``{rows, total}`` envelope.
+
+    *pipeline* is the ``Get-AD… | Select-Object …`` expression whose output is
+    wrapped in ``@(…)`` (so a single object still counts as one row and an
+    empty result stays JSON-shaped — never an empty-stdout
+    :class:`~meho_backplane.connectors._shared.pwsh.PwshRunError`). *prelude* is
+    any statement(s) that must run first (e.g. a ``$q = '…'`` assignment for a
+    search); it is emitted verbatim before the pipeline. Running under
+    ``$ErrorActionPreference = 'Stop'`` turns a cmdlet error (bad identity,
+    directory unreachable) into a real ``PwshRunError`` rather than a
+    false-empty read.
+    """
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        + prelude
+        + f"$x = @({pipeline}); "
+        + "ConvertTo-Json -Depth 4 -InputObject @{ rows = $x; total = $x.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+#: The identity canary op. ``msad.about`` is the operator-facing wrapper around
+#: :meth:`MsadConnector.fingerprint` — same vendor / product / domain payload,
+#: surfaced through the typed-op dispatcher so callers see the standard
+#: :class:`OperationResult` envelope. Mirrors ``winsrv.about``.
+_MSAD_ABOUT_OP = MsadOp(
+    op_id="msad.about",
+    handler_attr="about",
+    summary="Return the AD domain identity (DNS root / NetBIOS / forest / DC) behind the target.",
+    description=(
+        "Connects to the domain controller over SSH and runs a single "
+        "``powershell -EncodedCommand`` script that reads ``Get-ADDomain`` "
+        "(DNS root, NetBIOS name, domain mode, forest, PDC emulator) plus the "
+        "ActiveDirectory module version. Returns a flat dict with the vendor "
+        "(``microsoft``), product (``active-directory``), the domain "
+        "functional level as ``version``, and the domain identity. Use to "
+        "confirm the target is a reachable domain controller before issuing "
+        "higher-level domain / user / group / computer / ou ops; no params; "
+        "safe on any healthy DC."
+    ),
+    parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "dns_root": {"type": ["string", "null"]},
+            "netbios_name": {"type": ["string", "null"]},
+            "forest": {"type": ["string", "null"]},
+            "pdc_emulator": {"type": ["string", "null"]},
+            "ad_module_version": {"type": ["string", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="domain",
+    tags=("read-only", "identity", "active-directory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the AD domain behind a "
+            "target — its DNS root / NetBIOS name / forest / functional level "
+            "— or to confirm the target is a reachable domain controller "
+            "before issuing higher-level ops. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``version`` carries the domain functional level (e.g. "
+            "``Windows2016Domain``), ``dns_root`` the domain DNS name (e.g. "
+            "``c1sql.lab``), ``forest`` the forest root, ``pdc_emulator`` the "
+            "PDC-emulator DC host name."
+        ),
+    },
+)
+
+
+def _msad_ops() -> tuple[MsadOp, ...]:
+    """Return the merged registration tuple (identity canary + per-group tuples).
+
+    Implemented as a function call (not a module-level literal-and-splat) so the
+    import order stays linear: ``ops.py`` defines :class:`MsadOp` +
+    ``_MSAD_ABOUT_OP`` + the shared helpers, then imports the per-domain op
+    tuples from their modules. Mirrors
+    :func:`meho_backplane.connectors.winsrv.ops._winsrv_ops`.
+    """
+    from meho_backplane.connectors.msad.ops_computers import COMPUTER_OPS
+    from meho_backplane.connectors.msad.ops_domain import DOMAIN_OPS
+    from meho_backplane.connectors.msad.ops_groups import GROUP_OPS
+    from meho_backplane.connectors.msad.ops_ou import OU_OPS
+    from meho_backplane.connectors.msad.ops_users import USER_OPS
+
+    return (
+        _MSAD_ABOUT_OP,
+        *DOMAIN_OPS,
+        *USER_OPS,
+        *GROUP_OPS,
+        *COMPUTER_OPS,
+        *OU_OPS,
+    )
+
+
+#: The ops :class:`MsadConnector` registers at lifespan startup.
+MSAD_OPS: tuple[MsadOp, ...] = _msad_ops()

--- a/backend/src/meho_backplane/connectors/msad/ops_computers.py
+++ b/backend/src/meho_backplane/connectors/msad/ops_computers.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""msad computer ops — ``list`` / ``get`` (safe) + ``join-prestage`` / ``unjoin`` / ``delete``.
+
+``join-prestage`` (create a computer account so a machine can join the domain)
+and ``unjoin`` (disable a computer account so it can no longer authenticate,
+while the object is retained) are ``caution`` / recoverable; ``delete`` is
+``dangerous`` + ``requires_approval``. Computers are driven by the
+``ActiveDirectory`` module cmdlets (``Get-ADComputer`` / ``New-ADComputer`` /
+``Disable-ADAccount`` / ``Remove-ADComputer``) over the shared
+PowerShell-over-SSH transport.
+
+Why ``unjoin`` disables rather than removes
+-------------------------------------------
+
+The recoverable inverse of a live domain join, from the directory side, is
+``Disable-ADAccount`` — the computer can no longer authenticate to the domain,
+but its account object is retained and re-enabling it restores the trust. A full
+object removal is the separate ``dangerous`` ``msad.computer.delete`` op. This
+mirrors the winsrv tier doctrine (recoverable = ``caution``, destructive =
+``dangerous`` + approval).
+
+PowerShell injection safety
+---------------------------
+
+The computer name / identity and the OU path are interpolated only inside
+single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`. ``delete``
+carries ``-Confirm:$false`` (the approval gate is MEHO's, not AD's).
+
+References
+----------
+
+* ``Get-ADComputer`` / ``New-ADComputer`` / ``Remove-ADComputer`` /
+  ``Disable-ADAccount``:
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.msad.ops import (
+    SSH_TRANSPORT_NOTE,
+    MsadOp,
+    ad_list_read,
+    validate_limit,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "COMPUTER_OPS",
+    "msad_computer_delete",
+    "msad_computer_get",
+    "msad_computer_join_prestage",
+    "msad_computer_list",
+    "msad_computer_unjoin",
+]
+
+_COMPUTER_SELECT: str = (
+    "Name, SamAccountName, DNSHostName, Enabled, DistinguishedName, "
+    "OperatingSystem, IPv4Address, LastLogonDate"
+)
+_COMPUTER_PROPS: str = "OperatingSystem,IPv4Address,LastLogonDate"
+
+
+async def msad_computer_list(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.computer.list`` — ``Get-ADComputer -Filter *`` (list, capped)."""
+    limit = validate_limit(params.get("limit"))
+    return await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADComputer -Filter * -ResultSetSize {limit} -Properties {_COMPUTER_PROPS} "
+            f"| Select-Object {_COMPUTER_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+async def msad_computer_get(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.computer.get`` — ``Get-ADComputer -Identity`` (one account)."""
+    identity = ps_single_quote(params["identity"])
+    result = await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADComputer -Identity {identity} -Properties {_COMPUTER_PROPS} "
+            f"| Select-Object {_COMPUTER_SELECT}"
+        ),
+        operator=operator,
+    )
+    return {"identity": params["identity"], **result}
+
+
+async def msad_computer_join_prestage(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.computer.join-prestage`` (caution) — ``New-ADComputer``.
+
+    Prestages a computer account (optionally in an OU, optionally with an
+    explicit sAMAccountName / DNS host name) so the target machine can bind to
+    it during a domain join. Created enabled by default. Recoverable via
+    ``unjoin`` / ``delete``.
+    """
+    name = params["name"]
+    sam = params.get("sam_account_name")
+    # Read the account back by its sAMAccountName when the operator set one that
+    # differs from the CN -- ``Get-ADComputer -Identity <name>`` resolves by SAM,
+    # so a divergent SAM would not round-trip. Mirrors ``user.create``.
+    readback = sam if sam is not None else name
+    clauses = [f"New-ADComputer -Name {ps_single_quote(name)}"]
+    if sam is not None:
+        clauses.append(f"-SamAccountName {ps_single_quote(sam)}")
+    if params.get("dns_host_name") is not None:
+        clauses.append(f"-DNSHostName {ps_single_quote(params['dns_host_name'])}")
+    if params.get("path") is not None:
+        clauses.append(f"-Path {ps_single_quote(params['path'])}")
+    new_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{new_expr} | Out-Null; "
+        f"$c = Get-ADComputer -Identity {ps_single_quote(readback)} -Properties {_COMPUTER_PROPS} "
+        f"| Select-Object {_COMPUTER_SELECT}; "
+        "ConvertTo-Json -Depth 4 -Compress -InputObject @{ ok = $true; computer = $c }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    computer = payload.get("computer") if isinstance(payload, dict) else None
+    return {
+        "identity": readback,
+        "action": "join-prestage",
+        "computer": computer,
+        "op_class": "write",
+    }
+
+
+async def msad_computer_unjoin(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.computer.unjoin`` (caution) — ``Disable-ADAccount`` (recoverable).
+
+    Disables the computer account so the machine can no longer authenticate to
+    the domain while the object is retained (re-enable to restore trust). A full
+    object removal is ``msad.computer.delete``.
+    """
+    identity = params["identity"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Disable-ADAccount -Identity {ps_single_quote(identity)}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"identity": identity, "action": "unjoin", "op_class": "write"}
+
+
+async def msad_computer_delete(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.computer.delete`` (dangerous, resume path only) — ``Remove-ADComputer``.
+
+    Runs ``Remove-ADComputer -Identity <computer> -Confirm:$false``.
+    Irreversible — ``requires_approval`` parks a dispatch for a human first.
+    """
+    identity = params["identity"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Remove-ADComputer -Identity {ps_single_quote(identity)} -Confirm:$false; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"identity": identity, "action": "delete", "op_class": "write"}
+
+
+_COMPUTER_IDENTITY_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The computer identity — sAMAccountName (usually ``NAME$``), name, DN, "
+        "GUID, or SID (the ``-Identity`` operand, e.g. ``SQLNODE1``)."
+    ),
+}
+
+_LIMIT_PROP: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "description": "Max rows to return (maps to ``-ResultSetSize``). Default 500.",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_IDENTITY_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "identity": {"type": "string"},
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["identity", "rows", "total"],
+    "additionalProperties": True,
+}
+
+_ACTION_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "identity": {"type": "string"},
+        "action": {"type": "string"},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["identity", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+COMPUTER_OPS: tuple[MsadOp, ...] = (
+    MsadOp(
+        op_id="msad.computer.list",
+        handler_attr="msad_computer_list",
+        summary="List AD computer accounts via ``Get-ADComputer -Filter *`` (capped by limit).",
+        description=(
+            "Runs ``Get-ADComputer -Filter *`` (capped at ``limit`` rows, "
+            "default 500) and returns one row per computer (Name, "
+            "SamAccountName, DNSHostName, Enabled, DN, OperatingSystem, "
+            "IPv4Address, LastLogonDate). Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"limit": _LIMIT_PROP},
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="computers",
+        tags=("read-only", "computer", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate AD computer accounts (bounded by ``limit``). "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"limit": "Optional; max rows (default 500)."},
+            "output_shape": (
+                "{'rows': [{Name, DNSHostName, Enabled, OperatingSystem, ...}], 'total': <int>}."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.computer.get",
+        handler_attr="msad_computer_get",
+        summary="Read one AD computer by identity via ``Get-ADComputer -Identity``.",
+        description=(
+            "Runs ``Get-ADComputer -Identity <id>`` and returns the single "
+            "matching computer projection as a ``{rows, total}`` envelope plus "
+            "the echoed ``identity``. A missing identity is a terminating "
+            "error. Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _COMPUTER_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_IDENTITY_LIST_RESPONSE_SCHEMA,
+        group_key="computers",
+        tags=("read-only", "computer", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one AD computer account's OS / DNS host / enabled "
+                "state by identity. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. sAMAccountName / name / DN / GUID / SID."},
+            "output_shape": "{'identity', 'rows': [<computer>], 'total': <int>}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.computer.join-prestage",
+        handler_attr="msad_computer_join_prestage",
+        summary="Prestage an AD computer account via ``New-ADComputer`` (caution).",
+        description=(
+            "Runs ``New-ADComputer -Name <name>`` with optional sAMAccountName "
+            "/ DNS host name / OU path, creating a computer account so a "
+            "machine can join the domain against it. Recoverable (via "
+            "``unjoin`` / ``delete``). safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The computer account name (``-Name``).",
+                },
+                "sam_account_name": {
+                    "type": "string",
+                    "description": "Optional explicit sAMAccountName (usually ``NAME$``).",
+                },
+                "dns_host_name": {"type": "string", "description": "Optional DNS host name."},
+                "path": {"type": "string", "description": "Optional OU distinguished name."},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "identity": {"type": "string"},
+                "action": {"type": "string"},
+                "computer": {"type": ["object", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["identity", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="computers",
+        tags=("write", "computer", "join-prestage"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Prestage a computer account so a machine can join the domain "
+                "into a chosen OU. Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The computer account name.",
+                "path": "Optional. OU distinguished name to create the account in.",
+            },
+            "output_shape": (
+                "{'identity': <name>, 'action': 'join-prestage', 'computer': "
+                "<created>, 'op_class': 'write'}."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.computer.unjoin",
+        handler_attr="msad_computer_unjoin",
+        summary="Disable an AD computer account via ``Disable-ADAccount`` (caution, recoverable).",
+        description=(
+            "Runs ``Disable-ADAccount -Identity <computer>`` — the machine can "
+            "no longer authenticate to the domain, but the account object is "
+            "retained (re-enable to restore trust). Recoverable; the "
+            "destructive object removal is ``msad.computer.delete``. "
+            "safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _COMPUTER_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_ACTION_RESPONSE_SCHEMA,
+        group_key="computers",
+        tags=("write", "computer", "unjoin"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Disable a computer account so the machine leaves the domain's "
+                "trust while the object is retained (recoverable). For "
+                "irreversible removal use ``msad.computer.delete``. "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. The computer identity."},
+            "output_shape": "{'identity', 'action': 'unjoin', 'op_class': 'write'}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.computer.delete",
+        handler_attr="msad_computer_delete",
+        summary="Delete an AD computer account via ``Remove-ADComputer`` (dangerous, approval).",
+        description=(
+            "Runs ``Remove-ADComputer -Identity <computer> -Confirm:$false``. "
+            "Irreversible — the account object and its SID are gone. "
+            "safety_level=dangerous, requires_approval=True: a dispatch parks "
+            "for a human to approve first."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _COMPUTER_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_ACTION_RESPONSE_SCHEMA,
+        group_key="computers",
+        tags=("write", "computer", "delete"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Delete an AD computer account. Irreversible; approval-gated — "
+                "parks for a human decision first. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. The computer identity to remove."},
+            "output_shape": "{'identity', 'action': 'delete', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/msad/ops_domain.py
+++ b/backend/src/meho_backplane/connectors/msad/ops_domain.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""msad domain ops — ``info`` / ``forest`` / ``controllers`` / ``replication`` (all safe).
+
+Read-only domain / forest topology facts via ``Get-ADDomain`` /
+``Get-ADForest`` (FSMO role holders + functional level), ``Get-ADDomainController``
+(the DC inventory), and ``Get-ADReplicationPartnerMetadata`` (the inbound
+replication summary), routed through the shared PowerShell-over-SSH transport
+:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`. **No operator input is
+interpolated into any of these scripts** (they are constants — the domain /
+forest / replication targets are derived on the DC itself), so the domain-read
+group has no injection surface.
+
+References
+----------
+
+* ``Get-ADDomain`` / ``Get-ADForest`` (FSMO roles, functional level):
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/get-addomain
+* ``Get-ADDomainController``:
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/get-addomaincontroller
+* ``Get-ADReplicationPartnerMetadata`` (``-Target`` / ``-Scope Domain``):
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/get-adreplicationpartnermetadata
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+from meho_backplane.connectors.msad.ops import (
+    SSH_TRANSPORT_NOTE,
+    MsadOp,
+    ad_list_read,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "DOMAIN_OPS",
+    "msad_domain_controllers",
+    "msad_domain_forest",
+    "msad_domain_info",
+    "msad_domain_replication",
+]
+
+
+#: Explicit hashtable projection (not ``Select-Object``) so the FSMO role
+#: holders and the domain SID render as flat scalars rather than nested AD
+#: objects ``ConvertTo-Json`` would either truncate or blow up.
+_DOMAIN_INFO_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$d = Get-ADDomain; "
+    "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+    "DNSRoot = $d.DNSRoot; "
+    "NetBIOSName = $d.NetBIOSName; "
+    "DomainMode = $d.DomainMode.ToString(); "
+    "Forest = $d.Forest; "
+    "DistinguishedName = $d.DistinguishedName; "
+    "PDCEmulator = $d.PDCEmulator; "
+    "RIDMaster = $d.RIDMaster; "
+    "InfrastructureMaster = $d.InfrastructureMaster; "
+    "DomainSID = $d.DomainSID.Value; "
+    "DomainControllers = @($d.ReplicaDirectoryServers) }"
+)
+
+_FOREST_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$f = Get-ADForest; "
+    "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+    "Name = $f.Name; "
+    "ForestMode = $f.ForestMode.ToString(); "
+    "RootDomain = $f.RootDomain; "
+    "SchemaMaster = $f.SchemaMaster; "
+    "DomainNamingMaster = $f.DomainNamingMaster; "
+    "Domains = @($f.Domains); "
+    "GlobalCatalogs = @($f.GlobalCatalogs); "
+    "Sites = @($f.Sites) }"
+)
+
+_DC_SELECT: str = (
+    "Name, HostName, Site, IPv4Address, IsGlobalCatalog, IsReadOnly, "
+    "OperatingSystem, OperationMasterRoles"
+)
+
+_REPL_SELECT: str = (
+    "Server, Partner, Partition, LastReplicationSuccess, "
+    "LastReplicationAttempt, LastReplicationResult"
+)
+
+
+async def msad_domain_info(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.domain.info`` — ``Get-ADDomain`` (FSMO + mode). Read-only."""
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _DOMAIN_INFO_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def msad_domain_forest(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.domain.forest`` — ``Get-ADForest`` (FSMO + mode). Read-only."""
+    del params
+    payload = await pwsh_run(connector, target, _FOREST_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def msad_domain_controllers(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.domain.controllers`` — ``Get-ADDomainController -Filter *`` (list)."""
+    del params
+    return await ad_list_read(
+        connector,
+        target,
+        pipeline=f"Get-ADDomainController -Filter * | Select-Object {_DC_SELECT}",
+        operator=operator,
+    )
+
+
+async def msad_domain_replication(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.domain.replication`` — inbound replication summary (list).
+
+    Reads ``Get-ADReplicationPartnerMetadata -Target <domain> -Scope Domain``.
+    The ``-Target`` is derived on the DC (``(Get-ADDomain).DNSRoot``), so the
+    script is a constant — no injection surface. A single-DC lab domain has no
+    replication partners; the ``{rows, total}`` envelope renders that as
+    ``{rows: [], total: 0}`` rather than a false-empty failure.
+    """
+    del params
+    return await ad_list_read(
+        connector,
+        target,
+        prelude="$dom = (Get-ADDomain).DNSRoot; ",
+        pipeline=(
+            "Get-ADReplicationPartnerMetadata -Target $dom -Scope Domain "
+            f"| Select-Object {_REPL_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+_EMPTY_PARAMS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+DOMAIN_OPS: tuple[MsadOp, ...] = (
+    MsadOp(
+        op_id="msad.domain.info",
+        handler_attr="msad_domain_info",
+        summary="Read the AD domain projection (FSMO holders, mode, forest) via Get-ADDomain.",
+        description=(
+            "Runs ``Get-ADDomain`` and returns the domain DNS root, NetBIOS "
+            "name, functional mode, forest, distinguished name, the three "
+            "domain-level FSMO role holders (PDC emulator, RID master, "
+            "infrastructure master), the domain SID, and the DC list. "
+            "Read-only."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "DNSRoot": {"type": ["string", "null"]},
+                "NetBIOSName": {"type": ["string", "null"]},
+                "DomainMode": {"type": ["string", "null"]},
+                "Forest": {"type": ["string", "null"]},
+                "PDCEmulator": {"type": ["string", "null"]},
+                "RIDMaster": {"type": ["string", "null"]},
+                "InfrastructureMaster": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="domain",
+        tags=("read-only", "domain", "fsmo"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for domain topology — DNS root, functional level, and "
+                "the domain-level FSMO role holders (PDC emulator / RID / "
+                "infrastructure master). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict: DNSRoot, NetBIOSName, DomainMode, Forest, "
+                "PDCEmulator, RIDMaster, InfrastructureMaster, DomainSID, "
+                "DomainControllers."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.domain.forest",
+        handler_attr="msad_domain_forest",
+        summary="Read the AD forest projection (schema/naming FSMO, mode) via Get-ADForest.",
+        description=(
+            "Runs ``Get-ADForest`` and returns the forest name, functional "
+            "mode, root domain, the two forest-level FSMO role holders (schema "
+            "master, domain-naming master), and the domain / global-catalog / "
+            "site lists. Read-only."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Name": {"type": ["string", "null"]},
+                "ForestMode": {"type": ["string", "null"]},
+                "RootDomain": {"type": ["string", "null"]},
+                "SchemaMaster": {"type": ["string", "null"]},
+                "DomainNamingMaster": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="domain",
+        tags=("read-only", "forest", "fsmo"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for forest topology — functional level and the "
+                "forest-level FSMO role holders (schema master / domain-naming "
+                "master). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict: Name, ForestMode, RootDomain, SchemaMaster, "
+                "DomainNamingMaster, Domains, GlobalCatalogs, Sites."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.domain.controllers",
+        handler_attr="msad_domain_controllers",
+        summary="List the domain controllers via Get-ADDomainController (name/site/roles).",
+        description=(
+            "Runs ``Get-ADDomainController -Filter *`` and returns one row per "
+            "DC (Name, HostName, Site, IPv4Address, IsGlobalCatalog, "
+            "IsReadOnly, OperatingSystem, OperationMasterRoles). Read-only."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="domain",
+        tags=("read-only", "domain", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the domain controllers and which FSMO roles "
+                "each holds. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Name, HostName, Site, IPv4Address, "
+                "IsGlobalCatalog, OperationMasterRoles}], 'total': <int>}."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.domain.replication",
+        handler_attr="msad_domain_replication",
+        summary="Summarise inbound replication via Get-ADReplicationPartnerMetadata.",
+        description=(
+            "Runs ``Get-ADReplicationPartnerMetadata -Target <domain> -Scope "
+            "Domain`` and returns one row per inbound replication partner "
+            "(Server, Partner, Partition, LastReplicationSuccess, "
+            "LastReplicationAttempt, LastReplicationResult). A single-DC domain "
+            "returns an empty list. Read-only."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="domain",
+        tags=("read-only", "domain", "replication"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to check AD replication health — the last replication "
+                "success / attempt / result per partner. A non-zero "
+                "LastReplicationResult flags a failing pairing. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Server, Partner, Partition, "
+                "LastReplicationSuccess, LastReplicationResult}], 'total': "
+                "<int>}. Empty on a single-DC domain."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/msad/ops_groups.py
+++ b/backend/src/meho_backplane/connectors/msad/ops_groups.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""msad group ops — ``list`` / ``get`` / ``members`` (safe) + membership writes.
+
+``add-member`` / ``remove-member`` are ``caution`` (recoverable); ``delete`` is
+``dangerous`` + ``requires_approval``. Groups are driven by the
+``ActiveDirectory`` module cmdlets (``Get-ADGroup`` / ``Get-ADGroupMember`` /
+``Add-ADGroupMember`` / ``Remove-ADGroupMember`` / ``Remove-ADGroup``) over the
+shared PowerShell-over-SSH transport.
+
+PowerShell injection safety
+---------------------------
+
+The group identity and each member identity are interpolated only inside
+single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; the member list
+renders as a PowerShell array literal ``@('a','b')`` of escaped literals. Every
+write cmdlet that would otherwise prompt -- ``Add-ADGroupMember`` /
+``Remove-ADGroupMember`` / ``Remove-ADGroup`` -- carries ``-Confirm:$false`` so
+the cmdlet's own interactive prompt does not hang the non-interactive
+``-EncodedCommand`` run (the approval gate is MEHO's, not AD's).
+
+References
+----------
+
+* ``Get-ADGroup`` / ``Get-ADGroupMember`` / ``Add-ADGroupMember`` /
+  ``Remove-ADGroupMember`` / ``Remove-ADGroup``:
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.msad.ops import (
+    SSH_TRANSPORT_NOTE,
+    MsadOp,
+    ad_list_read,
+    validate_limit,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "GROUP_OPS",
+    "msad_group_add_member",
+    "msad_group_delete",
+    "msad_group_get",
+    "msad_group_list",
+    "msad_group_members",
+    "msad_group_remove_member",
+]
+
+_GROUP_SELECT: str = (
+    "SamAccountName, Name, GroupCategory, GroupScope, DistinguishedName, Description"
+)
+_MEMBER_SELECT: str = "SamAccountName, Name, objectClass, distinguishedName"
+
+
+def _members_literal(members: list[Any]) -> str:
+    """Render *members* as a PowerShell array literal of escaped single-quoted strings."""
+    if not members or not all(isinstance(m, str) and m.strip() for m in members):
+        raise ValueError("members must be a non-empty list of non-blank identity strings")
+    return "@(" + ", ".join(ps_single_quote(m) for m in members) + ")"
+
+
+async def msad_group_list(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.list`` — ``Get-ADGroup -Filter *`` (list, capped)."""
+    limit = validate_limit(params.get("limit"))
+    return await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADGroup -Filter * -ResultSetSize {limit} -Properties Description "
+            f"| Select-Object {_GROUP_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+async def msad_group_get(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.get`` — ``Get-ADGroup -Identity`` (one group)."""
+    identity = ps_single_quote(params["identity"])
+    result = await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADGroup -Identity {identity} -Properties Description "
+            f"| Select-Object {_GROUP_SELECT}"
+        ),
+        operator=operator,
+    )
+    return {"identity": params["identity"], **result}
+
+
+async def msad_group_members(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.members`` — ``Get-ADGroupMember -Identity`` (list)."""
+    identity = ps_single_quote(params["identity"])
+    result = await ad_list_read(
+        connector,
+        target,
+        pipeline=(f"Get-ADGroupMember -Identity {identity} | Select-Object {_MEMBER_SELECT}"),
+        operator=operator,
+    )
+    return {"identity": params["identity"], **result}
+
+
+async def msad_group_add_member(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.add-member`` (caution) — ``Add-ADGroupMember``."""
+    return await _member_write(
+        connector, target, params, "Add-ADGroupMember", "add-member", operator
+    )
+
+
+async def msad_group_remove_member(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.remove-member`` (caution) — ``Remove-ADGroupMember``."""
+    return await _member_write(
+        connector, target, params, "Remove-ADGroupMember", "remove-member", operator
+    )
+
+
+async def msad_group_delete(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.group.delete`` (dangerous, resume path only) — ``Remove-ADGroup``.
+
+    Runs ``Remove-ADGroup -Identity <group> -Confirm:$false``. Irreversible —
+    ``requires_approval`` parks a dispatch for a human decision first.
+    """
+    identity = params["identity"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Remove-ADGroup -Identity {ps_single_quote(identity)} -Confirm:$false; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"identity": identity, "action": "delete", "op_class": "write"}
+
+
+async def _member_write(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    cmdlet: str,
+    action: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run ``Add/Remove-ADGroupMember -Identity <group> -Members @(...) -Confirm:$false``."""
+    identity = params["identity"]
+    members: list[Any] = params["members"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{cmdlet} -Identity {ps_single_quote(identity)} "
+        f"-Members {_members_literal(members)} -Confirm:$false; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"identity": identity, "action": action, "members": members, "op_class": "write"}
+
+
+_GROUP_IDENTITY_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The group identity — sAMAccountName, distinguished name, GUID, or SID "
+        "(the ``-Identity`` operand, e.g. ``SQL-Admins``)."
+    ),
+}
+
+_MEMBERS_PROP: dict[str, Any] = {
+    "type": "array",
+    "items": {"type": "string", "minLength": 1, "pattern": "\\S"},
+    "minItems": 1,
+    "description": "Member identities (sAMAccountName / DN / GUID / SID) to add or remove.",
+}
+
+_LIMIT_PROP: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "description": "Max rows to return (maps to ``-ResultSetSize``). Default 500.",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_IDENTITY_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "identity": {"type": "string"},
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["identity", "rows", "total"],
+    "additionalProperties": True,
+}
+
+_MEMBER_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "identity": {"type": "string"},
+        "action": {"type": "string"},
+        "members": {"type": "array", "items": {"type": "string"}},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["identity", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+def _member_write_op(op_id: str, handler_attr: str, verb: str, cmdlet: str) -> MsadOp:
+    """Build one caution-tier membership write op (add-member / remove-member)."""
+    return MsadOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"{verb.replace('-', ' ').capitalize()} an AD group via ``{cmdlet}`` (caution).",
+        description=(
+            f"Runs ``{cmdlet} -Identity <group> -Members @(...) -Confirm:$false`` "
+            "on the domain controller. Recoverable (the inverse op restores the "
+            "prior membership). safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _GROUP_IDENTITY_PROP, "members": _MEMBERS_PROP},
+            "required": ["identity", "members"],
+            "additionalProperties": False,
+        },
+        response_schema=_MEMBER_WRITE_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("write", "group", verb),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                f"{verb.replace('-', ' ').capitalize()} of an AD group (e.g. "
+                "grant a service account into a role group). Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "identity": "Required. The group identity.",
+                "members": "Required. Non-empty list of member identities.",
+            },
+            "output_shape": f"{{'identity', 'action': '{verb}', 'members', 'op_class': 'write'}}.",
+        },
+    )
+
+
+GROUP_OPS: tuple[MsadOp, ...] = (
+    MsadOp(
+        op_id="msad.group.list",
+        handler_attr="msad_group_list",
+        summary="List AD groups via ``Get-ADGroup -Filter *`` (capped by limit).",
+        description=(
+            "Runs ``Get-ADGroup -Filter *`` (capped at ``limit`` rows, default "
+            "500) and returns one row per group (SamAccountName, Name, "
+            "GroupCategory, GroupScope, DN, Description). Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"limit": _LIMIT_PROP},
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("read-only", "group", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate AD groups (bounded by ``limit``) or find a "
+                "group's exact identity. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"limit": "Optional; max rows (default 500)."},
+            "output_shape": (
+                "{'rows': [{SamAccountName, Name, GroupScope, ...}], 'total': <int>}."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.group.get",
+        handler_attr="msad_group_get",
+        summary="Read one AD group by identity via ``Get-ADGroup -Identity``.",
+        description=(
+            "Runs ``Get-ADGroup -Identity <id>`` and returns the single "
+            "matching group projection as a ``{rows, total}`` envelope plus the "
+            "echoed ``identity``. A missing identity is a terminating error. "
+            "Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _GROUP_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_IDENTITY_LIST_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("read-only", "group", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one AD group's category / scope / description by "
+                "identity. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. sAMAccountName / DN / GUID / SID."},
+            "output_shape": "{'identity', 'rows': [<group>], 'total': <int>}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.group.members",
+        handler_attr="msad_group_members",
+        summary="List a group's members via ``Get-ADGroupMember -Identity``.",
+        description=(
+            "Runs ``Get-ADGroupMember -Identity <group>`` and returns one row "
+            "per direct member (SamAccountName, Name, objectClass, DN) as a "
+            "``{rows, total}`` envelope plus the echoed ``identity``. Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _GROUP_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_IDENTITY_LIST_RESPONSE_SCHEMA,
+        group_key="groups",
+        tags=("read-only", "group", "members"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to list the direct members of an AD group (e.g. confirm a "
+                "service account was granted). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. The group identity."},
+            "output_shape": (
+                "{'identity', 'rows': [{SamAccountName, objectClass, ...}], 'total': <int>}."
+            ),
+        },
+    ),
+    _member_write_op(
+        "msad.group.add-member", "msad_group_add_member", "add-member", "Add-ADGroupMember"
+    ),
+    _member_write_op(
+        "msad.group.remove-member",
+        "msad_group_remove_member",
+        "remove-member",
+        "Remove-ADGroupMember",
+    ),
+    MsadOp(
+        op_id="msad.group.delete",
+        handler_attr="msad_group_delete",
+        summary="Delete an AD group via ``Remove-ADGroup`` (dangerous, approval-gated).",
+        description=(
+            "Runs ``Remove-ADGroup -Identity <group> -Confirm:$false``. "
+            "Irreversible — the group object and its SID are gone. "
+            "safety_level=dangerous, requires_approval=True: a dispatch parks "
+            "for a human to approve first."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _GROUP_IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "identity": {"type": "string"},
+                "action": {"type": "string"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["identity", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="groups",
+        tags=("write", "group", "delete"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Delete an AD group. Irreversible; approval-gated — parks for a "
+                "human decision first. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. The group identity to remove."},
+            "output_shape": "{'identity', 'action': 'delete', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/msad/ops_ou.py
+++ b/backend/src/meho_backplane/connectors/msad/ops_ou.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""msad organizational-unit ops — ``list`` (safe) + ``create`` / ``move`` (caution).
+
+OU inventory / provisioning via the ``ActiveDirectory`` module cmdlets
+(``Get-ADOrganizationalUnit`` / ``New-ADOrganizationalUnit`` / ``Move-ADObject``)
+over the shared PowerShell-over-SSH transport. ``create`` and ``move`` are
+``caution`` (recoverable — an OU can be moved back / removed). OU deletion is out
+of scope for this connector cut.
+
+PowerShell injection safety
+---------------------------
+
+The OU name, distinguished names, and target path are interpolated only inside
+single-quoted PowerShell literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`; the
+``protected`` toggle renders as a ``$true`` / ``$false`` literal.
+
+References
+----------
+
+* ``Get-ADOrganizationalUnit`` / ``New-ADOrganizationalUnit`` / ``Move-ADObject``:
+  https://learn.microsoft.com/en-us/powershell/module/activedirectory/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.msad.ops import (
+    SSH_TRANSPORT_NOTE,
+    MsadOp,
+    ad_list_read,
+    validate_limit,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "OU_OPS",
+    "msad_ou_create",
+    "msad_ou_list",
+    "msad_ou_move",
+]
+
+_OU_SELECT: str = "Name, DistinguishedName, Description, ProtectedFromAccidentalDeletion"
+
+
+async def msad_ou_list(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.ou.list`` — ``Get-ADOrganizationalUnit -Filter *`` (list, capped)."""
+    limit = validate_limit(params.get("limit"))
+    return await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADOrganizationalUnit -Filter * -ResultSetSize {limit} "
+            f"-Properties Description,ProtectedFromAccidentalDeletion "
+            f"| Select-Object {_OU_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+async def msad_ou_create(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.ou.create`` (caution) — ``New-ADOrganizationalUnit``.
+
+    Creates an OU under the optional parent ``path`` (defaults to the domain
+    root). ``protected`` maps to ``-ProtectedFromAccidentalDeletion`` (default
+    true, matching the cmdlet default). Recoverable. safety_level=caution.
+    """
+    name = params["name"]
+    clauses = [f"New-ADOrganizationalUnit -Name {ps_single_quote(name)}"]
+    if params.get("path") is not None:
+        clauses.append(f"-Path {ps_single_quote(params['path'])}")
+    protected = params.get("protected")
+    if protected is not None:
+        clauses.append(f"-ProtectedFromAccidentalDeletion ${'true' if protected else 'false'}")
+    new_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{new_expr} -PassThru "
+        f"| Select-Object {_OU_SELECT} "
+        "| ConvertTo-Json -Depth 3 -Compress"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    ou = payload if isinstance(payload, dict) else None
+    return {"name": name, "action": "create", "ou": ou, "op_class": "write"}
+
+
+async def msad_ou_move(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.ou.move`` (caution) — ``Move-ADObject``.
+
+    Moves the object at ``identity`` (a distinguished name) under the new parent
+    ``target_path`` (a distinguished name). Recoverable (move it back).
+    safety_level=caution.
+    """
+    identity = params["identity"]
+    target_path = params["target_path"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Move-ADObject -Identity {ps_single_quote(identity)} "
+        f"-TargetPath {ps_single_quote(target_path)}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {
+        "identity": identity,
+        "target_path": target_path,
+        "action": "move",
+        "op_class": "write",
+    }
+
+
+_LIMIT_PROP: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "description": "Max rows to return (maps to ``-ResultSetSize``). Default 500.",
+}
+
+_DN_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "A distinguished name (e.g. ``OU=Servers,DC=c1sql,DC=lab``).",
+}
+
+
+OU_OPS: tuple[MsadOp, ...] = (
+    MsadOp(
+        op_id="msad.ou.list",
+        handler_attr="msad_ou_list",
+        summary="List OUs via ``Get-ADOrganizationalUnit -Filter *`` (capped by limit).",
+        description=(
+            "Runs ``Get-ADOrganizationalUnit -Filter *`` (capped at ``limit`` "
+            "rows, default 500) and returns one row per OU (Name, "
+            "DistinguishedName, Description, ProtectedFromAccidentalDeletion). "
+            "Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"limit": _LIMIT_PROP},
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="ou",
+        tags=("read-only", "ou", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the OU tree (find the DN of an OU to create "
+                "objects in or move objects to). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"limit": "Optional; max rows (default 500)."},
+            "output_shape": (
+                "{'rows': [{Name, DistinguishedName, ProtectedFromAccidentalDeletion}], "
+                "'total': <int>}."
+            ),
+        },
+    ),
+    MsadOp(
+        op_id="msad.ou.create",
+        handler_attr="msad_ou_create",
+        summary="Create an OU via ``New-ADOrganizationalUnit`` (caution).",
+        description=(
+            "Runs ``New-ADOrganizationalUnit -Name <name>`` under the optional "
+            "parent ``path`` (defaults to the domain root). ``protected`` maps "
+            "to ``-ProtectedFromAccidentalDeletion`` (default true). "
+            "Recoverable. safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The OU name (``-Name``).",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional parent OU / container distinguished name.",
+                },
+                "protected": {
+                    "type": "boolean",
+                    "description": "``-ProtectedFromAccidentalDeletion``. Default true.",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "action": {"type": "string"},
+                "ou": {"type": ["object", "null"]},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["name", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="ou",
+        tags=("write", "ou", "create"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Create an OU (optionally under a parent OU). Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The OU name.",
+                "path": "Optional. Parent OU/container DN (defaults to domain root).",
+            },
+            "output_shape": "{'name', 'action': 'create', 'ou': <created>, 'op_class': 'write'}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.ou.move",
+        handler_attr="msad_ou_move",
+        summary="Move an object / OU to a new parent via ``Move-ADObject`` (caution).",
+        description=(
+            "Runs ``Move-ADObject -Identity <dn> -TargetPath <parent-dn>`` — "
+            "moves the object at ``identity`` under the parent at "
+            "``target_path``. Recoverable (move it back). safety_level=caution. "
+            "Note: a ``ProtectedFromAccidentalDeletion`` object refuses the "
+            "move until the protection is cleared."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "identity": {
+                    **_DN_PROP,
+                    "description": "The distinguished name of the object / OU to move.",
+                },
+                "target_path": {
+                    **_DN_PROP,
+                    "description": "The distinguished name of the new parent OU / container.",
+                },
+            },
+            "required": ["identity", "target_path"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "identity": {"type": "string"},
+                "target_path": {"type": "string"},
+                "action": {"type": "string"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["identity", "target_path", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="ou",
+        tags=("write", "ou", "move"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Move an object or OU to a new parent OU (both given as "
+                "distinguished names). Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "identity": "Required. DN of the object/OU to move.",
+                "target_path": "Required. DN of the new parent OU/container.",
+            },
+            "output_shape": ("{'identity', 'target_path', 'action': 'move', 'op_class': 'write'}."),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/msad/ops_users.py
+++ b/backend/src/meho_backplane/connectors/msad/ops_users.py
@@ -1,0 +1,599 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""msad user ops — ``list`` / ``get`` / ``search`` (safe) + guarded writes.
+
+``create`` / ``set`` / ``enable`` / ``disable`` are ``caution`` (recoverable);
+``delete`` is ``dangerous`` + ``requires_approval`` (the rke2 approval-parked
+mold). Driven by the ``ActiveDirectory`` module cmdlets (``Get-ADUser`` /
+``New-ADUser`` / ``Set-ADUser`` / ``*-ADAccount`` / ``Remove-ADUser``) over the
+shared PowerShell-over-SSH transport.
+
+**No plaintext password on the wire (deliberate).** The shared transport's
+safety contract forbids credential material in the ``-EncodedCommand`` script
+(it lands on the remote argv). So ``create`` omits ``-AccountPassword`` — per the
+cmdlet's documented behaviour an account created without a password is **disabled
+until a password is set** — and ``set`` never touches it. Password provisioning /
+reset is a deferred Vault-brokered follow-up (rke2 ``token.rotate`` mold); see
+``docs/codebase/connectors-msad.md``.
+
+**Injection safety.** Identities / attribute values are interpolated only inside
+single-quoted literals via ``ps_single_quote``. The ``search`` query is bound
+through a **script-block** ``-Filter`` (``{Name -like $q}``), the documented
+injection-safe form: the AD filter engine binds the session variable's value as a
+data operand rather than re-parsing an interpolated string. Cmdlet reference:
+https://learn.microsoft.com/en-us/powershell/module/activedirectory/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.msad.ops import (
+    SSH_TRANSPORT_NOTE,
+    MsadOp,
+    ad_list_read,
+    validate_limit,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.msad.connector import MsadConnector
+
+__all__ = [
+    "USER_OPS",
+    "msad_user_create",
+    "msad_user_delete",
+    "msad_user_disable",
+    "msad_user_enable",
+    "msad_user_get",
+    "msad_user_list",
+    "msad_user_search",
+    "msad_user_set",
+]
+
+_USER_PROPS: str = "DisplayName,Description,EmailAddress"  # non-default props to fetch
+#: The bounded projection every user read returns — a stable, JSON-safe subset.
+_USER_SELECT: str = (
+    "SamAccountName, Name, DisplayName, Enabled, UserPrincipalName, "
+    "DistinguishedName, GivenName, Surname, Description, EmailAddress"
+)
+
+
+async def msad_user_list(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.list`` — ``Get-ADUser -Filter *`` (list, capped)."""
+    limit = validate_limit(params.get("limit"))
+    return await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADUser -Filter * -ResultSetSize {limit} -Properties {_USER_PROPS} "
+            f"| Select-Object {_USER_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+async def msad_user_get(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.get`` — ``Get-ADUser -Identity`` (one account)."""
+    identity = ps_single_quote(params["identity"])
+    result = await ad_list_read(
+        connector,
+        target,
+        pipeline=(
+            f"Get-ADUser -Identity {identity} -Properties {_USER_PROPS} "
+            f"| Select-Object {_USER_SELECT}"
+        ),
+        operator=operator,
+    )
+    return {"identity": params["identity"], **result}
+
+
+async def msad_user_search(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.search`` — name / SAM ``-like`` match (list, capped).
+
+    The query is wrapped in ``*…*``, assigned to ``$q`` as a single-quoted literal,
+    and bound through a script-block ``-Filter`` (injection-safe — see the module
+    docstring).
+    """
+    limit = validate_limit(params.get("limit"))
+    q_literal = ps_single_quote(f"*{params['query']}*")
+    return await ad_list_read(
+        connector,
+        target,
+        prelude=f"$q = {q_literal}; ",
+        pipeline=(
+            "Get-ADUser -Filter {(Name -like $q) -or (SamAccountName -like $q)} "
+            f"-ResultSetSize {limit} -Properties {_USER_PROPS} "
+            f"| Select-Object {_USER_SELECT}"
+        ),
+        operator=operator,
+    )
+
+
+async def msad_user_create(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.create`` (caution) — ``New-ADUser`` (disabled, no password).
+
+    Creates the account WITHOUT a password, so it is created disabled (see the
+    module docstring). Optional UPN / names / OU path / description / email.
+    """
+    name = params["name"]
+    sam = params["sam_account_name"]
+    clauses = [
+        f"New-ADUser -Name {ps_single_quote(name)}",
+        f"-SamAccountName {ps_single_quote(sam)}",
+    ]
+    _append_str_clause(clauses, params, "user_principal_name", "-UserPrincipalName")
+    _append_str_clause(clauses, params, "display_name", "-DisplayName")
+    _append_str_clause(clauses, params, "given_name", "-GivenName")
+    _append_str_clause(clauses, params, "surname", "-Surname")
+    _append_str_clause(clauses, params, "path", "-Path")
+    _append_str_clause(clauses, params, "description", "-Description")
+    _append_str_clause(clauses, params, "email", "-EmailAddress")
+    new_expr = " ".join(clauses)
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{new_expr} | Out-Null; "
+        f"$u = Get-ADUser -Identity {ps_single_quote(sam)} -Properties {_USER_PROPS} "
+        f"| Select-Object {_USER_SELECT}; "
+        "ConvertTo-Json -Depth 4 -Compress -InputObject @{ ok = $true; user = $u }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    user = payload.get("user") if isinstance(payload, dict) else None
+    return {"identity": sam, "action": "create", "user": user, "op_class": "write"}
+
+
+async def msad_user_set(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.set`` (caution) — ``Set-ADUser`` attributes (never a password).
+
+    Applies display name / description / email / given / surname. At least one is
+    required. Enable / disable are separate ops.
+    """
+    identity = ps_single_quote(params["identity"])
+    set_clauses: list[str] = []
+    _append_str_clause(set_clauses, params, "display_name", "-DisplayName")
+    _append_str_clause(set_clauses, params, "description", "-Description")
+    _append_str_clause(set_clauses, params, "email", "-EmailAddress")
+    _append_str_clause(set_clauses, params, "given_name", "-GivenName")
+    _append_str_clause(set_clauses, params, "surname", "-Surname")
+    if not set_clauses:
+        raise ValueError(
+            "user.set requires at least one attribute to change "
+            "(display_name / description / email / given_name / surname)"
+        )
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Set-ADUser -Identity {identity} {' '.join(set_clauses)}; "
+        f"$u = Get-ADUser -Identity {identity} -Properties {_USER_PROPS} "
+        f"| Select-Object {_USER_SELECT}; "
+        "ConvertTo-Json -Depth 4 -Compress -InputObject @{ ok = $true; user = $u }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    user = payload.get("user") if isinstance(payload, dict) else None
+    return {"identity": params["identity"], "action": "set", "user": user, "op_class": "write"}
+
+
+async def msad_user_enable(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.enable`` (caution) — ``Enable-ADAccount``.
+
+    Enabling requires a password to already be set on the account (see the
+    module docstring); on a passwordless account this surfaces as a real
+    ``PwshRunError``.
+    """
+    return await _account_action(
+        connector, target, params["identity"], "Enable-ADAccount", "enable", operator
+    )
+
+
+async def msad_user_disable(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.disable`` (caution) — ``Disable-ADAccount``."""
+    return await _account_action(
+        connector, target, params["identity"], "Disable-ADAccount", "disable", operator
+    )
+
+
+async def msad_user_delete(
+    connector: MsadConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``msad.user.delete`` (dangerous, resume path only) — ``Remove-ADUser``.
+
+    Runs ``Remove-ADUser -Identity <id> -Confirm:$false``. Irreversible — the
+    op is ``requires_approval`` so a dispatch parks for a human decision before
+    the account is removed. ``-Confirm:$false`` suppresses the cmdlet's own
+    interactive prompt (it would hang non-interactively); the approval gate is
+    MEHO's, not AD's.
+    """
+    return await _account_action(
+        connector,
+        target,
+        params["identity"],
+        "Remove-ADUser",
+        "delete",
+        operator,
+        confirm_false=True,
+    )
+
+
+def _append_str_clause(clauses: list[str], params: dict[str, Any], key: str, flag: str) -> None:
+    """Append ``<flag> '<escaped>'`` to *clauses* when *key* is a non-None string."""
+    value = params.get(key)
+    if value is not None:
+        clauses.append(f"{flag} {ps_single_quote(value)}")
+
+
+async def _account_action(
+    connector: MsadConnector,
+    target: Any,
+    identity: str,
+    cmdlet: str,
+    action: str,
+    operator: Operator | None,
+    *,
+    confirm_false: bool = False,
+) -> dict[str, Any]:
+    """Run a single-cmdlet ``-Identity`` write and return the write envelope."""
+    quoted = ps_single_quote(identity)
+    confirm = " -Confirm:$false" if confirm_false else ""
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{cmdlet} -Identity {quoted}{confirm}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {"identity": identity, "action": action, "op_class": "write"}
+
+
+_IDENTITY_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The user identity — sAMAccountName, distinguished name, GUID, or SID "
+        "(the ``-Identity`` operand, e.g. ``svc-sql``)."
+    ),
+}
+
+_LIMIT_PROP: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "description": "Max rows to return (maps to ``-ResultSetSize``). Default 500.",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_ACCOUNT_ACTION_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "identity": {"type": "string"},
+        "action": {"type": "string"},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["identity", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+# create/set additionally echo the resulting object under ``user``.
+_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    **_ACCOUNT_ACTION_RESPONSE_SCHEMA,
+    "properties": {
+        **_ACCOUNT_ACTION_RESPONSE_SCHEMA["properties"],
+        "user": {"type": ["object", "null"]},
+    },
+}
+
+
+def _account_action_op(
+    op_id: str,
+    handler_attr: str,
+    verb: str,
+    cmdlet: str,
+    *,
+    safety_level: str,
+    requires_approval: bool,
+) -> MsadOp:
+    """Build one identity-only user write op (enable / disable / delete)."""
+    note = (
+        "Irreversible; approval-gated — parks for a human decision first."
+        if requires_approval
+        else "Recoverable."
+    )
+    confirm = " -Confirm:$false" if requires_approval else ""
+    return MsadOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"{verb.capitalize()} an AD user account via ``{cmdlet}``.",
+        description=(
+            f"Runs ``{cmdlet} -Identity <id>``{confirm}. {note} safety_level={safety_level}."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_ACCOUNT_ACTION_RESPONSE_SCHEMA,
+        group_key="users",
+        tags=("write", "user", verb),
+        safety_level=safety_level,  # type: ignore[arg-type]
+        requires_approval=requires_approval,
+        llm_instructions={
+            "when_to_use": f"{verb.capitalize()} an AD user account. {note} " + SSH_TRANSPORT_NOTE,
+            "parameter_hints": {"identity": "Required. sAMAccountName / DN / GUID / SID."},
+            "output_shape": f"{{'identity', 'action': '{verb}', 'op_class': 'write'}}.",
+        },
+    )
+
+
+USER_OPS: tuple[MsadOp, ...] = (
+    MsadOp(
+        op_id="msad.user.list",
+        handler_attr="msad_user_list",
+        summary="List AD users via ``Get-ADUser -Filter *`` (capped by limit).",
+        description=(
+            "Runs ``Get-ADUser -Filter *`` (capped at ``limit`` rows, default 500) "
+            "and returns one row per user (SamAccountName, Name, DisplayName, "
+            "Enabled, UPN, DN, GivenName, Surname, Description, EmailAddress). "
+            "Read-only; no password material is ever read."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"limit": _LIMIT_PROP},
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="users",
+        tags=("read-only", "user", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate AD user accounts (bounded by ``limit``). "
+                "Read-only; no password material. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"limit": "Optional; max rows (default 500)."},
+            "output_shape": "{'rows': [{SamAccountName, Name, Enabled, ...}], 'total': <int>}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.user.get",
+        handler_attr="msad_user_get",
+        summary="Read one AD user by identity via ``Get-ADUser -Identity``.",
+        description=(
+            "Runs ``Get-ADUser -Identity <id>`` and returns the single matching "
+            "user projection as a ``{rows, total}`` envelope plus the echoed "
+            "``identity``. A missing identity is a terminating error. Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"identity": _IDENTITY_PROP},
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "identity": {"type": "string"},
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["identity", "rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="users",
+        tags=("read-only", "user", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one AD user's attributes and enabled state by "
+                "sAMAccountName / DN / GUID / SID. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. sAMAccountName / DN / GUID / SID."},
+            "output_shape": "{'identity', 'rows': [<user>], 'total': <int>}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.user.search",
+        handler_attr="msad_user_search",
+        summary="Search AD users by name / SAM substring (``-like``, capped).",
+        description=(
+            "Runs ``Get-ADUser`` with a script-block ``-Filter`` matching the "
+            "query as a ``*…*`` substring against Name or SamAccountName "
+            "(capped at ``limit`` rows, default 500). The query is bound as a "
+            "data operand (injection-safe). Read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "Substring matched against Name / SamAccountName.",
+                },
+                "limit": _LIMIT_PROP,
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="users",
+        tags=("read-only", "user", "search"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to find AD users whose name or SAM account name contains "
+                "a substring (e.g. ``sql``). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "query": "Required. Substring to match (wrapped in wildcards).",
+                "limit": "Optional; max rows (default 500).",
+            },
+            "output_shape": "{'rows': [{SamAccountName, Name, ...}], 'total': <int>}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.user.create",
+        handler_attr="msad_user_create",
+        summary="Create an AD user via ``New-ADUser`` (disabled, no password) (caution).",
+        description=(
+            "Runs ``New-ADUser -Name <name> -SamAccountName <sam>`` with optional "
+            "UPN / display name / given / surname / OU path / description / email. "
+            "Created WITHOUT a password, so it is **disabled** until a password is "
+            "set out of band (see the connector doc). safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The account name / CN (``-Name``).",
+                },
+                "sam_account_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The sAMAccountName (``-SamAccountName``).",
+                },
+                "user_principal_name": {"type": "string", "description": "Optional UPN."},
+                "display_name": {"type": "string", "description": "Optional display name."},
+                "given_name": {"type": "string", "description": "Optional given name."},
+                "surname": {"type": "string", "description": "Optional surname."},
+                "path": {"type": "string", "description": "Optional OU distinguished name."},
+                "description": {"type": "string", "description": "Optional description."},
+                "email": {"type": "string", "description": "Optional email address."},
+            },
+            "required": ["name", "sam_account_name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="users",
+        tags=("write", "user", "create"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Create an AD user account (created disabled + passwordless — set "
+                "the password out of band, then enable). Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "name": "Required. The account name / CN.",
+                "sam_account_name": "Required. The sAMAccountName.",
+                "path": "Optional. OU distinguished name to create the user in.",
+            },
+            "output_shape": "{'identity': <sam>, 'action': 'create', 'user': <created>, ...}.",
+        },
+    ),
+    MsadOp(
+        op_id="msad.user.set",
+        handler_attr="msad_user_set",
+        summary="Update an AD user's attributes via ``Set-ADUser`` (never a password) (caution).",
+        description=(
+            "Applies display name / description / email / given name / surname via "
+            "``Set-ADUser``. Never touches the password. At least one attribute is "
+            "required. Enable / disable are separate ops. safety_level=caution."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "identity": _IDENTITY_PROP,
+                "display_name": {"type": "string", "description": "New display name."},
+                "description": {"type": "string", "description": "New description."},
+                "email": {"type": "string", "description": "New email address."},
+                "given_name": {"type": "string", "description": "New given name."},
+                "surname": {"type": "string", "description": "New surname."},
+            },
+            "required": ["identity"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="users",
+        tags=("write", "user", "set"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Update an AD user's display name / description / email / given / "
+                "surname. Never touches the password. Recoverable; "
+                "safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"identity": "Required. sAMAccountName / DN / GUID / SID."},
+            "output_shape": "{'identity', 'action': 'set', 'user': <updated>, ...}.",
+        },
+    ),
+    _account_action_op(
+        "msad.user.enable",
+        "msad_user_enable",
+        "enable",
+        "Enable-ADAccount",
+        safety_level="caution",
+        requires_approval=False,
+    ),
+    _account_action_op(
+        "msad.user.disable",
+        "msad_user_disable",
+        "disable",
+        "Disable-ADAccount",
+        safety_level="caution",
+        requires_approval=False,
+    ),
+    _account_action_op(
+        "msad.user.delete",
+        "msad_user_delete",
+        "delete",
+        "Remove-ADUser",
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+)

--- a/backend/tests/test_connectors_msad.py
+++ b/backend/tests/test_connectors_msad.py
@@ -1,0 +1,703 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the msad connector (SSH → PowerShell / Active Directory).
+
+Mirrors the winsrv harness (``test_connectors_winsrv.py``): a ``_StubTarget``
+dataclass, a ``_completed_process`` SSHCompletedProcess stub, and
+``patch.object(connector, "_run_command", AsyncMock(...))`` so the AD-cmdlet
+handlers can be exercised without a real domain controller. Because the
+transport is ``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell
+5.1), the assertions decode the base64 payload back to the script and assert on
+the cmdlet + quoted arguments the handler built.
+
+There is no spec-reconcile lane — the cmdlet surface ships no OpenAPI (the
+confirmed convention for SSH-typed connectors). Drift protection is this
+ordinary unit suite. Coverage spans every op group, the injection-safety escape
+on every parameterized script, the search script-block filter form, and the
+secret-hygiene invariant that no op exposes a secret-value parameter (password
+provisioning is deferred — see the connector doc).
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.msad  # noqa: F401 -- registers connector at import
+from meho_backplane.connectors.msad import MSAD_OPS, MsadConnector
+from meho_backplane.connectors.msad.ops import MSAD_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.msad.ops_computers import (
+    msad_computer_delete,
+    msad_computer_get,
+    msad_computer_join_prestage,
+    msad_computer_list,
+    msad_computer_unjoin,
+)
+from meho_backplane.connectors.msad.ops_domain import (
+    msad_domain_controllers,
+    msad_domain_forest,
+    msad_domain_info,
+    msad_domain_replication,
+)
+from meho_backplane.connectors.msad.ops_groups import (
+    msad_group_add_member,
+    msad_group_delete,
+    msad_group_get,
+    msad_group_list,
+    msad_group_members,
+    msad_group_remove_member,
+)
+from meho_backplane.connectors.msad.ops_ou import (
+    msad_ou_create,
+    msad_ou_list,
+    msad_ou_move,
+)
+from meho_backplane.connectors.msad.ops_users import (
+    msad_user_create,
+    msad_user_delete,
+    msad_user_disable,
+    msad_user_enable,
+    msad_user_get,
+    msad_user_list,
+    msad_user_search,
+    msad_user_set,
+)
+from meho_backplane.connectors.registry import product_impl_id_round_trips
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires (mirrors the winsrv suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="msad-test",
+    host="dc.test.invalid",
+    port=22,
+    secret_ref="meho/testing/msad/msad-test",
+)
+
+
+def _completed_process(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Stub mimicking asyncssh's :class:`SSHCompletedProcess`."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _script_from_call(run_mock: AsyncMock) -> str:
+    """Recover the PowerShell script from the mocked ``_run_command`` argv."""
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    encoded = cmd.rsplit(" ", 1)[1]
+    return base64.b64decode(encoded).decode("utf-16-le")
+
+
+def _run(stdout: str) -> AsyncMock:
+    return AsyncMock(return_value=_completed_process(stdout=stdout))
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+async def test_transport_uses_windows_powershell_and_suppresses_progress() -> None:
+    connector = MsadConnector()
+    assert connector.POWERSHELL_EXECUTABLE == "powershell"
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_list(connector, _TARGET, {})
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    assert not cmd.startswith("pwsh ")
+    assert _script_from_call(run_mock).startswith("$ProgressPreference = 'SilentlyContinue';")
+
+
+# ---------------------------------------------------------------------------
+# Registration / metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_connector_id_triple_round_trips() -> None:
+    assert MsadConnector.product == "msad"
+    assert MsadConnector.version == "2022.x"
+    assert MsadConnector.impl_id == "msad-ssh"
+    assert product_impl_id_round_trips(product="msad", version="2022.x", impl_id="msad-ssh")
+
+
+def test_op_surface_ids_and_safety_tiers() -> None:
+    by_id = {op.op_id: op for op in MSAD_OPS}
+    assert len(by_id) == 27
+    dangerous = {k for k, v in by_id.items() if v.safety_level == "dangerous"}
+    assert dangerous == {
+        "msad.user.delete",
+        "msad.group.delete",
+        "msad.computer.delete",
+    }
+    # Every dangerous op requires approval; nothing else does.
+    assert {k for k, v in by_id.items() if v.requires_approval} == dangerous
+    caution = {k for k, v in by_id.items() if v.safety_level == "caution"}
+    assert caution == {
+        "msad.user.create",
+        "msad.user.set",
+        "msad.user.enable",
+        "msad.user.disable",
+        "msad.group.add-member",
+        "msad.group.remove-member",
+        "msad.computer.join-prestage",
+        "msad.computer.unjoin",
+        "msad.ou.create",
+        "msad.ou.move",
+    }
+    safe = {k for k, v in by_id.items() if v.safety_level == "safe"}
+    assert len(safe) == 14
+    assert {"msad.about", "msad.domain.info", "msad.user.list"} <= safe
+
+
+def test_every_group_has_a_curated_when_to_use() -> None:
+    groups = {op.group_key for op in MSAD_OPS}
+    assert groups == {"domain", "users", "groups", "computers", "ou"}
+    assert groups <= set(MSAD_WHEN_TO_USE_BY_GROUP)
+
+
+def test_every_handler_attr_resolves_on_the_class() -> None:
+    for op in MSAD_OPS:
+        assert getattr(MsadConnector, op.handler_attr, None) is not None, op.op_id
+
+
+def test_no_op_exposes_a_secret_value_field() -> None:
+    """The secret-leak guard at the schema level: no op accepts a plaintext
+    secret-value parameter, so a secret can never reach the ``-EncodedCommand``
+    argv. Password-reset / password-set is deliberately not shipped — a
+    plaintext AD password cannot ride the pwsh transport (see the connector
+    doc); it is a Vault-brokered follow-up."""
+    secret_fields = {
+        "password",
+        "account_password",
+        "new_password",
+        "secret",
+        "credential",
+        "chap_secret",
+    }
+    for op in MSAD_OPS:
+        props = op.parameter_schema.get("properties", {})
+        leaked = secret_fields & {key.lower() for key in props}
+        assert not leaked, (op.op_id, sorted(leaked))
+
+
+def test_no_op_id_is_password_reset() -> None:
+    """Password-reset is deferred by design (secret-hygiene contract)."""
+    ids = {op.op_id for op in MSAD_OPS}
+    assert "msad.user.password-reset" not in ids
+    assert not any("password" in op_id for op_id in ids)
+
+
+# ---------------------------------------------------------------------------
+# domain group (constant scripts — no injection surface)
+# ---------------------------------------------------------------------------
+
+
+async def test_domain_info_projects_fsmo_roles() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"DNSRoot":"c1sql.lab","PDCEmulator":"dc1.c1sql.lab"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_domain_info(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ADDomain" in script
+    assert "PDCEmulator = $d.PDCEmulator" in script
+    assert "InfrastructureMaster = $d.InfrastructureMaster" in script
+    assert result["DNSRoot"] == "c1sql.lab"
+
+
+async def test_domain_forest_projects_forest_fsmo() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"Name":"c1sql.lab","SchemaMaster":"dc1.c1sql.lab"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_domain_forest(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ADForest" in script
+    assert "SchemaMaster = $f.SchemaMaster" in script
+    assert "DomainNamingMaster = $f.DomainNamingMaster" in script
+    assert result["Name"] == "c1sql.lab"
+
+
+async def test_domain_controllers_builds_list_envelope() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[{"Name":"DC1"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_domain_controllers(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ADDomainController -Filter *" in script
+    assert "rows = $x; total = $x.Count" in script
+    assert result["total"] == 1
+
+
+@pytest.mark.parametrize("rows_json", ["[]", "null"])
+async def test_domain_replication_empty_single_dc(rows_json: str) -> None:
+    connector = MsadConnector()
+    run_mock = _run(f'{{"rows":{rows_json},"total":0}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_domain_replication(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-ADReplicationPartnerMetadata -Target $dom -Scope Domain" in script
+    assert result == {"rows": [], "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# users group
+# ---------------------------------------------------------------------------
+
+
+async def test_user_list_caps_result_set() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_list(connector, _TARGET, {"limit": 25})
+    script = _script_from_call(run_mock)
+    assert "Get-ADUser -Filter * -ResultSetSize 25" in script
+
+
+async def test_user_list_default_limit_is_500() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_list(connector, _TARGET, {})
+    assert "-ResultSetSize 500" in _script_from_call(run_mock)
+
+
+@pytest.mark.parametrize("bad", [0, -1, "10", 3.5, True])
+async def test_user_list_rejects_bad_limit(bad: Any) -> None:
+    connector = MsadConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await msad_user_list(connector, _TARGET, {"limit": bad})
+    run_mock.assert_not_awaited()
+
+
+async def test_user_get_escapes_identity() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[{"SamAccountName":"o\'db"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_user_get(connector, _TARGET, {"identity": "o'db"})
+    script = _script_from_call(run_mock)
+    assert "Get-ADUser -Identity 'o''db'" in script  # single quote doubled
+    assert result["identity"] == "o'db"
+
+
+async def test_user_search_uses_scriptblock_filter_and_escapes() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_search(connector, _TARGET, {"query": "sq'l"})
+    script = _script_from_call(run_mock)
+    # The query is a single-quoted literal (embedded quote doubled), wrapped in
+    # wildcards, and bound via a script-block filter (injection-safe form).
+    assert "$q = '*sq''l*';" in script
+    assert "Get-ADUser -Filter {(Name -like $q) -or (SamAccountName -like $q)}" in script
+
+
+async def test_user_create_is_passwordless_and_disabled() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true,"user":{"SamAccountName":"svc-sql","Enabled":false}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_user_create(
+            connector,
+            _TARGET,
+            {"name": "svc sql", "sam_account_name": "svc-sql", "description": "SQL svc"},
+        )
+    script = _script_from_call(run_mock)
+    assert "New-ADUser -Name 'svc sql' -SamAccountName 'svc-sql'" in script
+    assert "-Description 'SQL svc'" in script
+    # Secret-hygiene: no password material ever enters the script.
+    assert "-AccountPassword" not in script
+    assert "ConvertTo-SecureString" not in script
+    assert result["identity"] == "svc-sql"
+    assert result["action"] == "create"
+
+
+async def test_user_create_escapes_optional_fields() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true,"user":{}}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_create(
+            connector,
+            _TARGET,
+            {
+                "name": "n",
+                "sam_account_name": "s",
+                "path": "OU=x,DC=c1sql,DC=lab",
+                "user_principal_name": "u'p@c1sql.lab",
+            },
+        )
+    script = _script_from_call(run_mock)
+    assert "-Path 'OU=x,DC=c1sql,DC=lab'" in script
+    assert "-UserPrincipalName 'u''p@c1sql.lab'" in script
+
+
+async def test_user_set_requires_an_attribute() -> None:
+    connector = MsadConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await msad_user_set(connector, _TARGET, {"identity": "svc-sql"})
+    run_mock.assert_not_awaited()
+
+
+async def test_user_set_builds_setaduser_never_password() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true,"user":{}}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_user_set(
+            connector, _TARGET, {"identity": "svc-sql", "description": "x", "email": "a@b"}
+        )
+    script = _script_from_call(run_mock)
+    assert "Set-ADUser -Identity 'svc-sql' -Description 'x' -EmailAddress 'a@b'" in script
+    assert "-AccountPassword" not in script
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet", "action", "confirm"),
+    [
+        (msad_user_enable, "Enable-ADAccount", "enable", False),
+        (msad_user_disable, "Disable-ADAccount", "disable", False),
+        (msad_user_delete, "Remove-ADUser", "delete", True),
+    ],
+)
+async def test_user_account_actions(handler: Any, cmdlet: str, action: str, confirm: bool) -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(connector, _TARGET, {"identity": "svc-sql"})
+    script = _script_from_call(run_mock)
+    assert f"{cmdlet} -Identity 'svc-sql'" in script
+    assert ("-Confirm:$false" in script) is confirm
+    assert result == {"identity": "svc-sql", "action": action, "op_class": "write"}
+
+
+# ---------------------------------------------------------------------------
+# groups group
+# ---------------------------------------------------------------------------
+
+
+async def test_group_list_and_get_and_members() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[{"Name":"SQL-Admins"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_group_list(connector, _TARGET, {})
+        assert "Get-ADGroup -Filter *" in _script_from_call(run_mock)
+        result = await msad_group_get(connector, _TARGET, {"identity": "SQL-Admins"})
+        assert "Get-ADGroup -Identity 'SQL-Admins'" in _script_from_call(run_mock)
+        assert result["identity"] == "SQL-Admins"
+        members = await msad_group_members(connector, _TARGET, {"identity": "SQL-Admins"})
+        assert "Get-ADGroupMember -Identity 'SQL-Admins'" in _script_from_call(run_mock)
+        assert members["identity"] == "SQL-Admins"
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet", "action"),
+    [
+        (msad_group_add_member, "Add-ADGroupMember", "add-member"),
+        (msad_group_remove_member, "Remove-ADGroupMember", "remove-member"),
+    ],
+)
+async def test_group_member_writes_build_array_and_escape(
+    handler: Any, cmdlet: str, action: str
+) -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(
+            connector, _TARGET, {"identity": "SQL-Admins", "members": ["svc-sql", "o'db"]}
+        )
+    script = _script_from_call(run_mock)
+    assert (
+        f"{cmdlet} -Identity 'SQL-Admins' -Members @('svc-sql', 'o''db') -Confirm:$false" in script
+    )
+    assert result == {
+        "identity": "SQL-Admins",
+        "action": action,
+        "members": ["svc-sql", "o'db"],
+        "op_class": "write",
+    }
+
+
+@pytest.mark.parametrize("members", [[], ["ok", ""], ["ok", 5]])
+async def test_group_add_member_rejects_bad_members(members: Any) -> None:
+    connector = MsadConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await msad_group_add_member(connector, _TARGET, {"identity": "g", "members": members})
+    run_mock.assert_not_awaited()
+
+
+async def test_group_delete_builds_remove_with_confirm() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_group_delete(connector, _TARGET, {"identity": "SQL-Admins"})
+    script = _script_from_call(run_mock)
+    assert "Remove-ADGroup -Identity 'SQL-Admins' -Confirm:$false" in script
+    assert result == {"identity": "SQL-Admins", "action": "delete", "op_class": "write"}
+
+
+# ---------------------------------------------------------------------------
+# computers group
+# ---------------------------------------------------------------------------
+
+
+async def test_computer_list_and_get() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[{"Name":"SQLNODE1"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        await msad_computer_list(connector, _TARGET, {})
+        assert "Get-ADComputer -Filter *" in _script_from_call(run_mock)
+        result = await msad_computer_get(connector, _TARGET, {"identity": "SQLNODE1"})
+        assert "Get-ADComputer -Identity 'SQLNODE1'" in _script_from_call(run_mock)
+        assert result["identity"] == "SQLNODE1"
+
+
+async def test_computer_join_prestage_builds_new_adcomputer() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true,"computer":{"Name":"SQLNODE1"}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_computer_join_prestage(
+            connector, _TARGET, {"name": "SQLNODE1", "path": "OU=Servers,DC=c1sql,DC=lab"}
+        )
+    script = _script_from_call(run_mock)
+    assert "New-ADComputer -Name 'SQLNODE1'" in script
+    assert "-Path 'OU=Servers,DC=c1sql,DC=lab'" in script
+    # No explicit SAM → read the account back by the CN.
+    assert "Get-ADComputer -Identity 'SQLNODE1'" in script
+    assert result["action"] == "join-prestage"
+    assert result["identity"] == "SQLNODE1"
+
+
+async def test_computer_join_prestage_reads_back_by_explicit_sam() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true,"computer":{"Name":"SQLNODE1"}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_computer_join_prestage(
+            connector, _TARGET, {"name": "SQLNODE1", "sam_account_name": "SQLALT$"}
+        )
+    script = _script_from_call(run_mock)
+    assert "New-ADComputer -Name 'SQLNODE1' -SamAccountName 'SQLALT$'" in script
+    # Read-back resolves by the explicit SAM (which differs from the CN), not the name.
+    assert "Get-ADComputer -Identity 'SQLALT$'" in script
+    assert result["identity"] == "SQLALT$"
+
+
+async def test_computer_unjoin_disables_recoverably() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_computer_unjoin(connector, _TARGET, {"identity": "SQLNODE1"})
+    script = _script_from_call(run_mock)
+    assert "Disable-ADAccount -Identity 'SQLNODE1'" in script
+    assert "Remove-ADComputer" not in script  # unjoin is recoverable, not a delete
+    assert result == {"identity": "SQLNODE1", "action": "unjoin", "op_class": "write"}
+
+
+async def test_computer_delete_builds_remove_with_confirm() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_computer_delete(connector, _TARGET, {"identity": "SQLNODE1$"})
+    script = _script_from_call(run_mock)
+    assert "Remove-ADComputer -Identity 'SQLNODE1$' -Confirm:$false" in script
+    assert result["action"] == "delete"
+
+
+# ---------------------------------------------------------------------------
+# ou group
+# ---------------------------------------------------------------------------
+
+
+async def test_ou_list_builds_envelope() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_ou_list(connector, _TARGET, {})
+    assert "Get-ADOrganizationalUnit -Filter *" in _script_from_call(run_mock)
+    assert result == {"rows": [], "total": 0}
+
+
+async def test_ou_create_builds_and_renders_protected() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"Name":"Servers","DistinguishedName":"OU=Servers,DC=c1sql,DC=lab"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_ou_create(
+            connector,
+            _TARGET,
+            {"name": "Serv'ers", "path": "DC=c1sql,DC=lab", "protected": False},
+        )
+    script = _script_from_call(run_mock)
+    assert "New-ADOrganizationalUnit -Name 'Serv''ers'" in script
+    assert "-Path 'DC=c1sql,DC=lab'" in script
+    assert "-ProtectedFromAccidentalDeletion $false" in script
+    assert result["action"] == "create"
+
+
+async def test_ou_move_builds_move_adobject() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await msad_ou_move(
+            connector,
+            _TARGET,
+            {
+                "identity": "CN=svc-sql,DC=c1sql,DC=lab",
+                "target_path": "OU=Servers,DC=c1sql,DC=lab",
+            },
+        )
+    script = _script_from_call(run_mock)
+    assert "Move-ADObject -Identity 'CN=svc-sql,DC=c1sql,DC=lab'" in script
+    assert "-TargetPath 'OU=Servers,DC=c1sql,DC=lab'" in script
+    assert result == {
+        "identity": "CN=svc-sql,DC=c1sql,DC=lab",
+        "target_path": "OU=Servers,DC=c1sql,DC=lab",
+        "action": "move",
+        "op_class": "write",
+    }
+
+
+# ---------------------------------------------------------------------------
+# about (fingerprint wrapper) + probe
+# ---------------------------------------------------------------------------
+
+
+async def test_about_maps_fingerprint_into_identity_dict() -> None:
+    connector = MsadConnector()
+    payload = (
+        '{"DNSRoot":"c1sql.lab","NetBIOSName":"C1SQL","Forest":"c1sql.lab",'
+        '"DomainMode":"Windows2016Domain","PDCEmulator":"dc1.c1sql.lab",'
+        '"ADModuleVersion":"1.0.1.0"}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await connector.about(_TARGET, {})
+    assert result["vendor"] == "microsoft"
+    assert result["product"] == "active-directory"
+    assert result["version"] == "Windows2016Domain"
+    assert result["dns_root"] == "c1sql.lab"
+    assert result["netbios_name"] == "C1SQL"
+    assert result["forest"] == "c1sql.lab"
+    assert result["pdc_emulator"] == "dc1.c1sql.lab"
+    assert result["ad_module_version"] == "1.0.1.0"
+
+
+async def test_fingerprint_reads_get_addomain() -> None:
+    connector = MsadConnector()
+    run_mock = _run('{"DNSRoot":"c1sql.lab","DomainMode":"Windows2016Domain"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await connector.fingerprint(_TARGET)
+    assert "Get-ADDomain" in _script_from_call(run_mock)
+    assert result.reachable is True
+    assert result.product == "active-directory"
+    assert result.version == "Windows2016Domain"
+
+
+async def test_fingerprint_unreachable_is_not_an_exception() -> None:
+    connector = MsadConnector()
+    with patch.object(connector, "_run_command", AsyncMock(side_effect=OSError("down"))):
+        result = await connector.fingerprint(_TARGET)
+    assert result.reachable is False
+    assert result.vendor == "microsoft"
+    assert "error" in result.extras
+
+
+async def test_probe_tcp_unreachable_and_auth_failed() -> None:
+    connector = MsadConnector()
+    with patch.object(connector, "_connect", AsyncMock(side_effect=OSError("no route"))):
+        assert (await connector.probe(_TARGET)).reason == "tcp_unreachable"
+    with patch.object(
+        connector, "_connect", AsyncMock(side_effect=asyncssh.PermissionDenied("no"))
+    ):
+        assert (await connector.probe(_TARGET)).reason == "ssh_auth_failed"
+
+
+async def test_probe_powershell_unavailable_when_pwsh_errors() -> None:
+    connector = MsadConnector()
+    from meho_backplane.connectors._shared.pwsh import PwshRunError
+
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout="", exit_status=1)),
+        ),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.reason == "powershell_unavailable"
+    assert isinstance(PwshRunError("x", exit_status=1, stderr=""), Exception)  # import guard
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [OSError("reset"), asyncssh.ConnectionLost("closed"), TimeoutError("timeout")],
+)
+async def test_probe_command_failed_after_connect(boom: Exception) -> None:
+    connector = MsadConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.reason == "command_failed"
+
+
+async def test_probe_ad_module_unavailable() -> None:
+    connector = MsadConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"ad_module":false,"domain":false}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "ad_module_unavailable"
+
+
+async def test_probe_domain_unreachable() -> None:
+    connector = MsadConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"ad_module":true,"domain":false}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "domain_unreachable"
+
+
+async def test_probe_ok_when_module_and_domain_present() -> None:
+    connector = MsadConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"ad_module":true,"domain":true}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is True
+    assert result.reason is None

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -432,6 +432,7 @@ _EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
         "loki-api",
         "mail-smtp",
         "mongodb-wire",
+        "msad-ssh",
         "net-probe",
         "nsx-rest",
         "pfsense-ssh",

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -32383,6 +32383,7 @@
               "keycloak",
               "loki",
               "mongodb",
+              "msad",
               "nsx",
               "pfsense",
               "postgres",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -543,6 +543,7 @@ const (
 	TargetCreateProductKeycloak   TargetCreateProduct = "keycloak"
 	TargetCreateProductLoki       TargetCreateProduct = "loki"
 	TargetCreateProductMongodb    TargetCreateProduct = "mongodb"
+	TargetCreateProductMsad       TargetCreateProduct = "msad"
 	TargetCreateProductNsx        TargetCreateProduct = "nsx"
 	TargetCreateProductPfsense    TargetCreateProduct = "pfsense"
 	TargetCreateProductPostgres   TargetCreateProduct = "postgres"

--- a/docs/codebase/connectors-msad.md
+++ b/docs/codebase/connectors-msad.md
@@ -1,0 +1,321 @@
+# Connector: msad (msad-2022.x / `msad-ssh`)
+
+## Overview
+
+The `msad` connector is the typed `Connector` subclass that manages **Active
+Directory** — domain / forest / DC topology facts, and day-2 reads plus guarded
+writes over users, groups, computers, and organizational units — through the
+`ActiveDirectory` PowerShell module (Windows PowerShell 5.1) run on a **domain
+controller** over SSH. It is registered under the `(product="msad",
+version="2022.x", impl_id="msad-ssh")` registry triple plus the `("msad", "",
+"")` wildcard fallback row, and is a child of the shared `SshConnector` adapter
+(`connectors/adapters/ssh.py`) — the same transport base as `WindowsDnsConnector`
+and `WinsrvConnector`.
+
+AD exposes **no unified REST API** for these operations; before this connector
+the c1sql1 program (evoila-bosnia/claude-rdc-hetzner-dc#2789) stood up the
+`c1sql.lab` domain and drove day-2 AD tasks through ungoverned `govc guest.run` +
+hand-run PowerShell. The connector is a structural copy of the `winsrv` **estate
+mold** (#3261): identity canary + per-domain op groups on the `SshConnector` base,
+the PowerShell-over-SSH transport `_shared/pwsh` (base64 UTF-16LE
+`-EncodedCommand` + stdlib `json` parse), the `{rows, total}` JSONFlux envelope
+for list reads, and the `rke2` approval-parked-write mold for destructive ops. It
+complements — not duplicates — `windows_dns` (DNS records) on the same DC.
+
+Registry-triple rationale: `product="msad"` is a short, **separator-free** token
+because `parse_connector_id` derives the product from the first hyphen-segment of
+`impl_id`, so `connector_id="msad-ssh-2022.x"` round-trips (a hyphen/underscore in
+the product token breaks the registry's round-trip guard at boot).
+`version="2022.x"` marks the cmdlet surface (stable across Windows Server 2019 →
+2025 DCs). `impl_id="msad-ssh"` leaves room for a future `msad-winrm` sibling.
+
+Source: `backend/src/meho_backplane/connectors/msad/`.
+
+## In-task decisions (on the record)
+
+### DC-targeting: the SSH target host IS the domain controller
+
+Every AD cmdlet runs on the SSH target **without** an explicit `-Server` — the
+`ActiveDirectory` module contacts the local DC by default. The default and **only
+supported topology is "the SSH target host IS a domain controller."** A jump-host
+pattern — where the SSH host is not the DC and the cmdlets carry `-Server
+<other-dc>` plus a second `-Credential` secret to reach the DC — is **explicitly
+deferred**: it needs a second credential brokered from Vault (the connector's
+single Vault secret is the SSH credential), and no consumer needs it yet. When a
+consumer does, the follow-up adds an optional `-Server` + Vault-brokered
+`-Credential` seam; until then, point `msad` targets directly at a DC.
+
+### Password provisioning / reset is deferred (secret-hygiene contract)
+
+The shared pwsh transport's safety contract **forbids credential material in the
+`-EncodedCommand` script** — the encoded payload lands on the remote process argv
+and is visible to a privileged remote observer (see `_shared/pwsh`). A plaintext
+AD password therefore cannot ride the transport. Consequences, mirroring winsrv's
+passwordless-create:
+
+- **`user.create` creates a disabled, passwordless account.** Per `New-ADUser`'s
+  documented behaviour an account created without `-AccountPassword` is disabled
+  and "cannot be enabled until a password is set." Set the password out of band,
+  then `user.enable`.
+- **`user.set` never touches the password**, and there is **no `password-reset`
+  op.** Password provisioning / reset is a Vault-brokered follow-up (the `rke2`
+  `token.rotate` mint-and-stash mold, so no secret enters the script).
+
+A unit test (`test_no_op_exposes_a_secret_value_field` +
+`test_no_op_id_is_password_reset`) pins this at the schema level: no op declares a
+`password` / `secret` / `credential` parameter, and no op id contains
+"password". This is the "password-bearing params provably redacted" acceptance
+criterion, satisfied the winsrv way — there are none, proven at the schema level.
+
+## Op surface (27 ops across five groups)
+
+Safety tier is a reach decision per the Initiative #3259 satellite table: reads =
+`safe` (ride satellite runners); recoverable writes = `caution` (satellite-
+executable only through the Stage-3 composed write gate, #2901); destructive =
+`dangerous` + `requires_approval` (satellite-EXCLUDED by the tier ladder,
+central-dial / on-site only).
+
+| op | safety | approval | cmdlet(s) |
+| --- | --- | --- | --- |
+| `msad.about` | safe | no | `Get-ADDomain` (minimal) + AD module version |
+| `msad.domain.info` | safe | no | `Get-ADDomain` (FSMO PDC/RID/Infra, mode) |
+| `msad.domain.forest` | safe | no | `Get-ADForest` (FSMO schema/naming, mode) |
+| `msad.domain.controllers` | safe | no | `Get-ADDomainController -Filter *` |
+| `msad.domain.replication` | safe | no | `Get-ADReplicationPartnerMetadata -Scope Domain` |
+| `msad.user.list` | safe | no | `Get-ADUser -Filter *` (capped) |
+| `msad.user.get` | safe | no | `Get-ADUser -Identity` |
+| `msad.user.search` | safe | no | `Get-ADUser -Filter {name/sam -like}` (capped) |
+| `msad.user.create` | caution | no | `New-ADUser` (disabled, no password) |
+| `msad.user.set` | caution | no | `Set-ADUser` (never a password) |
+| `msad.user.enable` | caution | no | `Enable-ADAccount` |
+| `msad.user.disable` | caution | no | `Disable-ADAccount` |
+| `msad.user.delete` | **dangerous** | **yes** | `Remove-ADUser -Confirm:$false` |
+| `msad.group.list` | safe | no | `Get-ADGroup -Filter *` (capped) |
+| `msad.group.get` | safe | no | `Get-ADGroup -Identity` |
+| `msad.group.members` | safe | no | `Get-ADGroupMember -Identity` |
+| `msad.group.add-member` | caution | no | `Add-ADGroupMember -Confirm:$false` |
+| `msad.group.remove-member` | caution | no | `Remove-ADGroupMember -Confirm:$false` |
+| `msad.group.delete` | **dangerous** | **yes** | `Remove-ADGroup -Confirm:$false` |
+| `msad.computer.list` | safe | no | `Get-ADComputer -Filter *` (capped) |
+| `msad.computer.get` | safe | no | `Get-ADComputer -Identity` |
+| `msad.computer.join-prestage` | caution | no | `New-ADComputer` |
+| `msad.computer.unjoin` | caution | no | `Disable-ADAccount` (recoverable) |
+| `msad.computer.delete` | **dangerous** | **yes** | `Remove-ADComputer -Confirm:$false` |
+| `msad.ou.list` | safe | no | `Get-ADOrganizationalUnit -Filter *` (capped) |
+| `msad.ou.create` | caution | no | `New-ADOrganizationalUnit` |
+| `msad.ou.move` | caution | no | `Move-ADObject` |
+
+The three `dangerous` ops (`user.delete`, `group.delete`, `computer.delete`) are
+`requires_approval=True` — a dispatch parks at `needs-approval` for a human
+decision (the rke2 write mold; the generic params-echo default (#1856) surfaces
+target / params redaction-safely to the reviewer). The **agent-principal ceiling**
+therefore applies: an agent session cannot self-approve these — approval is a
+human decision (v0.1-spec §7), so an agent dispatch floors at the approval queue
+until an operator approves in the console / CLI. Reads ride satellite runners; the
+`dangerous` ops are excluded from satellites by the tier ladder.
+
+`-Confirm:$false` on the delete / remove-member ops suppresses the AD cmdlets'
+own interactive confirmation prompt (they carry a High `ConfirmImpact` and would
+otherwise hang over the non-interactive `-EncodedCommand` transport) — the
+governance gate is MEHO's `requires_approval`, not AD's `-Confirm`.
+
+### "unjoin" is a disable, not a delete
+
+`computer.unjoin` runs `Disable-ADAccount` — the recoverable inverse of a live
+domain join from the directory side: the machine can no longer authenticate to
+the domain, but its account object is retained (re-enable restores trust). A full
+object removal is the separate `dangerous` `computer.delete`. This keeps the
+`caution` (recoverable) / `dangerous` (destructive) split honest.
+
+## Key types
+
+- **`MsadConnector`** (`connector.py`) — `SshConnector` subclass. Class
+  attributes: `product="msad"`, `version="2022.x"`, `impl_id="msad-ssh"`,
+  `POWERSHELL_EXECUTABLE="powershell"`, `POWERSHELL_SCRIPT_PREFIX` (the
+  `$ProgressPreference` guard), `POWERSHELL_LOG_EVENT="msad_pwsh_executed"`. Ships
+  `fingerprint`, `probe`, `about`, the 27 bound-method op shims,
+  `register_operations`, and the operator-less `execute` dispatcher shim.
+- **Shared pwsh transport** (`_shared/pwsh.py`, #3260) — `pwsh_run`,
+  `ps_single_quote` (the `shlex.quote` analogue), `encode_pwsh_command`,
+  `strip_clixml`, `PwshRunError`.
+- **Op metadata** (`ops.py`) — `MsadOp` frozen dataclass (mirrors `WinsrvOp`),
+  `MSAD_OPS` (`about` + the five per-domain tuples), `MSAD_WHEN_TO_USE_BY_GROUP`
+  (curated per-group blurbs, registration fails closed without them),
+  `normalise_json_rows`, `validate_limit`, and `ad_list_read` (the shared
+  read-under-`'Stop'` helper that builds the `{rows, total}` envelope).
+- **Per-domain op modules** — `ops_domain.py`, `ops_users.py`, `ops_groups.py`,
+  `ops_computers.py`, `ops_ou.py`.
+- **Registration** (`__init__.py`) — two-phase, mirroring winsrv: synchronous
+  `register_connector_v2` at import time (versioned triple + wildcard row); async
+  `register_msad_typed_operations` queued onto the lifespan registrar list. No v1
+  `register_connector` — no chassis history.
+
+## Transport: PowerShell-over-SSH
+
+Every op runs `powershell -NoProfile -NonInteractive -EncodedCommand <base64>`
+over the pooled SSH connection:
+
+- **`powershell` (Windows PowerShell 5.1), not `pwsh` (PS7).** A Windows DC ships
+  5.1; PS7 is absent by default. The connector sets
+  `POWERSHELL_EXECUTABLE="powershell"` explicitly — **the load-bearing estate
+  trap:** the shared transport's fallback is `pwsh`, so a connector that forgets
+  this attribute silently emits `pwsh -EncodedCommand` and fails confusingly on
+  every 5.1-only host.
+- **`-EncodedCommand` wire shape** — the script is UTF-16LE-encoded and base64'd
+  (no BOM). The shell never parses the script text; only the PowerShell parser
+  does.
+- **`$ProgressPreference = 'SilentlyContinue'` guard** — prepended so the
+  ActiveDirectory module's first-use progress / import warning never CLIXML-
+  serialises onto the streams.
+- **JSON out** — reads pipe through `ConvertTo-Json` (explicit `-Depth`) and
+  `pwsh_run` parses stdout with stdlib `json`. Rich AD objects are projected to a
+  bounded scalar subset via `Select-Object` (or an explicit hashtable projection
+  for the FSMO-bearing domain / forest reads) so the JSON stays stable and small.
+- **`{rows, total}` envelope for list reads** — `ConvertTo-Json` emits *nothing*
+  on a zero-object pipeline (which trips `pwsh_run`'s empty-stdout guard), so
+  every list read wraps its result in `@{ rows = $x; total = $x.Count }` under
+  `$ErrorActionPreference = 'Stop'` (a cmdlet error must surface as a real
+  `PwshRunError`, not read as a false-empty inventory). The envelope is what the
+  dispatcher's JSONFlux reducer keys on to spill a set-shaped result to a
+  `result_query` handle. `-Filter *` reads carry a `-ResultSetSize` cap (default
+  500, operator-overridable via `limit`) so a large domain can't blow the payload.
+
+### Injection safety
+
+Operator-supplied identities, attribute values, member identities, and DNs are
+interpolated only inside **single-quoted** PowerShell literals via
+`ps_single_quote` (embedded `'` doubled — complete escaping inside a single-quoted
+PowerShell string). The `limit` cap is Python-validated to a positive `int` before
+interpolation; the `protected` toggle renders as a fixed `$true` / `$false`
+literal.
+
+The **`user.search`** query is the one non-`-Identity` operator input on a
+filter. It is bound the documented injection-safe way: the query is wrapped in
+`*…*`, assigned to `$q` as a single-quoted literal, and passed through a
+**script-block** `-Filter {(Name -like $q) -or (SamAccountName -like $q)}`. Per
+the `about_ActiveDirectory_Filter` guidance, the AD filter engine binds the
+session variable's *value* as a data operand rather than re-parsing an
+interpolated string — so a value containing a quote can't break out of the filter.
+
+## `fingerprint(target)` / `probe(target)`
+
+`fingerprint` runs one `-EncodedCommand` round-trip reading `Get-ADDomain` (DNS
+root / NetBIOS / forest / domain mode / PDC emulator) + the ActiveDirectory module
+version; returns `vendor="microsoft"`, `product="active-directory"`,
+`version=<domain functional level>`, with `extras={dns_root, netbios_name, forest,
+pdc_emulator, ad_module_version}`. Any transport / credential / non-DC failure
+maps to `reachable=False` + `extras["error"]` — never an unhandled exception
+(#986). `about` (`msad.about`) wraps `fingerprint` + `_assert_reachable`.
+
+`probe` surfaces six distinct `ProbeResult.reason` values:
+
+| reason | meaning |
+| --- | --- |
+| `tcp_unreachable` | the SSH TCP socket cannot connect |
+| `ssh_auth_failed` | credentials rejected / handshake failed / Vault credential unresolvable |
+| `powershell_unavailable` | SSH succeeded but the PowerShell reachability script failed |
+| `command_failed` | post-connect transport failure (drop / timeout / socket error) after a successful handshake (the #986 guard) |
+| `ad_module_unavailable` | PowerShell runs but the `ActiveDirectory` module is not installed (target is not a DC / lacks RSAT-AD) |
+| `domain_unreachable` | the module is present but `Get-ADDomain` fails (directory services down / not a DC) |
+
+The probe script checks module presence + domain readability in one round-trip and
+always emits JSON (the `Get-ADDomain` failure is caught inside the script), so a
+`PwshRunError` unambiguously means `powershell_unavailable`.
+
+## Auth
+
+Uses the base `SshConnector._auth_config` **unchanged** — a Vault secret with
+`ssh_private_key` prefers key auth, otherwise password auth runs. Credentials
+resolve via `_shared/vault_creds` from the Vault KV-v2 path in
+`target.secret_ref`. The transport prerequisite is an **OpenSSH server on the
+domain controller** with `powershell` reachable, plus the `RSAT-AD-PowerShell` /
+AD DS role installed (present by default on a DC). `probe()` carries no operator,
+so its Vault read runs under the synthesised system operator and fails closed to
+`ssh_auth_failed`.
+
+## Control flow
+
+1. **Boot** — `_eager_import_connectors()` imports the `msad` subpackage;
+   `__init__.py` registers the v2 triple + wildcard synchronously and queues the
+   typed-op registrar.
+2. **Lifespan startup** — `run_typed_op_registrars()` →
+   `register_msad_typed_operations` → `MsadConnector.register_operations`, which
+   upserts each `MSAD_OPS` entry into `endpoint_descriptor` (idempotent across
+   restarts) with the curated per-group `when_to_use`. The op rows come from
+   **runtime registration, not an alembic migration** — there is no schema change.
+3. **Dispatch** — `POST /api/v1/operations/call` resolves
+   `connector_id="msad-ssh-2022.x"` + the target and invokes the bound handler
+   through the policy/audit path. `dangerous` + `requires_approval` ops park at
+   `needs-approval` first. The CLI reaches the same path via `meho operation call
+   msad-ssh-2022.x <op_id> --params-json '{...}'`.
+
+## Building on the estate mold
+
+`msad` copies the `winsrv` package (see `docs/codebase/connectors-winsrv.md` →
+"Building the next estate connector"). The single most important footgun is the
+`POWERSHELL_EXECUTABLE = "powershell"` override (documented above). Other copy
+points honoured here: the `$ProgressPreference` prefix; a connector-scoped
+`POWERSHELL_LOG_EVENT`; the `{rows, total}` envelope under `$ErrorActionPreference
+= 'Stop'` for list reads; `ps_single_quote` on every operator string; no
+credential material in any script; and destructive ops on the `dangerous` +
+`requires_approval` tier.
+
+## Tests
+
+`backend/tests/test_connectors_msad.py` — mirrors the winsrv harness
+(`_StubTarget`, `_completed_process`, `patch.object(connector, "_run_command",
+AsyncMock(...))`); assertions decode the `-EncodedCommand` base64 back to the
+script text. Covers the transport (`powershell` + `$ProgressPreference`), the
+registry-triple round-trip, the 27-op surface + safety-tier + group-coverage
+invariants, every op group's script construction, the injection-safety escape on
+every parameterized script (identity / member / search query / OU DN —
+single-quote doubling), the `user.search` script-block filter form, the
+`limit`/`-ResultSetSize` validation, the secret-hygiene invariant (no
+secret-value parameter on any op; no `password-reset` op; passwordless create),
+the `about` fingerprint mapping, and the full six-reason probe matrix. The global
+`test_flight_recorder_typed_spans.py` conformance sweep lists `msad-ssh` in
+`_EXPECTED_TYPED_IMPLS`. **No spec-reconcile lane** — the cmdlet surface ships no
+OpenAPI (the confirmed convention for SSH-typed connectors); drift protection is
+this ordinary unit suite.
+
+## CLI
+
+No dedicated `meho msad` verb package (the windows_dns / winsrv / rke2 precedent
+for SSH-typed connectors). CLI parity is the generic dispatch path — `meho
+operation call msad-ssh-2022.x <op_id> --params-json '{...}'` — plus the `msad`
+product token added to the OpenAPI `TargetCreate.product` enum (regenerated from
+the live registry, so `meho targets create --product msad ...` validates and the
+generated Go client knows the token).
+
+## Known issues / scope
+
+- **Password provisioning / reset** is not shipped (create is passwordless →
+  disabled; there is no `password-reset` op) — a Vault-minted-password flow
+  (rke2 `token.rotate` mold) is a follow-up. See the in-task decision above.
+- **Jump-host / `-Server` targeting** is deferred — the SSH target must itself be
+  a domain controller. See the in-task decision above.
+- **Group creation** and **OU deletion** are out of scope for this cut (the issue
+  enumerates group add/remove-member + delete, and ou list/create/move); they are
+  natural follow-ups when a consumer needs them.
+- **Consumer proof against the live `c1sql-dc1` DC is an OPEN acceptance
+  criterion** — the c1sql1 domain-controller VM/probe path is not reachable from
+  this build; the probe + governed guarded-write (e.g. group-member add) proof is
+  deferred to the lab program (evoila-bosnia/claude-rdc-hetzner-dc#2789 / #2792).
+- Host-key checking is disabled (`known_hosts=None`) at the adapter level for
+  v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
+
+## References
+
+- Task #3262 (connector); Initiative #3259 (Microsoft estate); prerequisites
+  #3260 (shared `_shared/pwsh` transport hoist) and #3261 (`winsrv` estate mold).
+- Molds: `docs/codebase/connectors-winsrv.md` (structure + probe #986 discipline +
+  PowerShell-over-SSH transport + the `POWERSHELL_EXECUTABLE` trap),
+  `docs/codebase/connectors-windows-dns.md`, `docs/codebase/connectors-rke2.md`
+  (approval-parked-write mold).
+- Cmdlet references (ActiveDirectory module, Windows Server 2022 / PowerShell
+  5.1): <https://learn.microsoft.com/en-us/powershell/module/activedirectory/>
+  (`Get-ADDomain` / `Get-ADForest` / `Get-ADUser` / `New-ADUser` / `Set-ADUser` /
+  `*-ADAccount` / `Get-ADGroup` / `Add-ADGroupMember` / `Get-ADComputer` /
+  `New-ADComputer` / `Get-ADOrganizationalUnit` / `Move-ADObject` /
+  `Get-ADReplicationPartnerMetadata`), and `about_ActiveDirectory_Filter` for the
+  safe script-block filter form.


### PR DESCRIPTION
## Summary

- **`msad` — the Active Directory typed connector** (Initiative #3259, Wave 2), a
  structured copy of the `winsrv` estate mold (#3261) on the shared
  PowerShell-over-SSH transport (`_shared/pwsh`, #3260) + `SshConnector` base. It
  governs the c1sql1 lab domain (and the AD backbone of every Windows estate MEHO
  meets in migration engagements); complements `windows_dns` on the same DC.
- **27 ops across five groups**, safety-tiered per the #3259 satellite table:
  `domain` (about / info / forest / controllers / replication — FSMO holders +
  functional level + inbound-replication summary) and the read halves of `users`
  / `groups` / `computers` / `ou` are `safe`; recoverable writes are `caution`;
  `user.delete` / `group.delete` / `computer.delete` are `dangerous` +
  `requires_approval` (rke2 approval-parked-write mold). `computer.unjoin`
  disables the account (recoverable), distinct from the destructive
  `computer.delete`. List reads return the `{rows, total}` JSONFlux envelope,
  capped by `-ResultSetSize` (default 500).
- Registered versioned (`msad`/`2022.x`/`msad-ssh`) + wildcard; separator-free
  product token (round-trip guard). `POWERSHELL_EXECUTABLE = "powershell"` set
  explicitly (the load-bearing winsrv trap). `msad-ssh` added to the F8
  flight-recorder `_EXPECTED_TYPED_IMPLS` conformance set up front.

## In-task decisions (documented in `docs/codebase/connectors-msad.md`)

- **DC-targeting:** the SSH target host IS the domain controller — every cmdlet
  runs locally without `-Server`. A jump-host `-Server` + second-credential
  pattern is **explicitly deferred** (rationale in the doc).
- **Password-reset is deferred (secret-hygiene contract):** a plaintext AD
  password cannot ride the `-EncodedCommand` argv, so — mirroring winsrv's
  passwordless-create — `user.create` creates a **disabled, passwordless**
  account, `user.set` never touches the password, and there is **no
  `password-reset` op**. Provisioning is a Vault-brokered follow-up (rke2
  `token.rotate` mold). A schema-level test proves no op exposes a secret-value
  field and no op id is a password reset — the "password-bearing params provably
  redacted" AC, satisfied the winsrv way.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/msad/` — clean (8 files)
- [x] `code-quality.py --diff` — 0 blockers (file-size warnings only, all <600)
- [x] `pytest tests/test_connectors_msad.py` — 53 passed (transport, registry
  round-trip, 27-op surface + safety tiers + group coverage, every group's script
  construction, injection-safety escapes, `user.search` script-block filter,
  `limit` validation, secret-hygiene + no-password-reset guards, `about`
  fingerprint mapping, six-reason probe matrix)
- [x] `pytest tests/test_flight_recorder_typed_spans.py` — 17 passed (the
  registry-driven conformance sweep now covers `msad-ssh`)
- [x] `pytest` global registry/enum/resolver/targets/surface set (product-enum,
  registry v1+v2, resolver, shim-shadowing, mcp-surface-conformance, api targets)
  — 202 passed (no count/enum breakage from the new product)
- [ ] **Consumer proof against live `c1sql-dc1` (probe + one governed
  guarded-write, e.g. group-member add): OPEN** — the lab DC is not reachable
  from this build; deferred to the lab program
  (evoila-bosnia/claude-rdc-hetzner-dc#2789 / #2792), consistent with the winsrv
  precedent. The scripted-transport unit suite + injection-safety + secret-leak
  guard + probe matrix are the deliverable.

## CLI snapshot: **CHANGED (new product token `msad`)**

`make snapshot-openapi && make generate` regenerated `cli/api/openapi.json`
(+1: the `msad` `TargetCreate.product` enum entry) and
`cli/internal/api/client.gen.go` (+1: `TargetCreateProductMsad`). No other churn.

## Out of scope

- Group creation and OU deletion (the issue enumerates group add/remove-member +
  delete and ou list/create/move) — natural follow-ups when a consumer needs them.
- Password provisioning / reset and jump-host `-Server` targeting — deferred (see
  in-task decisions above).
- **No alembic migration** — op rows come from runtime typed-op registration, not
  a schema change (peer lanes own heads 0096/0097). **No spec-reconcile lane** —
  the cmdlet surface ships no OpenAPI (the confirmed SSH-typed-connector
  convention).
- Sibling `wsfc` (#3263) builds in parallel; merges are serialized (both touch the
  CLI snapshot). If `wsfc` lands first, this branch rebases + re-runs the regen.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3262
