### PR TITLE
feat(cli): operation preview verb + --preview-hash threading (#3293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,27 @@ connector-related release-notes line.
   replays the shared-disk build through the governed ops.
 - [#3256](https://github.com/evoila/meho/issues/3256).
 
+### Added — cli: `operation preview` verb + `--preview-hash` threading (#3293)
+
+- **`meho operation preview <connector_id> <op_id>`** — the CLI twin of
+  the MCP `preview_operation` tool, wrapping `POST /api/v1/operations/preview`
+  (the read-only sibling of `/call` added by #3197). It resolves the same
+  op + target + params a real call would and returns the literal would-be
+  request (`method` / `resolved_path` / `query` / redacted `body`) plus the
+  **`preview_hash`** — printed prominently in both the human render and
+  `--json` — instead of dispatching. Flags mirror `operation call`
+  (`--target`, `--params '<json>'`/`@<file>`, `--json`, `--backplane`);
+  operator-input faults ride the envelope (`status="error"`/`"unavailable"`,
+  exit 1), not transport.
+- **`meho operation call --preview-hash <hash>`** — threads the binding a
+  `safety_level='destructive'` op requires (#3197) into
+  `CallOperationBody.preview_hash`. Before this, destructive-tier ops were
+  **un-drivable from the CLI**: the dispatcher fail-closed with
+  `status=denied` / `error_code=preview_binding_required` and the CLI had no
+  way to obtain or pass the hash (MCP-only). An unset flag leaves a bare
+  call byte-identical to the pre-#3197 wire shape. Restores CLI/MCP parity
+  for the whole destructive tier.
+
 ### Added — Keycloak provisioning recipe for the `approver` claim (#3283)
 
 - **`docs/cross-repo/keycloak-tenant-claims.md`** gains a group-based

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -50,6 +50,7 @@ type CallResult struct {
 //	meho operation call <connector_id> <op_id> \
 //	  [--target <slug>]                        # target name (required for ops that read a target)
 //	  [--params '<json>' | @<file>]            # operation params (object)
+//	  [--preview-hash <hash>]                  # destructive-tier binding from `operation preview` (#3197)
 //	  [--json]                                 # machine-readable output
 //	  [--backplane <url>]                      # override the backplane URL
 //
@@ -65,6 +66,7 @@ func newCallCmd() *cobra.Command {
 	var (
 		targetName        string
 		paramsFlag        string
+		previewHash       string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -87,7 +89,13 @@ func newCallCmd() *cobra.Command {
 			"or a file reference (`--params @./params.json`). The empty case " +
 			"(`--params` omitted) sends no params key on the wire — typed " +
 			"handlers that don't read params see an empty mapping at the " +
-			"validation layer.",
+			"validation layer.\n\n" +
+			"--preview-hash carries the binding a `safety_level='destructive'` " +
+			"op requires (#3197): obtain it from `meho operation preview` of the " +
+			"IDENTICAL (connector_id, op_id, target, params), then pass it here. " +
+			"The dispatcher fail-closes with status=denied / " +
+			"error_code=preview_binding_required when a destructive op is called " +
+			"without a matching hash; it is ignored for every non-destructive op.",
 		Args:          cobra.ExactArgs(2),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -97,6 +105,7 @@ func newCallCmd() *cobra.Command {
 				OpID:              args[1],
 				TargetName:        targetName,
 				ParamsFlag:        paramsFlag,
+				PreviewHash:       previewHash,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -106,6 +115,8 @@ func newCallCmd() *cobra.Command {
 		"target slug to dispatch against (required for ops that read a target)")
 	cmd.Flags().StringVar(&paramsFlag, "params", "",
 		"operation params as inline JSON or @<file>; omitted means no params")
+	cmd.Flags().StringVar(&previewHash, "preview-hash", "",
+		"preview_hash from a prior `meho operation preview` — required for a destructive-tier op (#3197)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit the full OperationResult envelope as JSON instead of the human render")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -118,6 +129,7 @@ type callOptions struct {
 	OpID              string
 	TargetName        string
 	ParamsFlag        string
+	PreviewHash       string
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -231,6 +243,13 @@ func postCall(
 	if params != nil {
 		p := params
 		body.Params = &p
+	}
+	// Thread the destructive-tier preview binding (#3197). Left nil when
+	// --preview-hash is unset so a bare call stays byte-identical to the
+	// pre-#3197 wire shape; the field is ignored for non-destructive ops.
+	if opts.PreviewHash != "" {
+		h := opts.PreviewHash
+		body.PreviewHash = &h
 	}
 	apiParams := &api.PostCallApiV1OperationsCallPostParams{}
 	resp, err := client.PostCallApiV1OperationsCallPostWithResponse(ctx, apiParams, body)

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -34,6 +34,8 @@ type fakeOperationsClient struct {
 	// raw-string URL concatenation).
 	lastCallParams        *api.PostCallApiV1OperationsCallPostParams
 	lastCallBody          *api.CallOperationBody
+	lastPreviewParams     *api.PostPreviewApiV1OperationsPreviewPostParams
+	lastPreviewBody       *api.PreviewOperationBody
 	lastGroupsParams      *api.GetGroupsApiV1OperationsGroupsGetParams
 	lastSearchParams      *api.GetSearchApiV1OperationsSearchGetParams
 	lastResultQueryParams *api.PostResultQueryApiV1OperationsResultQueryPostParams
@@ -44,6 +46,7 @@ type fakeOperationsClient struct {
 	// 401, then the post-refresh outcome) and one on every other
 	// path.
 	callResponses        []*api.PostCallApiV1OperationsCallPostResponse
+	previewResponses     []*api.PostPreviewApiV1OperationsPreviewPostResponse
 	groupsResponses      []*api.GetGroupsApiV1OperationsGroupsGetResponse
 	searchResponses      []*api.GetSearchApiV1OperationsSearchGetResponse
 	resultQueryResponses []*api.PostResultQueryApiV1OperationsResultQueryPostResponse
@@ -52,6 +55,7 @@ type fakeOperationsClient struct {
 	// the response queues so a refresh-then-transport-failure scenario
 	// can be authored.
 	callErrors        []error
+	previewErrors     []error
 	groupsErrors      []error
 	searchErrors      []error
 	resultQueryErrors []error
@@ -75,6 +79,18 @@ func (f *fakeOperationsClient) PostCallApiV1OperationsCallPostWithResponse(
 	bodyCopy := body
 	f.lastCallBody = &bodyCopy
 	return popCallResp(&f.callResponses), popErr(&f.callErrors)
+}
+
+func (f *fakeOperationsClient) PostPreviewApiV1OperationsPreviewPostWithResponse(
+	_ context.Context,
+	params *api.PostPreviewApiV1OperationsPreviewPostParams,
+	body api.PostPreviewApiV1OperationsPreviewPostJSONRequestBody,
+	_ ...api.RequestEditorFn,
+) (*api.PostPreviewApiV1OperationsPreviewPostResponse, error) {
+	f.lastPreviewParams = params
+	bodyCopy := body
+	f.lastPreviewBody = &bodyCopy
+	return popPreviewResp(&f.previewResponses), popErr(&f.previewErrors)
 }
 
 func (f *fakeOperationsClient) GetGroupsApiV1OperationsGroupsGetWithResponse(
@@ -124,6 +140,17 @@ func popResultQueryResp(
 }
 
 func popCallResp(q *[]*api.PostCallApiV1OperationsCallPostResponse) *api.PostCallApiV1OperationsCallPostResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popPreviewResp(
+	q *[]*api.PostPreviewApiV1OperationsPreviewPostResponse,
+) *api.PostPreviewApiV1OperationsPreviewPostResponse {
 	if len(*q) == 0 {
 		return nil
 	}
@@ -873,5 +900,252 @@ func TestRunResultQueryHappyPathRendersWindow(t *testing.T) {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("result-query render missing %q in output:\n%s", want, out.String())
 		}
+	}
+}
+
+// ---- postPreview ----
+
+// okPreviewBody is the canned status=ok preview envelope the postPreview
+// / runPreview tests decode. It carries the load-bearing preview_hash
+// plus the resolved-request projection.
+func okPreviewBody(t *testing.T) []byte {
+	t.Helper()
+	pr, err := json.Marshal(PreviewResult{
+		Status:       "ok",
+		OpID:         "vmware.composite.vm.destroy",
+		ConnectorID:  "vmware-rest-9.0",
+		SourceKind:   "composite",
+		Method:       "COMPOSITE",
+		ResolvedPath: "vmware.composite.vm.destroy",
+		RedactedBody: json.RawMessage(`{"vm":"vm-1812"}`),
+		PreviewHash:  "abc123def456",
+	})
+	if err != nil {
+		t.Fatalf("marshal preview body: %v", err)
+	}
+	return pr
+}
+
+// TestPostPreviewThreadsTargetAndParams — --target lands on the
+// bare-string oneOf shape and non-nil params thread onto body.Params,
+// mirroring postCall's plumbing.
+func TestPostPreviewThreadsTargetAndParams(t *testing.T) {
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: okPreviewBody(t)},
+		},
+	}
+	opts := previewOptions{
+		ConnectorID: "vmware-rest-9.0",
+		OpID:        "vmware.composite.vm.destroy",
+		TargetName:  "rdc-vcenter",
+	}
+	params := map[string]any{"vm": "vm-1812"}
+	if _, err := postPreview(context.Background(), f, opts, params); err != nil {
+		t.Fatalf("postPreview: %v", err)
+	}
+	if f.lastPreviewBody.Target == nil {
+		t.Fatalf("--target should set body.Target; got nil")
+	}
+	gotTarget, err := f.lastPreviewBody.Target.AsPreviewOperationBodyTarget0()
+	if err != nil {
+		t.Fatalf("target not the bare-string shape: %v", err)
+	}
+	if gotTarget != "rdc-vcenter" {
+		t.Fatalf("target not threaded; got %q", gotTarget)
+	}
+	if f.lastPreviewBody.Params == nil || (*f.lastPreviewBody.Params)["vm"] != "vm-1812" {
+		t.Fatalf("params not threaded; got %+v", f.lastPreviewBody.Params)
+	}
+}
+
+// TestPostPreviewTargetOmittedNullOnWire — omitting --target leaves
+// body.Target nil so the wire emits `"target":null`, same contract as
+// postCall.
+func TestPostPreviewTargetOmittedNullOnWire(t *testing.T) {
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: okPreviewBody(t)},
+		},
+	}
+	opts := previewOptions{ConnectorID: "k8s-1.x", OpID: "k8s.about"}
+	if _, err := postPreview(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postPreview: %v", err)
+	}
+	if f.lastPreviewBody.Target != nil {
+		t.Fatalf("omitted --target should leave body.Target=nil; got %+v", f.lastPreviewBody.Target)
+	}
+	raw, err := json.Marshal(f.lastPreviewBody)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"target":null`)) {
+		t.Fatalf("expected `\"target\":null` on the wire; got %s", string(raw))
+	}
+}
+
+// TestPostPreviewRefreshOn401 — the one-shot refresh dance fires exactly
+// once on a 401, then the retried call decodes cleanly.
+func TestPostPreviewRefreshOn401(t *testing.T) {
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: okPreviewBody(t)},
+		},
+	}
+	opts := previewOptions{ConnectorID: "vmware-rest-9.0", OpID: "vmware.composite.vm.destroy", TargetName: "rdc-vcenter"}
+	if _, err := postPreview(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postPreview after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestPostPreviewNon2xxClassifiesAsApiResponseError — a 500 wraps as
+// *apiResponseError so renderRequestError maps it to unexpected_response.
+func TestPostPreviewNon2xxClassifiesAsApiResponseError(t *testing.T) {
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(500), Body: []byte(`{"detail":"backplane unavailable"}`)},
+		},
+	}
+	opts := previewOptions{ConnectorID: "vmware-rest-9.0", OpID: "vmware.composite.vm.destroy"}
+	_, err := postPreview(context.Background(), f, opts, nil)
+	var apiErr *apiResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 500 {
+		t.Fatalf("expected *apiResponseError{StatusCode:500}; got %+v", err)
+	}
+}
+
+// TestRunPreviewOkPrintsHashRealPath — the full runPreview path (real
+// cobra command + fake client) prints the preview_hash prominently on
+// stdout and exits 0.
+func TestRunPreviewOkPrintsHashRealPath(t *testing.T) {
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: okPreviewBody(t)},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newPreviewCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"vmware-rest-9.0", "vmware.composite.vm.destroy",
+		"--target", "rdc-vcenter", "--params", `{"vm":"vm-1812"}`, "--backplane", "https://x",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("ok preview must exit 0; got %v", err)
+	}
+	for _, want := range []string{"status=ok", "preview_hash: abc123def456", "--preview-hash abc123def456"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("preview render missing %q in output:\n%s", want, out.String())
+		}
+	}
+}
+
+// TestRunPreviewErrorExitsNonZero — a status=error envelope (unknown op,
+// invalid params, unresolvable target) surfaces the error and exits 1
+// via errOpError, same gate-failed semantic as `operation call`.
+func TestRunPreviewErrorExitsNonZero(t *testing.T) {
+	errMsg := "unknown_op: vmware.bogus"
+	pr, _ := json.Marshal(PreviewResult{
+		Status:      "error",
+		OpID:        "vmware.bogus",
+		ConnectorID: "vmware-rest-9.0",
+		Error:       &errMsg,
+		Extras:      json.RawMessage(`{"error_code":"unknown_op"}`),
+	})
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: pr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newPreviewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"vmware-rest-9.0", "vmware.bogus", "--backplane", "https://x"})
+	if err := cmd.Execute(); !errors.Is(err, errOpError) {
+		t.Fatalf("status=error should exit via errOpError; got %v", err)
+	}
+	for _, want := range []string{"status=error", "unknown_op: vmware.bogus", "error_code"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("error preview render missing %q in output:\n%s", want, out.String())
+		}
+	}
+}
+
+// TestRunPreviewInvalidStatusRejected — a status the preview contract
+// does not define (ok/error/unavailable) is a malformed response:
+// surface as unexpected_response on stderr, print no envelope on stdout.
+func TestRunPreviewInvalidStatusRejected(t *testing.T) {
+	pr, _ := json.Marshal(PreviewResult{Status: "weird", OpID: "x", ConnectorID: "c"})
+	f := &fakeOperationsClient{
+		previewResponses: []*api.PostPreviewApiV1OperationsPreviewPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: pr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newPreviewCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"c", "x", "--backplane", "https://x"})
+	_ = cmd.Execute()
+	if !strings.Contains(errBuf.String(), "invalid preview status") {
+		t.Errorf("expected invalid-status diagnostic on stderr; got %q", errBuf.String())
+	}
+	if strings.Contains(out.String(), "status=weird") {
+		t.Errorf("malformed status must not render an envelope on stdout; got %q", out.String())
+	}
+}
+
+// TestPostCallThreadsPreviewHash — --preview-hash lands on
+// body.PreviewHash so a destructive-tier dispatch carries the binding
+// (#3197); an unset flag leaves it nil (bare call byte-identical to
+// pre-#3197).
+func TestPostCallThreadsPreviewHash(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "vmware.composite.vm.destroy", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{
+		ConnectorID: "vmware-rest-9.0",
+		OpID:        "vmware.composite.vm.destroy",
+		TargetName:  "rdc-vcenter",
+		PreviewHash: "abc123def456",
+	}
+	if _, err := postCall(context.Background(), f, opts, map[string]any{"vm": "vm-1812"}); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	if f.lastCallBody.PreviewHash == nil || *f.lastCallBody.PreviewHash != "abc123def456" {
+		t.Fatalf("preview hash not threaded onto body.PreviewHash; got %+v", f.lastCallBody.PreviewHash)
+	}
+}
+
+// TestPostCallPreviewHashNilWhenOmitted — no --preview-hash leaves
+// body.PreviewHash nil.
+func TestPostCallPreviewHashNilWhenOmitted(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "vault.kv.read", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{ConnectorID: "vault-1.x", OpID: "vault.kv.read", TargetName: "rdc-vault"}
+	if _, err := postCall(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	if f.lastCallBody.PreviewHash != nil {
+		t.Fatalf("omitted --preview-hash should leave body.PreviewHash=nil; got %+v", f.lastCallBody.PreviewHash)
 	}
 }

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -58,6 +58,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newGroupsCmd())
 	cmd.AddCommand(newSearchCmd())
 	cmd.AddCommand(newCallCmd())
+	cmd.AddCommand(newPreviewCmd())
 	cmd.AddCommand(newResultQueryCmd())
 	return cmd
 }
@@ -76,6 +77,12 @@ type operationsAPI interface {
 		body api.PostCallApiV1OperationsCallPostJSONRequestBody,
 		reqEditors ...api.RequestEditorFn,
 	) (*api.PostCallApiV1OperationsCallPostResponse, error)
+	PostPreviewApiV1OperationsPreviewPostWithResponse(
+		ctx context.Context,
+		params *api.PostPreviewApiV1OperationsPreviewPostParams,
+		body api.PostPreviewApiV1OperationsPreviewPostJSONRequestBody,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.PostPreviewApiV1OperationsPreviewPostResponse, error)
 	GetGroupsApiV1OperationsGroupsGetWithResponse(
 		ctx context.Context,
 		params *api.GetGroupsApiV1OperationsGroupsGetParams,

--- a/cli/internal/cmd/operation/operation_test.go
+++ b/cli/internal/cmd/operation/operation_test.go
@@ -194,6 +194,85 @@ func TestPrintCallResultOkNullResult(t *testing.T) {
 	}
 }
 
+// TestPrintPreviewResultOkRendersHash — a status=ok preview renders the
+// resolved-request projection and prints the preview_hash prominently
+// with the ready-to-paste `call --preview-hash` hint (the whole point of
+// the verb, #3197).
+func TestPrintPreviewResultOkRendersHash(t *testing.T) {
+	r := &PreviewResult{
+		Status:       "ok",
+		OpID:         "vmware.composite.vm.destroy",
+		ConnectorID:  "vmware-rest-9.0",
+		SourceKind:   "composite",
+		Method:       "COMPOSITE",
+		ResolvedPath: "vmware.composite.vm.destroy",
+		RedactedBody: json.RawMessage(`{"vm":"vm-1812"}`),
+		PreviewHash:  "abc123def456",
+	}
+	var buf bytes.Buffer
+	printPreviewResult(&buf, "vmware-rest-9.0", "vmware.composite.vm.destroy", r)
+	out := buf.String()
+	for _, want := range []string{
+		"status=ok", "source_kind=composite", "COMPOSITE", "body (redacted)",
+		`"vm"`, "preview_hash: abc123def456", "--preview-hash abc123def456",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printPreviewResult ok missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintPreviewResultErrorRendersExtras — a status=error preview
+// surfaces the error string and the extras envelope, and never prints a
+// preview_hash line.
+func TestPrintPreviewResultErrorRendersExtras(t *testing.T) {
+	errMsg := "unknown_op: vmware.bogus"
+	r := &PreviewResult{
+		Status:      "error",
+		OpID:        "vmware.bogus",
+		ConnectorID: "vmware-rest-9.0",
+		Error:       &errMsg,
+		Extras:      json.RawMessage(`{"error_code":"unknown_op"}`),
+	}
+	var buf bytes.Buffer
+	printPreviewResult(&buf, "vmware-rest-9.0", "vmware.bogus", r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "unknown_op: vmware.bogus", "extras:", "error_code"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printPreviewResult error missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "preview_hash:") {
+		t.Errorf("a non-ok preview must not print a preview_hash line; got:\n%s", out)
+	}
+}
+
+// TestPrintPreviewResultUnavailable — a status=unavailable preview (a
+// typed/composite op with no literal HTTP request to preview) surfaces
+// the reason and prints no hash.
+func TestPrintPreviewResultUnavailable(t *testing.T) {
+	errMsg := "preview_unavailable: op 'k8s.about' is source_kind='typed'"
+	r := &PreviewResult{
+		Status:      "unavailable",
+		OpID:        "k8s.about",
+		ConnectorID: "k8s-1.x",
+		SourceKind:  "typed",
+		Error:       &errMsg,
+		Extras:      json.RawMessage(`{"error_code":"preview_unavailable"}`),
+	}
+	var buf bytes.Buffer
+	printPreviewResult(&buf, "k8s-1.x", "k8s.about", r)
+	out := buf.String()
+	for _, want := range []string{"status=unavailable", "preview_unavailable", "error_code"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printPreviewResult unavailable missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "preview_hash:") {
+		t.Errorf("an unavailable preview must not print a preview_hash line; got:\n%s", out)
+	}
+}
+
 // TestLoadParamsFlagEmpty — empty flag value returns (nil, nil) so
 // runCall can omit the params key from the body.
 func TestLoadParamsFlagEmpty(t *testing.T) {

--- a/cli/internal/cmd/operation/preview.go
+++ b/cli/internal/cmd/operation/preview.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// PreviewResult mirrors the backend preview envelope — the
+// `dict[str, Any]` returned by POST /api/v1/operations/preview
+// (:func:`preview_operation`). Hand-written for the same reason as
+// CallResult / ResultQueryResult: the FastAPI route types its return as
+// `dict[str, Any]`, so the oapi-codegen generator emits
+// `*map[string]interface{}` with no typed model worth using.
+//
+// On `status="ok"` the envelope carries the literal would-be request
+// (`method` / `resolved_path` / `query` / `redacted_body`) plus the
+// `preview_hash` (#3197) — the stable binding a caller presents on the
+// subsequent governed `call_operation` of a `destructive`-tier op. On
+// `status="error"` / `status="unavailable"` the `error` string and the
+// `extras.error_code` describe why no preview (and no hash) was produced.
+// `query` / `redacted_body` / `extras` stay `json.RawMessage` so the
+// renderer pretty-prints them without imposing a per-vendor shape.
+type PreviewResult struct {
+	Status       string          `json:"status"`
+	OpID         string          `json:"op_id"`
+	ConnectorID  string          `json:"connector_id"`
+	SourceKind   string          `json:"source_kind"`
+	Method       string          `json:"method"`
+	ResolvedPath string          `json:"resolved_path"`
+	Query        json.RawMessage `json:"query,omitempty"`
+	RedactedBody json.RawMessage `json:"redacted_body,omitempty"`
+	PreviewHash  string          `json:"preview_hash"`
+	Error        *string         `json:"error"`
+	Extras       json.RawMessage `json:"extras,omitempty"`
+}
+
+// newPreviewCmd returns the `meho operation preview` command — the
+// read-only diagnosis sibling of `meho operation call`, and the CLI
+// twin of the MCP `preview_operation` tool. It is the operator's only
+// way to obtain the `preview_hash` the destructive tier requires
+// (#3197): a `safety_level='destructive'` op refuses to dispatch
+// without a `--preview-hash` from a prior preview of the identical
+// (connector_id, op_id, target, params).
+//
+// CLI shape:
+//
+//	meho operation preview <connector_id> <op_id> \
+//	  [--target <name>]                        # target name (required for ops that read a target)
+//	  [--params '<json>' | @<file>]            # operation params (object)
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Exit codes mirror `meho operation call`'s gate-failed semantic — a
+// preview resolves the SAME op + target + params but never sends the
+// request, so operator-input faults ride the envelope, not transport:
+//   - 0   preview resolved (status == "ok") — the `preview_hash` is printed
+//   - 1   preview reported status == "error" or status == "unavailable"
+//     (unknown op, invalid params, or a typed/composite op with no
+//     literal HTTP request to preview)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. unknown / missing status)
+func newPreviewCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "preview <connector_id> <op_id>",
+		Short: "Resolve an op to its would-be request + preview_hash, without sending",
+		Long: "preview invokes POST /api/v1/operations/preview — the read-only " +
+			"diagnosis sibling of `meho operation call` and the CLI twin of the " +
+			"MCP `preview_operation` tool. It resolves the SAME op + target + " +
+			"params a real call would, then returns the literal would-be HTTP " +
+			"request (`method` / `resolved_path` / `query` / redacted `body`) " +
+			"and a `preview_hash` INSTEAD of dispatching. Nothing is sent and " +
+			"no audit row is written.\n\n" +
+			"The `preview_hash` is the binding the destructive tier requires " +
+			"(#3197): a `safety_level='destructive'` op refuses to dispatch " +
+			"unless `meho operation call` carries a `--preview-hash` from a " +
+			"prior preview of the IDENTICAL (connector_id, op_id, target, " +
+			"params). Run this first, then pass the printed hash to `call`.\n\n" +
+			"--target and --params mirror `operation call` exactly. Operator-" +
+			"input faults (unknown op, invalid params, unresolvable target) ride " +
+			"the envelope as `status=\"error\"` — HTTP is 200. A typed/composite " +
+			"op with no single literal HTTP request to preview comes back " +
+			"`status=\"unavailable\"` (the destructive-tier composite is the " +
+			"exception — it previews a param-bound request tuple).",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPreview(cmd, previewOptions{
+				ConnectorID:       args[0],
+				OpID:              args[1],
+				TargetName:        targetName,
+				ParamsFlag:        paramsFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to resolve against (required for ops that read a target)")
+	cmd.Flags().StringVar(&paramsFlag, "params", "",
+		"operation params as inline JSON or @<file>; omitted means no params")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full preview envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type previewOptions struct {
+	ConnectorID       string
+	OpID              string
+	TargetName        string
+	ParamsFlag        string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runPreview(cmd *cobra.Command, opts previewOptions) error {
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	params, err := loadParamsFlag(opts.ParamsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	client, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result, err := postPreview(cmd.Context(), client, opts, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	// Classify status BEFORE rendering, mirroring `operation call`. The
+	// preview envelope's three valid values are "ok" / "error" /
+	// "unavailable" (see `_request_preview.py`); anything else is a
+	// malformed response — surface as unexpected_response (exit 4)
+	// without printing the envelope first, so --json never emits two
+	// objects on stdout.
+	switch result.Status {
+	case "ok", "error", "unavailable":
+		// fall through to rendering + exit-code branching below.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid preview status %q (expected one of: ok / error / unavailable)",
+				result.Status,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), result); err != nil {
+			return err
+		}
+	} else {
+		printPreviewResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, result)
+	}
+	// "ok" → success (exit 0). "error" / "unavailable" → exit 1 via
+	// errOpError so shell pipelines see the gate-failed signal, same as
+	// `operation call`.
+	if result.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// postPreview constructs the typed PreviewOperationBody, picks the bare-
+// string target shape via FromPreviewOperationBodyTarget0 when --target
+// is supplied (mirroring postCall — the CLI never needs the dict-shape
+// override), and issues the POST through the generated *WithResponse
+// helper. The 401-refresh dance mirrors postCall.
+func postPreview(
+	ctx context.Context,
+	client operationsAPI,
+	opts previewOptions,
+	params map[string]any,
+) (*PreviewResult, error) {
+	body := api.PreviewOperationBody{
+		ConnectorId: opts.ConnectorID,
+		OpId:        opts.OpID,
+	}
+	if opts.TargetName != "" {
+		var target api.PreviewOperationBody_Target
+		if err := target.FromPreviewOperationBodyTarget0(opts.TargetName); err != nil {
+			return nil, fmt.Errorf("encode target: %w", err)
+		}
+		body.Target = &target
+	}
+	if params != nil {
+		p := params
+		body.Params = &p
+	}
+	apiParams := &api.PostPreviewApiV1OperationsPreviewPostParams{}
+	resp, err := client.PostPreviewApiV1OperationsPreviewPostWithResponse(ctx, apiParams, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.PostPreviewApiV1OperationsPreviewPostWithResponse(ctx, apiParams, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
+	var out PreviewResult
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		return nil, fmt.Errorf("decode preview response: %w", err)
+	}
+	return &out, nil
+}
+
+// printPreviewResult renders a PreviewResult as a human-readable header
+// line plus the resolved-request projection, then prints the
+// `preview_hash` prominently with the ready-to-paste `call` hint — that
+// hash is the whole point of the verb (#3197). --json carries the raw
+// envelope instead.
+func printPreviewResult(w io.Writer, connectorID, opID string, r *PreviewResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (source_kind=%s)\n",
+		connectorID, opID, r.Status, r.SourceKind)
+	if r.Status != "ok" {
+		// status == "error" / "unavailable": surface the reason + extras.
+		if r.Error != nil && *r.Error != "" {
+			fmt.Fprintf(w, "meho: preview %s: %s\n", r.Status, *r.Error)
+		}
+		if len(r.Extras) > 0 && string(r.Extras) != "null" {
+			fmt.Fprintln(w, "extras:")
+			printPrettyOrRaw(w, r.Extras)
+		}
+		return
+	}
+	fmt.Fprintf(w, "  method:        %s\n", r.Method)
+	fmt.Fprintf(w, "  resolved_path: %s\n", r.ResolvedPath)
+	if len(r.Query) > 0 && string(r.Query) != "null" {
+		fmt.Fprintln(w, "  query:")
+		printPrettyOrRaw(w, r.Query)
+	}
+	if len(r.RedactedBody) > 0 && string(r.RedactedBody) != "null" {
+		fmt.Fprintln(w, "  body (redacted):")
+		printPrettyOrRaw(w, r.RedactedBody)
+	}
+	// The hash is the load-bearing output — print it prominently, last,
+	// with the exact flag to thread it into a governed call.
+	fmt.Fprintf(w, "\npreview_hash: %s\n", r.PreviewHash)
+	fmt.Fprintf(w,
+		"  → pass to a governed dispatch: meho operation call %s %s --preview-hash %s [--target … --params …]\n",
+		connectorID, opID, r.PreviewHash)
+}
+
+// printPrettyOrRaw pretty-prints a JSON fragment, falling back to the
+// raw bytes when it does not parse. Shared by the query / body / extras
+// slots of the preview render.
+func printPrettyOrRaw(w io.Writer, raw json.RawMessage) {
+	pretty, err := prettyJSON(raw)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+	} else {
+		fmt.Fprintln(w, string(raw))
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -998,13 +998,32 @@ narrow-waist contract.
   RRF over `endpoint_descriptor` rows scoped to the connector
   (optionally narrowed to one `group_key`) and renders the top hits
   with `fused_score`. `--limit` is clamped by the API at 50.
-- `meho operation call <connector_id> <op_id> --target <slug> [--params ...]`
+- `meho operation call <connector_id> <op_id> --target <slug> [--params ...] [--preview-hash <hash>]`
   — calls `POST /api/v1/operations/call`. Invokes the G0.6 dispatcher
   end-to-end (parameter validation, policy gate, audit, JSONFlux,
   broadcast). The dispatcher always returns a structured
   `OperationResult` envelope; HTTP 200 carries both `status="ok"` and
   `status="error"` outcomes. The verb exits 1 on a non-ok envelope so
-  shell pipelines see the gate-failed signal.
+  shell pipelines see the gate-failed signal. `--preview-hash` threads
+  the destructive-tier binding (#3197) into
+  `CallOperationBody.preview_hash` (see below).
+- `meho operation preview <connector_id> <op_id> [--target <slug>] [--params ...]`
+  — calls `POST /api/v1/operations/preview`, the read-only diagnosis
+  sibling of `/call` (#1683) and the CLI twin of the MCP
+  `preview_operation` tool. Resolves the SAME op + target + params a
+  real call would and returns the literal would-be request
+  (`method` / `resolved_path` / `query` / redacted `body`) plus a
+  `preview_hash` **instead of dispatching** — nothing is sent, no audit
+  row is written. The `preview_hash` is the binding a
+  `safety_level='destructive'` op requires (#3197): the dispatcher
+  fail-closes a destructive `call` with `status=denied` /
+  `error_code=preview_binding_required` unless it carries a
+  `--preview-hash` from a prior preview of the identical
+  `(connector_id, op_id, target, params)`. Without this verb the CLI
+  had no way to obtain the hash, so the destructive tier was
+  MCP-only. The verb exits 1 on a non-ok envelope (`status="error"`
+  for input faults, `status="unavailable"` for a typed/composite op
+  with no literal HTTP request to preview).
 
 ### Reserved flags (same shape across all three verbs)
 
@@ -1012,11 +1031,17 @@ narrow-waist contract.
   render. Useful for piping into `jq` or capturing for diff.
 - `--backplane <url>` — override the backplane URL (defaults to the URL
   recorded by `meho login`).
-- `--params '<json>'` / `--params @<file>` (call only) — operation
+- `--params '<json>'` / `--params @<file>` (call + preview) — operation
   params. Inline JSON object or `@`-prefixed file path. The empty case
   (`--params` omitted) sends no `params` key on the wire — typed
   handlers that don't read params see an empty mapping at the
   validation layer.
+- `--preview-hash <hash>` (call only) — the destructive-tier binding
+  (#3197) from a prior `meho operation preview` of the identical
+  `(connector_id, op_id, target, params)`. Threaded into
+  `api.CallOperationBody.PreviewHash`; left nil when unset so a bare
+  call is byte-identical to the pre-#3197 wire shape. Ignored by the
+  dispatcher for every non-destructive op.
 
 ### HTTP shape
 
@@ -1082,12 +1107,15 @@ scenarios.
 
 ### MCP parity
 
-The same three handlers also back the MCP tools registered in
+The same handlers also back the MCP tools registered in
 [backend/src/meho_backplane/mcp/tools/operations.py](../../backend/src/meho_backplane/mcp/tools/operations.py)
-(`list_operation_groups`, `search_operations`, `call_operation`).
-Agents call the MCP tools; operators call the CLI verbs; both hit
-the same backend functions in
+(`list_operation_groups`, `search_operations`, `call_operation`,
+`preview_operation`). Agents call the MCP tools; operators call the CLI
+verbs; both hit the same backend functions in
 [backend/src/meho_backplane/operations/meta_tools.py](../../backend/src/meho_backplane/operations/meta_tools.py).
+The CLI `operation preview` verb + `call --preview-hash` flag (#3293)
+give operators the same destructive-tier preview/dispatch pair the MCP
+`preview_operation` + `call_operation(preview_hash)` tools give agents.
 The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
 admin diagnostic for `llm_instructions` inspection) is deferred — the
 G0.6-T13 DoD was "three CLI verbs", not four.


### PR DESCRIPTION
## What

Adds the missing CLI surface for the destructive-tier preview binding
introduced in #3197.

- **`meho operation preview <connector_id> <op_id>`** — wraps
  `POST /api/v1/operations/preview` (the read-only sibling of `/call`
  the MCP `preview_operation` tool already uses). Resolves the same op +
  target + params a real call would and returns the literal would-be
  request (`method` / `resolved_path` / `query` / redacted `body`) plus
  the **`preview_hash`**, printed prominently in both the human render
  and `--json`, **without dispatching**. Flags mirror `operation call`
  (`--target`, `--params`, `--json`, `--backplane`); request plumbing is
  copied from `postCall` (typed `PreviewOperationBody`, bare-string
  `target` oneOf via `FromPreviewOperationBodyTarget0`, one-shot
  401-refresh dance).
- **`meho operation call --preview-hash <hash>`** — threads the hash
  into the already-generated `CallOperationBody.PreviewHash` field. Unset
  leaves a bare call byte-identical to the pre-#3197 wire shape.

## Why

Post-#3197 the dispatcher fail-closes a `safety_level='destructive'`
`call_operation` with `status=denied` / `error_code=preview_binding_required`
unless it carries a `preview_hash` from a prior preview of the identical
`(connector_id, op_id, target, params)`. The MCP surface has both
`preview_operation` and `call_operation(preview_hash)`; the CLI had
neither a preview verb nor a flag to thread the hash — so the whole
destructive tier was **un-drivable from the CLI** (MCP-only), breaking
CLI/MCP dual-front-end parity.

## No backend change / no snapshot regen

The `/preview` route and the `CallOperationBody.PreviewHash` field
already exist in the generated client post-#3197. Only CLI Go files,
CHANGELOG, and `docs/codebase/cli.md` change — the OpenAPI snapshot is
untouched.

## Tests

Go tests alongside the existing operation-verb tests:
- `postPreview` threads `--target` (bare-string oneOf) and `--params`;
  omitted target emits `"target":null`; 401-refresh fires once; non-2xx
  wraps as `*apiResponseError`.
- `runPreview` real path: `status=ok` prints the hash + `call` hint and
  exits 0; `status=error` exits 1 via `errOpError`; an out-of-contract
  status is rejected as `unexpected_response` (exit 4) with no envelope
  on stdout.
- `postCall` threads `--preview-hash` onto `body.PreviewHash`; unset
  leaves it nil.
- `printPreviewResult` render cases (ok/error/unavailable).

## Verification (live lab, read-only)

Built the branch binary and ran the preview verb against the live lab
backplane on a destructive op (preview is read-only by definition — no
dispatch, no approval):

```
$ meho operation preview vmware-rest-9.0 vmware.composite.vm.destroy \
    --target rdc-vcenter --params '{"vm":"vm-1812"}'
vmware-rest-9.0 vmware.composite.vm.destroy — status=ok (source_kind=composite)
  method:        COMPOSITE
  resolved_path: vmware.composite.vm.destroy
  body (redacted):
{ "vm": "vm-1812" }

preview_hash: df19c9d5…
  → pass to a governed dispatch: meho operation call … --preview-hash df19c9d5…
```

`--json` carries the same `preview_hash`. Exit 0. Nothing dispatched.

Closes #3293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
