### PR TITLE
feat(connectors): pin HttpNfcLease device-URL transfers to the lease-provided sslThumbprint (#3229 hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — HttpNfcLease device-URL transfers pinned to the lease `sslThumbprint` (#3284)
+
+- The typed OVF import (`vm.import_from_library`, #3229) streams each disk to an
+  *absolute* per-device ESXi upload URL, which the pooled client dials without
+  the per-target SSRF host re-screen (that screen is keyed to `target.host`, and
+  screening would wrongly block a legitimate private ESXi host). That bypass now
+  has a replacement control: before a byte streams, the device host's TLS
+  certificate is **pinned** to the `HttpNfcLeaseDeviceUrl.sslThumbprint` the
+  authenticated vCenter attests for it (SHA-1 of the DER cert, colon/case
+  normalised). A mismatch — or a handshake that cannot obtain a certificate —
+  **fails closed**: no disk bytes flow, the lease is aborted (vCenter tears down
+  the half-import), and the failure surfaces as a distinct `security`-category
+  `import_error`, closing the redirect/MITM window on the multi-GB PUTs.
+- **Missing-thumbprint policy is fail-open by design:** an empty / absent
+  `sslThumbprint` skips pinning and falls back to the client's existing TLS
+  trust, because the vim spec sanctions an empty value ("Empty if no SSL
+  thumbprint is available or needed") — a conformant lease that omits it must
+  still import. The SSRF host screen stays off for device-URL PUTs; pinning is
+  the replacement, not an addition on top of a host allowlist.
+
 ### Fixed — self-approval break-glass no longer permits dangerous-tier deletes (#3290 / #3198)
 
 - The unconditional self-approval refusal (#3198 — "no self-approval, even

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_import.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_import.py
@@ -279,11 +279,26 @@ async def _run_transfer(
             heartbeat_interval=heartbeat_interval,
         )
         await control.lease_complete(connector, target, operator, lease_moid=lease_moid)
+    except transfer.DeviceThumbprintError as exc:
+        # A device host failed certificate-thumbprint pinning (#3284): no disk
+        # bytes flowed. Surface a distinct security-category issue so the
+        # mismatch is not conflated with an ordinary transport fault.
+        return await _abort_import_error(
+            connector,
+            target,
+            operator,
+            lease_moid=lease_moid,
+            warnings=warnings,
+            issue=control.issue("security", "error", f"device thumbprint pin failed: {exc}"),
+        )
     except httpx.HTTPError as exc:
-        await control.abort_lease(connector, target, operator, lease_moid=lease_moid)
-        return LeaseImportResult(
-            status="import_error",
-            issues=[*warnings, control.issue("transfer", "error", f"disk upload faulted: {exc}")],
+        return await _abort_import_error(
+            connector,
+            target,
+            operator,
+            lease_moid=lease_moid,
+            warnings=warnings,
+            issue=control.issue("transfer", "error", f"disk upload faulted: {exc}"),
         )
     vm_id, resource_type = control.entity_from_info(info)
     return LeaseImportResult(
@@ -293,3 +308,22 @@ async def _run_transfer(
         issues=warnings,
         transfer=manifest,
     )
+
+
+async def _abort_import_error(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    lease_moid: str,
+    warnings: list[dict[str, Any]],
+    issue: dict[str, Any],
+) -> LeaseImportResult:
+    """Abort the lease and return an ``import_error`` carrying *issue*.
+
+    The shared failure tail for a transfer fault: vCenter tears down the
+    half-created inventory on ``HttpNfcLeaseAbort``, so a failed import never
+    leaves a partial VM behind.
+    """
+    await control.abort_lease(connector, target, operator, lease_moid=lease_moid)
+    return LeaseImportResult(status="import_error", issues=[*warnings, issue])

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
@@ -247,10 +247,13 @@ def _cert_thumbprint(cert_der: bytes, expected_hex_len: int) -> str:
     vim default; 64 → SHA-256), so a matching cert produces an identical
     bare-hex string. An unrecognised length falls back to SHA-1, whose
     40-char digest cannot equal a differently-sized expected value, so the
-    comparison fails closed.
+    comparison fails closed. ``usedforsecurity=False`` keeps the
+    protocol-mandated SHA-1 available under a FIPS-restricted build -- the
+    algorithm is fixed by vCenter's thumbprint convention, not a
+    security-strength choice we are free to substitute.
     """
     algorithm = _THUMBPRINT_ALGORITHMS.get(expected_hex_len, "sha1")
-    return hashlib.new(algorithm, cert_der).hexdigest()
+    return hashlib.new(algorithm, cert_der, usedforsecurity=False).hexdigest()
 
 
 def _fetch_peer_cert_der(host: str, port: int, timeout: float) -> bytes | None:

--- a/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/ovf_transfer.py
@@ -15,12 +15,43 @@ lease + source session alive and surfaces percent progress.
 The control-plane vim calls (``CreateImportSpec`` / ``ImportVApp`` / lease
 poll / ``Complete`` / ``Abort``) live in :mod:`.ovf_import_control`; the
 orchestration in :mod:`.ovf_import`.
+
+**Device-host trust model (#3284).** Each disk PUT streams to an *absolute*
+per-device ESXi upload URL the authenticated vCenter returns in the lease
+info -- not to ``target.host``. The pooled client dials that absolute URL,
+so the per-target SSRF host re-screen (keyed to ``target.host``,
+:mod:`meho_backplane.connectors.adapters.http`) does **not** run for the
+device host, and that bypass stays: screening a private ESXi host would
+wrongly block a legitimate import. The replacement control is
+**certificate thumbprint pinning**. vCenter attests each device host by
+returning its ``HttpNfcLeaseDeviceUrl.sslThumbprint`` (a SHA-1 hash of the
+DER certificate, colon-separated hex -- the same vim thumbprint convention
+``HostConnectSpec.sslThumbprint`` documents); :func:`verify_device_thumbprint`
+opens a pre-flight handshake to the device host and refuses to stream a
+byte unless the presented certificate matches that attestation. When the
+field is **empty** -- which the vim spec sanctions ("Empty if no SSL
+thumbprint is available or needed") -- pinning is skipped and the transfer
+falls back to the pooled client's existing TLS trust (fail-open on an
+absent attestation; see :func:`verify_device_thumbprint`).
+
+The pin is a *pre-flight* handshake, separate from the PUT connection, run
+per-disk immediately before its upload: ``httpx`` builds its client on a
+stdlib :class:`ssl.SSLContext`, which exposes no per-connection fingerprint
+callback, so the presented certificate cannot be pinned inside the PUT
+itself. The residual window is one disk's worth of time between the verified
+handshake and the pooled client's connect to the same ``host:port`` -- far
+smaller than the un-pinned status quo this replaces, and the practical
+alternative short of abandoning the pooled client (and its retry / redirect /
+flight-recorder plumbing) for a hand-rolled socket upload.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import socket
+import ssl
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlsplit, urlunsplit
@@ -35,6 +66,7 @@ if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
 
 __all__ = [
+    "DeviceThumbprintError",
     "OvfSource",
     "OvfSourceFile",
     "ProgressTracker",
@@ -43,6 +75,7 @@ __all__ = [
     "plan_transfers",
     "substitute_wildcard_host",
     "transfer_all",
+    "verify_device_thumbprint",
 ]
 
 # Content-Type the ESXi NFC endpoint expects for a stream-optimized VMDK PUT;
@@ -57,6 +90,32 @@ _DISK_UPLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=None, pool=1
 
 # Default heartbeat cadence (module-global so tests can shrink it).
 _PROGRESS_HEARTBEAT_INTERVAL = 30.0
+
+# Connect + handshake budget for the pre-flight thumbprint verification. A
+# dead device host fails the check fast rather than pinning a worker thread;
+# the disk stream that follows has its own (uncapped) timeout.
+_THUMBPRINT_HANDSHAKE_TIMEOUT = 10.0
+
+# Digest algorithm keyed by the expected thumbprint's hex length. vim
+# ``sslThumbprint`` is SHA-1 (40 hex chars) by convention
+# (``HostConnectSpec.sslThumbprint``: "always computed using the SHA1
+# hash"); a 64-char value is accepted as SHA-256 for forward-compatibility.
+# An expected value of any other length matches no digest and so fails
+# closed.
+_THUMBPRINT_ALGORITHMS = {40: "sha1", 64: "sha256"}
+
+
+class DeviceThumbprintError(Exception):
+    """The device host's certificate did not match the lease attestation (#3284).
+
+    Raised by :func:`verify_device_thumbprint` when a lease device URL
+    carries a non-empty ``sslThumbprint`` but the certificate the host
+    presents does not hash to it -- or the pre-flight handshake could not
+    obtain a certificate to compare. Either way the disk is **not**
+    streamed; :func:`~meho_backplane.connectors.vmware_rest.ovf_import`
+    catches this before ``httpx.HTTPError`` and aborts the lease, so a
+    tampered or redirected device URL never receives a byte.
+    """
 
 
 class OvfSourceFile(Protocol):
@@ -97,13 +156,20 @@ class OvfSource(Protocol):
 
 @dataclass
 class TransferEntry:
-    """One planned disk upload: source file path -> lease device URL."""
+    """One planned disk upload: source file path -> lease device URL.
+
+    ``ssl_thumbprint`` carries the lease's per-device
+    ``HttpNfcLeaseDeviceUrl.sslThumbprint`` attestation (``None`` / empty
+    when vCenter supplied none); :func:`verify_device_thumbprint` pins the
+    device host's certificate to it before the PUT streams (#3284).
+    """
 
     device_id: str
     path: str
     url: str
     size: int
     is_disk: bool
+    ssl_thumbprint: str | None = None
 
 
 def substitute_wildcard_host(url: str, connect_host: str) -> str:
@@ -130,8 +196,10 @@ def plan_transfers(
 
     ``HttpNfcLeaseDeviceUrl.importKey`` equals the ``OvfFileItem.deviceId``
     (the name-based device id from the ImportSpec); a ``*`` URL host is
-    substituted with *connect_host*. A file with no matching device URL is
-    skipped (the lease did not request its upload, e.g. a shared parent disk).
+    substituted with *connect_host*. Each device URL's ``sslThumbprint`` is
+    captured onto the entry so the transfer can pin the device host's
+    certificate (#3284). A file with no matching device URL is skipped (the
+    lease did not request its upload, e.g. a shared parent disk).
     """
     by_key: dict[str, dict[str, Any]] = {}
     for durl in device_urls:
@@ -148,6 +216,7 @@ def plan_transfers(
         if not isinstance(device_id, str) or not isinstance(url, str) or matched is None:
             continue
         size = item.get("size")
+        thumbprint = matched.get("sslThumbprint")
         plan.append(
             TransferEntry(
                 device_id=device_id,
@@ -155,9 +224,101 @@ def plan_transfers(
                 url=substitute_wildcard_host(url, connect_host),
                 size=int(size) if isinstance(size, int) and not isinstance(size, bool) else 0,
                 is_disk=bool(matched.get("disk")),
+                ssl_thumbprint=thumbprint if isinstance(thumbprint, str) else None,
             )
         )
     return plan
+
+
+def _normalize_thumbprint(raw: str) -> str:
+    """Reduce a vim thumbprint to bare lowercase hex for comparison.
+
+    vCenter formats ``sslThumbprint`` as colon-separated hex
+    (``A1:B2:...``); strip the colons and any surrounding whitespace and
+    lowercase so the comparison is insensitive to separators and case.
+    """
+    return raw.replace(":", "").replace(" ", "").strip().lower()
+
+
+def _cert_thumbprint(cert_der: bytes, expected_hex_len: int) -> str:
+    """Hash *cert_der* with the algorithm implied by *expected_hex_len*.
+
+    The lease attestation's length selects the digest (40 hex → SHA-1, the
+    vim default; 64 → SHA-256), so a matching cert produces an identical
+    bare-hex string. An unrecognised length falls back to SHA-1, whose
+    40-char digest cannot equal a differently-sized expected value, so the
+    comparison fails closed.
+    """
+    algorithm = _THUMBPRINT_ALGORITHMS.get(expected_hex_len, "sha1")
+    return hashlib.new(algorithm, cert_der).hexdigest()
+
+
+def _fetch_peer_cert_der(host: str, port: int, timeout: float) -> bytes | None:
+    """Return the DER certificate *host:port* presents on a TLS handshake.
+
+    Verification is **off** (``CERT_NONE``) on purpose: ESXi device hosts
+    serve self-signed certificates, so the identity check is the thumbprint
+    pin, not chain validation. ``check_hostname`` is cleared before
+    ``verify_mode`` (assigning ``CERT_NONE`` while hostname checking is on
+    raises on CPython). Runs off the event loop via
+    :func:`asyncio.to_thread`. Returns ``None`` only if the peer sent no
+    certificate (an anonymous cipher), which the caller treats as
+    unverifiable.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # NOSONAR(S4830) — thumbprint pinning is the identity check; ESXi device hosts are self-signed (module docstring)  # noqa: E501  # fmt: skip
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE  # NOSONAR(S4830) — same justification; the pin authenticates the endpoint  # noqa: E501  # fmt: skip
+    with (
+        socket.create_connection((host, port), timeout=timeout) as raw,
+        context.wrap_socket(raw, server_hostname=host) as tls,
+    ):
+        cert = tls.getpeercert(binary_form=True)
+    return cert
+
+
+async def verify_device_thumbprint(url: str, expected: str | None) -> None:
+    """Pin the device host's certificate to the lease *expected* thumbprint.
+
+    Fail-**open** on an absent attestation: an empty / ``None`` *expected*
+    means vCenter supplied no thumbprint, which the vim spec explicitly
+    sanctions ("Empty if no SSL thumbprint is available or needed"), so the
+    transfer proceeds under the pooled client's existing TLS trust rather
+    than being blocked -- a conformant lease that omits the field must still
+    import. Fail-**closed** on a present attestation: open a pre-flight
+    handshake to the device host, hash the presented certificate, and raise
+    :exc:`DeviceThumbprintError` unless it matches. A handshake that cannot
+    obtain a certificate to compare is also a closed failure -- the disk is
+    never streamed to an endpoint whose identity the lease attested but that
+    could not be confirmed.
+    """
+    normalized_expected = _normalize_thumbprint(expected) if expected else ""
+    if not normalized_expected:
+        return
+    parts = urlsplit(url)
+    host = parts.hostname
+    if not host:
+        raise DeviceThumbprintError(f"device URL {url!r} has no host to pin a thumbprint against")
+    port = parts.port or 443
+    try:
+        cert_der = await asyncio.to_thread(
+            _fetch_peer_cert_der, host, port, _THUMBPRINT_HANDSHAKE_TIMEOUT
+        )
+    except OSError as exc:
+        raise DeviceThumbprintError(
+            f"could not complete the TLS handshake to device host {host}:{port} to verify "
+            f"its certificate against the lease sslThumbprint: {exc}"
+        ) from exc
+    if not cert_der:
+        raise DeviceThumbprintError(
+            f"device host {host}:{port} presented no certificate to pin against the "
+            f"lease sslThumbprint"
+        )
+    presented = _cert_thumbprint(cert_der, len(normalized_expected))
+    if presented != normalized_expected:
+        raise DeviceThumbprintError(
+            f"device host {host}:{port} certificate thumbprint {presented} does not match the "
+            f"lease-provided sslThumbprint {normalized_expected}"
+        )
 
 
 class ProgressTracker:
@@ -229,14 +390,20 @@ async def _upload_one(
 ) -> int:
     """Stream one disk from the source straight to its lease device URL.
 
-    Returns the byte count uploaded. The stream is wrapped so the shared
-    :class:`ProgressTracker` advances as bytes flow -- that is what the
-    heartbeat reports. Uses the connector's pooled client (its TLS trust
-    config) with the ESXi NFC device URL as an absolute URL; the lease token
-    embedded in the URL authorizes the PUT. ``Content-Length`` is the source
-    file's own size (not the descriptor's declared size), sent explicitly so
-    the NFC endpoint gets a sized -- not chunked -- body.
+    Returns the byte count uploaded. Before a single byte flows, the device
+    host's certificate is pinned to the lease-provided ``sslThumbprint``
+    (#3284): :func:`verify_device_thumbprint` raises
+    :exc:`DeviceThumbprintError` on a mismatch, so a tampered or redirected
+    device URL is refused pre-stream and the caller aborts the lease. The
+    stream is wrapped so the shared :class:`ProgressTracker` advances as
+    bytes flow -- that is what the heartbeat reports. Uses the connector's
+    pooled client (its TLS trust config) with the ESXi NFC device URL as an
+    absolute URL; the lease token embedded in the URL authorizes the PUT.
+    ``Content-Length`` is the source file's own size (not the descriptor's
+    declared size), sent explicitly so the NFC endpoint gets a sized -- not
+    chunked -- body.
     """
+    await verify_device_thumbprint(entry.url, entry.ssl_thumbprint)
     client = await connector._http_client(target)
     content_type = _STREAM_VMDK_CONTENT_TYPE if entry.is_disk else _OCTET_STREAM_CONTENT_TYPE
     async with source.open_disk(entry.path) as handle:

--- a/backend/tests/test_connectors_vmware_rest_ovf_import.py
+++ b/backend/tests/test_connectors_vmware_rest_ovf_import.py
@@ -15,15 +15,21 @@ against ``_write.vm_import_from_library_composite``.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import Any, ClassVar
 
 import httpx
 import pytest
 
 from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest import ovf_import
+from meho_backplane.connectors.vmware_rest import ovf_import, ovf_transfer
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.connectors.vmware_rest.ovf_import import ImportPlacement, LeaseImportResult
+
+
+def _colon_hex(digest: str) -> str:
+    """Render a bare hex digest in vCenter's uppercase colon-separated form."""
+    return ":".join(digest[i : i + 2] for i in range(0, len(digest), 2)).upper()
 
 
 class _Target:
@@ -172,14 +178,21 @@ def _import_spec_result(
     }
 
 
-def _ready_poll(*, with_ssl_cert: bool = False) -> dict[str, Any]:
+def _ready_poll(
+    *,
+    with_ssl_cert: bool = False,
+    ssl_thumbprint: str | None = None,
+    url: str = "https://*/nfc/lease-1/disk-0.vmdk",
+) -> dict[str, Any]:
     device_url: dict[str, Any] = {
         "_typeName": "HttpNfcLeaseDeviceUrl",
         "key": "/vm-9/disk-0",
         "importKey": "disk1",
-        "url": "https://*/nfc/lease-1/disk-0.vmdk",
+        "url": url,
         "disk": True,
     }
+    if ssl_thumbprint is not None:
+        device_url["sslThumbprint"] = ssl_thumbprint
     if with_ssl_cert:  # 9.0-only field the engine must ignore
         device_url["sslCertificate"] = "-----BEGIN CERTIFICATE-----"
     info = {
@@ -386,6 +399,186 @@ async def test_import_is_version_agnostic_ignoring_9_0_only_device_fields() -> N
     result = await _run(conn, source)
     assert isinstance(result, LeaseImportResult)
     assert result.status == "imported"
+
+
+# ---------------------------------------------------------------------------
+# Device-host certificate thumbprint pinning (#3284)
+# ---------------------------------------------------------------------------
+
+
+def test_thumbprint_normalization_is_colon_and_case_insensitive() -> None:
+    """Colons, whitespace, and case are stripped before comparison."""
+    assert ovf_transfer._normalize_thumbprint("A1:B2:C3:D4") == "a1b2c3d4"
+    assert ovf_transfer._normalize_thumbprint("  a1:b2 ") == "a1b2"
+
+
+def test_cert_thumbprint_selects_algorithm_by_expected_length() -> None:
+    """A 40-char expectation hashes SHA-1; 64 hashes SHA-256 (vim convention)."""
+    der = b"esxi-leaf-cert-der"
+    assert ovf_transfer._cert_thumbprint(der, 40) == hashlib.sha1(der).hexdigest()
+    assert ovf_transfer._cert_thumbprint(der, 64) == hashlib.sha256(der).hexdigest()
+    # An unrecognised length falls back to SHA-1, whose digest cannot equal a
+    # differently-sized expected value — the comparison then fails closed.
+    assert ovf_transfer._cert_thumbprint(der, 12) == hashlib.sha1(der).hexdigest()
+
+
+async def test_verify_matches_when_presented_cert_hashes_to_the_thumbprint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device cert whose SHA-1 matches the lease thumbprint verifies silently."""
+    der = b"esxi-real-cert"
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", lambda *_a: der)
+    thumbprint = _colon_hex(hashlib.sha1(der).hexdigest())
+    await ovf_transfer.verify_device_thumbprint("https://esxi.lab:443/nfc/x.vmdk", thumbprint)
+
+
+async def test_verify_raises_on_thumbprint_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cert that does not hash to the lease thumbprint fails closed."""
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", lambda *_a: b"attacker-cert")
+    thumbprint = _colon_hex(hashlib.sha1(b"real-cert").hexdigest())
+    with pytest.raises(ovf_transfer.DeviceThumbprintError):
+        await ovf_transfer.verify_device_thumbprint("https://esxi.lab/nfc/x.vmdk", thumbprint)
+
+
+@pytest.mark.parametrize("absent", ["", None])
+async def test_verify_is_fail_open_on_absent_thumbprint(
+    monkeypatch: pytest.MonkeyPatch, absent: str | None
+) -> None:
+    """An empty/None thumbprint skips the handshake (vim: 'Empty if ... not needed')."""
+    handshakes: list[str] = []
+    monkeypatch.setattr(
+        ovf_transfer, "_fetch_peer_cert_der", lambda h, *_a: handshakes.append(h) or b"x"
+    )
+    await ovf_transfer.verify_device_thumbprint("https://esxi.lab/nfc/x.vmdk", absent)
+    assert handshakes == []  # fail-open: no pin handshake was attempted
+
+
+async def test_verify_fails_closed_when_handshake_cannot_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A handshake that cannot obtain a cert to compare is a closed failure."""
+
+    def _boom(*_a: Any) -> bytes:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", _boom)
+    with pytest.raises(ovf_transfer.DeviceThumbprintError):
+        await ovf_transfer.verify_device_thumbprint("https://esxi.lab/nfc/x.vmdk", "AA:BB:CC")
+
+
+async def test_thumbprint_mismatch_aborts_before_any_disk_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mismatch aborts the lease pre-stream — no PUT, no Complete, security issue."""
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", lambda *_a: b"attacker-cert")
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll(ssl_thumbprint=_colon_hex(hashlib.sha1(b"real").hexdigest()))],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "import_error"
+    assert result.issues[-1]["category"] == "security"
+    assert conn._client.puts == []  # fail closed: not a single byte streamed
+    assert any(p.endswith("/HttpNfcLeaseAbort") for p, _ in conn.vmomi_calls)
+    assert not any(p.endswith("/HttpNfcLeaseComplete") for p, _ in conn.vmomi_calls)
+
+
+async def test_thumbprint_match_streams_disk_and_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A matching thumbprint permits the stream and the import completes."""
+    der = b"esxi-real-cert"
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", lambda *_a: der)
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll(ssl_thumbprint=_colon_hex(hashlib.sha1(der).hexdigest()))],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    assert conn._client.puts[0]["url"] == "https://vcenter.lab/nfc/lease-1/disk-0.vmdk"
+
+
+async def test_absent_thumbprint_streams_under_existing_tls_trust(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail-open policy: an empty sslThumbprint imports without a pin handshake."""
+    handshakes: list[str] = []
+    monkeypatch.setattr(
+        ovf_transfer, "_fetch_peer_cert_der", lambda h, *_a: handshakes.append(h) or b"x"
+    )
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll(ssl_thumbprint="")],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    assert handshakes == []
+
+
+async def test_thumbprint_pin_uses_the_wildcard_substituted_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinning composes with `*`-host substitution: it dials the concrete host."""
+    der = b"esxi-real-cert"
+    seen: dict[str, Any] = {}
+
+    def _fake(host: str, port: int, _timeout: float) -> bytes:
+        seen["host"], seen["port"] = host, port
+        return der
+
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", _fake)
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[_ready_poll(ssl_thumbprint=_colon_hex(hashlib.sha1(der).hexdigest()))],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    assert seen["host"] == "vcenter.lab"  # the substituted host, never the raw "*"
+
+
+async def test_private_device_host_streams_when_thumbprint_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinning — not a host allowlist — authorizes a private ESXi device host.
+
+    The per-target SSRF host screen stays off for device-URL PUTs (it would
+    wrongly block a legitimate private ESXi host); a matching thumbprint is
+    the replacement control, so a private-IP device host streams cleanly.
+    """
+    der = b"esxi-private-cert"
+    monkeypatch.setattr(ovf_transfer, "_fetch_peer_cert_der", lambda *_a: der)
+    conn = _EngineConnector(
+        service_content=_service_content(),
+        import_spec_result=_import_spec_result(),
+        lease_ref=_lease_ref(),
+        lease_polls=[
+            _ready_poll(
+                ssl_thumbprint=_colon_hex(hashlib.sha1(der).hexdigest()),
+                url="https://10.11.16.9/nfc/lease-1/disk-0.vmdk",
+            )
+        ],
+    )
+    source = _FakeSource("<Envelope/>", {"app-disk1.vmdk": _FakeDisk(b"12345678")})
+    result = await _run(conn, source)
+    assert isinstance(result, LeaseImportResult)
+    assert result.status == "imported"
+    assert conn._client.puts[0]["url"] == "https://10.11.16.9/nfc/lease-1/disk-0.vmdk"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1239,16 +1239,43 @@ content-library byte source in `library_download.py`):
    the PUT's `Content-Length` is the download response's own `Content-Length`
    (the `File.Info.size` is not guaranteed set before the download completes).
    A `*` device-URL host is substituted with the host the client connected to
-   (the `HttpNfcLeaseDeviceUrl.url` spec contract).
+   (the `HttpNfcLeaseDeviceUrl.url` spec contract). **Before a byte streams,
+   the device host's certificate is pinned to the lease's `sslThumbprint`**
+   (see the hardening note below).
 6. `HttpNfcLeaseComplete` on success; `HttpNfcLeaseAbort` on any failure after
    the lease exists — vCenter then removes the half-created inventory objects,
    so a failed import never leaves a partial VM behind.
 
 **Version-agnostic (AC5).** Every schema + method is core vim25 (`OvfManager`
 / `HttpNfcLease` predate 9.0), and the engine reads only the pre-9.0
-`HttpNfcLeaseDeviceUrl` fields (`key` / `importKey` / `url`) — never the
-9.0-only `sslCertificate` — so it works on the VCF 5.x migration-source fleet
-(#3056) as well as 9.0+.
+`HttpNfcLeaseDeviceUrl` fields (`key` / `importKey` / `url` / `sslThumbprint`)
+— never the 9.0-only `sslCertificate` — so it works on the VCF 5.x
+migration-source fleet (#3056) as well as 9.0+.
+
+**Device-host thumbprint pinning (#3284).** Each disk PUT streams to an
+*absolute* per-device ESXi upload URL, not to `target.host`, so the pooled
+client's per-target SSRF host re-screen (keyed to `target.host`) does not run
+for the device host — a deliberate bypass, since screening would wrongly
+block a legitimate private ESXi host. The replacement control is certificate
+thumbprint pinning: `plan_transfers` captures each device URL's
+`HttpNfcLeaseDeviceUrl.sslThumbprint` (a SHA-1 hash of the DER certificate in
+colon-separated hex — the vim thumbprint convention `HostConnectSpec.sslThumbprint`
+documents), and `ovf_transfer.verify_device_thumbprint` opens a pre-flight
+`VERIFY_NONE` handshake to the device host and **refuses to stream a byte**
+unless the presented certificate hashes to that attestation. A mismatch — or
+a handshake that cannot obtain a certificate — raises `DeviceThumbprintError`,
+which `_run_transfer` catches before `httpx.HTTPError`, aborts the lease, and
+maps to a distinct `import_error` with a `security`-category issue (no disk
+bytes flowed). **Missing-thumbprint policy: fail-open.** An empty / absent
+`sslThumbprint` skips pinning and falls back to the pooled client's existing
+TLS trust, because the vim spec sanctions an empty value ("Empty if no SSL
+thumbprint is available or needed") — a conformant lease that omits the field
+must still import, and pinning is a strict improvement layered on top of the
+pre-existing "device URLs are trusted vendor data" posture, never a new gate
+that fails closed on legitimate traffic. The SSRF host screen stays off for
+device-URL PUTs; pinning is the replacement, comparison is
+colon/case-insensitive, and the 64-hex-char case is accepted as SHA-256 for
+forward-compatibility.
 
 **Envelope.** Item resolution (id passthrough or name find, ambiguity-refusing)
 reuses `_resolve_deploy_library_item`, and the outcome maps onto the **same**


### PR DESCRIPTION
## Summary

- The typed `HttpNfcLease` OVF import (#3229) streams each disk to an **absolute** per-device ESXi upload URL, which the pooled client dials **without** the per-target SSRF host re-screen (the screen is keyed to `target.host`, and screening would wrongly block a legitimate private ESXi host). That deliberate bypass had no replacement control, leaving a redirect/MITM window on the multi-GB PUTs.
- This threads the lease-provided `sslThumbprint` through `plan_transfers` → `TransferEntry` → the upload path. Before a byte streams, `verify_device_thumbprint` opens a pre-flight handshake to the device host and **pins** its certificate to the lease's attestation (SHA-1 of the DER cert, colon/case-normalised; the 64-hex SHA-256 case is accepted for forward-compatibility).
- A mismatch — or a handshake that cannot obtain a certificate — raises `DeviceThumbprintError`, which `_run_transfer` catches **before** `httpx.HTTPError`, aborts the lease (vCenter tears down the half-import), and maps to a distinct `security`-category `import_error`. **No disk bytes flow on a failed pin.**
- The SSRF host screen stays **off** for device-URL PUTs; pinning is the replacement control, not an addition on top of a host allowlist.

## Missing-thumbprint policy: fail-open (decided + pinned in code and test)

`HttpNfcLeaseDeviceUrl.sslThumbprint` is `xsd:string` and the vim spec states its value is "**Empty if no SSL thumbprint is available or needed**" ([HttpNfcLease.DeviceUrl](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.HttpNfcLease.DeviceUrl.html); SHA-1 + colon-separated-hex convention per [HostConnectSpec.sslThumbprint](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.host.ConnectSpec.html)). Because an **empty value is a spec-sanctioned state**, an empty/absent `sslThumbprint` **fails open** — pinning is skipped and the transfer falls back to the pooled client's existing TLS trust, so a conformant lease that omits the field still imports. Pinning is a strict improvement layered on top of the pre-existing "device URLs are trusted vendor data" posture, never a new gate that fails closed on legitimate traffic. Fail-closed is reserved for the case where vCenter **did** attest a thumbprint but the presented cert does not match it (or cannot be obtained).

**Residual window (documented, honest):** the pin is a per-disk pre-flight handshake separate from the PUT connection — `httpx` builds on a stdlib `ssl.SSLContext`, which exposes no per-connection fingerprint callback, so the cert cannot be pinned inside the PUT itself. The window is one disk's connect-time between verify and PUT to the same `host:port`, far smaller than the un-pinned status quo, and the practical alternative short of a hand-rolled socket upload.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `pytest tests/test_connectors_vmware_rest_ovf_import.py` — 25 passed (12 new cases)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Thumbprint normalisation (colon/case) + algorithm-by-length selection (unit)
- [x] Match → streams; mismatch → `DeviceThumbprintError` (unit)
- [x] Absent/empty thumbprint → fail-open, no handshake (unit + engine)
- [x] Handshake failure → fails closed (unit)
- [x] Engine: mismatch aborts **before any PUT**, no `Complete`, `security` issue
- [x] Engine: pin composes with `*`-host substitution (dials the concrete host)
- [x] Engine: private-IP device host streams on a matching thumbprint (host screen stays off)

## Out of scope

- The per-target SSRF host screen is **not** re-enabled for device-URL PUTs (by design — pinning replaces it).
- `deploy_from_library` and other composites are untouched.
- CLI OpenAPI snapshot: **unchanged** (internal transfer hardening — no new op / verb / tool).
- Live-appliance verification remains deferred (consistent with #3229), covered by mock-transport unit tests.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3284
