### PR TITLE
ci(fast-path): docs-only PRs skip the two heavy Python lanes (#3252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@
 # ~6-8-min parallel shards, cutting the dominant PR-wall contributor. Per-job
 # `timeout-minutes` caps a runaway gate at roughly twice its observed cost.
 #
+# Docs-only fast path (#3252): the `changes` detector also classifies a PR
+# whose diff is PURELY documentation (every path under `docs/` or ending in
+# `.md`). On such a PR the heavy Python lanes — `python-lint`, the three
+# `python-unit-shard` legs, and `python-integration` — skip via their own
+# job-level `if:` (skipped-by-`if:` == Success per #2140), so a changelog
+# roll / guide edit / README fix finishes CI in minutes instead of paying the
+# ~17-19-min Python tax for zero signal. The required `Python (ruff + mypy +
+# pytest)` fan-in still RUNS and reports (its inspection step treats the
+# detect-driven skips as pass ONLY when `docs_only=true`). The cheap lanes
+# (Go, Helm) and the security/secret/license scans keep running unchanged —
+# docs can still leak secrets, and those lanes are already fast. The skip is
+# an ALLOW-LIST that fails CLOSED: anything the detector cannot prove is
+# docs-only runs the FULL matrix. See the `changes` job's SAFETY NOTE.
+#
 # Out of scope (deliberately delegated to existing workflows; do not
 # duplicate here):
 #   * Backplane image build / push  -> .github/workflows/image.yml
@@ -116,27 +130,48 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect migration-related changes
-    # Emits `migrations=true` when a PR touches migration-related files,
-    # so the required `python-migration-tests` job runs only then. On
-    # push / merge_group it emits `true` unconditionally, so the required
-    # check is never left Pending on a non-PR event.
+    name: Detect migration + docs-only changes
+    # Single change-detector for TWO downstream gates, both #2140-shaped
+    # (job-level `if:` on this job's outputs, NEVER `on.paths`):
+    #
+    #   migrations — `true` when a PR touches migration-related files, so the
+    #                required `python-migration-tests` job runs only then.
+    #   docs_only  — `true` when a PR's diff is PURELY documentation (every
+    #                changed path is under `docs/` or ends in `.md`), so the
+    #                heavy Python lanes (`python-lint`, the `python-unit-shard`
+    #                matrix, and `python-integration`) skip via their own `if:`
+    #                and report success-by-skip (#3252).
     #
     # WHY a `changes`-job + job-level `if:` and NOT `on.paths` (#2140):
     # GitHub treats a job skipped by its own `if:` as **Success** (it
-    # satisfies a required status check), whereas a whole workflow
+    # satisfies a required status check), whereas a whole workflow / job
     # skipped by a path filter stays **Pending** and blocks merge. For a
     # *required* test check the `if:` gate is the only shape that skips
-    # cleanly. There is no in-repo precedent — chart.yml uses
-    # `on.pull_request.paths` (fine for a publish workflow, wrong here).
+    # cleanly. chart.yml uses `on.pull_request.paths` (fine for a publish
+    # workflow, wrong for a required test lane).
     #
-    # Same fork-PR guard as the other jobs; the dependent test job's
-    # `if:` re-checks head.repo too.
+    # SAFETY NOTE — docs_only fails CLOSED, and this is load-bearing.
+    # The classifier is an ALLOW-LIST: `docs_only` starts `false` and only a
+    # positive, COMPLETE match (every changed path is docs) flips it to
+    # `true`. Any unrecognised path — code, a test, a workflow, a config,
+    # anything under `cli/` or `deploy/` — and any inability to compute the
+    # diff leaves `docs_only=false` (full run). A required lane that skipped
+    # on a *code* diff would let an untested change land green; so the ONLY
+    # thing allowed to skip the heavy lanes is a diff we can PROVE is
+    # docs-only. `--no-renames` makes a rename appear as delete(old)+add(new)
+    # so a code→`*.md` (or `*.md`→code) rename can never smuggle a non-docs
+    # path past the allow-list. merge_group / push NEVER fast-path (a queue
+    # batch may mix docs + code; a push to `main` must always run the full
+    # matrix) — they emit `docs_only=false` unconditionally.
+    #
+    # Same fork-PR guard as the other jobs; the dependent jobs re-check
+    # head.repo in their own `if:`.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners-ci
     timeout-minutes: 5
     outputs:
       migrations: ${{ steps.detect.outputs.migrations }}
+      docs_only: ${{ steps.detect.outputs.docs_only }}
     steps:
       - name: Checkout
         # fetch-depth: 0 so the PR base commit is present for the
@@ -145,28 +180,55 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - name: Detect migration-related changes
+      - name: Detect migration-related + docs-only changes
         id: detect
         run: |
           set -euo pipefail
+          # Fail-safe defaults: RUN the migration gate, and DO NOT take the
+          # docs-only fast path. Only a positive classification flips either.
+          migrations=true
+          docs_only=false
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "non-PR event (${{ github.event_name }}) -> migrations=true"
-            echo "migrations=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          base="${{ github.event.pull_request.base.sha }}"
-          # Files that make the migration suite meaningful to run: the
-          # alembic tree, the relocated migration test suite, the db
-          # migrate/migrations modules under test, the compat script, and
-          # the workflows that define this gate.
-          changed="$(git diff --name-only "${base}"...HEAD)"
-          if printf '%s\n' "${changed}" | grep -qE '^(backend/alembic/|backend/tests/migrations/|backend/src/meho_backplane/db/(migrations|migrate)\.py$|scripts/ci/check_migration_compat\.py$|\.github/workflows/(ci|migration-compat)\.yml$)'; then
-            echo "migration-related change detected -> migrations=true"
-            echo "migrations=true" >> "$GITHUB_OUTPUT"
+            # push / merge_group: never fast-path; always the full matrix.
+            echo "non-PR event (${{ github.event_name }}) -> migrations=${migrations}, docs_only=${docs_only} (full run)"
+          elif ! changed="$(git diff --name-only --no-renames "${{ github.event.pull_request.base.sha }}...HEAD")"; then
+            # Diff unavailable -> keep fail-safe defaults (full run + migration gate on).
+            echo "git diff failed -> migrations=${migrations}, docs_only=${docs_only} (fail-safe full run)"
+          elif [ -z "${changed}" ]; then
+            # No file changes (e.g. an empty / branch-only PR) -> full run, fail-safe.
+            echo "empty diff -> migrations=${migrations}, docs_only=${docs_only} (fail-safe full run)"
           else
-            echo "no migration-related change -> migrations=false"
-            echo "migrations=false" >> "$GITHUB_OUTPUT"
+            # --- migration classification (#2140, unchanged) ---
+            # Files that make the migration suite meaningful to run: the
+            # alembic tree, the relocated migration test suite, the db
+            # migrate/migrations modules under test, the compat script, and
+            # the workflows that define this gate.
+            if printf '%s\n' "${changed}" | grep -qE '^(backend/alembic/|backend/tests/migrations/|backend/src/meho_backplane/db/(migrations|migrate)\.py$|scripts/ci/check_migration_compat\.py$|\.github/workflows/(ci|migration-compat)\.yml$)'; then
+              migrations=true
+              echo "migration-related change detected -> migrations=true"
+            else
+              migrations=false
+              echo "no migration-related change -> migrations=false"
+            fi
+            # --- docs-only classification (allow-list; #3252) ---
+            # docs-only IFF every changed path matches the allow-list:
+            #   ^docs/   any file under docs/
+            #   \.md$    any Markdown file anywhere (covers CHANGELOG.md,
+            #            README.md, docs/**/*.md, backend/README.md, ...)
+            # `grep -qvE` exits 0 iff SOME line does NOT match the allow-list
+            # — that line is a non-docs path (code / tests / workflows /
+            # configs / cli/ / deploy/ ...) and forces the full run. Only when
+            # grep finds no such line (exit 1) is the diff proven docs-only.
+            if printf '%s\n' "${changed}" | grep -qvE '(^docs/|\.md$)'; then
+              docs_only=false
+              echo "non-docs file(s) present -> docs_only=false (full run)"
+            else
+              docs_only=true
+              echo "all changed files are docs/*.md -> docs_only=true (fast path)"
+            fi
           fi
+          echo "migrations=${migrations}" >> "$GITHUB_OUTPUT"
+          echo "docs_only=${docs_only}" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Required unit lane, sharded (#3251). The pre-#3251 monolithic
@@ -200,8 +262,17 @@ jobs:
     # of it is shardable by test file, none of it needs testcontainers / the
     # vendor spec-shelf / the embedding or spaCy models, and it is CPU-cheap
     # (~1-2 min), so it runs ONCE here on the dense light pool rather than N
-    # times inside every pytest shard. Same fork-PR guard as every other job.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # times inside every pytest shard. Same fork-PR guard as every other job,
+    # plus the #3252 docs-only skip: a proven docs-only PR skips this job (and
+    # the shards) so the required unit-lane fan-in reports success-by-skip.
+    # `needs: changes` makes `docs_only` readable here; if the detect job
+    # fails, this job skip-cascades and the fan-in fails the required context
+    # CLOSED (it asserts `needs.changes.result == 'success'`).
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       needs.changes.outputs.docs_only != 'true')
     runs-on: meho-runners-ci
     # Twice the ~1-2 min observed cost, per the file's per-job cap convention.
     timeout-minutes: 10
@@ -255,8 +326,16 @@ jobs:
     # Fork-PR guard: never execute project code from a fork on the self-hosted
     # runner pool. Same stance as the old lane — job-level so no step ever
     # starts on a fork PR. On a fork PR all three legs skip (→ reported
-    # Success), which the fan-in's own fork guard mirrors.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Success), which the fan-in's own fork guard mirrors. Plus the #3252
+    # docs-only skip (identical shape to python-lint): a proven docs-only PR
+    # skips all three legs → the fan-in reports success-by-skip. `needs:
+    # changes` makes `docs_only` readable; a detect-job failure skip-cascades
+    # these legs and the fan-in fails the required context CLOSED.
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       needs.changes.outputs.docs_only != 'true')
     # Dedicated heavy ARC scale set (6000m requests=limits, max 5 pods) — #761.
     # Three shards fit inside the 5-pod ceiling. Only the pytest sweep is
     # CPU/memory-bound enough to want the extra cores; ruff/mypy stayed on the
@@ -712,32 +791,50 @@ jobs:
     # `python-lint-test` job onto this fan-in (the `python-coverage-combine`
     # shape #3172/#3177 used to keep the downstream contract byte-identical).
     #
-    # It depends on python-lint (ruff + ruff format + mypy) and every
-    # python-unit-shard leg, and PASSES iff all of them passed. Two correctness
-    # properties this shape must have:
+    # It depends on the change-detector (`changes`), python-lint (ruff + ruff
+    # format + mypy), and every python-unit-shard leg, and PASSES iff all of
+    # them passed OR were skipped for a PROVEN docs-only diff. Three
+    # correctness properties this shape must have:
     #
     #  1. NOT fail-open. A required aggregation gate that just `needs:` the
     #     shards would be SKIPPED when a shard fails (GitHub's default
     #     skip-on-needs-failure), and a skipped required check counts as
     #     Success (#2140) — i.e. a red shard would let the PR merge. `always()`
     #     forces this job to RUN regardless of upstream results, and the step
-    #     below inspects `needs.*.result` and FAILS on anything that is not
-    #     `success`/`skipped`. A shard that hangs → its own timeout-minutes →
-    #     `cancelled` leg → aggregate result `cancelled`/`failure` → this gate
-    #     FAILS (not open). Verified reasoning, not luck.
+    #     below inspects `needs.*.result` and FAILS on anything not permitted.
+    #     A shard that hangs → its own timeout-minutes → `cancelled` leg →
+    #     aggregate result `cancelled`/`failure` → this gate FAILS (not open).
+    #     Verified reasoning, not luck.
     #  2. Clean fork-PR + skip behaviour. The fork guard is AND-ed in, so on a
     #     fork PR (and only then) this job — like python-lint / python-unit-
     #     shard — is skipped by its own `if:`, which reports the required
     #     context as Success exactly as the old single job did (#2140). On
     #     same-repo PRs / push / merge_group the guard is true and the gate
     #     evaluates the real results.
+    #  3. Docs-only fast path WITHOUT weakening the code path (#3252). On a
+    #     proven docs-only PR, python-lint + every shard skip via their own
+    #     detect-gated `if:` and the step below must PASS on their `skipped`
+    #     results. But `skipped` must mean pass ONLY because the diff is
+    #     docs-only — never because a needed job was cancelled/failed. So the
+    #     step reads `needs.changes.outputs.docs_only` (available because
+    #     `changes` is in `needs`) and BRANCHES:
+    #       * docs_only == 'true'  → accept success|skipped (fast path).
+    #       * else (full run)      → require STRICT success (a skipped lint /
+    #                                shard here is anomalous — these jobs' only
+    #                                skip paths are fork-PR or docs-only, and we
+    #                                are in neither — so treat it as failure and
+    #                                fail CLOSED). This is STRICTER than the
+    #                                pre-#3252 gate; the fork path is handled by
+    #                                this job's own `if:` skip, not by this step.
+    #     And FIRST: if `changes` did not itself succeed, the docs_only value is
+    #     untrustworthy, so the gate fails CLOSED regardless.
     #
     # Concurrency: the shards, python-lint and this fan-in all share the
     # workflow-level concurrency group, so a PR force-push cancels the whole
     # in-flight run as a SET and a fresh run supersedes it — there is no
     # partial-cancel path that could leave this gate green on stale shards.
     # Light pool: this job does no setup and runs one bash step.
-    needs: [python-lint, python-unit-shard]
+    needs: [changes, python-lint, python-unit-shard]
     if: >-
       always() &&
       (github.event_name != 'pull_request' ||
@@ -749,26 +846,61 @@ jobs:
         # needs.<job>.result is one of success / failure / cancelled / skipped.
         # For the matrix job, needs.python-unit-shard.result is the AGGREGATE:
         # success only if every leg succeeded, otherwise failure/cancelled.
-        # Pass iff both upstreams are success or skipped (skipped == the
-        # fork-PR path, where this job is itself skipped and never runs this
-        # step); anything else FAILS the required gate.
         run: |
+          detect='${{ needs.changes.result }}'
+          docs_only='${{ needs.changes.outputs.docs_only }}'
           lint='${{ needs.python-lint.result }}'
           shards='${{ needs.python-unit-shard.result }}'
+          echo "changes (detect): result=${detect}, docs_only=${docs_only}"
           echo "python-lint (ruff + ruff format + mypy): ${lint}"
           echo "python-unit-shard (aggregate of all 3 stride legs): ${shards}"
+
+          # The detect job MUST have succeeded for its docs_only classification
+          # to be trustworthy. If not (failure / cancelled / an unexpected
+          # skip on a non-fork path), fail the required lane CLOSED — never
+          # infer docs-only from a broken detector. On a fork PR the detect job
+          # IS skipped, but so is THIS job via its own fork-guard `if:`, so this
+          # step never runs there.
+          if [ "${detect}" != "success" ]; then
+            echo "::error title=Python unit lane — detector not green::the change-detector ('changes') result is '${detect}', so the docs-only classification cannot be trusted. Failing the required unit lane closed."
+            exit 1
+          fi
+
           fail=0
-          for r in "${lint}" "${shards}"; do
-            case "${r}" in
-              success|skipped) ;;
-              *) fail=1 ;;
-            esac
-          done
+          if [ "${docs_only}" = "true" ]; then
+            # DOCS-ONLY FAST PATH — python-lint + every shard were skipped by
+            # their detect-gated `if:` (they never ran). Accept `skipped` (the
+            # expected state) or `success` (defensive: if one somehow ran and
+            # passed). Anything else — failure/cancelled — still FAILS closed.
+            for r in "${lint}" "${shards}"; do
+              case "${r}" in
+                success|skipped) ;;
+                *) fail=1 ;;
+              esac
+            done
+          else
+            # FULL RUN — require STRICT success. A `skipped` lint/shard here is
+            # anomalous (no skip-cascade is possible: `changes` succeeded above,
+            # and their only other skip paths are fork-PR / docs-only, neither
+            # of which holds), so treat skipped as a failure and fail CLOSED.
+            for r in "${lint}" "${shards}"; do
+              case "${r}" in
+                success) ;;
+                *) fail=1 ;;
+              esac
+            done
+          fi
+
           if [ "${fail}" -ne 0 ]; then
             echo "::error title=Python unit lane red::ruff / ruff format / mypy or one or more pytest stride shards did not pass. This fan-in carries the branch-protection required context 'Python (ruff + mypy + pytest)'; open the 'Python lint + typecheck (ruff + mypy)' / 'Python unit shard N/3' jobs above for the failing detail."
             exit 1
           fi
-          echo "Unit lane GREEN — ruff + ruff format + mypy + all 3 pytest stride shards passed."
+
+          if [ "${docs_only}" = "true" ]; then
+            echo "Unit lane GREEN (docs-only fast path #3252) — lint + all 3 pytest stride shards skipped-by-detect; nothing to test for a pure docs/*.md diff."
+          else
+            echo "Unit lane GREEN — ruff + ruff format + mypy + all 3 pytest stride shards passed."
+          fi
 
   python-coverage:
     name: Python coverage (SonarCloud, shard ${{ matrix.shard }}/3)
@@ -1253,7 +1385,24 @@ jobs:
     # 60-min cap: container pulls + DinD spin-up + the serial
     # integration sweep. pytest-xdist loadgroup parallelization to
     # bring this well under cap is tracked in #564.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    #
+    # #3252 docs-only skip — SAME shape as the python-migration-tests gate
+    # below (plain `needs: changes` + an `if:` that ANDs in the detect
+    # output), deliberately NOT `always()`: this is a HEAVY 60-min lane, so
+    # keeping cancel-in-progress (a force-push must cancel it) matters more
+    # than the marginal robustness `always()` would add. The residual — if the
+    # detect job hard-CRASHES, `needs: changes` skip-cascades this job to
+    # `skipped`/Success — is identical to (and no worse than) the pre-existing
+    # migration gate's exposure, and is mitigated by the detect step being
+    # written to never exit non-zero on the classification path (it defaults
+    # `docs_only=false` on any diff error). The CLASSIFIER itself is fail-safe:
+    # only a proven-docs-only diff sets `docs_only=true`, so a code PR is never
+    # skipped here.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       needs.changes.outputs.docs_only != 'true')
+    needs: changes
     runs-on: meho-runners-ci
     timeout-minutes: 60
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,33 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — docs-only CI fast path (#3252)
+
+- A PR whose diff is **purely documentation** — every changed path under
+  `docs/` or ending in `.md` (README, CHANGELOG, guides) — now skips the two
+  heavy Python lanes (`Python (ruff + mypy + pytest)` ~19 min and
+  `Python (integration testcontainers)` ~17 min) and finishes CI in minutes
+  instead of paying the ~25-min tax for zero signal. The `changes` detector in
+  `ci.yml` classifies the diff and the heavy jobs (`python-lint`, the three
+  `python-unit-shard` legs, `python-integration`) skip via their own
+  job-level `if:` — a job skipped by `if:` reports **Success** and satisfies
+  branch protection (#2140), unlike an `on.paths` filter which would leave a
+  required check **Pending** and block merge.
+- **Branch protection is untouched and the fast path fails CLOSED.** The
+  classifier is an allow-list: `docs_only` is `true` only when *every* changed
+  path is proven docs — any code / test / workflow / config / `cli/` /
+  `deploy/` path, an unresolvable diff, a rename (classified with
+  `--no-renames` so the old path is also checked), or any `merge_group` /
+  `push` event forces the **full** matrix. The required
+  `Python (ruff + mypy + pytest)` fan-in still runs and reports; its
+  result-inspection accepts the detect-driven skips **only** when
+  `docs_only=true` and requires strict success otherwise, and it fails closed
+  if the detector itself did not succeed — so a broken or misfiring detector
+  can never let an untested code change land green.
+- The cheap lanes (`Go`, `Helm`) and the Semgrep / TruffleHog / license /
+  DCO checks keep running on docs-only PRs unchanged — they are already fast,
+  and docs can still leak a secret.
+
 ### Changed — merge-queue readiness: every required check now reports on `merge_group` refs (#3253)
 
 - `chart.yml` — the last required-check workflow without a `merge_group`

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -946,7 +946,7 @@ workflow files, this doc, and the changelog.
 | --- | --- | --- |
 | `python-lint` (`Python lint + typecheck (ruff + mypy)`) | `backend/src/` + `backend/tests/` | `uv sync --locked --all-groups` -> `ruff check` -> `ruff format --check` -> `mypy --strict`. Non-required; whole-tree, unshardable-by-file, runs once on the light pool (#3251). |
 | `python-unit-shard` (`Python unit shard N/3`) | `backend/` unit + acceptance subtree, split 3 ways | `pytest -n 3 --dist loadscope --maxfail=1` over a deterministic file-stride slice (excludes `tests/integration/` and `tests/migrations/`; `-n 3` per shard for CPU/memory headroom — see [runner-CPU rule](#runner-cpu-rule)). Non-required matrix (#3251). |
-| `python-unit-lane` (`Python (ruff + mypy + pytest)`) | fan-in | `needs: [python-lint, python-unit-shard]`; **required check** — fails iff lint or any shard failed. Carries the exact branch-protection required context so the ruleset is untouched (#3251). |
+| `python-unit-lane` (`Python (ruff + mypy + pytest)`) | fan-in | `needs: [changes, python-lint, python-unit-shard]`; **required check** — fails iff lint or any shard failed (or the detector is not green). Carries the exact branch-protection required context so the ruleset is untouched (#3251); reports success-by-skip on a docs-only diff (#3252). |
 | `python-integration` (`Python (integration testcontainers)`) | `backend/tests/integration/` | `uv sync --locked --all-groups` -> `pytest tests/integration/` against pgvector / valkey / k3d / vcsim / vault testcontainers via DinD. **Required merge gate (#698)** so the lane that exercises real connector dispatch can no longer ship red. |
 | `go-lint-test` (`Go (golangci-lint + go test)`) | `cli/` | `golangci-lint` (v6 action) -> `go build ./...` -> `go test -race -cover ./...` |
 | `helm-lint-template` (`Helm (lint + template + kubeconform)`) | `deploy/charts/meho/` | `helm lint` -> `helm template` -> `kubeconform --strict --kubernetes-version 1.28.0` |
@@ -1000,15 +1000,21 @@ shape (deterministic file-stride matrix + fan-in):
   canary opt-out (#2980) are preserved on **every** shard.
 - **`python-unit-lane`** — the **fan-in** carrying the exact
   branch-protection required context `Python (ruff + mypy + pytest)`. It
-  `needs: [python-lint, python-unit-shard]` and, via `if: always() && <fork
-  guard>`, runs regardless of upstream results, then FAILS unless both are
-  `success`/`skipped`. `always()` is load-bearing: a plain `needs:` gate
-  would be *skipped* when a shard fails, and a skipped required check
-  counts as Success (#2140) — i.e. a red shard would let the PR merge. A
-  hung shard hits its own `timeout-minutes` → `cancelled` leg → aggregate
+  `needs: [changes, python-lint, python-unit-shard]` and, via `if: always()
+  && <fork guard>`, runs regardless of upstream results, then inspects
+  `needs.*.result`. `always()` is load-bearing: a plain `needs:` gate would
+  be *skipped* when a shard fails, and a skipped required check counts as
+  Success (#2140) — i.e. a red shard would let the PR merge. A hung shard
+  hits its own `timeout-minutes` → `cancelled` leg → aggregate
   `cancelled`/`failure` → the gate FAILS (not open). On a fork PR the fork
   guard skips this job (and the shards), reporting the required context as
-  Success exactly as the old single job did.
+  Success exactly as the old single job did. Since #3252 the step first
+  fails CLOSED if the `changes` detector did not itself succeed, then
+  branches on `needs.changes.outputs.docs_only`: on the **docs-only fast
+  path** it accepts the detect-driven `skipped` lint/shards as pass; on a
+  **full run** it requires strict `success` (a `skipped` lint/shard there is
+  anomalous and fails the gate). See [Docs-only fast path
+  (#3252)](#docs-only-fast-path-3252).
 
 Because the required context string is unchanged and stays on a job, the
 **branch-protection ruleset and merge-queue required-check list need no
@@ -1018,6 +1024,50 @@ byte-identical). No escape-hatch label (the coverage lane's
 `ci-coverage-validate`) is needed: the coverage lane is push-only and must
 be *forced* onto a PR, whereas the unit lane runs on every PR by default,
 so a sharding PR self-validates through its own `pull_request` run.
+
+### Docs-only fast path (#3252)
+
+A PR whose diff is **purely documentation** cannot affect the Python
+toolchain, yet it used to pay the full ~25-min tax of both heavy Python
+lanes. The `changes` detector now classifies the diff and the heavy jobs
+skip via their own `if:`, so a changelog roll / guide edit / README fix
+completes CI in minutes.
+
+- **Classification (allow-list, fail-closed).** In the `changes` job,
+  `docs_only` starts `false` and flips to `true` **only** when *every*
+  changed path matches the allow-list `^docs/` (any file under `docs/`) **or**
+  `\.md$` (any Markdown file anywhere). Anything else — a `.py`, a workflow, a
+  config, a `cli/` or `deploy/` file — sets `docs_only=false` and forces the
+  full matrix. The diff is taken with `git diff --name-only --no-renames
+  <base>...HEAD`: `--no-renames` makes a rename appear as delete(old) +
+  add(new) so a code→`*.md` (or `*.md`→code) rename can never smuggle a
+  non-docs path past the allow-list. The step is written to always exit `0`
+  and emit both outputs — an unresolvable diff or an empty diff keeps the
+  fail-safe defaults (`docs_only=false`). `merge_group` and `push` NEVER
+  fast-path (a queue batch may mix docs + code; a `main` push must always run
+  the full matrix).
+- **What skips.** `python-lint`, the three `python-unit-shard` legs, and
+  `python-integration` gain `needs: changes` and an `if:` that skips them when
+  `docs_only == 'true'` (same #2140 shape as the `python-migration-tests`
+  gate). A job skipped by its own `if:` reports **Success**, so the required
+  contexts `Python (ruff + mypy + pytest)` (via the fan-in) and
+  `Python (integration testcontainers)` stay green without running.
+- **What still runs.** `go-lint-test`, `helm-lint-template`, and the sibling
+  workflows' required contexts (`Semgrep SAST`, `TruffleHog Secret Scan`,
+  `Python License Check`, `NPM License Check`, `helm install + helm test`,
+  `DCO`) are untouched — already fast, and docs can still leak a secret.
+- **Why it cannot skip for code.** A required check that skipped on a *code*
+  diff would let an untested change land green. Two independent guards prevent
+  it: (1) the classifier is fail-safe, so a code path is never proven
+  docs-only; (2) if the detector itself does not succeed, the
+  `python-unit-lane` fan-in fails **CLOSED** (it asserts
+  `needs.changes.result == 'success'` before trusting `docs_only`), which
+  blocks a code PR even though `python-integration` would skip-cascade to
+  green off the failed `needs`. The integration lane deliberately stays on the
+  plain `needs:`+`if:` shape (no `always()`) to preserve cancel-in-progress on
+  the heavy 60-min lane; its detect-crash exposure is identical to the
+  pre-existing migration gate and is neutralised for code PRs by the unit
+  lane's fail-closed guard above.
 
 ### Runner-CPU rule
 


### PR DESCRIPTION
Closes #3252.

## What

A PR whose diff is **purely documentation** (every changed path under `docs/` or ending in `.md`) now skips the two heavy Python lanes and finishes CI in minutes instead of paying the ~25-min tax for zero signal. Changelog rolls, guide edits, and README fixes stop paying the full Python bill.

The existing `changes` change-detector is extended to also emit `docs_only`. `python-lint`, the three `python-unit-shard` legs, and `python-integration` gain `needs: changes` + a job-level `if:` that skips them when `docs_only == 'true'` — the exact #2140 shape the `python-migration-tests` gate already uses (skipped-by-`if:` == **Success**, unlike an `on.paths` filter which would leave a required check **Pending** and hang the PR). The `Python (ruff + mypy + pytest)` fan-in was reworked to stay required-and-reporting while treating the detect-driven skips as pass **only** for a proven docs-only diff.

## Fails CLOSED (the load-bearing property)

- The classifier is an **allow-list**: `docs_only` defaults `false` and flips `true` only when *every* changed path is proven docs. Any code / test / workflow / config / `cli/` / `deploy/` path, an unresolvable/empty diff, or a rename forces the **full** matrix.
- The diff uses `git diff --name-only --no-renames <base>...HEAD` so a code→`*.md` (or `*.md`→code) rename surfaces the old path and cannot smuggle a non-docs change past the allow-list. `git diff` (not the 300-capped GitHub files API) means no pagination fail-open.
- `merge_group` and `push` **never** fast-path (`docs_only=false` unconditionally) — a queue batch may mix docs + code, and a `main` push must always run the full matrix. This keeps #3269's "all required contexts report on `merge_group`" invariant intact.
- Even if the detect **job** hard-crashes, the fan-in fails **CLOSED** (it asserts `needs.changes.result == 'success'` before trusting `docs_only`), which blocks any code PR regardless of integration's skip-cascade off the failed `needs`.

Validated under **GNU grep 3.11** (the CI runners' grep) across 17+ adversarial classifier cases including the code→`.md` rename, delete-only code, `foo.md.py`, uppercase `.MD`, a root file named `docs`, and workflow/config/lock files — all correctly → full run.

## Per-context decision table (docs-only PR)

| Required context | Job / workflow | Docs-only behavior |
|---|---|---|
| `Python (ruff + mypy + pytest)` | `python-unit-lane` fan-in | **Runs, reports Success** — reads `docs_only`, accepts detect-driven skips |
| `Python (integration testcontainers)` | `python-integration` | **Success-by-skip** (`if: docs_only!='true'`) |
| `Python (database migrations)` | `python-migration-tests` | Success-by-skip (already; `migrations=false`) — unchanged |
| `Go (golangci-lint + go test)` | `go-lint-test` | **Runs** (real green) — untouched |
| `Helm (lint + template + kubeconform)` | `helm-lint-template` | **Runs** (real green) — untouched |
| `Semgrep SAST` | security-scan.yml | Runs — untouched (docs can leak secrets) |
| `TruffleHog Secret Scan` | secret-scan.yml | Runs — untouched |
| `Python License Check` / `NPM License Check` | dependency-license-check.yml | Success-by-skip via its own `changes` gate — pre-existing, unaffected |
| `helm install + helm test (pgvector preflight)` | chart.yml | Success-by-skip via chart.yml's own gate — untouched (#3253) |
| `DCO` | DCO app | Runs — untouched |

Non-required helper jobs skipped on docs-only: `python-lint`, `python-unit-shard×3`. `cli-api-snapshot-freshness` (NOT required) is kept running — it is not the wall-time bottleneck and reports real green.

## Fan-in result-matrix (`python-unit-lane`)

Same-repo events. On a fork PR the fan-in is itself `if`-skipped → Success, and the step never runs.

| changes.result | docs_only | lint | shards (agg) | Gate |
|---|---|---|---|---|
| success | false | success | success | **PASS** (normal code PR) |
| success | false | success | failure | **FAIL** (red shard blocks) |
| success | false | success | cancelled | **FAIL** (hung shard → timeout blocks) |
| success | false | failure | success | **FAIL** (red lint blocks) |
| success | false | success | **skipped** | **FAIL** (anomalous skip on full run → closed) |
| success | **true** | skipped | skipped | **PASS** (docs-only fast path) |
| success | true | success | skipped | **PASS** (defensive) |
| success | true | skipped | **failure** | **FAIL** (closed) |
| failure / cancelled | any | * | * | **FAIL** (detector-not-green guard) |

The full-run path now requires **strict** success (stricter than pre-#3252, which accepted `skipped` for a now-removed dead fork branch); the fork path is handled by this job's own `if:` skip. No masking of a genuine shard failure.

## Conformance note (`< 5 min`)

Argued on paper: **this PR changes workflow files, so it is NOT docs-only and rides the full lane.** On a docs-only diff the two ~17-19-min Python lanes are eliminated, leaving Go (long pole ~3-5 min), Helm, Semgrep, TruffleHog, and the detector + fan-in — all running in parallel under 5 min. The live `< 5 min` proof needs a **follow-up docs-only PR** (e.g. a changelog/README-only change) or stands on the wall-time argument above.

## Scope

Workflow + docs + CHANGELOG only. Branch protection and the merge-queue required-check list need **no edit** — every required-context string is unchanged. `chart.yml` untouched (no collision with #3253/#3269). actionlint clean (zero new findings); YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
