### PR TITLE
feat(connectors): vault-1.x — per-target Vault role resolution (#3274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,33 @@ connector-related release-notes line.
   blast-radius block, the fail-closed refusal paths, and the full
   preview → parked approval (hash + blast radius) → **distinct human**
   approve → audited resume flow deleting exactly one record.
+
+### Added — vault-1.x: per-target Vault role resolution (#3274)
+
+- The `vault` connector now resolves its **JWT role per target**, so a governed
+  teardown's `vault.kv.delete` can dispatch under a **dedicated, narrow role**
+  instead of the shared read-only `meho-mcp` identity — closing the
+  credential-retirement ACL gap without widening `meho-mcp`. A vault `Target`
+  carries the role (and, optionally, the JWT auth mount) in its `extras`:
+  `extras["vault_role"]` selects the login role, `extras["vault_mount"]` the
+  auth-method mount. Both ride the existing JSON column — no migration, no new
+  schema field, no CLI-surface change. The Vault **address** stays global.
+- **Backward-compatible + fail-closed.** A target naming no role (and every
+  non-vault caller) keeps the settings-global role byte-for-byte; a resolved
+  role Vault denies surfaces `VaultRoleDeniedError` with no silent fallback to
+  `meho-mcp` (mirroring the #2757 rule). Selection precedence is per-target
+  override → check-runner role (#2757) → deployment-global `vault_oidc_role`.
+  The park-time write-capability preflight runs under the resolved role too, so
+  the approval banner reflects the role that will execute.
+- Threaded through the KV (`ops.py`) and auth (`ops_auth.py`,
+  `ops_auth_write.py`) handler groups via a single `target_auth.py`
+  resolver (`resolve_vault_target_auth` / `vault_client_for_target`);
+  `vault_client_for_operator` gains keyword-only `role` / `mount_path`
+  overrides. The live `rdc-vault-teardown` target ships `version=null` and
+  resolves via the connector's wildcard registration. Consumer-side
+  provisioning is documented in `docs/cross-repo/vault-provisioning.md` §8;
+  lab-verified in `claude-rdc-hetzner-dc#2814` (PR `#2815`).
+
 ### Added — satellite write path: per-runner capability allowlist (#3190)
 
 - Mechanism 2 of the composed write-tier gate: a per-runner-principal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,22 @@ connector-related release-notes line.
   provisioning is documented in `docs/cross-repo/vault-provisioning.md` §8;
   lab-verified in `claude-rdc-hetzner-dc#2814` (PR `#2815`).
 
+### Fixed — vault-1.x: park-time capability preflight probes the KV-v2 `delete/` path for `vault.kv.delete` (#3274)
+
+- The park-time write-capability preflight probed `sys/capabilities-self` on
+  `<mount>/data/<path>` for **every** KV write — but a version soft-delete
+  (`delete_secret_versions`) `POST`s to `<mount>/delete/<path>` and Vault
+  authorizes it with `update` on that **delete** path, not the data path. The
+  preflight therefore gave a false `will_be_denied` verdict for
+  `vault.kv.delete` — the exact "wasted approval" failure the preflight
+  (#1504) exists to prevent. `vault_kv_write_target_path` is now op-aware:
+  `vault.kv.delete` renders the `delete/` path, `put`/`patch` keep the `data/`
+  path. The same error is corrected in
+  `docs/cross-repo/connector-vault-policy.md` §6.1 — the `meho-mcp` write
+  policy needs an `update` grant on `secret/delete/…` (a second stanza), not
+  just `secret/data/…`, to authorize a soft-delete. Found during the #3274
+  lab verification (`claude-rdc-hetzner-dc#2814`).
+
 ### Added — satellite write path: per-runner capability allowlist (#3190)
 
 - Mechanism 2 of the composed write-tier gate: a per-runner-principal

--- a/backend/src/meho_backplane/auth/vault.py
+++ b/backend/src/meho_backplane/auth/vault.py
@@ -222,8 +222,35 @@ async def _to_thread_read_health(client: hvac.Client) -> Any:
     return await asyncio.to_thread(_do_read_health, client)
 
 
+def _resolve_login_role(operator: Operator, settings: Settings, override: str | None) -> str:
+    """Select the Vault JWT role for a login. Precedence (highest first):
+
+    1. an explicit *override* — the per-target role the vault connector
+       resolved off the dispatch ``Target``'s ``extras["vault_role"]``
+       (#3274), so a governed teardown's ``vault.kv.delete`` logs in under a
+       dedicated narrow role instead of the shared ``meho-mcp`` identity;
+    2. the check-runner's dedicated ``vault_check_runner_role`` (#2757),
+       selected only for the synthetic background-dispatch operator;
+    3. the deployment-global ``vault_oidc_role`` — today's default.
+
+    No fallback on denial: the caller surfaces :class:`VaultRoleDeniedError`
+    rather than silently widening back to ``vault_oidc_role`` (the #2757 rule,
+    extended to the per-target role).
+    """
+    if override is not None:
+        return override
+    if operator.check_runner_dispatch:
+        return settings.vault_check_runner_role or settings.vault_oidc_role
+    return settings.vault_oidc_role
+
+
 @asynccontextmanager
-async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Client]:
+async def vault_client_for_operator(
+    operator: Operator,
+    *,
+    role: str | None = None,
+    mount_path: str | None = None,
+) -> AsyncIterator[hvac.Client]:
     """Yield an authenticated :class:`hvac.Client` bound to *operator*.
 
     Performs the JWT/OIDC login on every entry — v0.1 has no per-operator
@@ -232,6 +259,29 @@ async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Cl
     token on exit, capping the token's lifetime at one request even
     when Vault's role TTL is generous.
 
+    Parameters
+    ----------
+    role:
+        Explicit Vault JWT role override. When ``None`` (the default) the
+        role is resolved from settings — the ``vault_check_runner_role``
+        dedicated role for the check-runner's synthetic dispatch operator
+        (#2757), the deployment-global ``vault_oidc_role`` otherwise. When
+        a caller passes a non-``None`` value it wins over both — this is
+        the per-target role the vault connector resolves off the dispatch
+        ``Target``'s ``extras["vault_role"]`` (#3274), so a governed
+        teardown's ``vault.kv.delete`` logs in under a dedicated narrow
+        role instead of the shared ``meho-mcp`` identity. This module is
+        connector-agnostic: it only *applies* the role, it does not read
+        the ``Target`` (:mod:`meho_backplane.connectors.vault.target_auth`
+        owns that).
+    mount_path:
+        Explicit JWT auth-method mount-path override. ``None`` (the
+        default) keeps the deployment-global ``vault_oidc_mount_path``; a
+        non-``None`` value (the target's ``extras["vault_mount"]``, #3274)
+        logs in against a non-default auth mount. The Vault *address*
+        stays global — there is one Vault — so only the role + auth mount
+        are ever per-target.
+
     Raises
     ------
     VaultUnreachableError:
@@ -239,7 +289,9 @@ async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Cl
         translate this into a 503 from any HTTP route that needed Vault.
     VaultRoleDeniedError:
         Vault returned 403 — JWT valid but role bindings did not match
-        or the role is missing.
+        or the role is missing. A denied *override* role fails closed here
+        with no fallback to ``vault_oidc_role`` (#3274, mirroring the
+        #2757 no-silent-widen rule).
     VaultClientError:
         Any other Vault-side failure (4xx / 5xx that isn't 403, sealed
         Vault, malformed response, etc.).
@@ -247,24 +299,19 @@ async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Cl
     settings = get_settings()
     client = _build_client(settings)
 
-    # #2757 -- only the check-runner's synthetic dispatch operator
-    # (``check_runner_dispatch``) uses the dedicated ``vault_check_runner_role``
-    # when set; every other operator, and the unset case, keeps
-    # ``vault_oidc_role`` byte-for-byte. No fallback on denial: a refused
-    # dedicated-role login surfaces ``VaultRoleDeniedError`` (Sensor ->
-    # ``unknown``), never a silent widen back to the wide role.
-    role = (
-        (settings.vault_check_runner_role or settings.vault_oidc_role)
-        if operator.check_runner_dispatch
-        else settings.vault_oidc_role
-    )
+    resolved_role = _resolve_login_role(operator, settings, role)
+    # The JWT auth-method mount path is likewise per-target overridable
+    # (``extras["vault_mount"]``, #3274) for a role that lives on a non-default
+    # auth mount; absent, the deployment-global ``vault_oidc_mount_path``
+    # stands. The Vault *address* stays global — there is one Vault.
+    resolved_mount_path = mount_path if mount_path is not None else settings.vault_oidc_mount_path
 
     try:
         await _to_thread_jwt_login(
             client,
-            role=role,
+            role=resolved_role,
             jwt=operator.raw_jwt,
-            mount_path=settings.vault_oidc_mount_path,
+            mount_path=resolved_mount_path,
         )
     except VaultClientError:
         # Already a backplane error — propagate verbatim. (Caught by the

--- a/backend/src/meho_backplane/connectors/vault/connector.py
+++ b/backend/src/meho_backplane/connectors/vault/connector.py
@@ -20,12 +20,21 @@ exit (behaviour inherited from
 Target contract (G0.3 #224, operator-aware dispatch G0.8-T3 #629):
 
 The connector is typed against the real
-:class:`~meho_backplane.targets.schemas.Target`. It reads Vault
-connection parameters (address, role, mount path, namespace, timeout)
-from :func:`~meho_backplane.settings.get_settings`, not from the
-target, because those are deployment-level settings, not per-operator
-overrides — so ``probe``/``fingerprint`` accept ``Target | None`` and
-ignore the value entirely. The operator's bearer token is **not** on
+:class:`~meho_backplane.targets.schemas.Target`. It reads Vault's
+**address**, namespace, and timeout from
+:func:`~meho_backplane.settings.get_settings` — there is one Vault, so
+those stay deployment-global. The JWT **role** and the JWT auth-method
+**mount path** are per-target as of #3274: a dispatch ``Target``
+advertising ``extras["vault_role"]`` (and optionally
+``extras["vault_mount"]``) logs in under that dedicated role, so a
+governed teardown's ``vault.kv.delete`` runs under a narrow role
+(``meho-teardown``) instead of the shared ``meho-mcp`` identity; a
+target naming neither key keeps today's settings-global role byte-for-
+byte. The KV/auth handlers resolve this off the threaded ``Target`` via
+:func:`~meho_backplane.connectors.vault.target_auth.vault_client_for_target`.
+``probe``/``fingerprint`` still accept ``Target | None`` and ignore the
+value entirely — ``/sys/health`` is unauthenticated, so no role
+applies. The operator's bearer token is **not** on
 the persisted ``Target`` row (a per-request token must not be
 persisted on a shared target); typed KV/auth/sys handlers read it from
 the request-scoped :class:`~meho_backplane.auth.operator.Operator` the

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -934,17 +934,18 @@ async def vault_kv_delete(
 # Park-time write-capability preflight (G0.20-T4 #1504)
 # ---------------------------------------------------------------------------
 
-#: Vault ACL capabilities each KV-v2 write op needs on its target
-#: ``<mount>/data/<path>``, keyed by op-id. ``put`` / ``patch`` create
-#: a new secret version (``create`` for a first write, ``update`` for a
-#: subsequent one — Vault requires *both* on the path for an
-#: unconditional write); ``delete`` soft-deletes versions via
-#: ``POST <mount>/delete/<path>``, which Vault authorizes with ``update``
-#: on the *data* path (the canonical KV-v2 write capability). The doc
-#: stanza in ``docs/cross-repo/connector-vault-policy.md`` §6 grants
-#: exactly ``["create", "update"]`` on the templated write path, which
-#: satisfies every op here. A token "passes" the preflight when its
-#: capabilities on the data path are a superset of the op's requirement.
+#: Vault ACL capabilities each KV-v2 write op needs on the path it
+#: authorizes against (rendered per-op by :func:`vault_kv_write_target_path`),
+#: keyed by op-id. ``put`` / ``patch`` create a new secret version
+#: (``create`` for a first write, ``update`` for a subsequent one — Vault
+#: requires *both* on ``<mount>/data/<path>`` for an unconditional write);
+#: ``delete`` soft-deletes versions via ``POST <mount>/delete/<path>``, which
+#: Vault authorizes with ``update`` on that **delete** path — not the data
+#: path (#3274). The write policy stanza in
+#: ``docs/cross-repo/connector-vault-policy.md`` §6.1 therefore grants
+#: ``create``/``update`` on ``secret/data/…`` **and** ``update`` on
+#: ``secret/delete/…`` to cover every op here. A token "passes" the preflight
+#: when its capabilities on that path are a superset of the op's requirement.
 VAULT_KV_WRITE_CAPABILITIES: dict[str, frozenset[str]] = {
     "vault.kv.put": frozenset({"create", "update"}),
     "vault.kv.patch": frozenset({"create", "update"}),
@@ -952,14 +953,25 @@ VAULT_KV_WRITE_CAPABILITIES: dict[str, frozenset[str]] = {
 }
 
 
-def vault_kv_write_target_path(params: dict[str, Any]) -> str:
-    """Render the ``<mount>/data/<path>`` a KV-v2 write op authorizes against.
+def vault_kv_write_target_path(op_id: str, params: dict[str, Any]) -> str:
+    """Render the Vault path a KV-v2 write op authorizes against.
 
-    KV-v2 splits the API surface: the value lives under ``<mount>/data/``
-    and Vault authorizes a write (``put`` / ``patch`` / version
-    soft-delete) against that data path. The preflight queries
-    ``sys/capabilities-self`` on this exact string so the answer matches
-    what the real write would be authorized against.
+    KV-v2 splits its API surface by operation, and Vault authorizes each
+    against a *different* path prefix:
+
+    * ``vault.kv.put`` / ``vault.kv.patch`` write the value under
+      ``<mount>/data/<path>`` (``create`` / ``update`` there).
+    * ``vault.kv.delete`` soft-deletes versions via ``POST
+      <mount>/delete/<path>`` (hvac's ``delete_secret_versions``), which
+      Vault authorizes with ``update`` on that **delete** path — NOT the
+      data path (#3274, lab-verified in claude-rdc-hetzner-dc#2814).
+
+    The preflight probes ``sys/capabilities-self`` on this exact string, so
+    it must match the path the real op authorizes against: ``vault.kv.delete``
+    renders ``<mount>/delete/<path>`` and every other write renders
+    ``<mount>/data/<path>``. Probing the data path for a delete gave a false
+    ``will_be_denied`` signal — the very "wasted approval" failure the
+    preflight (#1504) exists to prevent.
 
     Mirrors the ``mount`` / ``path`` defaulting + ``.strip()`` the write
     handlers apply (default mount ``"secret"``; ``path`` is the location
@@ -970,7 +982,10 @@ def vault_kv_write_target_path(params: dict[str, Any]) -> str:
     """
     mount = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path = str(params["path"]).strip().lstrip("/")
-    return f"{mount}/data/{path}"
+    # Version soft-delete (POST <mount>/delete/<path>) authorizes on the
+    # delete/ path; put/patch (POST <mount>/data/<path>) on the data path.
+    segment = "delete" if op_id == "vault.kv.delete" else "data"
+    return f"{mount}/{segment}/{path}"
 
 
 def _capabilities_grant_write(granted: list[str], required: frozenset[str]) -> bool:
@@ -1034,20 +1049,22 @@ async def vault_kv_write_capability_preflight(
     block the park, exactly as the ``proposed_effect`` builder hook
     degrades. On success returns a redaction-safe summary:
 
-    ``{"check": "vault.capabilities-self", "path": <data-path>,
+    ``{"check": "vault.capabilities-self", "path": <auth-path>,
     "required": [...], "granted": [...], "will_be_denied": bool,
-    "principal_sub": <dispatching-operator-sub>}``.
+    "principal_sub": <dispatching-operator-sub>}`` — where ``<auth-path>``
+    is ``<mount>/delete/<path>`` for ``vault.kv.delete`` and
+    ``<mount>/data/<path>`` for ``put`` / ``patch`` (#3274).
     """
     required = VAULT_KV_WRITE_CAPABILITIES.get(op_id)
     if required is None:
         return None
 
-    data_path = vault_kv_write_target_path(params)
+    auth_path = vault_kv_write_target_path(op_id, params)
     try:
         async with vault_client_for_target(operator, target) as client:
             response = await asyncio.to_thread(
                 client.sys.get_capabilities,
-                paths=[data_path],
+                paths=[auth_path],
             )
     except Exception:
         # Fail-soft: the park is the safety-relevant action; a probe that
@@ -1059,7 +1076,7 @@ async def vault_kv_write_capability_preflight(
         _structlog.get_logger(__name__).warning(
             "vault_capability_preflight_failed",
             op_id=op_id,
-            path=data_path,
+            path=auth_path,
             operator_sub=operator.sub,
             exc_info=True,
         )
@@ -1068,7 +1085,7 @@ async def vault_kv_write_capability_preflight(
     # ``sys/capabilities-self`` returns the per-path capability list under
     # the path key, with a top-level ``capabilities`` mirror for a single
     # path. Prefer the path key; fall back to the mirror.
-    granted_raw = response.get(data_path)
+    granted_raw = response.get(auth_path)
     if granted_raw is None:
         granted_raw = response.get("capabilities")
     granted = [str(c) for c in granted_raw] if isinstance(granted_raw, list) else []
@@ -1076,7 +1093,7 @@ async def vault_kv_write_capability_preflight(
     will_be_denied = not _capabilities_grant_write(granted, required)
     return {
         "check": "vault.capabilities-self",
-        "path": data_path,
+        "path": auth_path,
         "required": sorted(required),
         "granted": sorted(granted),
         "will_be_denied": will_be_denied,

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -55,12 +55,16 @@ subclasses to "login phase"; everything else is "read phase". The
 :mod:`meho_backplane.api.v1.health` route does exactly this mapping for
 the federation-proof endpoint.
 
-The ``_auth_vault`` module reference is used throughout so that the
-test seam (``monkeypatch.setattr(vault_module, "_build_client", fake)``
-and ``monkeypatch.setattr(vault_module, "vault_client_for_operator",
-fake)``) applies transparently. Binding the helpers by name (``from ...
-import _build_client``) would break the monkeypatch because the local
-name would still point at the original object.
+The handlers open their Vault client through
+:func:`~meho_backplane.connectors.vault.target_auth.vault_client_for_target`,
+which resolves the per-target role + auth mount (#3274) and forwards them
+to ``vault_client_for_operator`` **through the ``_auth_vault`` module
+reference**, so the test seam
+(``monkeypatch.setattr(vault_module, "_build_client", fake)`` /
+``monkeypatch.setattr(vault_module, "vault_client_for_operator", fake)``)
+still applies transparently across that one extra hop. Binding a helper
+by name (``from ... import _build_client``) would break the monkeypatch
+because the local name would still point at the original object.
 """
 
 from __future__ import annotations
@@ -68,10 +72,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vault.ops_auth import register_vault_auth_operations
 from meho_backplane.connectors.vault.ops_auth_write import register_vault_auth_write_operations
+from meho_backplane.connectors.vault.target_auth import vault_client_for_target
 from meho_backplane.connectors.vault.tenant_scope import enforce_tenant_scope
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
@@ -374,7 +378,7 @@ async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any])
     # vault_client_for_operator is accessed via the module reference so
     # test monkeypatches on vault_module._build_client propagate through
     # the call chain. It reads operator.raw_jwt for the JWT/OIDC login.
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         secret_payload = await asyncio.to_thread(
             client.secrets.kv.v2.read_secret_version,
             path=path,
@@ -471,7 +475,7 @@ async def vault_kv_list(operator: Operator, target: Any, params: dict[str, Any])
     # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         list_payload = await asyncio.to_thread(
             client.secrets.kv.v2.list_secrets,
             path=path,
@@ -579,7 +583,7 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
     # platform-path allow-list does NOT apply (read-only only, #1725 M1).
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         write_payload = await asyncio.to_thread(
             client.secrets.kv.v2.create_or_update_secret,
             path=path,
@@ -743,7 +747,7 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     # platform-path allow-list does NOT apply (read-only only, #1725 M1).
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         patch_payload = await asyncio.to_thread(
             client.secrets.kv.v2.patch,
             path=path,
@@ -820,7 +824,7 @@ async def vault_kv_versions(
     # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         meta_payload = await asyncio.to_thread(
             client.secrets.kv.v2.read_secret_metadata,
             path=path,
@@ -916,7 +920,7 @@ async def vault_kv_delete(
     # platform-path allow-list does NOT apply (read-only only, #1725 M1).
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         await asyncio.to_thread(
             client.secrets.kv.v2.delete_secret_versions,
             path=path,
@@ -991,6 +995,7 @@ async def vault_kv_write_capability_preflight(
     operator: Operator,
     op_id: str,
     params: dict[str, Any],
+    target: Any = None,
 ) -> dict[str, Any] | None:
     """Check, via ``sys/capabilities-self``, whether a KV-v2 write will be denied.
 
@@ -1000,15 +1005,18 @@ async def vault_kv_write_capability_preflight(
     denied" on the approval row instead of failing only *after* a human
     has spent a four-eyes review approving it.
 
-    The probe logs in exactly as the real write does
-    (:func:`~meho_backplane.auth.vault.vault_client_for_operator`, the
-    ``meho-mcp`` OIDC role) and issues ``POST sys/capabilities-self`` on
-    the op's ``<mount>/data/<path>``. ``sys/capabilities-self`` returns
-    only the *capability names* the calling token holds on the path
-    (``["create", "update"]`` / ``["read"]`` / ``["deny"]``) — **never
-    any secret material** — so it sidesteps the credential-class
-    preview-suppression rule that bars a value-revealing dry-run for a
-    credential write.
+    The probe logs in exactly as the real write does — via
+    :func:`~meho_backplane.connectors.vault.target_auth.vault_client_for_target`,
+    under the same per-target role the write will use (#3274: the
+    dispatch ``target``'s ``extras["vault_role"]``, or the settings-global
+    ``meho-mcp`` role when the target names none) — and issues ``POST
+    sys/capabilities-self`` on the op's authorization path so the
+    ``will_be_denied`` banner reflects the exact role + path that will
+    execute. ``sys/capabilities-self`` returns only the *capability names*
+    the calling token holds on the path (``["create", "update"]`` /
+    ``["read"]`` / ``["deny"]``) — **never any secret material** — so it
+    sidesteps the credential-class preview-suppression rule that bars a
+    value-revealing dry-run for a credential write.
 
     Identity caveat (documented, not enforced here): this probe runs
     under the **dispatching** operator's token, but an approved
@@ -1036,7 +1044,7 @@ async def vault_kv_write_capability_preflight(
 
     data_path = vault_kv_write_target_path(params)
     try:
-        async with _auth_vault.vault_client_for_operator(operator) as client:
+        async with vault_client_for_target(operator, target) as client:
             response = await asyncio.to_thread(
                 client.sys.get_capabilities,
                 paths=[data_path],

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -53,13 +53,16 @@ via the ``VaultClientError`` hierarchy. A missing user/role under a
 *mounted* backend keeps surfacing as the underlying ``InvalidPath`` so
 the two not-found shapes stay distinguishable.
 
-The ``_auth_vault`` module reference (not a ``from ... import`` binding)
-is used so the existing test seam -- ``monkeypatch.setattr(vault_module,
+These handlers open their Vault client through
+:func:`~meho_backplane.connectors.vault.target_auth.vault_client_for_target`,
+which resolves the per-target role + auth mount (#3274) and forwards them
+to ``vault_client_for_operator`` through the ``_auth_vault`` module
+reference, so the existing test seam -- ``monkeypatch.setattr(vault_module,
 "_build_client", fake)`` driving
 :func:`~meho_backplane.auth.vault.vault_client_for_operator` -- applies
-to these handlers transparently, with no respx/httpx layer: hvac's
-transport is ``requests``, so the canonical Vault unit-test seam in
-this codebase is the in-process fake hvac client, not an httpx mock.
+to these handlers transparently across that hop, with no respx/httpx
+layer: hvac's transport is ``requests``, so the canonical Vault unit-test
+seam in this codebase is the in-process fake hvac client, not an httpx mock.
 
 The JSON Schema + ``llm_instructions`` constants live in
 :mod:`meho_backplane.connectors.vault.ops_auth_schemas` to keep this
@@ -76,7 +79,6 @@ from typing import Any
 
 import hvac.exceptions
 
-import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
 from meho_backplane.auth.vault import VaultClientError
 from meho_backplane.connectors.vault.ops_auth_schemas import (
@@ -93,6 +95,7 @@ from meho_backplane.connectors.vault.ops_auth_schemas import (
     VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA,
     VAULT_AUTH_USERPASS_READ_RESPONSE_SCHEMA,
 )
+from meho_backplane.connectors.vault.target_auth import vault_client_for_target
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -153,7 +156,7 @@ async def vault_auth_userpass_list(
         branch surfaces ``extras["exception_class"]``.
     """
     mount: str = str(params.get("mount", "userpass")).strip()
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             payload = await asyncio.to_thread(client.auth.userpass.list_user, mount_point=mount)
         except hvac.exceptions.InvalidPath as exc:
@@ -184,7 +187,7 @@ async def vault_auth_userpass_read(
     """
     username: str = str(params["username"]).strip()
     mount: str = str(params.get("mount", "userpass")).strip()
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             payload = await asyncio.to_thread(
                 client.auth.userpass.read_user,
@@ -214,7 +217,7 @@ async def vault_auth_approle_list(
         Login-side failure (Vault unreachable, role denied).
     """
     mount: str = str(params.get("mount", "approle")).strip()
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             payload = await asyncio.to_thread(client.auth.approle.list_roles, mount_point=mount)
         except hvac.exceptions.InvalidPath as exc:
@@ -242,7 +245,7 @@ async def vault_auth_approle_read(
     """
     role_name: str = str(params["role_name"]).strip()
     mount: str = str(params.get("mount", "approle")).strip()
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             payload = await asyncio.to_thread(
                 client.auth.approle.read_role,

--- a/backend/src/meho_backplane/connectors/vault/ops_auth_write.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth_write.py
@@ -58,7 +58,6 @@ from typing import Any
 
 import hvac.exceptions
 
-import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vault.ops_auth import (
     VaultAuthBackendNotMountedError,
@@ -84,6 +83,7 @@ from meho_backplane.connectors.vault.ops_auth_write_schemas import (
     VAULT_AUTH_USERPASS_WRITE_PARAMETER_SCHEMA,
     VAULT_AUTH_USERPASS_WRITE_RESPONSE_SCHEMA,
 )
+from meho_backplane.connectors.vault.target_auth import vault_client_for_target
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -131,7 +131,7 @@ async def vault_auth_userpass_write(
     if token_policies is not None:
         kwargs["token_policies"] = list(token_policies)
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             await asyncio.to_thread(client.auth.userpass.create_or_update_user, **kwargs)
         except hvac.exceptions.InvalidPath as exc:
@@ -168,7 +168,7 @@ async def vault_auth_userpass_update_password(
     password: str = str(params["password"])
     mount: str = str(params.get("mount", "userpass")).strip()
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             await asyncio.to_thread(
                 client.auth.userpass.update_password_on_user,
@@ -197,7 +197,7 @@ async def vault_auth_userpass_delete(
     username: str = str(params["username"]).strip()
     mount: str = str(params.get("mount", "userpass")).strip()
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             await asyncio.to_thread(
                 client.auth.userpass.delete_user,
@@ -247,7 +247,7 @@ async def vault_auth_approle_write(
         if field in params and params[field] is not None:
             kwargs[field] = params[field]
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             await asyncio.to_thread(client.auth.approle.create_or_update_approle, **kwargs)
         except hvac.exceptions.InvalidPath as exc:
@@ -271,7 +271,7 @@ async def vault_auth_approle_delete(
     role_name: str = str(params["role_name"]).strip()
     mount: str = str(params.get("mount", "approle")).strip()
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             await asyncio.to_thread(
                 client.auth.approle.delete_role,
@@ -315,7 +315,7 @@ async def vault_auth_approle_generate_secret_id(
         if field in params and params[field] is not None:
             kwargs[field] = params[field]
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
+    async with vault_client_for_target(operator, target) as client:
         try:
             payload = await asyncio.to_thread(client.auth.approle.generate_secret_id, **kwargs)
         except hvac.exceptions.InvalidPath as exc:

--- a/backend/src/meho_backplane/connectors/vault/target_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/target_auth.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-target Vault auth resolution — role + auth-mount off the ``Target`` (#3274).
+
+The vault connector is **JWT-federated**: the operator's runtime Keycloak JWT
+is forwarded to Vault's JWT/OIDC auth method under a **role**, and that role's
+Vault policy *is* the ACL for the dispatch. There is no stored per-target
+credential — a vault ``Target``'s ``secret_ref`` stays ``NULL`` — so the only
+per-target auth datum the connector reads is the role name (and, optionally,
+the auth-method mount the role lives on).
+
+Contract (frozen; lab-verified in ``claude-rdc-hetzner-dc#2814`` / PR
+``#2815``):
+
+* ``extras["vault_role"]`` (string) — when present and the target's product is
+  in the vault family, :func:`~meho_backplane.auth.vault.vault_client_for_operator`
+  logs in under this role instead of ``settings.vault_oidc_role``. Absent →
+  byte-for-byte today's behaviour. This is the load-bearing selector that
+  routes a governed teardown's ``vault.kv.delete`` under a dedicated narrow
+  role (``meho-teardown``) without widening the shared ``meho-mcp`` identity.
+* ``extras["vault_mount"]`` (string, optional) — the JWT auth-method mount
+  path the role lives on (e.g. ``jwt-meho``); absent,
+  ``settings.vault_oidc_mount_path`` stands.
+* The Vault **address** stays global (``settings.vault_addr``) — there is one
+  Vault. Only role + auth-mount are per-target.
+* ``version`` is **not** consulted here: the live teardown target ships
+  ``version=null`` and resolves to the connector through its wildcard
+  registration (G0.15-T6 #1215). Role resolution keys on ``product`` +
+  ``extras`` alone, so a null-version target is fully supported.
+
+Fail-closed is enforced downstream, not here: this module only *selects* the
+role. A selected role Vault denies surfaces
+:class:`~meho_backplane.auth.vault.VaultRoleDeniedError` from the login with no
+fallback to the settings-global role. A blank / whitespace / non-string extras
+value is treated as *absent* (no override → settings default), mirroring how a
+blank ``VAULT_CHECK_RUNNER_ROLE`` normalises to ``None`` in settings — an empty
+string does not *name* a role, so it is not a denial, just no selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractAsyncContextManager
+from typing import Any, NamedTuple
+
+import hvac
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+from meho_backplane.targets.schemas import Target
+
+__all__ = [
+    "VAULT_MOUNT_EXTRAS_KEY",
+    "VAULT_ROLE_EXTRAS_KEY",
+    "VaultTargetAuth",
+    "resolve_vault_target_auth",
+    "vault_client_for_target",
+]
+
+#: Reserved ``Target.extras`` key naming the per-target Vault JWT role.
+VAULT_ROLE_EXTRAS_KEY = "vault_role"
+#: Reserved ``Target.extras`` key naming the JWT auth-method mount path.
+VAULT_MOUNT_EXTRAS_KEY = "vault_mount"
+
+#: Products whose targets may carry a per-target Vault role. The connector
+#: registers under ``product="vault"``; the gate keeps a stray
+#: ``extras["vault_role"]`` on a non-vault target from ever selecting a role.
+_VAULT_PRODUCT_FAMILY = frozenset({"vault"})
+
+
+class VaultTargetAuth(NamedTuple):
+    """The per-target Vault auth overrides resolved off a ``Target``.
+
+    Both fields are ``None`` when the target carries no override (or is
+    ``None`` / not a vault-family product), in which case
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator` falls back to
+    the settings-global role + auth mount byte-for-byte.
+    """
+
+    role: str | None
+    mount_path: str | None
+
+
+#: The no-override singleton — returned for a ``None`` target, a non-vault
+#: product, or a target whose extras name neither override.
+_NO_OVERRIDE = VaultTargetAuth(role=None, mount_path=None)
+
+
+def _extras_string(extras: Mapping[str, Any], key: str) -> str | None:
+    """Return a non-empty stripped string extras value, or ``None``.
+
+    A missing key, a non-string value, or a blank / whitespace-only string all
+    resolve to ``None`` ("no override"), matching the blank-role normalisation
+    the settings layer applies to ``VAULT_CHECK_RUNNER_ROLE``.
+    """
+    value = extras.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def resolve_vault_target_auth(target: Target | None) -> VaultTargetAuth:
+    """Resolve the per-target Vault role + auth mount off *target*'s extras.
+
+    Returns :data:`_NO_OVERRIDE` (both fields ``None``) unless *target* is a
+    vault-family product carrying ``extras["vault_role"]`` /
+    ``extras["vault_mount"]``. The product gate is defence-in-depth: only the
+    vault connector's own handlers call this, and they only run for a target
+    the resolver matched to the vault connector, but gating on the product
+    keeps a non-vault target's stray extras key from ever selecting a role.
+    """
+    if target is None or target.product not in _VAULT_PRODUCT_FAMILY:
+        return _NO_OVERRIDE
+    return VaultTargetAuth(
+        role=_extras_string(target.extras, VAULT_ROLE_EXTRAS_KEY),
+        mount_path=_extras_string(target.extras, VAULT_MOUNT_EXTRAS_KEY),
+    )
+
+
+def vault_client_for_target(
+    operator: Operator, target: Target | None
+) -> AbstractAsyncContextManager[hvac.Client]:
+    """Open a Vault client bound to *operator* under *target*'s resolved role.
+
+    Thin convenience over
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator` that resolves
+    the per-target role + auth mount (:func:`resolve_vault_target_auth`) and
+    forwards them. Every vault KV/auth handler routes through here so the
+    per-target selection lives in one place.
+
+    The call is qualified through the ``_auth_vault`` module reference (not a
+    direct symbol import) so the existing test seams —
+    ``monkeypatch.setattr(vault_module, "vault_client_for_operator", fake)``
+    and the ``_build_client`` fake — propagate to this call site unchanged.
+    """
+    resolved = resolve_vault_target_auth(target)
+    return _auth_vault.vault_client_for_operator(
+        operator, role=resolved.role, mount_path=resolved.mount_path
+    )

--- a/backend/src/meho_backplane/connectors/vault/target_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/target_auth.py
@@ -109,12 +109,23 @@ def resolve_vault_target_auth(target: Target | None) -> VaultTargetAuth:
     vault connector's own handlers call this, and they only run for a target
     the resolver matched to the vault connector, but gating on the product
     keeps a non-vault target's stray extras key from ever selecting a role.
+
+    Attribute access is duck-typed via :func:`getattr`: the handlers pass
+    ``target: Any`` and the dispatcher/resolver contract admits any
+    target-shaped object — a real :class:`Target` (``extras`` is a dict), an
+    ORM row (``extras`` may be SQL ``NULL`` → ``None``), or a minimal
+    duck-typed descriptor that carries no ``extras`` at all. Any of those
+    that does not present a ``Mapping`` ``extras`` simply names no override,
+    so the login falls back to the settings-global role — never a crash.
     """
-    if target is None or target.product not in _VAULT_PRODUCT_FAMILY:
+    if getattr(target, "product", None) not in _VAULT_PRODUCT_FAMILY:
+        return _NO_OVERRIDE
+    extras = getattr(target, "extras", None)
+    if not isinstance(extras, Mapping):
         return _NO_OVERRIDE
     return VaultTargetAuth(
-        role=_extras_string(target.extras, VAULT_ROLE_EXTRAS_KEY),
-        mount_path=_extras_string(target.extras, VAULT_MOUNT_EXTRAS_KEY),
+        role=_extras_string(extras, VAULT_ROLE_EXTRAS_KEY),
+        mount_path=_extras_string(extras, VAULT_MOUNT_EXTRAS_KEY),
     )
 
 

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -1584,21 +1584,23 @@ def result_connector_vault_write_forbidden(
     :func:`result_connector_vault_forbidden` (#2091). The four-eyes flow
     can succeed end to end — park → approve → re-dispatch — and the write
     still fails at Vault's ACL because the identity the connector dispatches
-    with lacks ``create`` / ``update`` on the target ``<mount>/data/<path>``.
-    Routing that denial through the read-oriented
-    :func:`result_connector_vault_forbidden` mis-describes it: that builder
-    talks about a target's ``secret_ref`` being outside the readable
-    per-tenant subtree, which does not apply to a typed ``vault.kv.*`` write
-    (the write authorizes against the operator's own templated write path,
-    not a target credential read). This builder names the **write** cause
-    instead — the exact data path Vault denied, the acting identity, the
-    write-policy stanza to add — so the operator sees the actionable
-    problem rather than a bare ``permission denied`` or a misleading
-    read-path diagnosis.
+    with lacks the required capability on the path the op authorizes against
+    (``create``/``update`` on ``<mount>/data/<path>`` for ``put``/``patch``,
+    ``update`` on ``<mount>/delete/<path>`` for the ``vault.kv.delete``
+    version soft-delete — #3274). Routing that denial through the
+    read-oriented :func:`result_connector_vault_forbidden` mis-describes it:
+    that builder talks about a target's ``secret_ref`` being outside the
+    readable per-tenant subtree, which does not apply to a typed
+    ``vault.kv.*`` write (the write authorizes against the operator's own
+    templated write path, not a target credential read). This builder names
+    the **write** cause instead — the exact path Vault denied, the acting
+    identity, the write-policy stanza to add — so the operator sees the
+    actionable problem rather than a bare ``permission denied`` or a
+    misleading read-path diagnosis.
 
     Unlike the read builder there is no ``secret_ref`` to fabricate: the
-    path is the op's own ``<mount>/data/<path>`` (rendered by the caller
-    via :func:`~meho_backplane.connectors.vault.ops.vault_kv_write_target_path`),
+    path is the op's own authorization path (rendered by the caller via
+    :func:`~meho_backplane.connectors.vault.ops.vault_kv_write_target_path`),
     and the identity hint is the dispatching / reviewing operator's ``sub``.
     The remediation points at the write-capability stanza (§6.1) and the
     ``sys/capabilities-self`` probe (§6.2) of the policy doc, and repeats
@@ -1620,16 +1622,25 @@ def result_connector_vault_write_forbidden(
     identity_clause = (
         f" The write dispatched under identity {identity_hint!r}." if identity_hint else ""
     )
+    # #3274: the capability + path kind is op-aware. A version soft-delete
+    # (``vault.kv.delete``) authorizes with ``update`` on the ``/delete/``
+    # path; ``put`` / ``patch`` with ``create``/``update`` on the ``/data/``
+    # path. Keep the message consistent with the ``write_path`` rendered by
+    # ``vault_kv_write_target_path`` so the two never disagree.
+    if op_id == "vault.kv.delete":
+        capability_clause = "lacks 'update' on that delete path"
+    else:
+        capability_clause = "lacks 'create'/'update' on that data path"
     summary = (
         f"vault_write_identity_forbidden: Vault denied the KV-v2 write{path_clause} "
         f"(permission denied). The approval handshake succeeded, but the identity "
-        f"the connector dispatched the write with lacks 'create'/'update' on that "
-        f"data path.{identity_clause} This is a deploy write-identity gap, not a bug "
-        f"in the approve→execute flow: add the per-operator write-capability stanza "
-        f"(§6.1) so the dispatching/reviewing operator's token can write the path, "
-        f"and verify it with the 'sys/capabilities-self' probe (§6.2). Do NOT widen "
-        f"the backplane's shared Vault policy — the write grant is per-operator "
-        f"templated. See {_VAULT_WRITE_POLICY_DOC} §6 for the write-identity contract."
+        f"the connector dispatched the write with {capability_clause}.{identity_clause} "
+        f"This is a deploy write-identity gap, not a bug in the approve→execute flow: "
+        f"add the per-operator write-capability stanza (§6.1) so the "
+        f"dispatching/reviewing operator's token can write the path, and verify it "
+        f"with the 'sys/capabilities-self' probe (§6.2). Do NOT widen the backplane's "
+        f"shared Vault policy — the write grant is per-operator templated. See "
+        f"{_VAULT_WRITE_POLICY_DOC} §6 for the write-identity contract."
     )
     if msg:
         # hvac renders Forbidden as "permission denied, on POST <url>" — the

--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -645,13 +645,16 @@ async def _vault_kv_write_preflight(ctx: PreviewContext) -> dict[str, Any] | Non
 
     Delegates to
     :func:`~meho_backplane.connectors.vault.ops.vault_kv_write_capability_preflight`,
-    which logs in under the operator's ``meho-mcp`` role and issues
-    ``POST sys/capabilities-self`` on the op's ``<mount>/data/<path>`` to
-    learn whether the dispatching token holds the ``create`` / ``update``
-    capability the write needs. The response carries only capability
-    names -- no secret value -- so it is redaction-safe and runs even
-    though ``vault.kv.put`` / ``vault.kv.patch`` classify as
-    ``credential_write``.
+    which logs in under the **resolved per-target role** the write will
+    use (#3274 — the dispatch ``target``'s ``extras["vault_role"]``, or
+    the settings-global ``meho-mcp`` role when the target names none) and
+    issues ``POST sys/capabilities-self`` on the op's authorization path
+    to learn whether that token holds the ``create`` / ``update``
+    capability the write needs. Threading ``ctx.target`` is what makes the
+    banner reflect the role that will actually execute. The response
+    carries only capability names -- no secret value -- so it is
+    redaction-safe and runs even though ``vault.kv.put`` /
+    ``vault.kv.patch`` classify as ``credential_write``.
     """
     from meho_backplane.connectors.vault.ops import vault_kv_write_capability_preflight
 
@@ -659,6 +662,7 @@ async def _vault_kv_write_preflight(ctx: PreviewContext) -> dict[str, Any] | Non
         ctx.operator,
         ctx.descriptor.op_id,
         ctx.params,
+        target=ctx.target,
     )
 
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1174,7 +1174,7 @@ async def _run_branch_with_error_handling(
 
         if op_id in VAULT_KV_WRITE_CAPABILITIES:
             try:
-                write_path = vault_kv_write_target_path(params)
+                write_path = vault_kv_write_target_path(op_id, params)
             except (KeyError, ValueError):
                 # ``path`` normalises to nothing (validate_params guarantees
                 # presence, but stay defensive inside the never-raises arm) —

--- a/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
+++ b/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
@@ -270,7 +270,12 @@ async def vault_operations_app(
     seen_operator: dict[str, Any] = {}
 
     @asynccontextmanager
-    async def _root_client_cm(operator: Any) -> AsyncIterator[Any]:
+    async def _root_client_cm(
+        operator: Any,
+        *,
+        role: str | None = None,
+        mount_path: str | None = None,
+    ) -> AsyncIterator[Any]:
         # ``operator`` is the request-scoped Operator the dispatcher
         # threads. Production would OIDC-login with ``operator.raw_jwt``;
         # dev mode has no OIDC method wired, so only the credential

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -385,7 +385,12 @@ async def vault_e2e(
     await register_vault_identity_token_operations(embedding_service=stub_embedding_service)
 
     @asynccontextmanager
-    async def _root_client_cm(_target: Any) -> AsyncIterator[hvac.Client]:
+    async def _root_client_cm(
+        _operator: Any,
+        *,
+        role: str | None = None,
+        mount_path: str | None = None,
+    ) -> AsyncIterator[hvac.Client]:
         # Mirrors the production context manager's contract: yield an
         # authenticated client, no revoke needed for a root token on a
         # throwaway in-memory dev Vault.

--- a/backend/tests/test_auth_vault.py
+++ b/backend/tests/test_auth_vault.py
@@ -667,3 +667,122 @@ async def test_check_runner_role_denial_fails_closed_without_falling_back(
     assert fake.auth.jwt.login_calls == [
         {"role": "meho-check-runner", "jwt": "runner-jwt", "path": "jwt"},
     ]
+
+
+# ---------------------------------------------------------------------------
+# #3274 — per-target role / auth-mount override
+# ---------------------------------------------------------------------------
+
+
+async def test_explicit_role_override_wins_over_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``role`` logs in under that role, not ``vault_oidc_role``.
+
+    This is the per-target selector (#3274): the vault connector resolves a
+    target's ``extras["vault_role"]`` and passes it here so a governed
+    teardown's ``vault.kv.delete`` runs under the dedicated ``meho-teardown``
+    role instead of the shared ``meho-mcp`` identity. The auth-mount defaults
+    to ``vault_oidc_mount_path`` when no mount override is given.
+    """
+    get_settings.cache_clear()
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator(jwt="op-jwt")
+
+    async with vault_client_for_operator(operator, role="meho-teardown"):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "op-jwt", "path": "jwt"},
+    ]
+
+
+async def test_explicit_mount_path_override_wins_over_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``mount_path`` logs in against that JWT auth mount.
+
+    The ``rdc-vault-teardown`` target's role lives on the ``jwt-meho`` auth
+    mount (``extras["vault_mount"]``); absent, the settings-global mount
+    stands. The role is untouched when only the mount is overridden.
+    """
+    get_settings.cache_clear()
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator(jwt="op-jwt")
+
+    async with vault_client_for_operator(operator, mount_path="jwt-meho"):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt-meho"},
+    ]
+
+
+async def test_no_overrides_keep_settings_role_and_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``role=None, mount_path=None`` is today's behaviour byte-for-byte.
+
+    A target that names no role/mount (or a non-vault caller) leaves both
+    ``None`` so the login resolves the settings-global role + mount exactly
+    as before #3274 — the backward-compatibility guarantee for every existing
+    deployment.
+    """
+    get_settings.cache_clear()
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator(jwt="op-jwt")
+
+    async with vault_client_for_operator(operator):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
+    ]
+
+
+async def test_explicit_role_override_wins_over_check_runner_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``role`` outranks the check-runner's dedicated role (#2757).
+
+    Precedence is: per-target override → ``vault_check_runner_role`` → wide
+    role. So even a synthetic check-runner dispatch that also names a target
+    role logs in under the target role — the most specific signal wins.
+    """
+    monkeypatch.setenv("VAULT_CHECK_RUNNER_ROLE", "meho-check-runner")
+    get_settings.cache_clear()
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator(jwt="runner-jwt", check_runner_dispatch=True)
+
+    async with vault_client_for_operator(operator, role="meho-teardown"):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "runner-jwt", "path": "jwt"},
+    ]
+
+
+async def test_explicit_role_denial_fails_closed_without_falling_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A denied per-target role surfaces ``VaultRoleDeniedError``, no fallback.
+
+    The security core of #3274 (mirroring the #2757 rule): a mis-scoped target
+    role must fail closed rather than silently widening the dispatch back to
+    ``vault_oidc_role``. The single login call, pinned to the override role,
+    is the proof there is no retry under the wide role.
+    """
+    get_settings.cache_clear()
+    fake = _install_fake_client(
+        monkeypatch,
+        login_exc=hvac.exceptions.Forbidden("role denied"),
+    )
+    operator = _make_operator(jwt="op-jwt")
+
+    with pytest.raises(VaultRoleDeniedError):
+        async with vault_client_for_operator(operator, role="meho-teardown"):
+            pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "op-jwt", "path": "jwt"},
+    ]

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -1208,17 +1208,27 @@ def test_kv_read_ops_do_not_require_approval(op_id: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("params", "expected"),
+    ("op_id", "params", "expected"),
     [
-        ({"path": "meho/test/x"}, "secret/data/meho/test/x"),
-        ({"mount": "kv", "path": "meho/y"}, "kv/data/meho/y"),
+        # put / patch authorize on the data path.
+        ("vault.kv.put", {"path": "meho/test/x"}, "secret/data/meho/test/x"),
+        ("vault.kv.patch", {"mount": "kv", "path": "meho/y"}, "kv/data/meho/y"),
         # The handler-mirroring strip: leading slash + surrounding space.
-        ({"path": "  /meho/z  "}, "secret/data/meho/z"),
+        ("vault.kv.put", {"path": "  /meho/z  "}, "secret/data/meho/z"),
+        # #3274: the version soft-delete authorizes on the DELETE path,
+        # not the data path — mirroring hvac's POST <mount>/delete/<path>.
+        ("vault.kv.delete", {"path": "meho/test/x"}, "secret/delete/meho/test/x"),
+        ("vault.kv.delete", {"mount": "kv", "path": "meho/y"}, "kv/delete/meho/y"),
     ],
 )
-def test_write_target_path_renders_data_path(params: dict[str, Any], expected: str) -> None:
-    """The preflight probes ``<mount>/data/<path>`` — the KV-v2 write path."""
-    assert vault_kv_write_target_path(params) == expected
+def test_write_target_path_renders_authorization_path(
+    op_id: str, params: dict[str, Any], expected: str
+) -> None:
+    """The preflight probes the path the op authorizes against, per op-id.
+
+    put/patch -> ``<mount>/data/<path>``; delete -> ``<mount>/delete/<path>``.
+    """
+    assert vault_kv_write_target_path(op_id, params) == expected
 
 
 def test_write_capabilities_cover_every_write_op() -> None:
@@ -1286,20 +1296,54 @@ async def test_preflight_passes_for_role_with_write(
 
 
 @pytest.mark.asyncio
-async def test_preflight_delete_needs_only_update(
+async def test_preflight_delete_probes_delete_path_needs_only_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``vault.kv.delete`` authorizes against ``update`` on the data path."""
+    """``vault.kv.delete`` probes ``update`` on the DELETE path, not data (#3274).
+
+    hvac's ``delete_secret_versions`` POSTs to ``<mount>/delete/<path>`` and
+    Vault authorizes it with ``update`` there — so the preflight must probe
+    that path. A token holding ``update`` on ``secret/delete/meho/v`` passes;
+    the old code probed ``secret/data/meho/v`` and would have missed the grant.
+    """
     fake = install_fake_vault(monkeypatch)
-    fake.sys.capabilities_by_path = {"secret/data/meho/v": ["read", "update"]}
+    fake.sys.capabilities_by_path = {"secret/delete/meho/v": ["read", "update"]}
 
     result = await vault_kv_write_capability_preflight(
         _make_operator(), "vault.kv.delete", {"path": "meho/v", "versions": [1]}
     )
 
     assert result is not None
+    assert result["path"] == "secret/delete/meho/v"
     assert result["required"] == ["update"]
     assert result["will_be_denied"] is False
+    # The probe queried the delete path, never the data path.
+    assert fake.sys.get_capabilities_calls == [
+        {"paths": ["secret/delete/meho/v"], "token": None, "accessor": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preflight_delete_denied_when_only_data_path_granted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grant on ``data/`` but not ``delete/`` flags the delete as denied (#3274).
+
+    The regression this fix prevents: a token with ``update`` on the data
+    path (but nothing on the delete path) would have falsely passed the old
+    preflight, wasting a four-eyes approval on a delete Vault then rejects.
+    """
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/v": ["create", "read", "update"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.delete", {"path": "meho/v", "versions": [1]}
+    )
+
+    assert result is not None
+    assert result["path"] == "secret/delete/meho/v"
+    assert result["granted"] == []
+    assert result["will_be_denied"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vault_target_auth.py
+++ b/backend/tests/test_connectors_vault_target_auth.py
@@ -144,6 +144,27 @@ def test_resolve_no_extras_keys_is_no_override() -> None:
     assert resolve_vault_target_auth(_make_vault_target()) == VaultTargetAuth(None, None)
 
 
+def test_resolve_duck_typed_target_without_extras_is_no_override() -> None:
+    """A duck-typed target lacking ``extras`` (or with ``extras=None``) is safe.
+
+    The handlers receive ``target: Any``; the dispatcher/resolver contract
+    admits a minimal descriptor (e.g. the integration suite's ``_VaultTarget``
+    stub) that carries no ``extras`` attribute, and an ORM row can present
+    ``extras=None``. Either must resolve to no override rather than raising
+    ``AttributeError`` — the login then falls back to the settings-global role.
+    """
+
+    class _NoExtrasTarget:
+        product = "vault"
+
+    class _NullExtrasTarget:
+        product = "vault"
+        extras = None
+
+    assert resolve_vault_target_auth(_NoExtrasTarget()) == VaultTargetAuth(None, None)  # type: ignore[arg-type]
+    assert resolve_vault_target_auth(_NullExtrasTarget()) == VaultTargetAuth(None, None)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # vault_client_for_target — resolution threaded into the login
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vault_target_auth.py
+++ b/backend/tests/test_connectors_vault_target_auth.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-target Vault role/auth-mount resolution (#3274).
+
+Pins the ``Target``-side contract frozen with the lab
+(``claude-rdc-hetzner-dc#2814`` / PR ``#2815``): a vault target advertising
+``extras["vault_role"]`` (optionally ``extras["vault_mount"]``) selects that
+role at login; anything else falls through to the settings-global role +
+mount byte-for-byte. The live ``rdc-vault-teardown`` target ships
+``version=null`` / ``secret_ref=null``, so the resolver is exercised against
+that exact shape.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vault.target_auth import (
+    VaultTargetAuth,
+    resolve_vault_target_auth,
+    vault_client_for_target,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.targets.schemas import Target
+
+from ._vault_fakes import install_fake_vault
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var the Settings model reads (cached per-process)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.delenv("VAULT_CHECK_RUNNER_ROLE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_vault_target(**overrides: Any) -> Target:
+    """Build a ``Target`` in the live ``rdc-vault-teardown`` shape.
+
+    ``product="vault"``, ``version=None`` (resolves via the connector's
+    wildcard registration), ``secret_ref=None`` (JWT-federated — no stored
+    per-target credential). ``extras`` is the only per-target auth carrier.
+    """
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "tenant_id": uuid.uuid4(),
+        "name": "rdc-vault-teardown",
+        "aliases": [],
+        "product": "vault",
+        "version": None,
+        "host": "vault.rdc.internal",
+        "port": 8200,
+        "fqdn": "vault.rdc.internal",
+        "secret_ref": None,
+        "auth_model": AuthModel.SHARED_SERVICE_ACCOUNT,
+        "vpn_required": True,
+        "extras": {},
+        "notes": None,
+        "fingerprint": None,
+        "preferred_impl_id": None,
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return Target(**defaults)
+
+
+def _make_operator(jwt: str = "op-jwt") -> Operator:
+    return Operator(
+        sub="op-1",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_vault_target_auth
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_none_target_is_no_override() -> None:
+    """A ``None`` target (connector-id-routed call) selects no override."""
+    assert resolve_vault_target_auth(None) == VaultTargetAuth(None, None)
+
+
+def test_resolve_role_only() -> None:
+    """``extras["vault_role"]`` alone selects the role; mount stays settings-global."""
+    target = _make_vault_target(extras={"vault_role": "meho-teardown"})
+    assert resolve_vault_target_auth(target) == VaultTargetAuth("meho-teardown", None)
+
+
+def test_resolve_role_and_mount_live_teardown_shape() -> None:
+    """The live ``rdc-vault-teardown`` shape resolves both role and auth mount.
+
+    version=None, secret_ref=None, extras carry role ``meho-teardown`` on the
+    ``jwt-meho`` auth mount — the exact registered target this ships for.
+    """
+    target = _make_vault_target(
+        version=None,
+        secret_ref=None,
+        extras={"vault_role": "meho-teardown", "vault_mount": "jwt-meho"},
+    )
+    assert resolve_vault_target_auth(target) == VaultTargetAuth("meho-teardown", "jwt-meho")
+
+
+def test_resolve_non_vault_product_ignores_role() -> None:
+    """The product gate: a non-vault target's stray ``vault_role`` is ignored."""
+    target = _make_vault_target(product="vsphere", extras={"vault_role": "meho-teardown"})
+    assert resolve_vault_target_auth(target) == VaultTargetAuth(None, None)
+
+
+@pytest.mark.parametrize("role_value", ["", "   ", 123, None, {"nested": "x"}])
+def test_resolve_blank_or_non_string_role_is_no_override(role_value: Any) -> None:
+    """Blank / whitespace / non-string ``vault_role`` normalises to no override.
+
+    An empty string does not *name* a role (it is not a denial, just no
+    selection) — matching the blank-``VAULT_CHECK_RUNNER_ROLE`` normalisation.
+    """
+    target = _make_vault_target(extras={"vault_role": role_value})
+    assert resolve_vault_target_auth(target) == VaultTargetAuth(None, None)
+
+
+def test_resolve_no_extras_keys_is_no_override() -> None:
+    """A vault target with empty extras keeps today's settings-global login."""
+    assert resolve_vault_target_auth(_make_vault_target()) == VaultTargetAuth(None, None)
+
+
+# ---------------------------------------------------------------------------
+# vault_client_for_target — resolution threaded into the login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vault_client_for_target_threads_role_and_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A teardown target logs in under its role on its auth mount."""
+    get_settings.cache_clear()
+    fake = install_fake_vault(monkeypatch)
+    target = _make_vault_target(
+        extras={"vault_role": "meho-teardown", "vault_mount": "jwt-meho"},
+    )
+
+    async with vault_client_for_target(_make_operator(jwt="op-jwt"), target):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "op-jwt", "path": "jwt-meho"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vault_client_for_target_none_target_uses_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``None`` target keeps the settings-global role + mount byte-for-byte."""
+    get_settings.cache_clear()
+    fake = install_fake_vault(monkeypatch)
+
+    async with vault_client_for_target(_make_operator(jwt="op-jwt"), None):
+        pass
+
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_kv_delete_dispatches_under_target_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC1: a governed ``vault.kv.delete`` runs under the target's role.
+
+    Drives the real handler end-to-end — resolution → login — proving the
+    governed teardown's soft-delete authenticates as ``meho-teardown`` on the
+    ``jwt-meho`` mount, not the shared ``meho-mcp`` identity.
+    """
+    from meho_backplane.connectors.vault.ops import vault_kv_delete
+
+    # Disable the orthogonal tenant-scope guard (#1643, its own tests) so this
+    # test isolates the role-selection contract, not the path allow-list.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
+    get_settings.cache_clear()
+    fake = install_fake_vault(monkeypatch)
+    target = _make_vault_target(
+        extras={"vault_role": "meho-teardown", "vault_mount": "jwt-meho"},
+    )
+
+    result = await vault_kv_delete(
+        _make_operator(jwt="op-jwt"),
+        target,
+        {"path": "meho/scratch", "versions": [1]},
+    )
+
+    assert result == {"deleted_versions": [1]}
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "op-jwt", "path": "jwt-meho"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_preflight_runs_under_target_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC3: the park-time capability preflight probes under the resolved role.
+
+    So the approval banner reflects the role that will actually execute the
+    write, not the settings-global ``meho-mcp`` identity.
+    """
+    from meho_backplane.connectors.vault.ops import vault_kv_write_capability_preflight
+
+    get_settings.cache_clear()
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/x": ["create", "update"]}
+    target = _make_vault_target(
+        extras={"vault_role": "meho-teardown", "vault_mount": "jwt-meho"},
+    )
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(jwt="op-jwt"),
+        "vault.kv.put",
+        {"path": "meho/x"},
+        target=target,
+    )
+
+    assert result is not None
+    assert result["will_be_denied"] is False
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-teardown", "jwt": "op-jwt", "path": "jwt-meho"},
+    ]

--- a/backend/tests/test_operations_connector_vault_forbidden.py
+++ b/backend/tests/test_operations_connector_vault_forbidden.py
@@ -473,6 +473,31 @@ def test_write_forbidden_names_path_identity_and_write_stanza() -> None:
     assert "permission denied" in out.extras["exception_message"]
 
 
+def test_write_forbidden_delete_names_update_on_delete_path() -> None:
+    """#3274: a ``vault.kv.delete`` denial names ``update`` on the delete path.
+
+    The version soft-delete authorizes with ``update`` on
+    ``<mount>/delete/<path>`` — so the message must not claim
+    ``create``/``update`` on the data path (which would contradict the
+    ``write_path`` the caller renders for a delete).
+    """
+    from meho_backplane.operations._errors import result_connector_vault_write_forbidden
+
+    out = result_connector_vault_write_forbidden(
+        "vault.kv.delete",
+        _make_forbidden("targets/op-x/prod"),
+        duration_ms=1.0,
+        write_path="secret/delete/targets/op-x/prod",
+        identity_hint="op-x",
+    )
+    assert out.error is not None
+    assert "'secret/delete/targets/op-x/prod'" in out.error
+    assert "lacks 'update' on that delete path" in out.error
+    # NOT the put/patch data-path phrasing.
+    assert "create'/'update'" not in out.error
+    assert out.extras["path"] == "secret/delete/targets/op-x/prod"
+
+
 def test_write_forbidden_omits_clauses_when_path_and_identity_absent() -> None:
     """No path / identity → no fabricated clause, extras carry None."""
     from meho_backplane.operations._errors import result_connector_vault_write_forbidden

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -77,6 +77,12 @@ Guarantees:
   under the resolved role too (it takes the dispatch `target`), so the
   approval banner reflects the role that will execute.
 
+Checks/sensors pinned to a role-overridden target authenticate under that
+override — so if the override role lacks the grant a sensor's op needs, the
+evaluation fails closed to `unknown` (a `VaultRoleDeniedError`), which is a
+loud flag of a misconfigured sensor rather than a silent widen; pin
+monitoring sensors on the standard target, not the delete-scoped one.
+
 Consumer-side provisioning (the `meho-teardown` role + `rdc-vault-teardown`
 target registration) is documented in
 [`docs/cross-repo/vault-provisioning.md`](../cross-repo/vault-provisioning.md)

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -518,13 +518,20 @@ post-approval.
 To surface that **before** parking, `_handle_needs_approval`
 (`operations/dispatcher.py`) runs a permission preflight for the KV write
 ops. The preflight is `vault_kv_write_capability_preflight` (`ops.py`):
-it logs in exactly as the real write does
-(`vault_client_for_operator`, the `meho-mcp` role) and issues
-`POST sys/capabilities-self` on the op's `<mount>/data/<path>`
-(`client.sys.get_capabilities(paths=[...])`). It compares the granted
-capabilities against the per-op requirement in
-`VAULT_KV_WRITE_CAPABILITIES` (`put`/`patch` need `create`+`update`;
-`delete` needs `update`) and returns a redaction-safe summary:
+it logs in exactly as the real write does (through
+`vault_client_for_target`, under the **resolved per-target role** — the
+target's `extras["vault_role"]` or the settings-global `meho-mcp`, #3274 —
+so the banner reflects the role that will execute) and issues
+`POST sys/capabilities-self` on the exact path the op authorizes against
+(`client.sys.get_capabilities(paths=[...])`). That path is op-aware
+(`vault_kv_write_target_path`): `put`/`patch` render `<mount>/data/<path>`,
+but `vault.kv.delete`'s version soft-delete POSTs to `<mount>/delete/<path>`
+and Vault authorizes it with `update` on that **`/delete/`** path — not the
+data path (#3274; probing `/data/` for a delete gave a false pass). It
+compares the granted capabilities against the per-op requirement in
+`VAULT_KV_WRITE_CAPABILITIES` (`put`/`patch` need `create`+`update` on the
+data path; `delete` needs `update` on the delete path) and returns a
+redaction-safe summary:
 
 ```python
 {"check": "vault.capabilities-self", "path": "secret/data/...",

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -15,12 +15,72 @@ to generic-ingested is a v0.2.next consideration if Vault's surface
 grows substantially.
 
 Auth model: `shared_service_account`. Every operator's Keycloak JWT is
-forwarded to Vault's JWT/OIDC auth method (bound to the `meho-mcp`
-role); the resulting per-request Vault token is revoked on context
-exit. The unauthenticated `/sys/health` endpoint is the one exception —
-it needs no token.
+forwarded to Vault's JWT/OIDC auth method; the resulting per-request
+Vault token is revoked on context exit. The unauthenticated
+`/sys/health` endpoint is the one exception — it needs no token. The JWT
+**role** defaults to the deployment-global `meho-mcp` but is
+**per-target overridable** (#3274) — see
+[Per-target role resolution](#per-target-role-resolution-3274).
 
 Source: `backend/src/meho_backplane/connectors/vault/`.
+
+## Per-target role resolution (#3274)
+
+The connector is **JWT-federated**: the operator's runtime JWT is
+forwarded to Vault's JWT auth method under a **role**, and that role's
+policy *is* the ACL for the dispatch. There is no stored per-target
+credential — a vault `Target`'s `secret_ref` stays `NULL`. Before #3274
+there was exactly one role for all vault dispatch (`meho-mcp`, the #2757
+seam keyed only the check-runner). That made a governed teardown's
+`vault.kv.delete` run under the read-only `meho-mcp` role and
+fail-closed; the only alternatives were widening `meho-mcp` (grants every
+operator standing delete) or a dispatch-flag the human/blueprint-initiated
+delete does not carry.
+
+#3274 makes the **role target-derived**. A vault `Target` may carry, in
+its `extras`, the role — and optionally the JWT auth mount the role lives
+on:
+
+| `extras` key | required | meaning | fallback when absent |
+|---|---|---|---|
+| `vault_role` | selector | JWT role to log in under | `settings.vault_oidc_role` (`meho-mcp`) |
+| `vault_mount` | optional | JWT auth-method mount the role lives on | `settings.vault_oidc_mount_path` |
+
+The Vault **address** stays global (`settings.vault_addr`) — there is one
+Vault. Only role + auth-mount are per-target.
+
+`target_auth.py` owns the resolution: `resolve_vault_target_auth(target)`
+reads the two keys (product-gated to `product == "vault"`; a blank /
+whitespace / non-string value normalises to "no override"), and
+`vault_client_for_target(operator, target)` forwards them to
+`auth.vault.vault_client_for_operator(operator, role=…, mount_path=…)`.
+Every KV handler (`ops.py`) and auth handler (`ops_auth.py`,
+`ops_auth_write.py`) opens its client through that one helper, so a target
+naming a role governs its whole KV/auth dispatch. Role selection
+precedence at the login site is: **per-target override → check-runner
+role (#2757) → deployment-global `vault_oidc_role`**.
+
+Guarantees:
+
+- **Backward-compatible.** A target naming no role (and every non-vault
+  caller — `_shared/vault_creds.py`, `wrapped_creds.py`, the federation
+  read) passes `role=None` / `mount_path=None`, so the login resolves the
+  settings-global role byte-for-byte. Existing deployments are unchanged.
+- **Fail-closed.** A resolved role Vault denies surfaces
+  `VaultRoleDeniedError` from the login with **no** fallback to the wide
+  role — the #2757 no-silent-widen rule, extended to the per-target role.
+- **Null-version safe.** The live `rdc-vault-teardown` target ships
+  `version=null`; it resolves to the connector via the wildcard
+  registration (G0.15-T6 #1215), and role resolution keys on `product` +
+  `extras` alone, never `version`.
+- **Preflight-consistent.** The park-time write-capability preflight runs
+  under the resolved role too (it takes the dispatch `target`), so the
+  approval banner reflects the role that will execute.
+
+Consumer-side provisioning (the `meho-teardown` role + `rdc-vault-teardown`
+target registration) is documented in
+[`docs/cross-repo/vault-provisioning.md`](../cross-repo/vault-provisioning.md)
+§8; lab-verified in `claude-rdc-hetzner-dc#2814` (PR `#2815`).
 
 ## Key types
 

--- a/docs/cross-repo/connector-vault-policy.md
+++ b/docs/cross-repo/connector-vault-policy.md
@@ -326,20 +326,30 @@ path **before** an operator approves the parked write.
 ### 6.1 Write-capability policy stanza
 
 Like the §2 reads, KV-v2 writes are scoped per operator through ACL
-policy templating. KV-v2 authorizes a write against the **`/data/`**
-path (the value path); `vault.kv.delete`'s version soft-delete
-(`POST <mount>/delete/<path>`) is likewise authorized by `update` on the
-data path. Add this stanza alongside the §2 read grants (it is
-*additive* — keep both):
+policy templating. KV-v2 authorizes each write against a **different**
+path prefix: `vault.kv.put` / `vault.kv.patch` write the value under
+`<mount>/data/<path>` (`create`/`update` there), while `vault.kv.delete`'s
+version soft-delete (`POST <mount>/delete/<path>`) is authorized by
+`update` on the **`/delete/`** path — *not* the data path (evoila/meho#3274,
+lab-verified in claude-rdc-hetzner-dc#2814). Add **both** stanzas below
+alongside the §2 read grants (they are *additive* — keep all):
 
 ```hcl
 # Per-target connector secret WRITES, scoped to the operator's own
 # identity. <ACCESSOR> is the JWT mount accessor (resolve it as in §2).
 # `create` covers a first write to a path; `update` covers a subsequent
-# write (new version) and the version soft-delete. Vault requires BOTH
-# for an unconditional `vault.kv.put` / `vault.kv.patch`.
+# write (new version). Vault requires BOTH for an unconditional
+# `vault.kv.put` / `vault.kv.patch` on the /data/ path.
 path "secret/data/targets/{{identity.entity.aliases.<ACCESSOR>.name}}/*" {
   capabilities = ["create", "read", "update"]
+}
+
+# The version soft-delete (`vault.kv.delete`) POSTs to <mount>/delete/<path>
+# and Vault authorizes it with `update` on that /delete/ path — a SEPARATE
+# grant from the /data/ stanza above. Omit this and every delete is denied
+# post-approval even though /data/ carries `update` (evoila/meho#3274).
+path "secret/delete/targets/{{identity.entity.aliases.<ACCESSOR>.name}}/*" {
+  capabilities = ["update"]
 }
 ```
 
@@ -354,13 +364,16 @@ Notes:
   into one stanza if you prefer (the connector's write path does not
   itself read the value, but keeping `read` here is harmless and avoids
   two near-identical path blocks).
-- **`vault.kv.delete` needs only `update`** on the data path — the
-  soft-delete is a write against the version metadata, not a separate
-  `delete` capability on `/data/`. The `["create", "read", "update"]`
-  grant above already covers it.
-- **No `/metadata/` write grant is needed** for these three ops. They
-  operate on `/data/` (and the version soft-delete endpoint, authorized
-  by `update` on `/data/`); destroying versions or deleting all metadata
+- **`vault.kv.delete` needs `update` on the `/delete/` path** — the
+  version soft-delete POSTs to `<mount>/delete/<path>`, which Vault
+  authorizes with `update` on *that* path, **not** `/data/`
+  (evoila/meho#3274). This is why the second stanza above is required; the
+  `/data/` grant alone does **not** authorize a soft-delete, so a policy
+  that ships only `/data/` denies every delete post-approval. It is not a
+  `delete` capability and not a `/metadata/` grant.
+- **No `/metadata/` write grant is needed** for these three ops. `put` /
+  `patch` operate on `/data/`; the version soft-delete operates on
+  `/delete/`. Destroying versions or deleting all metadata
   (`vault kv metadata delete`) is **not** a wired op and deliberately
   needs no grant.
 - The **same per-operator templating constraints** from §2 apply: no
@@ -371,10 +384,12 @@ Notes:
 
 The backplane runs this exact check at **park time** — when a
 `vault.kv.put`/`patch`/`delete` parks for approval, the dispatcher
-probes `POST sys/capabilities-self` on the target `secret/data/<path>`
-and surfaces a `permission_preflight` banner on the approval row
-(`will_be_denied: true` when the token lacks `create`/`update`), so an
-operator is **not** asked to approve a write that Vault will then reject
+probes `POST sys/capabilities-self` on the path the op authorizes
+against (`secret/data/<path>` for `put`/`patch`, `secret/delete/<path>`
+for `delete` — evoila/meho#3274) and surfaces a `permission_preflight`
+banner on the approval row (`will_be_denied: true` when the token lacks
+the required capability), so an operator is **not** asked to approve a
+write that Vault will then reject
 ([`operations/dispatcher.py`](../../backend/src/meho_backplane/operations/dispatcher.py)
 `_handle_needs_approval` →
 [`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py)
@@ -389,9 +404,12 @@ would mask a missing operator grant):
 
 ```bash
 # Replace <op-sub> with the operator's JWT `sub` and <target> with the
-# target name; this is the exact `/data/` path the connector writes.
+# target name. put/patch authorize on the /data/ path; the soft-delete
+# authorizes on the /delete/ path (evoila/meho#3274).
 vault token capabilities "secret/data/targets/<op-sub>/<target>"
-# Expect for a writable path: create read update
+# Expect for a writable put/patch path: create read update
+vault token capabilities "secret/delete/targets/<op-sub>/<target>"
+# Expect for a soft-delete-capable path: update
 ```
 
 Or, equivalently, against the raw API (what the backplane preflight

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -566,6 +566,73 @@ vault write auth/jwt/login role=meho-mcp jwt="$OPERATOR_TOKEN"
 
 [vault-jwt-api]: https://developer.hashicorp.com/vault/api-docs/auth/jwt
 
+### 8. Per-target teardown role (#3274)
+
+Surfaces 1–7 give every operator one shared Vault role (`meho-mcp`) whose
+policy is the ACL for **all** vault dispatch. A governed **teardown** that
+must `vault.kv.delete` credential subtrees needs `update` on those paths —
+but widening `meho-mcp` to grant that would hand every operator (and the
+`/api/v1/health` federation read) standing delete on the credential store.
+The narrow-role alternative (aligned with the management-plane-lockdown
+principle: a dedicated role over widening the main identity) is a **second,
+dedicated role selected per target**.
+
+The backplane seam is per-target role resolution (evoila/meho#3274): a vault
+`Target` may carry the role — and, optionally, the JWT auth mount it lives on
+— in its `extras`, and the connector logs in under that role instead of
+`meho-mcp` for dispatch against that target. It is JWT-federated exactly like
+`meho-mcp`: the operator's runtime JWT is forwarded to `auth/<mount>/login`
+under the role, the role's policy is the ACL, and **no credential is stored on
+the target** (`secret_ref` stays `NULL`).
+
+**Consumer side (provision the role + register the target):**
+
+```bash
+# 1. Policy: read + update ONLY the credential subtrees the teardown deletes.
+#    (Two subtrees in the lab; adjust to your layout. `update` on the KV-v2
+#    `delete/` path is what authorizes a version soft-delete — NOT `data/`;
+#    see connector-vault-policy.md §6.1.)
+vault policy write meho-teardown - <<'HCL'
+path "secret/data/rdc/**"    { capabilities = ["read"] }
+path "secret/delete/rdc/**"  { capabilities = ["update"] }
+path "secret/data/lab/**"    { capabilities = ["read"] }
+path "secret/delete/lab/**"  { capabilities = ["update"] }
+HCL
+
+# 2. Role on the SAME JWT auth mount as meho-mcp (dedicated mount per surface
+#    1; the lab's is `jwt-meho`), same bound_audiences, its own policy.
+vault write auth/jwt-meho/role/meho-teardown \
+  role_type=jwt user_claim=sub \
+  bound_audiences=<keycloak-audience> \
+  policies=meho-teardown token_ttl=1h
+
+# 3. Register a backplane target that selects the role. secret_ref is NULL
+#    (JWT-federated); version may be null (resolves via the connector's
+#    wildcard registration). The role/mount ride the target's extras.
+meho targets register rdc-vault-teardown \
+  --product vault --host <vault-host> \
+  --extra vault_role=meho-teardown \
+  --extra vault_mount=jwt-meho
+```
+
+The reserved `extras` keys are the frozen contract:
+
+| key | required | meaning | fallback when absent |
+|---|---|---|---|
+| `vault_role` | yes (on a teardown target) | JWT role to log in under | `settings.vault_oidc_role` (`meho-mcp`) |
+| `vault_mount` | optional | JWT auth-method mount the role lives on | `settings.vault_oidc_mount_path` |
+
+Fail-closed: if the role is denied (mis-scoped policy, wrong `bound_*`), the
+dispatch surfaces `VaultRoleDeniedError` — it never silently widens back to
+`meho-mcp`. The park-time capability preflight runs under the resolved role
+too, so the approval banner reflects the role that will actually execute.
+Lab-verified end-to-end in
+[`evoila-bosnia/claude-rdc-hetzner-dc#2814`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2814)
+(PR [`#2815`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/pull/2815)):
+policy `meho-teardown` + role `auth/jwt-meho/role/meho-teardown` soft-deleted a
+scratch KV version through the connector, was denied outside its two subtrees,
+and left `meho-mcp` byte-identical.
+
 ## Verification
 
 Run from any host with the operator's Vault token (`vault login`


### PR DESCRIPTION
## Summary

Two parts, both grounded in the #3274 lab verification (`claude-rdc-hetzner-dc#2814`, PR `#2815`).

**Part 1 — per-target Vault role resolution (the feature, `Closes #3274`).** The vault connector authenticated every dispatch under one deployment-global role (`vault_check_runner_role or vault_oidc_role`, the #2757 seam) and never consulted the `Target`, so a governed teardown's `vault.kv.delete` ran under the read-only `meho-mcp` role and fail-closed. This resolves the JWT role **per target** so a dedicated narrow role (`meho-teardown`) carries the teardown deletes **without widening `meho-mcp`**. The role is Target data, not code: it rides the existing `extras` JSON column — **no migration, no new schema field, no CLI-surface change**.

**Part 2 — preflight probes the KV-v2 `delete/` path (the fix, own commit).** The park-time write-capability preflight probed `<mount>/data/<path>` for every KV write, but a version soft-delete authorizes on `<mount>/delete/<path>` — so `vault.kv.delete` was checked against the wrong path, giving a false `will_be_denied` verdict (the exact "wasted approval" failure #1504 exists to prevent). Found during the #3274 lab verification.

## Target-side contract (frozen; lab-verified, registration is LIVE)

1. **vault-1.x is JWT-FEDERATED**: the operator's runtime JWT → `auth/<mount>/login` under a Vault role; the role's policy IS the ACL. There is NO stored per-target credential — `secret_ref` stays NULL. The ONLY per-target auth datum is the role name.
2. **`extras.vault_role`** (string, REQUIRED on the teardown-class target): when present AND target product == "vault", `vault_client_for_operator` logs in under THIS role instead of `settings.vault_oidc_role`. Absent → byte-for-byte today's behavior. This is the load-bearing selector.
3. **`extras.vault_mount`** (string, OPTIONAL): honor when present, else fall back to `settings.vault_oidc_mount_path`.
4. Address stays GLOBAL (`settings.vault_addr`) — do NOT add per-target address.
5. **FAIL-CLOSED**: unknown/denied `vault_role` ⇒ raise a dedicated error (`VaultRoleDeniedError`) with the no-silent-fallback semantics; NEVER fall back to the settings role on failure (mirrors the #2757 no-fallback rule).

Live registration facts (from the lab side): `product=vault`, `secret_ref=null`, `extras.vault_role="meho-teardown"`, `extras.vault_mount="jwt-meho"`, `version=null`, probed reachable against Vault 1.21.2. The `version=null` target resolves to the connector via its **wildcard registration** (G0.15-T6 #1215); role resolution keys on `product` + `extras` alone, never `version` — a `version=None` test pins this.

Selection precedence at the login site: **per-target override → check-runner role (#2757) → deployment-global `vault_oidc_role`**. Precedence rationale (ratified): a target's `extras.vault_role` governs EVERY dispatch against that target, otherwise the same target would authenticate differently by dispatch class — a silent identity fork.

**Checks/sensors:** a sensor pinned to a role-overridden target authenticates under that override; if the override role lacks the grant the sensor's op needs, the evaluation fails closed to `unknown` (`VaultRoleDeniedError`) — a loud flag of a misconfigured sensor, not a silent widen. Pin monitoring sensors on the standard target, not the delete-scoped one.

**Robustness note:** `resolve_vault_target_auth` is duck-typed-safe — the dispatcher/resolver contract admits any target-shaped object, so a target lacking `extras` (a minimal descriptor, or an ORM row with `extras=NULL`) resolves to no override rather than raising, and the login falls back to the settings-global role. Pinned by unit + the vault dev-Vault integration suite.

## Part 1 — how it's built

- `auth/vault.py`: `vault_client_for_operator(operator, *, role=None, mount_path=None)` — keyword-only overrides; role selection extracted to `_resolve_login_role`. When both are `None` (every non-vault caller, and a target naming no role) the login resolves the settings-global role + mount **byte-for-byte**.
- `connectors/vault/target_auth.py` (new): `resolve_vault_target_auth(target)` reads the two extras keys (product-gated to `product == "vault"`; blank/whitespace/non-string → no override), and `vault_client_for_target(operator, target)` threads them through. Every KV handler (`ops.py`) and auth handler (`ops_auth.py`, `ops_auth_write.py`) opens its client through that one helper — so a target naming a role governs its whole KV/auth dispatch. Scope is KV + auth per the issue's "KV/auth handlers"; `sys`/`identity`/`token` diagnostics stay on the settings-global role (a teardown-scoped target is only ever dispatched KV/auth ops).
- The park-time write-capability preflight takes the dispatch `target` and runs under the resolved role (AC3), so the approval banner reflects the role that will execute.
- `_shared/` credential-read path (`vault_creds.py`, `wrapped_creds.py`, `vcf_auth.py`) is deliberately **unchanged** — it reads *other* vendors' secrets and correctly keeps the settings-global role (AC4: non-vault untouched).

## Part 2 — how it's built (own commit)

- `vault_kv_write_target_path(op_id, params)` is now op-aware: `vault.kv.delete` renders `<mount>/delete/<path>`, `put`/`patch` keep `<mount>/data/<path>` (verified against hvac's `delete_secret_versions` → `POST /v1/<mount>/delete/<path>`).
- The signature change propagates to the dispatcher's post-approval `Forbidden` arm; the `vault_write_identity_forbidden` message is now op-aware too (a delete denial says "lacks 'update' on that delete path", not the data-path phrasing) so the message and rendered path never disagree.
- `docs/cross-repo/connector-vault-policy.md` §6.1 corrected: the `meho-mcp` write policy needs a **second stanza** granting `update` on `secret/delete/…` — the `/data/` grant alone does NOT authorize a soft-delete, so a policy shipping only `/data/` denies every delete post-approval.

## Acceptance criteria

- [x] A vault target advertising a role dispatches `vault.kv.*` under that role; a target with none is byte-for-byte unchanged (`meho-mcp`). — `test_connectors_vault_target_auth.py`
- [x] Unknown/denied target role → `VaultRoleDeniedError`, no fall-through to `vault_oidc_role`. — `test_auth_vault.py::test_explicit_role_denial_fails_closed_without_falling_back`
- [x] Park-time write-capability preflight runs under the **resolved** role. — `test_connectors_vault_target_auth.py::test_write_preflight_runs_under_target_role`
- [x] Non-vault connectors + the `/api/v1/health` federation read untouched (no change to `_shared/` credential path; overrides default to `None`).
- [x] Unit tests: role override applied / absent / denied; preflight delete-path; full suite + ruff + mypy clean.
- [ ] Consumer self-test (register `rdc-vault-teardown`, flip the blueprint, governed `vault.kv.delete` executes under `meho-teardown`) — **deferred to the lab redeploy (their rev-87)**, per the connector precedents; the lab Vault side is already proven (`#2814`/`#2815`).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest` — vault/auth/operations/dispatcher/preview suites green
- Pre-existing local-only artifact: `test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` errors at teardown under a rich-`exc_info` secret-leak scanner (fake internals in the traceback) — **fails identically on `main`**, CI has no TTY so rich renders no frame locals; my change is functionally identical on that path (target defaults `None`).

## Migration / CLI

- **Migration: NONE** (target-carried config rides the existing `extras` JSON column; single head stays `0095` locally).
- **CLI snapshot: UNCHANGED** (no REST-surface change — `extras` is already a free-form dict on `TargetCreate`/`TargetUpdate`).

## Live verification deferred

The connector change is merged-and-redeployed on the lab side (their rev-87 picks it up); live end-to-end validation is deferred to that round, as with the connector precedents. The lab Vault side (`meho-teardown` policy + `auth/jwt-meho/role/meho-teardown`) is already proven in `claude-rdc-hetzner-dc#2814` / PR `#2815`.

Closes #3274
