### PR TITLE
fix(approvals): refuse self-approval on the dangerous tier under break-glass (#3290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — self-approval break-glass no longer permits dangerous-tier deletes (#3290 / #3198)
+
+- The unconditional self-approval refusal (#3198 — "no self-approval, even
+  under break-glass") was scoped to `safety_level == "destructive"` only, so a
+  delete-class op registered on the reversible **`dangerous`** tier (e.g. a KV
+  secret-version soft-delete) fell through to the break-glass allow-path: with
+  `APPROVAL_ALLOW_SELF_APPROVAL=true` a single operator could park *and*
+  approve their own governed delete. `_check_self_approval` now refuses
+  self-approval unconditionally for `safety_level in {"dangerous",
+  "destructive"}`; the `caution` / `safe` tiers still honour break-glass. The
+  user-`sub` keying is unchanged (a different operator, or a different client
+  carrying the same user, is unaffected — only genuine self-approval is
+  refused).
+- `POST /api/v1/approvals/{id}/decide` now returns `decided_by` (the effective
+  authenticated reviewer's `sub`) so a CLI / console can show *who* decided
+  without a second lookup. Additive and optional — existing clients are
+  unaffected.
+
 ### Changed — `bind9.record.remove` promoted to the governed destructive tier (#3247)
 
 - **Behaviour change for agents — approval now required.** `bind9.record.remove`

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line approvals REST
+# surface; #3290 adds one optional response field, not a split.
 
 """``/api/v1/approvals/*`` — approval queue REST surface.
 
@@ -765,6 +767,11 @@ class DecideResponseBody(BaseModel):
     first (the run-bound waiter-alive case) — a benign "executed elsewhere"
     that keeps the approver from double-dispatching. They stay ``None``
     only on a rejection.
+
+    ``decided_by`` names the effective authenticated user (the reviewer's
+    stable ``sub``) whose credential made this decision, so a CLI / console
+    can show *who* decided without a second lookup (#3290). Additive and
+    optional — a client that ignores it is unaffected.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -772,6 +779,7 @@ class DecideResponseBody(BaseModel):
     approval_request_id: uuid.UUID
     decision: str
     reason: str
+    decided_by: str | None = None
     dispatch_status: str | None = None
     dispatch_op_id: str | None = None
     dispatch_result: dict[str, Any] | list[Any] | None = None
@@ -852,6 +860,7 @@ async def decide_approval_request(
             approval_request_id=request_id,
             decision=decision,
             reason=body.reason,
+            decided_by=operator.sub,
             dispatch_status=dispatch_result.status,
             dispatch_op_id=dispatch_result.op_id,
             dispatch_result=dispatch_result.result,
@@ -862,4 +871,5 @@ async def decide_approval_request(
         approval_request_id=request_id,
         decision=decision,
         reason=body.reason,
+        decided_by=operator.sub,
     )

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line durable approval
+# queue module; #3290 is a surgical guard fix, not a split.
 
 """Durable approval queue for ``requires_approval`` dispatches.
 
@@ -1334,6 +1336,15 @@ def _check_reviewer_role(operator: Operator) -> None:
         )
 
 
+#: Safety tiers whose self-approval refusal is *unconditional* — the
+#: ``APPROVAL_ALLOW_SELF_APPROVAL`` break-glass switch never re-enables
+#: self-approval for them. ``destructive`` (#3198) plus ``dangerous``
+#: (#3290): a delete-class op can register on the reversible ``dangerous``
+#: tier while still being the four-eyes-critical action #3198 protects.
+#: Break-glass still applies to ``caution`` / ``safe``.
+_NO_SELF_APPROVAL_TIERS = frozenset({"dangerous", "destructive"})
+
+
 def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
     """Raise :class:`SelfApprovalForbiddenError` on a self-approval.
 
@@ -1344,14 +1355,21 @@ def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
     comparison is on the stable ``sub`` claim, so a renamed display name
     cannot launder a self-approval.
 
-    **The destructive tier does not honour break-glass (#3198).** For a
-    ``safety_level="destructive"`` request self-approval is refused
-    *unconditionally* — even under ``APPROVAL_ALLOW_SELF_APPROVAL`` — so a
-    governed delete is genuine four-eyes on every deployment (decision
+    **The dangerous and destructive tiers do not honour break-glass
+    (#3198, #3290).** For a ``safety_level`` of ``"dangerous"`` or
+    ``"destructive"`` self-approval is refused *unconditionally* — even
+    under ``APPROVAL_ALLOW_SELF_APPROVAL`` — so a governed delete is
+    genuine four-eyes on every deployment (decision
     ``governed-delete-operations.md`` requirement 1: "no self-approval, even
     under break-glass"; a single-operator tenant uses the agent-requester
-    pattern, never self-approval). The tier is read off the durable
-    ``proposed_effect`` envelope the dispatcher stamped at park time.
+    pattern, never self-approval). #3198 scoped this to ``destructive``
+    only, but a delete-class op can legitimately register on the
+    ``dangerous`` tier (a reversible soft-delete — e.g. a KV
+    secret-version delete) while still being exactly the four-eyes-critical
+    action #3198 protects; #3290 widened the refusal to cover it. Break-glass
+    still applies to the ``caution`` / ``safe`` tiers. The tier is read off
+    the durable ``proposed_effect`` envelope the dispatcher stamped at park
+    time.
 
     Imported lazily to keep the queue module decoupled from settings at
     import time (mirrors the local ``TenantRole`` import in
@@ -1361,11 +1379,11 @@ def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
         return
 
     effect = request.proposed_effect or {}
-    is_destructive = effect.get("safety_level") == "destructive"
+    no_break_glass_tier = effect.get("safety_level") in _NO_SELF_APPROVAL_TIERS
 
     from meho_backplane.settings import get_settings
 
-    if not is_destructive and get_settings().approval_allow_self_approval:
+    if not no_break_glass_tier and get_settings().approval_allow_self_approval:
         _log.warning(
             "approval_self_approval_break_glass",
             approval_request_id=str(request.id),

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -1213,6 +1213,130 @@ async def test_self_reject_is_always_allowed(session: AsyncSession) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Break-glass tier scoping (#3198 destructive, #3290 dangerous)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tier", ["dangerous", "destructive"])
+async def test_self_approval_refused_on_no_break_glass_tier_even_with_break_glass(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch, tier: str
+) -> None:
+    """``dangerous`` + ``destructive`` self-approval is refused even under break-glass.
+
+    #3198 made the ``destructive`` tier ignore ``APPROVAL_ALLOW_SELF_APPROVAL``
+    so a governed delete is genuine four-eyes on every deployment; #3290
+    extends that to ``dangerous`` because a delete-class op can legitimately
+    register on the reversible ``dangerous`` tier (e.g. a KV secret-version
+    soft-delete) while still being the four-eyes-critical action #3198
+    protects. The tier is read off the durable ``proposed_effect`` envelope
+    the dispatcher stamps at park time. The self-approval guard fires before
+    the destructive preview-binding check, so no ``preview_hash`` is needed
+    to reach it for the ``destructive`` case.
+    """
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+
+    requester = _make_operator(sub="solo-operator", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.delete",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+        proposed_effect={"op_id": "vault.kv.delete", "safety_level": tier},
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s2, pending.id, operator=requester, params=params)
+
+    # A refused self-approval is not a decision — the row stays pending.
+    async with get_sessionmaker()() as s3:
+        row = await s3.get(ApprovalRequest, pending.id)
+        assert row is not None
+        assert row.status == ApprovalRequestStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tier", ["caution", "safe"])
+async def test_self_approval_still_honours_break_glass_for_low_tiers(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch, tier: str
+) -> None:
+    """``caution`` / ``safe`` self-approval still succeeds under break-glass.
+
+    #3290 widened the unconditional refusal to ``dangerous`` + ``destructive``
+    only; the audited single-operator break-glass mode
+    (``APPROVAL_ALLOW_SELF_APPROVAL=true``) is unchanged for the lower tiers.
+    """
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+
+    requester = _make_operator(sub="solo-operator", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.put",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+        proposed_effect={"op_id": "vault.kv.put", "safety_level": tier},
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        row = await approve_request(s2, pending.id, operator=requester, params=params)
+        await s2.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+    assert row.reviewed_by == requester.sub
+
+
+@pytest.mark.asyncio
+async def test_different_sub_approval_on_dangerous_tier_passes(
+    session: AsyncSession,
+) -> None:
+    """A *different* operator approving a ``dangerous`` request is genuine four-eyes.
+
+    The guard keys on the stable ``sub`` claim: a distinct reviewer clears
+    the self-approval check and the approval proceeds normally — the #3290
+    widening only refuses *self*-approval, never a real second operator.
+    Break-glass is irrelevant here (default off).
+    """
+    requester = _make_operator(sub="requester-sub", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.delete",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+        proposed_effect={"op_id": "vault.kv.delete", "safety_level": "dangerous"},
+    )
+    await session.commit()
+
+    approver = _make_operator(sub="approver-sub", role=TenantRole.OPERATOR)
+    async with get_sessionmaker()() as s2:
+        row = await approve_request(s2, pending.id, operator=approver, params=params)
+        await s2.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+    assert row.reviewed_by == approver.sub
+
+
+# ---------------------------------------------------------------------------
 # expire_stale_requests
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_secret_move_approval.py
+++ b/backend/tests/test_secret_move_approval.py
@@ -541,6 +541,9 @@ async def test_decide_redispatch_executes_move_once(
 
     assert first.status_code == 200, first.text
     assert first.json()["dispatch_status"] == "ok"
+    # The decide response names the effective authenticated reviewer (#3290),
+    # so a CLI / console can show who decided without a second lookup.
+    assert first.json()["decided_by"] == "operator:decider"
     # The move executed exactly once on approval.
     assert len(fake.secrets.kv.v2.put_calls) == 1
     assert fake.secrets.kv.v2.put_calls[0]["secret"] == {"password": _SECRET_VALUE}

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -26308,6 +26308,11 @@
             "type": "string",
             "title": "Reason"
           },
+          "decided_by": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decided By"
+          },
           "dispatch_status": {
             "type": "string",
             "nullable": true,
@@ -26345,7 +26350,7 @@
           "reason"
         ],
         "title": "DecideResponseBody",
-        "description": "Response for a successful operator decision.\n\nThe ``dispatch_*`` fields are populated whenever ``/decide`` attempted\nthe approved op's re-dispatch \u2014 for **every** approved request now, not\nonly direct operator ops (#2293). ``dispatch_status`` is ``\"ok\"`` when\n``/decide`` won the exactly-one-resumer claim and executed (the direct\nop, or the run-bound fallback when the in-process waiter was gone), or\n``\"already_resumed\"`` when the in-process agent waiter won the claim\nfirst (the run-bound waiter-alive case) \u2014 a benign \"executed elsewhere\"\nthat keeps the approver from double-dispatching. They stay ``None``\nonly on a rejection."
+        "description": "Response for a successful operator decision.\n\nThe ``dispatch_*`` fields are populated whenever ``/decide`` attempted\nthe approved op's re-dispatch \u2014 for **every** approved request now, not\nonly direct operator ops (#2293). ``dispatch_status`` is ``\"ok\"`` when\n``/decide`` won the exactly-one-resumer claim and executed (the direct\nop, or the run-bound fallback when the in-process waiter was gone), or\n``\"already_resumed\"`` when the in-process agent waiter won the claim\nfirst (the run-bound waiter-alive case) \u2014 a benign \"executed elsewhere\"\nthat keeps the approver from double-dispatching. They stay ``None``\nonly on a rejection.\n\n``decided_by`` names the effective authenticated user (the reviewer's\nstable ``sub``) whose credential made this decision, so a CLI / console\ncan show *who* decided without a second lookup (#3290). Additive and\noptional \u2014 a client that ignores it is unaffected."
       },
       "DeclareCapabilitiesRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3947,8 +3947,14 @@ type DecideRequestBody struct {
 // first (the run-bound waiter-alive case) — a benign "executed elsewhere"
 // that keeps the approver from double-dispatching. They stay “None“
 // only on a rejection.
+//
+// “decided_by“ names the effective authenticated user (the reviewer's
+// stable “sub“) whose credential made this decision, so a CLI / console
+// can show *who* decided without a second lookup (#3290). Additive and
+// optional — a client that ignores it is unaffected.
 type DecideResponseBody struct {
 	ApprovalRequestId openapi_types.UUID                 `json:"approval_request_id"`
+	DecidedBy         *string                            `json:"decided_by"`
 	Decision          string                             `json:"decision"`
 	DispatchError     *string                            `json:"dispatch_error"`
 	DispatchOpId      *string                            `json:"dispatch_op_id"`

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -716,10 +716,15 @@ enforcement that #3196/#3197 left, plus one machinery limitation:
   (`consult_and_record_grant` already refuses the tier).
 - **The self-approval break-glass hole.** `_check_self_approval`
   (`operations/approval_queue.py`) honoured `APPROVAL_ALLOW_SELF_APPROVAL`
-  for every tier. It now refuses self-approval of a `destructive` row
-  *unconditionally* — the break-glass switch does not reach this tier
-  (decision requirement 1). A single-operator tenant uses the
-  agent-requester pattern, never self-approval.
+  for every tier. It now refuses self-approval of a `dangerous` **or**
+  `destructive` row *unconditionally* (`_NO_SELF_APPROVAL_TIERS`) — the
+  break-glass switch does not reach either tier (decision requirement 1).
+  #3198 scoped this to `destructive` only, but a delete-class op can
+  legitimately register on the reversible `dangerous` tier (e.g. a KV
+  secret-version soft-delete) while still being the four-eyes-critical
+  action the requirement protects, so #3290 widened the refusal to cover
+  it; `caution` / `safe` still honour break-glass. A single-operator
+  tenant uses the agent-requester pattern, never self-approval.
 - **Registration fail-fast.** `_register_in_session` (`operations/typed_register.py`)
   now rejects a `destructive` descriptor declared `requires_approval=False`
   at registration time — an inconsistent row can't exist. Belt-and-suspenders


### PR DESCRIPTION
## What & why

On a deployment with `APPROVAL_ALLOW_SELF_APPROVAL=true`, a single operator could park an approval-gated delete and then approve it themselves, and the op executed — contradicting the #3198 requirement "no self-approval, even under break-glass" for governed deletes.

Root cause: the unconditional-refusal branch in `_check_self_approval` (`operations/approval_queue.py`) was scoped to `safety_level == "destructive"`. A delete op registered on the reversible **`dangerous`** tier (e.g. a KV secret-version soft-delete) is not `destructive`, so it fell through to the break-glass allow-path.

## Changes

- **Guard fix** — `_check_self_approval` now refuses self-approval *unconditionally* for `safety_level in {"dangerous", "destructive"}` (new `_NO_SELF_APPROVAL_TIERS` frozenset). The stable user-`sub` keying is untouched — a different operator, or a different client carrying the same user, is unaffected; only genuine self-approval is refused. `caution` / `safe` still honour break-glass (#3198 requirement 1).
- **Decide response** — `POST /api/v1/approvals/{id}/decide` now returns an optional `decided_by` (the effective authenticated reviewer's `sub`) so a CLI / console can show *who* decided without a second lookup. Additive, non-breaking.
- **Generated artifacts** — `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated for the CI snapshot drift gate (`DecidedBy *string`).
- **Docs** — `docs/codebase/approvals.md` self-approval bullet updated to the widened scope.

## Tests

- `dangerous` + `destructive` self-approval refused even under `APPROVAL_ALLOW_SELF_APPROVAL=true` (parametrized).
- `caution` / `safe` self-approval still succeeds under break-glass (parametrized) — unchanged.
- A different-`sub` approval on a `dangerous` row passes (genuine four-eyes).
- The `/decide` happy-path test asserts `decided_by` names the reviewer.

## Verification (local)

- `uv run ruff check` / `ruff format --check` — clean.
- `uv run mypy src/` — clean on touched files (only a pre-existing macOS-only `MSG_ERRQUEUE` false positive in `connectors/net/icmp.py`, which resolves on Linux CI).
- `uv run pytest` on `test_approval_queue.py`, `test_secret_move_approval.py`, `test_api_v1_approvals.py`, plus the destructive-delete connector suites + `test_ui_approvals.py` / `test_features.py` — 287 passed.
- `cd cli && go build ./... && go test ./internal/cmd/approvals/... ./internal/api/...` — pass; snapshot/client regen produces a clean drift-gate diff.

Closes #3290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
