### PR TITLE
feat(connectors): WSFC shared-disk knobs — SCSI bus-sharing, eagerzeroedthick, shared-VMDK attach (#3256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,39 @@ connector-related release-notes line.
   precedent (winsrv / msad / mssql shipped the same way). See
   `docs/codebase/connectors-hyperv.md`.
 
+### Added — vmware: WSFC shared-disk knobs — SCSI bus-sharing, eagerzeroedthick, shared-VMDK attach (#3256)
+
+- **`vm.create` gains three shared-disk knobs.** A top-level
+  `scsi_bus_sharing` (`none` | `virtual` | `physical`) sets the folded SCSI
+  controller's bus-sharing mode, and each `disks[]` entry gains
+  `provisioning` (`thin` | `thick` | `eagerzeroedthick`) and `sharing`
+  (`none` | `multi_writer`). `physical` bus-sharing + `eagerzeroedthick` is
+  the Windows Server Failover Cluster (WSFC) / SQL FCI floor.
+- **New `vmware.composite.vm.disk.attach`** — attaches an **existing** VMDK
+  to a VM at an explicit SCSI `controller_key` + `unit_number` (the
+  shared-attach leg: the second cluster node opens the same disk the first
+  created, at the same address). Rides vim `ReconfigVM_Task` with a
+  `VirtualDeviceConfigSpec` add carrying **no** `fileOperation` (attach, not
+  create). Validates the `[datastore] path.vmdk` shape + the unit and refuses
+  a missing/non-SCSI controller or an occupied unit before any write.
+- **Vim-uniform by necessity.** The pinned REST `VmdkCreateSpec` has no
+  provisioning field, and neither controller bus-sharing nor multi-writer has
+  a REST expression, so a non-default knob routes `vm.create` through the vim
+  `CreateVM_Task` arm regardless of vCenter version (8.x + 9.x), and the
+  attach op is vim-only — mirroring `vm.disk.grow`. Default knobs keep the
+  9.0+ REST create body byte-identical.
+- **Docs distinguish bus-sharing from multi-writer.** `physical` SCSI
+  bus-sharing (SCSI-3 persistent reservations, for WSFC/FCI) vs per-disk
+  `sharingMultiWriter` (application-managed clustering, e.g. Oracle RAC) — so
+  operators pick correctly per workload. Same `dangerous` +
+  `requires_approval=True` tier as the sibling VM write composites; new op
+  reuses the already-pinned #2893 vim methods (no new reconcile pins).
+- Consumer: c1sql1 T4 (a 2-node SQL FCI on cluster1's vSAN,
+  `evoila-bosnia/claude-rdc-hetzner-dc#2789`); its live proof is deferred —
+  the corresponding acceptance criterion is declared OPEN until the estate
+  replays the shared-disk build through the governed ops.
+- [#3256](https://github.com/evoila/meho/issues/3256).
+
 ### Added — Keycloak provisioning recipe for the `approver` claim (#3283)
 
 - **`docs/cross-repo/keycloak-tenant-claims.md`** gains a group-based

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,12 +182,14 @@ connector-related release-notes line.
   `VirtualDeviceConfigSpec` add carrying **no** `fileOperation` (attach, not
   create). Validates the `[datastore] path.vmdk` shape + the unit and refuses
   a missing/non-SCSI controller or an occupied unit before any write.
-- **Vim-uniform by necessity.** The pinned REST `VmdkCreateSpec` has no
-  provisioning field, and neither controller bus-sharing nor multi-writer has
-  a REST expression, so a non-default knob routes `vm.create` through the vim
-  `CreateVM_Task` arm regardless of vCenter version (8.x + 9.x), and the
-  attach op is vim-only — mirroring `vm.disk.grow`. Default knobs keep the
-  9.0+ REST create body byte-identical.
+- **Vim-uniform by necessity.** The composite's folded SCSI controller
+  exposes no bus-sharing knob (the REST `Vm.CreateSpec.scsi_adapters[].sharing`
+  field could carry it, but the composite folds a single fixed controller),
+  and eagerzeroedthick + multi-writer are REST-inexpressible (`VmdkCreateSpec`
+  carries only name/capacity/storage_policy), so any shared-disk knob routes
+  `vm.create` uniformly through the vim `CreateVM_Task` arm regardless of
+  vCenter version (8.x + 9.x), and the attach op is vim-only — mirroring
+  `vm.disk.grow`. Default knobs keep the 9.0+ REST create body byte-identical.
 - **Docs distinguish bus-sharing from multi-writer.** `physical` SCSI
   bus-sharing (SCSI-3 persistent reservations, for WSFC/FCI) vs per-disk
   `sharingMultiWriter` (application-managed clustering, e.g. Oracle RAC) — so

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 33 composites land before
+``endpoint_descriptor`` upserts for the 37 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -105,6 +105,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_deploy_from_library_composite,
     vm_destroy_composite,
     vm_device_cdrom_composite,
+    vm_disk_attach_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
     vm_nic_repoint_composite,
@@ -159,6 +160,7 @@ __all__ = [
     "vm_deploy_from_library_composite",
     "vm_destroy_composite",
     "vm_device_cdrom_composite",
+    "vm_disk_attach_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
     "vm_nic_repoint_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 37 composites land before
+``endpoint_descriptor`` upserts for the 38 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -31,10 +31,11 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 28 write composites (G3.1-T6 / #509, the guest-ops writes
+* 29 write composites (G3.1-T6 / #509, the guest-ops writes
   ``vm.guest.file.write`` / #3100 + ``vm.guest.program.run`` / #3255,
   single-VM ``vm.power`` /
-  #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
+  #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893 + the WSFC/FCI
+  shared-attach ``vm.disk.attach`` / #3256, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
   ``folder.create`` / #2895, the #2891 post-clone hardware

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -93,6 +93,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_deploy_from_library_composite,
     vm_destroy_composite,
     vm_device_cdrom_composite,
+    vm_disk_attach_composite,
     vm_disk_grow_composite,
     vm_import_from_library_composite,
     vm_migrate_composite,
@@ -161,6 +162,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_DESTROY_RESPONSE_SCHEMA,
     VM_DEVICE_CDROM_PARAMETER_SCHEMA,
     VM_DEVICE_CDROM_RESPONSE_SCHEMA,
+    VM_DISK_ATTACH_PARAMETER_SCHEMA,
+    VM_DISK_ATTACH_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
     VM_DISK_GROW_RESPONSE_SCHEMA,
     VM_IMPORT_FROM_LIBRARY_PARAMETER_SCHEMA,
@@ -735,6 +738,37 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         ),
         parameter_schema=VM_DISK_GROW_PARAMETER_SCHEMA,
         response_schema=VM_DISK_GROW_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "disk", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.disk.attach",
+        handler=vm_disk_attach_composite,
+        summary="Attach an existing VMDK to a VM at an explicit SCSI controller/unit address.",
+        description=(
+            "Attaches an EXISTING VMDK to a VM at a caller-specified SCSI "
+            "controller_key + unit_number — the shared-attach leg of a Windows "
+            "Server Failover Cluster (WSFC) / SQL FCI or a multi-writer cluster "
+            "(the second node opens the same disk the first node created, at "
+            "the same address). Rides the #2893 mutating VI-JSON substrate: a "
+            "RetrievePropertiesEx read locates the SCSI controller and confirms "
+            "the unit is free, then a single ReconfigVM_Task carries a "
+            "VirtualDeviceConfigSpec add with NO fileOperation (attach, not "
+            "create). Validates vmdk_path ('[datastore] path.vmdk') and the "
+            "unit (0-15, not the reserved 7) before any write; refuses a "
+            "missing/non-SCSI controller or an occupied unit. Optional "
+            "sharing='multi_writer' sets the backing's sharingMultiWriter (for "
+            "application-managed clustering); WSFC instead uses a physical "
+            "bus-sharing controller (vm.create scsi_bus_sharing), not "
+            "multi-writer. The REST Disk.CreateSpec.backing can attach an "
+            "existing VMDK but cannot set the sharing flag, so this path is "
+            "vim-uniform (8.x + 9.x). Equivalent of 'govc device.scsi.add' + "
+            "'govc vm.disk.attach'."
+        ),
+        parameter_schema=VM_DISK_ATTACH_PARAMETER_SCHEMA,
+        response_schema=VM_DISK_ATTACH_RESPONSE_SCHEMA,
         group_key="vm",
         tags=["composite", "write", "vm", "disk", "vi-json"],
         safety_level="dangerous",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1439,11 +1439,12 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 37 composites total -- 9 read (T5 / #508 + the 4 guest-ops
-    reads / #3100) + 28 write (T6 / #509 + the destructive-tier
+    Scope: 38 composites total -- 9 read (T5 / #508 + the 4 guest-ops
+    reads / #3100) + 29 write (T6 / #509 + the destructive-tier
     ``vm.destroy`` / #3198,
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
-    ``vm.disk.grow`` / #2893, the folder-template
+    ``vm.disk.grow`` / #2893 + the WSFC/FCI shared-attach
+    ``vm.disk.attach`` / #3256, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
     ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
     hardware writes ``vm.resize`` / ``vm.nic.repoint`` /

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -90,7 +90,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 import httpx
 
@@ -333,6 +333,19 @@ _VIM_SUB_OPS_VM_DISK_GROW: tuple[str, ...] = (
     _OP_RECONFIG_VM_TASK,
 )
 
+#: vi-json sub-op manifest for the ``vm.disk.attach`` shared-attach leg
+#: (#3256). Reuses the exact #2893 substrate methods the disk-grow op
+#: pins: ``RetrievePropertiesEx`` reads ``config.hardware.device`` to
+#: locate the target SCSI controller + confirm the unit is free, and
+#: ``ReconfigVM_Task`` carries the ``VirtualDeviceConfigSpec`` ``add``
+#: (no ``fileOperation`` — an attach of the existing VMDK, not a create).
+#: Both paths are already reconciled against the pinned ``vi-json.yaml``
+#: via ``_VIM_SUB_OPS_VM_DISK_GROW``; this manifest names them for the op.
+_VIM_SUB_OPS_VM_DISK_ATTACH: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIG_VM_TASK,
+)
+
 # VI-JSON polymorphic-type discriminator (``Any._typeName`` in
 # vi-json.yaml) + the VirtualDisk data-object type name. A device read
 # from ``config.hardware.device`` carries ``_typeName`` so the handler can
@@ -474,6 +487,68 @@ _GIB_IN_BYTES = 1024**3
 # arm's ``CreateSpec.disks`` — a SCSI-attached ``new_vmdk`` (matches the
 # governed raw disk-add's ``{"type": "SCSI", "new_vmdk": {...}}`` shape).
 _REST_DISK_TYPE_SCSI = "SCSI"
+
+# WSFC / FCI shared-disk knobs (#3256). All three ride the vim seam: the
+# pinned REST ``VmdkCreateSpec`` has no provisioning field, and neither
+# controller bus-sharing nor per-disk multi-writer has a REST expression, so
+# a non-default knob routes ``vm.create`` through the vim ``CreateVM_Task``
+# arm (like ``vm.disk.grow`` is vim-only) and the shared-attach leg is
+# vim-only. Every literal is spec-grounded against the pinned ``vi-json.yaml``.
+#
+# ``VirtualSCSISharing`` enum (the controller ``sharedBus``): a bus shared
+# between VMs on the same host (``virtualSharing``) or on different hosts
+# (``physicalSharing`` — the WSFC/FCI SCSI-3 persistent-reservation mode).
+# ``noSharing`` is ``_VIM_SCSI_NO_SHARING`` above.
+_VIM_SCSI_SHARING_VIRTUAL = "virtualSharing"
+_VIM_SCSI_SHARING_PHYSICAL = "physicalSharing"
+# ``VirtualDiskSharing`` enum (the backing ``sharing`` field): multiple VMs
+# may open the same VMDK concurrently — application-managed clustering
+# (Oracle RAC), distinct from SCSI bus-sharing.
+_VIM_DISK_SHARING_MULTI_WRITER = "sharingMultiWriter"
+# The ``scsi_bus_sharing`` param enum → the ``VirtualSCSISharing`` value on
+# the folded controller's ``sharedBus``.
+_BUS_SHARING_TO_VIM: Final[dict[str, str]] = {
+    "none": _VIM_SCSI_NO_SHARING,
+    "virtual": _VIM_SCSI_SHARING_VIRTUAL,
+    "physical": _VIM_SCSI_SHARING_PHYSICAL,
+}
+# The per-disk ``provisioning`` param enum → the ``VirtualDiskFlatVer2Backing
+# Info`` allocation fields. ``thin`` allocate-on-write; ``thick`` lazy-zeroed;
+# ``eagerzeroedthick`` eager-zeroed (the shared-disk / multi-writer floor).
+_PROVISIONING_TO_BACKING: Final[dict[str, dict[str, bool]]] = {
+    "thin": {"thinProvisioned": True},
+    "thick": {"thinProvisioned": False, "eagerlyScrub": False},
+    "eagerzeroedthick": {"thinProvisioned": False, "eagerlyScrub": True},
+}
+# The per-disk ``sharing`` param enum → the backing ``sharing`` value
+# (``None`` omits the field, leaving the vendor default ``sharingNone``).
+_DISK_SHARING_TO_VIM: Final[dict[str, str | None]] = {
+    "none": None,
+    "multi_writer": _VIM_DISK_SHARING_MULTI_WRITER,
+}
+# New-device temp key for the shared-attach add — a distinct band from the
+# folded-create controller (``-100``) / disks (``-200``…) so nothing collides.
+_VIM_ATTACH_DISK_KEY = -300
+# The vim SCSI-controller ``_typeName`` family the shared-attach handler
+# accepts as a ``controller_key`` target (read-side matching only — none is
+# emitted, so the #3103 vocabulary lane is unaffected). Every name is a real
+# ``vi-json.yaml`` component schema.
+_VIM_SCSI_CONTROLLER_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        _VIRTUAL_LSILOGIC_SAS_CONTROLLER_TYPE,
+        "VirtualLsiLogicController",
+        "VirtualBusLogicController",
+        "ParaVirtualSCSIController",
+    }
+)
+# Canonical ``[datastore] dir/disk.vmdk`` datastore-path shape. The
+# shared-attach ``vmdk_path`` is validated against this before any read/write
+# so no malformed / control-char / injection-shaped string reaches the vim
+# backing ``fileName`` (#3256 param hygiene).
+_VALID_VMDK_PATH: Final[re.Pattern[str]] = re.compile(r"\[[^\[\]\r\n]+\]\s[^\r\n]+\.vmdk")
+# Default wall-clock bound for the shared-attach ReconfigVM_Task poll — the
+# 600s convention shared with disk-grow; module-global so tests can zero it.
+_DISK_ATTACH_TASK_TIMEOUT_SECONDS = 600.0
 
 # vim data-object ``_typeName`` discriminators for the request-body specs
 # the write composites assemble by hand (#3103, all spec-verified against
@@ -1683,6 +1758,66 @@ def _disk_capacities_bytes(disks: list[dict[str, Any]]) -> tuple[list[int] | Non
     return capacities, None
 
 
+class _VimDiskSpec(NamedTuple):
+    """A validated ``disks[]`` entry for the vim create arm (#3256).
+
+    Carries the capacity plus the WSFC/FCI provisioning + multi-writer
+    knobs, which only the vim arm can express (the REST ``VmdkCreateSpec``
+    has neither field).
+    """
+
+    capacity_bytes: int
+    provisioning: str  # "thin" | "thick" | "eagerzeroedthick"
+    sharing: str  # "none" | "multi_writer"
+
+
+def _vim_disk_specs(disks: list[dict[str, Any]]) -> tuple[list[_VimDiskSpec] | None, str | None]:
+    """Validate the ``disks`` param for the vim arm, returning per-disk specs (#3256).
+
+    Extends :func:`_disk_capacities_bytes` with the ``provisioning`` +
+    ``sharing`` knobs. Fail-closed handler-side net (the dispatch schema
+    already enums both): an unknown enum returns ``(None, reason)`` for the
+    caller to fold into a ``rolled_back`` envelope before any write.
+    """
+    specs: list[_VimDiskSpec] = []
+    for index, disk in enumerate(disks):
+        capacity_gb = disk.get("capacity_gb") if isinstance(disk, dict) else None
+        if isinstance(capacity_gb, bool) or not isinstance(capacity_gb, int) or capacity_gb < 1:
+            return None, (
+                f"disks[{index}] needs a positive integer ``capacity_gb``; got {capacity_gb!r}"
+            )
+        provisioning = disk.get("provisioning", "thin")
+        if provisioning not in _PROVISIONING_TO_BACKING:
+            return None, (
+                f"disks[{index}] provisioning {provisioning!r} is not one of "
+                "thin / thick / eagerzeroedthick"
+            )
+        sharing = disk.get("sharing", "none")
+        if sharing not in _DISK_SHARING_TO_VIM:
+            return None, (f"disks[{index}] sharing {sharing!r} is not one of none / multi_writer")
+        specs.append(_VimDiskSpec(capacity_gb * _GIB_IN_BYTES, provisioning, sharing))
+    return specs, None
+
+
+def _shared_disk_knobs_requested(params: dict[str, Any]) -> bool:
+    """Whether any WSFC/FCI shared-disk knob departs from its default (#3256).
+
+    ``scsi_bus_sharing`` other than ``none``, or any disk carrying a
+    non-default ``provisioning`` / ``sharing``, has no REST expression and
+    routes ``vm.create`` through the vim ``CreateVM_Task`` arm regardless of
+    the target's vCenter version (mirroring how ``vm.disk.grow`` is vim-only
+    because capacity has no REST path).
+    """
+    if params.get("scsi_bus_sharing", "none") != "none":
+        return True
+    for disk in params.get("disks") or []:
+        if isinstance(disk, dict) and (
+            disk.get("provisioning", "thin") != "thin" or disk.get("sharing", "none") != "none"
+        ):
+            return True
+    return False
+
+
 def _scsi_unit_number(index: int) -> int:
     """The SCSI unit number for the *index*-th folded disk, skipping unit 7.
 
@@ -1693,17 +1828,44 @@ def _scsi_unit_number(index: int) -> int:
     return index if index < _VIM_SCSI_CONTROLLER_UNIT else index + 1
 
 
-def _build_vim_disk_device_changes(capacities_bytes: list[int]) -> list[dict[str, Any]]:
-    """Build the controller + per-disk ``deviceChange`` adds for the vim arm (#3117).
+def _build_vim_disk_backing(spec: _VimDiskSpec) -> dict[str, Any]:
+    """Build a folded-disk ``VirtualDiskFlatVer2BackingInfo`` for the vim arm.
+
+    Empty ``fileName`` (vCenter auto-generates a unique path in the VM home),
+    ``persistent`` mode, plus the #3256 knobs: ``provisioning`` maps to the
+    ``thinProvisioned`` / ``eagerlyScrub`` allocation fields and ``sharing``
+    to the multi-writer backing ``sharing`` (omitted when ``none`` — the
+    vendor default ``sharingNone``). A ``thin`` / ``none`` disk yields the
+    pre-#3256 backing byte-for-byte. Every DataObject carries ``_typeName``
+    (#3103).
+    """
+    backing: dict[str, Any] = {
+        _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DISK_FLAT_BACKING_TYPE,
+        "fileName": "",
+        "diskMode": _VIM_DISK_MODE_PERSISTENT,
+    }
+    backing.update(_PROVISIONING_TO_BACKING[spec.provisioning])
+    disk_sharing = _DISK_SHARING_TO_VIM[spec.sharing]
+    if disk_sharing is not None:
+        backing["sharing"] = disk_sharing
+    return backing
+
+
+def _build_vim_disk_device_changes(
+    disk_specs: list[_VimDiskSpec], *, shared_bus: str
+) -> list[dict[str, Any]]:
+    """Build the controller + per-disk ``deviceChange`` adds for the vim arm (#3117, #3256).
 
     Always emits one ``VirtualLsiLogicSASController`` add (so a fresh
     vim-arm VM has a controller for the governed REST disk-add even when no
     disks were requested — the issue's minimum ask), followed by one
-    ``VirtualDisk`` add per requested capacity, each with ``fileOperation:
-    create`` and bound to that controller. The disk backing uses an empty
-    ``fileName`` (vCenter auto-generates a unique path inside the VM home),
-    ``persistent`` mode and thin provisioning — the canonical govmomi
-    ``CreateDisk`` shape. Every DataObject carries its ``_typeName`` (#3103).
+    ``VirtualDisk`` add per requested disk, each with ``fileOperation:
+    create`` and bound to that controller. ``shared_bus`` is the resolved
+    ``VirtualSCSISharing`` value on the controller's ``sharedBus`` (#3256:
+    ``physicalSharing`` for a WSFC/FCI node); each disk's backing carries its
+    provisioning + multi-writer knobs (:func:`_build_vim_disk_backing`). With
+    ``noSharing`` + ``thin`` disks the body is byte-identical to the pre-#3256
+    shape. Every DataObject carries its ``_typeName`` (#3103).
     """
     controller: dict[str, Any] = {
         _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DEVICE_CONFIG_SPEC_TYPE,
@@ -1712,7 +1874,7 @@ def _build_vim_disk_device_changes(capacities_bytes: list[int]) -> list[dict[str
             _VMOMI_TYPE_NAME_KEY: _VIRTUAL_LSILOGIC_SAS_CONTROLLER_TYPE,
             "key": _VIM_SCSI_CONTROLLER_KEY,
             "busNumber": 0,
-            "sharedBus": _VIM_SCSI_NO_SHARING,
+            "sharedBus": shared_bus,
         },
     }
     disk_changes = [
@@ -1725,16 +1887,11 @@ def _build_vim_disk_device_changes(capacities_bytes: list[int]) -> list[dict[str
                 "key": _VIM_DISK_KEY_BASE - index,
                 "controllerKey": _VIM_SCSI_CONTROLLER_KEY,
                 "unitNumber": _scsi_unit_number(index),
-                "capacityInBytes": capacity_bytes,
-                "backing": {
-                    _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DISK_FLAT_BACKING_TYPE,
-                    "fileName": "",
-                    "diskMode": _VIM_DISK_MODE_PERSISTENT,
-                    "thinProvisioned": True,
-                },
+                "capacityInBytes": spec.capacity_bytes,
+                "backing": _build_vim_disk_backing(spec),
             },
         }
-        for index, capacity_bytes in enumerate(capacities_bytes)
+        for index, spec in enumerate(disk_specs)
     ]
     return [controller, *disk_changes]
 
@@ -1763,12 +1920,13 @@ def _build_vim_create_request(
     memory_mib: int,
     datastore_name: str,
     nic_backings: list[dict[str, Any]],
-    disk_capacities_bytes: list[int],
+    disk_specs: list[_VimDiskSpec],
+    shared_bus: str,
     nested_hv: bool,
     pool_moid: str,
     host_moid: str | None,
 ) -> dict[str, Any]:
-    """Assemble the ``Folder.CreateVM_Task`` request body (#3099, #3117).
+    """Assemble the ``Folder.CreateVM_Task`` request body (#3099, #3117, #3256).
 
     ``CreateVMRequestType`` (spec-verified against the pinned
     ``vi-json.yaml``): ``{config: VirtualMachineConfigSpec, pool:
@@ -1814,7 +1972,7 @@ def _build_vim_create_request(
         for index, backing in enumerate(nic_backings)
     ]
     config["deviceChange"] = [
-        *_build_vim_disk_device_changes(disk_capacities_bytes),
+        *_build_vim_disk_device_changes(disk_specs, shared_bus=shared_bus),
         *nic_changes,
     ]
     body: dict[str, Any] = {"config": config, "pool": _moref(_RESOURCE_POOL_MO_TYPE, pool_moid)}
@@ -1935,8 +2093,13 @@ async def _vm_create_via_vim(
     Fail-closed validations run before any sub-call: an unmapped
     ``guest_os`` enum, missing ``resource_pool`` / ``datastore`` pins (vim
     needs an explicit pool and VM home — vCenter-side placement defaulting
-    exists only on the REST create), an invalid disk ``capacity_gb``, and an
-    unsupported NIC backing each return a structured ``rolled_back``.
+    exists only on the REST create), an invalid disk ``capacity_gb``, an
+    unknown ``scsi_bus_sharing`` / disk ``provisioning`` / disk ``sharing``
+    enum (#3256), and an unsupported NIC backing each return a structured
+    ``rolled_back``. The #3256 shared-disk knobs (SCSI bus-sharing on the
+    folded controller, per-disk eagerzeroedthick provisioning, per-disk
+    multi-writer) fold into the one ConfigSpec here — this arm is the sole
+    governed path for them since neither has a REST expression.
     """
     folder_name = params.get("folder_name")
     name = params["name"]
@@ -1950,6 +2113,7 @@ async def _vm_create_via_vim(
     pool_moid = params.get("resource_pool")
     datastore_moid = params.get("datastore")
     host_moid = params.get("host")
+    bus_sharing = params.get("scsi_bus_sharing", "none")
 
     guest_id = _VIM_GUEST_ID_BY_REST_GUEST_OS.get(guest_os)
     if guest_id is None:
@@ -1973,8 +2137,14 @@ async def _vm_create_via_vim(
                 "only on the REST create"
             ),
         )
-    disk_capacities_bytes, disk_err = _disk_capacities_bytes(disks)
-    if disk_capacities_bytes is None:
+    if bus_sharing not in _BUS_SHARING_TO_VIM:
+        return _rolled_back(
+            steps=[],
+            failed_step="scsi_bus_sharing",
+            reason=(f"scsi_bus_sharing {bus_sharing!r} is not one of none / virtual / physical"),
+        )
+    disk_specs, disk_err = _vim_disk_specs(disks)
+    if disk_specs is None:
         return _rolled_back(steps=[], failed_step="disk_spec", reason=disk_err or "")
 
     steps: list[str] = []
@@ -2020,14 +2190,17 @@ async def _vm_create_via_vim(
         memory_mib=memory_mib,
         datastore_name=datastore_name,
         nic_backings=nic_backings,
-        disk_capacities_bytes=disk_capacities_bytes,
+        disk_specs=disk_specs,
+        shared_bus=_BUS_SHARING_TO_VIM[bus_sharing],
         nested_hv=nested_hv,
         pool_moid=pool_moid,
         host_moid=host_moid if isinstance(host_moid, str) else None,
     )
     # Identity-only gate params: the durable ApprovalRequest names the
     # blast radius (what gets created, where) without the assembled vim
-    # body — mirroring the clone-from-template gate discipline.
+    # body — mirroring the clone-from-template gate discipline. The #3256
+    # shared-disk knobs (bus-sharing + per-disk provisioning / multi-writer)
+    # ride the gate so the approver sees a WSFC/FCI node's disk posture.
     gate_params = {
         "name": name,
         "folder_name": folder_name,
@@ -2039,7 +2212,15 @@ async def _vm_create_via_vim(
         "cpu_count": cpu_count,
         "memory_mib": memory_mib,
         "nics": [nic.get("network") for nic in nics],
-        "disks": [disk.get("capacity_gb") for disk in disks],
+        "disks": [
+            {
+                "capacity_gb": disk.get("capacity_gb"),
+                "provisioning": disk.get("provisioning", "thin"),
+                "sharing": disk.get("sharing", "none"),
+            }
+            for disk in disks
+        ],
+        "scsi_bus_sharing": bus_sharing,
         "nested_hv": nested_hv,
     }
     gate, vm_id, create_failure = await _issue_vim_create(
@@ -2133,9 +2314,19 @@ async def vm_create_composite(
     ``POST /api/vcenter/vm`` is vendor-defective on vCenter 8.0.x — with
     NICs, disks and ``nested_hv`` folded into the one ConfigSpec. 9.0+ and
     unresolved versions keep the REST path below byte-identical.
+
+    WSFC / FCI shared-disk knobs (#3256): when any of ``scsi_bus_sharing``,
+    per-disk ``provisioning``, or per-disk ``sharing`` departs from its
+    default, the create also rides the vim arm regardless of version — the
+    pinned REST ``VmdkCreateSpec`` has no provisioning field and neither
+    controller bus-sharing nor multi-writer has a REST expression, so vim is
+    the sole governed path (mirroring ``vm.disk.grow``). That arm needs
+    ``resource_pool`` + ``datastore`` pins; absent them it refuses with the
+    structured ``placement_params`` ``rolled_back`` before any write. All
+    knobs at default keep the REST path below byte-identical.
     """
     about_version = await connector._about_version(target, operator)
-    if _vim_create_required(about_version):
+    if _vim_create_required(about_version) or _shared_disk_knobs_requested(params):
         return await _vm_create_via_vim(
             operator=operator, target=target, params=params, connector=connector
         )
@@ -4776,6 +4967,298 @@ async def vm_disk_grow_composite(
         "delta_bytes": delta,
         "guidance": None,
     }
+
+
+# ===========================================================================
+# vm.disk.attach (shared-attach: attach an existing VMDK — WSFC/FCI, #3256)
+# ===========================================================================
+#
+# Attaches an EXISTING VMDK to a VM at an explicit SCSI controller/unit
+# address — the second-node leg of a Windows Server Failover Cluster / SQL
+# FCI (or a multi-writer cluster). Rides the #2893 mutating VI-JSON substrate
+# exactly as vm.disk.grow does: a RetrievePropertiesEx read locates the
+# target SCSI controller + confirms the unit is free, then a single
+# ReconfigVM_Task carries a VirtualDeviceConfigSpec `add` with NO
+# fileOperation (fileOperation="create" would create a new VMDK; its absence
+# attaches the existing one — the govmomi/govc convention). The REST
+# Disk.CreateSpec.backing can attach an existing VMDK but cannot set the
+# multi-writer sharing flag, so the governed path is vim-uniform (8.x + 9.x).
+
+
+def _find_scsi_controller(devices: list[Any], controller_key: int) -> dict[str, Any] | None:
+    """Return the SCSI controller device whose key matches, else ``None``.
+
+    Matches ``key == controller_key`` and ``_typeName`` in the SCSI
+    controller family (:data:`_VIM_SCSI_CONTROLLER_TYPES`) — a non-SCSI
+    device (NIC, CD-ROM, the disk itself) at that key is not a valid attach
+    target for a WSFC/FCI shared disk.
+    """
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        if dev.get(_VMOMI_TYPE_NAME_KEY) not in _VIM_SCSI_CONTROLLER_TYPES:
+            continue
+        if _coerce_int(dev.get("key")) == controller_key:
+            return dev
+    return None
+
+
+def _scsi_unit_occupied(devices: list[Any], controller_key: int, unit_number: int) -> bool:
+    """Whether a device already sits at ``(controller_key, unit_number)``."""
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        if _coerce_int(dev.get("controllerKey")) != controller_key:
+            continue
+        if _coerce_int(dev.get("unitNumber")) == unit_number:
+            return True
+    return False
+
+
+def _valid_scsi_unit(unit: int) -> bool:
+    """A SCSI unit number in range (0-15) and not the controller-reserved unit 7."""
+    return 0 <= unit <= 15 and unit != _VIM_SCSI_CONTROLLER_UNIT
+
+
+def _build_attach_disk_device_change(
+    *, vmdk_path: str, controller_key: int, unit_number: int, sharing: str
+) -> dict[str, Any]:
+    """Build the ``VirtualDeviceConfigSpec`` add attaching an existing VMDK (#3256).
+
+    ``operation="add"`` with **no** ``fileOperation`` — the seam that
+    distinguishes an attach of an existing backing from a create. The
+    backing's ``fileName`` is the validated ``vmdk_path``; ``sharing`` sets
+    the multi-writer flag when requested. No ``capacityInBytes`` — the server
+    reads the size from the existing VMDK. Every DataObject carries its
+    ``_typeName`` (#3103); all names are already-emitted, so the #3103
+    vocabulary lane needs no new entry.
+    """
+    backing: dict[str, Any] = {
+        _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DISK_FLAT_BACKING_TYPE,
+        "fileName": vmdk_path,
+        "diskMode": _VIM_DISK_MODE_PERSISTENT,
+    }
+    disk_sharing = _DISK_SHARING_TO_VIM.get(sharing)
+    if disk_sharing is not None:
+        backing["sharing"] = disk_sharing
+    return {
+        _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DEVICE_CONFIG_SPEC_TYPE,
+        "operation": "add",
+        "device": {
+            _VMOMI_TYPE_NAME_KEY: _VIRTUAL_DISK_TYPE,
+            "key": _VIM_ATTACH_DISK_KEY,
+            "controllerKey": controller_key,
+            "unitNumber": unit_number,
+            "backing": backing,
+        },
+    }
+
+
+def _attach_result(
+    status: str,
+    *,
+    vm: str,
+    vmdk_path: Any,
+    controller_key: Any,
+    unit_number: Any,
+    sharing: str,
+    task: str | None = None,
+    guidance: str | None = None,
+) -> dict[str, Any]:
+    """Build the canonical ``vm.disk.attach`` response envelope (#3256)."""
+    return {
+        "status": status,
+        "vm": vm,
+        "vmdk_path": vmdk_path,
+        "controller_key": controller_key,
+        "unit_number": unit_number,
+        "sharing": sharing,
+        "task": task,
+        "guidance": guidance,
+    }
+
+
+async def vm_disk_attach_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Attach an existing VMDK to a VM at an explicit SCSI controller/unit (#3256).
+
+    Op-id: ``vmware.composite.vm.disk.attach``. The shared-attach leg of a
+    WSFC/FCI or multi-writer cluster: the second node opens the same VMDK the
+    first node created, at the same controller/unit address. Rides the #2893
+    mutating VI-JSON substrate (vim-uniform on 8.x + 9.x, like
+    ``vm.disk.grow``).
+
+    Flow:
+
+    1. Fail-closed param hygiene before any I/O: ``vmdk_path`` must match the
+       ``[datastore] path.vmdk`` shape (``status='invalid_vmdk_path'``);
+       ``unit_number`` must be 0-15 and not the reserved unit 7
+       (``status='invalid_unit'``).
+    2. Read the VM's ``config.hardware.device`` (``RetrievePropertiesEx``, a
+       *read* — no gate) to locate the SCSI controller ``controller_key``
+       (``status='controller_not_found'`` when absent / not SCSI) and confirm
+       the unit is free (``status='unit_in_use'``).
+    3. Issue one ``ReconfigVM_Task`` add through the governed vmomi write seam
+       (:func:`_write_vmomi_sub_op` → the #2254 gate) — a
+       ``VirtualDeviceConfigSpec`` ``add`` with **no** ``fileOperation`` so
+       the existing VMDK is attached, not recreated. A parked/denied gate
+       returns the :class:`OperationResult` verbatim; no reconfigure fires.
+    4. Poll the returned ``*_Task`` MoRef to terminal via
+       :func:`~...vim_task.poll_vim_task`. A task fault raises
+       (``connector_error``, mirroring ``vm.disk.grow``); a poll timeout
+       returns ``status='timeout'`` with the task id.
+    """
+    vm_moid = params["vm"]
+    vmdk_path = params["vmdk_path"]
+    controller_key = _coerce_int(params.get("controller_key"))
+    unit_number = _coerce_int(params.get("unit_number"))
+    sharing = params.get("sharing", "none")
+
+    if not isinstance(vmdk_path, str) or _VALID_VMDK_PATH.fullmatch(vmdk_path) is None:
+        return _attach_result(
+            "invalid_vmdk_path",
+            vm=vm_moid,
+            vmdk_path=params.get("vmdk_path"),
+            controller_key=params.get("controller_key"),
+            unit_number=params.get("unit_number"),
+            sharing=sharing,
+            guidance=(
+                "vmdk_path must be a datastore path of the form "
+                "'[datastore] dir/disk.vmdk' — the existing shared VMDK created "
+                "on the first cluster node"
+            ),
+        )
+    if unit_number is None or not _valid_scsi_unit(unit_number):
+        return _attach_result(
+            "invalid_unit",
+            vm=vm_moid,
+            vmdk_path=vmdk_path,
+            controller_key=params.get("controller_key"),
+            unit_number=params.get("unit_number"),
+            sharing=sharing,
+            guidance="unit_number must be 0-15 and not the controller-reserved unit 7",
+        )
+    if controller_key is None:
+        return _attach_result(
+            "controller_not_found",
+            vm=vm_moid,
+            vmdk_path=vmdk_path,
+            controller_key=params.get("controller_key"),
+            unit_number=unit_number,
+            sharing=sharing,
+            guidance="controller_key must be the integer device key of a SCSI controller",
+        )
+
+    devices = _extract_vm_devices(
+        await connector._post_vmomi_json(
+            target,
+            _VMOMI_RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=_build_vm_devices_retrieve_params(vm_moid),
+        )
+    )
+    if _find_scsi_controller(devices, controller_key) is None:
+        return _attach_result(
+            "controller_not_found",
+            vm=vm_moid,
+            vmdk_path=vmdk_path,
+            controller_key=controller_key,
+            unit_number=unit_number,
+            sharing=sharing,
+            guidance=(
+                f"no SCSI controller with key {controller_key} on vm {vm_moid!r}; "
+                "list the VM's devices to confirm the controller key (for WSFC "
+                "create a dedicated bus-shared controller via vm.create "
+                "scsi_bus_sharing)"
+            ),
+        )
+    if _scsi_unit_occupied(devices, controller_key, unit_number):
+        return _attach_result(
+            "unit_in_use",
+            vm=vm_moid,
+            vmdk_path=vmdk_path,
+            controller_key=controller_key,
+            unit_number=unit_number,
+            sharing=sharing,
+            guidance=(
+                f"a device already occupies controller {controller_key} unit "
+                f"{unit_number}; pick a free unit (both cluster nodes must use "
+                "the same address for the shared disk)"
+            ),
+        )
+
+    reconfig_spec = {
+        "spec": {
+            _VMOMI_TYPE_NAME_KEY: _VM_CONFIG_SPEC_TYPE,
+            "deviceChange": [
+                _build_attach_disk_device_change(
+                    vmdk_path=vmdk_path,
+                    controller_key=controller_key,
+                    unit_number=unit_number,
+                    sharing=sharing,
+                )
+            ],
+        }
+    }
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_RECONFIG_VM_TASK,
+        vmomi_path=f"/VirtualMachine/{vm_moid}/ReconfigVM_Task",
+        body=reconfig_spec,
+        params={
+            "vm": vm_moid,
+            "vmdk_path": vmdk_path,
+            "controller_key": controller_key,
+            "unit_number": unit_number,
+            "sharing": sharing,
+        },
+    )
+    if gate is not None:
+        return gate
+
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_DISK_ATTACH_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == TASK_STATE_ERROR:
+        raise RuntimeError(
+            f"vm.disk.attach: ReconfigVM_Task on vm {vm_moid!r} attaching {vmdk_path!r} "
+            f"faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return _attach_result(
+            "timeout",
+            vm=vm_moid,
+            vmdk_path=vmdk_path,
+            controller_key=controller_key,
+            unit_number=unit_number,
+            sharing=sharing,
+            task=outcome.task,
+            guidance=(
+                f"ReconfigVM_Task {outcome.task} did not reach a terminal state within "
+                f"{int(_DISK_ATTACH_TASK_TIMEOUT_SECONDS)}s; poll the task or re-read the "
+                "VM's disks — the attach may still complete in the background"
+            ),
+        )
+    return _attach_result(
+        "attached",
+        vm=vm_moid,
+        vmdk_path=vmdk_path,
+        controller_key=controller_key,
+        unit_number=unit_number,
+        sharing=sharing,
+        task=outcome.task,
+    )
 
 
 # ===========================================================================

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -489,11 +489,15 @@ _GIB_IN_BYTES = 1024**3
 _REST_DISK_TYPE_SCSI = "SCSI"
 
 # WSFC / FCI shared-disk knobs (#3256). All three ride the vim seam: the
-# pinned REST ``VmdkCreateSpec`` has no provisioning field, and neither
-# controller bus-sharing nor per-disk multi-writer has a REST expression, so
-# a non-default knob routes ``vm.create`` through the vim ``CreateVM_Task``
-# arm (like ``vm.disk.grow`` is vim-only) and the shared-attach leg is
-# vim-only. Every literal is spec-grounded against the pinned ``vi-json.yaml``.
+# composite's folded SCSI controller exposes no bus-sharing knob (the REST
+# ``Vm.CreateSpec.scsi_adapters[].sharing`` field could carry it, but the
+# composite folds a single fixed controller with no such knob), and
+# eagerzeroedthick provisioning + per-disk multi-writer are REST-inexpressible
+# (the pinned ``VmdkCreateSpec`` carries only name / capacity / storage_policy).
+# So any shared-disk knob routes ``vm.create`` uniformly through the vim
+# ``CreateVM_Task`` arm (like ``vm.disk.grow`` is vim-only) and the
+# shared-attach leg is vim-only. Every literal is spec-grounded against the
+# pinned ``vi-json.yaml``.
 #
 # ``VirtualSCSISharing`` enum (the controller ``sharedBus``): a bus shared
 # between VMs on the same host (``virtualSharing``) or on different hosts
@@ -543,8 +547,11 @@ _VIM_SCSI_CONTROLLER_TYPES: Final[frozenset[str]] = frozenset(
 )
 # Canonical ``[datastore] dir/disk.vmdk`` datastore-path shape. The
 # shared-attach ``vmdk_path`` is validated against this before any read/write
-# so no malformed / control-char / injection-shaped string reaches the vim
-# backing ``fileName`` (#3256 param hygiene).
+# so no malformed / control-char / ``..``-traversal value reaches the vim
+# backing ``fileName`` (#3256 param hygiene). There is no shell on the vim
+# backing path, so the defence is shape + control-char + ``..``-segment
+# rejection (see :func:`_valid_vmdk_path`), not quoting. The shape check is
+# the regex; the ``..``-segment reject is applied by the helper on top.
 _VALID_VMDK_PATH: Final[re.Pattern[str]] = re.compile(r"\[[^\[\]\r\n]+\]\s[^\r\n]+\.vmdk")
 # Default wall-clock bound for the shared-attach ReconfigVM_Task poll — the
 # 600s convention shared with disk-grow; module-global so tests can zero it.
@@ -1803,10 +1810,12 @@ def _shared_disk_knobs_requested(params: dict[str, Any]) -> bool:
     """Whether any WSFC/FCI shared-disk knob departs from its default (#3256).
 
     ``scsi_bus_sharing`` other than ``none``, or any disk carrying a
-    non-default ``provisioning`` / ``sharing``, has no REST expression and
-    routes ``vm.create`` through the vim ``CreateVM_Task`` arm regardless of
-    the target's vCenter version (mirroring how ``vm.disk.grow`` is vim-only
-    because capacity has no REST path).
+    non-default ``provisioning`` / ``sharing``: the folded controller exposes
+    no bus-sharing knob and eagerzeroedthick + multi-writer are
+    REST-inexpressible, so any such knob routes ``vm.create`` uniformly
+    through the vim ``CreateVM_Task`` arm regardless of the target's vCenter
+    version (mirroring how ``vm.disk.grow`` is vim-only because capacity has
+    no REST path).
     """
     if params.get("scsi_bus_sharing", "none") != "none":
         return True
@@ -2099,7 +2108,8 @@ async def _vm_create_via_vim(
     ``rolled_back``. The #3256 shared-disk knobs (SCSI bus-sharing on the
     folded controller, per-disk eagerzeroedthick provisioning, per-disk
     multi-writer) fold into the one ConfigSpec here — this arm is the sole
-    governed path for them since neither has a REST expression.
+    governed path for them: the folded controller exposes no bus-sharing
+    knob, and eagerzeroedthick + multi-writer are REST-inexpressible.
     """
     folder_name = params.get("folder_name")
     name = params["name"]
@@ -2318,9 +2328,10 @@ async def vm_create_composite(
     WSFC / FCI shared-disk knobs (#3256): when any of ``scsi_bus_sharing``,
     per-disk ``provisioning``, or per-disk ``sharing`` departs from its
     default, the create also rides the vim arm regardless of version — the
-    pinned REST ``VmdkCreateSpec`` has no provisioning field and neither
-    controller bus-sharing nor multi-writer has a REST expression, so vim is
-    the sole governed path (mirroring ``vm.disk.grow``). That arm needs
+    composite's folded controller exposes no bus-sharing knob, and
+    eagerzeroedthick + multi-writer are REST-inexpressible (the pinned
+    ``VmdkCreateSpec`` carries no provisioning field), so vim is the sole
+    governed path (mirroring ``vm.disk.grow``). That arm needs
     ``resource_pool`` + ``datastore`` pins; absent them it refuses with the
     structured ``placement_params`` ``rolled_back`` before any write. All
     knobs at default keep the REST path below byte-identical.
@@ -5015,6 +5026,20 @@ def _scsi_unit_occupied(devices: list[Any], controller_key: int, unit_number: in
     return False
 
 
+def _valid_vmdk_path(path: str) -> bool:
+    """Whether *path* is a safe ``[datastore] dir/disk.vmdk`` value (#3256).
+
+    Shape check (:data:`_VALID_VMDK_PATH` — a bracketed datastore + a ``.vmdk``
+    suffix, no control chars) plus a ``..``-segment reject so a traversal like
+    ``[ds] a/../b.vmdk`` cannot walk outside the intended datastore directory.
+    There is no shell on the vim backing path, so the defence is
+    malformed-shape / control-char / path-traversal rejection, not quoting.
+    """
+    if _VALID_VMDK_PATH.fullmatch(path) is None:
+        return False
+    return not any(segment == ".." for segment in re.split(r"[\\/]", path))
+
+
 def _valid_scsi_unit(unit: int) -> bool:
     """A SCSI unit number in range (0-15) and not the controller-reserved unit 7."""
     return 0 <= unit <= 15 and unit != _VIM_SCSI_CONTROLLER_UNIT
@@ -5096,9 +5121,10 @@ async def vm_disk_attach_composite(
     Flow:
 
     1. Fail-closed param hygiene before any I/O: ``vmdk_path`` must match the
-       ``[datastore] path.vmdk`` shape (``status='invalid_vmdk_path'``);
-       ``unit_number`` must be 0-15 and not the reserved unit 7
-       (``status='invalid_unit'``).
+       ``[datastore] path.vmdk`` shape and carry no ``..`` path segment
+       (``status='invalid_vmdk_path'`` — no shell on this path, so the check
+       is shape + control-char + traversal rejection); ``unit_number`` must be
+       0-15 and not the reserved unit 7 (``status='invalid_unit'``).
     2. Read the VM's ``config.hardware.device`` (``RetrievePropertiesEx``, a
        *read* — no gate) to locate the SCSI controller ``controller_key``
        (``status='controller_not_found'`` when absent / not SCSI) and confirm
@@ -5119,7 +5145,7 @@ async def vm_disk_attach_composite(
     unit_number = _coerce_int(params.get("unit_number"))
     sharing = params.get("sharing", "none")
 
-    if not isinstance(vmdk_path, str) or _VALID_VMDK_PATH.fullmatch(vmdk_path) is None:
+    if not isinstance(vmdk_path, str) or not _valid_vmdk_path(vmdk_path):
         return _attach_result(
             "invalid_vmdk_path",
             vm=vm_moid,
@@ -5129,8 +5155,8 @@ async def vm_disk_attach_composite(
             sharing=sharing,
             guidance=(
                 "vmdk_path must be a datastore path of the form "
-                "'[datastore] dir/disk.vmdk' — the existing shared VMDK created "
-                "on the first cluster node"
+                "'[datastore] dir/disk.vmdk' with no '..' path segment — the "
+                "existing shared VMDK created on the first cluster node"
             ),
         )
     if unit_number is None or not _valid_scsi_unit(unit_number):

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires 25 of the 28 write composites onto the per-op preview hook
+This wires 26 of the 29 write composites onto the per-op preview hook
 shipped by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops. (The three most recent write ops —
@@ -1086,7 +1086,7 @@ async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
-#: op_id → builder for the 25 write composites. Module-level so the
+#: op_id → builder for the 26 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.guest.file.write": _guest_file_write_preview,
@@ -1119,7 +1119,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 25 write-composite park-time preview builders. Import-time.
+    """Wire the 26 write-composite park-time preview builders. Import-time.
 
     The 9 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -334,6 +334,18 @@ async def _vm_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         for disk in disks
         if isinstance(disk, dict) and "capacity_gb" in disk
     ]
+    # #3256: echo the shared-disk posture so the approver sees a WSFC/FCI node
+    # (eagerzeroedthick disks / multi-writer / a physical bus-shared
+    # controller) rather than a bare sizing list.
+    disks_detail = [
+        {
+            "capacity_gb": disk.get("capacity_gb"),
+            "provisioning": disk.get("provisioning", "thin"),
+            "sharing": disk.get("sharing", "none"),
+        }
+        for disk in disks
+        if isinstance(disk, dict) and "capacity_gb" in disk
+    ]
     return {
         "name": name,
         "guest_os": guest_os,
@@ -346,6 +358,8 @@ async def _vm_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "memory_mib": int(ctx.params.get("memory_mib", 1024)),
         "networks": networks,
         "disks_gb": disk_capacities_gb,
+        "disks": disks_detail,
+        "scsi_bus_sharing": ctx.params.get("scsi_bus_sharing", "none"),
         "nested_hv": bool(ctx.params.get("nested_hv", False)),
         "power_on_after_create": bool(ctx.params.get("power_on_after_create", False)),
     }
@@ -577,6 +591,29 @@ async def _vm_disk_grow_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "current_capacity_bytes": current_bytes,
         "requested_capacity_bytes": capacity_bytes,
         "delta_bytes": (capacity_bytes - current_bytes if current_bytes is not None else None),
+    }
+
+
+async def _vm_disk_attach_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.disk.attach`` — echo the shared-attach coordinates (no I/O).
+
+    The params fully name the blast radius: which existing VMDK attaches to
+    which VM at which SCSI controller/unit, and whether the backing is
+    multi-writer. Param-echo (like ``vm.create``) rather than a live-read
+    diff — the approver decides on the target address + sharing posture, and
+    the ReconfigVM_Task add never fires here. Declines (``None``) on malformed
+    params.
+    """
+    vm = ctx.params.get("vm")
+    vmdk_path = ctx.params.get("vmdk_path")
+    if not isinstance(vm, str) or not isinstance(vmdk_path, str):
+        return None
+    return {
+        "vm": vm,
+        "vmdk_path": vmdk_path,
+        "controller_key": ctx.params.get("controller_key"),
+        "unit_number": ctx.params.get("unit_number"),
+        "sharing": ctx.params.get("sharing", "none"),
     }
 
 
@@ -1064,6 +1101,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.power": _vm_power_preview,
     "vmware.composite.vm.power.bulk": _vm_power_bulk_preview,
     "vmware.composite.vm.disk.grow": _vm_disk_grow_preview,
+    "vmware.composite.vm.disk.attach": _vm_disk_attach_preview,
     "vmware.composite.vm.resize": _vm_resize_preview,
     "vmware.composite.vm.nic.repoint": _vm_nic_repoint_preview,
     "vmware.composite.vm.device.cdrom": _vm_device_cdrom_preview,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -4,7 +4,7 @@
 # for every vmware-rest composite (one parameter + response schema per op);
 # the sibling handler modules (_read.py / _write.py) carry the same marker.
 
-"""JSON Schema 2020-12 parameter + response schemas for the 37 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 38 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -1361,9 +1361,11 @@ VM_DISK_ATTACH_PARAMETER_SCHEMA: dict[str, Any] = {
                 "canonical ``[datastore] dir/disk.vmdk`` form (e.g. "
                 "``[vsanDatastore] wsfc-quorum/quorum.vmdk``). Validated "
                 "before any write; a value that does not match the "
-                "``[datastore] path.vmdk`` shape is refused with "
-                "``status='invalid_vmdk_path'`` (no shell/backing injection "
-                "reaches the reconfigure body)."
+                "``[datastore] path.vmdk`` shape, or that carries a ``..`` "
+                "path segment, is refused with ``status='invalid_vmdk_path'`` "
+                "(there is no shell on this path — the check rejects malformed "
+                "shape, control chars, and path traversal before the "
+                "reconfigure body is built)."
             ),
         },
         "controller_key": {
@@ -2262,7 +2264,8 @@ VM_DISK_ATTACH_RESPONSE_SCHEMA: dict[str, Any] = {
             "description": (
                 "``'attached'`` — the ReconfigVM_Task add reached terminal "
                 "success; ``'invalid_vmdk_path'`` — ``vmdk_path`` did not match "
-                "the ``[datastore] path.vmdk`` shape (refused before any "
+                "the ``[datastore] path.vmdk`` shape or carried a ``..`` path "
+                "segment (refused before any "
                 "write); ``'invalid_unit'`` — ``unit_number`` was out of range "
                 "or the reserved unit 7; ``'controller_not_found'`` — no SCSI "
                 "controller with ``controller_key`` on the VM; "

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pure JSON-Schema-constant declaration module
+# for every vmware-rest composite (one parameter + response schema per op);
+# the sibling handler modules (_read.py / _write.py) carry the same marker.
 
-"""JSON Schema 2020-12 parameter + response schemas for the 27 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 37 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -782,6 +785,43 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                             "Disk capacity in GiB (converted to bytes for the vendor spec)."
                         ),
                     },
+                    "provisioning": {
+                        "type": "string",
+                        "enum": ["thin", "thick", "eagerzeroedthick"],
+                        "default": "thin",
+                        "description": (
+                            "Disk provisioning policy (#3256). ``thin`` — "
+                            "allocate-on-write (``thinProvisioned=true``); "
+                            "``thick`` — lazy-zeroed thick "
+                            "(``thinProvisioned=false``, ``eagerlyScrub=false``); "
+                            "``eagerzeroedthick`` — eager-zeroed thick "
+                            "(``thinProvisioned=false``, ``eagerlyScrub=true``), "
+                            "the WSFC/FCI shared-disk and multi-writer "
+                            "requirement. The pinned REST ``VmdkCreateSpec`` "
+                            "has no provisioning field, so any value other than "
+                            "``thin`` routes the whole create through the vim "
+                            "``CreateVM_Task`` arm (which needs "
+                            "``resource_pool`` + ``datastore`` pins)."
+                        ),
+                    },
+                    "sharing": {
+                        "type": "string",
+                        "enum": ["none", "multi_writer"],
+                        "default": "none",
+                        "description": (
+                            "Per-disk multi-writer sharing (#3256), distinct "
+                            "from SCSI bus-sharing. ``multi_writer`` sets the "
+                            "backing's ``sharing=sharingMultiWriter`` so several "
+                            "VMs may open the same VMDK concurrently — the mode "
+                            "for application-managed clustering (e.g. Oracle "
+                            "RAC), where the guest coordinates its own locking. "
+                            "Use ``scsi_bus_sharing`` (not this) for WSFC/FCI, "
+                            "which relies on SCSI-3 persistent reservations on a "
+                            "shared bus. Multi-writer has no REST expression, so "
+                            "any value other than ``none`` routes the create "
+                            "through the vim arm."
+                        ),
+                    },
                 },
                 "required": ["capacity_gb"],
                 "additionalProperties": False,
@@ -799,9 +839,31 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "``POST:/vcenter/vm/{vm}/hardware/disk`` even when this "
                 "list is empty) plus one ``VirtualDisk`` "
                 "``fileOperation: create`` per entry, bound to it. "
-                "Thin-vs-thick follows the datastore default. Empty list "
-                "keeps the REST create body byte-identical to a pre-#3117 "
-                "call."
+                "``provisioning`` defaults to ``thin`` (the datastore default "
+                "on the REST arm); a non-default ``provisioning`` or "
+                "``sharing`` value routes the create through the vim arm "
+                "(#3256). Empty list keeps the REST create body byte-identical "
+                "to a pre-#3117 call."
+            ),
+        },
+        "scsi_bus_sharing": {
+            "type": "string",
+            "enum": ["none", "virtual", "physical"],
+            "default": "none",
+            "description": (
+                "SCSI bus-sharing mode for the VM's SCSI controller (#3256), "
+                "distinct from per-disk multi-writer. ``none`` — private bus "
+                "(``noSharing``); ``virtual`` — bus shared between VMs on the "
+                "same host (``virtualSharing``); ``physical`` — bus shared "
+                "between VMs on different hosts (``physicalSharing``), the "
+                "Windows Server Failover Cluster (WSFC) / SQL FCI requirement "
+                "(SCSI-3 persistent reservations). Applies to the controller "
+                "the create folds for the data ``disks``; the boot/OS disk is "
+                "not part of this fold, so it never lands on a shared bus. "
+                "Any value other than ``none`` routes the create through the "
+                "vim ``CreateVM_Task`` arm (the REST create fabricates a "
+                "non-shared controller with no sharing knob), which requires "
+                "``resource_pool`` + ``datastore`` pins."
             ),
         },
         "nested_hv": {
@@ -1265,6 +1327,88 @@ VM_DISK_GROW_PARAMETER_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["vm", "disk", "capacity_bytes"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.disk.attach`` parameter schema (#3256).
+#:
+#: Attach an **existing** VMDK to a VM at an explicit SCSI ``controller/unit``
+#: address — the shared-attach leg of a WSFC / FCI or multi-writer cluster
+#: build (the second node opens the same disk the first node created). Rides
+#: vim ``ReconfigVM_Task`` with a ``VirtualDeviceConfigSpec`` ``add`` that
+#: carries **no** ``fileOperation`` (``fileOperation="create"`` would make a
+#: new VMDK; its absence attaches the existing one). The pinned REST spec's
+#: ``Disk.CreateSpec.backing`` can attach an existing VMDK but cannot set the
+#: multi-writer ``sharing`` flag, so the governed path is vim-uniform (works
+#: on vSphere 8.x and 9.x, like ``vm.disk.grow``). Fail-closed before any
+#: write: an ill-formed ``vmdk_path``, an out-of-range ``unit_number``, a
+#: missing / non-SCSI ``controller_key``, or an occupied unit each return a
+#: structured status and issue no reconfigure.
+VM_DISK_ATTACH_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Managed-object ID of the VM to attach the disk to (e.g. 'vm-42').",
+        },
+        "vmdk_path": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Datastore path of the existing VMDK to attach, in the "
+                "canonical ``[datastore] dir/disk.vmdk`` form (e.g. "
+                "``[vsanDatastore] wsfc-quorum/quorum.vmdk``). Validated "
+                "before any write; a value that does not match the "
+                "``[datastore] path.vmdk`` shape is refused with "
+                "``status='invalid_vmdk_path'`` (no shell/backing injection "
+                "reaches the reconfigure body)."
+            ),
+        },
+        "controller_key": {
+            "type": "integer",
+            "description": (
+                "Device key of the target SCSI controller already present on "
+                "the VM (the vim ``VirtualController.key``, e.g. 1000). The "
+                "handler reads the VM's ``config.hardware.device`` and refuses "
+                "with ``status='controller_not_found'`` when no device with "
+                "this key exists or it is not a SCSI controller. For WSFC/FCI "
+                "this is a dedicated bus-shared controller (create it on the "
+                "VM with ``scsi_bus_sharing`` on ``vm.create``); the boot "
+                "controller must not be shared."
+            ),
+        },
+        "unit_number": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 15,
+            "description": (
+                "SCSI unit number on ``controller_key`` to attach the disk at "
+                "(0-15, excluding 7 which the controller reserves). Both "
+                "cluster nodes attach the shared VMDK at the **same** "
+                "controller/unit address. An occupied unit is refused with "
+                "``status='unit_in_use'``; unit 7 (or out of range) with "
+                "``status='invalid_unit'`` — both before any write."
+            ),
+        },
+        "sharing": {
+            "type": "string",
+            "enum": ["none", "multi_writer"],
+            "default": "none",
+            "description": (
+                "Per-disk multi-writer sharing on the attached backing, "
+                "distinct from the controller's bus-sharing. ``multi_writer`` "
+                "sets ``sharing=sharingMultiWriter`` (application-managed "
+                "clustering, e.g. Oracle RAC). WSFC/FCI does NOT use "
+                "multi-writer — it relies on SCSI-3 persistent reservations "
+                "from a ``physical`` bus-sharing controller instead — so leave "
+                "this ``none`` and attach to a bus-shared ``controller_key`` "
+                "for a Windows failover cluster."
+            ),
+        },
+    },
+    "required": ["vm", "vmdk_path", "controller_key", "unit_number"],
     "additionalProperties": False,
 }
 
@@ -2098,6 +2242,67 @@ VM_DISK_GROW_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm", "disk", "to_capacity_bytes"],
+}
+
+
+#: ``vmware.composite.vm.disk.attach`` response schema (#3256).
+VM_DISK_ATTACH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "attached",
+                "invalid_vmdk_path",
+                "invalid_unit",
+                "controller_not_found",
+                "unit_in_use",
+                "timeout",
+            ],
+            "description": (
+                "``'attached'`` — the ReconfigVM_Task add reached terminal "
+                "success; ``'invalid_vmdk_path'`` — ``vmdk_path`` did not match "
+                "the ``[datastore] path.vmdk`` shape (refused before any "
+                "write); ``'invalid_unit'`` — ``unit_number`` was out of range "
+                "or the reserved unit 7; ``'controller_not_found'`` — no SCSI "
+                "controller with ``controller_key`` on the VM; "
+                "``'unit_in_use'`` — a device already occupies that "
+                "controller/unit; ``'timeout'`` — the reconfigure task did not "
+                "reach a terminal state within the poll bound (it may still "
+                "complete in the background)."
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid the disk was attached to."},
+        "vmdk_path": {"type": "string", "description": "Datastore path of the attached VMDK."},
+        "controller_key": {
+            "type": "integer",
+            "description": "Device key of the SCSI controller the disk attached to.",
+        },
+        "unit_number": {
+            "type": "integer",
+            "description": "SCSI unit number the disk attached at.",
+        },
+        "sharing": {
+            "type": "string",
+            "enum": ["none", "multi_writer"],
+            "description": "The multi-writer sharing mode applied to the attached backing.",
+        },
+        "task": {
+            "type": ["string", "null"],
+            "description": (
+                "ReconfigVM_Task moid — present once the write was issued "
+                "(``attached`` / ``timeout``); ``null`` on the pre-write refusals."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``attached`` status; "
+                "``null`` on a successful attach."
+            ),
+        },
+    },
+    "required": ["status", "vm", "vmdk_path", "controller_key", "unit_number"],
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -453,6 +453,26 @@ def test_vm_disk_grow_vi_json_sub_ops_round_trip_through_ingest() -> None:
     assert required <= ingested_op_ids
 
 
+def test_vm_disk_attach_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
+    """Pin the shared-attach vi-json manifest so a drift can't shrink the reconcile (#3256).
+
+    ``vm.disk.attach`` rides the exact #2893 substrate methods disk-grow pins:
+    ``RetrievePropertiesEx`` (locate the SCSI controller + confirm the unit is
+    free) + ``ReconfigVM_Task`` (the ``VirtualDeviceConfigSpec`` add, no
+    ``fileOperation``). Both paths are already reconciled against the pinned
+    ``vi-json.yaml`` by the disk-grow round-trip / paths-exist lanes above (the
+    manifests are identical), so this pin only guards the attach manifest from
+    drifting to a bogus path.
+    """
+    assert set(_write._VIM_SUB_OPS_VM_DISK_ATTACH) == {
+        "POST:/VirtualMachine/{moId}/ReconfigVM_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+    # The two shared-attach paths are the disk-grow pair verbatim — the
+    # already-passing round-trip lane covers their ingest fidelity.
+    assert set(_write._VIM_SUB_OPS_VM_DISK_ATTACH) == set(_write._VIM_SUB_OPS_VM_DISK_GROW)
+
+
 def _vi_json_path_item_has_post(spec_text: str, path: str) -> bool:
     """Whether *path* is a top-level ``paths`` item with a POST operation.
 

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -196,9 +196,10 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 36 total: 9 reads
-    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 27 writes (T6 #509 +
+    # Embedding service called once per composite -- 38 total: 9 reads
+    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 29 writes (T6 #509 +
     # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
+    # WSFC/FCI shared-attach vm.disk.attach #3256 +
     # folder-template vm.clone_from_template #2894 + vim cluster/inventory
     # writes cluster.drs_rule.create + folder.create #2895 + the #2891
     # hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
@@ -211,7 +212,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # network.portgroup.security.set + the content-library import
     # vm.import_from_library #3229). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 37
+    assert stub_embedding_service.encode_one.call_count == 38
 
 
 @pytest.mark.asyncio
@@ -458,13 +459,14 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> read rows persist; embedding stays at 36.
+    """Running the registrar twice -> read rows persist; embedding stays at 38.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
     persist after the combined registrar (9 reads incl. the 4 guest-ops
-    reads #3100 + 27 writes / T6 + single-VM vm.power #2301 + mutating
-    VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
+    reads #3100 + 29 writes / T6 + single-VM vm.power #2301 + mutating
+    VI-JSON vm.disk.grow #2893 + WSFC/FCI vm.disk.attach #3256 +
+    folder-template vm.clone_from_template
     #2894 + vim cluster/inventory writes cluster.drs_rule.create +
     folder.create #2895 + the #2891 hardware writes vm.resize /
     vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
@@ -477,7 +479,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 37
+    assert first_count == 38
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -4341,8 +4341,14 @@ async def test_vm_disk_attach_multi_writer_sets_backing_sharing(gate: _GateRecor
     assert gate.calls[0]["params"]["sharing"] == "multi_writer"
 
 
-async def test_vm_disk_attach_rejects_injection_shaped_vmdk_path(gate: _GateRecorder) -> None:
-    """A path not matching '[datastore] path.vmdk' is refused before any I/O (hygiene)."""
+async def test_vm_disk_attach_rejects_malformed_vmdk_path(gate: _GateRecorder) -> None:
+    """A value not matching '[datastore] path.vmdk' is refused before any I/O (hygiene).
+
+    There is no shell on the vim backing path — the defence is
+    malformed-shape / control-char rejection, not quoting — but a value that
+    lacks the datastore-bracket + .vmdk shape (here a stray metacharacter
+    string) is still refused before the reconfigure body is built.
+    """
     conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
     out = await vm_disk_attach_composite(
         operator=_make_operator(),
@@ -4358,6 +4364,31 @@ async def test_vm_disk_attach_rejects_injection_shaped_vmdk_path(gate: _GateReco
     assert isinstance(out, dict)
     assert out["status"] == "invalid_vmdk_path"
     # Neither a read nor a write fired, and nothing was gated.
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_attach_rejects_dotdot_path_traversal(gate: _GateRecorder) -> None:
+    """A shape-valid path carrying a '..' segment is refused before any I/O (#3256).
+
+    ``[ds] a/../b.vmdk`` passes the bracket + .vmdk shape regex, so the
+    ``..``-segment reject (defence-in-depth on a dangerous, approval-gated op)
+    is what stops it from walking outside the intended datastore directory.
+    """
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": "[vsanDatastore] wsfc-quorum/../../secret/other.vmdk",
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "invalid_vmdk_path"
     assert conn.vmomi_calls == []
     assert gate.calls == []
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -69,6 +69,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_customize_composite,
     vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
+    vm_disk_attach_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
     vm_nic_repoint_composite,
@@ -1224,6 +1225,7 @@ async def test_vm_create_pre9_rides_create_vm_task(gate: _GateRecorder) -> None:
         "memory_mib": 16384,
         "nics": ["dvportgroup-1015"],
         "disks": [],
+        "scsi_bus_sharing": "none",
         "nested_hv": True,
     }
 
@@ -1610,7 +1612,13 @@ async def test_vm_create_pre9_folds_disks_and_controller(gate: _GateRecorder) ->
             },
         },
     ]
-    assert gate.calls[0]["params"]["disks"] == [10, 20]
+    # #3256: gate params echo the full per-disk posture (capacity +
+    # provisioning + sharing) so the approver sees a shared-disk build.
+    assert gate.calls[0]["params"]["disks"] == [
+        {"capacity_gb": 10, "provisioning": "thin", "sharing": "none"},
+        {"capacity_gb": 20, "provisioning": "thin", "sharing": "none"},
+    ]
+    assert gate.calls[0]["params"]["scsi_bus_sharing"] == "none"
     assert out["status"] == "created"
     assert out["steps_succeeded"] == ["create", "disk_attach"]
 
@@ -4187,6 +4195,440 @@ async def test_vm_disk_grow_reconfig_body_reaches_the_wire_respx(
         assert change["device"]["capacityInBytes"] == _TWENTY_GIB
     finally:
         await connector.aclose()
+
+
+# ===========================================================================
+# vm.disk.attach — shared-attach (attach an existing VMDK, WSFC/FCI, #3256)
+# ===========================================================================
+
+
+_QUORUM_VMDK = "[vsanDatastore] wsfc-quorum/quorum.vmdk"
+
+
+def _scsi_controller(
+    key: int = 1000, type_name: str = "VirtualLsiLogicSASController"
+) -> dict[str, Any]:
+    """A SCSI controller device as ``config.hardware.device`` returns it."""
+    return {"_typeName": type_name, "key": key, "busNumber": 1}
+
+
+class _DiskAttachConnector:
+    """Recording double for the shared-attach VI-JSON sub-ops (mirrors _DiskGrowConnector).
+
+    Serves the ``config.hardware.device`` read (locate the controller +
+    check the unit) and the ``Task.info`` poll — both RetrievePropertiesEx,
+    distinguished by the request body's ``specSet`` object type — and records
+    every ``ReconfigVM_Task`` add so a parked/refused write is provably off
+    the wire.
+    """
+
+    def __init__(
+        self,
+        *,
+        devices: list[Any],
+        task_state: str = "success",
+        task_error: str | None = None,
+        reconfig_task: str = "task-attach-1",
+    ) -> None:
+        self.devices = devices
+        self.task_state = task_state
+        self.task_error = task_error
+        self.reconfig_task = reconfig_task
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/ReconfigVM_Task"):
+            return {"type": "Task", "value": self.reconfig_task}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            boxed = {"_typeName": "ArrayOfVirtualDevice", "_value": self.devices}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                        "propSet": [{"name": "config.hardware.device", "val": boxed}],
+                    }
+                ]
+            }
+        if spec_type == "Task":
+            info: dict[str, Any] = {"state": self.task_state}
+            if self.task_error is not None:
+                info["error"] = {"localizedMessage": self.task_error}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": self.reconfig_task},
+                        "propSet": [{"name": "info", "val": info}],
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+
+    @property
+    def reconfig_bodies(self) -> list[Any]:
+        return [body for path, body in self.vmomi_calls if path.endswith("/ReconfigVM_Task")]
+
+
+async def test_vm_disk_attach_happy_path_adds_existing_vmdk(gate: _GateRecorder) -> None:
+    """Attach: read devices -> gated ReconfigVM_Task add (no fileOperation) -> attached."""
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "attached"
+    assert out["task"] == "task-attach-1"
+    assert out["controller_key"] == 1000
+    assert out["unit_number"] == 0
+
+    # The single mutating sub-op was gated with the vi-json governance op_id +
+    # the logical params naming the disk + address the write touches.
+    assert gate.gated_op_ids == ["POST:/VirtualMachine/{moId}/ReconfigVM_Task"]
+    assert gate.calls[0]["safety_level"] == "dangerous"
+    assert gate.calls[0]["requires_approval"] is False
+    assert gate.calls[0]["params"] == {
+        "vm": "vm-1",
+        "vmdk_path": _QUORUM_VMDK,
+        "controller_key": 1000,
+        "unit_number": 0,
+        "sharing": "none",
+    }
+
+    # The ReconfigVM_Task body is a single-device ADD with NO fileOperation
+    # (attach the existing VMDK, not create), at the requested address.
+    assert len(conn.reconfig_bodies) == 1
+    change = conn.reconfig_bodies[0]["spec"]["deviceChange"][0]
+    assert change["operation"] == "add"
+    assert "fileOperation" not in change
+    assert change["device"]["_typeName"] == "VirtualDisk"
+    assert change["device"]["controllerKey"] == 1000
+    assert change["device"]["unitNumber"] == 0
+    assert change["device"]["backing"]["fileName"] == _QUORUM_VMDK
+    # sharing=none omits the multi-writer field (WSFC uses bus-sharing, not this).
+    assert "sharing" not in change["device"]["backing"]
+
+
+async def test_vm_disk_attach_multi_writer_sets_backing_sharing(gate: _GateRecorder) -> None:
+    """sharing='multi_writer' sets the backing's sharingMultiWriter (Oracle-RAC style)."""
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 3,
+            "sharing": "multi_writer",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "attached"
+    change = conn.reconfig_bodies[0]["spec"]["deviceChange"][0]
+    assert change["device"]["backing"]["sharing"] == "sharingMultiWriter"
+    assert gate.calls[0]["params"]["sharing"] == "multi_writer"
+
+
+async def test_vm_disk_attach_rejects_injection_shaped_vmdk_path(gate: _GateRecorder) -> None:
+    """A path not matching '[datastore] path.vmdk' is refused before any I/O (hygiene)."""
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": "quorum.vmdk; rm -rf /",
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "invalid_vmdk_path"
+    # Neither a read nor a write fired, and nothing was gated.
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_attach_rejects_reserved_unit_7(gate: _GateRecorder) -> None:
+    """Unit 7 (controller-reserved) is refused before any I/O."""
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 7,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "invalid_unit"
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_attach_controller_not_found_when_not_scsi(gate: _GateRecorder) -> None:
+    """A device at controller_key that is not a SCSI controller -> controller_not_found."""
+    # A VirtualDisk sits at key 1000, not a SCSI controller.
+    conn = _DiskAttachConnector(devices=[_virtual_disk(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "controller_not_found"
+    # The device read fired; the write was never attempted or gated.
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_attach_unit_in_use(gate: _GateRecorder) -> None:
+    """A device already at (controller, unit) -> unit_in_use, no write."""
+    occupied = {"_typeName": "VirtualDisk", "key": 2000, "controllerKey": 1000, "unitNumber": 0}
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000), occupied])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "unit_in_use"
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_attach_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the ReconfigVM_Task add returns verbatim; no write fires."""
+    op_id = "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)])
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == op_id
+    # The device read fired; the ReconfigVM_Task add was gated off the wire.
+    assert conn.reconfig_bodies == []
+
+
+async def test_vm_disk_attach_poll_timeout_returns_timeout_status(
+    monkeypatch: pytest.MonkeyPatch, gate: _GateRecorder
+) -> None:
+    """A poll that never sees a terminal state returns status=timeout with the task id."""
+    monkeypatch.setattr(_write, "_DISK_ATTACH_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _DiskAttachConnector(devices=[_scsi_controller(key=1000)], task_state="running")
+    out = await vm_disk_attach_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "vmdk_path": _QUORUM_VMDK,
+            "controller_key": 1000,
+            "unit_number": 0,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "timeout"
+    assert out["task"] == "task-attach-1"
+
+
+async def test_vm_disk_attach_task_fault_raises(gate: _GateRecorder) -> None:
+    """A terminal task error raises (the dispatcher wraps it connector_error)."""
+    conn = _DiskAttachConnector(
+        devices=[_scsi_controller(key=1000)],
+        task_state="error",
+        task_error="Cannot open the disk '...' or one of the snapshot disks it depends on.",
+    )
+    with pytest.raises(RuntimeError, match="Cannot open the disk"):
+        await vm_disk_attach_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={
+                "vm": "vm-1",
+                "vmdk_path": _QUORUM_VMDK,
+                "controller_key": 1000,
+                "unit_number": 0,
+            },
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+# ===========================================================================
+# vm.create — WSFC/FCI shared-disk knobs (#3256)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_create_shared_disk_knobs_route_9x_to_vim_and_set_backing(
+    gate: _GateRecorder,
+) -> None:
+    """A physical bus + eagerzeroedthick + multi-writer create rides vim even on 9.0 (#3256).
+
+    The pinned REST ``VmdkCreateSpec`` has no provisioning field, and neither
+    controller bus-sharing nor multi-writer has a REST expression, so a
+    non-default knob routes the whole create through vim ``CreateVM_Task``
+    regardless of version, folding the WSFC posture into the one ConfigSpec.
+    """
+    conn = _UnifiedRecordingConnector(
+        {"/api/vcenter/datastore/datastore-11": {"name": "vsanDatastore"}},
+        about_version="9.0.0.24755230",
+        vmomi={
+            "/Folder/folder-7/CreateVM_Task": _task_moref("task-1"),
+            "Task": _task_info_result(
+                "task-1", "success", result={"type": "VirtualMachine", "value": "vm-1"}
+            ),
+        },
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder": "folder-7",
+            "name": "sql-fci-node-1",
+            "guest_os": "WINDOWS_SERVER_2019",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "disks": [
+                {"capacity_gb": 50, "provisioning": "eagerzeroedthick", "sharing": "multi_writer"}
+            ],
+            "scsi_bus_sharing": "physical",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    # Routed to vim despite the 9.0 target — the REST create never fired.
+    assert not any(c["path"] == "/api/vcenter/vm" for c in conn.calls)
+    create_body = next(body for path, body in conn.vmomi_calls if path.endswith("/CreateVM_Task"))
+    device_changes = create_body["config"]["deviceChange"]
+    # The folded controller carries the physical bus-sharing (WSFC SCSI-3 PR).
+    assert device_changes[0]["device"]["_typeName"] == "VirtualLsiLogicSASController"
+    assert device_changes[0]["device"]["sharedBus"] == "physicalSharing"
+    # The disk backing carries eagerzeroedthick + multi-writer.
+    disk_backing = device_changes[1]["device"]["backing"]
+    assert disk_backing["thinProvisioned"] is False
+    assert disk_backing["eagerlyScrub"] is True
+    assert disk_backing["sharing"] == "sharingMultiWriter"
+    # Gate params echo the per-disk posture + the bus-sharing mode.
+    assert gate.calls[0]["params"]["scsi_bus_sharing"] == "physical"
+    assert gate.calls[0]["params"]["disks"] == [
+        {"capacity_gb": 50, "provisioning": "eagerzeroedthick", "sharing": "multi_writer"}
+    ]
+    assert out["status"] == "created"
+
+
+@pytest.mark.asyncio
+async def test_vm_create_default_knobs_stay_on_rest_arm_9x(gate: _GateRecorder) -> None:
+    """Default shared-disk knobs keep a 9.0 create on the REST arm — byte-identical (#3256)."""
+    conn = _UnifiedRecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-9"},
+        },
+        about_version="9.0.0.24755230",
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "datastore": "datastore-11",
+            "disks": [{"capacity_gb": 40}],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    # No knobs set -> REST arm, no vim create.
+    assert conn.vmomi_calls == []
+    assert out["steps_succeeded"] == ["folder_lookup", "create", "disk_attach"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_invalid_bus_sharing_fails_closed(gate: _GateRecorder) -> None:
+    """An unknown scsi_bus_sharing enum refuses before any create (handler-side net)."""
+    conn = _UnifiedRecordingConnector({}, about_version="9.0.0.24755230")
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder": "folder-7",
+            "name": "x",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "scsi_bus_sharing": "bogus",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "scsi_bus_sharing"
+    assert conn.calls == []
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_invalid_provisioning_fails_closed(gate: _GateRecorder) -> None:
+    """An unknown disk provisioning enum refuses before any create (handler-side net)."""
+    conn = _UnifiedRecordingConnector({}, about_version="9.0.0.24755230")
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder": "folder-7",
+            "name": "x",
+            "guest_os": "UBUNTU_64",
+            "resource_pool": "resgroup-8",
+            "datastore": "datastore-11",
+            "disks": [{"capacity_gb": 10, "provisioning": "superthick"}],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "disk_spec"
+    assert conn.calls == []
+    assert conn.vmomi_calls == []
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -47,6 +47,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_deploy_from_library_composite,
+    vm_disk_attach_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
 )
@@ -423,6 +424,127 @@ async def test_disk_grow_human_operator_vmomi_write_auto_executes(
     assert isinstance(out, dict)
     assert out["status"] == "grown"
     # The reconfigure write executed on the session; the sub-op auto-executed.
+    assert len(conn.reconfig_writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ===========================================================================
+# vm.disk.attach — the shared-attach ReconfigVM_Task flows through the same
+# gate as disk-grow (#3256); the op reuses _RECONFIG_OP_ID above
+# ===========================================================================
+
+
+class _DiskAttachRecordingConnector:
+    """Recording double for the shared-attach governance tests.
+
+    Serves the ``config.hardware.device`` read (one SCSI controller, no
+    device at the target unit) + the ``Task.info`` poll, and records every
+    ``ReconfigVM_Task`` write so the tests can assert the mutating vmomi POST
+    never fired when the gate parks / denies.
+    """
+
+    def __init__(self) -> None:
+        self.reconfig_writes: list[Any] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        if path.endswith("/ReconfigVM_Task"):
+            self.reconfig_writes.append(json)
+            return {"type": "Task", "value": "task-attach-1"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            controller = {"_typeName": "VirtualLsiLogicSASController", "key": 1000, "busNumber": 1}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                        "propSet": [{"name": "config.hardware.device", "val": [controller]}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-attach-1"},
+                    "propSet": [{"name": "info", "val": {"state": "success"}}],
+                }
+            ]
+        }
+
+
+_ATTACH_PARAMS = {
+    "vm": "vm-1",
+    "vmdk_path": "[vsanDatastore] wsfc-quorum/quorum.vmdk",
+    "controller_key": 1000,
+    "unit_number": 0,
+}
+
+
+@pytest.mark.asyncio
+async def test_disk_attach_gated_vmomi_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated ReconfigVM_Task add queues for approval; the vmomi write never fires."""
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_RECONFIG_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _DiskAttachRecordingConnector()
+    out = await vm_disk_attach_composite(
+        operator=_operator(),
+        target=None,
+        params=dict(_ATTACH_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _RECONFIG_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _RECONFIG_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_attach_dangerous_vmomi_write_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous ReconfigVM_Task add; it never runs."""
+    conn = _DiskAttachRecordingConnector()
+    out = await vm_disk_attach_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params=dict(_ATTACH_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _RECONFIG_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_attach_human_operator_vmomi_write_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the ReconfigVM_Task add."""
+    conn = _DiskAttachRecordingConnector()
+    out = await vm_disk_attach_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params=dict(_ATTACH_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "attached"
     assert len(conn.reconfig_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -82,6 +82,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.vm.power",
         "vmware.composite.vm.power.bulk",
         "vmware.composite.vm.disk.grow",
+        "vmware.composite.vm.disk.attach",
         "vmware.composite.vm.resize",
         "vmware.composite.vm.nic.repoint",
         "vmware.composite.vm.device.cdrom",
@@ -308,14 +309,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 25 write composites register a builder (criterion 4)
+# Wiring — all 26 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 25
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 26
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -411,6 +412,11 @@ async def test_vm_create_preview_echoes_creation_spec() -> None:
         "memory_mib": 8192,
         "networks": ["net-1", "net-2"],
         "disks_gb": [50, 100],
+        "disks": [
+            {"capacity_gb": 50, "provisioning": "thin", "sharing": "none"},
+            {"capacity_gb": 100, "provisioning": "thin", "sharing": "none"},
+        ],
+        "scsi_bus_sharing": "none",
         "nested_hv": True,
         "power_on_after_create": True,
     }
@@ -963,6 +969,8 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
             "memory_mib": 1024,
             "networks": [],
             "disks_gb": [],
+            "disks": [],
+            "scsi_bus_sharing": "none",
             "nested_hv": False,
             "power_on_after_create": False,
         },

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 28 vmware-rest write composites.
+"""Registration tests for the 29 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -58,6 +58,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     vm_customize_composite,
     vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
+    vm_disk_attach_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
     vm_nic_repoint_composite,
@@ -71,8 +72,9 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 28 write composites (T6 / #509, single-VM vm.power / #2301, the
-# mutating VI-JSON vm.disk.grow / #2893, the folder-template
+# 29 write composites (T6 / #509, single-VM vm.power / #2301, the
+# mutating VI-JSON vm.disk.grow / #2893 + WSFC/FCI vm.disk.attach / #3256,
+# the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
 # hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom, the
@@ -93,6 +95,7 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.power",
     "vmware.composite.vm.power.bulk",
     "vmware.composite.vm.disk.grow",
+    "vmware.composite.vm.disk.attach",
     "vmware.composite.vm.resize",
     "vmware.composite.vm.nic.repoint",
     "vmware.composite.vm.device.cdrom",
@@ -130,7 +133,7 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
 )
 
-# 37 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 28 write
+# 38 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 29 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -138,7 +141,8 @@ _READ_OP_IDS: tuple[str, ...] = (
 # + the destructive-tier vm.destroy / #3198 + the #3091 vim portgroup writes
 # network.portgroup.create + network.portgroup.security.set + the
 # content-library import vm.import_from_library / #3229 + the guest-ops
-# program-exec write vm.guest.program.run / #3255).
+# program-exec write vm.guest.program.run / #3255 + the WSFC/FCI shared-attach
+# vm.disk.attach / #3256).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -175,6 +179,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.vm.disk.grow": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_disk_grow_composite"
+    ),
+    "vmware.composite.vm.disk.attach": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_disk_attach_composite"
     ),
     "vmware.composite.host.evacuate": (
         "meho_backplane.connectors.vmware_rest.composites._write.host_evacuate_composite"
@@ -244,6 +251,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.power": "vm",
     "vmware.composite.vm.power.bulk": "vm",
     "vmware.composite.vm.disk.grow": "vm",
+    "vmware.composite.vm.disk.attach": "vm",
     "vmware.composite.vm.resize": "vm",
     "vmware.composite.vm.nic.repoint": "vm",
     "vmware.composite.vm.device.cdrom": "vm",
@@ -304,7 +312,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 27 write composites land alongside the 9 reads (36 total)
+# 29 write composites land alongside the 9 reads (38 total)
 # ---------------------------------------------------------------------------
 
 
@@ -312,7 +320,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_all_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 27 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 29 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -332,14 +340,15 @@ async def test_register_vmware_composite_operations_inserts_all_write_rows(
 async def test_full_registration_produces_thirty_three_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """9 reads (#508 + guest-ops reads #3100) + 28 writes (#509 + vm.power #2301 +
-    vm.disk.grow #2893 + vm.clone_from_template #2894 + cluster.drs_rule.create +
-    folder.create #2895 + #2891 hardware writes vm.resize / vm.nic.repoint /
-    vm.device.cdrom + GOSC create/apply #2892 + OVF deploy #2909 + host-domain
-    writes #3182 + guest-ops writes vm.guest.file.write #3100 +
-    vm.guest.program.run #3255 + destructive-tier vm.destroy #3198 + #3091
-    portgroup writes network.portgroup.create / network.portgroup.security.set +
-    content-library import vm.import_from_library #3229) = 37 rows. DoD bar."""
+    """9 reads (#508 + guest-ops reads #3100) + 29 writes (#509 + vm.power #2301 +
+    vm.disk.grow #2893 + vm.disk.attach #3256 + vm.clone_from_template #2894 +
+    cluster.drs_rule.create + folder.create #2895 + #2891 hardware writes
+    vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF
+    deploy #2909 + host-domain writes #3182 + guest-ops writes
+    vm.guest.file.write #3100 + vm.guest.program.run #3255 + destructive-tier
+    vm.destroy #3198 + #3091 portgroup writes network.portgroup.create /
+    network.portgroup.security.set + content-library import
+    vm.import_from_library #3229) = 38 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -353,7 +362,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 37
+    assert len(rows) == 38
 
 
 @pytest.mark.asyncio
@@ -383,7 +392,7 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 27 write rows before iterating —
+    # Prove the query actually returned all 29 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
@@ -605,6 +614,14 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         "vmware.composite.vm.migrate": {"migrated", "no_recommendation"},
         "vmware.composite.vm.power": {"ok", "error", "tools_unavailable"},
         "vmware.composite.vm.disk.grow": {"grown", "invalid_shrink", "disk_not_found", "timeout"},
+        "vmware.composite.vm.disk.attach": {
+            "attached",
+            "invalid_vmdk_path",
+            "invalid_unit",
+            "controller_not_found",
+            "unit_in_use",
+            "timeout",
+        },
         "vmware.composite.host.evacuate": {"evacuated", "partial", "aborted"},
         # #2970: the DVS detach is a polled vim ReconfigureDvs_Task.
         "vmware.composite.host.detach_from_vds": {"detached", "incomplete", "timeout"},
@@ -672,14 +689,14 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 37 rows total, embedding called 37x once."""
+    """Running the registrar twice -> 38 rows total, embedding called 38x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 37
+    assert first_count == 38
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 37.
+    # pipeline; the row count stays at 38.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -693,7 +710,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 37
+    assert len(rows) == 38
 
 
 # ---------------------------------------------------------------------------
@@ -721,6 +738,7 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
         vm_power_composite,
         vm_power_bulk_composite,
         vm_disk_grow_composite,
+        vm_disk_attach_composite,
         vm_resize_composite,
         vm_nic_repoint_composite,
         vm_device_cdrom_composite,

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -479,7 +479,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 37 composites (9 reads + 28 writes) land as `source_kind="composite"`
+The 38 composites (9 reads + 29 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -546,7 +546,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 37 composites are hand-authored aggregators the connector ships as
+The 38 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -881,15 +881,21 @@ approver makes; a failing disk read parks with the #1628
 
 A Windows Server Failover Cluster (WSFC) / SQL FCI needs shared disks that
 two nodes open at identical SCSI addresses. Three knobs express the build,
-all on the **vim seam**: the pinned REST `Disk.VmdkCreateSpec` has no
-provisioning field (spec-verified — `eagerzeroedthick` is inexpressible over
-REST), and neither controller bus-sharing nor per-disk multi-writer has a
-REST spelling. So any non-default knob routes `vm.create` through the vim
-`CreateVM_Task` arm regardless of vCenter version (`_shared_disk_knobs_requested`
-generalises the pre-9.0 `_vim_create_required` gate; that arm requires
-`resource_pool` + `datastore` pins), and the shared-attach op is vim-only —
-both mirroring `vm.disk.grow`. All knobs at default keep the 9.0+ REST create
-body byte-identical.
+all on the **vim seam**. Two of the three are genuinely REST-inexpressible:
+the pinned `Disk.VmdkCreateSpec` carries only `name` / `capacity` /
+`storage_policy` (spec-verified — no provisioning field, so `eagerzeroedthick`
+cannot be asked for over REST), and there is no per-disk multi-writer field.
+The third — controller bus-sharing — *is* REST-expressible in principle
+(`Vm.CreateSpec.scsi_adapters[].sharing` accepts `NONE`/`VIRTUAL`/`PHYSICAL`),
+but the composite folds a single fixed SCSI controller and exposes no
+`scsi_adapters` knob, so it has no bus-sharing spelling on the REST arm
+either. Rather than support each knob on a different arm, any non-default
+knob routes `vm.create` uniformly through the vim `CreateVM_Task` arm
+regardless of vCenter version (`_shared_disk_knobs_requested` generalises the
+pre-9.0 `_vim_create_required` gate; that arm requires `resource_pool` +
+`datastore` pins), and the shared-attach op is vim-only — both mirroring
+`vm.disk.grow`. All knobs at default keep the 9.0+ REST create body
+byte-identical.
 
 - **`vm.create` disk/adapter knobs.** Top-level `scsi_bus_sharing`
   (`none`→`noSharing` | `virtual`→`virtualSharing` | `physical`→`physicalSharing`)

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,14 +8,15 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 32 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 38 hand-authored composites
 that orchestrate cross-spec workflows: 9 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`; plus the four guest-operations reads `#3100`) and 28 write
+in `#2258`; plus the four guest-operations reads `#3100`) and 29 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
-mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
+mutating VI-JSON `vm.disk.grow` / `#2893` + the WSFC/FCI shared-attach
+`vm.disk.attach` / `#3256`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
 `cluster.drs_rule.create` + `folder.create` / `#2895`, the `#2891`
 post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
@@ -662,6 +663,7 @@ enum) are:
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
 | `vm.power.bulk` | (per-VM `results` + aggregate `summary` + `aborted_on_failure`) |
 | `vm.disk.grow` | `grown`, `invalid_shrink`, `disk_not_found`, `timeout` (grow-only; `invalid_shrink` refuses a request ≤ current capacity before any write; `timeout` when the `ReconfigVM_Task` poll gives up) |
+| `vm.disk.attach` | `attached`, `invalid_vmdk_path`, `invalid_unit`, `controller_not_found`, `unit_in_use`, `timeout` (#3256; the first four are pre-write fail-closed refusals; `timeout` when the `ReconfigVM_Task` add poll gives up; a task *fault* raises `connector_error`) |
 | `vm.clone_from_template` | `cloned`, `template_not_found`, `ambiguous_template`, `not_a_template`, `timeout` (name-resolution refusals + the template assert are pre-write; `timeout` when the `CloneVM_Task` poll gives up; a task *fault* raises `connector_error`) |
 | `host.evacuate` | `evacuated`, `partial`, `aborted` (the maintenance-enter is the vim `EnterMaintenanceMode_Task`, polled; fault/timeout raises `connector_error`, #2970) |
 | `host.detach_from_vds` | `detached`, `incomplete`, `timeout` (the detach is the vim `ReconfigureDvs_Task` host-member remove, polled, #2970) |
@@ -874,6 +876,73 @@ capacity diff (`{vm, name, disk, disk_label, current_capacity_bytes,
 requested_capacity_bytes, delta_bytes}`) — the delta is the decision the
 approver makes; a failing disk read parks with the #1628
 `preview_unavailable` marker (the delta is unknowable).
+
+### Shared disks for WSFC/FCI — bus-sharing, eagerzeroedthick, shared-attach (#3256)
+
+A Windows Server Failover Cluster (WSFC) / SQL FCI needs shared disks that
+two nodes open at identical SCSI addresses. Three knobs express the build,
+all on the **vim seam**: the pinned REST `Disk.VmdkCreateSpec` has no
+provisioning field (spec-verified — `eagerzeroedthick` is inexpressible over
+REST), and neither controller bus-sharing nor per-disk multi-writer has a
+REST spelling. So any non-default knob routes `vm.create` through the vim
+`CreateVM_Task` arm regardless of vCenter version (`_shared_disk_knobs_requested`
+generalises the pre-9.0 `_vim_create_required` gate; that arm requires
+`resource_pool` + `datastore` pins), and the shared-attach op is vim-only —
+both mirroring `vm.disk.grow`. All knobs at default keep the 9.0+ REST create
+body byte-identical.
+
+- **`vm.create` disk/adapter knobs.** Top-level `scsi_bus_sharing`
+  (`none`→`noSharing` | `virtual`→`virtualSharing` | `physical`→`physicalSharing`)
+  sets the folded `VirtualLsiLogicSASController`'s `sharedBus`; each `disks[]`
+  entry's `provisioning` maps to the backing's allocation fields
+  (`thin`→`thinProvisioned:true`; `thick`→`thinProvisioned:false,eagerlyScrub:false`;
+  `eagerzeroedthick`→`thinProvisioned:false,eagerlyScrub:true`) and `sharing`
+  (`multi_writer`→`sharingMultiWriter`) to the backing `sharing`. The knobs
+  apply to the **data disks** the create folds; the boot/OS disk is not part
+  of that fold, so it never lands on a shared bus.
+- **`vm.disk.attach` (the shared-attach leg).** Attaches an **existing** VMDK
+  to a VM at an explicit `controller_key` + `unit_number`. A `RetrievePropertiesEx`
+  read (un-gated) locates the SCSI controller by key and confirms the unit is
+  free; a single `ReconfigVM_Task` carries a `VirtualDeviceConfigSpec` add with
+  **no `fileOperation`** — the seam that attaches an existing backing instead of
+  creating one (`fileOperation:"create"` would make a new VMDK). Fail-closed
+  before any write: `vmdk_path` must match `[datastore] path.vmdk`
+  (`invalid_vmdk_path` — no injection reaches the backing `fileName`),
+  `unit_number` 0-15 and not the reserved 7 (`invalid_unit`), the controller
+  must exist and be SCSI (`controller_not_found`), and the unit must be free
+  (`unit_in_use`). Reuses the already-pinned #2893 vim methods
+  (`ReconfigVM_Task` + `RetrievePropertiesEx`) — no new reconcile pins.
+
+**Bus-sharing vs multi-writer — pick correctly per workload.** These are two
+different vim fields for two different clustering models:
+
+- **SCSI bus-sharing** (`scsi_bus_sharing`, the controller's `sharedBus`) is
+  the **WSFC / SQL FCI** mechanism. `physicalSharing` shares the SCSI bus
+  across VMs on different hosts and turns on SCSI-3 persistent reservations,
+  which the Windows cluster uses to arbitrate exclusive ownership of each
+  clustered disk. WSFC disks are **not** multi-writer — only one node owns a
+  disk at a time.
+- **Multi-writer** (`sharing`, the disk backing's `sharingMultiWriter`) lets
+  several VMs open the **same VMDK concurrently** with the vendor lock
+  disabled, for **application-managed** clustering where the guest coordinates
+  its own locking (e.g. Oracle RAC, or a clustered filesystem). It is a disk
+  property, independent of the controller's bus-sharing.
+
+Both require `eagerzeroedthick` disks. For a WSFC/FCI node: create the OS
+separately (or clone from a template), give each node a dedicated
+`physical`-bus-sharing controller with the EZT shared disks (`vm.create`
+`scsi_bus_sharing="physical"` + `provisioning="eagerzeroedthick"` on the first
+node), then `vm.disk.attach` the same VMDKs onto the second node at the
+identical `controller_key`/`unit_number`. Leave `sharing="none"` for WSFC —
+reach for `multi_writer` only when the guest application (not SCSI-3 PR) owns
+the locking. (`vm.create` currently folds shared disks at create time; adding
+a newly-created EZT shared disk to an *already-provisioned* VM is a follow-up,
+not in this task's scope.)
+
+The `vm.disk.attach` park-time preview is a param-echo (`{vm, vmdk_path,
+controller_key, unit_number, sharing}`) — the params fully name the blast
+radius (which disk attaches to which VM at which address), so no live read is
+needed, unlike disk-grow's from→to delta.
 
 ### Governed destructive delete (`vm.destroy`, #3198)
 


### PR DESCRIPTION
## Summary

- **`vm.create` gains WSFC/FCI shared-disk knobs.** A top-level `scsi_bus_sharing` (`none` | `virtual` | `physical`) sets the folded SCSI controller's `sharedBus`; each `disks[]` entry gains `provisioning` (`thin` | `thick` | `eagerzeroedthick`) and `sharing` (`none` | `multi_writer`). `physical` bus + `eagerzeroedthick` is the Windows failover-cluster floor.
- **New `vmware.composite.vm.disk.attach`** — attaches an **existing** VMDK to a VM at an explicit SCSI `controller_key` + `unit_number` (the shared-attach leg: the second cluster node opens the same disk the first created, at the same address). A `ReconfigVM_Task` add with **no** `fileOperation` (attach, not create).
- **Vim-uniform by necessity, documented.** The pinned REST `VmdkCreateSpec` has no provisioning field and neither controller bus-sharing nor multi-writer has a REST expression, so a non-default knob routes `vm.create` through the vim `CreateVM_Task` arm regardless of vCenter version (mirroring `vm.disk.grow`), and the attach op is vim-only. Default knobs keep the 9.0+ REST create body byte-identical. The doc distinguishes SCSI bus-sharing (SCSI-3 PR / WSFC) from per-disk multi-writer (Oracle-RAC-style) so operators pick correctly.
- Composites-only: no product token, no CLI verb, no CLI OpenAPI snapshot regen, no DB migration. The attach op reuses the already-pinned #2893 vim methods (`ReconfigVM_Task` + `RetrievePropertiesEx`) and emits no new `_typeName` discriminators — no new reconcile pins.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest` composite lanes (register ×2, write, write_gate, preview, l2/body reconcile) — **319 passed** with the pinned `vcenter.yaml`/`vi-json.yaml` shelf
  - counts moved 37→38 total (28→29 write, 9 read); every count/set/handler/group/status-enum lane updated
  - new attach op: happy-path (byte-for-byte `add` with no `fileOperation`), multi-writer backing, injection-shaped path / reserved unit / non-SCSI controller / occupied unit refusals, parked-gate reachability (agent-gated / denied / human auto-exec), poll timeout, task fault
  - vm.create knobs: `physical` + `eagerzeroedthick` + `multi_writer` route a 9.0 create to vim and set `sharedBus`/`eagerlyScrub`/`sharing`; default knobs stay on the REST arm byte-identical; invalid enums fail closed
  - reconcile: `_VIM_SUB_OPS_VM_DISK_ATTACH` pinned; every emitted `_typeName` still grounds against `vi-json.yaml`
- [x] Injection/param hygiene: `vmdk_path` validated against `[datastore] path.vmdk` before any read/write; no secret-shaped params

## Out of scope

- **Consumer proof (AC #5) declared OPEN.** c1sql1 T4 (2-node SQL FCI on cluster1's vSAN, `evoila-bosnia/claude-rdc-hetzner-dc#2789`) live-replays the governed shared-disk build; its proof is deferred per estate precedent.
- Adding a *newly-created* EZT shared disk to an *already-provisioned* VM (this task creates shared disks at `vm.create` time; a create-on-existing-VM leg is a documented follow-up).
- RDM attach (no FC/iSCSI LUN substrate in the driving lab — file separately per the issue).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3256
