### PR TITLE
feat(flight-recorder): operator mutation surface for capture policy (#3272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — flight recorder: operator mutation surface for capture policy (#3272)
+
+- The writable path the live-instance verification pass found missing: the
+  flight-recorder capture policy (#3212/#3216) resolved per dispatch but could
+  only be seeded by direct DB writes. New `PATCH
+  /api/v1/tenants/flight-recorder-policy` (`meho tenants flight-recorder-policy
+  set`) flips the three per-tenant fields — `flight_recorder_enabled` (F1),
+  `flight_recorder_agent_readable` (F5, tri-state), and
+  `flight_recorder_retention_days` (F4, bounded 1..365). The route is
+  **tenant-scoped to the caller's own tenant** (from the JWT — no tenant id is
+  accepted, so no cross-tenant write is expressible) and gated at
+  `tenant_admin`.
+- The per-target override `flight_recorder_capture` (tri-state: force on / force
+  off / `null` inherit) now rides the existing `PATCH /api/v1/targets/{name}`
+  and `POST /api/v1/targets` (and `meho targets import --update`), preserving the
+  JSON-null-vs-absent distinction via `exclude_unset`.
+- Operator-plane only — REST + CLI, no MCP tool (the 25-tool agent surface is
+  unchanged): enabling capture is a governance decision. Every applied change
+  writes an `audit_log` row naming field / old / new, and the route evicts the
+  resolver's 60s per-tenant / per-target cache so the flip takes effect on the
+  next dispatch without a restart.
+
 ### Added — `wsfc` connector: Windows Server Failover Clustering over PowerShell-5.1-over-SSH (#3263)
 
 - **`wsfc` connector** — typed connector for Windows Server Failover Clustering
@@ -120,7 +142,6 @@ connector-related release-notes line.
   regenerated. Live c1sql1 consumer proof (probe + governed failover + live
   Sensor) is deferred (lab cluster not yet built); scripted-transport unit suite
   + injection-safety + secret-leak guard are the deliverable.
-
 ### Changed — docs-only CI fast path (#3252)
 
 - A PR whose diff is **purely documentation** — every changed path under
@@ -221,7 +242,6 @@ connector-related release-notes line.
   `hyperv` connectors. Live c1sql1 consumer proof is deferred (lab VMs not yet
   built); scripted-transport unit suite + injection-safety + secret-leak guard
   are the deliverable, consistent with recent connector tasks.
-
 ### Added — typed HttpNfcLease OVF import: `vm.import_from_library` (#3229)
 
 - The durable, transfer-window-decoupled sibling of `vm.deploy_from_library`.

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -99,6 +99,11 @@ TAG_FEATURE: Final[dict[str, str]] = {
     # same substrate, same maturity tier as the approval queue.
     "service-principal-grants": "approvals",
     "targets": "targets",
+    # The per-tenant flight-recorder capture policy (#3272) is the write-side
+    # companion of the operator flight-recorder read surface, which rides the
+    # ``audit`` tag (``GET /api/v1/audit/{id}/trace``, #3215) -- same plane, same
+    # tenant_admin forensic posture, so it follows the ``audit`` feature.
+    "tenants": "audit",
     "topology": "topology",
 }
 

--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -155,6 +155,7 @@ from meho_backplane.connectors.vault.tenant_scope import rendered_tenant_prefix
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import GraphNode
 from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.flight_recorder.config import invalidate_target_override_cache
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.settings import get_settings
 from meho_backplane.targets.resolver import resolve_target
@@ -390,6 +391,7 @@ def _to_full(t: TargetORM) -> Target:
         notes=t.notes,
         fingerprint=t.fingerprint,
         preferred_impl_id=t.preferred_impl_id,
+        flight_recorder_capture=t.flight_recorder_capture,
         created_at=t.created_at,
         updated_at=t.updated_at,
         deleted_at=t.deleted_at,
@@ -585,6 +587,59 @@ def _audit_target_tls_writes(
             before=ca_pin_before,
             after=t.tls_ca_pin,
         )
+
+
+def _fr_capture_audit_value(value: bool | None) -> str:
+    """Render the tri-state capture override for the audit payload (#3272).
+
+    ``None`` (inherit) becomes the ``"inherit"`` sentinel rather than being
+    left as ``None`` -- :func:`~meho_backplane.audit._resolve_audit_payload`
+    drops ``None`` contextvars, so a clear-to-inherit transition would
+    otherwise silently vanish from the ``audit_log`` payload (the same reason
+    the CA-pin audit coerces its "unpinned" state to ``""``).
+    """
+    if value is None:
+        return "inherit"
+    return "on" if value else "off"
+
+
+def _audit_flight_recorder_capture_write(
+    t: TargetORM,
+    *,
+    tenant_id: uuid.UUID,
+    before: bool | None,
+) -> None:
+    """Record a per-target flight-recorder capture-override change (#3272).
+
+    Governance-relevant config write, so it must leave a durable, queryable
+    trail rather than a silent column update -- the same never-silent posture
+    as the ``verify_tls`` / ``tls_ca_pin`` audits. Reads the post-write value
+    off *t* (``t.flight_recorder_capture``), folds the tri-state before/after
+    into this request's ``audit_log`` payload (via ``audit_*`` contextvars the
+    :class:`~meho_backplane.audit.AuditMiddleware` reads) + a WARN, and evicts
+    the resolver's per-target cache so the flip takes effect on the next
+    dispatch. Called by ``create_target`` (a non-inherit initial value) and
+    ``update_target`` (the override sent AND changed).
+    """
+    after = t.flight_recorder_capture
+    structlog.contextvars.bind_contextvars(
+        audit_flight_recorder_capture_changed=True,
+        audit_target_id=str(t.id),
+        audit_flight_recorder_capture_before=_fr_capture_audit_value(before),
+        audit_flight_recorder_capture_after=_fr_capture_audit_value(after),
+    )
+    _log.warning(
+        "target_flight_recorder_capture_changed",
+        target_id=str(t.id),
+        name=t.name,
+        tenant_id=str(tenant_id),
+        flight_recorder_capture_before=_fr_capture_audit_value(before),
+        flight_recorder_capture_after=_fr_capture_audit_value(after),
+    )
+    # Evict the resolver's per-target override cache so the change is visible on
+    # the next dispatch instead of waiting out the 60s TTL. Harmless no-op on a
+    # freshly-created target id (not yet cached).
+    invalidate_target_override_cache(t.id)
 
 
 def _registered_products() -> set[str]:
@@ -1328,6 +1383,8 @@ async def create_target(
         ca_pin_changed=t.tls_ca_pin is not None,
         ca_pin_before=None,
     )
+    if t.flight_recorder_capture is not None:  # #3272: audit a seeded override
+        _audit_flight_recorder_capture_write(t, tenant_id=operator.tenant_id, before=None)
     return _to_full(t)
 
 
@@ -1410,6 +1467,10 @@ async def update_target(
     # ``setattr`` loop mutates anything.
     ca_pin_sent = "tls_ca_pin" in updates
     ca_pin_before = t.tls_ca_pin
+    # #3272. Snapshot the tri-state capture override; ``in updates`` is the
+    # null-vs-absent gate (``exclude_unset``), the same one the TLS fields use.
+    fr_capture_sent = "flight_recorder_capture" in updates
+    fr_capture_before = t.flight_recorder_capture
     effective_ca_pin = updates["tls_ca_pin"] if ca_pin_sent else ca_pin_before
     effective_verify_tls = updates["verify_tls"] if verify_tls_sent else verify_tls_before
     _enforce_tls_trust_exclusion(effective_ca_pin, effective_verify_tls)
@@ -1453,6 +1514,11 @@ async def update_target(
         ca_pin_changed=ca_pin_sent and t.tls_ca_pin != ca_pin_before,
         ca_pin_before=ca_pin_before,
     )
+    # #3272. Audit + cache-invalidate a capture-override change (sent + changed).
+    if fr_capture_sent and t.flight_recorder_capture != fr_capture_before:
+        _audit_flight_recorder_capture_write(
+            t, tenant_id=operator.tenant_id, before=fr_capture_before
+        )
     return _to_full(t)
 
 

--- a/backend/src/meho_backplane/api/v1/tenants.py
+++ b/backend/src/meho_backplane/api/v1/tenants.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator mutation surface for the per-tenant flight-recorder policy (#3272).
+
+The flight-recorder decision (``docs/decisions/dispatch-flight-recorder.md``,
+F1) models capture enablement as an operator action -- "a lab-class tenant is
+one an operator flips ON". The policy columns shipped (#3212/#3216) and the
+resolver (:mod:`meho_backplane.flight_recorder.config`) reads them per dispatch,
+but there was **no writable path**: no ``/api/v1/tenants`` CRUD, so capture
+could not be enabled on a deployment without direct DB writes (which the
+governance model forbids). This route closes that gap for the three per-tenant
+policy fields; the per-target tri-state override
+(``targets.flight_recorder_capture``) rides the existing
+``PATCH /api/v1/targets/{name}`` route (see :mod:`meho_backplane.api.v1.targets`).
+
+Surface posture (postulate 5): this is an **operator-plane** route -- REST +
+CLI (``meho tenants flight-recorder-policy set``) only. It is deliberately
+**not** on the 25-tool agent working surface and has **no MCP tool** at all; a
+governance-config mutation is an operator action, not an agent one.
+
+Scope + authorization:
+
+* **Tenant-scoped, self-only.** The route operates on ``operator.tenant_id``
+  read from the JWT -- it accepts *no* tenant id in the path or body, so it
+  structurally cannot write another tenant's policy (no cross-tenant write).
+* **``tenant_admin`` claim.** Capture policy is governance config, so the
+  mutation is gated at the admin tier via
+  :func:`~meho_backplane.auth.rbac.require_role` -- the same gate the target
+  PATCH and the tenant-convention writes use. ``operator`` / ``read_only``
+  callers get 403 ``insufficient_role``.
+
+Audit + cache: every applied change binds ``audit_*`` contextvars naming
+field / old / new, which :class:`~meho_backplane.audit.AuditMiddleware` folds
+into this request's ``audit_log`` row (governance-relevant mutation, never
+silent). On a change the route also evicts the resolver's per-tenant cache via
+:func:`~meho_backplane.flight_recorder.config.invalidate_tenant_policy_cache`
+so the flip takes effect on the next dispatch rather than waiting out the 60s
+TTL or a restart.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_session
+from meho_backplane.db.models import Tenant
+from meho_backplane.flight_recorder.config import invalidate_tenant_policy_cache
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/tenants", tags=["tenants"])
+
+#: Module-level :class:`Depends` closure -- built once at import time to
+#: satisfy ruff's B008 rule. Capture policy is governance config, gated at the
+#: admin tier (same as the target PATCH and tenant-convention writes).
+_require_tenant_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: Audit-payload sentinel for the tri-state fields' ``inherit`` (NULL) state.
+#: :func:`~meho_backplane.audit._resolve_audit_payload` drops ``None``
+#: contextvars, so a ``True``/``False`` -> ``NULL`` transition would silently
+#: lose its "after" value; the sentinel keeps the transition legible in the
+#: ``audit_log`` payload. Mirrors the ``""`` unpinned marker the target CA-pin
+#: audit uses for the same reason.
+_INHERIT_SENTINEL = "inherit"
+
+
+def _audit_value(value: object) -> object:
+    """Render a policy field value for the audit payload (``None`` -> sentinel).
+
+    Booleans and ints pass through as-is (queryable); ``None`` -- the tri-state
+    ``inherit`` / retention-default state -- becomes :data:`_INHERIT_SENTINEL`
+    so the change does not vanish from the ``audit_log`` payload (which drops
+    ``None`` contextvars).
+    """
+    return _INHERIT_SENTINEL if value is None else value
+
+
+class TenantFlightRecorderPolicy(BaseModel):
+    """Resolved per-tenant flight-recorder policy -- the PATCH read-back shape.
+
+    Frozen; maps 1:1 to the three ``tenant`` policy columns plus the tenant id.
+    ``flight_recorder_agent_readable`` and ``flight_recorder_retention_days``
+    are nullable: ``None`` means "inherit" (agent-read follows the capture
+    default) / "use the global default" (retention) respectively.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tenant_id: UUID
+    flight_recorder_enabled: bool
+    flight_recorder_agent_readable: bool | None
+    flight_recorder_retention_days: int | None
+
+
+class TenantFlightRecorderPolicyUpdate(BaseModel):
+    """``PATCH /api/v1/tenants/flight-recorder-policy`` body.
+
+    All three fields are optional-partial: only fields the client actually
+    sends are applied (``model_dump(exclude_unset=True)`` in the handler keys
+    off ``model_fields_set``, so a JSON ``null`` is distinguished from an
+    absent key). ``extra='forbid'`` rejects unknown keys with a 422.
+
+    * ``flight_recorder_enabled`` (F1) -- Boolean, ``NOT NULL`` at the DB
+      layer. Absent = leave unchanged; ``true`` / ``false`` flips the
+      per-tenant capture default. An explicit ``null`` is rejected (the column
+      has no inherit state) -- the validator fires only when the key is
+      present, so an absent field never trips it.
+    * ``flight_recorder_agent_readable`` (F5) -- **tri-state**. Absent = leave
+      unchanged; ``true`` / ``false`` force the agent-read override on / off;
+      ``null`` clears it back to inherit (follow the capture default). This is
+      the JSON-``null``-vs-absent distinction the tri-state needs.
+    * ``flight_recorder_retention_days`` (F4) -- nullable, bounded ``1..365``
+      (the reaper window; matches ``Settings.flight_recorder_retention_days_default``'s
+      ``ge=1, le=365``). Absent = leave unchanged; an int sets the per-tenant
+      window; ``null`` clears it back to the global default. The bound applies
+      only to the int arm -- a ``null`` clear is always legal.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    flight_recorder_enabled: bool | None = None
+    flight_recorder_agent_readable: bool | None = None
+    flight_recorder_retention_days: Annotated[int, Field(ge=1, le=365)] | None = None
+
+    @field_validator("flight_recorder_enabled")
+    @classmethod
+    def _reject_null_enabled(cls, value: bool | None) -> bool | None:
+        """Reject an explicit ``{"flight_recorder_enabled": null}``.
+
+        The column is ``NOT NULL`` (no inherit state); ``null`` is a caller
+        error, not a clear-to-default. Pydantic runs a ``field_validator`` only
+        for a *provided* field, so an absent ``flight_recorder_enabled`` (the
+        leave-unchanged case) never reaches this check.
+        """
+        if value is None:
+            raise ValueError(
+                "flight_recorder_enabled cannot be null (the column is NOT NULL); "
+                "omit it to leave it unchanged, or send true / false"
+            )
+        return value
+
+
+@router.patch("/flight-recorder-policy", response_model=TenantFlightRecorderPolicy)
+async def update_flight_recorder_policy(
+    body: TenantFlightRecorderPolicyUpdate,
+    operator: Operator = _require_tenant_admin,
+    session: AsyncSession = Depends(get_session),
+) -> TenantFlightRecorderPolicy:
+    """Partially update the caller's tenant flight-recorder policy (#3272).
+
+    Tenant-scoped to ``operator.tenant_id`` (no cross-tenant write is
+    expressible). Applies only the fields present in the body; each field whose
+    value actually changes is folded into this request's ``audit_log`` row
+    (field / old / new) and, once any change lands, the resolver's per-tenant
+    cache is evicted so the next dispatch sees the new policy without a restart.
+    """
+    tenant = await session.get(Tenant, operator.tenant_id)
+    if tenant is None:
+        # Defensive depth: every authenticated request runs the
+        # ``ensure_tenant`` middleware get-or-create first, so the row exists by
+        # the time we read it. This guard only fires if that invariant is ever
+        # bypassed -- surface it structured rather than 500-ing on the setattr.
+        raise HTTPException(status_code=404, detail="tenant_not_found")
+
+    updates = body.model_dump(exclude_unset=True)
+    changed_fields: list[str] = []
+    for field, new_value in updates.items():
+        old_value = getattr(tenant, field)
+        if old_value == new_value:
+            continue
+        setattr(tenant, field, new_value)
+        # Fold field / old / new into the audit payload (never-silent
+        # governance mutation). ``None`` -> sentinel so a clear-to-inherit
+        # transition is not dropped by the payload's None-stripping.
+        # The field name already carries the ``flight_recorder_`` prefix, so
+        # the payload keys read ``flight_recorder_enabled_before`` etc. after
+        # the middleware strips the ``audit_`` prefix.
+        structlog.contextvars.bind_contextvars(
+            **{
+                f"audit_{field}_before": _audit_value(old_value),
+                f"audit_{field}_after": _audit_value(new_value),
+            }
+        )
+        changed_fields.append(field)
+
+    if changed_fields:
+        structlog.contextvars.bind_contextvars(
+            audit_flight_recorder_policy_changed=True,
+            audit_tenant_id=str(operator.tenant_id),
+        )
+        # Evict the resolver's per-tenant cache so the flip takes effect on the
+        # next dispatch. The dependency commits after this handler returns; the
+        # next resolver read (a fresh session, post-request) misses the cache
+        # and reads the committed value -- proven by the without-restart test.
+        invalidate_tenant_policy_cache(operator.tenant_id)
+        _log.info(
+            "tenant_flight_recorder_policy_updated",
+            tenant_id=str(operator.tenant_id),
+            fields=changed_fields,
+        )
+
+    return TenantFlightRecorderPolicy(
+        tenant_id=tenant.id,
+        flight_recorder_enabled=tenant.flight_recorder_enabled,
+        flight_recorder_agent_readable=tenant.flight_recorder_agent_readable,
+        flight_recorder_retention_days=tenant.flight_recorder_retention_days,
+    )

--- a/backend/src/meho_backplane/flight_recorder/config.py
+++ b/backend/src/meho_backplane/flight_recorder/config.py
@@ -72,6 +72,8 @@ from meho_backplane.settings import get_settings
 
 __all__ = [
     "compute_expires_at",
+    "invalidate_target_override_cache",
+    "invalidate_tenant_policy_cache",
     "reset_flight_recorder_config_cache_for_testing",
     "resolve_retention_days",
     "should_capture",
@@ -98,6 +100,31 @@ def reset_flight_recorder_config_cache_for_testing() -> None:
     """Clear both per-key caches (test isolation only)."""
     _TENANT_CACHE.clear()
     _TARGET_CACHE.clear()
+
+
+def invalidate_tenant_policy_cache(tenant_id: UUID) -> None:
+    """Evict the cached policy for *tenant_id* after an operator policy write.
+
+    The per-tenant cache holds all three policy questions (capture default F1,
+    retention override F4, agent-read override F5) for up to
+    :data:`_CACHE_TTL_SECONDS`. An operator mutation to
+    ``tenant.flight_recorder_enabled`` / ``_agent_readable`` /
+    ``_retention_days`` must call this so the flip takes effect on the next
+    dispatch instead of waiting out the TTL (or a process restart). Idempotent
+    -- popping an absent key is a no-op, so a no-op write can call it safely.
+    """
+    _TENANT_CACHE.pop(tenant_id, None)
+
+
+def invalidate_target_override_cache(target_id: UUID) -> None:
+    """Evict the cached per-target capture override for *target_id* after a write.
+
+    Companion to :func:`invalidate_tenant_policy_cache` for the tri-state
+    ``targets.flight_recorder_capture`` override. The target PATCH route calls
+    this whenever the column changes so :func:`should_capture` sees the new
+    tri-state on the next dispatch rather than a stale cached one. Idempotent.
+    """
+    _TARGET_CACHE.pop(target_id, None)
 
 
 def compute_expires_at(created_at: datetime, retention_days: int) -> datetime:

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -116,6 +116,7 @@ from meho_backplane.api.v1.search_docs import router as api_v1_search_docs_route
 from meho_backplane.api.v1.sensors import router as api_v1_sensors_router
 from meho_backplane.api.v1.service_grants import router as api_v1_service_grants_router
 from meho_backplane.api.v1.targets import router as api_v1_targets_router
+from meho_backplane.api.v1.tenants import router as api_v1_tenants_router
 from meho_backplane.api.v1.topology import router as api_v1_topology_router
 from meho_backplane.api.well_known import router as well_known_router
 from meho_backplane.audit import AuditMiddleware
@@ -866,6 +867,10 @@ app.include_router(api_v1_doc_collections_router)
 # G9.1-T5 (#453) extends this router with GET /api/v1/targets/discover
 # (registered before GET /{name} so the literal path wins).
 app.include_router(api_v1_targets_router)
+# #3272 -- operator mutation surface for the per-tenant flight-recorder
+# capture policy (PATCH /api/v1/tenants/flight-recorder-policy;
+# tenant-scoped, tenant_admin). Operator-plane REST + CLI only; no MCP tool.
+app.include_router(api_v1_tenants_router)
 # T3 (#2880) -- event_source registry admin surface at
 # /api/v1/event-sources*. Tenant-scoped CRUD (operator reads,
 # tenant_admin writes) the inbound webhook ingest (#2881) resolves a

--- a/backend/src/meho_backplane/targets/schemas.py
+++ b/backend/src/meho_backplane/targets/schemas.py
@@ -175,6 +175,9 @@ class TargetSummary(BaseModel):
     tls_server_name: str | None = None
     fingerprint: Mapping[str, Any] | None
     preferred_impl_id: str | None
+    # #3272. Per-target capture tri-state (see :class:`Target`); listed so the
+    # list row doesn't silently mask the detail field (api-shape-conventions §5).
+    flight_recorder_capture: bool | None = None
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None = None
@@ -284,6 +287,9 @@ class Target(BaseModel):
     notes: str | None
     fingerprint: Mapping[str, Any] | None
     preferred_impl_id: str | None
+    # #3272 / #3212 (F1). Per-target capture override, tri-state: ``None`` inherit
+    # / ``True`` force ON / ``False`` force OFF (resolved by ``should_capture``).
+    flight_recorder_capture: bool | None = None
     created_at: datetime
     updated_at: datetime
     # Soft-delete timestamp (G0.14-T4 #1145). ``None`` for live
@@ -361,6 +367,11 @@ class TargetCreate(BaseModel):
     extras: dict[str, Any] = Field(default_factory=dict)
     notes: str | None = None
     preferred_impl_id: str | None = Field(default=None, max_length=200)
+    # #3272 / #3212 (F1). Optional per-target capture override (tri-state:
+    # ``None`` inherit / ``True`` ON / ``False`` OFF) so an operator can seed a
+    # capture-on / -off target at create time; a non-inherit initial value is
+    # audited like the ``verify_tls`` / ``tls_ca_pin`` create-time opt-outs.
+    flight_recorder_capture: bool | None = None
 
     @field_validator("tls_ca_pin")
     @classmethod
@@ -489,6 +500,14 @@ class TargetUpdate(BaseModel):
     extras: dict[str, Any] | None = None
     notes: str | None = None
     preferred_impl_id: str | None = Field(default=None, max_length=200)
+    # #3272 / #3212 (F1). Patchable per-target capture override, **tri-state** --
+    # the field the null-vs-absent distinction is load-bearing on, so the route
+    # keys off ``model_fields_set`` (``exclude_unset=True``), NOT off ``None``:
+    # absent = leave untouched; ``true`` = force ON; ``false`` = force OFF;
+    # explicit ``null`` = clear back to inherit (same idiom as ``secret_ref``).
+    # A change is audited and evicts the resolver's per-target cache so the flip
+    # takes effect on the next dispatch.
+    flight_recorder_capture: bool | None = None
 
     @field_validator("tls_ca_pin")
     @classmethod
@@ -573,6 +592,7 @@ def project_target_to_summary(t: TargetORM) -> TargetSummary:
         tls_server_name=t.tls_server_name,
         fingerprint=t.fingerprint,
         preferred_impl_id=t.preferred_impl_id,
+        flight_recorder_capture=t.flight_recorder_capture,
         created_at=t.created_at,
         updated_at=t.updated_at,
         deleted_at=t.deleted_at,

--- a/backend/tests/test_api_v1_tenants_flight_recorder.py
+++ b/backend/tests/test_api_v1_tenants_flight_recorder.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.tenants` (#3272).
+
+Covers the operator mutation surface for the per-tenant flight-recorder policy
+(``PATCH /api/v1/tenants/flight-recorder-policy``):
+
+* Happy path: each of the three fields flips + the resolved policy is returned;
+  the DB row reflects the write.
+* Tri-state semantics: ``flight_recorder_agent_readable`` sets ``true`` /
+  ``false`` and clears with an explicit ``null``; ``flight_recorder_retention_days``
+  sets, clears (``null``), and rejects out-of-bounds; ``flight_recorder_enabled``
+  rejects an explicit ``null`` (the column is NOT NULL).
+* Null-vs-absent: an omitted field leaves its column untouched.
+* RBAC: ``operator`` / ``read_only`` -> 403 ``insufficient_role``;
+  ``tenant_admin`` -> 200.
+* Tenant isolation: a PATCH writes only the caller's own tenant (no path/body
+  tenant id exists to reach another tenant).
+* Audit: an applied change writes one ``audit_log`` row naming field / old / new;
+  a no-op PATCH binds no policy-change keys.
+* Cache invalidation (the load-bearing one): flipping the flag through the route
+  is reflected by the next :func:`should_capture` **without** a cache reset or
+  restart -- proving the handler evicts the resolver's per-tenant cache.
+
+Drives the production ``meho_backplane.main:app`` so the real middleware chain
+(RequestContext -> Audit -> router) is exercised. DB is the autouse per-test
+SQLite + ``alembic upgrade head``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Tenant
+from meho_backplane.flight_recorder.config import (
+    reset_flight_recorder_config_cache_for_testing,
+    should_capture,
+    should_expose_to_agent,
+)
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._vault_fakes import install_fake_vault
+
+_ROUTE = "/api/v1/tenants/flight-recorder-policy"
+_TENANT_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires + isolate the resolver cache."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    reset_flight_recorder_config_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    reset_flight_recorder_config_cache_for_testing()
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-admin",
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    tenant_id: UUID = _TENANT_A,
+) -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+
+
+async def _seed_tenants(
+    *,
+    a_enabled: bool = False,
+    a_agent_readable: bool | None = None,
+    a_retention: int | None = None,
+) -> None:
+    """Insert the two test tenants; tenant A carries the given policy seed."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT_A))
+        ).scalar_one_or_none() is None:
+            session.add(
+                Tenant(
+                    id=_TENANT_A,
+                    slug="tenant-a",
+                    name="Tenant A",
+                    flight_recorder_enabled=a_enabled,
+                    flight_recorder_agent_readable=a_agent_readable,
+                    flight_recorder_retention_days=a_retention,
+                )
+            )
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT_B))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT_B, slug="tenant-b", name="Tenant B"))
+        await session.commit()
+
+
+async def _fetch_tenant(tenant_id: UUID) -> Tenant:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return (await session.execute(select(Tenant).where(Tenant.id == tenant_id))).scalar_one()
+
+
+async def _fetch_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return list(
+            (await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))).scalars().all()
+        )
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    install_fake_vault(monkeypatch)
+    yield TestClient(app)
+
+
+def _patch(
+    client: TestClient,
+    token: str,
+    body: dict[str, Any],
+) -> Any:
+    return client.patch(_ROUTE, json=body, headers={"Authorization": f"Bearer {token}"})
+
+
+# ---------------------------------------------------------------------------
+# Happy path + resolved read-back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_enables_capture_and_returns_resolved_policy(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-enable")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_enabled": True})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tenant_id"] == str(_TENANT_A)
+    assert body["flight_recorder_enabled"] is True
+    assert body["flight_recorder_agent_readable"] is None
+    assert body["flight_recorder_retention_days"] is None
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.flight_recorder_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_partial_patch_leaves_absent_fields_untouched(client: TestClient) -> None:
+    """A PATCH that sends only one field does not disturb the others (null-vs-absent)."""
+    await _seed_tenants(a_enabled=True, a_agent_readable=True, a_retention=14)
+    key = make_rsa_keypair("kid-partial")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_retention_days": 30})
+    assert resp.status_code == 200, resp.text
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.flight_recorder_enabled is True  # untouched
+    assert tenant.flight_recorder_agent_readable is True  # untouched
+    assert tenant.flight_recorder_retention_days == 30  # changed
+
+
+# ---------------------------------------------------------------------------
+# Tri-state semantics: null clears, absent keeps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_readable_tristate_set_false_then_clear_to_null(client: TestClient) -> None:
+    await _seed_tenants(a_enabled=True, a_agent_readable=True)
+    key = make_rsa_keypair("kid-agent")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Force OFF while capture stays on (the F5 independent gate-off).
+        resp_false = _patch(client, _token(key), {"flight_recorder_agent_readable": False})
+        # Clear back to inherit with an explicit null.
+        resp_null = _patch(client, _token(key), {"flight_recorder_agent_readable": None})
+    assert resp_false.status_code == 200, resp_false.text
+    assert resp_false.json()["flight_recorder_agent_readable"] is False
+    assert resp_null.status_code == 200, resp_null.text
+    assert resp_null.json()["flight_recorder_agent_readable"] is None
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.flight_recorder_agent_readable is None  # inherit
+
+
+@pytest.mark.asyncio
+async def test_retention_set_then_clear_to_null(client: TestClient) -> None:
+    await _seed_tenants(a_retention=14)
+    key = make_rsa_keypair("kid-retention")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp_null = _patch(client, _token(key), {"flight_recorder_retention_days": None})
+    assert resp_null.status_code == 200, resp_null.text
+    assert resp_null.json()["flight_recorder_retention_days"] is None
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.flight_recorder_retention_days is None  # back to global default
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_days", [0, -1, 366, 100000])
+async def test_retention_out_of_bounds_rejected(client: TestClient, bad_days: int) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair(f"kid-bound-{bad_days}")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_retention_days": bad_days})
+    assert resp.status_code == 422, resp.text
+    # unchanged
+    assert (await _fetch_tenant(_TENANT_A)).flight_recorder_retention_days is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_explicit_null_rejected(client: TestClient) -> None:
+    """``flight_recorder_enabled`` has no inherit state -- explicit null is a 422."""
+    await _seed_tenants(a_enabled=True)
+    key = make_rsa_keypair("kid-null-enabled")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_enabled": None})
+    assert resp.status_code == 422, resp.text
+    assert (await _fetch_tenant(_TENANT_A)).flight_recorder_enabled is True  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_unknown_field_rejected(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-extra")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_bogus": True})
+    assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [TenantRole.OPERATOR, TenantRole.READ_ONLY])
+async def test_non_admin_roles_get_403(client: TestClient, role: TenantRole) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair(f"kid-rbac-{role.value}")
+    token = _token(key, sub=f"op-{role.value}", role=role)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, token, {"flight_recorder_enabled": True})
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == "insufficient_role"
+    # The rejected write mutated nothing.
+    assert (await _fetch_tenant(_TENANT_A)).flight_recorder_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_touches_only_callers_own_tenant(client: TestClient) -> None:
+    """Tenant A's admin PATCH must not touch tenant B (no cross-tenant path)."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-isolation")
+    token = _token(key, tenant_id=_TENANT_A)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, token, {"flight_recorder_enabled": True})
+    assert resp.status_code == 200, resp.text
+    assert (await _fetch_tenant(_TENANT_A)).flight_recorder_enabled is True
+    assert (await _fetch_tenant(_TENANT_B)).flight_recorder_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_writes_audit_row_naming_field_old_new(client: TestClient) -> None:
+    await _seed_tenants(a_enabled=False, a_retention=None)
+    key = make_rsa_keypair("kid-audit")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(
+            client,
+            _token(key),
+            {"flight_recorder_enabled": True, "flight_recorder_retention_days": 14},
+        )
+    assert resp.status_code == 200, resp.text
+    rows = await _fetch_audit_rows()
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["flight_recorder_policy_changed"] is True
+    assert payload["tenant_id"] == str(_TENANT_A)
+    assert payload["flight_recorder_enabled_before"] is False
+    assert payload["flight_recorder_enabled_after"] is True
+    assert payload["flight_recorder_retention_days_before"] == "inherit"
+    assert payload["flight_recorder_retention_days_after"] == 14
+
+
+@pytest.mark.asyncio
+async def test_noop_patch_binds_no_policy_audit_keys(client: TestClient) -> None:
+    """A PATCH that sends the current value writes an audit row with no policy keys."""
+    await _seed_tenants(a_enabled=True)
+    key = make_rsa_keypair("kid-noop")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_enabled": True})
+    assert resp.status_code == 200, resp.text
+    rows = await _fetch_audit_rows()
+    assert len(rows) == 1
+    assert "flight_recorder_policy_changed" not in rows[0].payload
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation (the load-bearing property)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_flip_reflected_by_resolver_without_restart(client: TestClient) -> None:
+    """Flipping the flag through the route is seen by the next ``should_capture``.
+
+    Primes the resolver cache (capture OFF), PATCHes capture ON, then re-reads
+    WITHOUT resetting the cache. A stale cache would still answer ``False``; the
+    ``True`` proves the handler evicted the per-tenant entry.
+    """
+    await _seed_tenants(a_enabled=False)
+    reset_flight_recorder_config_cache_for_testing()
+    # Prime the cache: capture OFF for tenant A.
+    assert await should_capture(tenant_id=_TENANT_A) is False
+    key = make_rsa_keypair("kid-cache")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_enabled": True})
+    assert resp.status_code == 200, resp.text
+    # No cache reset here on purpose -- the route must have invalidated it.
+    assert await should_capture(tenant_id=_TENANT_A) is True
+
+
+@pytest.mark.asyncio
+async def test_agent_read_flip_reflected_without_restart(client: TestClient) -> None:
+    """The same cache-eviction proof for the F5 agent-read gate."""
+    await _seed_tenants(a_enabled=True, a_agent_readable=None)
+    reset_flight_recorder_config_cache_for_testing()
+    # Inherit -> follows capture default (ON) -> exposed.
+    assert await should_expose_to_agent(tenant_id=_TENANT_A) is True
+    key = make_rsa_keypair("kid-agent-cache")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_agent_readable": False})
+    assert resp.status_code == 200, resp.text
+    assert await should_expose_to_agent(tenant_id=_TENANT_A) is False
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unseeded_tenant_is_autoprovisioned_then_patched(client: TestClient) -> None:
+    """An unseeded tenant is get-or-created by the ``ensure_tenant`` middleware.
+
+    The route's own ``tenant_not_found`` 404 is defensive depth only: every
+    authenticated request runs ``ensure_tenant`` first, so the row exists by the
+    time the handler reads it and the PATCH lands 200 with the flag applied.
+    """
+    # Deliberately do NOT seed tenants -- the middleware provisions the row.
+    key = make_rsa_keypair("kid-autoseed")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"flight_recorder_enabled": True})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["flight_recorder_enabled"] is True
+    assert (await _fetch_tenant(_TENANT_A)).flight_recorder_enabled is True

--- a/backend/tests/test_flight_recorder_config.py
+++ b/backend/tests/test_flight_recorder_config.py
@@ -34,6 +34,8 @@ from meho_backplane.db.models import Target, Tenant
 from meho_backplane.flight_recorder import config as fr_config
 from meho_backplane.flight_recorder.config import (
     compute_expires_at,
+    invalidate_target_override_cache,
+    invalidate_tenant_policy_cache,
     reset_flight_recorder_config_cache_for_testing,
     resolve_retention_days,
     should_capture,
@@ -313,3 +315,48 @@ async def test_cache_reset_reflects_updated_tenant_flag() -> None:
     # Without a reset the 60s-TTL cache would still answer False.
     reset_flight_recorder_config_cache_for_testing()
     assert await should_capture(tenant_id=tenant_id) is True
+
+
+# --------------------------------------------------------------------------
+# targeted cache invalidation (#3272 -- the operator-mutation eviction path)
+# --------------------------------------------------------------------------
+
+
+async def test_invalidate_tenant_policy_cache_reflects_flipped_flag() -> None:
+    """Evicting one tenant's cache re-reads its flipped policy without a restart."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug="fr-tenant-evict", enabled=False)
+    assert await should_capture(tenant_id=tenant_id) is False  # primes the cache
+
+    async with sessionmaker() as session:
+        row = (await session.execute(select(Tenant).where(Tenant.id == tenant_id))).scalar_one()
+        row.flight_recorder_enabled = True
+        await session.commit()
+
+    # The mutation surface calls exactly this after a policy write.
+    invalidate_tenant_policy_cache(tenant_id)
+    assert await should_capture(tenant_id=tenant_id) is True
+
+
+async def test_invalidate_tenant_policy_cache_is_idempotent() -> None:
+    """Popping an uncached / already-evicted tenant is a harmless no-op."""
+    invalidate_tenant_policy_cache(uuid.uuid4())  # must not raise
+
+
+async def test_invalidate_target_override_cache_reflects_flipped_override() -> None:
+    """Evicting one target's cache re-reads its flipped tri-state override."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug="fr-target-evict", enabled=False)
+        target_id = await _seed_target(session, tenant_id=tenant_id, name="tgt", override=None)
+    # Inherit -> tenant default (OFF); primes both caches.
+    assert await should_capture(tenant_id=tenant_id, target_id=target_id) is False
+
+    async with sessionmaker() as session:
+        row = (await session.execute(select(Target).where(Target.id == target_id))).scalar_one()
+        row.flight_recorder_capture = True
+        await session.commit()
+
+    invalidate_target_override_cache(target_id)
+    assert await should_capture(tenant_id=tenant_id, target_id=target_id) is True

--- a/backend/tests/test_targets_flight_recorder_capture.py
+++ b/backend/tests/test_targets_flight_recorder_capture.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the per-target flight-recorder capture tri-state on the target
+PATCH / create routes (#3272).
+
+The ``targets.flight_recorder_capture`` override rides the existing
+``PATCH /api/v1/targets/{name}`` and ``POST /api/v1/targets`` routes rather
+than a new endpoint. Coverage:
+
+* Tri-state semantics: PATCH sets ``true`` / ``false`` and clears with an
+  explicit ``null`` (back to inherit); an absent field leaves the column
+  untouched (null-vs-absent gated on ``exclude_unset``).
+* Audit: an applied change folds ``flight_recorder_capture`` before / after
+  into the request's ``audit_log`` payload (with the ``inherit`` sentinel for
+  the tri-state NULL); a no-op / unrelated PATCH binds no capture keys. Create
+  with a non-inherit override audits the seeded value.
+* Cache invalidation: flipping the override through the route is reflected by
+  the next :func:`should_capture` **without** a cache reset -- proving the
+  handler evicts the resolver's per-target cache.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import respx
+from alembic import command
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from meho_backplane.db import engine as engine_module
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    get_sessionmaker,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.db.models import AuditLog
+from meho_backplane.flight_recorder.config import (
+    reset_flight_recorder_config_cache_for_testing,
+    should_capture,
+)
+
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._targets_helpers import (
+    _build_app,
+    _empty_connector_registry,  # noqa: F401
+    _insert_target,
+    _isolated_jwks_cache,  # noqa: F401
+    _settings_env,  # noqa: F401
+)
+
+_DEFAULT_TENANT_UUID = uuid.UUID(DEFAULT_TENANT_ID)
+
+
+@pytest.fixture
+def _audit_db_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    db_path = tmp_path / "fr_capture.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+    return url
+
+
+@pytest.fixture
+async def isolated_engine(_audit_db_url: str) -> AsyncIterator[AsyncEngine]:
+    reset_engine_for_testing()
+    reset_flight_recorder_config_cache_for_testing()
+    eng = create_engine_for_url(_audit_db_url, pool_size=5, pool_timeout=10.0)
+    engine_module._engine = eng
+    try:
+        yield eng
+    finally:
+        await dispose_engine()
+        reset_engine_for_testing()
+        reset_flight_recorder_config_cache_for_testing()
+
+
+async def _fetch_audit_rows(eng: AsyncEngine) -> list[AuditLog]:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+def _admin_token(key: object) -> str:
+    return mint_token(key, sub="adm-fr", tenant_role="tenant_admin")
+
+
+# ---------------------------------------------------------------------------
+# PATCH tri-state + audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("value", "after_sentinel"),
+    [(True, "on"), (False, "off")],
+)
+async def test_patch_capture_sets_override_and_audits(
+    isolated_engine: AsyncEngine, value: bool, after_sentinel: str
+) -> None:
+    t = await _insert_target(name="fr-set", flight_recorder_capture=None)
+    key = make_rsa_keypair(f"kid-cap-{value}")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"flight_recorder_capture": value},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["flight_recorder_capture"] is value
+    rows = await _fetch_audit_rows(isolated_engine)
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["flight_recorder_capture_changed"] is True
+    assert payload["target_id"] == str(t.id)
+    assert payload["flight_recorder_capture_before"] == "inherit"
+    assert payload["flight_recorder_capture_after"] == after_sentinel
+    assert rows[0].target_id == t.id
+
+
+@pytest.mark.asyncio
+async def test_patch_capture_clear_to_null_reverts_to_inherit(
+    isolated_engine: AsyncEngine,
+) -> None:
+    t = await _insert_target(name="fr-clear", flight_recorder_capture=True)
+    key = make_rsa_keypair("kid-cap-clear")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"flight_recorder_capture": None},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["flight_recorder_capture"] is None
+    payload = (await _fetch_audit_rows(isolated_engine))[0].payload
+    assert payload["flight_recorder_capture_before"] == "on"
+    assert payload["flight_recorder_capture_after"] == "inherit"
+
+
+@pytest.mark.asyncio
+async def test_patch_without_capture_binds_no_capture_keys(
+    isolated_engine: AsyncEngine,
+) -> None:
+    t = await _insert_target(name="fr-unrelated", flight_recorder_capture=True)
+    key = make_rsa_keypair("kid-cap-unrelated")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"notes": "ticket-99"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    payload = (await _fetch_audit_rows(isolated_engine))[0].payload
+    assert "flight_recorder_capture_changed" not in payload
+    assert "flight_recorder_capture_before" not in payload
+
+
+@pytest.mark.asyncio
+async def test_patch_capture_noop_resend_binds_no_capture_keys(
+    isolated_engine: AsyncEngine,
+) -> None:
+    """Re-sending the same override value is not a change -> no audit noise."""
+    t = await _insert_target(name="fr-noop", flight_recorder_capture=True)
+    key = make_rsa_keypair("kid-cap-noop")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"flight_recorder_capture": True},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    payload = (await _fetch_audit_rows(isolated_engine))[0].payload
+    assert "flight_recorder_capture_changed" not in payload
+
+
+@pytest.mark.asyncio
+async def test_create_target_with_capture_override_audits(
+    isolated_engine: AsyncEngine,
+) -> None:
+    key = make_rsa_keypair("kid-cap-create")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "fr-created",
+                "product": "rke2",
+                "host": "10.0.0.9",
+                "flight_recorder_capture": True,
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["flight_recorder_capture"] is True
+    payload = (await _fetch_audit_rows(isolated_engine))[0].payload
+    assert payload["flight_recorder_capture_changed"] is True
+    assert payload["flight_recorder_capture_before"] == "inherit"
+    assert payload["flight_recorder_capture_after"] == "on"
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation (the load-bearing property)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_flip_reflected_by_resolver_without_restart(
+    isolated_engine: AsyncEngine,
+) -> None:
+    """Flipping the per-target override through the route is seen by the next
+    ``should_capture`` without a cache reset -- proving per-target eviction.
+
+    The target's tenant has no policy row (capture OFF default), so with the
+    override at inherit the resolver answers ``False``. After the override flips
+    to force-ON, the resolver must answer ``True`` even though the cache was
+    primed with the old value.
+    """
+    t = await _insert_target(name="fr-cache", flight_recorder_capture=None)
+    reset_flight_recorder_config_cache_for_testing()
+    # Prime: inherit -> tenant default (OFF) -> False.
+    assert await should_capture(tenant_id=_DEFAULT_TENANT_UUID, target_id=t.id) is False
+    key = make_rsa_keypair("kid-cap-cache")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        resp = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"flight_recorder_capture": True},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    # No cache reset -- the route must have invalidated the per-target entry.
+    assert await should_capture(tenant_id=_DEFAULT_TENANT_UUID, target_id=t.id) is True

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -34071,6 +34071,10 @@
       "x-maturity": "ga"
     },
     {
+      "name": "tenants",
+      "x-maturity": "ga"
+    },
+    {
       "name": "topology",
       "x-maturity": "beta"
     }

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1361,6 +1361,60 @@
         }
       }
     },
+    "/api/v1/tenants/flight-recorder-policy": {
+      "patch": {
+        "tags": [
+          "tenants"
+        ],
+        "summary": "Update Flight Recorder Policy",
+        "description": "Partially update the caller's tenant flight-recorder policy (#3272).\n\nTenant-scoped to ``operator.tenant_id`` (no cross-tenant write is\nexpressible). Applies only the fields present in the body; each field whose\nvalue actually changes is folded into this request's ``audit_log`` row\n(field / old / new) and, once any change lands, the resolver's per-tenant\ncache is evicted so the next dispatch sees the new policy without a restart.",
+        "operationId": "update_flight_recorder_policy_api_v1_tenants_flight_recorder_policy_patch",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantFlightRecorderPolicyUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantFlightRecorderPolicy"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/event-sources": {
       "get": {
         "tags": [
@@ -32309,6 +32363,11 @@
             "nullable": true,
             "title": "Preferred Impl Id"
           },
+          "flight_recorder_capture": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Capture"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -32473,6 +32532,11 @@
             "maxLength": 200,
             "nullable": true,
             "title": "Preferred Impl Id"
+          },
+          "flight_recorder_capture": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Capture"
           }
         },
         "additionalProperties": false,
@@ -32590,6 +32654,11 @@
             "type": "string",
             "nullable": true,
             "title": "Preferred Impl Id"
+          },
+          "flight_recorder_capture": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Capture"
           },
           "created_at": {
             "type": "string",
@@ -32716,6 +32785,11 @@
             "maxLength": 200,
             "nullable": true,
             "title": "Preferred Impl Id"
+          },
+          "flight_recorder_capture": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Capture"
           }
         },
         "additionalProperties": false,
@@ -32793,6 +32867,63 @@
         ],
         "title": "TemplateSummary",
         "description": "Operator-readable summary row surfaced by ``meho_runbook_list_templates``.\n\nThe list-view projection -- enough to identify a template and its\nlifecycle state without loading the full step list (which\n:class:`ShowTemplateResponse` carries)."
+      },
+      "TenantFlightRecorderPolicy": {
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "flight_recorder_enabled": {
+            "type": "boolean",
+            "title": "Flight Recorder Enabled"
+          },
+          "flight_recorder_agent_readable": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Agent Readable"
+          },
+          "flight_recorder_retention_days": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Flight Recorder Retention Days"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tenant_id",
+          "flight_recorder_enabled",
+          "flight_recorder_agent_readable",
+          "flight_recorder_retention_days"
+        ],
+        "title": "TenantFlightRecorderPolicy",
+        "description": "Resolved per-tenant flight-recorder policy -- the PATCH read-back shape.\n\nFrozen; maps 1:1 to the three ``tenant`` policy columns plus the tenant id.\n``flight_recorder_agent_readable`` and ``flight_recorder_retention_days``\nare nullable: ``None`` means \"inherit\" (agent-read follows the capture\ndefault) / \"use the global default\" (retention) respectively."
+      },
+      "TenantFlightRecorderPolicyUpdate": {
+        "properties": {
+          "flight_recorder_enabled": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Enabled"
+          },
+          "flight_recorder_agent_readable": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Flight Recorder Agent Readable"
+          },
+          "flight_recorder_retention_days": {
+            "type": "integer",
+            "maximum": 365.0,
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Flight Recorder Retention Days"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "TenantFlightRecorderPolicyUpdate",
+        "description": "``PATCH /api/v1/tenants/flight-recorder-policy`` body.\n\nAll three fields are optional-partial: only fields the client actually\nsends are applied (``model_dump(exclude_unset=True)`` in the handler keys\noff ``model_fields_set``, so a JSON ``null`` is distinguished from an\nabsent key). ``extra='forbid'`` rejects unknown keys with a 422.\n\n* ``flight_recorder_enabled`` (F1) -- Boolean, ``NOT NULL`` at the DB\n  layer. Absent = leave unchanged; ``true`` / ``false`` flips the\n  per-tenant capture default. An explicit ``null`` is rejected (the column\n  has no inherit state) -- the validator fires only when the key is\n  present, so an absent field never trips it.\n* ``flight_recorder_agent_readable`` (F5) -- **tri-state**. Absent = leave\n  unchanged; ``true`` / ``false`` force the agent-read override on / off;\n  ``null`` clears it back to inherit (follow the capture default). This is\n  the JSON-``null``-vs-absent distinction the tri-state needs.\n* ``flight_recorder_retention_days`` (F4) -- nullable, bounded ``1..365``\n  (the reaper window; matches ``Settings.flight_recorder_retention_days_default``'s\n  ``ge=1, le=365``). Absent = leave unchanged; an int sets the per-tenant\n  window; ``null`` clears it back to the global default. The bound applies\n  only to the int arm -- a ``null`` clear is always legal."
       },
       "TenantRole": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -7884,27 +7884,28 @@ type Target struct {
 	Aliases []string `json:"aliases"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel       AuthModel               `json:"auth_model"`
-	CreatedAt       time.Time               `json:"created_at"`
-	DeletedAt       *time.Time              `json:"deleted_at"`
-	Extras          map[string]interface{}  `json:"extras"`
-	Fingerprint     *map[string]interface{} `json:"fingerprint"`
-	Fqdn            *string                 `json:"fqdn"`
-	Host            string                  `json:"host"`
-	Id              openapi_types.UUID      `json:"id"`
-	Name            string                  `json:"name"`
-	Notes           *string                 `json:"notes"`
-	Port            *int                    `json:"port"`
-	PreferredImplId *string                 `json:"preferred_impl_id"`
-	Product         string                  `json:"product"`
-	SecretRef       *string                 `json:"secret_ref"`
-	TenantId        openapi_types.UUID      `json:"tenant_id"`
-	TlsCaPin        *string                 `json:"tls_ca_pin"`
-	TlsServerName   *string                 `json:"tls_server_name"`
-	UpdatedAt       time.Time               `json:"updated_at"`
-	VerifyTls       *bool                   `json:"verify_tls,omitempty"`
-	Version         *string                 `json:"version"`
-	VpnRequired     bool                    `json:"vpn_required"`
+	AuthModel             AuthModel               `json:"auth_model"`
+	CreatedAt             time.Time               `json:"created_at"`
+	DeletedAt             *time.Time              `json:"deleted_at"`
+	Extras                map[string]interface{}  `json:"extras"`
+	Fingerprint           *map[string]interface{} `json:"fingerprint"`
+	FlightRecorderCapture *bool                   `json:"flight_recorder_capture"`
+	Fqdn                  *string                 `json:"fqdn"`
+	Host                  string                  `json:"host"`
+	Id                    openapi_types.UUID      `json:"id"`
+	Name                  string                  `json:"name"`
+	Notes                 *string                 `json:"notes"`
+	Port                  *int                    `json:"port"`
+	PreferredImplId       *string                 `json:"preferred_impl_id"`
+	Product               string                  `json:"product"`
+	SecretRef             *string                 `json:"secret_ref"`
+	TenantId              openapi_types.UUID      `json:"tenant_id"`
+	TlsCaPin              *string                 `json:"tls_ca_pin"`
+	TlsServerName         *string                 `json:"tls_server_name"`
+	UpdatedAt             time.Time               `json:"updated_at"`
+	VerifyTls             *bool                   `json:"verify_tls,omitempty"`
+	Version               *string                 `json:"version"`
+	VpnRequired           bool                    `json:"vpn_required"`
 }
 
 // TargetCreate POST /api/v1/targets body.
@@ -7932,14 +7933,15 @@ type TargetCreate struct {
 	Aliases *[]string `json:"aliases,omitempty"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel       *AuthModel              `json:"auth_model,omitempty"`
-	Extras          *map[string]interface{} `json:"extras,omitempty"`
-	Fqdn            *string                 `json:"fqdn"`
-	Host            string                  `json:"host"`
-	Name            string                  `json:"name"`
-	Notes           *string                 `json:"notes"`
-	Port            *int                    `json:"port"`
-	PreferredImplId *string                 `json:"preferred_impl_id"`
+	AuthModel             *AuthModel              `json:"auth_model,omitempty"`
+	Extras                *map[string]interface{} `json:"extras,omitempty"`
+	FlightRecorderCapture *bool                   `json:"flight_recorder_capture"`
+	Fqdn                  *string                 `json:"fqdn"`
+	Host                  string                  `json:"host"`
+	Name                  string                  `json:"name"`
+	Notes                 *string                 `json:"notes"`
+	Port                  *int                    `json:"port"`
+	PreferredImplId       *string                 `json:"preferred_impl_id"`
 
 	// Product Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss.
 	Product       TargetCreateProduct `json:"product"`
@@ -8002,25 +8004,26 @@ type TargetSummary struct {
 	Aliases []string `json:"aliases"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel       AuthModel               `json:"auth_model"`
-	CreatedAt       time.Time               `json:"created_at"`
-	DeletedAt       *time.Time              `json:"deleted_at"`
-	Fingerprint     *map[string]interface{} `json:"fingerprint"`
-	Fqdn            *string                 `json:"fqdn"`
-	Host            string                  `json:"host"`
-	Id              openapi_types.UUID      `json:"id"`
-	Name            string                  `json:"name"`
-	Port            *int                    `json:"port"`
-	PreferredImplId *string                 `json:"preferred_impl_id"`
-	Product         string                  `json:"product"`
-	SecretRef       *string                 `json:"secret_ref"`
-	TenantId        openapi_types.UUID      `json:"tenant_id"`
-	TlsCaPin        *string                 `json:"tls_ca_pin"`
-	TlsServerName   *string                 `json:"tls_server_name"`
-	UpdatedAt       time.Time               `json:"updated_at"`
-	VerifyTls       *bool                   `json:"verify_tls,omitempty"`
-	Version         *string                 `json:"version"`
-	VpnRequired     bool                    `json:"vpn_required"`
+	AuthModel             AuthModel               `json:"auth_model"`
+	CreatedAt             time.Time               `json:"created_at"`
+	DeletedAt             *time.Time              `json:"deleted_at"`
+	Fingerprint           *map[string]interface{} `json:"fingerprint"`
+	FlightRecorderCapture *bool                   `json:"flight_recorder_capture"`
+	Fqdn                  *string                 `json:"fqdn"`
+	Host                  string                  `json:"host"`
+	Id                    openapi_types.UUID      `json:"id"`
+	Name                  string                  `json:"name"`
+	Port                  *int                    `json:"port"`
+	PreferredImplId       *string                 `json:"preferred_impl_id"`
+	Product               string                  `json:"product"`
+	SecretRef             *string                 `json:"secret_ref"`
+	TenantId              openapi_types.UUID      `json:"tenant_id"`
+	TlsCaPin              *string                 `json:"tls_ca_pin"`
+	TlsServerName         *string                 `json:"tls_server_name"`
+	UpdatedAt             time.Time               `json:"updated_at"`
+	VerifyTls             *bool                   `json:"verify_tls,omitempty"`
+	Version               *string                 `json:"version"`
+	VpnRequired           bool                    `json:"vpn_required"`
 }
 
 // TargetUpdate PATCH /api/v1/targets/{name} body.
@@ -8061,20 +8064,21 @@ type TargetUpdate struct {
 	Aliases *[]string `json:"aliases"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel       *AuthModel              `json:"auth_model,omitempty"`
-	Extras          *map[string]interface{} `json:"extras"`
-	Fqdn            *string                 `json:"fqdn"`
-	Host            *string                 `json:"host"`
-	Notes           *string                 `json:"notes"`
-	Port            *int                    `json:"port"`
-	PreferredImplId *string                 `json:"preferred_impl_id"`
-	Product         *string                 `json:"product"`
-	SecretRef       *string                 `json:"secret_ref"`
-	TlsCaPin        *string                 `json:"tls_ca_pin"`
-	TlsServerName   *string                 `json:"tls_server_name"`
-	VerifyTls       *bool                   `json:"verify_tls"`
-	Version         *string                 `json:"version"`
-	VpnRequired     *bool                   `json:"vpn_required"`
+	AuthModel             *AuthModel              `json:"auth_model,omitempty"`
+	Extras                *map[string]interface{} `json:"extras"`
+	FlightRecorderCapture *bool                   `json:"flight_recorder_capture"`
+	Fqdn                  *string                 `json:"fqdn"`
+	Host                  *string                 `json:"host"`
+	Notes                 *string                 `json:"notes"`
+	Port                  *int                    `json:"port"`
+	PreferredImplId       *string                 `json:"preferred_impl_id"`
+	Product               *string                 `json:"product"`
+	SecretRef             *string                 `json:"secret_ref"`
+	TlsCaPin              *string                 `json:"tls_ca_pin"`
+	TlsServerName         *string                 `json:"tls_server_name"`
+	VerifyTls             *bool                   `json:"verify_tls"`
+	Version               *string                 `json:"version"`
+	VpnRequired           *bool                   `json:"vpn_required"`
 }
 
 // TargetsDiscoverResult Aggregated discover output across every connector for a product.
@@ -8106,6 +8110,46 @@ type TemplateSummary struct {
 
 // TemplateSummaryStatus defines model for TemplateSummary.Status.
 type TemplateSummaryStatus string
+
+// TenantFlightRecorderPolicy Resolved per-tenant flight-recorder policy -- the PATCH read-back shape.
+//
+// Frozen; maps 1:1 to the three “tenant“ policy columns plus the tenant id.
+// “flight_recorder_agent_readable“ and “flight_recorder_retention_days“
+// are nullable: “None“ means "inherit" (agent-read follows the capture
+// default) / "use the global default" (retention) respectively.
+type TenantFlightRecorderPolicy struct {
+	FlightRecorderAgentReadable *bool              `json:"flight_recorder_agent_readable"`
+	FlightRecorderEnabled       bool               `json:"flight_recorder_enabled"`
+	FlightRecorderRetentionDays *int               `json:"flight_recorder_retention_days"`
+	TenantId                    openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantFlightRecorderPolicyUpdate “PATCH /api/v1/tenants/flight-recorder-policy“ body.
+//
+// All three fields are optional-partial: only fields the client actually
+// sends are applied (“model_dump(exclude_unset=True)“ in the handler keys
+// off “model_fields_set“, so a JSON “null“ is distinguished from an
+// absent key). “extra='forbid'“ rejects unknown keys with a 422.
+//
+//   - “flight_recorder_enabled“ (F1) -- Boolean, “NOT NULL“ at the DB
+//     layer. Absent = leave unchanged; “true“ / “false“ flips the
+//     per-tenant capture default. An explicit “null“ is rejected (the column
+//     has no inherit state) -- the validator fires only when the key is
+//     present, so an absent field never trips it.
+//   - “flight_recorder_agent_readable“ (F5) -- **tri-state**. Absent = leave
+//     unchanged; “true“ / “false“ force the agent-read override on / off;
+//     “null“ clears it back to inherit (follow the capture default). This is
+//     the JSON-“null“-vs-absent distinction the tri-state needs.
+//   - “flight_recorder_retention_days“ (F4) -- nullable, bounded “1..365“
+//     (the reaper window; matches “Settings.flight_recorder_retention_days_default“'s
+//     “ge=1, le=365“). Absent = leave unchanged; an int sets the per-tenant
+//     window; “null“ clears it back to the global default. The bound applies
+//     only to the int arm -- a “null“ clear is always legal.
+type TenantFlightRecorderPolicyUpdate struct {
+	FlightRecorderAgentReadable *bool `json:"flight_recorder_agent_readable"`
+	FlightRecorderEnabled       *bool `json:"flight_recorder_enabled"`
+	FlightRecorderRetentionDays *int  `json:"flight_recorder_retention_days"`
+}
 
 // TenantRole Per-tenant role granted to the operator by the JWT issuer.
 //
@@ -9748,6 +9792,11 @@ type ProbeTargetApiV1TargetsNameProbePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams defines parameters for UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch.
+type UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // DependenciesApiV1TopologyDependenciesNameGetParams defines parameters for DependenciesApiV1TopologyDependenciesNameGet.
 type DependenciesApiV1TopologyDependenciesNameGetParams struct {
 	Depth      *int    `form:"depth,omitempty" json:"depth,omitempty"`
@@ -10366,6 +10415,9 @@ type CreateTargetApiV1TargetsPostJSONRequestBody = TargetCreate
 
 // UpdateTargetApiV1TargetsNamePatchJSONRequestBody defines body for UpdateTargetApiV1TargetsNamePatch for application/json ContentType.
 type UpdateTargetApiV1TargetsNamePatchJSONRequestBody = TargetUpdate
+
+// UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody defines body for UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch for application/json ContentType.
+type UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody = TenantFlightRecorderPolicyUpdate
 
 // AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody defines body for AnnotateEdgeRouteApiV1TopologyEdgesPost for application/json ContentType.
 type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotateEdgeRequest
@@ -12555,6 +12607,11 @@ type ClientInterface interface {
 
 	// ProbeTargetApiV1TargetsNameProbePost request
 	ProbeTargetApiV1TargetsNameProbePost(ctx context.Context, name string, params *ProbeTargetApiV1TargetsNameProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody request with any body
+	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DependenciesApiV1TopologyDependenciesNameGet request
 	DependenciesApiV1TopologyDependenciesNameGet(ctx context.Context, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -15921,6 +15978,30 @@ func (c *Client) UpdateTargetApiV1TargetsNamePatch(ctx context.Context, name str
 
 func (c *Client) ProbeTargetApiV1TargetsNameProbePost(ctx context.Context, name string, params *ProbeTargetApiV1TargetsNameProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProbeTargetApiV1TargetsNameProbePostRequest(c.Server, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -29842,6 +29923,61 @@ func NewProbeTargetApiV1TargetsNameProbePostRequest(server string, name string, 
 	return req, nil
 }
 
+// NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequest calls the generic UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch builder with application/json body
+func NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequest(server string, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequestWithBody generates requests for UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch with any type of body
+func NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequestWithBody(server string, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/tenants/flight-recorder-policy")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewDependenciesApiV1TopologyDependenciesNameGetRequest generates requests for DependenciesApiV1TopologyDependenciesNameGet
 func NewDependenciesApiV1TopologyDependenciesNameGetRequest(server string, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams) (*http.Request, error) {
 	var err error
@@ -42081,6 +42217,11 @@ type ClientWithResponsesInterface interface {
 	// ProbeTargetApiV1TargetsNameProbePostWithResponse request
 	ProbeTargetApiV1TargetsNameProbePostWithResponse(ctx context.Context, name string, params *ProbeTargetApiV1TargetsNameProbePostParams, reqEditors ...RequestEditorFn) (*ProbeTargetApiV1TargetsNameProbePostResponse, error)
 
+	// UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBodyWithResponse request with any body
+	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBodyWithResponse(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error)
+
+	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithResponse(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error)
+
 	// DependenciesApiV1TopologyDependenciesNameGetWithResponse request
 	DependenciesApiV1TopologyDependenciesNameGetWithResponse(ctx context.Context, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams, reqEditors ...RequestEditorFn) (*DependenciesApiV1TopologyDependenciesNameGetResponse, error)
 
@@ -46457,6 +46598,29 @@ func (r ProbeTargetApiV1TargetsNameProbePostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ProbeTargetApiV1TargetsNameProbePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TenantFlightRecorderPolicy
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -53243,6 +53407,23 @@ func (c *ClientWithResponses) ProbeTargetApiV1TargetsNameProbePostWithResponse(c
 		return nil, err
 	}
 	return ParseProbeTargetApiV1TargetsNameProbePostResponse(rsp)
+}
+
+// UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBodyWithResponse request with arbitrary body returning *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse
+func (c *ClientWithResponses) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBodyWithResponse(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error) {
+	rsp, err := c.UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithResponse(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error) {
+	rsp, err := c.UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse(rsp)
 }
 
 // DependenciesApiV1TopologyDependenciesNameGetWithResponse request returning *DependenciesApiV1TopologyDependenciesNameGetResponse
@@ -61087,6 +61268,39 @@ func ParseProbeTargetApiV1TargetsNameProbePostResponse(rsp *http.Response) (*Pro
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest FingerprintResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse parses an HTTP response from a UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithResponse call
+func ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse(rsp *http.Response) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TenantFlightRecorderPolicy
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -48,6 +48,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/secret"
 	"github.com/evoila/meho/cli/internal/cmd/sensor"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
+	"github.com/evoila/meho/cli/internal/cmd/tenants"
 	"github.com/evoila/meho/cli/internal/cmd/topology"
 	"github.com/evoila/meho/cli/internal/cmd/vault"
 	vcfautomation "github.com/evoila/meho/cli/internal/cmd/vcf-automation"
@@ -143,6 +144,10 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `targets` parent.
 	root.AddCommand(targets.NewRootCmd())
+	// #3272 -- operator-plane per-tenant flight-recorder capture policy
+	// (`meho tenants flight-recorder-policy set`). Wraps PATCH
+	// /api/v1/tenants/flight-recorder-policy; tenant-scoped, tenant_admin.
+	root.AddCommand(tenants.NewRootCmd())
 	// T3 (#2880) -- event_source registry admin verbs (add / list /
 	// describe / update / delete). Wraps /api/v1/event-sources/*.
 	root.AddCommand(eventsource.NewRootCmd())

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -80,21 +80,22 @@ type importDoc struct {
 // (no mutual-exclusion validator); the server caps it at 512 chars and
 // returns 422 on overflow, which the import path already surfaces.
 var knownTopLevel = map[string]struct{}{
-	"aliases":           {},
-	"auth_model":        {},
-	"extras":            {},
-	"fqdn":              {},
-	"host":              {},
-	"name":              {},
-	"notes":             {},
-	"port":              {},
-	"preferred_impl_id": {},
-	"product":           {},
-	"secret_ref":        {},
-	"tls_ca_pin":        {},
-	"tls_server_name":   {},
-	"verify_tls":        {},
-	"vpn_required":      {},
+	"aliases":                 {},
+	"auth_model":              {},
+	"extras":                  {},
+	"flight_recorder_capture": {},
+	"fqdn":                    {},
+	"host":                    {},
+	"name":                    {},
+	"notes":                   {},
+	"port":                    {},
+	"preferred_impl_id":       {},
+	"product":                 {},
+	"secret_ref":              {},
+	"tls_ca_pin":              {},
+	"tls_server_name":         {},
+	"verify_tls":              {},
+	"vpn_required":            {},
 }
 
 // skipSilent is the set of YAML keys we deliberately drop on the
@@ -191,8 +192,8 @@ func newImportCmd() *cobra.Command {
 			"Mapping rules. Top-level columns recognised on the API's " +
 			"TargetCreate / TargetUpdate models are mapped 1:1: name, aliases, " +
 			"product, host, port, fqdn, secret_ref, auth_model, vpn_required, " +
-			"notes, preferred_impl_id, verify_tls, tls_ca_pin, tls_server_name. " +
-			"Any other field " +
+			"notes, preferred_impl_id, verify_tls, tls_ca_pin, tls_server_name, " +
+			"flight_recorder_capture. Any other field " +
 			"is spilled into the `extras` JSONB column. `fingerprint` is " +
 			"server-managed and skipped with a warning if present in the YAML " +
 			"(the probe verb is the only legitimate writer).\n\n" +

--- a/cli/internal/cmd/tenants/flight_recorder.go
+++ b/cli/internal/cmd/tenants/flight_recorder.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package tenants
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newFlightRecorderPolicyCmd returns `meho tenants flight-recorder-policy`.
+func newFlightRecorderPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "flight-recorder-policy",
+		Short:        "Manage the tenant's flight-recorder capture policy (tenant_admin)",
+		Long:         "Read/write the operator's own tenant flight-recorder capture policy.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSetCmd())
+	return cmd
+}
+
+type setOptions struct {
+	enabled           bool
+	agentReadable     string
+	retentionDays     int
+	clearRetention    bool
+	enabledSet        bool
+	agentReadableSet  bool
+	retentionDaysSet  bool
+	jsonOut           bool
+	backplaneOverride string
+}
+
+// newSetCmd returns `meho tenants flight-recorder-policy set`.
+//
+//	meho tenants flight-recorder-policy set
+//	  [--enabled=true|false]              # F1 per-tenant capture default
+//	  [--agent-readable=true|false|inherit] # F5 tri-state (inherit clears to null)
+//	  [--retention-days N]                # F4 window (1..365)
+//	  [--clear-retention]                 # clear retention back to the global default
+//	  [--json] [--backplane <url>]
+//
+// Tenant-scoped (the caller's own tenant, from the JWT). tenant_admin only.
+// Only the flags the operator actually set are sent (sparse PATCH), so an
+// unset field is left unchanged — the tri-state null-vs-absent distinction.
+//
+// Exit codes: 0 ok; 2 auth_expired; 3 unreachable; 4 unexpected (incl. 422 /
+// 404); 5 insufficient_role.
+func newSetCmd() *cobra.Command {
+	var opts setOptions
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Update the tenant flight-recorder capture policy (tenant_admin)",
+		Long: "set PATCHes /api/v1/tenants/flight-recorder-policy for the operator's own " +
+			"tenant. tenant_admin only — operator / read_only land as 403 insufficient_role.\n\n" +
+			"Only the flags you pass are sent; an omitted field is left unchanged. " +
+			"--enabled flips the per-tenant capture default (F1). --agent-readable is " +
+			"tri-state (F5): true / false force the agent-read override, inherit clears it " +
+			"back to following the capture default. --retention-days sets the per-tenant " +
+			"trace window (F4, 1..365 days); --clear-retention resets it to the global " +
+			"default. Pass at least one field flag.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.enabledSet = cmd.Flags().Changed("enabled")
+			opts.agentReadableSet = cmd.Flags().Changed("agent-readable")
+			opts.retentionDaysSet = cmd.Flags().Changed("retention-days")
+			return runSet(cmd, opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.enabled, "enabled", false,
+		"per-tenant capture default (F1); send true or false")
+	cmd.Flags().StringVar(&opts.agentReadable, "agent-readable", "",
+		"agent-read override (F5): true | false | inherit (inherit clears to the capture default)")
+	cmd.Flags().IntVar(&opts.retentionDays, "retention-days", 0,
+		"per-tenant trace retention window in days (F4; 1..365)")
+	cmd.Flags().BoolVar(&opts.clearRetention, "clear-retention", false,
+		"clear the retention override back to the global default")
+	cmd.Flags().BoolVar(&opts.jsonOut, "json", false,
+		"emit the resolved policy as JSON instead of the human summary")
+	cmd.Flags().StringVar(&opts.backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// buildBody assembles the sparse PATCH body from the flags the operator set.
+// Returns an error for contradictory / empty / malformed flag combinations
+// before any network call. A nil map value marshals to JSON null (an explicit
+// clear); a key absent from the map is left unchanged server-side.
+func buildBody(opts setOptions) (map[string]any, error) {
+	body := map[string]any{}
+	if opts.enabledSet {
+		body["flight_recorder_enabled"] = opts.enabled
+	}
+	if opts.agentReadableSet {
+		switch opts.agentReadable {
+		case "true":
+			body["flight_recorder_agent_readable"] = true
+		case "false":
+			body["flight_recorder_agent_readable"] = false
+		case "inherit":
+			body["flight_recorder_agent_readable"] = nil // explicit null -> clear
+		default:
+			return nil, fmt.Errorf(
+				"--agent-readable must be one of: true, false, inherit; got %q", opts.agentReadable)
+		}
+	}
+	if opts.retentionDaysSet && opts.clearRetention {
+		return nil, fmt.Errorf("--retention-days and --clear-retention are mutually exclusive")
+	}
+	if opts.retentionDaysSet {
+		if opts.retentionDays < 1 || opts.retentionDays > 365 {
+			return nil, fmt.Errorf(
+				"--retention-days must be between 1 and 365; got %d", opts.retentionDays)
+		}
+		body["flight_recorder_retention_days"] = opts.retentionDays
+	}
+	if opts.clearRetention {
+		body["flight_recorder_retention_days"] = nil // explicit null -> global default
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf(
+			"nothing to change; pass at least one of --enabled / --agent-readable / " +
+				"--retention-days / --clear-retention")
+	}
+	return body, nil
+}
+
+func runSet(cmd *cobra.Command, opts setOptions) error {
+	body, err := buildBody(opts)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.jsonOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.jsonOut)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("encode request body: %v", err)), opts.jsonOut)
+	}
+	resp, err := patchPolicy(cmd.Context(), backplaneURL, payload)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.jsonOut)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.jsonOut)
+	}
+	var policy api.TenantFlightRecorderPolicy
+	if err := json.Unmarshal(resp.Body, &policy); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode policy response: %v", err)), opts.jsonOut)
+	}
+	if opts.jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), policy)
+	}
+	printPolicySummary(cmd.OutOrStdout(), &policy)
+	return nil
+}
+
+func patchPolicy(ctx context.Context, backplaneURL string, payload []byte) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return doRequest(ctx, authed, func(ctx context.Context) (*http.Response, error) {
+		return authed.UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody(
+			ctx,
+			&api.UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams{},
+			"application/json",
+			bytes.NewReader(payload),
+		)
+	})
+}
+
+// printPolicySummary renders the resolved policy as a compact confirmation.
+// The nullable fields render "inherit" / "default (global)" for a NULL so the
+// operator sees the tri-state resolution, not an empty cell.
+func printPolicySummary(w io.Writer, p *api.TenantFlightRecorderPolicy) {
+	if p == nil {
+		return
+	}
+	agent := "inherit (follows capture default)"
+	if p.FlightRecorderAgentReadable != nil {
+		agent = fmt.Sprintf("%t", *p.FlightRecorderAgentReadable)
+	}
+	retention := "default (global)"
+	if p.FlightRecorderRetentionDays != nil {
+		retention = fmt.Sprintf("%d days", *p.FlightRecorderRetentionDays)
+	}
+	fmt.Fprintln(w, "updated flight-recorder policy")
+	fmt.Fprintf(w, "%-16s %s\n", "tenant_id:", p.TenantId.String())
+	fmt.Fprintf(w, "%-16s %t\n", "capture:", p.FlightRecorderEnabled)
+	fmt.Fprintf(w, "%-16s %s\n", "agent-readable:", agent)
+	fmt.Fprintf(w, "%-16s %s\n", "retention:", retention)
+}

--- a/cli/internal/cmd/tenants/flight_recorder_test.go
+++ b/cli/internal/cmd/tenants/flight_recorder_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package tenants
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestBuildBodySparseTriState is the load-bearing CLI test: the PATCH body must
+// carry ONLY the fields the operator set (absent = leave unchanged), and an
+// inherit / clear must serialize to an explicit JSON null (clear), never be
+// dropped. This is the null-vs-absent distinction the generated struct (no
+// omitempty on its pointers) would get wrong.
+func TestBuildBodySparseTriState(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     setOptions
+		wantJSON string
+	}{
+		{
+			name:     "enabled only omits the untouched fields",
+			opts:     setOptions{enabled: true, enabledSet: true},
+			wantJSON: `{"flight_recorder_enabled":true}`,
+		},
+		{
+			name:     "agent-readable inherit clears to explicit null",
+			opts:     setOptions{agentReadable: "inherit", agentReadableSet: true},
+			wantJSON: `{"flight_recorder_agent_readable":null}`,
+		},
+		{
+			name:     "agent-readable false forces off",
+			opts:     setOptions{agentReadable: "false", agentReadableSet: true},
+			wantJSON: `{"flight_recorder_agent_readable":false}`,
+		},
+		{
+			name:     "retention set",
+			opts:     setOptions{retentionDays: 14, retentionDaysSet: true},
+			wantJSON: `{"flight_recorder_retention_days":14}`,
+		},
+		{
+			name:     "clear-retention clears to explicit null",
+			opts:     setOptions{clearRetention: true},
+			wantJSON: `{"flight_recorder_retention_days":null}`,
+		},
+		{
+			name: "all three at once",
+			opts: setOptions{
+				enabled: true, enabledSet: true,
+				agentReadable: "true", agentReadableSet: true,
+				retentionDays: 7, retentionDaysSet: true,
+			},
+			wantJSON: `{"flight_recorder_agent_readable":true,"flight_recorder_enabled":true,` +
+				`"flight_recorder_retention_days":7}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := buildBody(tc.opts)
+			if err != nil {
+				t.Fatalf("buildBody: unexpected error: %v", err)
+			}
+			got, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tc.wantJSON {
+				t.Fatalf("body JSON = %s, want %s", got, tc.wantJSON)
+			}
+		})
+	}
+}
+
+func TestBuildBodyRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		opts setOptions
+	}{
+		{"nothing set", setOptions{}},
+		{
+			"agent-readable invalid",
+			setOptions{agentReadable: "maybe", agentReadableSet: true},
+		},
+		{
+			"retention out of bounds low",
+			setOptions{retentionDays: 0, retentionDaysSet: true},
+		},
+		{
+			"retention out of bounds high",
+			setOptions{retentionDays: 366, retentionDaysSet: true},
+		},
+		{
+			"retention + clear contradictory",
+			setOptions{retentionDays: 14, retentionDaysSet: true, clearRetention: true},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := buildBody(tc.opts); err == nil {
+				t.Fatalf("buildBody(%+v): expected an error, got nil", tc.opts)
+			}
+		})
+	}
+}

--- a/cli/internal/cmd/tenants/tenants.go
+++ b/cli/internal/cmd/tenants/tenants.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package tenants hosts the cobra commands under `meho tenants ...` for the
+// operator-plane per-tenant policy surface (#3272).
+//
+// v0.2 ships one policy family — the flight-recorder capture policy:
+//
+//   - `meho tenants flight-recorder-policy set [--enabled] [--agent-readable]
+//     [--retention-days N | --clear-retention]` — PATCH
+//     /api/v1/tenants/flight-recorder-policy. Tenant-scoped (the caller's own
+//     tenant, from the JWT — no tenant id is accepted, so there is no
+//     cross-tenant write). tenant_admin only; operator / read_only land as 403
+//     insufficient_role.
+//
+// The verb builds a **sparse** JSON body (only the fields the operator set)
+// rather than the generated `TenantFlightRecorderPolicyUpdate` struct: that
+// struct's pointer fields carry no `omitempty`, so a nil pointer would marshal
+// to an explicit JSON `null` — which the backend reads as "clear to inherit /
+// default", not "leave unchanged". The sparse-map approach preserves the
+// tri-state null-vs-absent distinction the flight-recorder policy needs (same
+// reason `meho targets import` builds sparse PATCH bodies). See
+// flight_recorder.go.
+//
+// Auth + error-classification plumbing mirrors the `meho conventions` package:
+// the bearer `meho login` wrote, a one-shot 401-refresh-retry, and the
+// structured-error categories (auth_expired / unreachable / insufficient_role
+// / unexpected). CLI and agent exercise the same backplane dispatch path.
+package tenants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho tenants` parent command, grafted onto the
+// top-level meho command tree by cmd/root.go.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "tenants",
+		Short:        "Operate per-tenant policy (flight-recorder capture policy)",
+		Long:         "Manage the operator's own tenant policy. v0.2 ships the flight-recorder capture policy.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFlightRecorderPolicyCmd())
+	return cmd
+}
+
+// errMissingAccessToken is the sentinel newAuthedClient returns when the stored
+// token row exists but its access_token is empty. Mirrors the sibling verb
+// trees so an operator sees the same `meho login` hint everywhere.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// newAuthedClient builds an api.AuthedClient and verifies a non-empty bearer.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// responseBodyCap bounds the response body the CLI will read (the resolved
+// policy is a handful of fields; 1 MiB is comfortable adversarial headroom).
+const responseBodyCap int64 = 1 << 20
+
+// rawResponse is the (status, body) pair the verbs render after a round-trip.
+type rawResponse struct {
+	StatusCode int
+	Body       []byte
+}
+
+func readAllBody(rsp *http.Response) ([]byte, error) {
+	defer rsp.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(io.LimitReader(rsp.Body, responseBodyCap+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf("response body exceeds %d-byte cap", responseBodyCap)
+	}
+	return raw, nil
+}
+
+// doRequest invokes call once and, on a 401, runs a one-shot bearer refresh +
+// re-issues. Returns the drained (status, body) pair on the final response.
+func doRequest(
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*http.Response, error),
+) (*rawResponse, error) {
+	rsp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if rsp.StatusCode == http.StatusUnauthorized {
+		_, _ = io.Copy(io.Discard, rsp.Body)
+		rsp.Body.Close() //nolint:errcheck
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		rsp, err = call(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	raw, err := readAllBody(rsp)
+	if err != nil {
+		return nil, err
+	}
+	return &rawResponse{StatusCode: rsp.StatusCode, Body: raw}, nil
+}
+
+// renderRequestError maps a transport-layer request error to a structured-error
+// category (auth_expired / unreachable).
+func renderRequestError(cmd *cobra.Command, backplaneURL string, err error, jsonOut bool) error {
+	switch {
+	case errors.Is(err, errMissingAccessToken):
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL)),
+			jsonOut)
+	case api.IsTokenNotFound(err):
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL)),
+			jsonOut)
+	case api.IsNoRefreshToken(err):
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL)),
+			jsonOut)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut)
+	}
+}
+
+// renderHTTPStatus classifies a non-2xx response into the right structured
+// category. 403 -> insufficient_role (the operator sees the required role);
+// 404 -> tenant_not_found / route absent; 422 -> invalid request; else raw.
+func renderHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
+	body []byte,
+	jsonOut bool,
+) error {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`", backplaneURL)),
+			jsonOut)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(bodyStr)), jsonOut)
+	case http.StatusNotFound:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(bodyStr)), jsonOut)
+	case http.StatusUnprocessableEntity:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("invalid request: "+decodeDetailString(bodyStr)), jsonOut)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s", backplaneURL, statusCode, bodyStr)),
+			jsonOut)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape ({"detail": ...}),
+// where detail is either a plain string or the pydantic validation list.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls a plain-string `detail` out of a FastAPI error body,
+// falling back to the raw body when the shape doesn't match.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}

--- a/docs/codebase/flight-recorder-policy.md
+++ b/docs/codebase/flight-recorder-policy.md
@@ -1,0 +1,79 @@
+# Flight-recorder capture policy — operator mutation surface
+
+## Overview
+
+The dispatch flight recorder (`docs/decisions/dispatch-flight-recorder.md`)
+captures redacted vendor traffic per dispatch, gated by a per-tenant policy and
+a per-target override that the resolver
+(`meho_backplane/flight_recorder/config.py`) reads on the hot path. The policy
+columns (#3212/#3216) and the resolver shipped, but there was **no writable
+path** — capture could not be enabled on a deployment without direct DB writes.
+This surface (#3272) is the operator-plane mutation path that closes that gap.
+
+It is an **operator-plane** surface: REST + CLI only, gated at the
+`tenant_admin` tier. It is deliberately **not** on the 25-tool agent working
+surface and has **no MCP tool** — enabling capture is a governance decision, an
+operator action, not an agent one. (Simplest correct answer per postulate 5:
+REST + CLI, no MCP tool at all.)
+
+## Routes
+
+- `PATCH /api/v1/tenants/flight-recorder-policy`
+  (`meho_backplane/api/v1/tenants.py`) — the three per-tenant policy fields.
+  **Tenant-scoped to the caller's own tenant** (`operator.tenant_id` from the
+  JWT); it accepts no tenant id in the path or body, so a cross-tenant write is
+  not expressible. `require_role(TenantRole.TENANT_ADMIN)`. Body
+  `TenantFlightRecorderPolicyUpdate` (all fields optional-partial,
+  `extra='forbid'`); returns the resolved `TenantFlightRecorderPolicy`.
+  - `flight_recorder_enabled` (F1) — Boolean, `NOT NULL`. Absent = unchanged;
+    `true`/`false` flips the capture default. Explicit `null` is a 422 (no
+    inherit state).
+  - `flight_recorder_agent_readable` (F5) — **tri-state**. Absent = unchanged;
+    `true`/`false` force the agent-read override; `null` clears it to inherit.
+  - `flight_recorder_retention_days` (F4) — nullable, bounded **1..365** (the
+    reaper window; matches `Settings.flight_recorder_retention_days_default`).
+    Absent = unchanged; an int sets the window; `null` clears to the global
+    default.
+
+- `PATCH /api/v1/targets/{name}` (`meho_backplane/api/v1/targets.py`) — the
+  per-target override `flight_recorder_capture` rides the **existing** target
+  PATCH (and `POST /api/v1/targets` for a seeded value), not a new route.
+  **Tri-state** on `TargetUpdate`: absent = unchanged; `true`/`false` force
+  capture on/off for the target; explicit `null` clears back to inherit. The
+  handler keys off `model_fields_set` (`exclude_unset`), **not** off `None`, so
+  the JSON-null-vs-absent distinction is preserved.
+
+## Null-vs-absent (the tri-state discipline)
+
+Both routes lean on Pydantic `exclude_unset`: an omitted key leaves the column
+untouched; an explicit JSON `null` is an intentional clear-to-inherit /
+clear-to-default. The CLI mirrors this by sending a **sparse** body (only the
+flags the operator set) rather than the generated update struct, whose pointer
+fields carry no `omitempty` and would marshal a nil to an unintended `null`.
+
+## Audit
+
+Every applied change is folded into the request's `audit_log` row via `audit_*`
+contextvars naming field / old / new (governance-relevant, never silent) —
+`update_flight_recorder_policy` for the tenant fields,
+`_audit_flight_recorder_capture_write` for the target override. Tri-state `None`
+is bound as the `inherit` sentinel because the audit-payload builder drops
+`None` contextvars (mirroring the CA-pin audit's `""` marker). A no-op / absent
+field binds nothing.
+
+## Cache invalidation
+
+The resolver caches per-tenant policy and per-target override for 60s. Each
+route calls `invalidate_tenant_policy_cache` / `invalidate_target_override_cache`
+on a change so the flip takes effect on the **next dispatch** rather than
+waiting out the TTL or a restart (proven by the without-restart tests in
+`test_api_v1_tenants_flight_recorder.py`, `test_targets_flight_recorder_capture.py`,
+and `test_flight_recorder_config.py`).
+
+## CLI
+
+- `meho tenants flight-recorder-policy set [--enabled] [--agent-readable
+  true|false|inherit] [--retention-days N | --clear-retention]`
+  (`cli/internal/cmd/tenants/`) — the tenant policy PATCH.
+- `meho targets import --update` maps a YAML `flight_recorder_capture` key onto
+  the target PATCH (`cli/internal/cmd/targets/import.go`, `knownTopLevel`).


### PR DESCRIPTION
Closes #3272

## What

Adds the operator-plane **mutation surface** for the flight-recorder capture policy — the writable path the live-instance verification pass (2026-09-01) found missing. The policy columns + resolver shipped (#3212/#3216) but capture could only be enabled by direct DB writes, which the governance model forbids; this also blocked #3218.

## Route shapes

**Tenant policy (new)** — `PATCH /api/v1/tenants/flight-recorder-policy`
- Gated `require_role(TenantRole.TENANT_ADMIN)`; **tenant-scoped to `operator.tenant_id` from the JWT** — no tenant id in path/body, so a cross-tenant write is not expressible.
- Body `TenantFlightRecorderPolicyUpdate` (`extra='forbid'`, optional-partial via `exclude_unset`):
  - `flight_recorder_enabled: bool|None` (F1) — absent=keep, true/false=flip, explicit `null` → 422 (NOT NULL, no inherit state).
  - `flight_recorder_agent_readable: bool|None` (F5, tri-state) — absent=keep, true/false=force, `null`=clear-to-inherit.
  - `flight_recorder_retention_days: int(1..365)|None` (F4) — absent=keep, int=set, `null`=clear-to-global-default.
- Returns `TenantFlightRecorderPolicy` { tenant_id, flight_recorder_enabled, flight_recorder_agent_readable, flight_recorder_retention_days }.

**Per-target tri-state** — rides the **existing** `PATCH /api/v1/targets/{name}` + `POST /api/v1/targets`: `flight_recorder_capture: bool|None` on `TargetUpdate`/`TargetCreate`/`Target`/`TargetSummary`. Handler keys off `model_fields_set` (not `None`) so `null`=clear-to-inherit vs absent=keep. Listed on `TargetSummary` to satisfy the list/detail no-silent-masking conformance test.

## MCP-exposure choice

**No MCP tool at all — REST + CLI only.** Enabling capture is a governance decision (operator action), the simplest correct answer per postulate 5. `docs/codebase/mcp.md` and `test_mcp_surface_conformance.py` are **untouched**; the 25-tool agent working surface is unchanged (conformance green).

## Cache-invalidation proof

Added `invalidate_tenant_policy_cache` / `invalidate_target_override_cache` to `flight_recorder/config.py`; each route calls them on an applied change (invalidate-before-commit is safe — a rollback becomes a cache miss that re-reads the committed value; the ≤60s concurrency window matches the existing announce-gate discipline). Proven **without restart** by:
- `test_enable_flip_reflected_by_resolver_without_restart` + `test_agent_read_flip_reflected_without_restart` (tenant)
- `test_capture_flip_reflected_by_resolver_without_restart` (target)
- `test_invalidate_tenant_policy_cache_reflects_flipped_flag` / `_is_idempotent` / `test_invalidate_target_override_cache_reflects_flipped_override` (unit)

## Audit

Every applied change binds `audit_{field}_before/_after` in the same branch as the setattr — no unaudited write path. Tri-state `None` → `"inherit"` sentinel (the payload builder drops `None` contextvars). No-op/absent field binds nothing.

## CLI

- `meho tenants flight-recorder-policy set [--enabled] [--agent-readable true|false|inherit] [--retention-days N | --clear-retention]` — builds a **sparse** body (the generated update struct has no `omitempty`, so a nil pointer would marshal to an unintended `null`; sparse map preserves null-vs-absent, unit-tested).
- `meho targets import --update` maps a YAML `flight_recorder_capture` key.
- `make snapshot-openapi && make generate` re-run post-rebase; snapshot is fresh (zero regen delta).

## Tests / gates

- New: 18 (tenant route) + 7 (target tri-state) + 3 (config unit) + 11 CLI sparse-body cases — all green.
- Broad regression (`-k "flight_recorder or targets or tenants or mcp_surface_conformance or list_envelope"`): 662 passed, 1 skipped, 0 failed.
- `ruff check` + `ruff format --check` + `mypy` clean; CLI `gofmt`/`vet`/`build`/`test` green; verb reachable end-to-end.

## No migration. No agent-surface change.

## Review

Inline adversarial review (RBAC holes / missing audit / cache staleness / tri-state null-vs-absent / agent-surface creep) — **VERDICT: APPROVE**, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
