### PR TITLE
test(ui): pin /ui/approvals* console admits the approver capability (#3282)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/approvals/routes.py
+++ b/backend/src/meho_backplane/ui/routes/approvals/routes.py
@@ -24,6 +24,26 @@ in-process (``list_pending`` / ``get_request`` / ``approve_request`` /
 memory surfaces use. The in-process call keeps the synchronous-audit
 binding and avoids a self-HTTP hop that the cookie could not auth anyway.
 
+Access model -- operator-or-approver, parity with REST (#3243 / #3282)
+----------------------------------------------------------------------
+
+The read surfaces (badge / panel / history / detail) gate on the BFF
+session alone (``require_ui_session`` + CSRF): any authenticated console
+session may glance the queue, exactly as before. The **decision** POSTs
+carry the same access model the Bearer REST plane adopted in #3243/#3270:
+``approve_request`` / ``reject_request`` run the shared service gate
+``_check_reviewer_role``, which admits a principal that is
+``operator``-or-higher **or** carries the orthogonal ``approver``
+capability (``Operator.approver``, lifted from the JWT ``approver`` claim
+by :func:`~meho_backplane.auth.jwt._operator_from_claims`). So a dedicated
+approver provisioned as ``read_only`` role + ``approver=true`` can clear a
+four-eyes gate through the console just as it can over REST/CLI, while a
+``read_only`` principal *without* the flag is still refused (403). The
+capability is scoped to the approvals decision: it grants no dispatch or
+other ``require_role``-gated console surface (those never read
+``operator.approver``), and the ``sub``-keyed self-approval refusal
+(#1401) is unchanged -- an approver cannot decide a request it parked.
+
 Route inventory
 ---------------
 
@@ -714,9 +734,17 @@ async def _commit_decision(
             detail="approval_request_not_found",
         ) from exc
     except UnauthorizedApprovalError as exc:
+        # The console decide path admits the same principals the REST plane
+        # does (#3243 / #3270): operator-or-higher, OR a principal carrying
+        # the orthogonal ``approver`` capability. Only a ``read_only``
+        # principal *without* ``approver`` lands here, so the banner names
+        # both levers rather than implying operator role is the sole one.
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Your role cannot decide approval requests (operator role required).",
+            detail=(
+                "Your role cannot decide approval requests "
+                "(operator role or the approver capability required)."
+            ),
         ) from exc
     except SelfApprovalForbiddenError as exc:
         # The disabled Approve button is UX only; a forged self-approve

--- a/backend/tests/test_ui_approvals.py
+++ b/backend/tests/test_ui_approvals.py
@@ -283,13 +283,21 @@ def _operator(
     tenant_id: uuid.UUID,
     sub: str = _REVIEWER_SUB,
     role: TenantRole = TenantRole.OPERATOR,
+    approver: bool = False,
 ) -> Operator:
-    """Build an :class:`Operator` the patched ``_resolve_operator`` returns."""
+    """Build an :class:`Operator` the patched ``_resolve_operator`` returns.
+
+    ``approver`` sets the orthogonal approve-only capability (#3243) that
+    ``_operator_from_claims`` lifts from the JWT ``approver`` claim, so a
+    dedicated approver principal is expressed as ``role=READ_ONLY`` +
+    ``approver=True`` — the parity fixture #3282 pins for the console BFF.
+    """
     return Operator(
         sub=sub,
         raw_jwt="header.payload.signature",
         tenant_id=tenant_id,
         tenant_role=role,
+        approver=approver,
     )
 
 
@@ -737,6 +745,221 @@ def test_self_approve_allowed_when_break_glass_enabled(
     assert "Request approved" in response.text
     assert _request_status(rid) == ApprovalRequestStatus.APPROVED.value
     resume_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Approver capability parity (#3282 — console parity with the #3243/#3270
+# REST decoupling). The console decide path runs the same shared service
+# gate ``_check_reviewer_role`` the REST plane does, so it admits a
+# principal that is operator-or-higher OR carries the orthogonal
+# ``approver`` capability, refuses ``read_only`` without it, and keeps the
+# self-approval refusal (#1401) orthogonal to the capability.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("role", "approver"),
+    [
+        (TenantRole.OPERATOR, False),
+        (TenantRole.READ_ONLY, True),
+    ],
+    ids=["operator", "read_only+approver"],
+)
+def test_console_decide_admits_operator_or_approver(role: TenantRole, approver: bool) -> None:
+    """A console approve succeeds for either principal the #3243 gate admits.
+
+    Parity with the REST decoupling: the BFF's approve path runs the shared
+    service gate ``_check_reviewer_role``, which admits ``operator``-or-higher
+    OR a ``read_only`` principal carrying the ``approver`` capability. The row
+    flips to approved and the parked op re-dispatches identically for both — so
+    a dedicated approver (``read_only`` role + ``approver=true``) clears a
+    four-eyes gate through the console exactly as an operator does.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=_REQUESTER_SUB)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_REVIEWER_SUB)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, sub=_REVIEWER_SUB, role=role, approver=approver)
+    resume_mock = AsyncMock(return_value=_dispatch_result())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RESUME_DISPATCH, resume_mock),
+        ):
+            response = client.post(
+                f"/ui/approvals/{rid}/approve",
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    assert "Request approved" in response.text
+    assert _request_status(rid) == ApprovalRequestStatus.APPROVED.value
+    resume_mock.assert_awaited_once()
+
+
+def test_approver_read_only_can_reject_via_bff() -> None:
+    """A ``read_only`` + ``approver`` principal can reject via the console.
+
+    Reject runs the same ``_check_reviewer_role`` gate as approve, so the
+    approver capability clears it; the row flips to rejected and — as for any
+    reject — the parked op is never re-dispatched.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=_REQUESTER_SUB)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_REVIEWER_SUB)
+    csrf = _csrf_token(session_id)
+    operator = _operator(
+        tenant_id=_TENANT_A, sub=_REVIEWER_SUB, role=TenantRole.READ_ONLY, approver=True
+    )
+    resume_mock = AsyncMock(return_value=_dispatch_result())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RESUME_DISPATCH, resume_mock),
+        ):
+            response = client.post(
+                f"/ui/approvals/{rid}/reject",
+                data={"reason": "not now"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    assert "Request denied" in response.text
+    assert _request_status(rid) == ApprovalRequestStatus.REJECTED.value
+    resume_mock.assert_not_awaited()
+
+
+@pytest.mark.parametrize("action", ["approve", "reject"])
+def test_console_decide_refuses_read_only_without_approver(action: str) -> None:
+    """A ``read_only`` principal WITHOUT ``approver`` cannot decide on the console.
+
+    The service ``_check_reviewer_role`` raises ``UnauthorizedApprovalError``,
+    which the BFF maps to a 403 re-rendered in the modal banner naming *both*
+    levers (operator role OR the approver capability). The row stays pending
+    and nothing re-dispatches — fail-closed, unchanged by #3243. Covers both
+    decision verbs since each runs the gate on its own service call.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=_REQUESTER_SUB)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_REVIEWER_SUB)
+    csrf = _csrf_token(session_id)
+    operator = _operator(
+        tenant_id=_TENANT_A, sub=_REVIEWER_SUB, role=TenantRole.READ_ONLY, approver=False
+    )
+    resume_mock = AsyncMock(return_value=_dispatch_result())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RESUME_DISPATCH, resume_mock),
+        ):
+            response = client.post(
+                f"/ui/approvals/{rid}/{action}",
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "403" in body
+    assert "approver capability" in body
+    assert "Request approved" not in body
+    assert "Request denied" not in body
+    assert _request_status(rid) == ApprovalRequestStatus.PENDING.value
+    resume_mock.assert_not_awaited()
+
+
+def test_approver_read_only_cannot_self_approve_via_bff() -> None:
+    """The ``approver`` capability does NOT bypass the self-approval refusal (#1401).
+
+    An approver who parked the request (``operator.sub == principal_sub``) is
+    still refused a forged self-approve — the ``sub``-keyed guard is orthogonal
+    to the role/approver gate, exactly as the REST plane enforces. The row
+    stays pending; nothing re-dispatches; break-glass is the only override.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # Requester == the approver-capable reviewer; break-glass OFF (default).
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=_REVIEWER_SUB)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_REVIEWER_SUB)
+    csrf = _csrf_token(session_id)
+    operator = _operator(
+        tenant_id=_TENANT_A, sub=_REVIEWER_SUB, role=TenantRole.READ_ONLY, approver=True
+    )
+    resume_mock = AsyncMock(return_value=_dispatch_result())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RESUME_DISPATCH, resume_mock),
+        ):
+            response = client.post(
+                f"/ui/approvals/{rid}/approve",
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    assert "cannot approve your own request" in response.text.lower()
+    assert _request_status(rid) == ApprovalRequestStatus.PENDING.value
+    resume_mock.assert_not_awaited()
+
+
+def test_detail_modal_approve_enabled_for_approver() -> None:
+    """The detail modal shows an ENABLED Approve button for an approver principal.
+
+    Button visibility is computed from the self-approval guard alone, never the
+    tenant role, so a ``read_only`` + ``approver`` reviewer (not the requester)
+    sees an actionable Approve control — the console UX matches the capability
+    rather than hiding the action behind an operator-role assumption.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=_REQUESTER_SUB)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(
+        tenant_id=_TENANT_A, sub=_REVIEWER_SUB, role=TenantRole.READ_ONLY, approver=True
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get(f"/ui/approvals/{rid}")
+
+    assert response.status_code == 200, response.text
+    approve_button = response.text.split('data-action="approve"')[1].split("</button>")[0]
+    assert "disabled" not in approve_button
+
+
+def test_approver_read_only_sees_badge_and_history() -> None:
+    """A ``read_only`` + ``approver`` session reaches the read surfaces (AC1).
+
+    The read surfaces (badge / panel / history / detail) gate on the BFF
+    session alone, so an approver-provisioned principal reaches the same
+    tenant-scoped queue the REST list/show routes return. This also pins that
+    the read surfaces stay session-open — a future over-tightening to an
+    operator-role gate would regress here (and would wrongly hide the queue
+    from an approver whose role is ``read_only``).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_request(tenant_id=_TENANT_A, op_id="vsphere.vm.create")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        badge = client.get("/ui/approvals/badge")
+        history = client.get("/ui/approvals/list", headers=_HX_HEADERS)
+
+    assert badge.status_code == 200, badge.text
+    assert 'data-pending-count="1"' in " ".join(badge.text.split())
+    assert history.status_code == 200, history.text
+    assert "vsphere.vm.create" in history.text
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -902,6 +902,32 @@ those). Every read + decision derives `tenant_id` from the validated
 `UISessionContext` only, and calls the `approval_queue` service
 in-process (same in-process-audit binding the REST routes get).
 
+**Access model — operator-or-approver, parity with REST (#3243 / #3270 /
+#3282).** The console decide path carries the **same** access model the
+Bearer REST plane adopted in #3243/#3270, reached through the *same*
+shared service gate rather than a console-local role check. The BFF
+reconstructs the full `Operator` via `_resolve_operator` →
+`verify_access_token_with_refresh` → `_operator_from_claims` (which lifts
+the orthogonal `approver` claim, `Operator.approver`), then calls
+`approve_request` / `reject_request`; their `_check_reviewer_role` admits
+a principal that is `operator`-or-higher **or** carries `approver`, and
+refuses only a `read_only` principal *without* the flag (403, re-rendered
+in the modal banner naming both levers). So a dedicated approver
+provisioned as `read_only` role + `approver=true` can clear a four-eyes
+gate through the console exactly as it can over REST/CLI. The read
+surfaces (badge / panel / history / detail) stay gated on the BFF session
+alone — any authenticated console session may glance the tenant-scoped
+queue, unchanged. Two invariants are preserved and pinned in
+`test_ui_approvals.py`: the `sub`-keyed self-approval refusal (#1401) is
+orthogonal to the capability (an approver still cannot decide a request it
+parked), and the capability grants **no other console surface** —
+`operator.approver` is consulted only by `require_approvals_access` (REST)
+and `_check_reviewer_role` (service), never by dispatch or any
+`require_role`-gated admin plane, so `read_only + approver` remains denied
+the operations/dispatch console and every operator plane. This is a
+verify-and-pin of parity #3270 already established at the service layer —
+no new gate, service call, route, or migration.
+
 | Verb | Path | Purpose |
 |---|---|---|
 | `GET` | `/ui/approvals/badge` | Live **pending** count for the app-shell bell. Always `status='pending'` — it counts actionable work, not history. |


### PR DESCRIPTION
## Summary

- **Verify-and-pin, not re-gate.** The console `/ui/approvals*` BFF already admits the orthogonal `approver` capability with REST-identical semantics: it reconstructs the `Operator` via `_operator_from_claims` (which lifts the `approver` claim) and delegates decisions to the shared `approve_request` / `reject_request`, whose `_check_reviewer_role` was updated by #3270 (`192de872`) to admit operator-or-approver. **The decide path functioned end-to-end for a `read_only + approver=true` principal before this PR — it was just untested and unpinned on the console surface.** This PR adds the coverage and closes the one residual console-only operator-role assumption.
- **The only functional delta** is a copy fix: the `UnauthorizedApprovalError` 403 banner said "operator role required"; it now names both levers ("operator role or the approver capability required"), matching the decoupled model. No new gate, service call, route, or migration.
- **BFF coverage** pins the parity trio (`read_only+approver`, `operator`, `read_only`-no-flag) plus the invariants the audit had to confirm.
- **Docs**: `docs/codebase/approvals.md` Operator-console section now records the BFF decide model as operator-or-approver, aligned with REST.

## What verification actually found

Everything already worked; the deliverable is tests + one copy fix + docs. Concretely:

| Acceptance criterion | Outcome | Where pinned |
|---|---|---|
| `read_only+approver` sees badge / pending+history / detail | already worked (reads are session-gated, open to any console session) | `test_approver_read_only_sees_badge_and_history`, `test_detail_modal_approve_enabled_for_approver` |
| `read_only+approver` can approve + reject via BFF | already worked (service `_check_reviewer_role` admits approver) | `test_console_decide_admits_operator_or_approver[read_only+approver]`, `test_approver_read_only_can_reject_via_bff` |
| Self-approval refusal (#1401) unchanged on console | already worked (`sub`-keyed guard is orthogonal to the capability) | `test_approver_read_only_cannot_self_approve_via_bff` |
| Approver grants **no other** console surface | already true — `operator.approver` is consulted only by `require_approvals_access` (REST) + `_check_reviewer_role` (service), never by dispatch or any `require_role` plane | documented in `routes.py` + `approvals.md`; dispatch stays `require_role(OPERATOR)` |
| `read_only` **without** approver still refused decisions | already worked (fail-closed) | `test_console_decide_refuses_read_only_without_approver[approve,reject]` |
| BFF test coverage regression-guards the trio | **added** | `test_ui_approvals.py` (10 new cases) |
| Docs record console access model as operator-or-approver | **added** | `docs/codebase/approvals.md` |

**Residual assumption closed:** the 403 banner copy. Modal action-button visibility and nav gating were audited and are **not** role-computed — buttons key off the self-approval guard alone, and the sidebar/bell render unconditionally — so an approver already sees actionable controls; no change needed there.

**Scope note (honest pin):** the console read surfaces (badge / panel / history / detail) gate on the BFF session alone, so they are open to any authenticated console session (including a plain `read_only`), which is *broader* than the REST list/show routes. That is pre-existing #1778 console behavior; the issue asks only that `read_only`-without-approver be refused **decisions** (it is) and does not ask to tighten reads, so reads are left unchanged and the asymmetry is documented rather than "fixed".

## Test plan

- [x] `ruff check` — clean (touched files)
- [x] `ruff format --check` — clean (touched files)
- [x] `mypy src/.../approvals/routes.py` — clean
- [x] `pytest tests/test_ui_approvals.py` — 65 passed (10 new)
- [x] `code-quality.py --diff` — 0 blockers (4 warnings all pre-existing debt in a file already >600 lines)

## Migration

None. This task needs no migration (single head 0096 unchanged).

## CLI OpenAPI snapshot

**Unchanged.** No `/ui/approvals*` route path/param/response-model signature changed — only an error-detail string (runtime response body, not in the schema), a docstring, tests, and docs. `cli/api/openapi.json` was not touched and no regen is required.

## Out of scope

- Peer lanes tonight (mssql #3264, guest program.run #3255) are disjoint from console/BFF/auth; no shared files.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3282
