### PR TITLE
feat(connectors): hyperv — Hyper-V migration-source typed connector (reads-first) (#3265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,36 @@ connector-related release-notes line.
   registration-constant value, re-registered on startup). CLI OpenAPI snapshot
   unchanged (no per-op safety metadata in the REST surface).
 
+### Added — hyperv: Hyper-V migration-source typed connector (reads-first) (#3265)
+
+- New `hyperv` typed connector for the **Hyper-V migration source** (registry
+  triple `hyperv-2022.x` / `hyperv-ssh`), a structured copy of the `winsrv`
+  estate mold — the shared PowerShell-over-SSH transport driving the Windows
+  PowerShell 5.1 `Hyper-V` module cmdlets on a Hyper-V host. It is MEHO's
+  governed, source-side reach for a Hyper-V→VMware migration: the safe reads
+  answer what a migration plan needs (which VMs, what firmware, what the disks
+  convert to), and the guarded `Export-VM` seeds it.
+- **18 reads-first ops across six groups** with tiers per the estate satellite
+  table: `host` (Get-VMHost / NUMA / vSwitch — safe), `vms`
+  (list / get / config / state, generation + secure-boot + integration-services
+  version — safe, the migration-assessment surface), `disks` (VHD/VHDX
+  format / size / parent-chain / fragmentation — safe, the VHDX→VMDK planning
+  input), `checkpoints` (list — safe; create — caution; revert / delete —
+  dangerous + approval), `export` (`Export-VM` — caution; long-running, bounded
+  by a `timeout_seconds` budget), and `power` (start / stop — caution, the
+  source-side cutover verbs). Non-goals named on the record: no VM
+  create / delete, no SCVMM, no Hyper-V Replica; cluster-wide views stay in the
+  `wsfc` connector on the same nodes.
+- **Probe distinguishes `hyperv_module_absent` from `hypervisor_role_absent`**
+  (module present but the hypervisor not running). Operator strings are
+  single-quote-escaped into `-EncodedCommand` scripts; no op carries a
+  secret-value parameter. CLI grows the `meho hyperv ...` verbs (the
+  `TargetCreate.product` enum + generated client were regenerated). Consumer
+  proof against the lab's nested Hyper-V cluster c1hv1
+  (`evoila-bosnia/claude-rdc-hetzner-dc#2802`) is tracked open — the estate
+  precedent (winsrv / msad / mssql shipped the same way). See
+  `docs/codebase/connectors-hyperv.md`.
+
 ### Added — Keycloak provisioning recipe for the `approver` claim (#3283)
 
 - **`docs/cross-repo/keycloak-tenant-claims.md`** gains a group-based

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,8 +140,10 @@ connector-related release-notes line.
 - **Probe distinguishes `hyperv_module_absent` from `hypervisor_role_absent`**
   (module present but the hypervisor not running). Operator strings are
   single-quote-escaped into `-EncodedCommand` scripts; no op carries a
-  secret-value parameter. CLI grows the `meho hyperv ...` verbs (the
-  `TargetCreate.product` enum + generated client were regenerated). Consumer
+  secret-value parameter. No dedicated `meho hyperv` verb package (the SSH-typed
+  connector precedent) — CLI parity is the generic dispatch path (`meho operation
+  call hyperv-ssh-2022.x <op_id> ...`), and the `TargetCreate.product` enum +
+  generated Go client were regenerated for the new token. Consumer
   proof against the lab's nested Hyper-V cluster c1hv1
   (`evoila-bosnia/claude-rdc-hetzner-dc#2802`) is tracked open — the estate
   precedent (winsrv / msad / mssql shipped the same way). See

--- a/backend/src/meho_backplane/connectors/hyperv/__init__.py
+++ b/backend/src/meho_backplane/connectors/hyperv/__init__.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.hyperv -- HypervConnector package.
+
+Importing the package registers :class:`HypervConnector` against the v2
+connector registry under the natural key
+``(product="hyperv", version="2022.x", impl_id="hyperv-ssh")``, and queues the
+connector's typed-op upserts onto the lifespan-driven registrar list so
+``endpoint_descriptor`` rows land before the first dispatch. The package is
+discovered automatically by
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` (which
+imports every ``connectors/<product>/`` subpackage in name-sorted order) --
+there is no central connector list to edit; self-registration at import time is
+the whole wiring.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.winsrv.__init__` and
+:mod:`meho_backplane.connectors.wsfc.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` inside this
+  module, so a probe firing during startup sees a fully-populated registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_hyperv_typed_operations`, which delegates to
+  :meth:`HypervConnector.register_operations`.
+
+The ``(product, version, impl_id)`` triple is chosen so
+``connector_id="hyperv-ssh-2022.x"`` round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` (``product`` = the
+first hyphen-segment of ``impl_id`` = ``"hyperv"``); ``hyper-v`` -- with a hyphen
+-- would break that round-trip and the registry's
+``_assert_product_impl_id_round_trips`` guard would crash
+``_eager_import_connectors`` at boot.
+
+Like winsrv / wsfc, this connector has no v1 chassis history, so the v1
+``register_connector`` write is intentionally omitted -- only the v2 triple
+advertises this class.
+"""
+
+from meho_backplane.connectors.hyperv.connector import HypervConnector
+from meho_backplane.connectors.hyperv.ops import HYPERV_OPS, HypervOp
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_hyperv_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``HypervConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level ``async def
+    register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via :func:`register_typed_op_registrar`. The
+    ``embedding_service`` keyword-only parameter mirrors the winsrv / wsfc
+    sibling contract -- :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` to every registrar, so each registrar **must**
+    accept the kwarg or the lifespan crashes with :class:`TypeError`. The
+    wrapper accepts-and-discards it because
+    :meth:`HypervConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await HypervConnector.register_operations()
+
+
+__all__ = [
+    "HYPERV_OPS",
+    "HypervConnector",
+    "HypervOp",
+    "register_hyperv_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key.
+register_connector_v2(
+    product="hyperv",
+    version="2022.x",
+    impl_id="hyperv-ssh",
+    cls=HypervConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh, unfingerprinted)
+# resolves to this connector through the resolver's ``versioned_over_wildcard``
+# step rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1). Mirrors the
+# winsrv / wsfc wildcard rows.
+register_connector_v2(
+    product="hyperv",
+    version="",
+    impl_id="",
+    cls=HypervConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_hyperv_typed_operations)

--- a/backend/src/meho_backplane/connectors/hyperv/connector.py
+++ b/backend/src/meho_backplane/connectors/hyperv/connector.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""HypervConnector -- typed SSH-transport connector for the Hyper-V migration source.
+
+Reads a Hyper-V host's inventory, VM configuration, and virtual-disk / checkpoint
+facts -- the inputs to a Hyper-V→VMware migration plan -- plus the guarded export
+that seeds that migration, over SSH → PowerShell: the Hyper-V host runs an
+OpenSSH server whose shell drives ``powershell`` (Windows PowerShell 5.1)
+executing the built-in ``Hyper-V`` module cmdlets. The connector is a structured
+copy of :class:`~meho_backplane.connectors.winsrv.connector.WinsrvConnector` (the
+estate mold -- same ``SshConnector`` base + shared PowerShell-over-SSH transport
+:mod:`~meho_backplane.connectors._shared.pwsh`) and adopts the
+:mod:`~meho_backplane.connectors.rke2.ops_write` approval-parked-write mold for
+its destructive ops (checkpoint revert / delete).
+
+The **target is a single Hyper-V host** (standalone or a cluster node).
+Cluster-wide views of a Hyper-V *cluster*'s nodes belong to the
+:class:`~meho_backplane.connectors.wsfc.connector.WsfcConnector` (#3263) on the
+same nodes -- not duplicated here. Explicit non-goals in this increment: VM
+create / delete on Hyper-V, SCVMM, and Hyper-V Replica.
+
+This module ships :class:`HypervConnector` (registry-v2 triple ``("hyperv",
+"2022.x", "hyperv-ssh")``): :meth:`fingerprint` (one round-trip reading the
+hostname + OS + Hyper-V module presence + hypervisor state), :meth:`probe` (six
+distinct ``ProbeResult.reason`` values, two of them Hyper-V specific),
+:meth:`about` (the ``hyperv.about`` op), the bound-method op shims for the six
+groups, and the operator-less :meth:`execute` dispatcher shim (same shape as
+winsrv / wsfc / windows_dns / rke2).
+
+Like winsrv, this connector sets ``POWERSHELL_EXECUTABLE = "powershell"``
+explicitly: the shared transport's fallback is ``pwsh`` (PS7), which a Windows
+Server / Hyper-V host does NOT ship (see ``docs/codebase/connectors-winsrv.md``
+-- "building the next estate connector").
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.hyperv.ops import HYPERV_OPS, HYPERV_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["HypervConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- mirrors the placeholder in the SSH adapter and the
+# winsrv / wsfc / windows_dns / rke2 siblings.
+type Target = Any
+
+
+#: The fingerprint / about script -- hostname + OS version/build + PowerShell
+#: version + Hyper-V module presence/version + hypervisor state in one
+#: round-trip. No operator input is interpolated (constant script), so the
+#: identity path has no injection surface.
+_FINGERPRINT_SCRIPT: str = (
+    "$os = Get-CimInstance -ClassName Win32_OperatingSystem; "
+    "$cs = Get-CimInstance -ClassName Win32_ComputerSystem; "
+    "$mod = Get-Module -ListAvailable -Name Hyper-V | Select-Object -First 1; "
+    "ConvertTo-Json -Compress -InputObject @{ "
+    "Hostname = [System.Net.Dns]::GetHostName(); "
+    "Caption = $os.Caption; "
+    "OsVersion = $os.Version; "
+    "BuildNumber = $os.BuildNumber; "
+    "PowerShellVersion = $PSVersionTable.PSVersion.ToString(); "
+    "HyperVModule = [bool]$mod; "
+    "HyperVModuleVersion = if ($mod) { $mod.Version.ToString() } else { $null }; "
+    "HypervisorPresent = [bool]$cs.HypervisorPresent }"
+)
+
+#: The probe script -- Hyper-V module presence + hypervisor-running state. Always
+#: emits JSON. ``Win32_ComputerSystem.HypervisorPresent`` is True when the
+#: hypervisor is actually running, which distinguishes an installed-but-not-a-
+#: Hyper-V-host box from a live Hyper-V host.
+_PROBE_SCRIPT: str = (
+    "$mod = [bool](Get-Module -ListAvailable -Name Hyper-V); "
+    "$cs = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction SilentlyContinue; "
+    "$hyp = [bool]($cs.HypervisorPresent); "
+    "ConvertTo-Json -Compress -InputObject @{ module = $mod; hypervisor = $hyp }"
+)
+
+
+class HypervConnector(SshConnector):
+    """Hyper-V migration-source connector on the :class:`SshConnector` adapter.
+
+    Registry v2 triple: ``("hyperv", "2022.x", "hyperv-ssh")``.
+
+    * ``product="hyperv"`` -- a short, separator-free product token (the repo
+      convention: ``parse_connector_id`` derives the product from the first
+      hyphen-segment of ``impl_id``, so ``connector_id="hyperv-ssh-2022.x"``
+      round-trips; ``hyper-v`` -- with a hyphen -- would break the registry's
+      round-trip guard at boot).
+    * ``version="2022.x"`` -- the ``Hyper-V`` cmdlet surface targets Windows
+      Server 2022 (stable across 2019 → 2025).
+    * ``impl_id="hyperv-ssh"`` -- leaves room for a future ``hyperv-winrm``
+      sibling.
+
+    **Auth: password-default + key-fallback.** Inherits the base
+    :class:`SshConnector` ``_auth_config`` unchanged.
+
+    **Transport: PowerShell-over-SSH.** Cmdlets reach the host through
+    ``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1 --
+    see :attr:`POWERSHELL_EXECUTABLE`) routed by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`; output is parsed
+    via stdlib :mod:`json` from the cmdlet's ``ConvertTo-Json`` pipe.
+    """
+
+    product = "hyperv"
+    version = "2022.x"
+    impl_id = "hyperv-ssh"
+
+    #: The PowerShell executable the shared transport invokes. ``powershell``
+    #: (Windows PowerShell 5.1) -- NOT ``pwsh`` (PS7). Set explicitly because the
+    #: shared transport's fallback is ``pwsh``; every Windows-estate connector
+    #: MUST set this (see the connectors-winsrv doc).
+    POWERSHELL_EXECUTABLE = "powershell"
+
+    #: Prepended to every script so the Hyper-V module's first-use progress
+    #: stream does not CLIXML-serialise onto the remote streams.
+    POWERSHELL_SCRIPT_PREFIX = "$ProgressPreference = 'SilentlyContinue'; "
+
+    #: The structured-log event name the shared transport emits per run, kept
+    #: connector-scoped so log queries stay per-connector.
+    POWERSHELL_LOG_EVENT = "hyperv_pwsh_executed"
+
+    async def fingerprint(
+        self,
+        target: Target,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Read the host OS + Hyper-V module + hypervisor state -- the fingerprint.
+
+        Runs :data:`_FINGERPRINT_SCRIPT` (one round-trip) and parses the JSON
+        object. Unreachable / SSH-failed / cmdlet-failed → ``reachable=False`` +
+        ``extras["error"]`` (the #986 discipline). ``operator`` is threaded to
+        the SSH adapter for the Vault read on a pool miss; ``None`` fails closed.
+        Whether the Hyper-V role is *present* is metadata here
+        (``hyperv_module`` / ``hypervisor_present``); :meth:`probe` is where its
+        absence becomes a distinct reason.
+        """
+        probed_at = datetime.now(UTC)
+        method = "ssh: powershell Get-Module Hyper-V / Win32_ComputerSystem"
+        try:
+            payload = await pwsh_run(self, target, _FINGERPRINT_SCRIPT, operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            CredentialsReadError,
+            PwshRunError,
+        ) as exc:
+            _log.warning(
+                "hyperv_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="microsoft",
+                product="hyper-v",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=method,
+                extras={"error": str(exc)},
+            )
+
+        data = payload if isinstance(payload, dict) else {}
+        return FingerprintResult(
+            vendor="microsoft",
+            product="hyper-v",
+            version=_as_str(data.get("OsVersion")),
+            build=_as_str(data.get("BuildNumber")),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=method,
+            extras={
+                "hostname": _as_str(data.get("Hostname")),
+                "os_caption": _as_str(data.get("Caption")),
+                "powershell_version": _as_str(data.get("PowerShellVersion")),
+                "hyperv_module": _as_bool(data.get("HyperVModule")),
+                "hyperv_module_version": _as_str(data.get("HyperVModuleVersion")),
+                "hypervisor_present": _as_bool(data.get("HypervisorPresent")),
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + PowerShell + Hyper-V module + hypervisor check.
+
+        Failure modes (each surfaces a distinct ``reason``):
+
+        * ``tcp_unreachable`` -- the SSH TCP socket cannot connect.
+        * ``ssh_auth_failed`` -- credentials rejected, the handshake failed, or
+          the Vault credential could not be resolved.
+        * ``powershell_unavailable`` -- SSH succeeded but the reachability script
+          failed (``powershell`` not on the shell, or a pwsh error).
+        * ``command_failed`` -- a post-connect transport failure (connection drop
+          / timeout / socket error) after a successful handshake.
+        * ``hyperv_module_absent`` -- PowerShell runs but the ``Hyper-V`` module
+          is not installed (not a Hyper-V host).
+        * ``hypervisor_role_absent`` -- the module is present but the hypervisor
+          is not running (``Win32_ComputerSystem.HypervisorPresent`` is false --
+          the Hyper-V role is not enabled / the host has not booted into it).
+
+        The probe does not mutate state -- both reads are read-only.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(ok=ok, reason=reason, latency_ms=latency_ms, probed_at=probed_at)
+
+        # Order matters: PermissionDenied (subclass of DisconnectError) before
+        # DisconnectError; OSError is the TCP-level failure.
+        try:
+            await self._connect(target)
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, CredentialsReadError):
+            return _result(False, "ssh_auth_failed")
+
+        try:
+            payload = await pwsh_run(self, target, _PROBE_SCRIPT)
+        except PwshRunError:
+            return _result(False, "powershell_unavailable")
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
+
+        data = payload if isinstance(payload, dict) else {}
+        if data.get("module") is not True:
+            return _result(False, "hyperv_module_absent")
+        if data.get("hypervisor") is not True:
+            return _result(False, "hypervisor_role_absent")
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Return the Hyper-V host's identity snapshot.
+
+        Op-id: ``hyperv.about``. Reuses :meth:`fingerprint` so the
+        operator-facing op and the canonical fingerprint share one round-trip.
+        ``_assert_reachable`` re-raises an unreachable fingerprint as a
+        :exc:`~meho_backplane.connectors.adapters.ssh.ConnectorUnreachableError`
+        so the dispatcher reports a non-ok op rather than empty identity fields
+        (#986).
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target, operator)
+        self._assert_reachable(result)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "build": result.build,
+            "hostname": result.extras.get("hostname"),
+            "os_caption": result.extras.get("os_caption"),
+            "powershell_version": result.extras.get("powershell_version"),
+            "hyperv_module": result.extras.get("hyperv_module"),
+            "hyperv_module_version": result.extras.get("hyperv_module_version"),
+            "hypervisor_present": result.extras.get("hypervisor_present"),
+        }
+
+    # -- host group shims ---------------------------------------------------
+
+    async def hyperv_host_info(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.host.info``."""
+        from meho_backplane.connectors.hyperv.ops_host import hyperv_host_info as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_host_numa(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.host.numa``."""
+        from meho_backplane.connectors.hyperv.ops_host import hyperv_host_numa as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_host_vswitch_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.host.vswitch.list``."""
+        from meho_backplane.connectors.hyperv.ops_host import hyperv_host_vswitch_list as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- vms group shims ----------------------------------------------------
+
+    async def hyperv_vms_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.vms.list``."""
+        from meho_backplane.connectors.hyperv.ops_vms import hyperv_vms_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_vms_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.vms.get``."""
+        from meho_backplane.connectors.hyperv.ops_vms import hyperv_vms_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_vms_config(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.vms.config``."""
+        from meho_backplane.connectors.hyperv.ops_vms import hyperv_vms_config as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_vms_state(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.vms.state``."""
+        from meho_backplane.connectors.hyperv.ops_vms import hyperv_vms_state as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- disks group shims --------------------------------------------------
+
+    async def hyperv_disks_vm_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.disks.vm.list``."""
+        from meho_backplane.connectors.hyperv.ops_disks import hyperv_disks_vm_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_disks_vhd_get(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.disks.vhd.get``."""
+        from meho_backplane.connectors.hyperv.ops_disks import hyperv_disks_vhd_get as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_disks_vhd_chain(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.disks.vhd.chain``."""
+        from meho_backplane.connectors.hyperv.ops_disks import hyperv_disks_vhd_chain as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- checkpoints group shims -------------------------------------------
+
+    async def hyperv_checkpoints_list(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.checkpoints.list``."""
+        from meho_backplane.connectors.hyperv.ops_checkpoints import hyperv_checkpoints_list as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_checkpoints_create(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.checkpoints.create`` (caution)."""
+        from meho_backplane.connectors.hyperv.ops_checkpoints import hyperv_checkpoints_create as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_checkpoints_revert(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.checkpoints.revert`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.hyperv.ops_checkpoints import hyperv_checkpoints_revert as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_checkpoints_delete(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.checkpoints.delete`` (dangerous, approval-gated)."""
+        from meho_backplane.connectors.hyperv.ops_checkpoints import hyperv_checkpoints_delete as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- export group shim --------------------------------------------------
+
+    async def hyperv_export_vm(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.export.vm`` (caution; long-running)."""
+        from meho_backplane.connectors.hyperv.ops_export import hyperv_export_vm as _h
+
+        return await _h(self, target, params, operator)
+
+    # -- power group shims --------------------------------------------------
+
+    async def hyperv_power_start(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.power.start`` (caution)."""
+        from meho_backplane.connectors.hyperv.ops_power import hyperv_power_start as _h
+
+        return await _h(self, target, params, operator)
+
+    async def hyperv_power_stop(
+        self, target: Target, params: dict[str, Any], operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``hyperv.power.stop`` (caution)."""
+        from meho_backplane.connectors.hyperv.ops_power import hyperv_power_stop as _h
+
+        return await _h(self, target, params, operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`HYPERV_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has eager-
+        imported every connector module. Walks
+        :data:`~meho_backplane.connectors.hyperv.ops.HYPERV_OPS` and routes each
+        row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+        Idempotent across pod restarts -- mirrors the winsrv / wsfc shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in HYPERV_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"HypervConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = HYPERV_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"HypervConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"HYPERV_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.hyperv.ops."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "hyperv_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`WinsrvConnector.execute`. Operator-less (no policy gate,
+        no audit row, no broadcast); the operator-aware surface is
+        ``POST /api/v1/operations/call`` via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )
+
+
+def _as_str(value: Any) -> str | None:
+    """Return *value* when it is a non-empty ``str``, else ``None`` (guards the
+    fingerprint projection: ``ConvertTo-Json`` can render an absent field as
+    ``null``, and :class:`FingerprintResult` fields are typed ``str | None``)."""
+    return value if isinstance(value, str) and value else None
+
+
+def _as_bool(value: Any) -> bool | None:
+    """Return *value* when it is a ``bool``, else ``None`` (guards the extras
+    projection: an absent CIM / module field renders as ``null``)."""
+    return value if isinstance(value, bool) else None

--- a/backend/src/meho_backplane/connectors/hyperv/ops.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`HypervConnector`.
+
+The connector is the **Hyper-V migration-source** reach: it reads a Hyper-V
+host's inventory, VM configuration, and virtual-disk / checkpoint facts — the
+inputs to a Hyper-V→VMware migration plan — plus the guarded export that seeds
+that migration, over SSH → PowerShell (``powershell`` running the Windows
+PowerShell 5.1 ``Hyper-V`` module cmdlets), routed through the shared
+PowerShell-over-SSH transport
+:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run` (hoisted by #3260).
+Structurally it is a copy of the ``winsrv`` estate mold (#3261): identity canary
++ per-domain op groups on the ``SshConnector`` base, the ``{rows, total}``
+JSONFlux envelope for list reads, and the ``rke2`` approval-parked-write mold
+for its destructive ops (checkpoint revert / delete).
+
+Op surface (18 ops across six groups; safety tier per the Initiative #3259
+satellite table — reads ``safe``, recoverable writes ``caution``, destructive
+``dangerous`` + ``requires_approval``):
+
+* ``hyperv.about``              [safe]   identity canary (OS + Hyper-V module + hypervisor).
+* ``hyperv.host.info``          [safe]   Get-VMHost (CPUs, memory, NUMA spanning, default paths).
+* ``hyperv.host.numa``          [safe]   Get-VMHostNumaNode (host NUMA topology; list).
+* ``hyperv.host.vswitch.list``  [safe]   Get-VMSwitch (virtual switch inventory; list).
+* ``hyperv.vms.list``           [safe]   Get-VM (VM inventory; the migration-assessment surface).
+* ``hyperv.vms.get``            [safe]   Get-VM -Name (one VM's identity + state + generation).
+* ``hyperv.vms.config``         [safe]   deep config: memory / processors / generation / firmware.
+* ``hyperv.vms.state``          [safe]   runtime state: State / Status / Uptime / Heartbeat.
+* ``hyperv.disks.vm.list``      [safe]   Get-VMHardDiskDrive (a VM's attached disks; list).
+* ``hyperv.disks.vhd.get``      [safe]   Get-VHD (one VHD/VHDX's format/size/parent/fragmentation).
+* ``hyperv.disks.vhd.chain``    [safe]   differencing-disk parent chain (leaf → base; list).
+* ``hyperv.checkpoints.list``   [safe]   Get-VMSnapshot (a VM's checkpoints; list).
+* ``hyperv.checkpoints.create`` [caution]              Checkpoint-VM.
+* ``hyperv.checkpoints.revert`` [dangerous+approval]   Restore-VMSnapshot.
+* ``hyperv.checkpoints.delete`` [dangerous+approval]   Remove-VMSnapshot.
+* ``hyperv.export.vm``          [caution]              Export-VM (the migration seed; long-running).
+* ``hyperv.power.start``        [caution]              Start-VM (source-side cutover verb).
+* ``hyperv.power.stop``         [caution]              Stop-VM (graceful / turn-off / save).
+
+**Explicit non-goals in this increment** (named so the scoping is on record):
+VM create / delete on Hyper-V (we manage the source, we do not build on it),
+SCVMM, and Hyper-V Replica. Cluster-wide views of a Hyper-V cluster's nodes
+belong to the ``wsfc`` connector (#3263) on the same nodes — not duplicated
+here.
+
+The dataclass + tuple shape mirrors :mod:`~meho_backplane.connectors.winsrv.ops`
+and :mod:`~meho_backplane.connectors.msad.ops`; the composition pattern
+(``_hyperv_ops()`` importing per-domain op tuples) mirrors them too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = [
+    "HYPERV_OPS",
+    "HYPERV_WHEN_TO_USE_BY_GROUP",
+    "SSH_TRANSPORT_NOTE",
+    "HypervOp",
+    "hyperv_list_read",
+    "normalise_json_rows",
+]
+
+
+#: Curated ``when_to_use`` strings per group key, consumed by
+#: :meth:`HypervConnector.register_operations` (the winsrv / rke2 precedent — the
+#: blurbs live with the op metadata, not the transport class). The registration
+#: walk fails closed with a :class:`ValueError` if a ``group_key`` lacks a
+#: curated entry here.
+HYPERV_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "host": (
+        "Use for Hyper-V host facts before any VM drill-in: identity "
+        "(``hyperv.about``), the host projection (``hyperv.host.info`` — logical "
+        "processors, memory capacity, NUMA spanning, default VM / VHD paths), "
+        "the NUMA topology (``hyperv.host.numa``), and the virtual-switch "
+        "inventory (``hyperv.host.vswitch.list``). All read-only. Call "
+        "``hyperv.about`` first to confirm the target is a reachable Hyper-V "
+        "host (Hyper-V module present + hypervisor running)."
+    ),
+    "vms": (
+        "Use to assess the VMs that are migration candidates: list every VM "
+        "(``hyperv.vms.list`` — the assessment surface: state, generation, "
+        "integration-services version), read one VM's identity "
+        "(``hyperv.vms.get``), its deep configuration (``hyperv.vms.config`` — "
+        "memory, processors, generation, firmware / secure-boot), and its "
+        "runtime state (``hyperv.vms.state`` — State / Status / Uptime / "
+        "Heartbeat). All read-only. Generation and secure-boot decide the "
+        "target-side VMware firmware (BIOS vs EFI)."
+    ),
+    "disks": (
+        "Use to plan the VHDX→VMDK conversion: enumerate a VM's attached "
+        "virtual disks (``hyperv.disks.vm.list`` — controller + path), read one "
+        "VHD/VHDX's facts (``hyperv.disks.vhd.get`` — format, virtual size, "
+        "on-disk file size, parent path, fragmentation), and walk a "
+        "differencing disk's parent chain to the base (``hyperv.disks.vhd.chain"
+        "``). All read-only. A differencing chain must be merged before a clean "
+        "single-file VMDK conversion."
+    ),
+    "checkpoints": (
+        "Use to inventory and manage a VM's checkpoints (snapshots): list "
+        "(``hyperv.checkpoints.list``, read-only, ``safe``); create a checkpoint "
+        "(``hyperv.checkpoints.create``, ``caution`` — recoverable); revert to a "
+        "checkpoint (``hyperv.checkpoints.revert``) and delete one "
+        "(``hyperv.checkpoints.delete``) are ``dangerous`` + "
+        "``requires_approval`` — a revert discards state written since the "
+        "checkpoint and a delete is irreversible, so both park for a human "
+        "decision. Take a checkpoint before a risky migration cutover step."
+    ),
+    "export": (
+        "Use to seed the migration: ``hyperv.export.vm`` runs ``Export-VM`` to "
+        "write a VM's configuration + virtual disks to a folder on the host "
+        "(the source artifact a VMware import consumes). ``caution`` — "
+        "recoverable (it copies, it does not remove the source) but "
+        "**long-running**: the call blocks over SSH until the export completes, "
+        "so set ``timeout_seconds`` to cover the VM's disk size. There is no "
+        "separate disk-export op — the exported folder already contains the "
+        "Virtual Hard Disks."
+    ),
+    "power": (
+        "Use for the source-side cutover verbs: start a VM "
+        "(``hyperv.power.start``) and stop one (``hyperv.power.stop`` — graceful "
+        "guest shutdown by default, ``turnoff`` for a hard power-off, or "
+        "``save`` to suspend). Both ``caution`` — recoverable (a stopped VM can "
+        "be started again). Stop the source VM as the final cutover step once "
+        "the target VMware VM is validated."
+    ),
+}
+
+
+#: Canonical SSH-only / pwsh transport reminder copied into every op's
+#: ``llm_instructions`` (the winsrv ``SSH_TRANSPORT_NOTE`` precedent) so an LLM
+#: does not compose against a non-existent Hyper-V REST surface.
+SSH_TRANSPORT_NOTE: str = (
+    "Hyper-V exposes no unified REST API for these operations; the underlying "
+    "transport is PowerShell-over-SSH (powershell -EncodedCommand routed "
+    "through asyncssh) driving the Windows PowerShell 5.1 Hyper-V module "
+    "cmdlets on the Hyper-V host."
+)
+
+
+@dataclass(frozen=True)
+class HypervOp:
+    """Metadata for one hyperv op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can splat
+    the dataclass into the helper. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.hyperv.connector.HypervConnector` exposing
+    the async handler; the connector resolves the bound method against itself at
+    registration time (identical shape to
+    :class:`~meho_backplane.connectors.winsrv.ops.WinsrvOp`).
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous", "destructive"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def normalise_json_rows(payload: Any) -> list[dict[str, Any]]:
+    """Normalise a ``ConvertTo-Json`` payload into a list of row dicts.
+
+    ``ConvertTo-Json`` renders a **single**-element result as a flat object and
+    a **multi**-element result as a JSON array; a zero-element result renders as
+    ``null`` (an empty stdout is caught upstream by
+    :func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). This collapses
+    all three shapes to a ``list[dict]`` — the winsrv ``normalise_json_rows``
+    shape, shared across every list op so the ``{rows, total}`` envelope the
+    JSONFlux reducer keys on is built identically.
+    """
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    return []
+
+
+async def hyperv_list_read(
+    connector: HypervConnector,
+    target: Any,
+    *,
+    pipeline: str,
+    operator: Operator | None,
+    prelude: str = "",
+) -> dict[str, Any]:
+    """Run a read *pipeline* under ``'Stop'`` and return the ``{rows, total}`` envelope.
+
+    *pipeline* is the ``Get-VM… | Select-Object …`` expression whose output is
+    wrapped in ``@(…)`` (so a single object still counts as one row and an empty
+    result stays JSON-shaped — never an empty-stdout
+    :class:`~meho_backplane.connectors._shared.pwsh.PwshRunError`). *prelude* is
+    any statement(s) that must run first (e.g. a ``$n = '…'`` assignment); it is
+    emitted verbatim before the pipeline. Running under
+    ``$ErrorActionPreference = 'Stop'`` turns a cmdlet error (unknown VM, bad
+    path) into a real ``PwshRunError`` rather than a false-empty read. ``-Depth
+    4`` keeps calculated / nested projections (NUMA processor arrays, VHD parent
+    metadata) from truncating.
+    """
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        + prelude
+        + f"$x = @({pipeline}); "
+        + "ConvertTo-Json -Depth 4 -InputObject @{ rows = $x; total = $x.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"rows": rows, "total": len(rows)}
+
+
+#: The identity canary op. ``hyperv.about`` is the operator-facing wrapper around
+#: :meth:`HypervConnector.fingerprint` — same vendor / product / host payload,
+#: surfaced through the typed-op dispatcher so callers see the standard
+#: :class:`OperationResult` envelope. Mirrors ``winsrv.about``.
+_HYPERV_ABOUT_OP = HypervOp(
+    op_id="hyperv.about",
+    handler_attr="about",
+    summary="Return the Hyper-V host identity (OS + Hyper-V module + hypervisor).",
+    description=(
+        "Connects to the Hyper-V host over SSH and runs a single ``powershell "
+        "-EncodedCommand`` script that reads the machine hostname, the "
+        "``Win32_OperatingSystem`` CIM instance (caption / version / build), the "
+        "Windows PowerShell version, whether the ``Hyper-V`` management module "
+        "is installed (and its version), and whether the hypervisor is running "
+        "(``Win32_ComputerSystem.HypervisorPresent``). Returns a flat dict with "
+        "the vendor (``microsoft``), product (``hyper-v``), the OS version + "
+        "build, and the host name. Use to confirm the target is a reachable "
+        "Hyper-V host before issuing higher-level host / vms / disks / "
+        "checkpoints / export / power ops; no params; safe on any healthy "
+        "target."
+    ),
+    parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "build": {"type": ["string", "null"]},
+            "hostname": {"type": ["string", "null"]},
+            "os_caption": {"type": ["string", "null"]},
+            "powershell_version": {"type": ["string", "null"]},
+            "hyperv_module": {"type": ["boolean", "null"]},
+            "hyperv_module_version": {"type": ["string", "null"]},
+            "hypervisor_present": {"type": ["boolean", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="host",
+    tags=("read-only", "identity", "hyper-v"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the Hyper-V host behind a "
+            "target — its OS caption / version / build, the Hyper-V module "
+            "version, whether the hypervisor is running — or to confirm the "
+            "target is a reachable Hyper-V host before issuing higher-level "
+            "ops. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``version`` carries the host OS version (e.g. "
+            "``10.0.20348``), ``hyperv_module_version`` the Hyper-V module "
+            "version, ``hypervisor_present`` whether the hypervisor is running, "
+            "``hostname`` the machine name."
+        ),
+    },
+)
+
+
+def _hyperv_ops() -> tuple[HypervOp, ...]:
+    """Return the merged registration tuple (identity canary + per-group tuples).
+
+    Implemented as a function call (not a module-level literal-and-splat) so the
+    import order stays linear: ``ops.py`` defines :class:`HypervOp` +
+    ``_HYPERV_ABOUT_OP`` + the shared helpers, then imports the per-domain op
+    tuples from their modules. Mirrors
+    :func:`meho_backplane.connectors.winsrv.ops._winsrv_ops`.
+    """
+    from meho_backplane.connectors.hyperv.ops_checkpoints import CHECKPOINT_OPS
+    from meho_backplane.connectors.hyperv.ops_disks import DISK_OPS
+    from meho_backplane.connectors.hyperv.ops_export import EXPORT_OPS
+    from meho_backplane.connectors.hyperv.ops_host import HOST_OPS
+    from meho_backplane.connectors.hyperv.ops_power import POWER_OPS
+    from meho_backplane.connectors.hyperv.ops_vms import VMS_OPS
+
+    return (
+        _HYPERV_ABOUT_OP,
+        *HOST_OPS,
+        *VMS_OPS,
+        *DISK_OPS,
+        *CHECKPOINT_OPS,
+        *EXPORT_OPS,
+        *POWER_OPS,
+    )
+
+
+#: The ops :class:`HypervConnector` registers at lifespan startup.
+HYPERV_OPS: tuple[HypervOp, ...] = _hyperv_ops()

--- a/backend/src/meho_backplane/connectors/hyperv/ops_checkpoints.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_checkpoints.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv checkpoints ops — ``list`` (safe) + ``create`` (caution) + guarded writes.
+
+Checkpoint (snapshot) management via the Hyper-V module cmdlets over the shared
+PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`):
+
+* ``list``   — ``Get-VMSnapshot -VMName`` (read-only, ``safe``).
+* ``create`` — ``Checkpoint-VM`` (``caution`` — recoverable).
+* ``revert`` — ``Restore-VMSnapshot`` (``dangerous`` + ``requires_approval``): a
+  revert discards everything written to the VM since the checkpoint.
+* ``delete`` — ``Remove-VMSnapshot`` (``dangerous`` + ``requires_approval``):
+  irreversible removal.
+
+``revert`` / ``delete`` follow the rke2 approval-parked-write mold: the
+dispatcher's policy gate parks a dispatch at ``needs-approval`` for a human
+decision, and the handler runs only on the ``_approved=True`` resume path. Per
+the Initiative #3259 satellite table a destructive op is satellite-EXCLUDED by
+the tier ladder — central-dial / on-site only. ``-Confirm:$false`` suppresses
+the cmdlet's own interactive prompt (it would hang non-interactively); the
+approval gate is MEHO's, not Hyper-V's.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied ``vm_name`` / ``checkpoint_name`` are interpolated only
+inside single-quoted literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`.
+
+References
+----------
+
+* ``Get-VMSnapshot`` / ``Checkpoint-VM`` / ``Restore-VMSnapshot`` /
+  ``Remove-VMSnapshot`` (Hyper-V module; snapshots were renamed *checkpoints* in
+  Windows Server 2012 R2 — the cmdlet nouns kept ``Snapshot``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmsnapshot
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.hyperv.ops import (
+    SSH_TRANSPORT_NOTE,
+    HypervOp,
+    hyperv_list_read,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = [
+    "CHECKPOINT_OPS",
+    "hyperv_checkpoints_create",
+    "hyperv_checkpoints_delete",
+    "hyperv_checkpoints_list",
+    "hyperv_checkpoints_revert",
+]
+
+
+#: Checkpoint projection (per ``Get-VMSnapshot`` row). ``SnapshotType`` is an
+#: enum, ``CreationTime`` a DateTime, ``Id`` a Guid → all stringified.
+_CHECKPOINT_SELECT: str = (
+    "Name, VMName, @{N='SnapshotType';E={\"$($_.SnapshotType)\"}}, "
+    "@{N='CreationTime';E={$_.CreationTime.ToString('o')}}, "
+    "ParentSnapshotName, @{N='Id';E={$_.Id.ToString()}}"
+)
+
+
+async def hyperv_checkpoints_list(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.checkpoints.list`` — ``Get-VMSnapshot -VMName`` (list)."""
+    vm_name = params["vm_name"]
+    result = await hyperv_list_read(
+        connector,
+        target,
+        prelude=f"$n = {ps_single_quote(vm_name)}; ",
+        pipeline=f"Get-VMSnapshot -VMName $n | Select-Object {_CHECKPOINT_SELECT}",
+        operator=operator,
+    )
+    return {"vm_name": vm_name, **result}
+
+
+async def hyperv_checkpoints_create(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.checkpoints.create`` (caution) — ``Checkpoint-VM``.
+
+    Creates a checkpoint of the VM. When ``checkpoint_name`` is omitted Hyper-V
+    auto-names it (VM name + timestamp). ``-Passthru`` returns the created
+    checkpoint so the handler echoes its resolved name.
+    """
+    vm_name = params["vm_name"]
+    n = ps_single_quote(vm_name)
+    name_clause = ""
+    checkpoint_name = params.get("checkpoint_name")
+    if checkpoint_name is not None:
+        name_clause = f" -SnapshotName {ps_single_quote(checkpoint_name)}"
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$n = {n}; "
+        f"$s = Checkpoint-VM -Name $n{name_clause} -Passthru; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true; vm = $n; checkpoint = $s.Name }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "vm_name": vm_name,
+        "checkpoint_name": data.get("checkpoint"),
+        "action": "create",
+        "op_class": "write",
+    }
+
+
+async def hyperv_checkpoints_revert(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.checkpoints.revert`` (dangerous, resume path only).
+
+    Runs ``Restore-VMSnapshot -Name <checkpoint_name> -VMName <vm_name>
+    -Confirm:$false``. Discards state written since the checkpoint —
+    ``requires_approval`` so a dispatch parks for a human decision first.
+    """
+    return await _checkpoint_action(
+        connector, target, params, cmdlet="Restore-VMSnapshot", action="revert", operator=operator
+    )
+
+
+async def hyperv_checkpoints_delete(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.checkpoints.delete`` (dangerous, resume path only).
+
+    Runs ``Remove-VMSnapshot -Name <checkpoint_name> -VMName <vm_name>
+    -Confirm:$false``. Irreversible — ``requires_approval`` so a dispatch parks
+    for a human decision first.
+    """
+    return await _checkpoint_action(
+        connector, target, params, cmdlet="Remove-VMSnapshot", action="delete", operator=operator
+    )
+
+
+async def _checkpoint_action(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    *,
+    cmdlet: str,
+    action: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run a ``-Name <checkpoint> -VMName <vm> -Confirm:$false`` checkpoint write."""
+    vm_name = params["vm_name"]
+    checkpoint_name = params["checkpoint_name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"{cmdlet} -Name {ps_single_quote(checkpoint_name)} "
+        f"-VMName {ps_single_quote(vm_name)} -Confirm:$false; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator)
+    return {
+        "vm_name": vm_name,
+        "checkpoint_name": checkpoint_name,
+        "action": action,
+        "op_class": "write",
+    }
+
+
+_VM_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The virtual machine name (the ``-VMName`` / ``-Name`` VM operand).",
+}
+
+_CHECKPOINT_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The checkpoint (snapshot) name.",
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm_name": {"type": "string"},
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["vm_name", "rows", "total"],
+    "additionalProperties": True,
+}
+
+_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm_name": {"type": "string"},
+        "checkpoint_name": {"type": ["string", "null"]},
+        "action": {"type": "string"},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["vm_name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+def _checkpoint_write_op(
+    op_id: str,
+    handler_attr: str,
+    verb: str,
+    cmdlet: str,
+    *,
+    safety_level: str,
+    requires_approval: bool,
+) -> HypervOp:
+    """Build one identity-based checkpoint write op (revert / delete)."""
+    note = (
+        "Destructive; approval-gated — parks for a human decision first."
+        if requires_approval
+        else "Recoverable."
+    )
+    return HypervOp(
+        op_id=op_id,
+        handler_attr=handler_attr,
+        summary=f"{verb.capitalize()} a VM checkpoint via ``{cmdlet}``.",
+        description=(
+            f"Runs ``{cmdlet} -Name <checkpoint_name> -VMName <vm_name> "
+            f"-Confirm:$false``. {note} safety_level={safety_level}."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"vm_name": _VM_NAME_PROP, "checkpoint_name": _CHECKPOINT_NAME_PROP},
+            "required": ["vm_name", "checkpoint_name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="checkpoints",
+        tags=("write", "checkpoint", verb),
+        safety_level=safety_level,  # type: ignore[arg-type]
+        requires_approval=requires_approval,
+        llm_instructions={
+            "when_to_use": (
+                f"{verb.capitalize()} a named VM checkpoint. {note} " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "vm_name": "Required. The VM name.",
+                "checkpoint_name": "Required. The checkpoint name.",
+            },
+            "output_shape": (
+                f"{{'vm_name', 'checkpoint_name', 'action': '{verb}', 'op_class': 'write'}}."
+            ),
+        },
+    )
+
+
+CHECKPOINT_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.checkpoints.list",
+        handler_attr="hyperv_checkpoints_list",
+        summary="List a VM's checkpoints via ``Get-VMSnapshot -VMName`` (list).",
+        description=(
+            "Runs ``Get-VMSnapshot -VMName <vm_name>`` and returns one row per "
+            "checkpoint (Name, VMName, SnapshotType, CreationTime, "
+            "ParentSnapshotName, Id). Read-only; a VM with a live checkpoint "
+            "tree carries differencing (.avhdx) disks that complicate a "
+            "migration."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"vm_name": _VM_NAME_PROP},
+            "required": ["vm_name"],
+            "additionalProperties": False,
+        },
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="checkpoints",
+        tags=("read-only", "checkpoint", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate a VM's checkpoints (snapshots). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": (
+                "{'vm_name', 'rows': [{Name, SnapshotType, CreationTime, "
+                "ParentSnapshotName, Id}], 'total': <int>}."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.checkpoints.create",
+        handler_attr="hyperv_checkpoints_create",
+        summary="Create a VM checkpoint via ``Checkpoint-VM`` (caution).",
+        description=(
+            "Runs ``Checkpoint-VM -Name <vm_name>`` (optionally ``-SnapshotName "
+            "<checkpoint_name>``; omit to let Hyper-V auto-name it). "
+            "safety_level=caution — recoverable. Take a checkpoint before a "
+            "risky migration cutover step so the source can be rolled back."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": _VM_NAME_PROP,
+                "checkpoint_name": {
+                    **_CHECKPOINT_NAME_PROP,
+                    "description": (
+                        "Optional checkpoint name (``-SnapshotName``); omit to "
+                        "let Hyper-V auto-name it (VM name + timestamp)."
+                    ),
+                },
+            },
+            "required": ["vm_name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="checkpoints",
+        tags=("write", "checkpoint", "create"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Create a checkpoint of a VM (e.g. before a cutover step). "
+                "Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "vm_name": "Required. The VM name.",
+                "checkpoint_name": "Optional. The checkpoint name; auto-named if omitted.",
+            },
+            "output_shape": (
+                "{'vm_name', 'checkpoint_name': <resolved>, 'action': 'create', "
+                "'op_class': 'write'}."
+            ),
+        },
+    ),
+    _checkpoint_write_op(
+        "hyperv.checkpoints.revert",
+        "hyperv_checkpoints_revert",
+        "revert",
+        "Restore-VMSnapshot",
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _checkpoint_write_op(
+        "hyperv.checkpoints.delete",
+        "hyperv_checkpoints_delete",
+        "delete",
+        "Remove-VMSnapshot",
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+)

--- a/backend/src/meho_backplane/connectors/hyperv/ops_disks.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_disks.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv disks ops — ``disks.vm.list`` / ``disks.vhd.get`` / ``disks.vhd.chain`` (all safe).
+
+The VHDX→VMDK planning input. Read-only virtual-disk facts via
+``Get-VMHardDiskDrive`` (a VM's attached disks) and ``Get-VHD`` (one VHD/VHDX's
+format / size / parent / fragmentation), routed through the shared
+PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`).
+
+``disks.vhd.chain`` walks a differencing disk's parent chain from the leaf
+(``.avhdx``) to the base disk by following ``ParentPath`` — a differencing chain
+must be merged before a clean single-file VMDK conversion, so surfacing the full
+chain is the load-bearing migration read.
+
+``Get-VHD`` note: when a VHD is attached to a running VM on shared storage it can
+only be read from the host currently using it (the cmdlet errors elsewhere); the
+handler runs under ``$ErrorActionPreference = 'Stop'`` so that surfaces as a
+real :class:`~meho_backplane.connectors._shared.pwsh.PwshRunError`, not a
+false-empty read.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied ``vm_name`` / ``path`` are interpolated only inside
+single-quoted literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote` (assigned to a
+prelude variable, then referenced).
+
+References
+----------
+
+* ``Get-VMHardDiskDrive`` (output ``Microsoft.HyperV.PowerShell.HardDiskDrive``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmharddiskdrive
+* ``Get-VHD`` (output ``Microsoft.Vhd.PowerShell.VirtualHardDisk``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vhd
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.hyperv.ops import (
+    SSH_TRANSPORT_NOTE,
+    HypervOp,
+    hyperv_list_read,
+    normalise_json_rows,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = [
+    "DISK_OPS",
+    "hyperv_disks_vhd_chain",
+    "hyperv_disks_vhd_get",
+    "hyperv_disks_vm_list",
+]
+
+
+#: Attached-disk projection (per ``Get-VMHardDiskDrive`` row). ``ControllerType``
+#: is an enum (IDE / SCSI) → stringified.
+_VMDISK_SELECT: str = (
+    "Path, @{N='ControllerType';E={\"$($_.ControllerType)\"}}, ControllerNumber, ControllerLocation"
+)
+
+
+async def hyperv_disks_vm_list(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.disks.vm.list`` — ``Get-VMHardDiskDrive -VMName`` (list)."""
+    vm_name = params["vm_name"]
+    result = await hyperv_list_read(
+        connector,
+        target,
+        prelude=f"$n = {ps_single_quote(vm_name)}; ",
+        pipeline=f"Get-VMHardDiskDrive -VMName $n | Select-Object {_VMDISK_SELECT}",
+        operator=operator,
+    )
+    return {"vm_name": vm_name, **result}
+
+
+async def hyperv_disks_vhd_get(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.disks.vhd.get`` — ``Get-VHD -Path`` (one disk's facts).
+
+    Returns the format (VHD / VHDX), type (Fixed / Dynamic / Differencing),
+    virtual size, on-disk file size, minimum size, parent path (for a
+    differencing disk), fragmentation percentage, and identifiers. Read-only.
+    """
+    p = ps_single_quote(params["path"])
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$v = Get-VHD -Path {p}; "
+        "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+        "Path = $v.Path; "
+        'VhdFormat = "$($v.VhdFormat)"; '
+        'VhdType = "$($v.VhdType)"; '
+        "Size = $v.Size; "
+        "FileSize = $v.FileSize; "
+        "MinimumSize = $v.MinimumSize; "
+        "ParentPath = $v.ParentPath; "
+        "FragmentationPercentage = $v.FragmentationPercentage; "
+        "Attached = $v.Attached; "
+        "DiskIdentifier = $v.DiskIdentifier; "
+        "BlockSize = $v.BlockSize; "
+        "LogicalSectorSize = $v.LogicalSectorSize; "
+        "PhysicalSectorSize = $v.PhysicalSectorSize }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def hyperv_disks_vhd_chain(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.disks.vhd.chain`` — the differencing parent chain (list).
+
+    Walks ``ParentPath`` from the given leaf disk to the base, returning one row
+    per link (Path, VhdFormat, VhdType, Size, FileSize, ParentPath) ordered
+    leaf → base. A single-file (non-differencing) disk yields a one-row chain.
+    Read-only.
+    """
+    p = ps_single_quote(params["path"])
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$p = {p}; "
+        "$chain = @(); "
+        "while ($p) { "
+        "$v = Get-VHD -Path $p; "
+        "$chain += @{ Path = $v.Path; "
+        'VhdFormat = "$($v.VhdFormat)"; '
+        'VhdType = "$($v.VhdType)"; '
+        "Size = $v.Size; FileSize = $v.FileSize; ParentPath = $v.ParentPath }; "
+        "$p = $v.ParentPath }; "
+        "ConvertTo-Json -Depth 4 -InputObject @{ rows = $chain; total = $chain.Count }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    raw_rows = payload.get("rows") if isinstance(payload, dict) else payload
+    rows = normalise_json_rows(raw_rows)
+    return {"path": params["path"], "rows": rows, "total": len(rows)}
+
+
+_VM_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The virtual machine name (the ``Get-VMHardDiskDrive -VMName`` operand).",
+}
+
+_PATH_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The path to the VHD / VHDX file on the Hyper-V host (the ``Get-VHD "
+        "-Path`` operand, e.g. ``C:\\\\VMs\\\\sql-01\\\\disk0.vhdx``)."
+    ),
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+DISK_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.disks.vm.list",
+        handler_attr="hyperv_disks_vm_list",
+        summary="List a VM's attached virtual disks via ``Get-VMHardDiskDrive`` (list).",
+        description=(
+            "Runs ``Get-VMHardDiskDrive -VMName <vm_name>`` and returns one row "
+            "per attached virtual disk (Path, ControllerType — IDE / SCSI, "
+            "ControllerNumber, ControllerLocation). Read-only; maps a VM to the "
+            "VHD/VHDX files that feed ``hyperv.disks.vhd.get`` / ``.chain``."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"vm_name": _VM_NAME_PROP},
+            "required": ["vm_name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": {"type": "string"},
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["vm_name", "rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="disks",
+        tags=("read-only", "disks", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate a VM's attached virtual disks (controller + "
+                "file path) before reading each VHD/VHDX's facts. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": (
+                "{'vm_name', 'rows': [{Path, ControllerType, ControllerNumber, "
+                "ControllerLocation}], 'total': <int>}."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.disks.vhd.get",
+        handler_attr="hyperv_disks_vhd_get",
+        summary="Read one VHD/VHDX's facts via ``Get-VHD -Path`` (format / size / parent).",
+        description=(
+            "Runs ``Get-VHD -Path <path>`` and returns the disk's format (VHD / "
+            "VHDX), type (Fixed / Dynamic / Differencing), virtual size, on-disk "
+            "file size, minimum size, parent path (for a differencing disk), "
+            "fragmentation percentage, and identifiers. Read-only; the primary "
+            "VHDX→VMDK planning input."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"path": _PATH_PROP},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Path": {"type": ["string", "null"]},
+                "VhdFormat": {"type": ["string", "null"]},
+                "VhdType": {"type": ["string", "null"]},
+                "Size": {"type": ["integer", "null"]},
+                "FileSize": {"type": ["integer", "null"]},
+                "ParentPath": {"type": ["string", "null"]},
+                "FragmentationPercentage": {"type": ["integer", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="disks",
+        tags=("read-only", "disks", "vhd"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one VHD/VHDX file's format, size, parent, and "
+                "fragmentation — the input to a VHDX→VMDK conversion plan. "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"path": "Required. The VHD/VHDX file path on the Hyper-V host."},
+            "output_shape": (
+                "Flat dict (VhdFormat, VhdType, Size, FileSize, MinimumSize, "
+                "ParentPath, FragmentationPercentage, ...)."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.disks.vhd.chain",
+        handler_attr="hyperv_disks_vhd_chain",
+        summary="Walk a differencing disk's parent chain (leaf → base; list).",
+        description=(
+            "Follows ``ParentPath`` from the given leaf VHD/VHDX to the base "
+            "disk and returns one row per link (Path, VhdFormat, VhdType, Size, "
+            "FileSize, ParentPath), ordered leaf → base. A single-file "
+            "(non-differencing) disk yields a one-row chain. Read-only; a "
+            "differencing chain must be merged before a clean single-file VMDK "
+            "conversion."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"path": _PATH_PROP},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["path", "rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="disks",
+        tags=("read-only", "disks", "vhd", "chain"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to see a differencing disk's full parent chain to the base "
+                "(the links that must be merged before a single-file VMDK "
+                "conversion). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"path": "Required. The leaf VHD/VHDX file path."},
+            "output_shape": (
+                "{'path', 'rows': [{Path, VhdType, ParentPath, ...}] leaf→base, 'total': <int>}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/hyperv/ops_export.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_export.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv export ops — ``export.vm`` (caution; the migration seed).
+
+``Export-VM`` writes a VM's configuration + virtual disks + checkpoints to a
+folder on the Hyper-V host (three subfolders: ``Virtual Machines``, ``Virtual
+Hard Disks``, ``Snapshots``) — the source artifact a Hyper-V→VMware migration
+consumes. ``caution``: recoverable (it copies, it does not remove the source),
+but the tier makes it satellite-executable only through the Stage-3 composed
+write gate (#2901).
+
+Long-running semantics (documented, deliberate)
+-----------------------------------------------
+
+``Export-VM`` is **synchronous** and can run for many minutes on a
+multi-hundred-GB VM: it blocks the ``powershell -EncodedCommand`` process (and
+therefore this SSH round-trip) until the copy finishes. Unlike a reboot it does
+**not** tear the SSH channel down, so a blocking read is safe — the only risk is
+the wall-clock budget. The handler therefore exposes ``timeout_seconds`` (default
+one hour) and forwards it to the transport's per-call timeout so the caller sizes
+the budget to the VM's disk size. A truly asynchronous ``-AsJob`` submission +
+out-of-band job polling is a documented follow-up (it needs a session-surviving
+job store the stateless per-call transport does not have); this cut ships the
+straightforward blocking export, which is correct for the lab-scale VMs the
+consumer proof exercises.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied ``vm_name`` / ``path`` are interpolated only inside
+single-quoted literals via
+:func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`. ``timeout_seconds``
+is a Python-validated bounded ``int`` and never reaches the script text.
+
+References
+----------
+
+* ``Export-VM`` (``-Name`` / ``-Path`` folder; no output on success):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/export-vm
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.hyperv.ops import SSH_TRANSPORT_NOTE, HypervOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = ["EXPORT_OPS", "hyperv_export_vm"]
+
+#: Default export wall-clock budget (seconds). One hour covers a lab-scale VM;
+#: the operator raises it for a large production disk.
+_DEFAULT_TIMEOUT_SECONDS: int = 3600
+
+#: Hard ceiling on the export budget — a full day. Guards against an
+#: accidentally unbounded blocking SSH round-trip.
+_MAX_TIMEOUT_SECONDS: int = 86400
+
+
+def _validate_timeout(raw: Any) -> int:
+    """Return a validated ``1..86400`` second budget (default when absent)."""
+    if raw is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if not isinstance(raw, int) or isinstance(raw, bool) or not (0 < raw <= _MAX_TIMEOUT_SECONDS):
+        raise ValueError(
+            f"timeout_seconds must be an integer 1..{_MAX_TIMEOUT_SECONDS}; got {raw!r}"
+        )
+    return raw
+
+
+async def hyperv_export_vm(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.export.vm`` (caution) — ``Export-VM -Name -Path``.
+
+    Exports the VM to ``path`` (a folder on the host). Blocks until the export
+    completes; ``timeout_seconds`` bounds the wall-clock budget (see the module
+    docstring on long-running semantics).
+    """
+    vm_name = params["vm_name"]
+    path = params["path"]
+    timeout = _validate_timeout(params.get("timeout_seconds"))
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"Export-VM -Name {ps_single_quote(vm_name)} -Path {ps_single_quote(path)}; "
+        "ConvertTo-Json -Compress -InputObject @{ ok = $true }"
+    )
+    await pwsh_run(connector, target, script, operator=operator, timeout=float(timeout))
+    return {
+        "vm_name": vm_name,
+        "path": path,
+        "action": "export",
+        "timeout_seconds": timeout,
+        "op_class": "write",
+    }
+
+
+EXPORT_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.export.vm",
+        handler_attr="hyperv_export_vm",
+        summary="Export a VM to a folder via ``Export-VM`` (caution; long-running migration seed).",
+        description=(
+            "Runs ``Export-VM -Name <vm_name> -Path <path>`` to write the VM's "
+            "configuration + virtual disks + checkpoints into a folder on the "
+            "Hyper-V host — the source artifact a Hyper-V→VMware migration "
+            "consumes. safety_level=caution — recoverable (it copies, does not "
+            "remove the source). LONG-RUNNING: the call blocks over SSH until "
+            "the export completes; set ``timeout_seconds`` (default 3600) to "
+            "cover the VM's disk size. The export folder already contains the "
+            "Virtual Hard Disks, so there is no separate disk-export op."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": "The VM name to export (``Export-VM -Name``).",
+                },
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "\\S",
+                    "description": (
+                        "The destination FOLDER on the Hyper-V host "
+                        "(``Export-VM -Path``); Export-VM creates a per-VM "
+                        "subfolder under it."
+                    ),
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_TIMEOUT_SECONDS,
+                    "description": (
+                        "Wall-clock budget for the blocking export (default "
+                        "3600). Raise for a large disk; the export blocks the "
+                        "SSH round-trip until it completes."
+                    ),
+                },
+            },
+            "required": ["vm_name", "path"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": {"type": "string"},
+                "path": {"type": "string"},
+                "action": {"type": "string"},
+                "timeout_seconds": {"type": "integer"},
+                "op_class": {"type": "string", "enum": ["write"]},
+            },
+            "required": ["vm_name", "path", "action", "op_class"],
+            "additionalProperties": True,
+        },
+        group_key="export",
+        tags=("write", "export", "migration"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Export a source VM to a folder on the Hyper-V host to seed a "
+                "Hyper-V→VMware migration. Recoverable; safety_level=caution. "
+                "LONG-RUNNING — set timeout_seconds to cover the VM's disk "
+                "size; the call blocks until the export finishes. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "vm_name": "Required. The VM name to export.",
+                "path": "Required. The destination folder on the Hyper-V host.",
+                "timeout_seconds": "Optional. Wall-clock budget in seconds (default 3600).",
+            },
+            "output_shape": (
+                "{'vm_name', 'path', 'action': 'export', 'timeout_seconds', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/hyperv/ops_host.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_host.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv host ops — ``host.info`` / ``host.numa`` / ``host.vswitch.list`` (all safe).
+
+Read-only Hyper-V host facts via ``Get-VMHost`` (logical processors, memory
+capacity, NUMA spanning, default VM / VHD paths), ``Get-VMHostNumaNode`` (the
+host's NUMA topology), and ``Get-VMSwitch`` (the virtual-switch inventory),
+routed through the shared PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). No operator input is
+interpolated into any of these scripts (they are constants), so the host-read
+group has no injection surface.
+
+References
+----------
+
+* ``Get-VMHost`` (output ``Microsoft.HyperV.PowerShell.VMHost``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmhost
+* ``Get-VMHostNumaNode`` (output ``Microsoft.HyperV.PowerShell.VMHostNumaNode``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmhostnumanode
+* ``Get-VMSwitch`` (output ``Microsoft.HyperV.PowerShell.VMSwitch``;
+  ``SwitchType`` is External / Internal / Private):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmswitch
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import pwsh_run
+from meho_backplane.connectors.hyperv.ops import (
+    SSH_TRANSPORT_NOTE,
+    HypervOp,
+    hyperv_list_read,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = [
+    "HOST_OPS",
+    "hyperv_host_info",
+    "hyperv_host_numa",
+    "hyperv_host_vswitch_list",
+]
+
+
+#: Host projection — a flat dict of ``Get-VMHost`` fields the migration
+#: assessment needs. Constant script (no operator input). ``MemoryCapacity`` is
+#: bytes; the default paths anchor where new / exported artifacts land.
+_HOST_INFO_SCRIPT: str = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$h = Get-VMHost; "
+    "ConvertTo-Json -Depth 3 -Compress -InputObject @{ "
+    "Hostname = [System.Net.Dns]::GetHostName(); "
+    "LogicalProcessorCount = $h.LogicalProcessorCount; "
+    "MemoryCapacity = $h.MemoryCapacity; "
+    "NumaSpanningEnabled = $h.NumaSpanningEnabled; "
+    "VirtualHardDiskPath = $h.VirtualHardDiskPath; "
+    "VirtualMachinePath = $h.VirtualMachinePath; "
+    "MaximumStorageMigrations = $h.MaximumStorageMigrations; "
+    "MaximumVirtualMachineMigrations = $h.MaximumVirtualMachineMigrations }"
+)
+
+#: NUMA topology — one row per node. ``ProcessorsAvailability`` is an array (per
+#: logical processor), so ``-Depth 4`` in the list helper keeps it intact.
+_NUMA_PIPELINE: str = (
+    "Get-VMHostNumaNode | Select-Object "
+    "NodeId, ProcessorsAvailability, MemoryAvailable, MemoryTotal"
+)
+
+#: Virtual-switch inventory — one row per switch. ``SwitchType`` is stringified
+#: (the enum renders as its integer under Windows PowerShell 5.1 ConvertTo-Json
+#: otherwise).
+_VSWITCH_PIPELINE: str = (
+    "Get-VMSwitch | Select-Object "
+    "Name, @{N='SwitchType';E={\"$($_.SwitchType)\"}}, "
+    "NetAdapterInterfaceDescription, AllowManagementOS, "
+    "@{N='Id';E={$_.Id.ToString()}}, EmbeddedTeamingEnabled"
+)
+
+
+async def hyperv_host_info(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.host.info`` — the ``Get-VMHost`` projection.
+
+    Reads logical processor count, memory capacity (bytes), NUMA spanning, and
+    the host's default VM / VHD paths. Read-only.
+    """
+    del params  # declared empty in schema; intentionally ignored
+    payload = await pwsh_run(connector, target, _HOST_INFO_SCRIPT, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def hyperv_host_numa(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.host.numa`` — ``Get-VMHostNumaNode`` (list-shaped)."""
+    del params
+    return await hyperv_list_read(connector, target, pipeline=_NUMA_PIPELINE, operator=operator)
+
+
+async def hyperv_host_vswitch_list(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.host.vswitch.list`` — ``Get-VMSwitch`` (list-shaped)."""
+    del params
+    return await hyperv_list_read(connector, target, pipeline=_VSWITCH_PIPELINE, operator=operator)
+
+
+_EMPTY_PARAMS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+HOST_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.host.info",
+        handler_attr="hyperv_host_info",
+        summary="Read Hyper-V host facts via ``Get-VMHost`` (CPUs, memory, NUMA, default paths).",
+        description=(
+            "Runs ``Get-VMHost`` and returns the host's logical processor "
+            "count, memory capacity (bytes), whether NUMA spanning is enabled, "
+            "the default virtual-machine and virtual-hard-disk paths, and the "
+            "storage / live-migration limits. Read-only; the host-capacity "
+            "context a migration plan sizes against."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Hostname": {"type": ["string", "null"]},
+                "LogicalProcessorCount": {"type": ["integer", "null"]},
+                "MemoryCapacity": {"type": ["integer", "null"]},
+                "NumaSpanningEnabled": {"type": ["boolean", "null"]},
+                "VirtualHardDiskPath": {"type": ["string", "null"]},
+                "VirtualMachinePath": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="host",
+        tags=("read-only", "host", "capacity"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for the Hyper-V host's capacity facts — logical CPUs, "
+                "memory, NUMA spanning, default VM / VHD paths. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "Flat dict (LogicalProcessorCount, MemoryCapacity, "
+                "NumaSpanningEnabled, VirtualHardDiskPath, VirtualMachinePath, "
+                "...)."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.host.numa",
+        handler_attr="hyperv_host_numa",
+        summary="List the host's NUMA topology via ``Get-VMHostNumaNode`` (list-shaped).",
+        description=(
+            "Runs ``Get-VMHostNumaNode`` and returns one row per NUMA node "
+            "(NodeId, per-processor availability, available / total memory). "
+            "Read-only; NUMA topology informs how a large source VM's vCPU / "
+            "memory maps onto the target host."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=("read-only", "host", "numa"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read the Hyper-V host's NUMA node topology. "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{NodeId, ProcessorsAvailability, MemoryAvailable, "
+                "MemoryTotal}], 'total': <int>}."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.host.vswitch.list",
+        handler_attr="hyperv_host_vswitch_list",
+        summary="List virtual switches via ``Get-VMSwitch`` (list-shaped).",
+        description=(
+            "Runs ``Get-VMSwitch`` and returns one row per virtual switch "
+            "(Name, SwitchType — External / Internal / Private, bound physical "
+            "adapter description, whether the management OS shares it). "
+            "Read-only; the source networking a migration must reproduce on the "
+            "target port groups."
+        ),
+        parameter_schema=_EMPTY_PARAMS_SCHEMA,
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=("read-only", "host", "networking"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate the Hyper-V host's virtual switches (the "
+                "source networking to reproduce on the target). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Name, SwitchType, NetAdapterInterfaceDescription, "
+                "AllowManagementOS, Id}], 'total': <int>}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/hyperv/ops_power.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_power.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv power ops — ``power.start`` / ``power.stop`` (both caution).
+
+The source-side cutover verbs. ``Start-VM`` / ``Stop-VM`` over the shared
+PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). Both ``caution`` —
+recoverable (a stopped VM can be started again). Stop the source VM as the final
+cutover step once the target VMware VM is validated.
+
+``Stop-VM`` modes (``mode`` param):
+
+* ``shutdown`` (default) — graceful guest shutdown (``-Force`` so it proceeds
+  non-interactively even with unsaved data; Hyper-V gives the guest five
+  minutes). Blocks until the guest is off, so a wider transport timeout is used.
+* ``turnoff`` — hard power-off (``-TurnOff``), equivalent to pulling the plug;
+  can lose unsaved data.
+* ``save`` — suspend to a saved state (``-Save``).
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied ``vm_name`` is interpolated only inside a single-quoted
+literal via :func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`;
+``mode`` is validated against a fixed enum in Python and maps to a constant
+switch string (never interpolated raw).
+
+References
+----------
+
+* ``Start-VM`` / ``Stop-VM`` (``-TurnOff`` hard-off, ``-Save`` suspend,
+  ``-Force`` non-interactive graceful shutdown):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/stop-vm
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.hyperv.ops import SSH_TRANSPORT_NOTE, HypervOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = ["POWER_OPS", "hyperv_power_start", "hyperv_power_stop"]
+
+#: ``mode`` → the mode-selecting ``Stop-VM`` switch (``None`` for the default
+#: graceful shutdown, which needs no mode switch). ``-Force`` is appended to
+#: every mode by the handler so the cmdlet runs non-interactively.
+_STOP_MODE_SWITCH: dict[str, str | None] = {
+    "shutdown": None,
+    "turnoff": "-TurnOff",
+    "save": "-Save",
+}
+
+#: Wider transport budget for a graceful stop — the guest gets up to five
+#: minutes to shut down, so a 30s default would falsely time out.
+_STOP_TIMEOUT_SECONDS: float = 360.0
+
+
+async def hyperv_power_start(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.power.start`` (caution) — ``Start-VM -Name``."""
+    vm_name = params["vm_name"]
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$s = Start-VM -Name {ps_single_quote(vm_name)} -Passthru; "
+        'ConvertTo-Json -Compress -InputObject @{ ok = $true; state = "$($s.State)" }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    data = payload if isinstance(payload, dict) else {}
+    return {"vm_name": vm_name, "action": "start", "state": data.get("state"), "op_class": "write"}
+
+
+async def hyperv_power_stop(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.power.stop`` (caution) — ``Stop-VM -Name`` (mode-selected)."""
+    vm_name = params["vm_name"]
+    mode = params.get("mode", "shutdown")
+    if mode not in _STOP_MODE_SWITCH:
+        raise ValueError(f"mode must be one of {sorted(_STOP_MODE_SWITCH)}; got {mode!r}")
+    mode_switch = _STOP_MODE_SWITCH[mode]
+    # -Force is always appended so the cmdlet never waits on an interactive
+    # confirmation; the default (graceful) mode adds no mode switch of its own.
+    switch = f"{mode_switch} -Force" if mode_switch else "-Force"
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$s = Stop-VM -Name {ps_single_quote(vm_name)} {switch} -Passthru; "
+        'ConvertTo-Json -Compress -InputObject @{ ok = $true; state = "$($s.State)" }'
+    )
+    payload = await pwsh_run(
+        connector, target, script, operator=operator, timeout=_STOP_TIMEOUT_SECONDS
+    )
+    data = payload if isinstance(payload, dict) else {}
+    return {
+        "vm_name": vm_name,
+        "action": "stop",
+        "mode": mode,
+        "state": data.get("state"),
+        "op_class": "write",
+    }
+
+
+_VM_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The virtual machine name (the ``Start-VM`` / ``Stop-VM -Name`` operand).",
+}
+
+_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm_name": {"type": "string"},
+        "action": {"type": "string"},
+        "state": {"type": ["string", "null"]},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": ["vm_name", "action", "op_class"],
+    "additionalProperties": True,
+}
+
+
+POWER_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.power.start",
+        handler_attr="hyperv_power_start",
+        summary="Start a VM via ``Start-VM`` (caution).",
+        description=(
+            "Runs ``Start-VM -Name <vm_name>`` and echoes the resulting state. "
+            "safety_level=caution — recoverable. A source-side cutover verb "
+            "(e.g. to bring a VM back after an aborted migration step)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {"vm_name": _VM_NAME_PROP},
+            "required": ["vm_name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="power",
+        tags=("write", "power", "start"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Start a Hyper-V VM. Recoverable; safety_level=caution. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": "{'vm_name', 'action': 'start', 'state', 'op_class': 'write'}.",
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.power.stop",
+        handler_attr="hyperv_power_stop",
+        summary="Stop a VM via ``Stop-VM`` — graceful / turn-off / save (caution).",
+        description=(
+            "Runs ``Stop-VM -Name <vm_name>`` in one of three modes: "
+            "``shutdown`` (default — graceful guest shutdown, ``-Force`` so it "
+            "proceeds non-interactively), ``turnoff`` (hard power-off, "
+            "``-TurnOff`` — can lose unsaved data), or ``save`` (suspend, "
+            "``-Save``). safety_level=caution — recoverable. Stop the source VM "
+            "as the final cutover step once the target is validated."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": _VM_NAME_PROP,
+                "mode": {
+                    "type": "string",
+                    "enum": ["shutdown", "turnoff", "save"],
+                    "default": "shutdown",
+                    "description": (
+                        "How to stop: ``shutdown`` (graceful, default), "
+                        "``turnoff`` (hard power-off), or ``save`` (suspend)."
+                    ),
+                },
+            },
+            "required": ["vm_name"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            **_WRITE_RESPONSE_SCHEMA,
+            "properties": {
+                **_WRITE_RESPONSE_SCHEMA["properties"],
+                "mode": {"type": "string"},
+            },
+        },
+        group_key="power",
+        tags=("write", "power", "stop"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Stop a Hyper-V VM — graceful shutdown (default), hard turn-off, "
+                "or save/suspend. Recoverable; safety_level=caution. The final "
+                "source-side cutover verb. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "vm_name": "Required. The VM name.",
+                "mode": "Optional; 'shutdown' (default) / 'turnoff' / 'save'.",
+            },
+            "output_shape": (
+                "{'vm_name', 'action': 'stop', 'mode', 'state', 'op_class': 'write'}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/hyperv/ops_vms.py
+++ b/backend/src/meho_backplane/connectors/hyperv/ops_vms.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""hyperv vms ops — ``list`` / ``get`` / ``config`` / ``state`` (all safe).
+
+The migration-assessment surface. Read-only VM facts via ``Get-VM`` (inventory,
+identity, deep configuration, runtime state) and — for a Generation 2 VM —
+``Get-VMFirmware`` (secure-boot state), routed through the shared
+PowerShell-over-SSH transport
+(:func:`~meho_backplane.connectors._shared.pwsh.pwsh_run`). ``Generation`` and
+secure-boot decide the target-side VMware firmware (Gen 1 → BIOS, Gen 2 → EFI,
+secure-boot On → EFI Secure Boot); ``IntegrationServicesVersion`` flags a guest
+whose integration components need refreshing before / after the move.
+
+Enum, ``Guid``, ``TimeSpan`` and ``Version`` properties are stringified with
+``Select-Object`` calculated properties / ``"$(...)"`` because Windows
+PowerShell 5.1 ``ConvertTo-Json`` renders an enum as its integer value and a
+compound object as a nested map — a stringified projection keeps the
+assessment surface readable and stable.
+
+PowerShell injection safety
+---------------------------
+
+The operator-supplied ``vm_name`` is interpolated only inside a single-quoted
+literal via :func:`~meho_backplane.connectors._shared.pwsh.ps_single_quote`
+(assigned to ``$n`` in a prelude, then referenced as a variable). The list op
+takes no operator input (constant script).
+
+References
+----------
+
+* ``Get-VM`` (output ``Microsoft.HyperV.PowerShell.VirtualMachine``):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vm
+* ``Get-VMFirmware`` (Generation 2 secure-boot state):
+  https://learn.microsoft.com/en-us/powershell/module/hyper-v/get-vmfirmware
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import ps_single_quote, pwsh_run
+from meho_backplane.connectors.hyperv.ops import (
+    SSH_TRANSPORT_NOTE,
+    HypervOp,
+    hyperv_list_read,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.hyperv.connector import HypervConnector
+
+__all__ = [
+    "VMS_OPS",
+    "hyperv_vms_config",
+    "hyperv_vms_get",
+    "hyperv_vms_list",
+    "hyperv_vms_state",
+]
+
+
+#: The bounded projection every VM inventory read returns — a stable, JSON-safe
+#: subset with enum / Guid / TimeSpan / Version fields stringified.
+_VM_SELECT: str = (
+    "Name, @{N='Id';E={$_.Id.ToString()}}, @{N='State';E={\"$($_.State)\"}}, "
+    "Status, CPUUsage, MemoryAssigned, @{N='Uptime';E={$_.Uptime.ToString()}}, "
+    "@{N='Version';E={\"$($_.Version)\"}}, Generation, ProcessorCount, "
+    "@{N='IntegrationServicesVersion';E={if ($_.IntegrationServicesVersion) "
+    "{ $_.IntegrationServicesVersion.ToString() } else { $null }}}, "
+    "IntegrationServicesState, Path"
+)
+
+
+async def hyperv_vms_list(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.vms.list`` — ``Get-VM`` (list-shaped, JSONFlux-reduced)."""
+    del params
+    return await hyperv_list_read(
+        connector, target, pipeline=f"Get-VM | Select-Object {_VM_SELECT}", operator=operator
+    )
+
+
+async def hyperv_vms_get(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.vms.get`` — ``Get-VM -Name`` (one VM)."""
+    vm_name = params["vm_name"]
+    result = await hyperv_list_read(
+        connector,
+        target,
+        prelude=f"$n = {ps_single_quote(vm_name)}; ",
+        pipeline=f"Get-VM -Name $n | Select-Object {_VM_SELECT}",
+        operator=operator,
+    )
+    return {"vm_name": vm_name, **result}
+
+
+async def hyperv_vms_config(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.vms.config`` — deep configuration of one VM.
+
+    Reads memory (startup / min / max, dynamic), processor count, generation,
+    automatic start / stop actions, checkpoint type, integration-services
+    version, and — for a Generation 2 VM — the secure-boot state via
+    ``Get-VMFirmware`` (guarded: a Generation 1 VM is BIOS and has none, so
+    ``SecureBoot`` is ``null``). Read-only.
+    """
+    n = ps_single_quote(params["vm_name"])
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$n = {n}; "
+        "$vm = Get-VM -Name $n; "
+        "$secureboot = $null; "
+        "if ($vm.Generation -eq 2) { try { "
+        '$secureboot = "$((Get-VMFirmware -VMName $n).SecureBoot)" } '
+        "catch { $secureboot = $null } }; "
+        "ConvertTo-Json -Depth 4 -Compress -InputObject @{ "
+        "Name = $vm.Name; "
+        "Generation = $vm.Generation; "
+        'Version = "$($vm.Version)"; '
+        "ProcessorCount = $vm.ProcessorCount; "
+        "MemoryStartup = $vm.MemoryStartup; "
+        "MemoryMinimum = $vm.MemoryMinimum; "
+        "MemoryMaximum = $vm.MemoryMaximum; "
+        "DynamicMemoryEnabled = $vm.DynamicMemoryEnabled; "
+        'AutomaticStartAction = "$($vm.AutomaticStartAction)"; '
+        'AutomaticStopAction = "$($vm.AutomaticStopAction)"; '
+        'CheckpointType = "$($vm.CheckpointType)"; '
+        "IntegrationServicesVersion = if ($vm.IntegrationServicesVersion) "
+        "{ $vm.IntegrationServicesVersion.ToString() } else { $null }; "
+        "ConfigurationLocation = $vm.ConfigurationLocation; "
+        "SecureBoot = $secureboot }"
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+async def hyperv_vms_state(
+    connector: HypervConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``hyperv.vms.state`` — runtime state of one VM.
+
+    Reads State / Status / Uptime / CPU + memory usage / Heartbeat (``null``
+    when the guest integration services are not reporting). Read-only.
+    """
+    n = ps_single_quote(params["vm_name"])
+    script = (
+        "$ErrorActionPreference = 'Stop'; "
+        f"$n = {n}; "
+        "$vm = Get-VM -Name $n; "
+        "ConvertTo-Json -Compress -InputObject @{ "
+        "Name = $vm.Name; "
+        'State = "$($vm.State)"; '
+        "Status = $vm.Status; "
+        "Uptime = $vm.Uptime.ToString(); "
+        "CPUUsage = $vm.CPUUsage; "
+        "MemoryAssigned = $vm.MemoryAssigned; "
+        "MemoryDemand = $vm.MemoryDemand; "
+        'Heartbeat = if ($vm.Heartbeat) { "$($vm.Heartbeat)" } else { $null } }'
+    )
+    payload = await pwsh_run(connector, target, script, operator=operator)
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+_VM_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "The virtual machine name (the ``Get-VM -Name`` operand, e.g. ``sql-01``).",
+}
+
+_VM_NAME_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"vm_name": _VM_NAME_PROP},
+    "required": ["vm_name"],
+    "additionalProperties": False,
+}
+
+_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+VMS_OPS: tuple[HypervOp, ...] = (
+    HypervOp(
+        op_id="hyperv.vms.list",
+        handler_attr="hyperv_vms_list",
+        summary="List all VMs via ``Get-VM`` (list-shaped, JSONFlux-reduced).",
+        description=(
+            "Runs ``Get-VM`` and returns one row per VM (Name, Id, State, "
+            "Status, CPUUsage, MemoryAssigned, Uptime, configuration Version, "
+            "Generation, ProcessorCount, IntegrationServicesVersion / State, "
+            "config Path). Read-only; the migration-assessment surface — the "
+            "starting inventory of source VMs. The ``{rows, total}`` envelope is "
+            "JSONFlux-reduced to a handle for large result sets."
+        ),
+        parameter_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        response_schema=_LIST_RESPONSE_SCHEMA,
+        group_key="vms",
+        tags=("read-only", "vms", "inventory"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to enumerate every VM on the Hyper-V host — the source "
+                "inventory for a migration assessment (state, generation, "
+                "integration-services version). Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "{'rows': [{Name, Id, State, Generation, ProcessorCount, "
+                "MemoryAssigned, IntegrationServicesVersion, ...}], "
+                "'total': <int>}."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.vms.get",
+        handler_attr="hyperv_vms_get",
+        summary="Read one VM by name via ``Get-VM -Name``.",
+        description=(
+            "Runs ``Get-VM -Name <vm_name>`` and returns the single matching VM "
+            "projection as a ``{rows, total}`` envelope plus the echoed "
+            "``vm_name``. An unknown VM is a terminating error. Read-only."
+        ),
+        parameter_schema=_VM_NAME_PARAM_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "vm_name": {"type": "string"},
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+            },
+            "required": ["vm_name", "rows", "total"],
+            "additionalProperties": True,
+        },
+        group_key="vms",
+        tags=("read-only", "vms", "lookup"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to read one VM's identity, state, and generation by name. "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": "{'vm_name', 'rows': [<vm>], 'total': <int>}.",
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.vms.config",
+        handler_attr="hyperv_vms_config",
+        summary="Read a VM's deep configuration (memory / processors / generation / firmware).",
+        description=(
+            "Runs ``Get-VM -Name <vm_name>`` (and, for a Generation 2 VM, "
+            "``Get-VMFirmware``) and returns the migration-relevant "
+            "configuration: memory (startup / min / max, dynamic), processor "
+            "count, generation, automatic start / stop actions, checkpoint "
+            "type, integration-services version, and secure-boot state "
+            "(``null`` on a Generation 1 / BIOS VM). Read-only. Generation + "
+            "secure-boot decide the target VMware firmware (BIOS vs EFI / EFI "
+            "Secure Boot)."
+        ),
+        parameter_schema=_VM_NAME_PARAM_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Name": {"type": ["string", "null"]},
+                "Generation": {"type": ["integer", "null"]},
+                "ProcessorCount": {"type": ["integer", "null"]},
+                "MemoryStartup": {"type": ["integer", "null"]},
+                "DynamicMemoryEnabled": {"type": ["boolean", "null"]},
+                "SecureBoot": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="vms",
+        tags=("read-only", "vms", "config"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call for a VM's deep configuration before planning its move — "
+                "memory, processors, generation, firmware / secure-boot. "
+                "Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": (
+                "Flat dict (Generation, ProcessorCount, MemoryStartup, "
+                "MemoryMinimum, MemoryMaximum, DynamicMemoryEnabled, SecureBoot, "
+                "...)."
+            ),
+        },
+    ),
+    HypervOp(
+        op_id="hyperv.vms.state",
+        handler_attr="hyperv_vms_state",
+        summary="Read a VM's runtime state (State / Status / Uptime / Heartbeat).",
+        description=(
+            "Runs ``Get-VM -Name <vm_name>`` and returns the runtime state: "
+            "State, Status, Uptime, CPU + memory usage, and guest Heartbeat "
+            "(``null`` when the integration services are not reporting). "
+            "Read-only; the pre-cutover check that the source VM is quiesced / "
+            "reporting healthy."
+        ),
+        parameter_schema=_VM_NAME_PARAM_SCHEMA,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "Name": {"type": ["string", "null"]},
+                "State": {"type": ["string", "null"]},
+                "Status": {"type": ["string", "null"]},
+                "Uptime": {"type": ["string", "null"]},
+                "Heartbeat": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="vms",
+        tags=("read-only", "vms", "state"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call to check a VM's runtime state (running / off), uptime, and "
+                "guest heartbeat before a cutover. Read-only. " + SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {"vm_name": "Required. The VM name."},
+            "output_shape": "{'Name', 'State', 'Status', 'Uptime', 'Heartbeat', ...}.",
+        },
+    ),
+)

--- a/backend/tests/test_connectors_hyperv.py
+++ b/backend/tests/test_connectors_hyperv.py
@@ -1,0 +1,637 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the hyperv connector (SSH → PowerShell / Hyper-V migration source).
+
+Mirrors the winsrv harness (``test_connectors_winsrv.py``): a ``_StubTarget``
+dataclass, a ``_completed_process`` SSHCompletedProcess stub, and
+``patch.object(connector, "_run_command", AsyncMock(...))`` so the cmdlet
+handlers can be exercised without a real Hyper-V host. Because the transport is
+``powershell -EncodedCommand <base64-utf16le>`` (Windows PowerShell 5.1), the
+assertions decode the base64 payload back to the script and assert on the cmdlet
++ quoted arguments the handler built.
+
+There is no spec-reconcile lane — the cmdlet surface ships no OpenAPI (the
+confirmed convention for SSH-typed connectors). Drift protection is this
+ordinary unit suite. Coverage spans every op group, the injection-safety escape
+on every parameterized script, the ``{rows, total}`` JSONFlux envelope on the
+list ops, and the secret-hygiene invariant that no op accepts a secret-value
+parameter.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.hyperv  # noqa: F401 -- registers connector at import
+from meho_backplane.connectors.hyperv import HYPERV_OPS, HypervConnector
+from meho_backplane.connectors.hyperv.ops import HYPERV_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.hyperv.ops_checkpoints import (
+    hyperv_checkpoints_create,
+    hyperv_checkpoints_delete,
+    hyperv_checkpoints_list,
+    hyperv_checkpoints_revert,
+)
+from meho_backplane.connectors.hyperv.ops_disks import (
+    hyperv_disks_vhd_chain,
+    hyperv_disks_vhd_get,
+    hyperv_disks_vm_list,
+)
+from meho_backplane.connectors.hyperv.ops_export import hyperv_export_vm
+from meho_backplane.connectors.hyperv.ops_host import (
+    hyperv_host_info,
+    hyperv_host_numa,
+    hyperv_host_vswitch_list,
+)
+from meho_backplane.connectors.hyperv.ops_power import (
+    hyperv_power_start,
+    hyperv_power_stop,
+)
+from meho_backplane.connectors.hyperv.ops_vms import (
+    hyperv_vms_config,
+    hyperv_vms_get,
+    hyperv_vms_list,
+    hyperv_vms_state,
+)
+from meho_backplane.connectors.registry import product_impl_id_round_trips
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires (mirrors the winsrv suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="hyperv-test",
+    host="hv.test.invalid",
+    port=22,
+    secret_ref="meho/testing/hyperv/hyperv-test",
+)
+
+
+def _completed_process(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Stub mimicking asyncssh's :class:`SSHCompletedProcess`."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _script_from_call(run_mock: AsyncMock) -> str:
+    """Recover the PowerShell script from the mocked ``_run_command`` argv.
+
+    ``pwsh_run`` builds ``powershell -NoProfile -NonInteractive -EncodedCommand
+    <base64-utf16le>`` and passes it as the 2nd positional arg to
+    ``_run_command``. Decode the base64 tail back to the script text (which
+    carries the transport's prepended ``$ProgressPreference`` guard).
+    """
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    encoded = cmd.rsplit(" ", 1)[1]
+    return base64.b64decode(encoded).decode("utf-16-le")
+
+
+def _run(stdout: str) -> AsyncMock:
+    return AsyncMock(return_value=_completed_process(stdout=stdout))
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+async def test_transport_uses_windows_powershell_and_suppresses_progress() -> None:
+    connector = HypervConnector()
+    assert connector.POWERSHELL_EXECUTABLE == "powershell"
+    run_mock = _run('{"rows":[],"total":0}')
+    with patch.object(connector, "_run_command", run_mock):
+        await hyperv_vms_list(connector, _TARGET, {})
+    cmd: str = run_mock.await_args.args[1]
+    assert cmd.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    assert not cmd.startswith("pwsh ")
+    assert _script_from_call(run_mock).startswith("$ProgressPreference = 'SilentlyContinue';")
+
+
+# ---------------------------------------------------------------------------
+# Registration / metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_connector_id_triple_round_trips() -> None:
+    assert HypervConnector.product == "hyperv"
+    assert HypervConnector.version == "2022.x"
+    assert HypervConnector.impl_id == "hyperv-ssh"
+    # The product token is separator-free so the connector_id round-trips
+    # (a `hyper-v` token would break the registry's round-trip guard at boot).
+    assert product_impl_id_round_trips(product="hyperv", version="2022.x", impl_id="hyperv-ssh")
+
+
+def test_op_surface_ids_and_safety_tiers() -> None:
+    by_id = {op.op_id: op for op in HYPERV_OPS}
+    assert len(by_id) == 18
+    safe = {k for k, v in by_id.items() if v.safety_level == "safe"}
+    caution = {k for k, v in by_id.items() if v.safety_level == "caution"}
+    dangerous = {k for k, v in by_id.items() if v.safety_level == "dangerous"}
+    # Reverting or deleting a checkpoint is the only destructive surface.
+    assert dangerous == {"hyperv.checkpoints.revert", "hyperv.checkpoints.delete"}
+    # Every dangerous op requires approval; nothing else does.
+    assert {k for k, v in by_id.items() if v.requires_approval} == dangerous
+    # Recoverable writes are caution (the migration-seed + cutover verbs).
+    assert caution == {
+        "hyperv.checkpoints.create",
+        "hyperv.export.vm",
+        "hyperv.power.start",
+        "hyperv.power.stop",
+    }
+    # The whole assessment surface (host / vms / disks / checkpoint-list) is safe.
+    assert {
+        "hyperv.about",
+        "hyperv.host.info",
+        "hyperv.vms.list",
+        "hyperv.disks.vhd.get",
+        "hyperv.checkpoints.list",
+    } <= safe
+
+
+def test_every_group_has_a_curated_when_to_use() -> None:
+    groups = {op.group_key for op in HYPERV_OPS}
+    assert groups == {"host", "vms", "disks", "checkpoints", "export", "power"}
+    assert groups <= set(HYPERV_WHEN_TO_USE_BY_GROUP)
+
+
+def test_every_handler_attr_resolves_on_the_class() -> None:
+    for op in HYPERV_OPS:
+        assert getattr(HypervConnector, op.handler_attr, None) is not None, op.op_id
+
+
+def test_no_op_exposes_a_secret_value_field() -> None:
+    """The secret-leak guard at the schema level: no op accepts a plaintext
+    secret-value parameter, so a secret can never reach the ``-EncodedCommand``
+    argv. The SSH credential is the only secret and it never enters a script."""
+    secret_fields = {"password", "secret", "credential", "chap_secret", "chapsecret"}
+    for op in HYPERV_OPS:
+        props = op.parameter_schema.get("properties", {})
+        leaked = secret_fields & {key.lower() for key in props}
+        assert not leaked, (op.op_id, sorted(leaked))
+
+
+# ---------------------------------------------------------------------------
+# host group
+# ---------------------------------------------------------------------------
+
+
+async def test_host_info_reads_vmhost() -> None:
+    connector = HypervConnector()
+    payload = (
+        '{"LogicalProcessorCount":32,"MemoryCapacity":137438953472,"NumaSpanningEnabled":true}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_host_info(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-VMHost" in script
+    assert "LogicalProcessorCount" in script
+    assert result["LogicalProcessorCount"] == 32
+
+
+async def test_host_numa_builds_envelope() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"rows":[{"NodeId":0,"MemoryTotal":68719476736}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_host_numa(connector, _TARGET, {})
+    assert "Get-VMHostNumaNode" in _script_from_call(run_mock)
+    assert result == {"rows": [{"NodeId": 0, "MemoryTotal": 68719476736}], "total": 1}
+
+
+@pytest.mark.parametrize("rows_json", ["[]", "null"])
+async def test_vswitch_list_empty_host(rows_json: str) -> None:
+    connector = HypervConnector()
+    run_mock = _run(f'{{"rows":{rows_json},"total":0}}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_host_vswitch_list(connector, _TARGET, {})
+    assert "Get-VMSwitch" in _script_from_call(run_mock)
+    assert result == {"rows": [], "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# vms group (the migration-assessment surface)
+# ---------------------------------------------------------------------------
+
+
+async def test_vms_list_builds_envelope_and_stringifies_state() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"rows":[{"Name":"sql-01","State":"Running","Generation":2}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_vms_list(connector, _TARGET, {})
+    script = _script_from_call(run_mock)
+    assert "Get-VM | Select-Object" in script
+    # State / Id / Version enum+compound fields are stringified for a readable
+    # assessment surface (PS 5.1 ConvertTo-Json renders enums as integers raw).
+    assert "@{N='State';E={\"$($_.State)\"}}" in script
+    assert "IntegrationServicesVersion" in script
+    assert result["total"] == 1
+
+
+async def test_vms_get_escapes_name() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"rows":[{"Name":"o\'db"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_vms_get(connector, _TARGET, {"vm_name": "o'db"})
+    script = _script_from_call(run_mock)
+    assert "$n = 'o''db'" in script  # single quote doubled inside the literal
+    assert "Get-VM -Name $n" in script
+    assert result["vm_name"] == "o'db"
+
+
+async def test_vms_config_guards_firmware_by_generation() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"Name":"sql-01","Generation":2,"SecureBoot":"On","ProcessorCount":4}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_vms_config(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "$n = 'sql-01'" in script
+    assert "if ($vm.Generation -eq 2)" in script  # firmware read guarded to Gen 2
+    assert "Get-VMFirmware -VMName $n" in script
+    assert "MemoryStartup = $vm.MemoryStartup" in script
+    assert result["SecureBoot"] == "On"
+
+
+async def test_vms_state_reads_runtime() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"Name":"sql-01","State":"Running","Heartbeat":"OkApplicationsHealthy"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_vms_state(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "$vm = Get-VM -Name $n" in script
+    assert "Heartbeat = if ($vm.Heartbeat)" in script
+    assert result["State"] == "Running"
+
+
+# ---------------------------------------------------------------------------
+# disks group (the VHDX→VMDK planning input)
+# ---------------------------------------------------------------------------
+
+
+async def test_disks_vm_list_builds_envelope() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"rows":[{"Path":"C:\\\\vm\\\\d.vhdx","ControllerType":"SCSI"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_disks_vm_list(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "Get-VMHardDiskDrive -VMName $n" in script
+    assert result["vm_name"] == "sql-01"
+    assert result["total"] == 1
+
+
+async def test_disks_vhd_get_escapes_path_and_reads_facts() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"Path":"C:\\\\vm\\\\d.vhdx","VhdFormat":"VHDX","VhdType":"Dynamic"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_disks_vhd_get(connector, _TARGET, {"path": "C:\\vm\\o'db.vhdx"})
+    script = _script_from_call(run_mock)
+    assert "Get-VHD -Path 'C:\\vm\\o''db.vhdx'" in script  # single quote doubled
+    assert 'VhdFormat = "$($v.VhdFormat)"' in script
+    assert "FragmentationPercentage = $v.FragmentationPercentage" in script
+    assert result["VhdFormat"] == "VHDX"
+
+
+async def test_disks_vhd_chain_walks_parent_and_normalises() -> None:
+    connector = HypervConnector()
+    payload = (
+        '{"rows":[{"Path":"leaf.avhdx","ParentPath":"base.vhdx"},'
+        '{"Path":"base.vhdx","ParentPath":null}],"total":2}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_disks_vhd_chain(connector, _TARGET, {"path": "leaf.avhdx"})
+    script = _script_from_call(run_mock)
+    assert "$p = 'leaf.avhdx'" in script
+    assert "while ($p) {" in script
+    assert "$p = $v.ParentPath" in script  # follows the parent link
+    assert result["path"] == "leaf.avhdx"
+    assert result["total"] == 2
+
+
+async def test_disks_vhd_chain_single_disk_collapses_to_one_row() -> None:
+    connector = HypervConnector()
+    # PS ConvertTo-Json can collapse a single-element array to a bare object;
+    # normalise_json_rows re-wraps it so total stays honest.
+    run_mock = _run('{"rows":{"Path":"base.vhdx","ParentPath":null},"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_disks_vhd_chain(connector, _TARGET, {"path": "base.vhdx"})
+    assert result["total"] == 1
+    assert result["rows"] == [{"Path": "base.vhdx", "ParentPath": None}]
+
+
+# ---------------------------------------------------------------------------
+# checkpoints group (list safe / create caution / revert+delete dangerous)
+# ---------------------------------------------------------------------------
+
+
+async def test_checkpoints_list_builds_envelope() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"rows":[{"Name":"pre-cutover","SnapshotType":"Standard"}],"total":1}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_checkpoints_list(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "Get-VMSnapshot -VMName $n" in script
+    assert result["vm_name"] == "sql-01"
+    assert result["total"] == 1
+
+
+async def test_checkpoints_create_named_and_passthru() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true,"vm":"sql-01","checkpoint":"pre-cutover"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_checkpoints_create(
+            connector, _TARGET, {"vm_name": "sql-01", "checkpoint_name": "pre'cut"}
+        )
+    script = _script_from_call(run_mock)
+    assert "Checkpoint-VM -Name $n -SnapshotName 'pre''cut' -Passthru" in script
+    assert result == {
+        "vm_name": "sql-01",
+        "checkpoint_name": "pre-cutover",
+        "action": "create",
+        "op_class": "write",
+    }
+
+
+async def test_checkpoints_create_auto_named_when_omitted() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true,"vm":"sql-01","checkpoint":"sql-01 - (2026)"}')
+    with patch.object(connector, "_run_command", run_mock):
+        await hyperv_checkpoints_create(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "Checkpoint-VM -Name $n -Passthru" in script
+    assert "-SnapshotName" not in script  # omitted → Hyper-V auto-names it
+
+
+@pytest.mark.parametrize(
+    ("handler", "cmdlet", "action"),
+    [
+        (hyperv_checkpoints_revert, "Restore-VMSnapshot", "revert"),
+        (hyperv_checkpoints_delete, "Remove-VMSnapshot", "delete"),
+    ],
+)
+async def test_checkpoint_writes_build_confirm_false_and_escape(
+    handler: Any, cmdlet: str, action: str
+) -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await handler(
+            connector, _TARGET, {"vm_name": "sql-01", "checkpoint_name": "pre'cut"}
+        )
+    script = _script_from_call(run_mock)
+    assert f"{cmdlet} -Name 'pre''cut' -VMName 'sql-01' -Confirm:$false" in script
+    assert result == {
+        "vm_name": "sql-01",
+        "checkpoint_name": "pre'cut",
+        "action": action,
+        "op_class": "write",
+    }
+
+
+# ---------------------------------------------------------------------------
+# export group (the migration seed; long-running)
+# ---------------------------------------------------------------------------
+
+
+async def test_export_vm_builds_cmdlet_and_forwards_timeout() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_export_vm(
+            connector,
+            _TARGET,
+            {"vm_name": "sql-01", "path": "E:\\exports", "timeout_seconds": 7200},
+        )
+    script = _script_from_call(run_mock)
+    assert "Export-VM -Name 'sql-01' -Path 'E:\\exports'" in script
+    # The wall-clock budget is forwarded to the transport's per-call timeout.
+    assert run_mock.await_args.kwargs["timeout"] == 7200.0
+    assert result == {
+        "vm_name": "sql-01",
+        "path": "E:\\exports",
+        "action": "export",
+        "timeout_seconds": 7200,
+        "op_class": "write",
+    }
+
+
+async def test_export_vm_default_timeout() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_export_vm(connector, _TARGET, {"vm_name": "vm", "path": "E:\\x"})
+    assert run_mock.await_args.kwargs["timeout"] == 3600.0
+    assert result["timeout_seconds"] == 3600
+
+
+@pytest.mark.parametrize("bad", [0, -1, 999999, "3600", 3.5, True])
+async def test_export_vm_rejects_bad_timeout(bad: Any) -> None:
+    connector = HypervConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await hyperv_export_vm(
+            connector, _TARGET, {"vm_name": "vm", "path": "E:\\x", "timeout_seconds": bad}
+        )
+    run_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# power group (source-side cutover verbs)
+# ---------------------------------------------------------------------------
+
+
+async def test_power_start_builds_cmdlet() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true,"state":"Running"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_power_start(connector, _TARGET, {"vm_name": "sql-01"})
+    script = _script_from_call(run_mock)
+    assert "Start-VM -Name 'sql-01' -Passthru" in script
+    assert result == {
+        "vm_name": "sql-01",
+        "action": "start",
+        "state": "Running",
+        "op_class": "write",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("shutdown", "Stop-VM -Name 'sql-01' -Force -Passthru"),
+        ("turnoff", "Stop-VM -Name 'sql-01' -TurnOff -Force -Passthru"),
+        ("save", "Stop-VM -Name 'sql-01' -Save -Force -Passthru"),
+    ],
+)
+async def test_power_stop_modes(mode: str, expected: str) -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true,"state":"Off"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_power_stop(connector, _TARGET, {"vm_name": "sql-01", "mode": mode})
+    script = _script_from_call(run_mock)
+    assert expected in script
+    # A graceful stop can take minutes; a wider transport timeout is used.
+    assert run_mock.await_args.kwargs["timeout"] == 360.0
+    assert result["mode"] == mode
+    assert result["action"] == "stop"
+
+
+async def test_power_stop_defaults_to_graceful_shutdown() -> None:
+    connector = HypervConnector()
+    run_mock = _run('{"ok":true,"state":"Off"}')
+    with patch.object(connector, "_run_command", run_mock):
+        result = await hyperv_power_stop(connector, _TARGET, {"vm_name": "vm"})
+    script = _script_from_call(run_mock)
+    # Default (graceful) mode adds no mode switch of its own — no double -Force.
+    assert "Stop-VM -Name 'vm' -Force -Force -Passthru" not in script
+    assert "Stop-VM -Name 'vm' -Force -Passthru" in script
+    assert result["mode"] == "shutdown"
+
+
+async def test_power_stop_rejects_bad_mode() -> None:
+    connector = HypervConnector()
+    run_mock = _run("{}")
+    with patch.object(connector, "_run_command", run_mock), pytest.raises(ValueError):
+        await hyperv_power_stop(connector, _TARGET, {"vm_name": "vm", "mode": "nuke"})
+    run_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# about (fingerprint wrapper) + probe
+# ---------------------------------------------------------------------------
+
+
+async def test_about_maps_fingerprint_into_identity_dict() -> None:
+    connector = HypervConnector()
+    payload = (
+        '{"Hostname":"HV01","Caption":"Microsoft Windows Server 2022 Datacenter",'
+        '"OsVersion":"10.0.20348","BuildNumber":"20348","PowerShellVersion":"5.1.20348.1",'
+        '"HyperVModule":true,"HyperVModuleVersion":"2.0.0.0","HypervisorPresent":true}'
+    )
+    run_mock = _run(payload)
+    with patch.object(connector, "_run_command", run_mock):
+        result = await connector.about(_TARGET, {})
+    assert result["vendor"] == "microsoft"
+    assert result["product"] == "hyper-v"
+    assert result["version"] == "10.0.20348"
+    assert result["build"] == "20348"
+    assert result["hostname"] == "HV01"
+    assert result["hyperv_module"] is True
+    assert result["hyperv_module_version"] == "2.0.0.0"
+    assert result["hypervisor_present"] is True
+
+
+async def test_probe_ok_when_module_and_hypervisor_present() -> None:
+    connector = HypervConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":true,"hypervisor":true}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is True
+    assert result.reason is None
+
+
+async def test_probe_hyperv_module_absent() -> None:
+    connector = HypervConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":false,"hypervisor":false}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "hyperv_module_absent"
+
+
+async def test_probe_hypervisor_role_absent() -> None:
+    connector = HypervConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", _run('{"module":true,"hypervisor":false}')),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "hypervisor_role_absent"
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("connection reset by peer"),
+        asyncssh.ConnectionLost("channel closed mid-command"),
+        TimeoutError("probe script timed out"),
+    ],
+)
+async def test_probe_command_failed_when_run_command_raises_after_connect(boom: Exception) -> None:
+    connector = HypervConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "command_failed"
+
+
+async def test_probe_tcp_unreachable_and_auth_failed() -> None:
+    connector = HypervConnector()
+    with patch.object(connector, "_connect", AsyncMock(side_effect=OSError("no route"))):
+        assert (await connector.probe(_TARGET)).reason == "tcp_unreachable"
+    with patch.object(
+        connector, "_connect", AsyncMock(side_effect=asyncssh.PermissionDenied("no"))
+    ):
+        assert (await connector.probe(_TARGET)).reason == "ssh_auth_failed"
+
+
+async def test_probe_powershell_unavailable() -> None:
+    from meho_backplane.connectors._shared.pwsh import PwshRunError
+
+    connector = HypervConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(side_effect=PwshRunError("boom", exit_status=1, stderr="")),
+        ),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "powershell_unavailable"
+
+
+async def test_fingerprint_unreachable_is_not_an_exception() -> None:
+    connector = HypervConnector()
+    with patch.object(connector, "_run_command", AsyncMock(side_effect=OSError("down"))):
+        result = await connector.fingerprint(_TARGET)
+    assert result.reachable is False
+    assert result.vendor == "microsoft"
+    assert result.product == "hyper-v"
+    assert "error" in result.extras

--- a/backend/tests/test_flight_recorder_typed_spans.py
+++ b/backend/tests/test_flight_recorder_typed_spans.py
@@ -426,6 +426,7 @@ _EXPECTED_TYPED_IMPLS: frozenset[str] = frozenset(
         "gcloud-rest",
         "harbor-rest",
         "holodeck-ssh",
+        "hyperv-ssh",
         "installer-rest",
         "k8s",
         "keycloak-admin",

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -32437,6 +32437,7 @@
               "harbor",
               "hetzner",
               "holodeck",
+              "hyperv",
               "installer",
               "k8s",
               "keycloak",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -538,6 +538,7 @@ const (
 	TargetCreateProductHarbor     TargetCreateProduct = "harbor"
 	TargetCreateProductHetzner    TargetCreateProduct = "hetzner"
 	TargetCreateProductHolodeck   TargetCreateProduct = "holodeck"
+	TargetCreateProductHyperv     TargetCreateProduct = "hyperv"
 	TargetCreateProductInstaller  TargetCreateProduct = "installer"
 	TargetCreateProductK8s        TargetCreateProduct = "k8s"
 	TargetCreateProductKeycloak   TargetCreateProduct = "keycloak"

--- a/docs/codebase/connectors-hyperv.md
+++ b/docs/codebase/connectors-hyperv.md
@@ -230,12 +230,14 @@ shared seam.
 
 ## CLI
 
-Every op is reachable as a `meho hyperv <verb>` command through the same dispatch
-path (the CLI and the agent are dual front-ends on one backplane). Adding the
-`hyperv` product token grew the `TargetCreate.product` enum, so the committed CLI
-OpenAPI snapshot (`cli/api/openapi.json`) and the generated Go client
-(`cli/internal/api/client.gen.go`) were regenerated via `cd cli && make
-snapshot-openapi && make generate`.
+No dedicated `meho hyperv` verb package (the windows_dns / winsrv / wsfc / msad /
+rke2 precedent for SSH-typed connectors). CLI parity is the generic dispatch path
+— `meho operation call hyperv-ssh-2022.x <op_id> --params-json '{...}'` — plus the
+`hyperv` product token added to the OpenAPI `TargetCreate.product` enum
+(regenerated from the live registry, so `meho targets create --product hyperv ...`
+validates and the generated Go client knows the token). The CLI OpenAPI snapshot
+(`cli/api/openapi.json` + the generated `cli/internal/api/client.gen.go`) is
+regenerated in this PR via `cd cli && make snapshot-openapi && make generate`.
 
 ## Known issues / scope
 

--- a/docs/codebase/connectors-hyperv.md
+++ b/docs/codebase/connectors-hyperv.md
@@ -1,0 +1,266 @@
+# Connector: hyperv (hyperv-2022.x / `hyperv-ssh`)
+
+## Overview
+
+`hyperv` is the **Hyper-V migration-source** connector: the governed,
+source-side reach for a Hyper-V→VMware migration. It reads a Hyper-V host's
+inventory, VM configuration, and virtual-disk / checkpoint facts — the inputs a
+migration plan is built from — plus the guarded `Export-VM` that seeds the
+migration, over SSH → PowerShell. The Hyper-V host runs an OpenSSH server whose
+shell drives `powershell` (Windows PowerShell 5.1) executing the built-in
+`Hyper-V` module cmdlets.
+
+It is a **structured copy of the `winsrv` estate mold** (#3261): the same
+`SshConnector` base and the same shared PowerShell-over-SSH transport
+(`meho_backplane.connectors._shared.pwsh`), an identity canary + per-domain op
+groups, the `{rows, total}` JSONFlux envelope for list reads, and the `rke2`
+approval-parked-write mold for its destructive ops. The agent never sees the
+difference between this typed connector and a generic one — it goes through the
+same `call_operation(connector_id, op_id, target?, params)` meta-tool.
+
+The **target is a single Hyper-V host** (standalone or a cluster node). The
+`Hyper-V` module cmdlets act on the local host, so one host is the control point
+for its own VMs. **Cluster-wide** views of a Hyper-V *cluster*'s nodes belong to
+the [`wsfc`](connectors-wsfc.md) connector (#3263) on the same nodes — this
+connector does not duplicate them.
+
+**Migration-source framing — what feeds a VHDX→VMDK plan.** The safe reads
+answer the questions a migration assessment asks:
+
+- *Which VMs, and how big?* — `hyperv.vms.list` (inventory: state, generation,
+  integration-services version), `hyperv.host.info` (host capacity to size
+  against).
+- *What firmware does the target need?* — `hyperv.vms.config` surfaces
+  `Generation` (1 → BIOS, 2 → EFI) and, for Gen 2, the secure-boot state (→ EFI
+  Secure Boot). Wrong firmware is the most common failed-boot after a migration.
+- *What do the disks convert to?* — `hyperv.disks.vm.list` maps a VM to its
+  virtual-disk files; `hyperv.disks.vhd.get` reports each VHD/VHDX's format,
+  virtual size, on-disk file size, and fragmentation; `hyperv.disks.vhd.chain`
+  walks a differencing (`.avhdx`) disk's parent chain to the base — a
+  differencing chain must be merged before a clean single-file VMDK conversion.
+- *Is the source safe to cut over?* — `hyperv.checkpoints.list` flags a live
+  checkpoint tree (differencing disks in play); `hyperv.vms.state` confirms the
+  guest is quiesced / heartbeating.
+
+The write surface is the seed and the cutover: `hyperv.export.vm` (the migration
+seed) and `hyperv.power.start` / `hyperv.power.stop` (source-side cutover
+verbs), plus checkpoint create / revert / delete.
+
+## Op surface (18 ops across six groups)
+
+Safety tiers follow the Initiative #3259 satellite table: reads are `safe` (ride
+satellite runners into un-dialable customer networks); recoverable writes are
+`caution` (satellite-executable only through the Stage-3 composed write gate,
+#2901); destructive ops are `dangerous` + `requires_approval` (satellite-EXCLUDED
+by the tier ladder — central-dial / on-site only).
+
+| op_id | group | safety | cmdlet(s) |
+|---|---|---|---|
+| `hyperv.about` | host | safe | `Get-Module Hyper-V` + `Win32_ComputerSystem` (identity canary) |
+| `hyperv.host.info` | host | safe | `Get-VMHost` |
+| `hyperv.host.numa` | host | safe | `Get-VMHostNumaNode` |
+| `hyperv.host.vswitch.list` | host | safe | `Get-VMSwitch` |
+| `hyperv.vms.list` | vms | safe | `Get-VM` (the assessment surface) |
+| `hyperv.vms.get` | vms | safe | `Get-VM -Name` |
+| `hyperv.vms.config` | vms | safe | `Get-VM` (+ `Get-VMFirmware` on Gen 2) |
+| `hyperv.vms.state` | vms | safe | `Get-VM -Name` (runtime state) |
+| `hyperv.disks.vm.list` | disks | safe | `Get-VMHardDiskDrive -VMName` |
+| `hyperv.disks.vhd.get` | disks | safe | `Get-VHD -Path` |
+| `hyperv.disks.vhd.chain` | disks | safe | `Get-VHD` (follows `ParentPath` leaf→base) |
+| `hyperv.checkpoints.list` | checkpoints | safe | `Get-VMSnapshot -VMName` |
+| `hyperv.checkpoints.create` | checkpoints | caution | `Checkpoint-VM` |
+| `hyperv.checkpoints.revert` | checkpoints | dangerous + approval | `Restore-VMSnapshot` |
+| `hyperv.checkpoints.delete` | checkpoints | dangerous + approval | `Remove-VMSnapshot` |
+| `hyperv.export.vm` | export | caution | `Export-VM -Name -Path` (long-running) |
+| `hyperv.power.start` | power | caution | `Start-VM` |
+| `hyperv.power.stop` | power | caution | `Stop-VM` (`shutdown` / `turnoff` / `save`) |
+
+12 `safe`, 4 `caution`, 2 `dangerous` + `requires_approval`. Every op carries an
+`llm_instructions` block; every group carries a `_WHEN_TO_USE_BY_GROUP` entry
+(registration fails closed without one).
+
+### Explicit non-goals (this increment)
+
+- **VM create / delete on Hyper-V** — we manage the source, we do not build on
+  it.
+- **SCVMM** — no consumer.
+- **Hyper-V Replica** — out of scope.
+- **Cluster-wide views** — the `wsfc` connector owns them on the same nodes.
+
+## Key types
+
+- `HypervConnector` (`connector.py`) — the `SshConnector` subclass. Sets
+  `POWERSHELL_EXECUTABLE = "powershell"`, `POWERSHELL_SCRIPT_PREFIX`
+  (`$ProgressPreference = 'SilentlyContinue'; `), and `POWERSHELL_LOG_EVENT =
+  "hyperv_pwsh_executed"`. Carries `fingerprint`, `probe`, `about`, the 17
+  bound-method op shims, `register_operations`, and the operator-less `execute`
+  dispatcher shim.
+- `HypervOp` (`ops.py`) — a frozen dataclass mirroring the
+  `register_typed_operation` kwargs; each op declares its `handler_attr`,
+  schemas, `group_key`, `safety_level`, `requires_approval`, and
+  `llm_instructions`.
+- `HYPERV_OPS` (`ops.py`) — the registration tuple, composed by `_hyperv_ops()`
+  from the identity canary + the per-group tuples (`HOST_OPS`, `VMS_OPS`,
+  `DISK_OPS`, `CHECKPOINT_OPS`, `EXPORT_OPS`, `POWER_OPS`).
+- `hyperv_list_read()` (`ops.py`) — the shared `{rows, total}` JSONFlux
+  envelope builder: wraps a `Get-… | Select-Object …` pipeline in `@(…)` under
+  `$ErrorActionPreference = 'Stop'` so a single object still counts as one row
+  and a cmdlet error is a real failure (not a false-empty read).
+
+## Transport: PowerShell-over-SSH
+
+Cmdlets reach the host as `powershell -NoProfile -NonInteractive -EncodedCommand
+<base64-utf16le>` (Windows PowerShell 5.1) via the shared transport
+`meho_backplane.connectors._shared.pwsh.pwsh_run`. Output is the cmdlet's
+`ConvertTo-Json` piped to stdout, parsed with the stdlib `json`. The transport
+strips any CLIXML warning/error block, logs only sizes + exit code (never the
+script body or the encoded payload), and raises a single structured
+`PwshRunError` on failure.
+
+**Enum / compound stringification.** Windows PowerShell 5.1 `ConvertTo-Json`
+renders an enum as its **integer** value and a compound object (`TimeSpan`,
+`Version`, `Guid`) as a nested map. The list / config projections therefore
+stringify those fields with `Select-Object` calculated properties / `"$(...)"`
+(e.g. `@{N='State';E={"$($_.State)"}}`) so the assessment surface is readable and
+stable.
+
+### Injection safety
+
+Operator-supplied strings — `vm_name`, `checkpoint_name`, VHD `path`, export
+`path` — are interpolated only inside single-quoted PowerShell literals via
+`ps_single_quote` (a single quote is doubled; a single-quoted literal does no
+`$` expansion). `mode` (power.stop) is validated against a fixed enum in Python
+and maps to a constant switch string; `timeout_seconds` (export) is a
+Python-validated bounded `int` and never reaches the script text. The identity /
+host-read scripts take no operator input (constant scripts). The unit suite
+decodes the `-EncodedCommand` base64 back to the script and asserts the escaped
+form (e.g. `Get-VHD -Path 'C:\vm\o''db.vhdx'`).
+
+### No secret on the wire (deliberate)
+
+No op accepts a secret-value parameter — the SSH credential (resolved from the
+target's Vault secret by the base `SshConnector`) is the only secret and never
+enters a script body. A schema-level test asserts no op exposes a
+`password` / `secret` / `credential`-shaped field.
+
+## `fingerprint(target)` / `probe(target)`
+
+`fingerprint` runs one round-trip reading hostname + `Win32_OperatingSystem`
+(caption / version / build) + PowerShell version + `Hyper-V` module
+presence/version + `Win32_ComputerSystem.HypervisorPresent`. It returns
+`vendor="microsoft"`, `product="hyper-v"`, and the host / module / hypervisor
+facts in `extras`. An unreachable / SSH-failed / cmdlet-failed target returns
+`reachable=False` with `extras["error"]` (the #986 discipline — never an
+unhandled exception).
+
+`probe` surfaces **six distinct reasons**, two of them Hyper-V specific:
+
+| reason | meaning |
+|---|---|
+| `tcp_unreachable` | the SSH TCP socket cannot connect |
+| `ssh_auth_failed` | credentials rejected / handshake failed / Vault read failed |
+| `powershell_unavailable` | SSH ok but the reachability script failed |
+| `command_failed` | a post-connect transport drop / timeout |
+| `hyperv_module_absent` | PowerShell runs but the `Hyper-V` module is not installed |
+| `hypervisor_role_absent` | the module is present but the hypervisor is not running (`HypervisorPresent` false) |
+
+## Auth
+
+Inherits the base `SshConnector._auth_config` unchanged (password-default +
+key-fallback; the credential resolves from the target's Vault secret in operator
+context). Windows Server / Hyper-V hosts ship an OpenSSH server that must be
+enabled and pointed at Windows PowerShell:
+
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd; Set-Service -Name sshd -StartupType Automatic
+```
+
+## Control flow
+
+1. `call_operation` resolves `HypervConnector` for the target (versioned
+   `hyperv-2022.x` wins; the wildcard row catches an unfingerprinted target).
+2. The dispatcher applies auth + policy (a `dangerous` + `requires_approval` op
+   parks at `needs-approval`) + JSONFlux + synchronous audit + broadcast.
+3. The bound-method shim imports and calls the per-group handler, which composes
+   a `-EncodedCommand` script and runs it through `pwsh_run`.
+4. List ops return `{rows, total}`; the JSONFlux reducer wraps large sets in a
+   result handle the agent drills into via `result_query`.
+
+## Long-running `export.vm` semantics
+
+`Export-VM` is **synchronous** — it blocks the `powershell` process (and this SSH
+round-trip) until the copy finishes, which can be many minutes for a
+multi-hundred-GB VM. Unlike a reboot it does **not** tear the SSH channel down,
+so a blocking read is safe; the only risk is the wall-clock budget. The handler
+exposes `timeout_seconds` (default 3600, max 86400) and forwards it to the
+transport's per-call timeout, so the caller sizes the budget to the VM's disk
+size. A truly asynchronous `-AsJob` submission + out-of-band job polling is a
+documented follow-up (it needs a session-surviving job store the stateless
+per-call transport does not have); this cut ships the straightforward blocking
+export, correct for the lab-scale VMs the consumer proof exercises.
+
+`Stop-VM` in the default `shutdown` mode likewise blocks (the guest gets up to
+five minutes), so `power.stop` uses a wider 360s transport timeout.
+
+## Building on the estate mold
+
+This connector sets `POWERSHELL_EXECUTABLE = "powershell"` explicitly — the
+shared transport's fallback is `pwsh` (PS7), which a Windows Server / Hyper-V
+host does **not** ship by default. See
+[`connectors-winsrv.md`](connectors-winsrv.md) — "building the next estate
+connector" — for the full checklist the estate connectors share.
+
+## Tests
+
+`backend/tests/test_connectors_hyperv.py` — the ordinary unit suite (there is
+**no** spec-reconcile lane: the cmdlet surface ships no OpenAPI, the confirmed
+convention for SSH-typed connectors). It uses the winsrv harness (a `_StubTarget`
++ a mocked `_run_command`) and decodes the `-EncodedCommand` base64 back to the
+script to assert the cmdlet + escaped arguments the handler built. Coverage:
+every op group, the injection-safety escape on every parameterized script, the
+`{rows, total}` envelope + single-row collapse, the export timeout validation +
+forwarding, the power `mode` switch mapping, the secret-hygiene schema invariant,
+`about` fingerprint mapping, and all six probe reasons.
+
+The registry-driven flight-recorder conformance sweep
+(`test_flight_recorder_typed_spans.py`) includes `hyperv-ssh` in
+`_EXPECTED_TYPED_IMPLS`, so every hyperv op emits a `typed` span through the
+shared seam.
+
+## CLI
+
+Every op is reachable as a `meho hyperv <verb>` command through the same dispatch
+path (the CLI and the agent are dual front-ends on one backplane). Adding the
+`hyperv` product token grew the `TargetCreate.product` enum, so the committed CLI
+OpenAPI snapshot (`cli/api/openapi.json`) and the generated Go client
+(`cli/internal/api/client.gen.go`) were regenerated via `cd cli && make
+snapshot-openapi && make generate`.
+
+## Known issues / scope
+
+- **Live-consumer proof is open.** The dev/test target is the lab's nested
+  Hyper-V cluster **c1hv1**
+  (`evoila-bosnia/claude-rdc-hetzner-dc#2802`), which is in this lane's own build
+  queue. Per the estate precedent (winsrv / msad / mssql all shipped with the
+  same honest open AC), the connector ships now with the live-probe / inventory /
+  export proof recorded on the issue once c1hv1 is reachable.
+- **Blocking export.** `export.vm` blocks for the export duration (see above); a
+  background-job path is a documented follow-up.
+- **`Get-VHD` on shared storage.** When a VHD is attached to a running VM on
+  shared storage it can only be read from the host currently using it; the
+  handler runs under `-ErrorAction Stop`, so that surfaces as a real
+  `PwshRunError`.
+
+## References
+
+- Initiative #3259 (Microsoft estate connectors) — design rules.
+- Task #3265; depends-on #3261 (estate mold); #3263 (cluster views stay in wsfc).
+- `evoila-bosnia/claude-rdc-hetzner-dc#2802` — the c1hv1 consumer target.
+- Hyper-V PowerShell module reference:
+  <https://learn.microsoft.com/en-us/powershell/module/hyper-v/>
+  (`Get-VMHost`, `Get-VM`, `Get-VHD`, `Get-VMSnapshot`, `Checkpoint-VM`,
+  `Export-VM`, `Stop-VM`).
+- [`connectors-winsrv.md`](connectors-winsrv.md) — the estate mold.
+- [`connectors-shared-vault-creds.md`](connectors-shared-vault-creds.md) — the
+  SSH credential resolution.


### PR DESCRIPTION
## Summary

- Ships `hyperv` — the **Hyper-V migration-source** typed connector (registry triple `hyperv-2022.x` / `hyperv-ssh`), MEHO's governed source-side reach for a Hyper-V→VMware migration. A structured copy of the `winsrv` estate mold on the shared PowerShell-over-SSH transport (`_shared/pwsh`), driving Windows PowerShell 5.1 `Hyper-V` module cmdlets on a Hyper-V host.
- **18 reads-first ops across six groups**, tiered per the #3259 satellite table: `host` (Get-VMHost / NUMA / vSwitch — safe), `vms` (list/get/config/state, generation + secure-boot + integration-services version — safe, the migration-assessment surface), `disks` (VHD/VHDX format/size/parent-chain/fragmentation — safe, the VHDX→VMDK planning input), `checkpoints` (list safe; create caution; revert/delete dangerous + approval), `export` (`Export-VM` — caution, long-running with a bounded `timeout_seconds`), `power` (start/stop — caution, source-side cutover verbs).
- Probe distinguishes `hyperv_module_absent` from `hypervisor_role_absent`; operator strings single-quote-escaped into `-EncodedCommand` scripts; no op carries a secret-value parameter. `hyperv-ssh` added to the flight-recorder `_EXPECTED_TYPED_IMPLS` conformance set.
- Non-goals on record: no VM create/delete, no SCVMM, no Hyper-V Replica; cluster-wide views stay in the `wsfc` connector on the same nodes.

## CLI snapshot — CHANGED

The new `hyperv` product token grew the `TargetCreate.product` enum, so `cli/api/openapi.json` and the generated Go client `cli/internal/api/client.gen.go` were regenerated via `cd cli && make snapshot-openapi && make generate` (one line each: `+ "hyperv"`). **No migration, no spec-reconcile lane** (cmdlet surface ships no OpenAPI — the confirmed convention for SSH-typed connectors).

## Test plan

- [x] `ruff check` — clean (hyperv package + touched tests)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (9 source files)
- [x] `pytest tests/test_connectors_hyperv.py` — 47 passed (every op group, injection escape per parameterized script, `{rows,total}` envelope + single-row collapse, export timeout validation/forwarding, power `mode` switch, secret-hygiene schema invariant, `about` mapping, all 6 probe reasons)
- [x] `pytest tests/test_flight_recorder_typed_spans.py` — 17 passed (`hyperv-ssh` in the registry-driven conformance sweep)
- [x] `pytest tests/test_openapi_target_product_enum.py` — passed (dynamic enum)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (1 sub-threshold warning on connector.py, consistent with the winsrv mold's 17-shim shape)
- [x] CLI snapshot fresh against the rebased base (empty diff after regen)
- [ ] **Live-consumer proof — OPEN (operator-approved).** Registers + probe green / inventory + VHD reads / export proof land against the lab's nested Hyper-V cluster c1hv1 (evoila-bosnia/claude-rdc-hetzner-dc#2802), which is in this lane's own build queue. Estate precedent: winsrv / msad / mssql all shipped with the same honest open AC.

## Out of scope

- Cluster-wide Hyper-V views — owned by the `wsfc` connector (#3263) on the same nodes.
- Background-job (`-AsJob`) export path — documented follow-up (needs a session-surviving job store the stateless per-call transport lacks); this cut ships the correct blocking export for lab-scale VMs.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3265
