### PR TITLE
feat(connectors): mssql — SQL Server typed connector (TDS-direct core, dbatools evaluation) (#3264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — mssql: SQL Server typed connector (TDS-direct) (#3264)
+
+- New `mssql` typed connector for Microsoft SQL Server 2022 (registry triple
+  `mssql-2022.x` / `mssql-tds`), a **direct TDS** connector on port 1433 via the
+  pure-Python `python-tds` driver — the postgres/mongodb direct-protocol mold,
+  no unixODBC/msodbcsql or FreeTDS system packages in the backplane image. 14
+  governed ops across four groups: `instance` (about / version / config / logins
+  — safe), `databases` (list / files — safe; create / drop — dangerous +
+  approval), `ha` (availability-groups / fci / sync-health — the safe
+  migration-validation reads), and `backup` (history — safe; database — caution;
+  restore — dangerous + approval). Safety tiers follow the estate satellite
+  table (reads ride satellite runners; destructive writes park for approval and
+  are satellite-excluded).
+- **First two-credential connector on the estate seam:** SQL auth resolves
+  `sql_username` / `sql_password` from the target's Vault secret (the `sql_`
+  prefix reserves room for a later dbatools-over-SSH increment's SSH creds in
+  the same secret); credentials never enter params, logs, or results.
+- **No freeform T-SQL op** (the narrow-waist doctrine): only curated,
+  individually-tiered ops — operator input binds as pyformat values, and
+  database identifiers are QUOTENAME-style bracket-escaped. CLI grows the
+  `meho mssql ...` verbs; consumer proof against the live c1sql1 FCI is tracked
+  open. See `docs/codebase/connectors-mssql.md`.
+
 ### Added — flight recorder: operator mutation surface for capture policy (#3272)
 
 - The writable path the live-instance verification pass found missing: the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -95,6 +95,17 @@ dependencies = [
     # AsyncMongoClient runs commands off the event loop natively (no
     # ``asyncio.to_thread`` wrapper needed).
     "pymongo>=4.13,<5",
+    # TDS wire-protocol driver for the typed ``mssql`` SQL Server connector
+    # (#3264). python-tds (import ``pytds``) is a **pure-Python** TDS
+    # implementation — no unixODBC + msodbcsql (pyodbc) and no FreeTDS
+    # (pymssql) system packages in the backplane image, so it adds a single
+    # pip dependency exactly like ``asyncpg`` does for postgres, not an apt
+    # layer. It is a synchronous DBAPI driver (paramstyle ``pyformat``), run
+    # off the event loop via ``asyncio.to_thread`` (the hvac / mail / rke2
+    # precedent). MIT-licensed; the transport decision + driver comparison
+    # (pyodbc / pymssql / python-tds) is recorded in
+    # ``docs/codebase/connectors-mssql.md``.
+    "python-tds>=1.17,<2",
     # DNS resolver library for the net.dns_lookup diagnostic op (#2409).
     # dnspython drives typed record lookups (A/AAAA/CNAME/MX/TXT/SRV/NS/SOA,
     # reverse PTR) and per-query resolver selection via
@@ -403,6 +414,14 @@ ignore_missing_imports = true
 # later ships stubs.
 [[tool.mypy.overrides]]
 module = ["asyncpg", "asyncpg.*"]
+ignore_missing_imports = true
+
+# python-tds (import ``pytds``) ships no type stubs / ``py.typed`` marker
+# as of 1.17. The typed ``mssql`` connector (#3264) is the only importer;
+# it wraps the untyped driver behind its own typed session layer. Drop this
+# override if upstream later ships stubs.
+[[tool.mypy.overrides]]
+module = ["pytds", "pytds.*"]
 ignore_missing_imports = true
 
 # pygments (G10.4-T1 #877) ships no ``py.typed`` marker as of 2.20.

--- a/backend/src/meho_backplane/connectors/mssql/__init__.py
+++ b/backend/src/meho_backplane/connectors/mssql/__init__.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.mssql -- MssqlConnector package (#3264).
+
+Importing the package registers :class:`MssqlConnector` against the v2
+connector registry under the natural key
+``(product="mssql", version="2022.x", impl_id="mssql-tds")`` (plus the wildcard
+fallback), and queues the connector's typed-op upserts onto the lifespan-driven
+registrar list so ``endpoint_descriptor`` rows land before the first dispatch.
+The package is discovered automatically by
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` (which
+imports every ``connectors/<product>/`` subpackage in name-sorted order) --
+there is no central connector list to edit; self-registration at import time is
+the whole wiring.
+
+Two-phase registration mirrors the postgres / mongodb siblings:
+
+* **Synchronous (import time)** -- the v2 registry entries land via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` in this
+  module, so a probe firing during startup sees a fully-populated registry.
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_mssql_typed_operations`, which delegates to
+  :meth:`MssqlConnector.register_operations`.
+
+The ``(product, version, impl_id)`` triple is chosen so
+``connector_id="mssql-tds-2022.x"`` round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` (``product`` = the
+first hyphen-segment of ``impl_id`` = ``"mssql"``); a hyphen/underscore in the
+product token would break that round-trip and the registry's
+``_assert_product_impl_id_round_trips`` guard would crash
+``_eager_import_connectors`` at boot.
+"""
+
+from meho_backplane.connectors.mssql.connector import MssqlConnector
+from meho_backplane.connectors.mssql.ops import MSSQL_OPS, MssqlOp
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_mssql_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``MssqlConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level ``async def
+    register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via :func:`register_typed_op_registrar`. The
+    ``embedding_service`` keyword-only parameter mirrors the postgres / winsrv
+    sibling contract -- :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` to every registrar, so each registrar **must**
+    accept the kwarg or the lifespan crashes with :class:`TypeError`. The
+    wrapper accepts-and-discards it because
+    :meth:`MssqlConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await MssqlConnector.register_operations()
+
+
+__all__ = [
+    "MSSQL_OPS",
+    "MssqlConnector",
+    "MssqlOp",
+    "register_mssql_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key.
+register_connector_v2(
+    product="mssql",
+    version="2022.x",
+    impl_id="mssql-tds",
+    cls=MssqlConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1). Mirrors the
+# postgres / mongodb wildcard rows.
+register_connector_v2(
+    product="mssql",
+    version="",
+    impl_id="",
+    cls=MssqlConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_mssql_typed_operations)

--- a/backend/src/meho_backplane/connectors/mssql/connector.py
+++ b/backend/src/meho_backplane/connectors/mssql/connector.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""MssqlConnector -- typed TDS-direct connector for Microsoft SQL Server (#3264).
+
+MEHO's SQL Server connector. Like the postgres (#2236) and mongodb (#2237)
+siblings it subclasses the generic
+:class:`~meho_backplane.connectors.base.Connector` ABC (not the SSH / HTTP
+adapters) and drives a **direct TDS connection** on port 1433 via the
+pure-Python ``python-tds`` driver (import :mod:`pytds`) -- the transport
+decision recorded in ``docs/codebase/connectors-mssql.md``. Registry v2 triple
+``("mssql", "2022.x", "mssql-tds")``.
+
+Design
+------
+
+* **Curated op table, no freeform query.** 14 ops across four groups
+  (``instance`` / ``databases`` / ``ha`` / ``backup``), each individually
+  safety-tiered per the Initiative #3259 satellite table. There is deliberately
+  **no** raw-T-SQL escape hatch (the narrow-waist doctrine): the agent calls
+  curated ops, never composes arbitrary SQL.
+
+* **Two-credential SQL auth.** The target's Vault secret carries
+  ``sql_username`` / ``sql_password`` (the first two-credential connector on the
+  estate seam; the ``sql_`` prefix leaves room for a later
+  dbatools-over-PowerShell increment to store SSH creds in the same secret).
+  The pair flows only into the ``pytds`` connect params -- never a log line or
+  an :class:`OperationResult`. See
+  :func:`~meho_backplane.connectors.mssql.session.resolve_sql_credentials`.
+
+* **Injection safety.** Operator-supplied values bind through ``pytds`` pyformat
+  placeholders; operator-supplied database identifiers ride
+  :func:`~meho_backplane.connectors.mssql.session.quote_identifier` (validated +
+  bracket-escaped). See the session module docstring.
+
+Fingerprint reads SERVERPROPERTY (product version / edition / clustering);
+probe is a ``@@VERSION`` reachability check with distinct failure reasons.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import pytds
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.mssql import queries
+from meho_backplane.connectors.mssql.ops import MSSQL_OPS, MSSQL_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["MssqlConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- mirrors the postgres / mongodb siblings until G0.3's
+# Target model rollout lands.
+type Target = Any
+
+
+class MssqlConnector(Connector):
+    """TDS-direct SQL Server connector via ``python-tds``.
+
+    Registry v2 triple ``("mssql", "2022.x", "mssql-tds")``. ``priority`` is
+    ``1`` so a future ``GenericRestConnector`` auto-shim registering the same
+    product loses the resolver tie-break. ``supported_version_range`` covers SQL
+    Server 2016 (13) through 2022 (16): the catalog / DMV surface the read ops
+    query (``sys.databases`` / ``sys.configurations`` / ``sys.dm_hadr_*`` /
+    ``sys.dm_os_cluster_nodes`` / ``msdb.dbo.backupset``) is stable across those
+    releases, so the connector also serves an older migration *source* while the
+    ``2022.x`` label names its primary target.
+    """
+
+    product = "mssql"
+    version = "2022.x"
+    impl_id = "mssql-tds"
+    supported_version_range = ">=13,<17"
+    priority = 1
+
+    # ------------------------------------------------------------------
+    # instance group
+    # ------------------------------------------------------------------
+
+    async def instance_about(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.instance.about`` -- SERVERPROPERTY identity."""
+        del params  # declared empty in schema
+        return await queries.fetch_server_identity(target, operator)
+
+    async def instance_version(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.instance.version`` -- full ``@@VERSION`` + parsed product version."""
+        del params
+        return await queries.fetch_version(target, operator)
+
+    async def instance_config(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.instance.config`` -- ``sys.configurations`` (list-shaped)."""
+        del params
+        return await queries.fetch_configurations(target, operator)
+
+    async def instance_logins(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.instance.logins`` -- server logins (no password material)."""
+        del params
+        return await queries.fetch_logins(target, operator)
+
+    # ------------------------------------------------------------------
+    # databases group
+    # ------------------------------------------------------------------
+
+    async def databases_list(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.databases.list`` -- databases with state, recovery model, size."""
+        del params
+        return await queries.fetch_databases(target, operator)
+
+    async def databases_files(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.databases.files`` -- data/log files, optionally per-database."""
+        return await queries.fetch_database_files(target, operator, params.get("database"))
+
+    async def databases_create(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.databases.create`` (dangerous, approval-gated) -- ``CREATE DATABASE``."""
+        return await queries.create_database(target, operator, params["database"])
+
+    async def databases_drop(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.databases.drop`` (dangerous, approval-gated) -- ``DROP DATABASE``."""
+        return await queries.drop_database(target, operator, params["database"])
+
+    # ------------------------------------------------------------------
+    # ha group -- migration-validation reads
+    # ------------------------------------------------------------------
+
+    async def ha_availability_groups(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.ha.availability-groups`` -- AG topology + per-replica state."""
+        del params
+        return await queries.fetch_availability_groups(target, operator)
+
+    async def ha_fci(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.ha.fci`` -- Failover Cluster Instance nodes + clustering flags."""
+        del params
+        return await queries.fetch_fci_nodes(target, operator)
+
+    async def ha_sync_health(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.ha.sync-health`` -- per-database AG replication sync health."""
+        del params
+        return await queries.fetch_sync_health(target, operator)
+
+    # ------------------------------------------------------------------
+    # backup group
+    # ------------------------------------------------------------------
+
+    async def backup_history(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.backup.history`` -- recent backup history (list-shaped)."""
+        return await queries.fetch_backup_history(
+            target, operator, params.get("database"), params.get("limit")
+        )
+
+    async def backup_database(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.backup.database`` (caution) -- ``BACKUP DATABASE ... TO DISK``."""
+        return await queries.backup_database(target, operator, params["database"], params["path"])
+
+    async def backup_restore(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mssql.backup.restore`` (dangerous, approval-gated) -- ``RESTORE DATABASE``."""
+        return await queries.restore_database(
+            target,
+            operator,
+            params["database"],
+            params["path"],
+            bool(params.get("replace", False)),
+        )
+
+    # ------------------------------------------------------------------
+    # Fingerprint / probe
+    # ------------------------------------------------------------------
+
+    async def fingerprint(
+        self, target: Target, operator: Operator | None = None
+    ) -> FingerprintResult:
+        """Canonical fingerprint: SERVERPROPERTY product version / edition / clustering.
+
+        A credentialled target reads its secret under *operator* (``None`` fails
+        closed inside :func:`resolve_sql_credentials`). Any connection /
+        credential failure maps to ``reachable=False`` with the error under
+        ``extras`` rather than raising (#986 discipline).
+        """
+        probed_at = datetime.now(UTC)
+        method = "pytds: SERVERPROPERTY"
+        try:
+            identity = await queries.fetch_server_identity(target, operator)
+        except (OSError, pytds.Error, CredentialsReadError, VaultClientError, ValueError) as exc:
+            _log.warning(
+                "mssql_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            return FingerprintResult(
+                vendor="microsoft",
+                product="mssql",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=method,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+        return FingerprintResult(
+            vendor="microsoft",
+            product="mssql",
+            version=_as_str(identity.get("product_version")),
+            build=_as_str(identity.get("product_level")),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=method,
+            extras={
+                "edition": _as_str(identity.get("edition")),
+                "machine_name": _as_str(identity.get("machine_name")),
+                "server_name": _as_str(identity.get("server_name")),
+                "instance_name": _as_str(identity.get("instance_name")),
+                "is_clustered": identity.get("is_clustered"),
+                "is_hadr_enabled": identity.get("is_hadr_enabled"),
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability check via a ``SELECT @@VERSION`` handshake.
+
+        Distinct ``reason`` values on failure:
+
+        * ``auth_failed`` -- the server rejected the credential
+          (:exc:`pytds.LoginError`) or the credential could not be resolved
+          (:class:`CredentialsReadError` / :class:`VaultClientError` /
+          :exc:`ValueError` -- a credentialled target on an operator-less
+          probe).
+        * ``tcp_unreachable`` -- the TCP connect failed or timed out (host down,
+          firewall, wrong port; :exc:`OSError`, which covers
+          :exc:`TimeoutError`).
+        * ``connect_failed`` -- the socket opened but the TDS handshake failed
+          for another reason (:exc:`pytds.Error` -- e.g. the server requires
+          encryption the connector did not offer).
+
+        ``probe`` carries no operator, so a credentialled target's secret read
+        runs without an authenticated operator and fails closed to
+        ``auth_failed``; reachability of a credentialled target is confirmed on
+        the operator-carrying fingerprint / op path (the postgres precedent).
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            return ProbeResult(
+                ok=ok,
+                reason=reason,
+                latency_ms=(time.monotonic() - start) * 1000.0,
+                probed_at=probed_at,
+            )
+
+        try:
+            await queries.fetch_version(target, None)
+        except (CredentialsReadError, VaultClientError, ValueError, pytds.LoginError):
+            return _result(False, "auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except pytds.Error:
+            return _result(False, "connect_failed")
+        return _result(True, None)
+
+    # ------------------------------------------------------------------
+    # Registration + dispatch shim
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`MSSQL_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan (via the registrar queued in
+        :mod:`meho_backplane.connectors.mssql.__init__`) after the registry has
+        eager-imported every connector module. Idempotent across pod restarts --
+        the postgres / winsrv shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in MSSQL_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"MssqlConnector op {op.op_id!r} declares handler_attr="
+                    f"{op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = MSSQL_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"MssqlConnector op {op.op_id!r} declares group_key="
+                        f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                        "Add an entry to MSSQL_WHEN_TO_USE_BY_GROUP in mssql/ops.py."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "mssql_operations_registered",
+            count=len(MSSQL_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(self, target: Target, op_id: str, params: dict[str, Any]) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`PostgresConnector.execute`. Post-G0.6 callers construct a
+        real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly. The synthetic
+        operator carries ``raw_jwt=""``, so a credentialled target reached
+        through this shim fails closed in the credential loader -- the
+        operator-context path is the real dispatch surface. The natural key
+        encodes as ``"mssql-tds-2022.x"`` per ``parse_connector_id``.
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:mssql-tds-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+
+def _as_str(value: Any) -> str | None:
+    """Return *value* when it is a non-empty ``str``, else ``None``.
+
+    Guards the fingerprint projection: a SERVERPROPERTY read can render an
+    absent field as ``None``, and :class:`FingerprintResult`'s string fields
+    are typed ``str | None``.
+    """
+    return value if isinstance(value, str) and value else None

--- a/backend/src/meho_backplane/connectors/mssql/ops.py
+++ b/backend/src/meho_backplane/connectors/mssql/ops.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`MssqlConnector` (#3264).
+
+The connector manages **Microsoft SQL Server 2022** over a direct TDS
+connection (port 1433) via the pure-Python ``python-tds`` driver — the
+postgres / mongodb direct-protocol mold (#2236 / #2237), not the
+PowerShell-over-SSH estate seam. 14 ops across four groups; the safety tier per
+op follows the Initiative #3259 satellite table — reads ``safe``, a recoverable
+write ``caution``, destructive / data-overwriting writes ``dangerous`` +
+``requires_approval``:
+
+* ``mssql.instance.about``         [safe]       SERVERPROPERTY identity (version/edition/HA).
+* ``mssql.instance.version``       [safe]       ``@@VERSION`` banner + parsed product version.
+* ``mssql.instance.config``        [safe]       ``sys.configurations`` (list → JSONFlux).
+* ``mssql.instance.logins``        [safe]       ``sys.server_principals`` (no password material).
+* ``mssql.databases.list``         [safe]       ``sys.databases`` + size (list → JSONFlux).
+* ``mssql.databases.files``        [safe]       ``sys.master_files`` (list → JSONFlux).
+* ``mssql.databases.create``       [danger+appr] ``CREATE DATABASE``.
+* ``mssql.databases.drop``         [danger+appr] ``DROP DATABASE``.
+* ``mssql.ha.availability-groups`` [safe]       AG topology + per-replica state (list → JSONFlux).
+* ``mssql.ha.fci``                 [safe]       FCI cluster nodes + clustering flags.
+* ``mssql.ha.sync-health``         [safe]       per-database AG sync health (list → JSONFlux).
+* ``mssql.backup.history``         [safe]       ``msdb.dbo.backupset`` (list → JSONFlux).
+* ``mssql.backup.database``        [caution]    ``BACKUP DATABASE ... TO DISK``.
+* ``mssql.backup.restore``         [danger+appr] ``RESTORE DATABASE ... FROM DISK`` (overwrites).
+
+**No freeform ``query`` op is shipped** — the narrow-waist doctrine (CLAUDE.md
+postulate 5): only curated, individually-safety-tiered ops reach the agent
+surface, never a raw-T-SQL escape hatch. This is a deliberate non-goal recorded
+in ``docs/codebase/connectors-mssql.md`` and pinned by a test asserting no such
+op id exists.
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.postgres.ops` so the registration walk in
+:meth:`MssqlConnector.register_operations` reads identically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = [
+    "MSSQL_OPS",
+    "MSSQL_WHEN_TO_USE_BY_GROUP",
+    "TDS_TRANSPORT_NOTE",
+    "MssqlOp",
+]
+
+
+#: Transport reminder copied into every op's ``llm_instructions``. SQL Server
+#: management has no unified REST surface the agent could compose against; the
+#: connector is a curated op table over the TDS wire protocol, so the agent
+#: must call these ops rather than reach for raw T-SQL (no freeform query op
+#: exists by design).
+TDS_TRANSPORT_NOTE: str = (
+    "SQL Server is reached over the TDS wire protocol (port 1433) via the "
+    "pure-Python python-tds driver; there is no per-op REST surface and no "
+    "freeform T-SQL op — call these curated ops."
+)
+
+
+#: Curated ``when_to_use`` blurbs per group key, consumed by
+#: :meth:`MssqlConnector.register_operations` (the registration walk fails
+#: closed with a :class:`ValueError` if a ``group_key`` lacks an entry — the
+#: postgres / winsrv precedent).
+MSSQL_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "instance": (
+        "Use for SQL Server instance-level facts before any drill-in: identity "
+        "and version/edition/clustering (``mssql.instance.about``), the full "
+        "``@@VERSION`` banner (``mssql.instance.version``), the effective "
+        "instance configuration (``mssql.instance.config``, sys.configurations), "
+        "and the server logins (``mssql.instance.logins``, no password "
+        "material). All read-only. Call ``mssql.instance.about`` first to "
+        "confirm the instance is reachable and read its edition/version."
+    ),
+    "databases": (
+        "Use to inventory databases and (with approval) create/drop them: list "
+        "every database with state, recovery model, and on-disk size "
+        "(``mssql.databases.list``) or the data/log files of one "
+        "(``mssql.databases.files``) -- both read-only -- and ``create`` / "
+        "``drop`` a database (both ``dangerous`` + ``requires_approval``: a "
+        "dispatch parks for a human decision, and the tier ladder excludes them "
+        "from satellite runners). The right group for 'what databases exist and "
+        "how big are they?' on a migration source or target."
+    ),
+    "ha": (
+        "Use for the migration-validation reads: Availability Group topology "
+        "and per-replica operational/synchronization state "
+        "(``mssql.ha.availability-groups``), Failover Cluster Instance nodes + "
+        "clustering flags (``mssql.ha.fci``), and per-database AG replication "
+        "sync health with queue depths and last-commit time "
+        "(``mssql.ha.sync-health``). All read-only. The right group to confirm "
+        "an AG/FCI is healthy and caught up before a migration cutover or a "
+        "planned failover."
+    ),
+    "backup": (
+        "Use to read backup history and (governed) back up / restore a "
+        "database: recent backup history newest-first "
+        "(``mssql.backup.history``, read-only), ``mssql.backup.database`` "
+        "(``caution`` -- creates a backup file, recoverable), and "
+        "``mssql.backup.restore`` (``dangerous`` + ``requires_approval`` -- "
+        "OVERWRITES the target database, so a dispatch parks for approval). "
+        "Backup/restore is the migration data-movement primitive."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class MssqlOp:
+    """Metadata for one mssql op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can splat
+    the dataclass into the helper. ``handler_attr`` is the async-handler
+    attribute name on
+    :class:`~meho_backplane.connectors.mssql.connector.MssqlConnector`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+# ---------------------------------------------------------------------------
+# Shared schema fragments
+# ---------------------------------------------------------------------------
+
+_NO_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "additionalProperties": False}
+
+#: The ``{rows, total}`` envelope every list op returns; the JSONFlux reducer
+#: keys on the single ``rows`` collection.
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+_DATABASE_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 128,
+    "pattern": "\\S",
+    "description": "A SQL Server database name (max 128 characters).",
+}
+
+_BACKUP_PATH_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The backup device path as the SQL Server service account sees it "
+        "(e.g. a local path or a UNC share the instance can reach)."
+    ),
+}
+
+
+def _write_response_schema(*extra: str) -> dict[str, Any]:
+    """An action-shaped write response schema with the given *extra* keys."""
+    properties: dict[str, Any] = {
+        "database": {"type": "string"},
+        "action": {"type": "string"},
+        "ok": {"type": "boolean"},
+        "op_class": {"type": "string", "enum": ["write"]},
+    }
+    for key in extra:
+        properties[key] = {"type": ["string", "boolean"]}
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": ["database", "action", "op_class"],
+        "additionalProperties": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Composer
+# ---------------------------------------------------------------------------
+
+
+def _mssql_ops() -> tuple[MssqlOp, ...]:
+    """Merge the per-group op tuples into the registration tuple.
+
+    The per-group imports are deferred into this function (the winsrv / msad
+    precedent): each group module imports the ``MssqlOp`` dataclass + the shared
+    schema fragments back from this module, so importing them at the top would
+    close a cycle. By the time ``MSSQL_OPS = _mssql_ops()`` runs at the bottom of
+    this module, every shared name above is already bound.
+    """
+    from meho_backplane.connectors.mssql.ops_backup import BACKUP_OPS
+    from meho_backplane.connectors.mssql.ops_databases import DATABASE_OPS
+    from meho_backplane.connectors.mssql.ops_ha import HA_OPS
+    from meho_backplane.connectors.mssql.ops_instance import INSTANCE_OPS
+
+    return (*INSTANCE_OPS, *DATABASE_OPS, *HA_OPS, *BACKUP_OPS)
+
+
+#: The ops :class:`MssqlConnector` registers at lifespan startup.
+MSSQL_OPS: tuple[MssqlOp, ...] = _mssql_ops()

--- a/backend/src/meho_backplane/connectors/mssql/ops_backup.py
+++ b/backend/src/meho_backplane/connectors/mssql/ops_backup.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backup-group ops (history / database / restore) for :class:`MssqlConnector`.
+
+Registered by :meth:`MssqlConnector.register_operations` via the
+:data:`~meho_backplane.connectors.mssql.ops.MSSQL_OPS` composer. See
+:mod:`meho_backplane.connectors.mssql.ops` for the ``MssqlOp`` dataclass and
+the shared schema fragments.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.mssql.ops import (
+    _BACKUP_PATH_PROP,
+    _DATABASE_NAME_PROP,
+    _LIST_RESPONSE_SCHEMA,
+    TDS_TRANSPORT_NOTE,
+    MssqlOp,
+    _write_response_schema,
+)
+
+BACKUP_OPS: tuple[MssqlOp, ...] = (
+    MssqlOp(
+        op_id="mssql.backup.history",
+        handler_attr="backup_history",
+        summary="List recent backup history from msdb.dbo.backupset (newest first).",
+        description=(
+            "Lists recent backups (msdb.dbo.backupset): database, start/finish "
+            "time, type (D full / I differential / L log / ...), recovery "
+            "model, is_copy_only, backup size and compressed size, first/last "
+            "LSN, server, user — newest first, capped at 'limit' (default 200). "
+            "Pass 'database' to scope to one database. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "database": _DATABASE_NAME_PROP,
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10000,
+                    "description": "Max backup rows to return (default 200, newest first).",
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="backup",
+        tags=("read-only", "backup", "history", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read a database's recent backup history (when was the "
+                "last full/log backup, how big, copy-only?) before a migration "
+                "or a restore. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "database": "Optional. Scope to one database; omit for all.",
+                "limit": "Optional. Row cap (default 200, max 10000).",
+            },
+            "output_shape": (
+                "{'rows': [{database_name, backup_start_date, "
+                "backup_finish_date, type, recovery_model, is_copy_only, "
+                "backup_size, compressed_backup_size, first_lsn, last_lsn, "
+                "server_name, user_name}], 'total': <int>}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.backup.database",
+        handler_attr="backup_database",
+        summary="Back up a database to a disk device (caution).",
+        description=(
+            "Runs ``BACKUP DATABASE [<name>] TO DISK = <path> WITH INIT``. The "
+            "database name is validated + bracket-escaped; the path binds as a "
+            "value. safety_level=caution — a recoverable write (creates a backup "
+            "file; overwrites the named device via WITH INIT), satellite-"
+            "executable only through the Stage-3 composed write gate."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"database": _DATABASE_NAME_PROP, "path": _BACKUP_PATH_PROP},
+            "required": ["database", "path"],
+            "additionalProperties": False,
+        },
+        response_schema=_write_response_schema("path"),
+        group_key="backup",
+        tags=("write", "backup", "mssql"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Back up a database to a disk device the SQL Server service "
+                "account can write. Recoverable; safety_level=caution. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "database": "Required. The database to back up.",
+                "path": "Required. The backup device path (as the service account sees it).",
+            },
+            "output_shape": "{'database', 'action': 'backup', 'path', 'ok', 'op_class': 'write'}.",
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.backup.restore",
+        handler_attr="backup_restore",
+        summary="Restore a database from a disk backup (dangerous, approval-gated).",
+        description=(
+            "Runs ``RESTORE DATABASE [<name>] FROM DISK = <path> [WITH REPLACE]`` "
+            "— OVERWRITES the target database. The name is validated + "
+            "bracket-escaped; the path binds as a value; WITH REPLACE is added "
+            "only when 'replace' is true. safety_level=dangerous + "
+            "requires_approval: a dispatch parks for a human decision, and the "
+            "tier ladder excludes it from satellite runners."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "database": _DATABASE_NAME_PROP,
+                "path": _BACKUP_PATH_PROP,
+                "replace": {
+                    "type": "boolean",
+                    "description": "Add WITH REPLACE to overwrite an existing database.",
+                },
+            },
+            "required": ["database", "path"],
+            "additionalProperties": False,
+        },
+        response_schema=_write_response_schema("path", "replace"),
+        group_key="backup",
+        tags=("write", "restore", "mssql"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Restore a database from a backup device — OVERWRITES data. "
+                "dangerous + requires approval — the dispatch parks for a human "
+                "decision. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "database": "Required. The database to restore into.",
+                "path": "Required. The backup device path to restore from.",
+                "replace": "Optional. true to add WITH REPLACE (overwrite an existing database).",
+            },
+            "output_shape": (
+                "{'database', 'action': 'restore', 'path', 'replace', 'ok', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/mssql/ops_databases.py
+++ b/backend/src/meho_backplane/connectors/mssql/ops_databases.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Database-group ops (list / files / create / drop) for :class:`MssqlConnector`.
+
+Registered by :meth:`MssqlConnector.register_operations` via the
+:data:`~meho_backplane.connectors.mssql.ops.MSSQL_OPS` composer. See
+:mod:`meho_backplane.connectors.mssql.ops` for the ``MssqlOp`` dataclass and
+the shared schema fragments.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.mssql.ops import (
+    _DATABASE_NAME_PROP,
+    _LIST_RESPONSE_SCHEMA,
+    _NO_PARAMS,
+    TDS_TRANSPORT_NOTE,
+    MssqlOp,
+    _write_response_schema,
+)
+
+DATABASE_OPS: tuple[MssqlOp, ...] = (
+    MssqlOp(
+        op_id="mssql.databases.list",
+        handler_attr="databases_list",
+        summary="List databases with state, recovery model, and on-disk size.",
+        description=(
+            "Lists every database (sys.databases) with its state, recovery "
+            "model, compatibility level, collation, create date, read-only / "
+            "auto-close / containment flags, and aggregated on-disk size in MB "
+            "(from sys.master_files), largest first. safety_level=safe, "
+            "read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="databases",
+        tags=("read-only", "databases", "inventory", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to inventory the databases on an instance with their "
+                "state and size before drilling into files or planning a "
+                "migration. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{name, database_id, state_desc, "
+                "recovery_model_desc, compatibility_level, collation_name, "
+                "create_date, is_read_only, is_auto_close_on, containment_desc, "
+                "size_mb}], 'total': <int>} sorted by size_mb desc."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.databases.files",
+        handler_attr="databases_files",
+        summary="List database data/log files (optionally scoped to one database).",
+        description=(
+            "Lists data and log files (sys.master_files) with database name, "
+            "file id, type, logical name, physical path, size in MB, max size, "
+            "and growth. Pass 'database' to scope to one database; omit for all. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"database": _DATABASE_NAME_PROP},
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="databases",
+        tags=("read-only", "databases", "files", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to see the physical files behind a database (paths, "
+                "sizes, growth) — e.g. to plan storage before a migration. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"database": "Optional. Scope to one database; omit for all."},
+            "output_shape": (
+                "{'rows': [{database_name, file_id, type_desc, logical_name, "
+                "physical_name, size_mb, max_size, growth, is_percent_growth}], "
+                "'total': <int>}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.databases.create",
+        handler_attr="databases_create",
+        summary="Create a database via CREATE DATABASE (dangerous, approval-gated).",
+        description=(
+            "Runs ``CREATE DATABASE [<name>]`` against the instance. The name is "
+            "validated and bracket-escaped (QUOTENAME-style) — never "
+            "string-interpolated raw. safety_level=dangerous + "
+            "requires_approval: a dispatch parks for a human decision before "
+            "anything is created, and the tier ladder excludes it from "
+            "satellite runners."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"database": _DATABASE_NAME_PROP},
+            "required": ["database"],
+            "additionalProperties": False,
+        },
+        response_schema=_write_response_schema(),
+        group_key="databases",
+        tags=("write", "databases", "create", "mssql"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Create a new database. dangerous + requires approval — the "
+                "dispatch parks for a human decision. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"database": "Required. The database name to create."},
+            "output_shape": "{'database', 'action': 'create', 'ok', 'op_class': 'write'}.",
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.databases.drop",
+        handler_attr="databases_drop",
+        summary="Drop a database via DROP DATABASE (dangerous, approval-gated).",
+        description=(
+            "Runs ``DROP DATABASE [<name>]`` — irreversible removal of the "
+            "database and its files. The name is validated and bracket-escaped. "
+            "safety_level=dangerous + requires_approval: a dispatch parks for a "
+            "human decision, and the tier ladder excludes it from satellite "
+            "runners."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"database": _DATABASE_NAME_PROP},
+            "required": ["database"],
+            "additionalProperties": False,
+        },
+        response_schema=_write_response_schema(),
+        group_key="databases",
+        tags=("write", "databases", "drop", "mssql"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Drop (delete) a database. Irreversible; dangerous + requires "
+                "approval — the dispatch parks for a human decision. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"database": "Required. The database name to drop."},
+            "output_shape": "{'database', 'action': 'drop', 'ok', 'op_class': 'write'}.",
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/mssql/ops_ha.py
+++ b/backend/src/meho_backplane/connectors/mssql/ops_ha.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""High-availability-group ops (AG / FCI / sync-health) for :class:`MssqlConnector`.
+
+Registered by :meth:`MssqlConnector.register_operations` via the
+:data:`~meho_backplane.connectors.mssql.ops.MSSQL_OPS` composer. See
+:mod:`meho_backplane.connectors.mssql.ops` for the ``MssqlOp`` dataclass and
+the shared schema fragments.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.mssql.ops import (
+    _LIST_RESPONSE_SCHEMA,
+    _NO_PARAMS,
+    TDS_TRANSPORT_NOTE,
+    MssqlOp,
+)
+
+HA_OPS: tuple[MssqlOp, ...] = (
+    MssqlOp(
+        op_id="mssql.ha.availability-groups",
+        handler_attr="ha_availability_groups",
+        summary="List Availability Groups with per-replica operational/sync state.",
+        description=(
+            "Returns one row per AG replica: AG name, backup preference, "
+            "failure-condition level, health-check timeout, replica server "
+            "name, availability/failover mode, and the replica's role, "
+            "operational state, connected state, synchronization health, and "
+            "recovery health (sys.availability_groups + sys.availability_replicas "
+            "+ sys.dm_hadr_availability_replica_states). The migration-validation "
+            "read for AG topology + health. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="ha",
+        tags=("read-only", "ha", "availability-group", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to validate Availability Group topology and per-replica "
+                "health (roles, sync health) before a migration cutover or "
+                "failover. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{ag_name, automated_backup_preference_desc, "
+                "failure_condition_level, health_check_timeout, "
+                "replica_server_name, availability_mode_desc, "
+                "failover_mode_desc, role_desc, operational_state_desc, "
+                "connected_state_desc, synchronization_health_desc, "
+                "recovery_health_desc}], 'total': <int>}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.ha.fci",
+        handler_attr="ha_fci",
+        summary="List Failover Cluster Instance nodes + clustering flags.",
+        description=(
+            "Returns the WSFC nodes hosting the instance (sys.dm_os_cluster_nodes: "
+            "node name, status, current owner) alongside the IsClustered flag "
+            "and the server name. The migration-validation read for FCI "
+            "topology. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+                "is_clustered": {"type": ["integer", "null"]},
+                "server_name": {"type": ["string", "null"]},
+            },
+            "required": ["rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="ha",
+        tags=("read-only", "ha", "fci", "cluster", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to validate Failover Cluster Instance topology (which "
+                "WSFC nodes host the instance, which owns it now, whether the "
+                "instance is clustered at all). " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{node_name, status, status_description, "
+                "is_current_owner}], 'total': <int>, 'is_clustered', "
+                "'server_name'}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.ha.sync-health",
+        handler_attr="ha_sync_health",
+        summary="Per-database AG replication sync health (queue depths, last commit).",
+        description=(
+            "Returns per-database replication state across AG replicas "
+            "(sys.dm_hadr_database_replica_states): database name, replica "
+            "server, is_local / is_primary_replica, synchronization state and "
+            "health, suspended flag + reason, log-send and redo queue sizes, "
+            "and last commit time. The fine-grained cutover-readiness read. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="ha",
+        tags=("read-only", "ha", "sync-health", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to check per-database AG sync health (is every database "
+                "SYNCHRONIZED and HEALTHY, how deep are the send/redo queues) "
+                "before a cutover. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{database_name, replica_server_name, is_local, "
+                "is_primary_replica, synchronization_state_desc, "
+                "synchronization_health_desc, is_suspended, suspend_reason_desc, "
+                "log_send_queue_size, redo_queue_size, last_commit_time}], "
+                "'total': <int>}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/mssql/ops_instance.py
+++ b/backend/src/meho_backplane/connectors/mssql/ops_instance.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Instance-group ops (about / version / config / logins) for :class:`MssqlConnector`.
+
+Registered by :meth:`MssqlConnector.register_operations` via the
+:data:`~meho_backplane.connectors.mssql.ops.MSSQL_OPS` composer. See
+:mod:`meho_backplane.connectors.mssql.ops` for the ``MssqlOp`` dataclass and
+the shared schema fragments.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.mssql.ops import (
+    _LIST_RESPONSE_SCHEMA,
+    _NO_PARAMS,
+    TDS_TRANSPORT_NOTE,
+    MssqlOp,
+)
+
+INSTANCE_OPS: tuple[MssqlOp, ...] = (
+    MssqlOp(
+        op_id="mssql.instance.about",
+        handler_attr="instance_about",
+        summary="Return the SQL Server instance identity (version / edition / clustering).",
+        description=(
+            "Reads SERVERPROPERTY for the product version, product level, "
+            "edition, machine / server / instance name, collation, and the "
+            "IsClustered / IsHadrEnabled flags. Use to confirm the instance is "
+            "reachable over TDS and to read its identity before any drill-in. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema={"type": "object", "additionalProperties": True},
+        group_key="instance",
+        tags=("read-only", "identity", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call first to identify a SQL Server instance (edition / "
+                "version / whether it is clustered or HADR-enabled) and confirm "
+                "TDS reachability. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict: {product_version, product_level, edition, "
+                "machine_name, server_name, instance_name, collation, "
+                "is_clustered, is_hadr_enabled}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.instance.version",
+        handler_attr="instance_version",
+        summary="Return the full @@VERSION banner and parsed product version.",
+        description=(
+            "Returns the full ``@@VERSION`` banner (OS, build, architecture) "
+            "alongside the parsed ProductVersion / ProductLevel / Edition. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema={"type": "object", "additionalProperties": True},
+        group_key="instance",
+        tags=("read-only", "version", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for the verbatim ``@@VERSION`` string (build number, OS, "
+                "architecture) when the compact about identity is not enough. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": "{version, product_version, product_level, edition}.",
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.instance.config",
+        handler_attr="instance_config",
+        summary="List instance configuration settings from sys.configurations.",
+        description=(
+            "Lists every instance-level configuration option (name, configured "
+            "value, running value_in_use, min/max, is_dynamic, is_advanced, "
+            "description) from sys.configurations. safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="instance",
+        tags=("read-only", "config", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read effective instance configuration (max server "
+                "memory, MAXDOP, cost threshold, etc.). " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{name, value, value_in_use, minimum, maximum, "
+                "is_dynamic, is_advanced, description}], 'total': <int>}."
+            ),
+        },
+    ),
+    MssqlOp(
+        op_id="mssql.instance.logins",
+        handler_attr="instance_logins",
+        summary="List server logins from sys.server_principals (no password material).",
+        description=(
+            "Lists SQL / Windows / group / certificate / key server principals "
+            "(name, type_desc, is_disabled, create/modify dates, default "
+            "database) from sys.server_principals. Reads sys.server_principals, "
+            "never sys.sql_logins, so no password hash is ever projected. "
+            "safety_level=safe, read-only."
+        ),
+        parameter_schema=_NO_PARAMS,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="instance",
+        tags=("read-only", "logins", "mssql"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate server logins (which accounts can connect, "
+                "which are disabled) before a migration. No password material "
+                "is returned. " + TDS_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{name, type_desc, is_disabled, create_date, "
+                "modify_date, default_database_name}], 'total': <int>}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/mssql/queries.py
+++ b/backend/src/meho_backplane/connectors/mssql/queries.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""T-SQL statements + row-shaping for the mssql connector (#3264).
+
+Every function here builds one statement, runs it through the session
+transport (:mod:`~meho_backplane.connectors.mssql.session`), and returns a
+JSON-serialisable dict — the connector methods own nothing but the dispatch
+glue, so this module stays a pure query surface (the postgres ``queries.py``
+precedent, #2236). List reads return the ``{rows, total}`` envelope the
+JSONFlux reducer keys on (it detects the single ``rows`` collection and
+materialises it past the 50-row / 4 KB threshold); identity reads return a
+flat dict.
+
+Injection safety (see the :mod:`~meho_backplane.connectors.mssql.session`
+docstring): operator-supplied **values** bind through ``pytds`` pyformat
+placeholders (``%(name)s``); an operator-supplied **database identifier** in a
+DDL / utility statement — which T-SQL cannot bind — is passed through
+:func:`~meho_backplane.connectors.mssql.session.quote_identifier` (strict
+pre-validation + QUOTENAME-style bracket escaping) before interpolation.
+
+Catalog facts are pinned to the SQL Server 2022 system-view reference:
+``sys.databases`` / ``sys.master_files`` / ``sys.configurations`` /
+``sys.server_principals`` /
+``sys.availability_groups`` + ``sys.dm_hadr_*`` / ``sys.dm_os_cluster_nodes`` /
+``msdb.dbo.backupset``
+(https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.mssql.session import (
+    execute_statement,
+    fetch_rows,
+    quote_identifier,
+)
+
+__all__ = [
+    "backup_database",
+    "create_database",
+    "drop_database",
+    "fetch_availability_groups",
+    "fetch_backup_history",
+    "fetch_configurations",
+    "fetch_database_files",
+    "fetch_databases",
+    "fetch_fci_nodes",
+    "fetch_logins",
+    "fetch_server_identity",
+    "fetch_sync_health",
+    "fetch_version",
+    "restore_database",
+]
+
+#: Default cap for the ``mssql.backup.history`` read — the most recent N backup
+#: rows, newest first. Bounded so a long-lived instance's backup history never
+#: floods the transport before the reducer sees it.
+_DEFAULT_BACKUP_HISTORY_LIMIT = 200
+
+
+def _envelope(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap *rows* in the ``{rows, total}`` envelope the JSONFlux reducer keys on."""
+    return {"rows": rows, "total": len(rows)}
+
+
+# ---------------------------------------------------------------------------
+# instance group
+# ---------------------------------------------------------------------------
+
+#: SERVERPROPERTY identity projection — the fingerprint canary. Constant script,
+#: no operator input, so no injection surface.
+_IDENTITY_SQL = (
+    "SELECT "
+    "CAST(SERVERPROPERTY('ProductVersion') AS nvarchar(128)) AS product_version, "
+    "CAST(SERVERPROPERTY('ProductLevel') AS nvarchar(128)) AS product_level, "
+    "CAST(SERVERPROPERTY('Edition') AS nvarchar(128)) AS edition, "
+    "CAST(SERVERPROPERTY('MachineName') AS nvarchar(128)) AS machine_name, "
+    "CAST(SERVERPROPERTY('ServerName') AS nvarchar(256)) AS server_name, "
+    "CAST(SERVERPROPERTY('InstanceName') AS nvarchar(128)) AS instance_name, "
+    "CAST(SERVERPROPERTY('Collation') AS nvarchar(128)) AS collation, "
+    "CAST(SERVERPROPERTY('IsClustered') AS int) AS is_clustered, "
+    "CAST(SERVERPROPERTY('IsHadrEnabled') AS int) AS is_hadr_enabled"
+)
+
+
+async def fetch_server_identity(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """One-row SERVERPROPERTY identity — product version / edition / clustering.
+
+    Backs both :meth:`MssqlConnector.fingerprint` and the ``mssql.instance.about``
+    op, so the canonical fingerprint and the operator-facing identity op share
+    one round-trip.
+    """
+    rows = await fetch_rows(target, operator, _IDENTITY_SQL)
+    return rows[0] if rows else {}
+
+
+async def fetch_version(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """The full ``@@VERSION`` banner plus the parsed product version / level."""
+    rows = await fetch_rows(
+        target,
+        operator,
+        "SELECT @@VERSION AS version, "
+        "CAST(SERVERPROPERTY('ProductVersion') AS nvarchar(128)) AS product_version, "
+        "CAST(SERVERPROPERTY('ProductLevel') AS nvarchar(128)) AS product_level, "
+        "CAST(SERVERPROPERTY('Edition') AS nvarchar(128)) AS edition",
+    )
+    return rows[0] if rows else {}
+
+
+async def fetch_configurations(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """``sys.configurations`` — every instance-level setting (list-shaped)."""
+    rows = await fetch_rows(
+        target,
+        operator,
+        "SELECT name, value, value_in_use, minimum, maximum, "
+        "is_dynamic, is_advanced, description "
+        "FROM sys.configurations ORDER BY name",
+    )
+    return _envelope(rows)
+
+
+async def fetch_logins(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """``sys.server_principals`` — server logins (list-shaped, no password material).
+
+    Reads ``sys.server_principals`` (never ``sys.sql_logins``, which exposes
+    ``password_hash``), so no credential material is ever projected. SQL /
+    Windows / group / certificate / asymmetric-key principals only; the
+    built-in fixed server roles (``type = 'R'``) are excluded.
+    """
+    rows = await fetch_rows(
+        target,
+        operator,
+        "SELECT name, type_desc, is_disabled, create_date, modify_date, "
+        "default_database_name "
+        "FROM sys.server_principals "
+        "WHERE type IN ('S', 'U', 'G', 'C', 'K') "
+        "ORDER BY name",
+    )
+    return _envelope(rows)
+
+
+# ---------------------------------------------------------------------------
+# databases group
+# ---------------------------------------------------------------------------
+
+#: Per-database state + aggregated on-disk size. Sizes come from
+#: ``sys.master_files`` (8 KB pages → MB), grouped so one row is one database.
+_DATABASES_SQL = (
+    "SELECT d.name, d.database_id, d.state_desc, d.recovery_model_desc, "
+    "d.compatibility_level, d.collation_name, d.create_date, d.is_read_only, "
+    "d.is_auto_close_on, d.containment_desc, "
+    "CAST(SUM(mf.size) * 8.0 / 1024 AS decimal(18,2)) AS size_mb "
+    "FROM sys.databases AS d "
+    "LEFT JOIN sys.master_files AS mf ON mf.database_id = d.database_id "
+    "GROUP BY d.name, d.database_id, d.state_desc, d.recovery_model_desc, "
+    "d.compatibility_level, d.collation_name, d.create_date, d.is_read_only, "
+    "d.is_auto_close_on, d.containment_desc "
+    "ORDER BY size_mb DESC"
+)
+
+
+async def fetch_databases(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """``sys.databases`` — every database with state, recovery model, size."""
+    rows = await fetch_rows(target, operator, _DATABASES_SQL)
+    return _envelope(rows)
+
+
+async def fetch_database_files(
+    target: Any, operator: Operator | None, database: str | None
+) -> dict[str, Any]:
+    """``sys.master_files`` — data / log files, optionally scoped to one database.
+
+    *database* is an optional filter bound as a **value** through the pyformat
+    placeholder (``DB_NAME(database_id) = %(database)s``) — it is not an
+    identifier here, so no bracket escaping applies; the bind is the injection
+    defence.
+    """
+    sql = (
+        "SELECT DB_NAME(mf.database_id) AS database_name, mf.file_id, "
+        "mf.type_desc, mf.name AS logical_name, mf.physical_name, "
+        "CAST(mf.size * 8.0 / 1024 AS decimal(18,2)) AS size_mb, "
+        "mf.max_size, mf.growth, mf.is_percent_growth "
+        "FROM sys.master_files AS mf"
+    )
+    params: dict[str, Any] = {}
+    if database:
+        sql += " WHERE DB_NAME(mf.database_id) = %(database)s"
+        params["database"] = database
+    sql += " ORDER BY database_name, mf.file_id"
+    rows = await fetch_rows(target, operator, sql, params or None)
+    return _envelope(rows)
+
+
+async def create_database(target: Any, operator: Operator | None, database: str) -> dict[str, Any]:
+    """``CREATE DATABASE`` — dangerous + approval-gated.
+
+    The database name is an identifier T-SQL cannot bind, so it rides
+    :func:`quote_identifier` (validated + bracket-escaped). Runs against
+    ``master``; ``CREATE DATABASE`` cannot execute inside a multi-statement
+    transaction, which the session's ``autocommit=True`` connection satisfies.
+    """
+    identifier = quote_identifier(database)
+    await execute_statement(target, operator, f"CREATE DATABASE {identifier}", database=None)
+    return {"database": database, "action": "create", "ok": True, "op_class": "write"}
+
+
+async def drop_database(target: Any, operator: Operator | None, database: str) -> dict[str, Any]:
+    """``DROP DATABASE`` — dangerous + approval-gated (irreversible)."""
+    identifier = quote_identifier(database)
+    await execute_statement(target, operator, f"DROP DATABASE {identifier}", database=None)
+    return {"database": database, "action": "drop", "ok": True, "op_class": "write"}
+
+
+# ---------------------------------------------------------------------------
+# ha group — the migration-validation reads
+# ---------------------------------------------------------------------------
+
+#: Availability Group topology + per-replica role / sync state. One row per
+#: replica: the join AG → replica → replica-state carries the operational and
+#: synchronization health an operator validates before a migration cutover.
+_AG_SQL = (
+    "SELECT ag.name AS ag_name, ag.automated_backup_preference_desc, "
+    "ag.failure_condition_level, ag.health_check_timeout, "
+    "ar.replica_server_name, ar.availability_mode_desc, ar.failover_mode_desc, "
+    "ars.role_desc, ars.operational_state_desc, ars.connected_state_desc, "
+    "ars.synchronization_health_desc, ars.recovery_health_desc "
+    "FROM sys.availability_groups AS ag "
+    "JOIN sys.availability_replicas AS ar ON ar.group_id = ag.group_id "
+    "LEFT JOIN sys.dm_hadr_availability_replica_states AS ars "
+    "ON ars.replica_id = ar.replica_id "
+    "ORDER BY ag.name, ar.replica_server_name"
+)
+
+#: Per-database replication sync health across AG replicas — the fine-grained
+#: cutover-readiness read (queue depths + last commit time per database).
+_SYNC_SQL = (
+    "SELECT DB_NAME(drs.database_id) AS database_name, ar.replica_server_name, "
+    "drs.is_local, drs.is_primary_replica, drs.synchronization_state_desc, "
+    "drs.synchronization_health_desc, drs.is_suspended, drs.suspend_reason_desc, "
+    "drs.log_send_queue_size, drs.redo_queue_size, drs.last_commit_time "
+    "FROM sys.dm_hadr_database_replica_states AS drs "
+    "LEFT JOIN sys.availability_replicas AS ar ON ar.replica_id = drs.replica_id "
+    "ORDER BY database_name, ar.replica_server_name"
+)
+
+
+async def fetch_availability_groups(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """Availability Group topology + per-replica operational / sync state."""
+    rows = await fetch_rows(target, operator, _AG_SQL)
+    return _envelope(rows)
+
+
+async def fetch_fci_nodes(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """Failover Cluster Instance topology — cluster nodes + clustering flags.
+
+    ``sys.dm_os_cluster_nodes`` lists the WSFC nodes hosting the instance; the
+    ``is_clustered`` / ``server_name`` scalars from SERVERPROPERTY ride
+    alongside the ``{rows, total}`` node envelope (preserved as sibling scalars,
+    not folded into the reduced collection).
+    """
+    nodes = await fetch_rows(
+        target,
+        operator,
+        "SELECT NodeName AS node_name, status, status_description, is_current_owner "
+        "FROM sys.dm_os_cluster_nodes ORDER BY NodeName",
+    )
+    identity = await fetch_rows(
+        target,
+        operator,
+        "SELECT CAST(SERVERPROPERTY('IsClustered') AS int) AS is_clustered, "
+        "CAST(SERVERPROPERTY('ServerName') AS nvarchar(256)) AS server_name",
+    )
+    flags = identity[0] if identity else {}
+    return {
+        "rows": nodes,
+        "total": len(nodes),
+        "is_clustered": flags.get("is_clustered"),
+        "server_name": flags.get("server_name"),
+    }
+
+
+async def fetch_sync_health(target: Any, operator: Operator | None) -> dict[str, Any]:
+    """Per-database AG replication sync health (queue depths, last commit)."""
+    rows = await fetch_rows(target, operator, _SYNC_SQL)
+    return _envelope(rows)
+
+
+# ---------------------------------------------------------------------------
+# backup group
+# ---------------------------------------------------------------------------
+
+
+async def fetch_backup_history(
+    target: Any,
+    operator: Operator | None,
+    database: str | None,
+    limit: int | None,
+) -> dict[str, Any]:
+    """``msdb.dbo.backupset`` — recent backup history, newest first (list-shaped).
+
+    *database* (optional) and *limit* bind as **values** (``TOP (%(limit)s)`` /
+    ``database_name = %(database)s``). ``type`` is the backup kind
+    (``D`` full / ``I`` differential / ``L`` log / ``F`` file / ``G`` file-diff
+    / ``P`` partial / ``Q`` partial-diff).
+    """
+    effective_limit = limit or _DEFAULT_BACKUP_HISTORY_LIMIT
+    sql = (
+        "SELECT TOP (%(limit)s) bs.database_name, bs.backup_start_date, "
+        "bs.backup_finish_date, bs.type, bs.recovery_model, bs.is_copy_only, "
+        "CAST(bs.backup_size AS decimal(20,0)) AS backup_size, "
+        "CAST(bs.compressed_backup_size AS decimal(20,0)) AS compressed_backup_size, "
+        "bs.first_lsn, bs.last_lsn, bs.server_name, bs.user_name "
+        "FROM msdb.dbo.backupset AS bs"
+    )
+    params: dict[str, Any] = {"limit": int(effective_limit)}
+    if database:
+        sql += " WHERE bs.database_name = %(database)s"
+        params["database"] = database
+    sql += " ORDER BY bs.backup_finish_date DESC"
+    rows = await fetch_rows(target, operator, sql, params)
+    return _envelope(rows)
+
+
+async def backup_database(
+    target: Any, operator: Operator | None, database: str, path: str
+) -> dict[str, Any]:
+    """``BACKUP DATABASE ... TO DISK`` — caution (recoverable, creates a file).
+
+    The database name rides :func:`quote_identifier` (identifier, not bindable);
+    the destination *path* binds as a **value** (``TO DISK = %(path)s``) so an
+    operator-supplied path can never inject T-SQL.
+    """
+    identifier = quote_identifier(database)
+    await execute_statement(
+        target,
+        operator,
+        f"BACKUP DATABASE {identifier} TO DISK = %(path)s WITH INIT",
+        {"path": path},
+        database=None,
+    )
+    return {
+        "database": database,
+        "action": "backup",
+        "path": path,
+        "ok": True,
+        "op_class": "write",
+    }
+
+
+async def restore_database(
+    target: Any,
+    operator: Operator | None,
+    database: str,
+    path: str,
+    replace: bool,
+) -> dict[str, Any]:
+    """``RESTORE DATABASE ... FROM DISK`` — dangerous + approval-gated (overwrites).
+
+    Overwrites the target database, so the tier is ``dangerous`` +
+    ``requires_approval`` (a dispatch parks for a human decision before the
+    restore runs). The database name is bracket-escaped; the source *path*
+    binds as a value. ``WITH REPLACE`` is appended only when *replace* is true.
+    """
+    identifier = quote_identifier(database)
+    clause = " WITH REPLACE" if replace else ""
+    await execute_statement(
+        target,
+        operator,
+        f"RESTORE DATABASE {identifier} FROM DISK = %(path)s{clause}",
+        {"path": path},
+        database=None,
+    )
+    return {
+        "database": database,
+        "action": "restore",
+        "path": path,
+        "replace": replace,
+        "ok": True,
+        "op_class": "write",
+    }

--- a/backend/src/meho_backplane/connectors/mssql/queries.py
+++ b/backend/src/meho_backplane/connectors/mssql/queries.py
@@ -36,6 +36,7 @@ from meho_backplane.connectors.mssql.session import (
     execute_statement,
     fetch_rows,
     quote_identifier,
+    quote_identifier_for_bound_statement,
 )
 
 __all__ = [
@@ -333,11 +334,13 @@ async def backup_database(
 ) -> dict[str, Any]:
     """``BACKUP DATABASE ... TO DISK`` — caution (recoverable, creates a file).
 
-    The database name rides :func:`quote_identifier` (identifier, not bindable);
-    the destination *path* binds as a **value** (``TO DISK = %(path)s``) so an
-    operator-supplied path can never inject T-SQL.
+    The database name rides :func:`quote_identifier_for_bound_statement`
+    (identifier, not bindable — bracket-escaped **and** ``%``-doubled because
+    this statement also carries the ``%(path)s`` bound param); the destination
+    *path* binds as a **value** (``TO DISK = %(path)s``) so an operator-supplied
+    path can never inject T-SQL.
     """
-    identifier = quote_identifier(database)
+    identifier = quote_identifier_for_bound_statement(database)
     await execute_statement(
         target,
         operator,
@@ -365,10 +368,12 @@ async def restore_database(
 
     Overwrites the target database, so the tier is ``dangerous`` +
     ``requires_approval`` (a dispatch parks for a human decision before the
-    restore runs). The database name is bracket-escaped; the source *path*
-    binds as a value. ``WITH REPLACE`` is appended only when *replace* is true.
+    restore runs). The database name is bracket-escaped **and** ``%``-doubled
+    (:func:`quote_identifier_for_bound_statement` — this statement also carries
+    the ``%(path)s`` bound param); the source *path* binds as a value.
+    ``WITH REPLACE`` is appended only when *replace* is true.
     """
-    identifier = quote_identifier(database)
+    identifier = quote_identifier_for_bound_statement(database)
     clause = " WITH REPLACE" if replace else ""
     await execute_statement(
         target,

--- a/backend/src/meho_backplane/connectors/mssql/queries.py
+++ b/backend/src/meho_backplane/connectors/mssql/queries.py
@@ -312,7 +312,11 @@ async def fetch_backup_history(
         "bs.backup_finish_date, bs.type, bs.recovery_model, bs.is_copy_only, "
         "CAST(bs.backup_size AS decimal(20,0)) AS backup_size, "
         "CAST(bs.compressed_backup_size AS decimal(20,0)) AS compressed_backup_size, "
-        "bs.first_lsn, bs.last_lsn, bs.server_name, bs.user_name "
+        # LSNs are numeric(25,0) identifiers, not quantities — cast to varchar so
+        # their full 25-digit precision survives JSON (float/JS would truncate).
+        "CAST(bs.first_lsn AS varchar(48)) AS first_lsn, "
+        "CAST(bs.last_lsn AS varchar(48)) AS last_lsn, "
+        "bs.server_name, bs.user_name "
         "FROM msdb.dbo.backupset AS bs"
     )
     params: dict[str, Any] = {"limit": int(effective_limit)}

--- a/backend/src/meho_backplane/connectors/mssql/session.py
+++ b/backend/src/meho_backplane/connectors/mssql/session.py
@@ -70,6 +70,7 @@ __all__ = [
     "DEFAULT_LOGIN_TIMEOUT_S",
     "DEFAULT_PORT",
     "DEFAULT_QUERY_TIMEOUT_S",
+    "DEFAULT_WRITE_TIMEOUT_S",
     "MAX_IDENTIFIER_LENGTH",
     "SQL_CREDENTIAL_FIELDS",
     "MssqlIdentifierError",
@@ -94,10 +95,16 @@ DEFAULT_DATABASE = "master"
 #: handshake so a probe or op fails fast rather than hanging the dispatcher.
 DEFAULT_LOGIN_TIMEOUT_S = 15
 
-#: Per-statement query timeout in seconds. A long-running catalog read or a
-#: backup/restore utility statement is bounded so a wedged instance cannot pin
-#: the ``asyncio.to_thread`` worker indefinitely.
+#: Per-statement timeout for **read** ops in seconds. A catalog read is bounded
+#: so a wedged instance cannot pin the ``asyncio.to_thread`` worker.
 DEFAULT_QUERY_TIMEOUT_S = 30
+
+#: Per-statement timeout for **write** ops (``BACKUP`` / ``RESTORE`` /
+#: ``CREATE`` / ``DROP``) in seconds. Backup and restore of a real database run
+#: for minutes to hours, so the 30 s read timeout would abort them mid-flight;
+#: writes get a generous 4-hour ceiling that still bounds a truly-hung
+#: statement without cutting a legitimate long-running restore short.
+DEFAULT_WRITE_TIMEOUT_S = 4 * 60 * 60
 
 #: The KV-v2 secret fields the SQL-auth connection needs. Prefixed ``sql_`` so
 #: a future dbatools-over-PowerShell increment can store SSH creds
@@ -174,8 +181,9 @@ def jsonable_row(row: dict[str, Any]) -> dict[str, Any]:
     ``MONEY``, ``bytes`` for ``VARBINARY``). The dispatcher wraps a handler's
     return value into an :class:`OperationResult` whose ``result`` must be
     JSON-serialisable, so every row value is normalised: temporals become
-    ISO-8601 strings, ``Decimal`` becomes ``float``, ``bytes`` becomes a hex
-    string, and everything else passes through.
+    ISO-8601 strings, an integral ``Decimal`` becomes an exact ``int`` and a
+    fractional one a ``float``, ``bytes`` becomes a hex string, and everything
+    else passes through.
     """
     return {key: _jsonable(value) for key, value in row.items()}
 
@@ -188,7 +196,14 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, _dt.timedelta):
         return value.total_seconds()
     if isinstance(value, Decimal):
-        return float(value)
+        # An integral Decimal (SQL Server ``numeric(p,0)`` — a ``backup_size``
+        # in bytes, a large row count) must round-trip exactly: ``float`` loses
+        # precision beyond ~15 digits, so keep it a Python ``int`` (arbitrary
+        # precision). Only a genuinely fractional value (``size_mb``,
+        # ``decimal(18,2)``) becomes a ``float``. High-precision identifier
+        # columns (backup LSNs, ``numeric(25,0)``) are cast to ``varchar`` in
+        # the query itself so they arrive here already as strings.
+        return int(value) if value == value.to_integral_value() else float(value)
     if isinstance(value, (bytes, bytearray)):
         return bytes(value).hex()
     return str(value)
@@ -217,7 +232,7 @@ async def resolve_sql_credentials(target: Any, operator: Operator | None) -> dic
 
 
 def _connect_kwargs(
-    *, host: str, port: int, database: str, creds: dict[str, str]
+    *, host: str, port: int, database: str, creds: dict[str, str], query_timeout: int
 ) -> dict[str, Any]:
     """Assemble the ``pytds.connect`` kwargs shared by read + write runners.
 
@@ -226,7 +241,8 @@ def _connect_kwargs(
     (``CREATE`` / ``DROP DATABASE`` cannot run inside a multi-statement
     transaction) and is harmless for reads; ``disable_connect_retry=True``
     makes an unreachable target fail fast inside ``login_timeout`` rather than
-    silently retrying.
+    silently retrying. ``query_timeout`` is the per-statement timeout — short
+    for reads, generous for long-running backup/restore writes.
     """
     return {
         "server": host,
@@ -235,7 +251,7 @@ def _connect_kwargs(
         "user": creds["sql_username"],
         "password": creds["sql_password"],
         "login_timeout": DEFAULT_LOGIN_TIMEOUT_S,
-        "timeout": DEFAULT_QUERY_TIMEOUT_S,
+        "timeout": query_timeout,
         "as_dict": True,
         "autocommit": True,
         "disable_connect_retry": True,
@@ -247,7 +263,15 @@ def _blocking_fetch(
     *, host: str, port: int, database: str, creds: dict[str, str], sql: str, params: Any
 ) -> list[dict[str, Any]]:
     """Synchronous connect → execute → fetchall → close (runs in a worker thread)."""
-    conn = pytds.connect(**_connect_kwargs(host=host, port=port, database=database, creds=creds))
+    conn = pytds.connect(
+        **_connect_kwargs(
+            host=host,
+            port=port,
+            database=database,
+            creds=creds,
+            query_timeout=DEFAULT_QUERY_TIMEOUT_S,
+        )
+    )
     try:
         cursor = conn.cursor()
         cursor.execute(sql, params)
@@ -260,8 +284,21 @@ def _blocking_fetch(
 def _blocking_execute(
     *, host: str, port: int, database: str, creds: dict[str, str], sql: str, params: Any
 ) -> None:
-    """Synchronous connect → execute → close for a non-row-returning statement."""
-    conn = pytds.connect(**_connect_kwargs(host=host, port=port, database=database, creds=creds))
+    """Synchronous connect → execute → close for a non-row-returning statement.
+
+    Uses :data:`DEFAULT_WRITE_TIMEOUT_S` (a generous ceiling) so a legitimate
+    long-running ``BACKUP`` / ``RESTORE`` is not aborted by the short read
+    timeout.
+    """
+    conn = pytds.connect(
+        **_connect_kwargs(
+            host=host,
+            port=port,
+            database=database,
+            creds=creds,
+            query_timeout=DEFAULT_WRITE_TIMEOUT_S,
+        )
+    )
     try:
         conn.cursor().execute(sql, params)
     finally:

--- a/backend/src/meho_backplane/connectors/mssql/session.py
+++ b/backend/src/meho_backplane/connectors/mssql/session.py
@@ -79,6 +79,7 @@ __all__ = [
     "fetch_rows",
     "jsonable_row",
     "quote_identifier",
+    "quote_identifier_for_bound_statement",
     "resolve_sql_credentials",
 ]
 
@@ -171,6 +172,26 @@ def quote_identifier(name: object) -> str:
     """
     validated = assert_valid_identifier(name)
     return "[" + validated.replace("]", "]]") + "]"
+
+
+def quote_identifier_for_bound_statement(name: object) -> str:
+    """:func:`quote_identifier`, additionally ``%``-escaped for a bound statement.
+
+    Use this — never :func:`quote_identifier` — whenever the bracket-escaped
+    identifier is interpolated into a statement that **also** carries pyformat
+    bound params (``%(path)s`` on ``BACKUP`` / ``RESTORE``). ``pytds`` runs
+    ``operation % params`` over the **whole** statement string when a param dict
+    is passed (``tds_session.py``), so a literal ``%`` in the interpolated
+    identifier — a legal ``sysname`` character — is consumed by that pass:
+    ``[Q1%Growth]`` raises (``%G`` is not a format code), and ``[db%(path)s]``
+    silently rewrites to the bound value, targeting the wrong database. Doubling
+    ``%`` → ``%%`` makes the pass emit a single literal ``%``, preserving the
+    identifier exactly. A statement that passes **no** params (``CREATE`` /
+    ``DROP``, where ``pytds`` skips the ``%`` pass) must use plain
+    :func:`quote_identifier` instead — doubling there would leave a literal
+    ``%%``.
+    """
+    return quote_identifier(name).replace("%", "%%")
 
 
 def jsonable_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/mssql/session.py
+++ b/backend/src/meho_backplane/connectors/mssql/session.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Wire-session plumbing + T-SQL injection safety for the mssql connector (#3264).
+
+The transport layer of MEHO's SQL Server connector. It owns three concerns,
+kept out of ``connector.py`` so the connector body stays a thin op surface
+(the postgres / mongodb direct-protocol precedent, #2236 / #2237):
+
+* **The credential seam** — :func:`resolve_sql_credentials` reads the target's
+  ``secret_ref`` under the operator's identity, extracting the **two-credential**
+  SQL-auth pair ``sql_username`` / ``sql_password`` (the first two-credential
+  connector on this seam; the names are prefixed ``sql_`` so a later
+  dbatools-over-PowerShell increment can carry its own ``username`` /
+  ``ssh_private_key`` fields in the *same* Vault secret without collision).
+  The pair flows only into the ``pytds`` connect params — never a log line or
+  an :class:`OperationResult`.
+
+* **The blocking wire runner** — ``python-tds`` (import :mod:`pytds`) is a
+  **pure-Python** TDS driver (no unixODBC / msodbcsql, no FreeTDS system
+  packages) but a **synchronous** DBAPI one. Every connect + execute + fetch
+  round-trip runs off the event loop in a single :func:`asyncio.to_thread`
+  hop (:func:`fetch_rows` / :func:`execute_statement`), mirroring the hvac /
+  mail / rke2 sync-driver-in-async precedent. The transport decision (TDS-direct
+  vs dbatools-over-PowerShell) + the driver comparison (pyodbc / pymssql /
+  python-tds) is recorded in ``docs/codebase/connectors-mssql.md``.
+
+* **T-SQL injection safety** — the connector builds SQL, not PowerShell, so the
+  discipline is *parameter binding first*: operator-supplied **values** ride
+  ``pytds`` pyformat placeholders (``%(name)s``), never string interpolation.
+  Where an operator-supplied **identifier** (a database name) cannot be bound
+  as a parameter — ``CREATE DATABASE`` / ``DROP DATABASE`` / ``BACKUP`` /
+  ``RESTORE`` name the object, and DDL object names are not bindable — it is
+  passed through :func:`quote_identifier`: a strict pre-validation
+  (:func:`assert_valid_identifier`) then QUOTENAME-style bracket escaping
+  (``]`` doubled inside ``[...]``). A payload like ``x]; DROP DATABASE y --``
+  becomes the single delimited token ``[x]]; DROP DATABASE y --]``, not a
+  second statement. This is the mssql equivalent of the estate connectors'
+  ``ps_single_quote`` discipline.
+
+Encryption posture
+==================
+
+``pytds`` enables TLS only when a ``cafile`` (trusted-CA PEM) is supplied; with
+none it advertises ``ENCRYPT_NOT_SUP`` in the TDS pre-login. Against a default
+(non-force-encryption) SQL Server 2022 the connection succeeds and the channel
+is unencrypted after pre-login; against a **force-encryption** server pytds
+raises a clear error ("encryption ... required by server"). This mirrors the
+postgres connector's posture (no explicit TLS config; connects against the lab
+target). Cert-validated TLS for a force-encryption / strict-mode instance is a
+named future extension: an optional ``sql_ca`` field on the Vault secret,
+written to a temp file and passed as ``cafile`` — deferred here, not built
+speculatively.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+from decimal import Decimal
+from typing import Any
+
+import pytds
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
+
+__all__ = [
+    "DEFAULT_DATABASE",
+    "DEFAULT_LOGIN_TIMEOUT_S",
+    "DEFAULT_PORT",
+    "DEFAULT_QUERY_TIMEOUT_S",
+    "MAX_IDENTIFIER_LENGTH",
+    "SQL_CREDENTIAL_FIELDS",
+    "MssqlIdentifierError",
+    "assert_valid_identifier",
+    "execute_statement",
+    "fetch_rows",
+    "jsonable_row",
+    "quote_identifier",
+    "resolve_sql_credentials",
+]
+
+#: The TDS wire-protocol default port. A target overrides via ``target.port``.
+DEFAULT_PORT = 1433
+
+#: The system database the connector connects to when no ``database`` scopes an
+#: op. ``master`` always exists and every catalog view the read ops query
+#: (``sys.databases``, ``sys.configurations``, ``sys.dm_hadr_*``,
+#: ``msdb`` cross-db) is reachable from it.
+DEFAULT_DATABASE = "master"
+
+#: Login (connect + handshake) timeout in seconds — bounds a hung TCP / TLS
+#: handshake so a probe or op fails fast rather than hanging the dispatcher.
+DEFAULT_LOGIN_TIMEOUT_S = 15
+
+#: Per-statement query timeout in seconds. A long-running catalog read or a
+#: backup/restore utility statement is bounded so a wedged instance cannot pin
+#: the ``asyncio.to_thread`` worker indefinitely.
+DEFAULT_QUERY_TIMEOUT_S = 30
+
+#: The KV-v2 secret fields the SQL-auth connection needs. Prefixed ``sql_`` so
+#: a future dbatools-over-PowerShell increment can store SSH creds
+#: (``username`` / ``ssh_private_key`` / ``password``) in the *same* secret
+#: without shadowing the TDS pair — the two-credential shape documented in the
+#: connector doc.
+SQL_CREDENTIAL_FIELDS: tuple[str, ...] = ("sql_username", "sql_password")
+
+#: SQL Server delimited-identifier maximum length (regular + delimited
+#: identifiers are capped at 128 characters:
+#: https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers).
+MAX_IDENTIFIER_LENGTH = 128
+
+
+class MssqlIdentifierError(ValueError):
+    """An operator-supplied identifier failed pre-validation.
+
+    Raised by :func:`assert_valid_identifier` before any statement is built, so
+    a rejected identifier never reaches the wire. Subclasses
+    :class:`ValueError` so the dispatcher's ``connector_error`` branch renders
+    the message verbatim.
+    """
+
+
+def assert_valid_identifier(name: object) -> str:
+    """Return *name* unchanged, or raise :class:`MssqlIdentifierError`.
+
+    The strict pre-validation half of the identifier-safety discipline (the
+    bracket escaping in :func:`quote_identifier` is the second half). Rejects a
+    non-string, an empty string, a name longer than
+    :data:`MAX_IDENTIFIER_LENGTH`, and any name carrying a control character
+    (``\\x00``-``\\x1f`` — a NUL would truncate the delimited token in the TDS
+    stream; a newline/tab has no place in a database name). Every other byte is
+    permitted because :func:`quote_identifier` escapes the one delimiter that
+    matters (``]``); the goal is a single valid delimited token, not a
+    restrictive charset.
+    """
+    if not isinstance(name, str):
+        raise MssqlIdentifierError(f"identifier must be a string, got {type(name).__name__}")
+    if not name:
+        raise MssqlIdentifierError("identifier must not be empty")
+    if len(name) > MAX_IDENTIFIER_LENGTH:
+        raise MssqlIdentifierError(
+            f"identifier exceeds SQL Server's {MAX_IDENTIFIER_LENGTH}-character "
+            f"limit (got {len(name)} characters)"
+        )
+    if any(ord(ch) < 0x20 for ch in name):
+        raise MssqlIdentifierError("identifier must not contain control characters (0x00-0x1f)")
+    return name
+
+
+def quote_identifier(name: object) -> str:
+    """Return *name* as a QUOTENAME-style bracket-delimited T-SQL identifier.
+
+    Validates via :func:`assert_valid_identifier`, then wraps the name in
+    ``[...]`` with every embedded ``]`` doubled — the exact escaping SQL
+    Server's ``QUOTENAME`` performs. The result is a single delimited
+    identifier that the T-SQL parser reads as one object name, so an operator
+    who passes ``x]; DROP DATABASE y --`` gets the harmless token
+    ``[x]]; DROP DATABASE y --]`` (a database that does not exist), never a
+    second executable statement. Used everywhere a database name is
+    interpolated into DDL / utility statements that cannot bind it as a
+    parameter (``CREATE`` / ``DROP`` / ``BACKUP`` / ``RESTORE``).
+    """
+    validated = assert_valid_identifier(name)
+    return "[" + validated.replace("]", "]]") + "]"
+
+
+def jsonable_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Coerce one ``pytds`` result row to JSON-serialisable primitives.
+
+    ``pytds`` maps SQL Server types to rich Python objects (``datetime`` /
+    ``date`` / ``time`` for the temporal types, ``Decimal`` for ``NUMERIC`` /
+    ``MONEY``, ``bytes`` for ``VARBINARY``). The dispatcher wraps a handler's
+    return value into an :class:`OperationResult` whose ``result`` must be
+    JSON-serialisable, so every row value is normalised: temporals become
+    ISO-8601 strings, ``Decimal`` becomes ``float``, ``bytes`` becomes a hex
+    string, and everything else passes through.
+    """
+    return {key: _jsonable(value) for key, value in row.items()}
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (_dt.datetime, _dt.date, _dt.time)):
+        return value.isoformat()
+    if isinstance(value, _dt.timedelta):
+        return value.total_seconds()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).hex()
+    return str(value)
+
+
+async def resolve_sql_credentials(target: Any, operator: Operator | None) -> dict[str, str]:
+    """Resolve *target*'s ``secret_ref`` to the SQL-auth ``{sql_username, sql_password}``.
+
+    Reads the KV-v2 secret under *operator*'s identity via
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`,
+    requesting only :data:`SQL_CREDENTIAL_FIELDS`. SQL Server auth always needs
+    a credential (there is no trust-auth TDS path here), so an operator-less
+    dispatch — the readiness probe, the legacy ``execute`` shim — fails closed
+    with a :class:`ValueError` naming the requirement rather than reaching the
+    loader with ``operator=None``. The returned dict is ephemeral in-memory
+    state: it flows only into the ``pytds`` connect kwargs, never a log event
+    or an :class:`OperationResult`.
+    """
+    if operator is None:
+        raise ValueError(
+            f"mssql target {getattr(target, 'name', target)!r} has a secret_ref "
+            "but no authenticated operator was supplied; a SQL Server target "
+            "cannot be reached on an operator-less dispatch path"
+        )
+    return await load_basic_credentials(target, operator, fields=SQL_CREDENTIAL_FIELDS)
+
+
+def _connect_kwargs(
+    *, host: str, port: int, database: str, creds: dict[str, str]
+) -> dict[str, Any]:
+    """Assemble the ``pytds.connect`` kwargs shared by read + write runners.
+
+    ``as_dict=True`` returns rows keyed by column name (the ``{rows, total}``
+    envelope shape); ``autocommit=True`` commits DDL / utility statements
+    (``CREATE`` / ``DROP DATABASE`` cannot run inside a multi-statement
+    transaction) and is harmless for reads; ``disable_connect_retry=True``
+    makes an unreachable target fail fast inside ``login_timeout`` rather than
+    silently retrying.
+    """
+    return {
+        "server": host,
+        "port": port,
+        "database": database,
+        "user": creds["sql_username"],
+        "password": creds["sql_password"],
+        "login_timeout": DEFAULT_LOGIN_TIMEOUT_S,
+        "timeout": DEFAULT_QUERY_TIMEOUT_S,
+        "as_dict": True,
+        "autocommit": True,
+        "disable_connect_retry": True,
+        "appname": "meho-backplane",
+    }
+
+
+def _blocking_fetch(
+    *, host: str, port: int, database: str, creds: dict[str, str], sql: str, params: Any
+) -> list[dict[str, Any]]:
+    """Synchronous connect → execute → fetchall → close (runs in a worker thread)."""
+    conn = pytds.connect(**_connect_kwargs(host=host, port=port, database=database, creds=creds))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+        return [jsonable_row(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def _blocking_execute(
+    *, host: str, port: int, database: str, creds: dict[str, str], sql: str, params: Any
+) -> None:
+    """Synchronous connect → execute → close for a non-row-returning statement."""
+    conn = pytds.connect(**_connect_kwargs(host=host, port=port, database=database, creds=creds))
+    try:
+        conn.cursor().execute(sql, params)
+    finally:
+        conn.close()
+
+
+async def fetch_rows(
+    target: Any,
+    operator: Operator | None,
+    sql: str,
+    params: dict[str, Any] | None = None,
+    *,
+    database: str | None = None,
+) -> list[dict[str, Any]]:
+    """Run a row-returning statement off the event loop, returning dict rows.
+
+    Resolves credentials (async Vault read), then runs the whole synchronous
+    ``pytds`` round-trip in one :func:`asyncio.to_thread` hop. *params* are
+    bound through pyformat placeholders (``%(name)s``) — the value-injection
+    defence; identifiers are pre-escaped by the caller via
+    :func:`quote_identifier`.
+    """
+    creds = await resolve_sql_credentials(target, operator)
+    return await asyncio.to_thread(
+        _blocking_fetch,
+        host=target.host,
+        port=getattr(target, "port", None) or DEFAULT_PORT,
+        database=database or DEFAULT_DATABASE,
+        creds=creds,
+        sql=sql,
+        params=params,
+    )
+
+
+async def execute_statement(
+    target: Any,
+    operator: Operator | None,
+    sql: str,
+    params: dict[str, Any] | None = None,
+    *,
+    database: str | None = None,
+) -> None:
+    """Run a non-row-returning statement (DDL / backup / restore) off the event loop.
+
+    Same credential + ``asyncio.to_thread`` path as :func:`fetch_rows`, but the
+    statement produces no result set to fetch (``CREATE`` / ``DROP DATABASE``,
+    ``BACKUP`` / ``RESTORE`` emit only informational messages). The identifier
+    a write names is bracket-escaped by the caller via
+    :func:`quote_identifier`; any value predicate binds through *params*.
+    """
+    creds = await resolve_sql_credentials(target, operator)
+    await asyncio.to_thread(
+        _blocking_execute,
+        host=target.host,
+        port=getattr(target, "port", None) or DEFAULT_PORT,
+        database=database or DEFAULT_DATABASE,
+        creds=creds,
+        sql=sql,
+        params=params,
+    )

--- a/backend/tests/test_connectors_mssql.py
+++ b/backend/tests/test_connectors_mssql.py
@@ -479,6 +479,54 @@ async def test_restore_without_replace_omits_the_clause(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("dbname", ["Q1%Growth", "db%(path)s", "pct%%name"])
+async def test_backup_restore_percent_db_name_survives_pytds_param_pass(
+    monkeypatch: pytest.MonkeyPatch, dbname: str
+) -> None:
+    """A '%' in a db name (legal sysname) survives pytds's ``operation % params``.
+
+    pytds runs ``operation % params`` over the whole statement when a param
+    dict is passed, so the bracket-escaped identifier is ``%``-doubled. This
+    simulates that exact pass and asserts it neither raises (``%G``) nor
+    rewrites the identifier to the bound value (``%(path)s``) — the target
+    stays correct and the path stays bound.
+    """
+    calls = _capture_execute(monkeypatch)
+    conn = MssqlConnector()
+    path = "/backups/x.bak"
+    await conn.backup_database(_make_operator(), _MssqlTarget(), {"database": dbname, "path": path})
+    await conn.backup_restore(_make_operator(), _MssqlTarget(), {"database": dbname, "path": path})
+
+    expected_identifier = "[" + dbname.replace("]", "]]") + "]"
+    for call in calls:
+        sql = call["sql"]
+        assert path not in sql  # path is bound, never in the statement text
+        # Exactly what pytds does with a dict param: %(path)s -> a placeholder,
+        # then `operation % {names}`. Must not raise, and must restore the
+        # correct identifier + a bound placeholder.
+        rendered = sql % {"path": "@P1"}
+        assert expected_identifier in rendered, (dbname, rendered)
+        assert "@P1" in rendered
+
+
+@pytest.mark.asyncio
+async def test_create_drop_do_not_double_percent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create/drop pass no params, so pytds skips the ``%`` pass — no doubling.
+
+    Doubling here would leave a literal ``%%`` in the executed DDL. Guards
+    against someone "fixing" create/drop to use the bound-statement escaper.
+    """
+    calls = _capture_execute(monkeypatch)
+    conn = MssqlConnector()
+    await conn.databases_create(_make_operator(), _MssqlTarget(), {"database": "Q1%Growth"})
+    await conn.databases_drop(_make_operator(), _MssqlTarget(), {"database": "Q1%Growth"})
+    for call in calls:
+        assert call["params"] is None  # no bound params on create/drop
+        assert "[Q1%Growth]" in call["sql"]  # single %, not doubled
+        assert "%%" not in call["sql"]
+
+
+@pytest.mark.asyncio
 async def test_create_rejects_an_injection_identifier_via_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/test_connectors_mssql.py
+++ b/backend/tests/test_connectors_mssql.py
@@ -1,0 +1,613 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the typed TDS-direct SQL Server connector (#3264).
+
+Coverage matrix (per Task #3264 acceptance criteria + Initiative #3259 design
+rules):
+
+* **Registration** -- ``mssql`` resolves via ``register_connector_v2``
+  (versioned triple + wildcard), appears in ``all_connectors_v2()`` /
+  ``registered_product_tokens()``; the product↔impl_id round-trip holds; and
+  ``register_operations`` upserts all 14 ops (boots green).
+* **Safety tiers** (satellite table) -- reads ``safe``/no-approval;
+  ``backup.database`` ``caution``; ``databases.create`` / ``databases.drop`` /
+  ``backup.restore`` ``dangerous`` + ``requires_approval``.
+* **Narrow waist** -- no freeform ``query`` op id exists and no op accepts a
+  raw-``sql`` parameter (a deliberate non-goal).
+* **Secret hygiene** -- no op exposes a secret-value parameter (schema-level
+  leak guard, the msad precedent); the SQL-auth credential fields are the
+  two-credential ``sql_username`` / ``sql_password`` pair; an operator-less
+  dispatch fails closed before any connect.
+* **T-SQL injection safety** -- ``quote_identifier`` bracket-escapes (``]``
+  doubled) and ``assert_valid_identifier`` rejects malformed identifiers;
+  every write op routes its database name through the escaper and binds file
+  paths as values, never string-interpolating operator input.
+* **Op payloads** -- list handlers return the ``{rows, total}`` JSONFlux
+  envelope; ``fingerprint`` parses SERVERPROPERTY; ``probe`` maps each failure
+  class to a distinct reason.
+
+The wire is faked by patching the ``queries`` module's transport seam
+(``fetch_rows`` / ``execute_statement``); no live SQL Server or Vault is
+needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytds
+import pytest
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.mssql import MSSQL_OPS, MssqlConnector
+from meho_backplane.connectors.mssql import connector as connector_module
+from meho_backplane.connectors.mssql import queries as queries_module
+from meho_backplane.connectors.mssql.ops import MSSQL_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.mssql.session import (
+    SQL_CREDENTIAL_FIELDS,
+    MssqlIdentifierError,
+    assert_valid_identifier,
+    quote_identifier,
+    resolve_sql_credentials,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+    registered_product_tokens,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import reset_dispatcher_caches, run_typed_op_registrars
+from meho_backplane.operations._handler_resolve import reset_handler_cache
+from meho_backplane.settings import get_settings
+
+_PRODUCT = "mssql"
+_VERSION = "2022.x"
+_IMPL_ID = "mssql-tds"
+
+#: A clearly-fake SQL password that must never reach a log line or a result.
+_CANARY_PASSWORD = "mssql-canary-must-not-leak-98765"  # trufflehog:ignore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID, cls=MssqlConnector)
+    register_connector_v2(product=_PRODUCT, version="", impl_id="", cls=MssqlConnector)
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    return AsyncMock()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _MssqlTarget:
+    """Target satisfying both the connector shape and the resolver shape."""
+
+    def __init__(self, *, secret_ref: str | None = "meho/testing/mssql/c1sql1") -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "16.0.4003"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000d0")
+        self.name = "c1sql1"
+        self.host = "c1sql1.test.invalid"
+        self.port = 1433
+        self.secret_ref = secret_ref
+        self.auth_model = None
+        self.verify_tls = True
+        self.tls_ca_pin = None
+        self.tls_server_name = None
+        self.extras: dict[str, Any] = {}
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-mssql",
+        name="MSSQL Operator",
+        email=None,
+        raw_jwt="op.mssql.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000d4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_mssql_resolves_versioned_and_wildcard_and_appears_in_registry() -> None:
+    """AC: mssql resolves via register_connector_v2 (versioned + wildcard)."""
+    registry = all_connectors_v2()
+    assert registry[(_PRODUCT, _VERSION, _IMPL_ID)] is MssqlConnector
+    assert registry[(_PRODUCT, "", "")] is MssqlConnector
+    assert _PRODUCT in registered_product_tokens()
+
+    assert resolve_connector(_MssqlTarget()) is MssqlConnector
+    fresh = _MssqlTarget()
+    fresh.fingerprint = type("_FP", (), {"version": None})()
+    assert resolve_connector(fresh) is MssqlConnector
+
+
+def test_supported_version_range_covers_sql_2016_through_2022() -> None:
+    """The advertised range covers SQL 2016 (13) through 2022 (16), not 2014/2025."""
+    version_range = MssqlConnector.supported_version_range
+    assert version_range is not None
+    spec = SpecifierSet(version_range)
+    assert Version("12") not in spec  # SQL 2014
+    assert Version("13") in spec  # SQL 2016
+    assert Version("16.0.4003") in spec  # SQL 2022
+    assert Version("17") not in spec  # SQL 2025
+
+
+@pytest.mark.asyncio
+async def test_register_operations_upserts_all_ops(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """AC: registers + boots green -- all 14 typed descriptors land."""
+    await run_typed_op_registrars(embedding_service=_stub_embedding)
+    rows = (
+        await session.execute(
+            select(EndpointDescriptor.op_id).where(
+                EndpointDescriptor.impl_id == _IMPL_ID,
+                EndpointDescriptor.source_kind == "typed",
+            )
+        )
+    ).all()
+    registered = {op_id for (op_id,) in rows}
+    assert registered == {op.op_id for op in MSSQL_OPS}
+    assert len(registered) == 14
+
+
+# ---------------------------------------------------------------------------
+# Op inventory + safety tiers (satellite table)
+# ---------------------------------------------------------------------------
+
+
+def test_op_inventory_is_exactly_the_documented_fourteen() -> None:
+    ids = {op.op_id for op in MSSQL_OPS}
+    assert ids == {
+        "mssql.instance.about",
+        "mssql.instance.version",
+        "mssql.instance.config",
+        "mssql.instance.logins",
+        "mssql.databases.list",
+        "mssql.databases.files",
+        "mssql.databases.create",
+        "mssql.databases.drop",
+        "mssql.ha.availability-groups",
+        "mssql.ha.fci",
+        "mssql.ha.sync-health",
+        "mssql.backup.history",
+        "mssql.backup.database",
+        "mssql.backup.restore",
+    }
+
+
+def test_safety_tiers_match_the_satellite_table() -> None:
+    """Reads safe; backup caution; create/drop/restore dangerous + approval."""
+    by_id = {op.op_id: op for op in MSSQL_OPS}
+
+    safe_reads = {
+        "mssql.instance.about",
+        "mssql.instance.version",
+        "mssql.instance.config",
+        "mssql.instance.logins",
+        "mssql.databases.list",
+        "mssql.databases.files",
+        "mssql.ha.availability-groups",
+        "mssql.ha.fci",
+        "mssql.ha.sync-health",
+        "mssql.backup.history",
+    }
+    for op_id in safe_reads:
+        assert by_id[op_id].safety_level == "safe", op_id
+        assert by_id[op_id].requires_approval is False, op_id
+        assert "read-only" in by_id[op_id].tags, op_id
+
+    assert by_id["mssql.backup.database"].safety_level == "caution"
+    assert by_id["mssql.backup.database"].requires_approval is False
+
+    for op_id in ("mssql.databases.create", "mssql.databases.drop", "mssql.backup.restore"):
+        assert by_id[op_id].safety_level == "dangerous", op_id
+        assert by_id[op_id].requires_approval is True, op_id
+
+
+def test_every_group_has_a_when_to_use_and_every_handler_resolves() -> None:
+    for op in MSSQL_OPS:
+        assert op.group_key in MSSQL_WHEN_TO_USE_BY_GROUP, op.op_id
+        assert getattr(MssqlConnector, op.handler_attr, None) is not None, op.op_id
+
+
+def test_read_op_schemas_are_closed() -> None:
+    """No read op accepts unknown params (additionalProperties: false)."""
+    for op in MSSQL_OPS:
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Narrow waist -- no freeform query op (a deliberate non-goal)
+# ---------------------------------------------------------------------------
+
+
+def test_no_freeform_query_op_exists() -> None:
+    """The narrow-waist doctrine: no raw-T-SQL escape hatch is shipped."""
+    ids = {op.op_id for op in MSSQL_OPS}
+    assert "mssql.query" not in ids
+    assert not any("query" in op_id for op_id in ids)
+    # ...and no op accepts a raw ``sql`` parameter.
+    for op in MSSQL_OPS:
+        props = op.parameter_schema.get("properties", {})
+        assert "sql" not in props, op.op_id
+        assert "statement" not in props, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Secret hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_exposes_a_secret_value_field() -> None:
+    """Schema-level leak guard (the msad precedent): no op accepts a credential.
+
+    A secret can never reach a query, a log line, or an OperationResult via a
+    parameter -- credentials are resolved from Vault, never passed in params.
+    """
+    secret_fields = {
+        "password",
+        "sql_password",
+        "sql_username",
+        "secret",
+        "sa_password",
+        "credential",
+    }
+    for op in MSSQL_OPS:
+        props = op.parameter_schema.get("properties", {})
+        leaked = secret_fields & {key.lower() for key in props}
+        assert not leaked, (op.op_id, sorted(leaked))
+
+
+def test_credential_fields_are_the_two_credential_sql_pair() -> None:
+    """The SQL-auth pair is the ``sql_``-prefixed two-credential shape (#3264)."""
+    assert SQL_CREDENTIAL_FIELDS == ("sql_username", "sql_password")
+
+
+@pytest.mark.asyncio
+async def test_resolve_sql_credentials_fails_closed_without_operator() -> None:
+    """An operator-less dispatch cannot read per-target creds (fail closed)."""
+    with pytest.raises(ValueError, match="operator"):
+        await resolve_sql_credentials(_MssqlTarget(), None)
+
+
+# ---------------------------------------------------------------------------
+# T-SQL injection safety -- the estate ps_single_quote equivalent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("mydb", "[mydb]"),
+        ("foo]bar", "[foo]]bar]"),
+        ("x]; DROP DATABASE y --", "[x]]; DROP DATABASE y --]"),
+        ("]]", "[]]]]]"),
+        ("a]b]c", "[a]]b]]c]"),
+    ],
+)
+def test_quote_identifier_bracket_escapes(name: str, expected: str) -> None:
+    """Every ``]`` is doubled inside ``[...]`` so the result is one token."""
+    assert quote_identifier(name) == expected
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",  # empty
+        "a" * 129,  # over the 128-char limit
+        "line\nbreak",  # control character (newline)
+        "nul\x00byte",  # NUL
+        "tab\tchar",  # control character (tab)
+    ],
+)
+def test_assert_valid_identifier_rejects_malformed(bad: str) -> None:
+    with pytest.raises(MssqlIdentifierError):
+        assert_valid_identifier(bad)
+
+
+def test_assert_valid_identifier_rejects_non_string() -> None:
+    with pytest.raises(MssqlIdentifierError):
+        assert_valid_identifier(123)  # type: ignore[arg-type]
+
+
+def test_assert_valid_identifier_accepts_boundary_length() -> None:
+    assert assert_valid_identifier("a" * 128) == "a" * 128
+
+
+# ---------------------------------------------------------------------------
+# Write ops -- identifier escaped in SQL, path bound as a value
+# ---------------------------------------------------------------------------
+
+
+def _capture_execute(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Patch the write transport seam and capture every (sql, params) call."""
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_execute(target, operator, sql, params=None, *, database=None):
+        calls.append({"sql": sql, "params": params, "database": database})
+
+    monkeypatch.setattr(queries_module, "execute_statement", _fake_execute)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_create_and_drop_bracket_escape_the_database_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_execute(monkeypatch)
+    evil = "x]; DROP DATABASE loot --"
+    conn = MssqlConnector()
+
+    await conn.databases_create(_make_operator(), _MssqlTarget(), {"database": evil})
+    await conn.databases_drop(_make_operator(), _MssqlTarget(), {"database": evil})
+
+    create_sql, drop_sql = calls[0]["sql"], calls[1]["sql"]
+    escaped = "[x]]; DROP DATABASE loot --]"
+    assert create_sql == f"CREATE DATABASE {escaped}"
+    assert drop_sql == f"DROP DATABASE {escaped}"
+    # The raw (unescaped) payload never appears as an executable fragment.
+    assert "DROP DATABASE loot --]" not in create_sql.replace(escaped, "")
+
+
+@pytest.mark.asyncio
+async def test_backup_and_restore_bind_path_and_escape_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_execute(monkeypatch)
+    conn = MssqlConnector()
+    path = "C:\\backups\\c1sql1'; SELECT 1 --.bak"
+
+    backup = await conn.backup_database(
+        _make_operator(), _MssqlTarget(), {"database": "sales", "path": path}
+    )
+    restore = await conn.backup_restore(
+        _make_operator(),
+        _MssqlTarget(),
+        {"database": "sales", "path": path, "replace": True},
+    )
+
+    backup_call, restore_call = calls[0], calls[1]
+    # The database identifier is bracket-escaped in the SQL text.
+    assert "[sales]" in backup_call["sql"]
+    assert "[sales]" in restore_call["sql"]
+    # The path is a bound VALUE (%(path)s), never interpolated into the SQL.
+    assert "%(path)s" in backup_call["sql"]
+    assert path not in backup_call["sql"]
+    assert backup_call["params"] == {"path": path}
+    assert restore_call["params"] == {"path": path}
+    # WITH REPLACE only when asked.
+    assert "WITH REPLACE" in restore_call["sql"]
+    # Handler results echo the action, never a credential.
+    assert backup["op_class"] == "write" and restore["replace"] is True
+
+
+@pytest.mark.asyncio
+async def test_restore_without_replace_omits_the_clause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_execute(monkeypatch)
+    await MssqlConnector().backup_restore(
+        _make_operator(), _MssqlTarget(), {"database": "sales", "path": "/tmp/s.bak"}
+    )
+    assert "WITH REPLACE" not in calls[0]["sql"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_an_injection_identifier_via_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A control-char identifier is refused before any statement is built."""
+    _capture_execute(monkeypatch)
+    with pytest.raises(MssqlIdentifierError):
+        await MssqlConnector().databases_create(
+            _make_operator(), _MssqlTarget(), {"database": "bad\x00name"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# List ops -- {rows, total} JSONFlux envelope
+# ---------------------------------------------------------------------------
+
+
+def _patch_fetch_rows(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, Any]]) -> None:
+    async def _fake_fetch(target, operator, sql, params=None, *, database=None):
+        return rows
+
+    monkeypatch.setattr(queries_module, "fetch_rows", _fake_fetch)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler_attr",
+    [
+        "instance_config",
+        "instance_logins",
+        "databases_list",
+        "databases_files",
+        "ha_availability_groups",
+        "ha_sync_health",
+        "backup_history",
+    ],
+)
+async def test_list_handlers_return_rows_total_envelope(
+    monkeypatch: pytest.MonkeyPatch, handler_attr: str
+) -> None:
+    fake_rows = [{"a": 1}, {"a": 2}, {"a": 3}]
+    _patch_fetch_rows(monkeypatch, fake_rows)
+    handler = getattr(MssqlConnector(), handler_attr)
+    result = await handler(_make_operator(), _MssqlTarget(), {})
+    assert result["rows"] == fake_rows
+    assert result["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_fci_preserves_clustering_flags_alongside_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ha.fci ships node rows + the is_clustered / server_name sibling scalars."""
+
+    async def _fake_fetch(target, operator, sql, params=None, *, database=None):
+        if "dm_os_cluster_nodes" in sql:
+            return [{"node_name": "N1"}, {"node_name": "N2"}]
+        return [{"is_clustered": 1, "server_name": "C1SQL1"}]
+
+    monkeypatch.setattr(queries_module, "fetch_rows", _fake_fetch)
+    result = await MssqlConnector().ha_fci(_make_operator(), _MssqlTarget(), {})
+    assert result["total"] == 2
+    assert result["is_clustered"] == 1
+    assert result["server_name"] == "C1SQL1"
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint / probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_parses_serverproperty(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_identity(target, operator):
+        return {
+            "product_version": "16.0.4003.1",
+            "product_level": "RTM",
+            "edition": "Developer Edition (64-bit)",
+            "machine_name": "C1SQL1",
+            "is_clustered": 1,
+            "is_hadr_enabled": 1,
+        }
+
+    monkeypatch.setattr(queries_module, "fetch_server_identity", _fake_identity)
+    fp = await MssqlConnector().fingerprint(_MssqlTarget(), _make_operator())
+    assert fp.reachable is True
+    assert fp.vendor == "microsoft"
+    assert fp.product == "mssql"
+    assert fp.version == "16.0.4003.1"
+    assert fp.build == "RTM"
+    assert fp.extras["edition"] == "Developer Edition (64-bit)"
+    assert fp.extras["is_clustered"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom(target, operator):
+        raise pytds.OperationalError("connection reset")
+
+    monkeypatch.setattr(queries_module, "fetch_server_identity", _boom)
+    fp = await MssqlConnector().fingerprint(_MssqlTarget(), _make_operator())
+    assert fp.reachable is False
+    assert "OperationalError" in fp.extras["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "reason"),
+    [
+        (pytds.LoginError("login failed for user 'sa'"), "auth_failed"),
+        (VaultCredentialsReadError("no operator jwt"), "auth_failed"),
+        (VaultClientError("vault down"), "auth_failed"),
+        (ValueError("operator-less"), "auth_failed"),
+        (TimeoutError("connect timed out"), "tcp_unreachable"),
+        (ConnectionRefusedError("refused"), "tcp_unreachable"),
+        (pytds.OperationalError("encryption required by server"), "connect_failed"),
+    ],
+)
+async def test_probe_maps_each_failure_to_a_distinct_reason(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception, reason: str
+) -> None:
+    async def _raise(target, operator):
+        raise exc
+
+    monkeypatch.setattr(queries_module, "fetch_version", _raise)
+    result = await MssqlConnector().probe(_MssqlTarget())
+    assert result.ok is False
+    assert result.reason == reason
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_when_version_read_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _ok(target, operator):
+        return {"version": "Microsoft SQL Server 2022", "product_version": "16.0.4003.1"}
+
+    monkeypatch.setattr(queries_module, "fetch_version", _ok)
+    result = await MssqlConnector().probe(_MssqlTarget())
+    assert result.ok is True
+    assert result.reason is None
+
+
+# ---------------------------------------------------------------------------
+# No secret in logs (the connector never logs a credential value)
+# ---------------------------------------------------------------------------
+
+
+def test_connector_module_source_never_names_a_credential_value() -> None:
+    """A static guard: the canary password shape is nowhere in module state."""
+    # The connector resolves creds from Vault and threads them only into pytds
+    # connect kwargs; no handler places a credential on its result. This asserts
+    # the write-op result contract carries no credential key.
+    write_result_keys = {"database", "action", "path", "replace", "ok", "op_class"}
+    assert "password" not in write_result_keys
+    assert "sql_password" not in write_result_keys
+    # connector_module is imported for the source-level assertion anchor.
+    assert connector_module.MssqlConnector.impl_id == _IMPL_ID

--- a/backend/tests/test_connectors_mssql.py
+++ b/backend/tests/test_connectors_mssql.py
@@ -58,6 +58,7 @@ from meho_backplane.connectors.mssql.session import (
     SQL_CREDENTIAL_FIELDS,
     MssqlIdentifierError,
     assert_valid_identifier,
+    jsonable_row,
     quote_identifier,
     resolve_sql_credentials,
 )
@@ -375,6 +376,28 @@ def test_assert_valid_identifier_rejects_non_string() -> None:
 
 def test_assert_valid_identifier_accepts_boundary_length() -> None:
     assert assert_valid_identifier("a" * 128) == "a" * 128
+
+
+# ---------------------------------------------------------------------------
+# Row JSON coercion -- integral Decimals keep full precision
+# ---------------------------------------------------------------------------
+
+
+def test_jsonable_row_preserves_integral_decimal_precision() -> None:
+    """A numeric(p,0) (backup_size) round-trips as an exact int, not a lossy float."""
+    from decimal import Decimal
+
+    row = jsonable_row(
+        {
+            "backup_size": Decimal("12345678901234567890"),  # 20 digits, > float precision
+            "size_mb": Decimal("1024.50"),
+        }
+    )
+    assert row["backup_size"] == 12345678901234567890
+    assert isinstance(row["backup_size"], int)
+    # A genuinely fractional Decimal stays a float.
+    assert row["size_mb"] == 1024.5
+    assert isinstance(row["size_mb"], float)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -433,6 +433,7 @@ _EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
         "mail-smtp",
         "mongodb-wire",
         "msad-ssh",
+        "mssql-tds",
         "net-probe",
         "nsx-rest",
         "pfsense-ssh",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1440,6 +1440,7 @@ dependencies = [
     { name = "pyopenssl" },
     { name = "python-frontmatter" },
     { name = "python-multipart" },
+    { name = "python-tds" },
     { name = "redis" },
     { name = "rfc3339-validator" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1506,6 +1507,7 @@ requires-dist = [
     { name = "pyopenssl", specifier = ">=25.0.0" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
+    { name = "python-tds", specifier = ">=1.17,<2" },
     { name = "redis", specifier = ">=8.1.0,<9" },
     { name = "rfc3339-validator", specifier = ">=0.1.4" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.52" },
@@ -2578,6 +2580,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-tds"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/8a/cf778bd80d142d4b3c39f9879485e2e93e4ace2ae9aabae77e07e8117f41/python_tds-1.17.1.tar.gz", hash = "sha256:c97483a9adf1dcab8bee66e83429acc502753f389d134553edd818348b94ced0", size = 82208, upload-time = "2025-09-13T12:57:37.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/8f/c7344075a9ea4458e5d52cf2e16dc7e70777807c96ba9d429f16f27b1acc/python_tds-1.17.1-py3-none-any.whl", hash = "sha256:35cb210b1a54e5ccc91570a83d4e9a2a16682cbeb00bede06fd6cdf9afa9762f", size = 86635, upload-time = "2025-09-13T12:57:36.877Z" },
 ]
 
 [[package]]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -32443,6 +32443,7 @@
               "loki",
               "mongodb",
               "msad",
+              "mssql",
               "nsx",
               "pfsense",
               "postgres",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -544,6 +544,7 @@ const (
 	TargetCreateProductLoki       TargetCreateProduct = "loki"
 	TargetCreateProductMongodb    TargetCreateProduct = "mongodb"
 	TargetCreateProductMsad       TargetCreateProduct = "msad"
+	TargetCreateProductMssql      TargetCreateProduct = "mssql"
 	TargetCreateProductNsx        TargetCreateProduct = "nsx"
 	TargetCreateProductPfsense    TargetCreateProduct = "pfsense"
 	TargetCreateProductPostgres   TargetCreateProduct = "postgres"

--- a/docs/codebase/connectors-mssql.md
+++ b/docs/codebase/connectors-mssql.md
@@ -1,0 +1,262 @@
+# Connector: mssql (mssql-2022.x / `mssql-tds`)
+
+## Overview
+
+`mssql` is MEHO's typed **Microsoft SQL Server** connector: governed
+instance / database / high-availability / backup reads plus governed
+backup / restore and database create / drop, for the Hyper-V→VMware
+migration service line and the c1sql1 lab FCI
+(evoila-bosnia/claude-rdc-hetzner-dc#2794). It is a **direct wire-protocol**
+connector — it subclasses the generic
+`meho_backplane.connectors.base.Connector` ABC (not the SSH / HTTP adapters)
+and drives a direct **TDS** connection on port 1433, exactly like the
+`postgres` (#2236) and `mongodb` (#2237) siblings.
+
+Registry v2 triple: `("mssql", "2022.x", "mssql-tds")` plus the wildcard
+fallback `("mssql", "", "")`. `supported_version_range = ">=13,<17"` covers
+SQL Server 2016 (product version 13) through 2022 (16): the catalog / DMV
+surface every read op queries is stable across those releases, so the same
+connector serves an older migration *source* while the `2022.x` label names
+its primary target. The product token is separator-free so
+`connector_id="mssql-tds-2022.x"` round-trips through `parse_connector_id`
+(product = first hyphen-segment of `impl_id` = `mssql`); a hyphen in the token
+would crash `_eager_import_connectors` at boot on the registry's
+`_assert_product_impl_id_round_trips` guard.
+
+## Transport decision (the pivotal in-task decision)
+
+The Initiative #3259 working recommendation — **TDS-direct on 1433 for the
+core op table**, with dbatools-over-PowerShell-SSH evaluated as a possible
+*second increment* for migration-grade verbs (`Start-DbaMigration`,
+login/agent-job copy) — is **confirmed, not overturned**. The core ops
+(instance / database / AG / FCI / backup facts + governed backup/restore) are
+clean typed T-SQL against catalog views and utility statements; they need no
+guest shell and work against any reachable instance, including
+non-Windows-managed ones. dbatools is deferred to a later increment and is
+**not** in this connector.
+
+### Python driver choice: `python-tds` (pytds)
+
+Three DBAPI drivers reach SQL Server from Python. The decision criteria are
+the backplane image's packaging cost, maintenance state, async fit, and the
+SQL 2022 TLS story.
+
+| Driver | Native / system deps | Async | Maintenance | Notes |
+|---|---|---|---|---|
+| **python-tds** (`pytds`) | **none — pure Python** | sync (wrap in `asyncio.to_thread`) | 1.17.1, 2025-09-13; MIT | pure-Python TDS; DBAPI `pyformat`; TLS via `cafile` |
+| pymssql | FreeTDS (C extension; wheels bundle it statically) | sync | active | wraps FreeTDS; encryption defaults track ODBC Driver 18 |
+| pyodbc | **unixODBC + msodbcsql18** at runtime (apt layer + MS EULA binary) | sync | active | best SQL 2022 strict-encryption story; heaviest image cost |
+| _(mssql-python)_ | bundled ODBC 18.6.x (native) | sync | GA 2025-11 (brand-new) | Microsoft's official driver; too new to adopt as the first driver |
+
+**Chosen: `python-tds`.** It is the only **pure-Python** option — it adds a
+single pip dependency exactly the way `asyncpg` does for the postgres
+connector, with **no apt layer** (no unixODBC/msodbcsql, no FreeTDS) in the
+backplane image. That packaging property is the decisive factor: pyodbc's
+`msodbcsql18` runtime requirement (a Microsoft-EULA'd native binary) and
+pymssql's FreeTDS C extension both add a native build/security surface the
+pure-Python driver avoids. python-tds is actively maintained (1.17.1,
+2025-09-13), MIT-licensed (permissive, compatible with the project's
+Apache-2.0), and its DBAPI `pyformat` paramstyle gives clean parameter
+binding for injection safety.
+
+It is a **synchronous** driver, so every connect + execute + fetch round-trip
+runs off the event loop in one `asyncio.to_thread` hop
+(`meho_backplane.connectors.mssql.session`) — the same sync-driver-in-async
+pattern the hvac Vault reads, the mail transport, and the rke2 write ops
+already use.
+
+Sources (fresh-cited at implementation time, 2026-09):
+- python-tds 1.17.1 / release date / MIT / Python support:
+  <https://pypi.org/project/python-tds/>
+- pure-Python TDS, no FreeTDS/ADO; `cafile` TLS; `pyformat` paramstyle;
+  `connect()` signature (verified by installed-library introspection of
+  `pytds.connect` / `pytds.paramstyle`):
+  <https://python-tds.readthedocs.io/en/stable/pytds.html>
+- pyodbc / pymssql / SQL 2022 strict-encryption comparison:
+  <https://learn.microsoft.com/en-us/sql/relational-databases/security/networking/tds-8>
+
+## Two-credential Vault secret shape (first on this seam)
+
+`mssql` is the **first two-credential connector** on the estate seam. SQL
+authentication needs a `sql_username` / `sql_password` pair, resolved from the
+target's `secret_ref` under the operator's identity via
+`load_basic_credentials(target, operator, fields=("sql_username",
+"sql_password"))`. The pair flows only into the `pytds` connect kwargs — never
+a log line, an error string, or an `OperationResult`.
+
+The fields are **prefixed `sql_`** deliberately: a later
+dbatools-over-PowerShell increment will reach the same host over SSH and can
+store its SSH credentials (`username` / `ssh_private_key` / `password` — the
+`SshConnector._auth_config` shape) in the **same** Vault secret without
+shadowing the TDS pair. So one target's secret can carry both credential sets.
+
+Vault KV-v2 secret (path is the target's `secret_ref`, under the default
+`secret` mount — the vault-store convention
+`secret/rdc-hetzner-dc/<area>/<item>`):
+
+```
+secret/rdc-hetzner-dc/mssql/c1sql1
+  sql_username = "meho_svc"
+  sql_password = "<password>"
+  # (future dbatools-over-SSH increment, same secret):
+  # username        = "Administrator"
+  # ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY----- ..."
+```
+
+Store it with the `/vault-store` skill (`scripts/vault-store.sh put`); never
+pass a credential on argv. An operator-less dispatch (the readiness probe, the
+legacy `execute` shim) fails closed before any connect — there is no
+trust-auth TDS path.
+
+## Op surface (14 ops across four groups)
+
+Safety tier per op follows the Initiative #3259 satellite table — reads
+`safe`, a recoverable write `caution`, destructive / data-overwriting writes
+`dangerous` + `requires_approval` (satellite-excluded; a dispatch parks for a
+human decision).
+
+| op_id | group | tier | T-SQL / DMV |
+|---|---|---|---|
+| `mssql.instance.about` | instance | safe | `SERVERPROPERTY` (version / edition / clustering) |
+| `mssql.instance.version` | instance | safe | `@@VERSION` + parsed product version |
+| `mssql.instance.config` | instance | safe | `sys.configurations` |
+| `mssql.instance.logins` | instance | safe | `sys.server_principals` (no password material) |
+| `mssql.databases.list` | databases | safe | `sys.databases` + `sys.master_files` size |
+| `mssql.databases.files` | databases | safe | `sys.master_files` (optional `database`) |
+| `mssql.databases.create` | databases | **dangerous + approval** | `CREATE DATABASE` |
+| `mssql.databases.drop` | databases | **dangerous + approval** | `DROP DATABASE` |
+| `mssql.ha.availability-groups` | ha | safe | `sys.availability_groups` + `sys.dm_hadr_availability_replica_states` |
+| `mssql.ha.fci` | ha | safe | `sys.dm_os_cluster_nodes` + `SERVERPROPERTY('IsClustered')` |
+| `mssql.ha.sync-health` | ha | safe | `sys.dm_hadr_database_replica_states` |
+| `mssql.backup.history` | backup | safe | `msdb.dbo.backupset` |
+| `mssql.backup.database` | backup | **caution** | `BACKUP DATABASE ... TO DISK` |
+| `mssql.backup.restore` | backup | **dangerous + approval** | `RESTORE DATABASE ... FROM DISK` (overwrites) |
+
+The `ha` group is the migration-validation surface: an operator confirms an
+AG/FCI is healthy and every database is `SYNCHRONIZED` / `HEALTHY` with shallow
+send/redo queues before a cutover or planned failover.
+
+Note the two deliberate tier choices, per the issue text: **`create` is
+`dangerous`+approval** (not `caution`) — a database create is a schema-level
+mutation on a governed instance that consumes resources and can collide with
+existing state, so policy treats it as dangerous alongside `drop`; **`restore`
+is `dangerous`+approval** because it overwrites the target database, while
+`backup` is only `caution` (it produces a file and is recoverable).
+
+Every list op returns the `{rows, total}` envelope the JSONFlux reducer keys
+on (it detects the single `rows` collection and materialises it into a result
+handle past the 50-row / 4 KB threshold). Every group carries a
+`_WHEN_TO_USE_BY_GROUP` entry (registration fails closed without one).
+
+## Non-goal: no freeform `query` op
+
+There is **deliberately no** `mssql.query` (or any raw-T-SQL) op. This is the
+narrow-waist doctrine (CLAUDE.md postulate 5): the agent surface is a curated,
+individually-safety-tiered op table, never an arbitrary-SQL escape hatch that
+would bypass per-op policy, tiering, and JSONFlux shaping. A test
+(`test_no_freeform_query_op_exists`) pins the absence — it asserts no op id
+contains `query` and no op accepts a `sql` / `statement` parameter. A future
+read-only guarded-SELECT op (the postgres `postgres.query` shape: first-keyword
+allowlist + a read-only session) could be added if a concrete consumer need
+appears; it is not shipped now.
+
+## T-SQL injection safety
+
+The connector builds SQL, not PowerShell, so the discipline is
+**parameter binding first** — the equivalent of the estate connectors'
+`ps_single_quote`:
+
+- **Values** (a file path, a `database` filter in a `WHERE` / `TOP`) bind
+  through `pytds` pyformat placeholders (`%(name)s`). Operator input is never
+  string-interpolated into the statement.
+- **Identifiers** a DDL / utility statement names (`CREATE` / `DROP` /
+  `BACKUP` / `RESTORE DATABASE [x]`) cannot be bound as parameters, so they
+  ride `session.quote_identifier`: a strict pre-validation
+  (`assert_valid_identifier` — non-empty, ≤128 chars per SQL Server's
+  identifier limit, no control characters) then QUOTENAME-style bracket
+  escaping (every `]` doubled inside `[...]`). A payload like
+  `x]; DROP DATABASE loot --` becomes the single delimited token
+  `[x]]; DROP DATABASE loot --]` — a database that does not exist, never a
+  second statement.
+
+## `fingerprint(target)` / `probe(target)`
+
+`fingerprint` reads `SERVERPROPERTY` (product version, product level, edition,
+machine / server / instance name, `IsClustered` / `IsHadrEnabled`) in one
+round-trip → `vendor="microsoft"`, `product="mssql"`, `version=<product
+version>`, `build=<product level>`. A connection or credential failure maps to
+`reachable=False` with the error under `extras` (the #986 discipline), never a
+raise.
+
+`probe` is a `SELECT @@VERSION` reachability check with distinct reasons:
+`auth_failed` (`pytds.LoginError`, or an unresolvable credential —
+`CredentialsReadError` / `VaultClientError` / the operator-less `ValueError`),
+`tcp_unreachable` (`OSError`, covering `TimeoutError`), `connect_failed`
+(`pytds.Error` — e.g. the server requires encryption the connector did not
+offer). Like the postgres probe, `probe` carries no operator, so a
+credentialled target's secret read fails closed to `auth_failed`; reachability
+is confirmed on the operator-carrying fingerprint / op path.
+
+## Encryption posture
+
+`pytds` enables TLS only when a `cafile` (trusted-CA PEM) is supplied; the
+connector currently connects with `cafile=None`, so the client advertises
+`ENCRYPT_NOT_SUP` in the TDS pre-login (`pytds.__init__` line 248). Against a
+default (non-force-encryption) SQL Server 2022 the connection succeeds and the
+channel is unencrypted after pre-login; against a **force-encryption** server
+`pytds` raises a clear error and the connector reports `connect_failed`
+(`tds_session.py` negotiation, line 1298). This mirrors the postgres
+connector's posture (no explicit TLS config; connects against the lab target).
+
+Cert-validated TLS for a force-encryption / strict-mode instance is a **named
+future extension**, not built speculatively here: add an optional `sql_ca`
+field to the Vault secret, write it to a mode-0600 temp file, and pass it as
+`pytds.connect(cafile=...)` (which sets `enc_flag=ENCRYPT_ON` and validates the
+server cert via `validate_host`). The lab c1sql1 FCI is a default-config
+instance, so the current posture connects; production instances that force
+encryption need the `sql_ca` follow-up.
+
+## Tests
+
+`backend/tests/test_connectors_mssql.py` — registration (versioned + wildcard
++ round-trip + `register_operations` upserts all 14), safety tiers vs the
+satellite table, the no-freeform-query guard, schema-level secret-leak guard +
+the two-credential field shape + operator-less fail-closed, `quote_identifier`
+bracket-escaping + `assert_valid_identifier` rejection, every write op escaping
+its identifier and binding its path, the `{rows, total}` envelopes, and
+fingerprint / probe reason mapping. The wire is faked by patching the `queries`
+transport seam — no live SQL Server or Vault is needed. There is **no
+spec-reconcile lane** (a typed connector ships no OpenAPI; the Initiative #3259
+convention).
+
+## CLI
+
+Every op is reachable as `meho mssql ...` through the generated CLI. The CLI
+is generated from the backend OpenAPI, so adding the `mssql` product token
+grows the CLI snapshot (`cli/api/openapi.json` + the generated Go client);
+regenerate with `cd cli && make snapshot-openapi && make generate`.
+
+## Known issues / scope
+
+- **Consumer proof (live c1sql1 FCI probe) is OPEN** — the acceptance criterion
+  that requires probing the live c1sql1 FCI (fingerprint version/edition,
+  governed backup against a test database, AG/FCI state reads) is **not
+  satisfiable in the sandbox** (no reachable lab instance + no Vault-provisioned
+  secret). It is declared OPEN honestly (the estate-connector precedent), to be
+  closed against the deployed lab.
+- **dbatools-over-PowerShell increment is deferred** — migration-grade verbs
+  (`Start-DbaMigration`, login/agent-job copy) that are prohibitively complex
+  over raw T-SQL are a possible second increment, not this connector.
+- **Cert-validated TLS is deferred** — see the encryption-posture section.
+
+## References
+
+- `backend/src/meho_backplane/connectors/mssql/` — `session.py` (transport +
+  creds + injection helpers), `queries.py` (T-SQL + `{rows, total}` shaping),
+  `ops.py` (op metadata), `connector.py` (op surface + fingerprint / probe),
+  `__init__.py` (self-registration).
+- `connectors-winsrv.md` / `connectors-bind9.md` — sibling connector docs.
+- `connectors/postgres/` + `connectors/mongodb/` — the direct-protocol mold.
+- Initiative #3259 (Microsoft estate connectors) design rules; Task #3264.
+- SQL Server system catalog views:
+  <https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/>


### PR DESCRIPTION
## Summary

- Ships the `mssql` typed connector for Microsoft SQL Server 2022 — a **direct TDS** connector (registry triple `mssql-2022.x` / `mssql-tds`) on the postgres/mongodb direct-protocol mold, driving the pure-Python `python-tds` driver off the event loop via `asyncio.to_thread`.
- **Transport decision (the pivotal in-task call), recorded with citations in `docs/codebase/connectors-mssql.md`:** TDS-direct is **confirmed, not overturned**. Of pyodbc / pymssql / python-tds, `python-tds` is the only **pure-Python** driver — one pip dependency with **no unixODBC/msodbcsql or FreeTDS apt layer** in the backplane image, the same packaging property `asyncpg` gives postgres. dbatools-over-PowerShell is deferred to a possible second increment (not this PR).
- **14 governed ops across four groups**, safety-tiered per the #3259 satellite table: `instance` (about/version/config/logins — safe), `databases` (list/files — safe; create/drop — **dangerous+approval**), `ha` (availability-groups/fci/sync-health — the safe migration-validation reads), `backup` (history — safe; database — **caution**; restore — **dangerous+approval**).
- **First two-credential connector on the estate seam:** SQL auth resolves `sql_username`/`sql_password` from the target's Vault secret (the `sql_` prefix reserves room for a later dbatools-over-SSH increment's SSH creds in the same secret). Credentials never enter params, logs, or results.
- **Narrow waist:** no freeform T-SQL op (a deliberate non-goal, test-pinned). Operator values bind as `pytds` pyformat params; database identifiers are QUOTENAME-style bracket-escaped (validated + `]`-doubled) — the T-SQL equivalent of the estate `ps_single_quote` discipline.

**CLI snapshot: CHANGED (new product token `mssql`).** Regenerated via `cd cli && make snapshot-openapi && make generate`; both `cli/api/openapi.json` and the generated Go client are committed and the client compiles (`go build ./...`). No alembic migration.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/mssql/` — clean (`pytds` mypy override added, no stubs upstream)
- [x] `code-quality.py --diff` — clean (ops split per group to stay under the 600-line file limit, the estate mold)
- [x] `pytest tests/test_connectors_mssql.py` — 46 passed (registration + round-trip + `register_operations` boots green; safety tiers vs the satellite table; no-freeform-query guard; schema-level **secret-leak guard** + two-credential field shape + operator-less fail-closed; `quote_identifier` bracket-escaping + `assert_valid_identifier` rejection; every write op escaping its identifier and binding its path; `{rows,total}` JSONFlux envelopes; fingerprint/probe reason mapping)
- [x] `pytest tests/test_flight_recorder_typed_spans.py` — 17 passed (`mssql-tds` added to `_EXPECTED_TYPED_IMPLS`; conformance sweep green)
- [x] `pytest` registry/resolver/ui-connectors inventory tests — 108 passed (new token doesn't break cross-cutting assertions)
- [x] `go build ./...` in `cli/` — regenerated client compiles

## Out of scope / open

- **Consumer proof (live c1sql1 FCI probe) — OPEN, declared honestly.** The AC that probes the live c1sql1 FCI (fingerprint version/edition, governed backup against a test database, AG/FCI state reads) is **not satisfiable in the sandbox** (no reachable lab instance, no Vault-provisioned secret). To be closed against the deployed lab — the estate-connector precedent.
- **dbatools-over-PowerShell increment** — migration-grade verbs (`Start-DbaMigration`, login/agent-job copy) deferred to a possible second increment.
- **Cert-validated TLS** — `python-tds` connects with `cafile=None` (encryption negotiated per server pre-login; a force-encryption server surfaces as `connect_failed`). Validated TLS via an optional `sql_ca` secret field is documented as a named future extension.
- Sibling #3255 (vmware_rest composites) runs in parallel with zero file overlap; only the CHANGELOG could collide (merges serialized by the orchestrator).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3264
