### PR TITLE
feat(connectors): vmware.composite.vm.guest.program.run — lift the deferred StartProgramInGuest tier (#3255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,34 @@ connector-related release-notes line.
   `meho mssql ...` verbs; consumer proof against the live c1sql1 FCI is tracked
   open. See `docs/codebase/connectors-mssql.md`.
 
+### Added — vmware: governed in-guest program execution `vm.guest.program.run` (#3255)
+
+- **`vmware.composite.vm.guest.program.run`** — the freeform in-guest
+  program-execution tier the guest-operations channel (#3100) deliberately
+  deferred, now lifted. Runs a program inside a VM's guest OS via the vim
+  `GuestProcessManager.StartProgramInGuest` over the existing VI-JSON seam
+  (no `pyvmomi`, no SSH), the governed replacement for out-of-band
+  `govc guest.run`. Params: `vm`, `program_path`, `arguments`,
+  `working_directory?`, `env?`, `timeout_seconds?`, `wait`.
+- **Exit-code semantics.** `StartProgramInGuest` is fire-and-forget and
+  returns only a PID (no stdout capture). With `wait=true` the op polls
+  `ListProcessesInGuest` (every 2s, up to `timeout_seconds`, default 300s)
+  for the exit code + start/end times. VMware Tools keeps a finished
+  process's exit code listable for only ~5 minutes after completion, so a
+  process no longer listable before an exit code is seen returns
+  `status='exit_unknown'` rather than hanging (alongside `started` /
+  `exited` / `timeout`).
+- **Governance.** `safety_level="dangerous"`, `requires_approval=True` (same
+  tier as `guest.file.write`): the call parks for a human decision unless a
+  standing grant auto-executes it, and gates *first* so a parked / denied
+  approval starts no program. Guest OS credentials resolve from the target's
+  Vault `secret_ref` (`guest_username` / `guest_password`), never in params.
+- **Secret hygiene.** `arguments` and `env` values (which can carry secrets)
+  are redacted from every durable surface — the approval preview echoes only
+  the program identity + argument byte size + env-var names, the result
+  echoes only PID / exit code / times, and the audit row stores a params
+  hash — proven by test.
+
 ### Added — flight recorder: operator mutation surface for capture policy (#3272)
 
 - The writable path the live-instance verification pass found missing: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,12 @@ connector-related release-notes line.
   program identity + argument byte size + env-var names, the operation
   result echoes only PID / exit code / times, and the sub-op policy gate
   never sees them (verified by test); the audit row records a params hash,
-  not raw params. Mirrors `guest.file.write` excluding `content`.
+  not raw params; and the op is pinned in `_CREDENTIAL_WRITE_OPS` so its
+  broadcast clamps to aggregate-only (the same remedy `k8s.job.create` and
+  the GOSC create use). The resume-bound `ApprovalRequest.params` row and
+  flight-recorder vendor spans still carry the values, so operators must not
+  pass bare secrets in `arguments` / `env` — same characteristic as
+  `guest.file.write`'s `content`.
 
 ### Added — flight recorder: operator mutation surface for capture policy (#3272)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,11 @@ connector-related release-notes line.
   approval starts no program. Guest OS credentials resolve from the target's
   Vault `secret_ref` (`guest_username` / `guest_password`), never in params.
 - **Secret hygiene.** `arguments` and `env` values (which can carry secrets)
-  are redacted from every durable surface — the approval preview echoes only
-  the program identity + argument byte size + env-var names, the result
-  echoes only PID / exit code / times, and the audit row stores a params
-  hash — proven by test.
+  are kept off the governed surfaces — the approval preview echoes only the
+  program identity + argument byte size + env-var names, the operation
+  result echoes only PID / exit code / times, and the sub-op policy gate
+  never sees them (verified by test); the audit row records a params hash,
+  not raw params. Mirrors `guest.file.write` excluding `content`.
 
 ### Added — flight recorder: operator mutation surface for capture policy (#3272)
 

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -202,6 +202,20 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # its staged env, never a param), so it keeps its param-echo preview
         # and is deliberately NOT pinned.
         "holodeck.router.patch",
+        # #3255 — the governed in-guest program-execution write. Its
+        # ``arguments`` string (a command line) and ``env`` values can hold
+        # credential material (``--token=…``, ``API_KEY=…``) in ``params``,
+        # and neither is a secret-*named* key nor a recognisable secret
+        # *shape*, so the key-name / Tier-1 scrub in ``scrub_broadcast_params``
+        # would miss them — a plain ``write`` classification (the ``.run``
+        # suffix) would ship the command line in full on the feed. Pinning it
+        # collapses the whole params dict to aggregate-only, exactly as
+        # ``k8s.job.create``'s inline-env case and the GOSC create above; the
+        # park-time preview additionally echoes only program identity +
+        # argument byte size + env-var names. The sibling ``guest.file.write``
+        # is unpinned (its ``content`` has the same characteristic) and is
+        # tracked under the estate-wide broadcast-hygiene follow-up, not here.
+        "vmware.composite.vm.guest.program.run",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -31,8 +31,9 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 24 write composites (G3.1-T6 / #509, the guest-ops write
-  ``vm.guest.file.write`` / #3100, single-VM ``vm.power`` /
+* 28 write composites (G3.1-T6 / #509, the guest-ops writes
+  ``vm.guest.file.write`` / #3100 + ``vm.guest.program.run`` / #3255,
+  single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
@@ -71,6 +72,7 @@ from meho_backplane.connectors.vmware_rest.composites._guest import (
     guest_file_write_composite,
     guest_net_show_composite,
     guest_process_list_composite,
+    guest_program_run_composite,
 )
 from meho_backplane.connectors.vmware_rest.composites._host import (
     datastore_mount_nfs_composite,
@@ -141,6 +143,7 @@ __all__ = [
     "guest_file_write_composite",
     "guest_net_show_composite",
     "guest_process_list_composite",
+    "guest_program_run_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "network_portgroup_audit_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
@@ -30,8 +30,13 @@ Design (see ``docs/codebase/connectors-vmware-rest-guest-ops.md``):
   ``arguments`` / ``env`` contract with the same ``dangerous`` /
   ``requires_approval`` governance as the file write, not an open
   ``run(cmd)`` shell endpoint. Its ``arguments`` / ``env`` values may
-  carry secrets and are kept off every durable surface, mirroring
-  ``file.write`` excluding ``content``.
+  carry secrets and are kept off the governed decision surfaces (sub-op
+  gate params, park preview, result, audit-row hash, logs) and clamped to
+  aggregate-only on broadcast via the ``_CREDENTIAL_WRITE_OPS`` pin; the
+  resume-bound ``ApprovalRequest.params`` and flight-recorder spans still
+  carry them, so operators must not pass bare secrets there -- the same
+  characteristic as ``file.write``'s ``content`` (see the guest-ops doc's
+  safety model).
 * **Read/write split.** ``process.list`` / ``env.read`` / ``net.show`` /
   ``file.read`` are ``safety_level="safe"`` reads; ``file.write`` and
   ``program.run`` are the ``dangerous`` / ``requires_approval`` writes,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_guest.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Governed guest-operations channel handlers (``vmware.composite.vm.guest.*``, #3100).
+"""Governed guest-operations channel handlers (``vmware.composite.vm.guest.*``, #3100 / #3255).
 
 A governed way to reach *inside* an arbitrary VM's guest OS -- list
 processes, read environment variables, inspect guest network state, read
-and write files -- riding **VMware Tools guest operations** (the vim
-``GuestOperationsManager`` family) over the existing VI-JSON write seam
+and write files, and run a program -- riding **VMware Tools guest
+operations** (the vim ``GuestOperationsManager`` family) over the existing
+VI-JSON write seam
 (:meth:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector._post_vmomi_json`),
 the same substrate the #2890 mutating-vmomi wave used. No ``pyvmomi``, no
 SSH, no in-guest agent of MEHO's own.
@@ -23,13 +24,19 @@ Design (see ``docs/codebase/connectors-vmware-rest-guest-ops.md``):
   ``NamePasswordAuthentication`` object the vim request body carries; it
   never enters params, a result, an audit row, a preview, or a log line.
 * **Structured sub-ops, not freeform shell.** Each op is a discrete
-  typed verb. There is no ``run(cmd)`` -- freeform in-guest program
-  execution (``StartProgramInGuest``) is a deliberately deferred tier.
+  typed verb. ``program.run`` *does* run an arbitrary program
+  (``StartProgramInGuest``, #3255 -- the freeform-exec tier #3100
+  deferred, now lifted), but through an explicit ``program_path`` /
+  ``arguments`` / ``env`` contract with the same ``dangerous`` /
+  ``requires_approval`` governance as the file write, not an open
+  ``run(cmd)`` shell endpoint. Its ``arguments`` / ``env`` values may
+  carry secrets and are kept off every durable surface, mirroring
+  ``file.write`` excluding ``content``.
 * **Read/write split.** ``process.list`` / ``env.read`` / ``net.show`` /
-  ``file.read`` are ``safety_level="safe"`` reads; ``file.write`` is the
-  single ``dangerous`` / ``requires_approval`` write, gated through the
-  same #2254 :func:`enforce_subop_policy` seam the other write composites
-  use.
+  ``file.read`` are ``safety_level="safe"`` reads; ``file.write`` and
+  ``program.run`` are the ``dangerous`` / ``requires_approval`` writes,
+  gated through the same #2254 :func:`enforce_subop_policy` seam the other
+  write composites use.
 
 Guest-operations manager MoRefs
 -------------------------------
@@ -48,6 +55,8 @@ An operator whose deployment names the top manager differently overrides
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors import OperationResult
@@ -69,6 +78,7 @@ __all__ = [
     "guest_file_write_composite",
     "guest_net_show_composite",
     "guest_process_list_composite",
+    "guest_program_run_composite",
 ]
 
 # --- governance facts (mirror the write-composite substrate, #2254) ---------
@@ -93,6 +103,7 @@ _DEFAULT_GUEST_OPS_MANAGER_MOID = "guestOperationsManager"
 _OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
 _OP_LIST_PROCESSES = "POST:/GuestProcessManager/{moId}/ListProcessesInGuest"
 _OP_READ_ENV = "POST:/GuestProcessManager/{moId}/ReadEnvironmentVariableInGuest"
+_OP_START_PROGRAM = "POST:/GuestProcessManager/{moId}/StartProgramInGuest"
 _OP_FILE_TRANSFER_FROM = "POST:/GuestFileManager/{moId}/InitiateFileTransferFromGuest"
 _OP_FILE_TRANSFER_TO = "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest"
 
@@ -101,6 +112,7 @@ _VIRTUAL_MACHINE_MO_TYPE = "VirtualMachine"
 _GUEST_OPS_MANAGER_MO_TYPE = "GuestOperationsManager"
 _NAME_PASSWORD_AUTH_TYPE = "NamePasswordAuthentication"
 _GUEST_FILE_ATTRIBUTES_TYPE = "GuestFileAttributes"
+_GUEST_PROGRAM_SPEC_TYPE = "GuestProgramSpec"
 _PROP_PROCESS_MANAGER = "processManager"
 _PROP_FILE_MANAGER = "fileManager"
 _PROP_GUEST_NET = "guest.net"
@@ -109,6 +121,18 @@ _PROP_GUEST_IP_STACK = "guest.ipStack"
 #: Cap on the number of processes returned inline before the list is
 #: JSONFlux-handled by the dispatcher.
 _DEFAULT_MAX_PROCESSES = 200
+
+#: Default wall-clock ceiling (seconds) for the ``guest.program.run``
+#: exit-code poll. Matches VMware Tools' ~5-minute retention of a finished
+#: process's exit code (``StartProgramInGuest`` doc: "its exit code and end
+#: time will be available for 5 minutes after completion") -- polling past
+#: that window risks the exit info ageing out.
+_DEFAULT_RUN_TIMEOUT_SECONDS = 300
+
+#: Interval (seconds) between ``ListProcessesInGuest`` polls while waiting
+#: for a started program's exit code. Well inside the ~5-minute exit-info
+#: window, so a fast-finishing process is still observed with its exit code.
+_RUN_POLL_INTERVAL_SECONDS = 2.0
 
 
 def _unwrap_envelope(payload: Any) -> Any:
@@ -522,3 +546,284 @@ async def _put_guest_file_bytes(
     client = await connector._http_client(target)
     response = await client.put(resolved, content=content)
     response.raise_for_status()
+
+
+async def guest_program_run_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Run a program in a VM's guest OS via ``StartProgramInGuest`` (#3255).
+
+    Op-id: ``vmware.composite.vm.guest.program.run``. The freeform in-guest
+    program-execution tier #3100 deliberately deferred, now lifted:
+    ``dangerous`` / ``requires_approval``, same governance shape as
+    ``guest.file.write``. Flow:
+
+    1. **Gate first** through the #2254 :func:`enforce_subop_policy` seam with
+       the ``StartProgramInGuest`` governance op_id. The gate params carry
+       only ``vm`` / ``program_path`` / ``working_directory`` -- never
+       ``arguments`` or ``env``, whose values may embed secrets (a password
+       on a command line, a token in an env var) and are redacted from every
+       durable surface. A parked / denied gate returns the
+       :class:`OperationResult` verbatim and nothing else runs -- no guest
+       credential is resolved, no program is started.
+    2. On a cleared gate, resolve the guest credential (from ``secret_ref``)
+       and the GuestProcessManager MoRef, then ``StartProgramInGuest`` starts
+       the program and returns its PID. It is fire-and-forget: **no output is
+       captured** (vim's only exec primitive returns a PID, not stdout).
+    3. When ``wait`` is true, :func:`_poll_for_exit` polls
+       ``ListProcessesInGuest`` (filtered to the PID) every
+       :data:`_RUN_POLL_INTERVAL_SECONDS` until the exit code is available or
+       ``timeout_seconds`` elapses. VMware Tools keeps a finished process's
+       exit code listable for only ~5 minutes after completion (and not
+       across a Tools restart), so a process no longer listed before an exit
+       code is seen yields ``status='exit_unknown'`` rather than a hang.
+
+    ``arguments`` / ``env`` never enter the result, the gate params, the
+    approval preview
+    (:func:`~meho_backplane.connectors.vmware_rest.composites._write_preview._guest_program_run_preview`),
+    or a log line -- only the PID, exit code, and start/end times surface.
+    """
+    vm_moid = params["vm"]
+    program_path = params["program_path"]
+    arguments = params.get("arguments", "")
+    working_directory = params.get("working_directory")
+    env = params.get("env")
+    wait = bool(params.get("wait", False))
+    timeout_seconds = int(params.get("timeout_seconds", _DEFAULT_RUN_TIMEOUT_SECONDS))
+    top_moid = params.get("guest_ops_manager_moid", _DEFAULT_GUEST_OPS_MANAGER_MOID)
+
+    gate = await enforce_subop_policy(
+        operator=operator,
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_START_PROGRAM,
+        safety_level=_WRITE_SAFETY_LEVEL,
+        requires_approval=_WRITE_REQUIRES_APPROVAL,
+        target=target,
+        params=_run_gate_params(vm_moid, program_path, working_directory),
+    )
+    if gate is not None:
+        return gate
+
+    manager_moid, auth, pid = await _start_guest_program(
+        connector,
+        target,
+        operator,
+        vm_moid=vm_moid,
+        program_path=program_path,
+        arguments=arguments,
+        working_directory=working_directory,
+        env=env,
+        top_moid=top_moid,
+    )
+    result: dict[str, Any] = {
+        "status": "started",
+        "vm": vm_moid,
+        "process_manager_moid": manager_moid,
+        "program_path": program_path,
+        "pid": pid,
+        "exit_code": None,
+        "start_time": None,
+        "end_time": None,
+        "wait": wait,
+    }
+    if not wait:
+        return result
+
+    result.update(
+        await _poll_for_exit(
+            connector,
+            target,
+            operator,
+            manager_moid=manager_moid,
+            vm_moid=vm_moid,
+            auth=auth,
+            pid=pid,
+            timeout_seconds=timeout_seconds,
+        )
+    )
+    return result
+
+
+async def _start_guest_program(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    vm_moid: str,
+    program_path: str,
+    arguments: str,
+    working_directory: Any,
+    env: Any,
+    top_moid: str,
+) -> tuple[str, dict[str, Any], int]:
+    """Resolve guest creds + the GuestProcessManager, then ``StartProgramInGuest``.
+
+    Returns ``(manager_moid, auth, pid)`` -- the resolved GuestProcessManager
+    MoId, the ephemeral guest auth object (reused by the exit-code poll), and
+    the started process's PID. Raises :class:`RuntimeError` if the vim call
+    returns no usable PID.
+    """
+    auth = await _guest_auth(connector, target, operator)
+    manager_moid = await _resolve_guest_manager_moid(
+        connector, target, operator, top_moid=top_moid, property_name=_PROP_PROCESS_MANAGER
+    )
+    raw_pid = await _vm_guest_method(
+        connector,
+        target,
+        operator,
+        op_id=_OP_START_PROGRAM,
+        manager_moid=manager_moid,
+        body={
+            "vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid),
+            "auth": auth,
+            "spec": _guest_program_spec(program_path, arguments, working_directory, env),
+        },
+    )
+    pid = _coerce_int(_unwrap_envelope(raw_pid))
+    if pid is None:
+        raise RuntimeError(
+            f"guest.program.run: {_OP_START_PROGRAM!r} returned no PID for "
+            f"{program_path!r} on vm {vm_moid!r}"
+        )
+    return manager_moid, auth, pid
+
+
+def _run_gate_params(vm_moid: str, program_path: str, working_directory: Any) -> dict[str, Any]:
+    """Build the redaction-safe gate/preview params for ``guest.program.run``.
+
+    Carries the program identity + working directory only. ``arguments`` and
+    ``env`` are deliberately excluded so their (possibly secret) values never
+    reach the sub-op policy gate, the durable approval row, or the audit
+    preview -- mirroring ``guest.file.write`` excluding ``content``.
+    """
+    gate_params: dict[str, Any] = {"vm": vm_moid, "program_path": program_path}
+    if working_directory is not None:
+        gate_params["working_directory"] = working_directory
+    return gate_params
+
+
+def _guest_program_spec(
+    program_path: str, arguments: str, working_directory: Any, env: Any
+) -> dict[str, Any]:
+    """Build the vim ``GuestProgramSpec`` body for ``StartProgramInGuest``.
+
+    ``programPath`` + ``arguments`` are required by the pinned spec
+    (``arguments`` defaults to an empty string). ``envVariables`` is the
+    ``NAME=value`` array vim expects; per the vim contract it **replaces**
+    the guest's whole environment rather than augmenting it.
+    """
+    spec: dict[str, Any] = {
+        "_typeName": _GUEST_PROGRAM_SPEC_TYPE,
+        "programPath": program_path,
+        "arguments": arguments,
+    }
+    if working_directory is not None:
+        spec["workingDirectory"] = working_directory
+    if env:
+        spec["envVariables"] = [f"{name}={value}" for name, value in env.items()]
+    return spec
+
+
+async def _poll_for_exit(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    manager_moid: str,
+    vm_moid: str,
+    auth: dict[str, Any],
+    pid: int,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Poll ``ListProcessesInGuest`` for ``pid``'s exit code until it exits or times out.
+
+    Returns the completion fields to merge into the result (``status`` +
+    ``exit_code`` / ``start_time`` / ``end_time``). Terminal cases:
+
+    * the process reports an ``exitCode`` (an int, including ``0``) ->
+      ``'exited'`` with the code + start/end times;
+    * ``timeout_seconds`` elapses while the process is still running ->
+      ``'timeout'`` (``exit_code`` null);
+    * the process is no longer listable before an exit code is seen -- it
+      finished and its exit info aged out of VMware Tools' ~5-minute window,
+      or Tools restarted -> ``'exit_unknown'`` (``exit_code`` null).
+
+    The loop is bounded by wall-clock ``timeout_seconds``: it always polls at
+    least once and never blocks indefinitely on a process that neither exits
+    nor disappears.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    body = {
+        "vm": vim_moref(_VIRTUAL_MACHINE_MO_TYPE, vm_moid),
+        "auth": auth,
+        "pids": [pid],
+    }
+    seen_running = False
+    while True:
+        raw = await _vm_guest_method(
+            connector,
+            target,
+            operator,
+            op_id=_OP_LIST_PROCESSES,
+            manager_moid=manager_moid,
+            body=body,
+        )
+        info = _process_info_for_pid(_unwrap_envelope(raw), pid)
+        if info is not None:
+            exit_code = _coerce_int(info.get("exitCode"))
+            if exit_code is not None:
+                return {
+                    "status": "exited",
+                    "exit_code": exit_code,
+                    "start_time": _as_str(info.get("startTime")),
+                    "end_time": _as_str(info.get("endTime")),
+                }
+            seen_running = True
+        elif seen_running:
+            # Was listable, now gone before an exit code surfaced: the exit
+            # info aged out of the ~5-minute window (or Tools restarted).
+            return _exit_unknown()
+        if time.monotonic() >= deadline:
+            return {"status": "timeout", "exit_code": None} if seen_running else _exit_unknown()
+        await asyncio.sleep(_RUN_POLL_INTERVAL_SECONDS)
+
+
+def _exit_unknown() -> dict[str, Any]:
+    """Completion fields for a process whose exit code could not be determined."""
+    return {"status": "exit_unknown", "exit_code": None, "start_time": None, "end_time": None}
+
+
+def _process_info_for_pid(payload: Any, pid: int) -> dict[str, Any] | None:
+    """Return the ``GuestProcessInfo`` entry matching ``pid``, or ``None``."""
+    if not isinstance(payload, list):
+        return None
+    for entry in payload:
+        if isinstance(entry, dict) and _coerce_int(entry.get("pid")) == pid:
+            return entry
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Unwrap a vim-boxed value to an ``int`` (PID / exit code), else ``None``.
+
+    ``bool`` is excluded (``isinstance(True, int)`` is truthy in Python) and a
+    numeric string is accepted -- VI-JSON may box an ``int64`` as a string.
+    """
+    unwrapped = unwrap_vim_value(value)
+    if isinstance(unwrapped, bool):
+        return None
+    if isinstance(unwrapped, int):
+        return unwrapped
+    if isinstance(unwrapped, str) and unwrapped.lstrip("-").isdigit():
+        return int(unwrapped)
+    return None
+
+
+def _as_str(value: Any) -> str | None:
+    """Unwrap a vim-boxed value to a ``str`` (a timestamp), else ``None``."""
+    unwrapped = unwrap_vim_value(value)
+    return unwrapped if isinstance(unwrapped, str) else None

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -63,6 +63,7 @@ from meho_backplane.connectors.vmware_rest.composites._guest import (
     guest_file_write_composite,
     guest_net_show_composite,
     guest_process_list_composite,
+    guest_program_run_composite,
 )
 from meho_backplane.connectors.vmware_rest.composites._host import (
     datastore_mount_nfs_composite,
@@ -126,6 +127,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     GUEST_NET_SHOW_RESPONSE_SCHEMA,
     GUEST_PROCESS_LIST_PARAMETER_SCHEMA,
     GUEST_PROCESS_LIST_RESPONSE_SCHEMA,
+    GUEST_PROGRAM_RUN_PARAMETER_SCHEMA,
+    GUEST_PROGRAM_RUN_RESPONSE_SCHEMA,
     HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA,
     HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA,
     HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
@@ -317,15 +320,16 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "guest environment variables (env.read), show Tools-reported guest "
         "network state (net.show -- per-NIC IPs / routes / DNS, needs NO guest "
         "credentials), and initiate a guest file read (file.read -- returns the "
-        "transfer handle: size + attributes + one-time URL). Write (dangerous / "
-        "approval-required): place a file into the guest (file.write). Guest OS "
+        "transfer handle: size + attributes + one-time URL). Writes (dangerous / "
+        "approval-required): place a file into the guest (file.write) and run a "
+        "program in the guest (program.run -- freeform in-guest execution via "
+        "StartProgramInGuest, with optional exit-code polling). Guest OS "
         "credentials resolve from the target's Vault secret_ref (guest_username "
         "/ guest_password) and are NEVER a parameter. The right group for "
         "'what's running in this appliance?', 'read /etc/os-release from the "
-        "guest', 'what does the guest think its network is?', or 'drop this "
-        "config file into the guest'. Requires VMware Tools in the guest. "
-        "Running an arbitrary in-guest command (freeform program exec) is a "
-        "deferred tier -- not in this group yet."
+        "guest', 'what does the guest think its network is?', 'drop this config "
+        "file into the guest', or 'run Install-WindowsFeature inside the guest'. "
+        "Requires VMware Tools in the guest."
     ),
 }
 
@@ -1333,6 +1337,58 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
             ),
         },
     ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.guest.program.run",
+        handler=guest_program_run_composite,
+        summary="Run a program in a VM's guest OS (dangerous / approval-required).",
+        description=(
+            "Runs a program inside a VM's guest OS via the vim "
+            "GuestProcessManager StartProgramInGuest, authenticating with the "
+            "guest credential from the target's secret_ref (never in params). "
+            "The governed replacement for out-of-band 'govc guest.run': the "
+            "freeform in-guest execution tier #3100 deliberately deferred, now "
+            "lifted. StartProgramInGuest is fire-and-forget and returns only a "
+            "PID (no output is captured); with wait=true the op polls "
+            "ListProcessesInGuest until the process exits or timeout_seconds "
+            "elapses, returning the exit code and start/end times. "
+            "dangerous / approval-required, gated through the standard "
+            "approvals plane -- a parked / denied approval starts no program. "
+            "The 'arguments' string and 'env' values may carry secrets and are "
+            "redacted from the approval preview, the result, and logs. Requires "
+            "VMware Tools."
+        ),
+        parameter_schema=GUEST_PROGRAM_RUN_PARAMETER_SCHEMA,
+        response_schema=GUEST_PROGRAM_RUN_RESPONSE_SCHEMA,
+        group_key="guest_ops",
+        tags=["composite", "write", "guest", "vi-json", "exec"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": (
+                "Execute a command inside a running guest OS (e.g. "
+                "Install-WindowsFeature, an AD DS promotion, a systemctl "
+                "invocation) without out-of-band govc guest.run. Approval-gated "
+                "-- expect the call to park for a human decision unless a "
+                "standing grant auto-executes it. Set wait=true to get the exit "
+                "code; note StartProgramInGuest captures no stdout, so redirect "
+                "to a file and read it back with guest.file.read if you need "
+                "output. Setting 'env' REPLACES the guest environment rather "
+                "than augmenting it."
+            ),
+            "preconditions": (
+                "VMware Tools running; guest credential in the target's "
+                "secret_ref. Guest user must be allowed to run the program."
+            ),
+            "result_shape": (
+                "On execute: {status, vm, process_manager_moid, program_path, "
+                "pid, exit_code, start_time, end_time, wait}. status is "
+                "'started' (wait=false), 'exited' (exit code captured), "
+                "'timeout' (still running at timeout), or 'exit_unknown' (exit "
+                "info aged out / Tools restarted). On gate: the approval "
+                "OperationResult verbatim (awaiting_approval / denied)."
+            ),
+        },
+    ),
 )
 
 
@@ -1349,8 +1405,8 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 33 composites total -- 9 read (T5 / #508 + the 4 guest-ops
-    reads / #3100) + 24 write (T6 / #509 + the destructive-tier
+    Scope: 37 composites total -- 9 read (T5 / #508 + the 4 guest-ops
+    reads / #3100) + 28 write (T6 / #509 + the destructive-tier
     ``vm.destroy`` / #3198,
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
@@ -1359,9 +1415,13 @@ async def register_vmware_composite_operations(
     hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
     ``vm.device.cdrom``, the two GOSC composites
     ``guest.customization_spec.create`` / ``vm.customize`` / #2892, the
-    OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909, and
-    the three host-domain writes ``host.datastore_mount_nfs`` /
-    ``host.disk_mark_flash`` / ``host.service_control`` / #3182). (The
+    OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909, the
+    three host-domain writes ``host.datastore_mount_nfs`` /
+    ``host.disk_mark_flash`` / ``host.service_control`` / #3182, the vim
+    portgroup writes ``network.portgroup.create`` /
+    ``network.portgroup.security.set`` / #3091, the content-library import
+    ``vm.import_from_library`` / #3229, and the two guest-ops writes
+    ``vm.guest.file.write`` / #3100 + ``vm.guest.program.run`` / #3255). (The
     former ``host.network_uplinks`` / ``host.vsan_health`` reads were
     re-shipped as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 20 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,10 +9,13 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 19 write composites onto the per-op preview hook shipped
-by #1437 (:mod:`meho_backplane.operations._preview`), following the
+This wires 25 of the 28 write composites onto the per-op preview hook
+shipped by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
-helpers, never the mutating sub-ops.
+helpers, never the mutating sub-ops. (The three most recent write ops —
+``network.portgroup.create`` / ``network.portgroup.security.set`` /
+``vm.import_from_library`` — carry no bespoke builder yet and fall back to
+the identifier-only default.)
 
 ========================  ====================================================
 ``vmware.composite.*``    preview stored in ``proposed_effect["preview"]``

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -943,6 +943,41 @@ async def _guest_file_write_preview(ctx: PreviewContext) -> dict[str, Any] | Non
     }
 
 
+async def _guest_program_run_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.guest.program.run`` — echo the program identity, never arguments/env (#3255).
+
+    The reviewer must see *which program* runs in *which guest*, its working
+    directory, and whether the call waits for an exit code — but never the
+    ``arguments`` string or ``env`` values, which can carry secrets (a
+    password on a command line, a token in an env var) and must not land on
+    the durable approval row. ``argument_bytes`` and ``env_var_names`` echo
+    the *shape* (how many argument bytes, which env-var NAMES) so the reviewer
+    judges blast radius without seeing any value. Declines (``None``) on
+    malformed params.
+    """
+    vm = ctx.params.get("vm")
+    program_path = ctx.params.get("program_path")
+    if not isinstance(vm, str) or not isinstance(program_path, str):
+        return None
+    preview: dict[str, Any] = {
+        "vm": vm,
+        "program_path": program_path,
+        "wait": bool(ctx.params.get("wait", False)),
+    }
+    working_directory = ctx.params.get("working_directory")
+    if isinstance(working_directory, str) and working_directory:
+        preview["working_directory"] = working_directory
+    arguments = ctx.params.get("arguments")
+    if isinstance(arguments, str) and arguments:
+        # Value withheld: may carry secrets. Echo only the byte magnitude.
+        preview["argument_bytes"] = len(arguments.encode("utf-8"))
+    env = ctx.params.get("env")
+    if isinstance(env, dict) and env:
+        # Names are not secret; values are. Echo only the variable names.
+        preview["env_var_names"] = sorted(str(name) for name in env)
+    return preview
+
+
 async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     """Preview ``vm.destroy`` — the mandatory destructive-tier blast radius (#3198).
 
@@ -1011,10 +1046,11 @@ async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
-#: op_id → builder for the 24 write composites. Module-level so the
+#: op_id → builder for the 25 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.guest.file.write": _guest_file_write_preview,
+    "vmware.composite.vm.guest.program.run": _guest_program_run_preview,
     "vmware.composite.vm.create": _vm_create_preview,
     "vmware.composite.vm.destroy": _vm_destroy_preview,
     "vmware.composite.vm.clone": _vm_clone_preview,
@@ -1042,7 +1078,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 24 write-composite park-time preview builders. Import-time.
+    """Wire the 25 write-composite park-time preview builders. Import-time.
 
     The 9 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -3706,7 +3706,8 @@ HOST_SERVICE_CONTROL_RESPONSE_SCHEMA: dict[str, Any] = {
 # Guest OS credentials are NEVER a parameter of these ops: they resolve
 # from the target's Vault ``secret_ref`` (the ``guest_username`` /
 # ``guest_password`` fields). The reads are ``safe``; ``guest.file.write``
-# is the single ``dangerous`` / ``requires_approval`` write.
+# (#3100) and ``guest.program.run`` (#3255) are the ``dangerous`` /
+# ``requires_approval`` writes.
 
 
 #: ``vmware.composite.vm.guest.process.list`` parameter schema.
@@ -4040,4 +4041,170 @@ GUEST_FILE_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm", "guest_path", "size_bytes", "overwrite"],
+}
+
+
+#: ``vmware.composite.vm.guest.program.run`` parameter schema (#3255).
+#:
+#: The freeform in-guest program-execution write #3100 deferred. ``dangerous``
+#: / ``requires_approval``. ``arguments`` and ``env`` values may carry secrets
+#: (a password on a command line, a token in an env var); they are redacted
+#: from the approval preview, never echoed into the result, and never logged
+#: (guest credentials themselves resolve from ``secret_ref``, never params).
+GUEST_PROGRAM_RUN_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the VM whose guest OS runs the program (e.g. 'vm-42')."
+            ),
+        },
+        "program_path": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Absolute path of the program to start inside the guest (vim "
+                "GuestProgramSpec.programPath), e.g. '/usr/bin/systemctl' or a "
+                "Windows 'powershell.exe'. On Linux/Solaris the program is "
+                "launched via a guest shell."
+            ),
+        },
+        "arguments": {
+            "type": "string",
+            "description": (
+                "Command-line arguments for the program as a single shell string "
+                "(vim GuestProgramSpec.arguments) -- e.g. '-Command "
+                '"Install-WindowsFeature AD-Domain-Services"\'. On Linux/Solaris '
+                "the guest shell interprets it (stdio redirection works; shell "
+                "metacharacters must be escaped). Defaults to an empty string. "
+                "MAY carry secrets: the value is redacted from the approval "
+                "preview and never appears in the result, the audit row, or logs."
+            ),
+        },
+        "working_directory": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Absolute working directory for the program (vim "
+                "GuestProgramSpec.workingDirectory). Omit to use the guest "
+                "default (the auth user's home directory on Linux)."
+            ),
+        },
+        "env": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Environment variables for the program, a NAME->value map "
+                "serialised to vim GuestProgramSpec.envVariables 'NAME=value' "
+                "entries. WARNING: vim REPLACES the guest's whole environment "
+                "with this set -- it is not additive, so an incomplete map can "
+                "drop PATH and system variables the program needs. Omit to "
+                "inherit the guest default environment. MAY carry secrets: "
+                "values are redacted from the approval preview and never appear "
+                "in the result, the audit row, or logs (only the variable NAMES "
+                "reach the reviewer)."
+            ),
+        },
+        "wait": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When false (default), return as soon as the program is started "
+                "-- StartProgramInGuest is fire-and-forget and yields only a PID "
+                "(no output is captured). When true, poll ListProcessesInGuest "
+                "until the process exits or ``timeout_seconds`` elapses, "
+                "returning the exit code and start/end times."
+            ),
+        },
+        "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3600,
+            "default": 300,
+            "description": (
+                "Only used when ``wait`` is true: the wall-clock ceiling for the "
+                "exit-code poll. VMware Tools keeps a finished process's exit "
+                "code listable for only ~5 minutes after completion (and not "
+                "across a Tools restart), so the default matches that window; a "
+                "program running longer may return status 'exit_unknown' if its "
+                "exit info ages out before a poll observes it."
+            ),
+        },
+        "guest_ops_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "guestOperationsManager",
+            "description": (
+                "MoId of the top-level GuestOperationsManager singleton (see process.list)."
+            ),
+        },
+    },
+    "required": ["vm", "program_path"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.guest.program.run`` response schema (#3255).
+GUEST_PROGRAM_RUN_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["started", "exited", "timeout", "exit_unknown"],
+            "description": (
+                "``'started'`` -- wait=false: the program was launched (PID "
+                "returned, no exit code polled). ``'exited'`` -- wait=true: the "
+                "process completed and its exit code was captured. ``'timeout'`` "
+                "-- wait=true: ``timeout_seconds`` elapsed while the process was "
+                "still running (exit_code null). ``'exit_unknown'`` -- wait=true: "
+                "the process was no longer listable before an exit code was seen "
+                "(it finished and aged out of VMware Tools' ~5-minute window, or "
+                "Tools restarted); exit_code null. (A parked / denied approval "
+                "returns the governance OperationResult verbatim, not this "
+                "envelope.)"
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid the program ran in."},
+        "process_manager_moid": {
+            "type": "string",
+            "description": (
+                "Resolved GuestProcessManager MoId the StartProgramInGuest call targeted."
+            ),
+        },
+        "program_path": {
+            "type": "string",
+            "description": (
+                "Absolute program path started (echoed; ``arguments`` / ``env`` "
+                "are never echoed back)."
+            ),
+        },
+        "pid": {
+            "type": "integer",
+            "description": "The process ID StartProgramInGuest returned.",
+        },
+        "exit_code": {
+            "type": ["integer", "null"],
+            "description": (
+                "The process exit code when ``status='exited'``; null for "
+                "'started' / 'timeout' / 'exit_unknown'."
+            ),
+        },
+        "start_time": {
+            "type": ["string", "null"],
+            "description": "GuestProcessInfo.startTime (ISO-8601) when captured; else null.",
+        },
+        "end_time": {
+            "type": ["string", "null"],
+            "description": (
+                "GuestProcessInfo.endTime (ISO-8601) when the process completed; else null."
+            ),
+        },
+        "wait": {
+            "type": "boolean",
+            "description": "Whether the caller requested the exit-code poll.",
+        },
+    },
+    "required": ["status", "vm", "process_manager_moid", "program_path", "pid", "wait"],
 }

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -213,6 +213,10 @@ class TestClassifyOp:
             "vault.kv.put",
             "vault.kv.patch",
             "k8s.secret.create",
+            # #3255 — in-guest program exec: arguments/env may carry secrets
+            # in params (not secret-named/shaped), so the pin collapses its
+            # broadcast to aggregate-only rather than shipping the command line.
+            "vmware.composite.vm.guest.program.run",
         ],
     )
     def test_credential_write_allowlist(self, op_id: str) -> None:

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -205,12 +205,13 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # create/apply #2892 + OVF/OVA content-library deploy
     # vm.deploy_from_library #2909 + the three host-domain writes
     # host.datastore_mount_nfs / host.disk_mark_flash / host.service_control
-    # #3182 + the guest-ops write vm.guest.file.write #3100 + the
-    # destructive-tier vm.destroy #3198 + the #3091 vim distributed-portgroup
-    # writes network.portgroup.create + network.portgroup.security.set). (The
-    # former host.network_uplinks / host.vsan_health reads were re-shipped as
-    # typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 36
+    # #3182 + the guest-ops writes vm.guest.file.write #3100 +
+    # vm.guest.program.run #3255 + the destructive-tier vm.destroy #3198 +
+    # the #3091 vim distributed-portgroup writes network.portgroup.create +
+    # network.portgroup.security.set + the content-library import
+    # vm.import_from_library #3229). (The former host.network_uplinks /
+    # host.vsan_health reads were re-shipped as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 37
 
 
 @pytest.mark.asyncio
@@ -468,13 +469,15 @@ async def test_register_vmware_composite_operations_is_idempotent(
     folder.create #2895 + the #2891 hardware writes vm.resize /
     vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
     content-library deploy vm.deploy_from_library #2909 + the three
-    host-domain writes #3182 + guest-ops write vm.guest.file.write #3100 +
-    the destructive-tier vm.destroy #3198 + the #3091 vim distributed-portgroup
-    writes network.portgroup.create + network.portgroup.security.set).
+    host-domain writes #3182 + guest-ops writes vm.guest.file.write #3100 +
+    vm.guest.program.run #3255 + the destructive-tier vm.destroy #3198 + the
+    #3091 vim distributed-portgroup writes network.portgroup.create +
+    network.portgroup.security.set + the content-library import
+    vm.import_from_library #3229).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 36
+    assert first_count == 37
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -96,6 +96,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.host.disk_mark_flash",
         "vmware.composite.host.service_control",
         "vmware.composite.vm.guest.file.write",
+        "vmware.composite.vm.guest.program.run",
     }
 )
 
@@ -307,14 +308,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 24 write composites register a builder (criterion 4)
+# Wiring — all 25 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 24
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 25
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -1479,3 +1480,58 @@ async def test_vm_resize_preview_failure_parks_with_unavailable_marker(
     assert effect["preview_unavailable"] is True
     assert "GET:/vcenter/vm/vm-1" in effect["preview_error"]
     assert "preview" not in effect
+
+
+# ===========================================================================
+# guest.program.run preview — argument/env values are never echoed (#3255)
+# ===========================================================================
+
+
+async def test_guest_program_run_preview_echoes_shape_never_secret_values() -> None:
+    """The park preview shows the program identity + shape, never arguments/env values.
+
+    ``arguments`` (a command line) and ``env`` values can carry secrets, so
+    the durable ``proposed_effect`` row must echo only what a reviewer needs
+    to judge the blast radius -- VM, program path, working directory, the wait
+    flag, the argument *byte size*, and the env-var *names* -- and never the
+    argument string or any env value.
+    """
+    preview = await _write_preview._guest_program_run_preview(
+        _make_preview_ctx(
+            {
+                "vm": "vm-42",
+                "program_path": "/usr/bin/psql",
+                "arguments": "-c 'ALTER USER svc PASSWORD hunter2'",
+                "working_directory": "/root",
+                "env": {"PGPASSWORD": "hunter2", "PATH": "/usr/bin"},
+                "wait": True,
+            }
+        )
+    )
+    assert preview is not None
+    assert preview == {
+        "vm": "vm-42",
+        "program_path": "/usr/bin/psql",
+        "wait": True,
+        "working_directory": "/root",
+        "argument_bytes": len(b"-c 'ALTER USER svc PASSWORD hunter2'"),
+        "env_var_names": ["PATH", "PGPASSWORD"],
+    }
+    # The secret argument/env VALUES never reach the durable approval row.
+    serialised = json.dumps(preview)
+    assert "hunter2" not in serialised
+    assert "ALTER USER" not in serialised
+
+
+async def test_guest_program_run_preview_minimal_and_declines_on_bad_params() -> None:
+    """Preview omits absent optionals; declines (None) without vm/program_path."""
+    minimal = await _write_preview._guest_program_run_preview(
+        _make_preview_ctx({"vm": "vm-7", "program_path": "/bin/true"})
+    )
+    assert minimal == {"vm": "vm-7", "program_path": "/bin/true", "wait": False}
+    assert (
+        await _write_preview._guest_program_run_preview(
+            _make_preview_ctx({"program_path": "/bin/true"})
+        )
+        is None
+    )

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 25 vmware-rest write composites.
+"""Registration tests for the 28 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -10,7 +10,7 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 25 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 28 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``requires_approval=True``, and
   ``safety_level="dangerous"`` (T4's defaults intentionally inherited) —
   except the destructive-tier ``vm.destroy`` / #3198, which is
@@ -20,7 +20,7 @@ and the GOSC composites ``guest.customization_spec.create`` /
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` / ``networking`` per the canary's stub-LLM taxonomy.
 * Combined with the 9 read composites (#508's 5 + the 4 guest-ops
-  reads / #3100), the registrar produces **36 rows** total. (The former
+  reads / #3100), the registrar produces **37 rows** total. (The former
   host.network_uplinks / host.vsan_health reads were re-shipped as typed
   ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
@@ -71,14 +71,16 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 27 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 28 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
 # hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom, the
 # GOSC composites guest.customization_spec.create + vm.customize / #2892,
-# the destructive-tier vm.destroy / #3198, and the vim distributed-portgroup
-# writes network.portgroup.create + network.portgroup.security.set / #3091).
+# the destructive-tier vm.destroy / #3198, the vim distributed-portgroup
+# writes network.portgroup.create + network.portgroup.security.set / #3091,
+# the content-library import vm.import_from_library / #3229, and the
+# guest-ops writes vm.guest.file.write / #3100 + vm.guest.program.run / #3255).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -106,8 +108,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.host.datastore_mount_nfs",
     "vmware.composite.host.disk_mark_flash",
     "vmware.composite.host.service_control",
-    # Guest-ops channel write (#3100).
+    # Guest-ops channel writes (#3100 / #3255).
     "vmware.composite.vm.guest.file.write",
+    "vmware.composite.vm.guest.program.run",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -127,13 +130,15 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
 )
 
-# 36 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 27 write
+# 37 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 28 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
 # writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892
 # + the destructive-tier vm.destroy / #3198 + the #3091 vim portgroup writes
-# network.portgroup.create + network.portgroup.security.set).
+# network.portgroup.create + network.portgroup.security.set + the
+# content-library import vm.import_from_library / #3229 + the guest-ops
+# program-exec write vm.guest.program.run / #3255).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -221,6 +226,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.file.write": (
         "meho_backplane.connectors.vmware_rest.composites._guest.guest_file_write_composite"
     ),
+    "vmware.composite.vm.guest.program.run": (
+        "meho_backplane.connectors.vmware_rest.composites._guest.guest_program_run_composite"
+    ),
 }
 
 
@@ -252,6 +260,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.host.disk_mark_flash": "host",
     "vmware.composite.host.service_control": "host",
     "vmware.composite.vm.guest.file.write": "guest_ops",
+    "vmware.composite.vm.guest.program.run": "guest_ops",
 }
 
 
@@ -323,13 +332,14 @@ async def test_register_vmware_composite_operations_inserts_all_write_rows(
 async def test_full_registration_produces_thirty_three_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """9 reads (#508 + guest-ops reads #3100) + 27 writes (#509 + vm.power #2301 +
+    """9 reads (#508 + guest-ops reads #3100) + 28 writes (#509 + vm.power #2301 +
     vm.disk.grow #2893 + vm.clone_from_template #2894 + cluster.drs_rule.create +
     folder.create #2895 + #2891 hardware writes vm.resize / vm.nic.repoint /
     vm.device.cdrom + GOSC create/apply #2892 + OVF deploy #2909 + host-domain
-    writes #3182 + guest-ops write vm.guest.file.write #3100 + destructive-tier
-    vm.destroy #3198 + #3091 portgroup writes network.portgroup.create /
-    network.portgroup.security.set) = 36 rows. DoD bar."""
+    writes #3182 + guest-ops writes vm.guest.file.write #3100 +
+    vm.guest.program.run #3255 + destructive-tier vm.destroy #3198 + #3091
+    portgroup writes network.portgroup.create / network.portgroup.security.set +
+    content-library import vm.import_from_library #3229) = 37 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -343,7 +353,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 36
+    assert len(rows) == 37
 
 
 @pytest.mark.asyncio
@@ -662,14 +672,14 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 36 rows total, embedding called 36x once."""
+    """Running the registrar twice -> 37 rows total, embedding called 37x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 36
+    assert first_count == 37
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 36.
+    # pipeline; the row count stays at 37.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -683,7 +693,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 36
+    assert len(rows) == 37
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_guest_ops.py
+++ b/backend/tests/test_connectors_vmware_rest_guest_ops.py
@@ -546,3 +546,289 @@ async def test_file_write_put_failure_propagates(
             params={"vm": "vm-42", "guest_path": "/tmp/x", "content": "hi"},
             connector=conn,  # type: ignore[arg-type]
         )
+
+
+# ---------------------------------------------------------------------------
+# program.run (the freeform in-guest exec write, #3255)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ProgramRunConnector:
+    """Records vmomi sub-calls; serves a queued ListProcessesInGuest sequence.
+
+    RetrievePropertiesEx resolves the GuestProcessManager (``pm-1``);
+    StartProgramInGuest returns ``start_pid``; ListProcessesInGuest returns
+    the next entry of ``list_responses`` (clamping to the last once the queue
+    is drained, so a still-running loop keeps polling the same state).
+    """
+
+    start_pid: Any = 4321
+    list_responses: list[Any] = field(default_factory=list)
+    vmomi_calls: list[dict[str, Any]] = field(default_factory=list)
+    _list_idx: int = 0
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append({"path": path, "json": json})
+        if path.endswith("/RetrievePropertiesEx"):
+            return _process_mgr()
+        if path.endswith("/StartProgramInGuest"):
+            return self.start_pid
+        if path.endswith("/ListProcessesInGuest"):
+            idx = min(self._list_idx, len(self.list_responses) - 1)
+            self._list_idx += 1
+            return self.list_responses[idx]
+        raise KeyError(path)
+
+
+def _proc(pid: int, *, exit_code: int | None = None) -> dict[str, Any]:
+    """A GuestProcessInfo entry; ``exit_code`` set marks a completed process."""
+    info: dict[str, Any] = {
+        "name": "psql",
+        "pid": pid,
+        "owner": "svc-guest",
+        "cmdLine": "/usr/bin/psql -c ...",
+        "startTime": "2026-09-01T10:00:00Z",
+    }
+    if exit_code is not None:
+        info["exitCode"] = exit_code
+        info["endTime"] = "2026-09-01T10:00:05Z"
+    return info
+
+
+@pytest.fixture
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the poll loop's inter-poll sleep a no-op so tests do not block."""
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_guest.asyncio, "sleep", _instant)
+
+
+@pytest.mark.asyncio
+async def test_program_run_no_wait_returns_pid_only(
+    creds: _CredRecorder, auto_gate: _GateRecorder
+) -> None:
+    conn = _ProgramRunConnector(start_pid=4321)
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={
+            "vm": "vm-42",
+            "program_path": "/usr/bin/systemctl",
+            "arguments": "is-system-running",
+            "working_directory": "/root",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "started"
+    assert out["pid"] == 4321
+    assert out["vm"] == "vm-42"
+    assert out["process_manager_moid"] == "pm-1"
+    assert out["program_path"] == "/usr/bin/systemctl"
+    assert out["exit_code"] is None
+    assert out["wait"] is False
+    # No poll happened (wait defaulted false): only RetrieveProperties + Start.
+    paths = [c["path"] for c in conn.vmomi_calls]
+    assert not any(p.endswith("/ListProcessesInGuest") for p in paths)
+    # The StartProgramInGuest body carried the VM MoRef, auth, and GuestProgramSpec.
+    start = next(c for c in conn.vmomi_calls if c["path"].endswith("/StartProgramInGuest"))
+    body = start["json"]
+    assert body["vm"] == {
+        "_typeName": "ManagedObjectReference",
+        "type": "VirtualMachine",
+        "value": "vm-42",
+    }
+    assert body["auth"]["_typeName"] == "NamePasswordAuthentication"
+    assert body["auth"]["username"] == "svc-guest"
+    assert body["spec"] == {
+        "_typeName": "GuestProgramSpec",
+        "programPath": "/usr/bin/systemctl",
+        "arguments": "is-system-running",
+        "workingDirectory": "/root",
+    }
+
+
+@pytest.mark.asyncio
+async def test_program_run_wait_returns_exit_code(
+    creds: _CredRecorder, auto_gate: _GateRecorder, no_sleep: None
+) -> None:
+    conn = _ProgramRunConnector(
+        start_pid=99,
+        list_responses=[[_proc(99)], [_proc(99, exit_code=0)]],
+    )
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "program_path": "/bin/true", "wait": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "exited"
+    assert out["pid"] == 99
+    assert out["exit_code"] == 0  # exit code 0 is captured, not read as "still running"
+    assert out["start_time"] == "2026-09-01T10:00:00Z"
+    assert out["end_time"] == "2026-09-01T10:00:05Z"
+    assert out["wait"] is True
+    # The poll filtered ListProcessesInGuest to the started PID.
+    poll = next(c for c in conn.vmomi_calls if c["path"].endswith("/ListProcessesInGuest"))
+    assert poll["json"]["pids"] == [99]
+    assert poll["json"]["auth"]["_typeName"] == "NamePasswordAuthentication"
+
+
+@pytest.mark.asyncio
+async def test_program_run_wait_nonzero_exit_code(
+    creds: _CredRecorder, auto_gate: _GateRecorder, no_sleep: None
+) -> None:
+    conn = _ProgramRunConnector(start_pid=7, list_responses=[[_proc(7, exit_code=1)]])
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "program_path": "/bin/false", "wait": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "exited"
+    assert out["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_program_run_wait_process_no_longer_listed(
+    creds: _CredRecorder, auto_gate: _GateRecorder, no_sleep: None
+) -> None:
+    """Seen running, then gone before an exit code -> exit_unknown, no hang."""
+    conn = _ProgramRunConnector(start_pid=55, list_responses=[[_proc(55)], []])
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "program_path": "/bin/sleep", "wait": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "exit_unknown"
+    assert out["exit_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_program_run_wait_times_out_while_running(
+    creds: _CredRecorder, auto_gate: _GateRecorder, no_sleep: None
+) -> None:
+    """Still running when the wall-clock deadline passes -> timeout status.
+
+    ``timeout_seconds=0`` makes the deadline the poll's start instant, so the
+    post-poll deadline check fires after exactly one poll (monotonic is
+    non-decreasing) -- a deterministic timeout without patching the clock.
+    """
+    conn = _ProgramRunConnector(start_pid=8, list_responses=[[_proc(8)]])
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={
+            "vm": "vm-42",
+            "program_path": "/bin/sleep",
+            "wait": True,
+            "timeout_seconds": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "timeout"
+    assert out["exit_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_program_run_gate_first_short_circuits(
+    creds: _CredRecorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A parked gate resolves no credential and starts no program."""
+    op_id = "POST:/GuestProcessManager/{moId}/StartProgramInGuest"
+    awaiting = OperationResult(
+        status="awaiting_approval",
+        op_id=op_id,
+        result=None,
+        duration_ms=1.0,
+        extras={"approval_request_id": "00000000-0000-0000-0000-0000000000bb"},
+    )
+    monkeypatch.setattr(_guest, "enforce_subop_policy", _GateRecorder({op_id: awaiting}))
+    conn = _ProgramRunConnector()
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "program_path": "/bin/true", "arguments": "x"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert creds.calls == []
+    assert conn.vmomi_calls == []
+
+
+@pytest.mark.asyncio
+async def test_program_run_redacts_arguments_and_env(
+    creds: _CredRecorder, auto_gate: _GateRecorder, no_sleep: None
+) -> None:
+    """arguments / env values never reach the result or the sub-op gate params.
+
+    They DO reach the vim wire body (the guest needs them) but must not land
+    on any governed surface -- mirroring guest.file.write excluding content.
+    """
+    secret_arg = "--token=SUPERSECRET123"
+    conn = _ProgramRunConnector(start_pid=321, list_responses=[[_proc(321, exit_code=0)]])
+    out = await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={
+            "vm": "vm-42",
+            "program_path": "/usr/bin/deploy",
+            "arguments": secret_arg,
+            "env": {"API_KEY": "SECRET_ENV_VALUE", "PATH": "/usr/bin"},
+            "wait": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    dumped = json.dumps(out)
+    assert "SUPERSECRET123" not in dumped
+    assert "SECRET_ENV_VALUE" not in dumped
+    # The gate ran with the redaction-safe params (no arguments, no env).
+    gate_call = auto_gate.calls[0]
+    assert gate_call["op_id"] == "POST:/GuestProcessManager/{moId}/StartProgramInGuest"
+    assert gate_call["safety_level"] == "dangerous"
+    assert gate_call["requires_approval"] is False
+    assert gate_call["params"] == {"vm": "vm-42", "program_path": "/usr/bin/deploy"}
+    assert "arguments" not in gate_call["params"]
+    assert "env" not in gate_call["params"]
+    # The values are still delivered to the guest on the vim wire body.
+    start = next(c for c in conn.vmomi_calls if c["path"].endswith("/StartProgramInGuest"))
+    spec = start["json"]["spec"]
+    assert spec["arguments"] == secret_arg
+    assert spec["envVariables"] == ["API_KEY=SECRET_ENV_VALUE", "PATH=/usr/bin"]
+
+
+@pytest.mark.asyncio
+async def test_program_run_defaults_arguments_to_empty_string(
+    creds: _CredRecorder, auto_gate: _GateRecorder
+) -> None:
+    """arguments is required by vim; omitting it sends an empty string."""
+    conn = _ProgramRunConnector(start_pid=1)
+    await _guest.guest_program_run_composite(
+        operator=_operator(),
+        target=_Target(),
+        params={"vm": "vm-42", "program_path": "/bin/true"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    start = next(c for c in conn.vmomi_calls if c["path"].endswith("/StartProgramInGuest"))
+    spec = start["json"]["spec"]
+    assert spec["arguments"] == ""
+    assert "workingDirectory" not in spec
+    assert "envVariables" not in spec
+
+
+@pytest.mark.asyncio
+async def test_program_run_no_pid_raises(creds: _CredRecorder, auto_gate: _GateRecorder) -> None:
+    conn = _ProgramRunConnector(start_pid={"not": "a pid"})
+    with pytest.raises(RuntimeError, match="returned no PID"):
+        await _guest.guest_program_run_composite(
+            operator=_operator(),
+            target=_Target(),
+            params={"vm": "vm-42", "program_path": "/bin/true"},
+            connector=conn,  # type: ignore[arg-type]
+        )

--- a/backend/tests/test_connectors_vmware_rest_guest_ops_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_guest_ops_reconcile.py
@@ -53,6 +53,7 @@ def test_guest_op_constants_are_all_vmomi_post_legs() -> None:
         "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
         "POST:/GuestProcessManager/{moId}/ListProcessesInGuest",
         "POST:/GuestProcessManager/{moId}/ReadEnvironmentVariableInGuest",
+        "POST:/GuestProcessManager/{moId}/StartProgramInGuest",
         "POST:/GuestFileManager/{moId}/InitiateFileTransferFromGuest",
         "POST:/GuestFileManager/{moId}/InitiateFileTransferToGuest",
     }

--- a/docs/codebase/connectors-vmware-rest-guest-ops.md
+++ b/docs/codebase/connectors-vmware-rest-guest-ops.md
@@ -85,7 +85,11 @@ start/end times (see "The exit-code poll" below). It deliberately does
 then `guest.file.read`), because baking it in would multiply the blast
 radius and the audited surface for the common "run this and tell me the
 exit code" case. `arguments` and `env` may carry secrets, so their values
-are redacted from every durable surface (see the safety model).
+are kept off the governed decision surfaces (the sub-op policy gate, the
+park preview, the result, and the audit-row hash) — but note that, exactly
+like `guest.file.write`'s `content`, they are **not** scrubbed on every
+surface (see the safety model for the precise split and the operator
+guidance on not passing bare secrets).
 
 **Why (b) is still deferred, not discarded.** After #3255, one capability
 branch (a) genuinely cannot serve remains:
@@ -113,11 +117,18 @@ load-bearing-ness:
    never appears in an operation parameter, an `OperationResult`, an
    audit row, a broadcast event, or a log line — it lives only as the
    ephemeral in-memory `NamePasswordAuthentication` object the vim
-   request body carries. This is a deliberate improvement on the GOSC
-   `credential-class` ops (`guest.customization_spec.create`), which
-   accept the Windows admin password *in params* and rely on
-   reviewer-surface suppression to hide it; here the secret is never in
-   params to begin with.
+   request body carries. For the guest **login** credential this is a
+   deliberate improvement on the GOSC `credential-class` ops
+   (`guest.customization_spec.create`), which accept the Windows admin
+   password *in params*: here the login secret is never in params to begin
+   with. For any secret an operator might pass *inside* `guest.program.run`'s
+   `arguments` / `env` (which, like GOSC's password param, do ride in
+   params), `program.run` **matches** the GOSC posture rather than
+   exceeding it — both are pinned in `_CREDENTIAL_WRITE_OPS` so their
+   broadcasts clamp to aggregate-only (point 4), and both rely on the
+   park-preview builder to keep values off the reviewer surface. The pin is
+   what makes that parity true; without it `program.run` would have been
+   *weaker* than GOSC on the broadcast surface.
 2. **Structured sub-ops, not freeform shell.** Each op is a discrete
    typed verb with a JSON-schema parameter contract. `guest.program.run`
    *does* run an arbitrary program, but through an explicit
@@ -137,16 +148,41 @@ load-bearing-ness:
    approval. Both writes gate *first* through the #2254
    `enforce_subop_policy` seam: a parked / denied gate resolves no guest
    credential and starts / writes nothing.
-4. **`arguments` / `env` are redaction-safe on every durable surface.**
-   A command line or an environment variable can carry a secret (a
-   password argument, an API token in an env var). For `guest.program.run`
-   these never reach the sub-op policy gate params, the audit row (the
-   dispatcher stores a `params_hash`, never the raw params, and the
-   handler's result echoes only PID / exit code / times — never
-   `arguments` / `env`), the approval preview (the bespoke builder echoes
-   only shape, above), or a log line. This mirrors `guest.file.write`
-   excluding `content`. Guest credentials themselves resolve from
-   `secret_ref` and are never a parameter (point 1).
+4. **`arguments` / `env` are kept off the governed decision surfaces —
+   but are not scrubbed everywhere.** A command line or an environment
+   variable can carry a secret (a password argument, an API token in an
+   env var). For `guest.program.run` these are kept off the surfaces an
+   operator's governance decision reads: they never reach the **sub-op
+   policy gate** params (`_run_gate_params` passes VM + program path +
+   working directory only), the **park preview** `proposed_effect` (the
+   bespoke builder echoes program identity + argument *byte size* + env-var
+   *names*, never the values), the **operation result** (only PID / exit
+   code / times), or a **log line** (the handler logs nothing; the vim
+   `_post_json` seam does not log its body). The **audit row** stores a
+   `params_hash`, never the raw params.
+
+   **Broadcast is clamped to aggregate-only.** `guest.program.run` is
+   pinned in `broadcast/events.py`'s `_CREDENTIAL_WRITE_OPS` frozenset, so
+   `classify_op` returns `credential_write` and the dispatch broadcast
+   collapses the whole params dict to aggregate-only — it never ships the
+   `arguments` string or `env` values on the SSE feed / Slack mirror /
+   durable `BroadcastEvent` row. This is the exact remedy the codebase
+   already applies to `k8s.job.create` (inline pod-template `env`) and the
+   GOSC `guest.customization_spec.create` write, so `program.run` **matches
+   the GOSC broadcast posture** rather than being weaker than it.
+
+   **What still carries the values — the same characteristic as
+   `guest.file.write`'s `content`, from shared machinery, not a
+   `program.run` bug:** the durable **`ApprovalRequest.params`** row stores
+   the *full* params verbatim (the resume path re-dispatches the exact call
+   after a human approves, so it must persist them), and **flight-recorder
+   vendor-call spans** (only when a capture policy is active) record the
+   `StartProgramInGuest` request body. So **operators must not put bare
+   secrets in `arguments` / `env`.** Where a program needs a secret, pass
+   its env-var *name* and stage the value guest-side (a file the guest user
+   reads, a Vault-agent-templated env file), or use the guest's own
+   credential store — the same discipline the guest OS credential itself
+   follows (point 1, resolved from `secret_ref`, never a parameter).
 5. **Full audit of command + result + truncated output.** Every op
    dispatches through the synchronous append-only audit path
    (v0.1-spec §6). The audit row names the op, the VM, and the outcome;

--- a/docs/codebase/connectors-vmware-rest-guest-ops.md
+++ b/docs/codebase/connectors-vmware-rest-guest-ops.md
@@ -19,8 +19,10 @@ mutating-vmomi wave used. No `pyvmomi`, no in-guest agent of MEHO's own,
 no shell. Guest OS credentials are resolved from the target's Vault
 `secret_ref` and never travel in operation params.
 
-First increment (this doc): four **read-only** guest ops plus **one**
-approval-gated write proving the governance posture.
+The channel shipped in two increments: **#3100** (four read-only guest
+ops plus one approval-gated `guest.file.write`, proving the governance
+posture) and **#3255** (`guest.program.run` — the freeform in-guest
+program-execution tier #3100 deliberately deferred, now lifted).
 
 ## The design fork: (a) vim guest-ops over (b) generic-ssh
 
@@ -54,30 +56,48 @@ later tier.** Rationale:
    guest ops are new op-ids on that substrate, not a new transport.
 4. **Structured sub-ops, not a shell.** (a) exposes discrete, typed
    verbs (`guest.process.list`, `guest.file.read`, …) whose parameters
-   are JSON-schema-validated. (b)'s natural shape is a safelisted-but-
-   still-textual command surface; the structured shape is a smaller,
-   more auditable blast radius.
+   are JSON-schema-validated. Even the freeform-exec op `guest.program.run`
+   is a typed verb — an explicit `program_path` + `arguments` + `env`
+   contract with `dangerous` / `requires_approval` governance around every
+   call — not an open shell surface.
 
-**Why (b) is deferred, not discarded.** Two capabilities (a) cannot
-serve cleanly:
+### The deferred freeform-exec tier, now lifted (#3255)
 
-- **Running a command and capturing its output** (`ip addr`,
-  `systemctl is-system-running`). vim's only exec primitive is
-  `StartProgramInGuest`, which starts a detached process and returns a
-  PID — output is not captured; you must redirect to a file, poll
-  `ListProcessesInGuest` for the exit code, then read the file back.
-  That freeform-program tier is deliberately **out of this increment**
-  (it is the crux of the dangerous-by-default posture and wants its own
-  design pass). Where the *reported* state suffices, this increment
-  serves it structurally instead: `guest.net.show` reads Tools-reported
-  guest network state directly, no program-exec.
-- **Guests without VMware Tools.** No Tools → no guest operations at
-  all; (b) is the only channel there.
+#3100 deferred one capability inside branch (a): **running an arbitrary
+program in the guest.** vim's only exec primitive is `StartProgramInGuest`,
+which starts a detached process and returns a PID — output is *not*
+captured; to capture output you redirect to a file, poll
+`ListProcessesInGuest` for the exit code, then read the file back. #3100
+judged that the crux of the dangerous-by-default posture and wanted a
+dedicated design pass, so it shipped only the reads plus the clean
+`guest.file.write`, and served the *reported*-state cases structurally
+(`guest.net.show` reads Tools-reported network state without running
+anything in the guest).
 
-If and when a concrete need for freeform in-guest command execution or a
-Tools-less guest lands, tier (b) (a `linux-ssh` typed connector, or a
-`guest.program.run` op with a stricter safety gate) is the follow-up.
-This increment does **not** build it.
+**#3255 lifts that deferral** as `vmware.composite.vm.guest.program.run`,
+under the same governance as `guest.file.write`
+(`safety_level="dangerous"`, `requires_approval=True`). It maps
+`StartProgramInGuest` directly (fire-and-forget, returns the PID), and
+when `wait=true` polls `ListProcessesInGuest` for the exit code and
+start/end times (see "The exit-code poll" below). It deliberately does
+**not** build the output-capture round-trip (redirect-to-file + read-back)
+— that stays a caller-composed pattern (`program.run` writing to a file,
+then `guest.file.read`), because baking it in would multiply the blast
+radius and the audited surface for the common "run this and tell me the
+exit code" case. `arguments` and `env` may carry secrets, so their values
+are redacted from every durable surface (see the safety model).
+
+**Why (b) is still deferred, not discarded.** After #3255, one capability
+branch (a) genuinely cannot serve remains:
+
+- **Guests without VMware Tools.** No Tools → no guest operations at all;
+  (b) — a `linux-ssh` typed connector — is the only channel there. If and
+  when a Tools-less guest is a concrete need, (b) is the follow-up. This
+  channel does **not** build it.
+
+(The other historically-cited gap — "running a command and capturing its
+output" — is now served by `guest.program.run` for exit code + status,
+and by the `program.run` → `guest.file.read` compose for stdout.)
 
 ## Safety model
 
@@ -99,32 +119,50 @@ load-bearing-ness:
    reviewer-surface suppression to hide it; here the secret is never in
    params to begin with.
 2. **Structured sub-ops, not freeform shell.** Each op is a discrete
-   typed verb with a JSON-schema parameter contract. There is no
-   `run(cmd)`. Freeform in-guest program execution is the explicitly
-   deferred tier.
-3. **The write is approval-gated.** `guest.file.write` is registered
-   `safety_level="dangerous"` + `requires_approval=True` and rides the
-   standard approvals plane: the dispatcher parks an
-   `ApprovalRequest` before the write executes, a human approves/rejects
-   via console/CLI (never MCP — v0.1-spec §7), and the park stores a
-   `proposed_effect` preview echoing **path + byte size + overwrite
-   intent only** (never the file content). The reads are
-   `safety_level="safe"` / no approval.
-4. **Full audit of command + result + truncated output.** Every op
+   typed verb with a JSON-schema parameter contract. `guest.program.run`
+   *does* run an arbitrary program, but through an explicit
+   `program_path` + `arguments` + `env` contract with the full
+   `dangerous` / `requires_approval` governance below around every call —
+   not an open `run(cmd)` shell endpoint.
+3. **The writes are approval-gated.** Both `guest.file.write` and
+   `guest.program.run` are registered `safety_level="dangerous"` +
+   `requires_approval=True` and ride the standard approvals plane: the
+   dispatcher parks an `ApprovalRequest` before the write executes, a
+   human approves/rejects via console/CLI (never MCP — v0.1-spec §7), and
+   the park stores a redaction-safe `proposed_effect` preview
+   (`guest.file.write`: path + byte size + overwrite intent, never the
+   content; `guest.program.run`: VM + program path + working directory +
+   wait flag + argument *byte size* + env-var *names*, never the argument
+   string or env values). The reads are `safety_level="safe"` / no
+   approval. Both writes gate *first* through the #2254
+   `enforce_subop_policy` seam: a parked / denied gate resolves no guest
+   credential and starts / writes nothing.
+4. **`arguments` / `env` are redaction-safe on every durable surface.**
+   A command line or an environment variable can carry a secret (a
+   password argument, an API token in an env var). For `guest.program.run`
+   these never reach the sub-op policy gate params, the audit row (the
+   dispatcher stores a `params_hash`, never the raw params, and the
+   handler's result echoes only PID / exit code / times — never
+   `arguments` / `env`), the approval preview (the bespoke builder echoes
+   only shape, above), or a log line. This mirrors `guest.file.write`
+   excluding `content`. Guest credentials themselves resolve from
+   `secret_ref` and are never a parameter (point 1).
+5. **Full audit of command + result + truncated output.** Every op
    dispatches through the synchronous append-only audit path
    (v0.1-spec §6). The audit row names the op, the VM, and the outcome;
    set-shaped and byte-shaped outputs are truncated (JSONFlux result
    handle for the process list; a byte cap on file reads) so the audit
    and the agent surface never carry an unbounded guest payload.
-5. **Read/write split is explicit.** The four reads never mutate guest
-   state; the single write is the only mutating op and is the only one
-   that parks.
+6. **Read/write split is explicit.** The four reads never mutate guest
+   state; the two writes (`guest.file.write`, `guest.program.run`) are the
+   only mutating ops and the only ones that park.
 
-## The op family (first increment)
+## The op family
 
-All five ops register under the existing `guest` operation group
-(`group_key="guest"`), alongside the GOSC customization writes, and
-carry `op_id`s under the `vmware.composite.vm.guest.*` namespace. Each
+All six ops register under the `guest_ops` operation group
+(`group_key="guest_ops"`) and carry `op_id`s under the
+`vmware.composite.vm.guest.*` namespace (distinct from the GOSC
+customization writes, which live in the sibling `guest` group). Each
 carries full `parameter_schema` + `response_schema` (JSON Schema
 2020-12), `tags`, `safety_level`, and `llm_instructions`.
 
@@ -135,6 +173,7 @@ carries full `parameter_schema` + `response_schema` (JSON Schema
 | `vmware.composite.vm.guest.net.show` | `PropertyCollector.RetrievePropertiesEx` on `guest.net` + `guest.ipStack` | **no** (Tools-reported) | safe | aggregate dict |
 | `vmware.composite.vm.guest.file.read` | `GuestFileManager.InitiateFileTransferFromGuest` + guest-transfer GET | yes | safe | truncated content + attrs |
 | `vmware.composite.vm.guest.file.write` | `GuestFileManager.InitiateFileTransferToGuest` + guest-transfer PUT | yes | **dangerous / approval** | write report |
+| `vmware.composite.vm.guest.program.run` | `GuestProcessManager.StartProgramInGuest` (+ `ListProcessesInGuest` poll when `wait=true`) | yes | **dangerous / approval** | pid (+ exit code / times) |
 
 Notes:
 
@@ -167,60 +206,118 @@ vim API supports **most cleanly through the seam**:
   It is a structured sub-op, not a shell command.
 - `guest.net.set_mtu` has **no** single vim guest-op method. Setting an
   MTU inside a guest means running `ip link set … mtu …` via
-  `StartProgramInGuest` — freeform program execution, the very tier this
-  increment defers, plus PID-polling and output-file gymnastics. It
-  belongs to the deferred freeform-exec tier, not the clean-write proof.
+  `StartProgramInGuest` — freeform program execution, which #3100 deferred.
+  With `guest.program.run` shipped (#3255), that MTU set is now expressible
+  (`program.run` with `program_path=/usr/sbin/ip`, `arguments="link set …
+  mtu …"`), but through the governed exec op, not a bespoke `set_mtu` verb.
 
-So consumer case 1's *MTU set* is served by the deferred tier; this
-increment proves the approval posture with the clean, symmetric
-`guest.file.write`.
+So #3100 proved the approval posture with the clean, symmetric
+`guest.file.write`, and #3255 lifted the freeform-exec tier as
+`guest.program.run`.
 
-## Consumer evidence (issue #3100)
+## The exit-code poll (`guest.program.run`, #3255)
 
-Two live cases in one program drove this, both observed falling back to
-out-of-band `govc guest.run` (see issue #3100 for the full context;
-lab-specific host/realm details are intentionally omitted from this
-public repo):
+`StartProgramInGuest` is fire-and-forget: it returns the started process's
+PID and nothing else — **no stdout is captured**. So:
 
-1. **Guest NIC MTU + connectivity diagnosis.** Setting a deployed
+- **`wait=false`** (default) returns immediately with `{status: "started",
+  pid, …}`. The caller polls `guest.process.list` itself if it cares.
+- **`wait=true`** polls `ListProcessesInGuest` (filtered to the PID) every
+  `_RUN_POLL_INTERVAL_SECONDS` (2s) until the exit code is available or
+  `timeout_seconds` (default 300) elapses, returning `{status, pid,
+  exit_code, start_time, end_time, …}`.
+
+The load-bearing vim quirk, verbatim from the pinned `vi-json.yaml`
+`StartProgramInGuest` description: *"When the process completes, its exit
+code and end time will be available for 5 minutes after completion. If
+VMware Tools is restarted, the exit code and end time will not be
+available."* So a completed process stays listable **with** its `exitCode`
+for ~5 minutes; the poll reliably catches it within that window (hence the
+300s default timeout matches the window). The poll handles the three
+terminal outcomes explicitly, and never hangs:
+
+- **`exited`** — the process reports an `exitCode` (an int, including `0`):
+  return it plus `startTime` / `endTime`.
+- **`timeout`** — `timeout_seconds` elapsed while the process is still
+  running (listable, no `exitCode`): return `exit_code: null`.
+- **`exit_unknown`** — the process is no longer listable before an exit
+  code was seen: it finished and its exit info aged out of the 5-minute
+  window, or VMware Tools restarted (or the PID was never observed). Return
+  `exit_code: null` rather than looping forever. This is the case the issue
+  called out — a finished process that is no longer listable is handled
+  explicitly, not by hanging.
+
+Capturing stdout is deliberately **not** built in: redirect the program's
+output to a file in `arguments`, then read it back with `guest.file.read`
+(the caller composes the two governed ops).
+
+## Consumer evidence
+
+Cases observed falling back to out-of-band `govc guest.run` (see the
+issues for full context; lab-specific host/realm details are intentionally
+omitted from this public repo):
+
+1. **Guest NIC MTU + connectivity diagnosis (#3100).** Setting a deployed
    appliance's guest NIC MTU (a fabric requirement) and reading
    `ip addr` / routes while diagnosing connectivity. `guest.net.show`
-   serves the read half now (Tools-reported, no creds); the MTU *set*
-   is the deferred freeform-exec tier.
-2. **First-boot service-state verification.** Verifying service state
-   inside a first-boot appliance (`systemctl is-system-running`,
+   serves the read half (Tools-reported, no creds); the MTU *set* is now
+   expressible via `guest.program.run` (#3255).
+2. **First-boot service-state verification (#3100).** Verifying service
+   state inside a first-boot appliance (`systemctl is-system-running`,
    listener checks) on a guest with no route back to MEHO.
-   `guest.process.list` + `guest.file.read` cover the state-inspection
-   half structurally; a `systemctl` *invocation* is again the deferred
-   freeform-exec tier.
-
-The point of the first increment is not to close both cases end-to-end —
-it is to land the governed channel, the credential-via-`secret_ref`
-model, the JSONFlux/audit discipline, and the approval-gated write, so
-the deferred freeform-exec tier has a proven substrate to extend.
+   `guest.process.list` + `guest.file.read` cover state inspection
+   structurally; a `systemctl` *invocation* is now `guest.program.run`.
+3. **In-guest Windows-estate bring-up (#3255).** The c1sql1 initiative
+   (`claude-rdc-hetzner-dc#2789`) brings up an AD DC + WSFC + SQL Server
+   FCI on Windows guests, where **every** step above the OS boundary
+   (AD DS promotion, cluster formation, clustered SQL install) rode
+   ungoverned `govc guest.run` as the documented-gap fallback. The lab's
+   standing signal `meho-signals/vmware-guest-ops-channel-missing.yaml`
+   tracks exactly this hole, and the automation windows-estate provider
+   pack (`meho-automation#169`) is gated on the governed
+   `vm.guest.program.run`. `guest.program.run` closes the governance gap:
+   policy, approval, synchronous audit, and broadcast around in-guest
+   execution.
 
 ## Verification basis
 
 No live guest is available in CI. Grounding is:
 
 - the pinned `vcenter-9.0/vi-json.yaml` on the spec shelf (the guest-op
-  method paths reconcile against it, same lane as the read composites);
+  method paths — including `StartProgramInGuest` — reconcile against it,
+  same lane as the read composites);
 - `respx`/stub unit tests with mocked `_post_vmomi_json` responses and a
   mocked guest-transfer endpoint, asserting the request bodies
-  (`vm` MoRef + `NamePasswordAuthentication`), the JSONFlux wrapping, the
-  approval park on the write, and that the guest credential never appears
-  in any params/audit/preview surface.
+  (`vm` MoRef + `NamePasswordAuthentication` + `GuestProgramSpec`), the
+  JSONFlux wrapping, the approval park + gate-first short-circuit on the
+  writes, the `guest.program.run` poll outcomes (`exited` / `timeout` /
+  `exit_unknown`), and that neither the guest credential **nor** the
+  `arguments` / `env` values ever appear in any result / audit / preview
+  surface.
 
-Live-appliance verification is deferred (tracked with the issue).
+Live-appliance verification is deferred (tracked with the issues). The
+c1sql1 consumer-proof step — one in-guest bring-up step (e.g.
+`Install-WindowsFeature`) executed via the governed op instead of
+`govc guest.run`, recorded on `vmware-guest-ops-channel-missing.yaml` —
+is **open** pending a lab redeploy carrying #3255 (it closes that lab
+signal when done).
 
 ## References
 
-- Issue: evoila/meho#3100.
+- Issues: evoila/meho#3100 (reads + `file.write`), evoila/meho#3255
+  (`program.run` — the freeform-exec tier lifted).
 - v0.1-spec §3 (operations), §4 (JSONFlux), §6 (audit), §7 (approval).
+- Handlers: `composites/_guest.py` (`guest_program_run_composite` +
+  `_poll_for_exit`); preview: `composites/_write_preview.py`
+  (`_guest_program_run_preview`); schemas: `composites/schemas.py`
+  (`GUEST_PROGRAM_RUN_*`).
 - Substrate: `connectors/vmware_rest/connector.py` (`_post_vmomi_json`),
   `composites/_write.py` (`_write_vmomi_sub_op`, the #2254 gate),
   `composites/_read.py` (`_read_sub_op`), `vim_body.py`.
 - Credential resolution: `connectors/_shared/vault_creds.py`
   (`load_basic_credentials`).
-- Deferred tier (b): a `linux-ssh` typed connector / a
-  `guest.program.run` freeform-exec op — not built here.
+- Redaction precedent: `guest.file.write` excludes `content` the same way
+  `guest.program.run` excludes `arguments` / `env`
+  (`operations/_preview.py`, `broadcast/events.py` `scrub_broadcast_params`).
+- Still-deferred tier (b): a `linux-ssh` typed connector for Tools-less
+  guests — not built here.

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -238,8 +238,12 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   params. The sub-manager MoRefs are resolved dynamically off the
   overridable `guestOperationsManager` default (no verified literal is
   hard-coded). `guest.program.run`'s `arguments` / `env` values may carry
-  secrets and are redacted from result / audit / preview like
-  `guest.file.write`'s `content`. The design fork (vim guest-ops over a
+  secrets and are kept off the governed surfaces (result / audit-hash /
+  preview / gate) and clamped to aggregate-only on broadcast via the
+  `_CREDENTIAL_WRITE_OPS` pin; the resume-bound `ApprovalRequest.params` and
+  flight-recorder spans still carry them (same characteristic as
+  `guest.file.write`'s `content`), so operators must not pass bare secrets
+  there. The design fork (vim guest-ops over a
   still-deferred generic-ssh tier for Tools-less guests) and the full
   safety model live in `connectors-vmware-rest-guest-ops.md`; the freeform
   in-guest program-exec tier `StartProgramInGuest` #3100 deferred is now

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -12,7 +12,7 @@ vSphere 8.5+ / ESXi 8.5+ targets, plus 32 hand-authored composites
 that orchestrate cross-spec workflows: 9 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`; plus the four guest-operations reads `#3100`) and 26 write
+in `#2258`; plus the four guest-operations reads `#3100`) and 28 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
@@ -25,8 +25,10 @@ OVF/OVA content-library deploy `vm.deploy_from_library` / `#2909`, and
 the three host-domain writes `host.datastore_mount_nfs` /
 `host.disk_mark_flash` / `host.service_control` / `#3182`, the two vim
 distributed-portgroup writes `network.portgroup.create` +
-`network.portgroup.security.set` / `#3091`, plus the
-governed guest-operations write `vm.guest.file.write` / `#3100` (see
+`network.portgroup.security.set` / `#3091`, the content-library import
+`vm.import_from_library` / `#3229`, plus the two governed
+guest-operations writes `vm.guest.file.write` / `#3100` +
+`vm.guest.program.run` / `#3255` (see
 `connectors-vmware-rest-guest-ops.md`)). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
@@ -226,20 +228,25 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `guest_net_show_composite` (Tools-reported `guest.net` / `guest.ipStack`
   via `RetrievePropertiesEx`, needs no guest credential), and
   `guest_file_read_composite` (`InitiateFileTransferFromGuest`, returns the
-  transfer handle) — plus one `dangerous` / approval-gated write,
+  transfer handle) — plus two `dangerous` / approval-gated writes,
   `guest_file_write_composite` (`InitiateFileTransferToGuest` + a direct
-  PUT of the bytes). **Guest OS credentials resolve from the target's
+  PUT of the bytes) and `guest_program_run_composite`
+  (`StartProgramInGuest`, with a `ListProcessesInGuest` exit-code poll when
+  `wait=true`; #3255). **Guest OS credentials resolve from the target's
   Vault `secret_ref` (`guest_username` / `guest_password`) and never
   travel in params** — a stronger posture than GOSC's credential-class
   params. The sub-manager MoRefs are resolved dynamically off the
   overridable `guestOperationsManager` default (no verified literal is
-  hard-coded). The design fork (vim guest-ops over a deferred generic-ssh
-  tier) and the full safety model live in
-  `connectors-vmware-rest-guest-ops.md`; freeform in-guest program exec
-  (`StartProgramInGuest`) is a deliberately deferred tier.
+  hard-coded). `guest.program.run`'s `arguments` / `env` values may carry
+  secrets and are redacted from result / audit / preview like
+  `guest.file.write`'s `content`. The design fork (vim guest-ops over a
+  still-deferred generic-ssh tier for Tools-less guests) and the full
+  safety model live in `connectors-vmware-rest-guest-ops.md`; the freeform
+  in-guest program-exec tier `StartProgramInGuest` #3100 deferred is now
+  lifted as `guest.program.run` (#3255).
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 33
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 37
   `_CompositeSpec` rows (9 read + 24 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
@@ -467,7 +474,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 33 composites (9 reads + 24 writes) land as `source_kind="composite"`
+The 37 composites (9 reads + 28 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -534,7 +541,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 33 composites are hand-authored aggregators the connector ships as
+The 37 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the


### PR DESCRIPTION
## Summary

- Ships `vmware.composite.vm.guest.program.run` — the freeform in-guest program-execution op the guest-operations channel (#3100) deliberately deferred. Runs a program inside a VM's guest OS via the vim `GuestProcessManager.StartProgramInGuest` over the existing VI-JSON seam (no `pyvmomi`, no SSH) — the governed replacement for out-of-band `govc guest.run`.
- **Exit-code semantics.** `StartProgramInGuest` is fire-and-forget (returns only a PID, no stdout capture). With `wait=true` the op polls `ListProcessesInGuest` (filtered to the PID, every 2s up to `timeout_seconds`, default 300s) for the exit code + start/end times. VMware Tools keeps a finished process's exit code listable for only ~5 minutes after completion (verbatim from the pinned `vi-json.yaml`), so a process no longer listable before an exit code is seen returns `status='exit_unknown'` rather than hanging (alongside `started` / `exited` / `timeout`).
- **Governance** mirrors `guest.file.write`: `safety_level="dangerous"`, `requires_approval=True`, gates *first* through the #2254 `enforce_subop_policy` seam (a parked/denied approval resolves no guest credential and starts no program). Guest creds resolve from the target's Vault `secret_ref`, never in params.
- **Secret hygiene.** `arguments`/`env` values may carry secrets, so they are kept off the governed decision surfaces — the park preview echoes only program identity + argument byte size + env-var names, the result echoes only PID/exit code/times, the sub-op gate never sees them, and the audit row stores a params hash. The op is **pinned in `_CREDENTIAL_WRITE_OPS`** so its broadcast clamps to aggregate-only (the exact remedy `k8s.job.create` and the GOSC create use). The resume-bound `ApprovalRequest.params` row and flight-recorder vendor spans still carry the values (same characteristic as `guest.file.write`'s `content`), so operators must not pass bare secrets in `arguments`/`env` — the docs give the env-name + guest-side staging pattern.
- Rewrites the "design fork" section of `docs/codebase/connectors-vmware-rest-guest-ops.md` (the deferral is lifted deliberately, with the c1sql1 consumer case named). Composite-only: **no product-enum change, no CLI snapshot regen, no migration** (diff leaves `cli/` untouched).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (composites + broadcast/events) — clean
- [x] code-quality gate (`--diff`) — 0 blockers (7 pre-existing file/function-size warnings on files this PR touches)
- [x] `pytest tests/test_connectors_vmware_rest_guest_ops.py` — 23 passed (wait=false PID-only; wait=true exit code incl. 0 and non-zero; process-no-longer-listed → `exit_unknown`; timeout; gate-first short-circuit; **arguments/env redaction** from result + gate params; empty-arguments default; no-PID raises)
- [x] `pytest tests/test_broadcast_events.py` — the `credential_write` allowlist pin now covers `vmware.composite.vm.guest.program.run` (broadcast clamps to aggregate-only)
- [x] `pytest` register / write-register / write-preview / write-gate lanes — counts updated **36→37 total, 24→25 preview builders**; reconcile pin adds `StartProgramInGuest`
- [x] full affected set (incl. broadcast) — 208 passed, 1 skipped (shelf reconcile skips in sandbox)
- **AC — `wait=true` returns a real exit code**: `test_program_run_wait_returns_exit_code` (poll loop, documented 5-min-window semantics)
- **AC — audit redaction of arguments/env verified by test**: `test_program_run_redacts_arguments_and_env` + `test_guest_program_run_preview_echoes_shape_never_secret_values` + `test_broadcast_events.py::test_credential_write_allowlist`
- **AC — guest-ops doc updated (design-fork rewritten); CLI verb present**: doc rewritten; the op is reachable via the same `call_operation` CLI verb / MCP meta-tool as every other op (no per-op verb by design — postulate 5), so no `cli/` change.

## Out of scope / open

- **Consumer proof (c1sql1 in-guest step via the governed op)** is **OPEN** — not satisfiable in CI; needs a lab redeploy carrying this op. When done it also closes the lab signal `meho-signals/vmware-guest-ops-channel-missing.yaml`. `automation#169` (windows-estate provider pack) is gated on this op.
- `guest.file.write` being unpinned in `_CREDENTIAL_WRITE_OPS` is **pre-existing** (its `content` has the same characteristic) — left for the estate-wide broadcast-hygiene follow-up, not drive-by'd here.
- stdout capture is deliberately not built in (compose `program.run` → `guest.file.read`); a `linux-ssh` tier for Tools-less guests remains the only still-deferred branch.
- Pre-existing large-file warnings in `_register.py` / `_write_preview.py` / `schemas.py` (adjacent findings, untouched debt).

<!-- auto-implement-issue: fresh, finalized -->

Closes #3255
