### PR TITLE
feat(connectors): govern three caution-tier permanent-removal ops (#3288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,42 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — three caution-tier permanent-removal ops promoted to governed approval (#3288)
+
+- **Behaviour change for agents — approval now required on three permanent-removal
+  ops**, per the #3288 operator ruling (per-op deliberate postures, mirroring the
+  #3247 bind9 precedent):
+  - **`windns.record.remove`** (the `-Force` RRset clear: every value of an RRType
+    at a name) moves from `caution` + approval-free to **`destructive` +
+    `requires_approval=True`**, tagged `delete`/`destructive`. It now runs only
+    through preview → park → distinct-human approval → audited resume; a bare
+    dispatch is refused `preview_binding_required` and a park without a resolvable
+    blast radius is refused `blast_radius_required`. A read-only park-time preview
+    (`ops_record_remove_preview`) names the `(zone, name, type)` record-set and
+    enumerates every value that dies (`irreversibility="recreatable"`).
+  - **`harbor.robot.delete`** moves from `caution` + approval-free to
+    **`destructive` + `requires_approval=True`**. Permanent removal of a
+    credential-bearing principal is not transparently reversible — re-creating the
+    robot mints a NEW secret and silently breaks every consumer of the old one (the
+    lab signal `bind9-harbor-dangerous-writes-bypass-approval-gate.yaml`). The
+    park-time preview (`ops_robot_delete_preview`, params-derived) names the robot
+    `{id, project, level}` + its project association
+    (`irreversibility="recreatable_new_secret"`).
+  - **`winsrv.feature.remove`** moves from `caution` + approval-free to
+    **`dangerous` + `requires_approval=True`** — disruptive enough to demand a
+    human, but deliberately **not** `destructive` (reversible by reinstall,
+    data-preserving), so no blast-radius preview is required at this tier (the
+    `winsrv.localuser.delete` mould). A dispatch parks at `awaiting_approval`.
+- **Single-sourced promotions** — only each op's `safety_level` + tags change. The
+  satellite ladder excludes all three (`dangerous`/`destructive` → EXCLUDED, never
+  runner-minted; `REMOTE_WRITE_SAFETY_LEVELS` stays `{caution}`), and the
+  service-grant guard + flight-recorder body-exclusion fold the destructive pair in
+  via the `destructive` tag — no re-declared op lists. `broadcast.events.classify_op`
+  is unaffected (all three stay `write`, the payload-sensitivity class orthogonal to
+  the safety tier). No DB migration (the tier is a registration-constant value,
+  re-registered on startup). CLI OpenAPI snapshot unchanged (no per-op safety
+  metadata in the REST surface).
+
 ### Fixed — self-approval break-glass no longer permits dangerous-tier deletes (#3290 / #3198)
 
 - The unconditional self-approval refusal (#3198 — "no self-approval, even

--- a/backend/src/meho_backplane/connectors/harbor/__init__.py
+++ b/backend/src/meho_backplane/connectors/harbor/__init__.py
@@ -50,6 +50,9 @@ ladder. Same pattern :mod:`meho_backplane.connectors.sddc_manager` and
 
 from typing import Final
 
+from meho_backplane.connectors.harbor import (
+    ops_robot_delete_preview,  # noqa: F401 -- registers the destructive-tier blast-radius preview builder at import
+)
 from meho_backplane.connectors.harbor.connector import HarborConnector
 from meho_backplane.connectors.harbor.ops import (
     register_harbor_artifact_operations,

--- a/backend/src/meho_backplane/connectors/harbor/ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops.py
@@ -25,8 +25,12 @@ Robot ops — registers two scoped-write ops against ``connector_id="harbor-rest
   appears in the SSE stream.
 
 * ``harbor.robot.delete`` — delete a project-scoped robot account by
-  numeric ID. Classified ``write`` (suffix-based). No secret material
-  in the response payload.
+  numeric ID. Classified ``write`` (suffix-based) for broadcast; no secret
+  material in the response payload. Governed destructive tier (#3288):
+  ``safety_level=destructive`` + ``requires_approval=True`` with a park-time
+  blast-radius preview (:mod:`.ops_robot_delete_preview`), because permanent
+  removal of a credential-bearing principal breaks every consumer of the old
+  secret when the robot is later re-minted.
 
 Both ops use non-retried HTTP calls (Harbor write endpoints are
 non-idempotent). ``harbor.robot.create`` calls
@@ -248,8 +252,15 @@ _HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
         "Use when decommissioning a CI credential or revoking machine access "
         "to a Harbor project. Requires the numeric 'id' returned by "
         "harbor.robot.create — Harbor's delete endpoint is keyed on the ID, "
-        "not the robot name. This operation is irreversible; the account and "
-        "its associated secret are permanently removed."
+        "not the robot name. GOVERNED DESTRUCTIVE TIER (#3288): "
+        "safety_level=destructive + requires_approval=True — the deletion parks "
+        "for mandatory human approval (no agent path, no standing grant, no "
+        "self-approval even under break-glass, a preview-hash binding, and a "
+        "blast-radius statement naming the robot + its project association). "
+        "This operation is irreversible: the account and its secret are "
+        "permanently removed, and re-creating the robot mints a BRAND-NEW "
+        "secret — every consumer still authenticating with the old credential "
+        "breaks and must be re-issued."
     ),
     "parameter_hints": {
         "project": "Harbor project name that scopes the robot account.",
@@ -336,29 +347,40 @@ async def register_harbor_robot_operations(
         impl_id="harbor-rest",
         op_id="harbor.robot.delete",
         handler=HarborConnector.robot_delete,
-        summary="Delete a project-scoped robot account from Harbor.",
+        summary="Delete a project-scoped robot account from Harbor — governed destructive tier.",
         description=(
             "Deletes a project-scoped robot account via "
             "DELETE /api/v2.0/robots/{id} (Harbor v2 robot API). "
             "Requires the numeric robot ID (returned by harbor.robot.create). "
-            "Non-idempotent write — permanent removal. safety_level=caution."
+            "Non-idempotent write — permanent removal of a credential-bearing "
+            "principal. safety_level=destructive, requires_approval=True (#3288): "
+            "the deletion parks for mandatory human approval with a preview-hash "
+            "binding and a park-time blast-radius statement (the robot identity + "
+            "its project association). Re-creating the robot mints a NEW secret, "
+            "so every consumer authenticating with the old credential breaks — the "
+            "'reversible' path is not silent."
         ),
         parameter_schema=_HARBOR_ROBOT_DELETE_PARAMETER_SCHEMA,
         response_schema=_HARBOR_ROBOT_DELETE_RESPONSE_SCHEMA,
         group_key="robot",
         when_to_use=_HARBOR_ROBOT_WHEN_TO_USE,
         tags=["write", "destructive"],
-        safety_level="caution",
-        # Left ungated (#147). ``harbor.robot.delete`` is a ``caution``-class
-        # ``write`` (suffix-classified) that revokes access — it does NOT mint
-        # or return any credential, so it is not part of the credential-mint
-        # bypass this Task closes. It mirrors the bind9 precedent (#129), which
-        # four-eyes-gated only the ``dangerous`` config-replacement ops and left
-        # ``caution`` ops default-allow for humans. Revoking a robot is
-        # recoverable (re-mint via ``harbor.robot.create``), so it does not clear
-        # the four-eyes bar. Gating it would also break the deliberate
-        # full-detail-broadcast contrast the credential_mint tests pin.
-        requires_approval=False,
+        safety_level="destructive",
+        # Governed destructive tier (#3288 operator ruling, superseding the
+        # #147 "left ungated" posture). ``harbor.robot.delete`` permanently
+        # removes a credential-bearing principal: recreation mints a NEW secret
+        # and silently breaks every consumer still using the old one (the lab
+        # signal ``bind9-harbor-dangerous-writes-bypass-approval-gate.yaml``).
+        # ``requires_approval=True`` parks the dispatch at ``awaiting_approval``
+        # for a distinct human. The promotion is single-sourced on
+        # ``safety_level`` + the ``destructive`` tag: the satellite ladder
+        # excludes it (destructive → EXCLUDED, never runner-minted), and the
+        # service-grant guard + flight-recorder body-exclusion fold it in via
+        # the tag — no re-declared op lists. ``broadcast.events.classify_op`` is
+        # unaffected: robot.delete stays ``write`` (full-detail broadcast, the
+        # deliberate contrast with credential_mint ``robot.create``), so the
+        # broadcast contrast the credential_mint tests pin still holds.
+        requires_approval=True,
         llm_instructions=_HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )

--- a/backend/src/meho_backplane/connectors/harbor/ops_robot_delete_preview.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops_robot_delete_preview.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time blast-radius preview builder for ``harbor.robot.delete`` (#3288).
+
+The Harbor arm of the governed-delete tier. ``harbor.robot.delete`` was promoted
+to ``safety_level=destructive`` + ``requires_approval=True`` by the #3288
+operator ruling: it permanently removes a **credential-bearing principal**, and
+re-creating the robot mints a BRAND-NEW secret, so every consumer still
+authenticating with the old credential breaks silently (the lab signal
+``bind9-harbor-dangerous-writes-bypass-approval-gate.yaml``). This module wires
+the mandatory blast-radius statement onto the per-op builder hook shipped by
+#1437 (:mod:`meho_backplane.operations._preview`) — the same shape the bind9
+(:mod:`~meho_backplane.connectors.bind9.ops_record_delete_preview`) and ArgoCD
+(:mod:`~meho_backplane.connectors.argocd.ops_write_preview`) previews use.
+
+The builder derives the blast radius from the **dispatch params alone** — no
+live Harbor call. ``harbor.robot.create`` only ever mints ``level=project``
+robots scoped to the named project, so the delete's ``{project, id}`` params
+fully identify what dies: a project-scoped robot and its single project
+association. A params-only preview is deliberate over a live
+``GET /robots/{id}`` enrichment — it keeps the builder robust (a destructive op
+whose preview *raises* is refused ``blast_radius_required`` and can never be
+approved, so a network-dependent read would turn a transient Harbor blip into a
+permanent inability to govern-delete) and surgical (no new dispatched HTTP path
+for the spec-reconcile lane to reconcile). The reviewer still sees the robot
+identity + its project scope + the honest irreversibility class.
+
+The returned ``{"blast_radius": {...}}`` sub-dict is promoted by the dispatcher
+to the top of ``ApprovalRequest.proposed_effect`` (#3197), so a ``destructive``
+op cannot park without the approver seeing what is destroyed:
+
+* ``object`` — the robot identity ``{kind: "harbor_robot", id, project, level:
+  "project"}``.
+* ``children`` — the enumerable reference that goes with it: the project
+  association ``{kind: "project_association", project}`` (the access footprint
+  the robot loses). One project by construction (project-scoped robots).
+* ``irreversibility`` — ``"recreatable_new_secret"``: unlike a bind9 record
+  (``"recreatable"`` from the same rdata), a Harbor robot CAN be re-created but
+  only with a fresh secret — the old credential is gone, so recovery is not
+  transparent to consumers. The class is honest so the approver weighs the real
+  cost (every consumer of the old secret breaks) against the recovery path.
+
+Declines (returns ``None`` → identifier-only default → the park is refused
+``blast_radius_required``, fail-closed) when the connector/target is unresolved
+or the required params are missing/malformed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.harbor.connector import HarborConnector
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    register_preview_builder,
+)
+
+_DELETE_OP_ID = "harbor.robot.delete"
+
+
+async def _harbor_robot_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Build the mandatory destructive-tier blast radius for ``robot.delete``.
+
+    Params-only (no live call). See the module docstring for the shape and the
+    decline contract. Never issues the DELETE — it stays parked until a human
+    approves.
+    """
+    connector = ctx.connector_instance
+    if not isinstance(connector, HarborConnector) or ctx.target is None:
+        return None
+    project = ctx.params.get("project")
+    robot_id = ctx.params.get("id")
+    if not isinstance(project, str) or not project:
+        return None
+    if not isinstance(robot_id, int) or isinstance(robot_id, bool):
+        return None
+
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "harbor_robot",
+                "id": robot_id,
+                "project": project,
+                "level": "project",
+            },
+            "children": [{"kind": "project_association", "project": project}],
+            "irreversibility": "recreatable_new_secret",
+            "match_count": 1,
+        },
+    }
+
+
+def _register_harbor_robot_delete_preview_builder() -> None:
+    """Wire the ``harbor.robot.delete`` park-time preview builder. Import-time.
+
+    Idempotent (``register_preview_builder`` overwrites), so a test reload is a
+    no-op-equivalent — same contract as the bind9 / ArgoCD wirings.
+    """
+    register_preview_builder(_DELETE_OP_ID, _harbor_robot_delete_preview)
+
+
+_register_harbor_robot_delete_preview_builder()

--- a/backend/src/meho_backplane/connectors/windows_dns/__init__.py
+++ b/backend/src/meho_backplane/connectors/windows_dns/__init__.py
@@ -43,6 +43,9 @@ triple advertises this class.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.windows_dns import (
+    ops_record_remove_preview,  # noqa: F401 -- registers the destructive-tier blast-radius preview builder at import
+)
 from meho_backplane.connectors.windows_dns.connector import WindowsDnsConnector
 from meho_backplane.connectors.windows_dns.ops import WINDOWS_DNS_OPS, WindowsDnsOp
 from meho_backplane.operations.typed_register import register_typed_op_registrar

--- a/backend/src/meho_backplane/connectors/windows_dns/ops_record.py
+++ b/backend/src/meho_backplane/connectors/windows_dns/ops_record.py
@@ -14,12 +14,20 @@ BIND9 ``dig`` / zonefile-transform machinery for the Windows
   ``Add-DnsServerResourceRecordCName`` (CNAME), selected by ``type``
   (caution).
 * ``windns.record.remove`` -- ``Remove-DnsServerResourceRecord ... -Force``
-  (caution).
+  (governed destructive tier, #3288).
 
-Safety levels mirror bind9 exactly: ``record.get`` is ``safe``;
-``record.add`` / ``record.remove`` are ``caution`` (a DNS change is
-global -- no per-caller scoping -- so it carries the same production-path
-policy weight bind9's record writes do).
+Safety levels mirror bind9's record surface: ``record.get`` is ``safe``;
+``record.add`` is ``caution`` (a DNS change is global -- no per-caller
+scoping -- so it carries the same production-path policy weight bind9's
+record writes do). ``record.remove`` was promoted to
+``safety_level=destructive`` + ``requires_approval=True`` by the #3288
+operator ruling (mirroring #3247 for ``bind9.record.remove``): the ``-Force``
+clear removes every value of an RRType at a name in one write, so it rides
+the governed-delete gate (human approval + preview-hash binding + a park-time
+blast-radius statement built by
+:func:`.ops_record_remove_preview._windns_record_remove_preview`). The remove
+handler itself is unchanged -- the tier change is metadata; it now runs only
+post-approval.
 
 PowerShell injection safety
 ---------------------------
@@ -244,6 +252,14 @@ async def windows_dns_record_remove(
     ``-Force`` suppresses the interactive confirmation prompt (mandatory
     for the non-interactive transport). Returns
     ``{zone, name, type, op_class}`` with ``op_class="write"``.
+
+    Governed destructive tier (#3288): the op is ``safety_level=destructive``
+    + ``requires_approval=True``, so a dispatch parks for a human decision (with
+    a preview-hash binding + a whole-RRset blast-radius statement, built by
+    :func:`.ops_record_remove_preview._windns_record_remove_preview`) before the
+    ``-Force`` clear runs. The handler body is unchanged -- the tier is
+    enforced upstream in the dispatcher; it executes only on the audited resume
+    after approval.
     """
     zone: str = params["zone"]
     name: str = params["name"]
@@ -436,6 +452,20 @@ WINDOWS_DNS_RECORD_ADD_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
+_REMOVE_WARNING = (
+    "GOVERNED RRSET CLEAR (destructive tier, #3288). This op clears EVERY "
+    "record of the given RRType at the name in one ``-Force`` write, so it "
+    "rides the same hardest gate as ``bind9.record.remove``: "
+    "``safety_level=destructive`` + ``requires_approval=True`` -- mandatory "
+    "human approval always (no agent path, no standing grant, no self-approval "
+    "even under break-glass), a mandatory preview-hash binding, and a mandatory "
+    "blast-radius statement (the zone/name/type plus EVERY value that dies) the "
+    "four-eyes approver reads before deciding. The change is global: DNS has no "
+    "per-caller scoping, so on the audited post-approval resume the records are "
+    "gone for every consumer of this server."
+)
+
+
 WINDOWS_DNS_RECORD_REMOVE_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -467,15 +497,20 @@ _WINDOWS_DNS_RECORD_REMOVE_RESPONSE_SCHEMA: dict[str, Any] = {
 
 WINDOWS_DNS_RECORD_REMOVE_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
-        "Remove the record(s) matching (zone, name, RRType) from the "
-        "Windows DNS server via ``Remove-DnsServerResourceRecord ... "
-        "-Force``. " + _ADD_WARNING + " Use ``windns.record.get`` first "
-        "to confirm the current state."
+        "Clear every record of an RRType at a name -- e.g. an environment "
+        "teardown that retires a host's forward resolution -- from the Windows "
+        "DNS server via ``Remove-DnsServerResourceRecord ... -Force`` under "
+        "governance. " + _REMOVE_WARNING + " Use ``windns.record.get`` first "
+        "to confirm the current state; removing a record the server doesn't "
+        "serve is a no-op."
     ),
     "parameter_hints": {
         "zone": "Required. The DNS zone name.",
         "name": "Required. Owner name relative to the zone.",
-        "type": "Required. The RRType to remove (A / AAAA / CNAME / ...).",
+        "type": (
+            "Required. The RRType to clear (A / AAAA / CNAME / ...); ALL "
+            "values of that type at the name are removed."
+        ),
     },
     "output_shape": "{'zone', 'name', 'type', 'op_class': 'write'}.",
 }
@@ -529,17 +564,18 @@ RECORD_OPS: tuple[WindowsDnsOp, ...] = (
     WindowsDnsOp(
         op_id="windns.record.remove",
         handler_attr="windows_dns_record_remove",
-        summary="Remove matching records via ``Remove-DnsServerResourceRecord ... -Force``.",
+        summary="Clear every value of an RRType at a name -- governed destructive tier.",
         description=(
-            "Removes the record(s) matching (zone, name, RRType) via "
-            "``Remove-DnsServerResourceRecord ... -Force``. " + _ADD_WARNING
+            "Removes every record matching (zone, name, RRType) via "
+            "``Remove-DnsServerResourceRecord ... -Force`` -- an RRset clear, "
+            "not a single-value delete. " + _REMOVE_WARNING
         ),
         parameter_schema=WINDOWS_DNS_RECORD_REMOVE_PARAMETER_SCHEMA,
         response_schema=_WINDOWS_DNS_RECORD_REMOVE_RESPONSE_SCHEMA,
         group_key="record",
-        tags=("write", "record"),
-        safety_level="caution",
-        requires_approval=False,
+        tags=("write", "record", "delete", "destructive"),
+        safety_level="destructive",
+        requires_approval=True,
         llm_instructions=WINDOWS_DNS_RECORD_REMOVE_LLM_INSTRUCTIONS,
     ),
 )

--- a/backend/src/meho_backplane/connectors/windows_dns/ops_record_remove_preview.py
+++ b/backend/src/meho_backplane/connectors/windows_dns/ops_record_remove_preview.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time blast-radius preview builder for ``windns.record.remove`` (#3288).
+
+The windows_dns arm of the governed-delete tier. ``windns.record.remove`` was
+promoted to ``safety_level=destructive`` + ``requires_approval=True`` by the
+#3288 operator ruling, mirroring how #3247 governed ``bind9.record.remove``.
+This module wires the mandatory blast-radius statement onto the per-op builder
+hook shipped by #1437 (:mod:`meho_backplane.operations._preview`) — the same
+shape the bind9 (:mod:`~meho_backplane.connectors.bind9.ops_record_delete_preview`)
+and ArgoCD (:mod:`~meho_backplane.connectors.argocd.ops_write_preview`) previews
+use.
+
+The builder is **read-only**: it runs ``Get-DnsServerResourceRecord`` scoped to
+the same ``(zone, name, RRType)`` the remove handler will clear, projects each
+matching record to a compact ``{type, rdata}`` pair, and never mutates. It
+returns a ``{"blast_radius": {...}}`` sub-dict the dispatcher promotes to the
+top of ``ApprovalRequest.proposed_effect`` (#3197), so a ``destructive`` op
+cannot park without the approver seeing *exactly which records die*:
+
+* ``object`` — the record-set identity ``{kind: "dns_record", zone, name,
+  type}``. ``windns.record.remove`` is scoped to one RRType (unlike bind9's
+  whole-name clear across A + AAAA), so the object names a single type.
+* ``children`` — every current value at that ``(zone, name, type)`` that the
+  ``-Force`` clear removes, each ``{kind: "record_value", type, rdata}`` (empty
+  is a valid "no such record currently" statement — the ``-Force`` clear then
+  no-ops post-approval; more than one is the multi-value RRset the whole-name
+  clear removes together).
+* ``irreversibility`` — ``"recreatable"``: a removed DNS record can be re-added
+  from the captured ``rdata`` (via ``windns.record.add`` for A / CNAME, or the
+  vendor tooling for other types), unlike a destroyed VM disk. The class is
+  honest so the approver weighs the real cost (live resolution breaks
+  immediately for every consumer) against the recovery path.
+
+Declines (returns ``None`` → identifier-only default → the park is refused
+``blast_radius_required``, fail-closed) when the connector/target is unresolved,
+when ``type`` is out of the removable set, or when the read fails (a
+:class:`~meho_backplane.connectors._shared.pwsh.PwshRunError` — the "cannot see
+current state → refuse at park time" contract, matching bind9's decline on a
+zonefile read failure).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.pwsh import PwshRunError, ps_single_quote, pwsh_run
+from meho_backplane.connectors.windows_dns.connector import WindowsDnsConnector
+from meho_backplane.connectors.windows_dns.ops_record import _REMOVE_SUPPORTED_TYPES
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    register_preview_builder,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+
+_REMOVE_OP_ID = "windns.record.remove"
+
+#: Read-only projection body: ``ForEach-Object`` over the read records,
+#: projecting each record's type-specific ``RecordData`` to a flat ``rdata``
+#: string, then a ``@{ rows = ...; total = ... }`` envelope that keeps stdout
+#: non-empty and JSON-shaped even for a zero-match read (the same
+#: empty-stdout-guard discipline the ``record.get`` handler uses). Kept as a
+#: brace-heavy raw literal (PowerShell hashtables + subexpressions), so the Get
+#: line below is concatenated in — never ``str.format``, which would trip on the
+#: literal ``{`` / ``}``.
+_PROJECTION_BODY = (
+    "$rows = @($recs | ForEach-Object { "
+    "$rd = $_.RecordData; "
+    "switch ($_.RecordType.ToString()) { "
+    "'A' { $val = $rd.IPv4Address.IPAddressToString } "
+    "'AAAA' { $val = $rd.IPv6Address.IPAddressToString } "
+    "'CNAME' { $val = $rd.HostNameAlias } "
+    "'PTR' { $val = $rd.PtrDomainName } "
+    "'NS' { $val = $rd.NameServer } "
+    "'MX' { $val = \"$($rd.Preference) $($rd.MailExchange)\" } "
+    "'TXT' { $val = ($rd.DescriptiveText -join ' ') } "
+    "'SRV' { $val = \"$($rd.Priority) $($rd.Weight) $($rd.Port) $($rd.DomainName)\" } "
+    "default { $val = ($rd | Out-String).Trim() } "
+    "} "
+    '@{ type = $_.RecordType.ToString(); rdata = "$val" } '
+    "}); "
+    "ConvertTo-Json -Depth 4 -InputObject @{ rows = $rows; total = $rows.Count }"
+)
+
+
+def _build_read_script(*, zone: str, name: str, record_type: str) -> str:
+    """Compose the read-only ``Get-DnsServerResourceRecord`` projection script.
+
+    A ``SilentlyContinue`` preference so a missing zone / no-match read yields an
+    empty array rather than a terminating error. Operator-supplied scalars are
+    single-quoted PowerShell literals (:func:`ps_single_quote`).
+    """
+    get_expr = (
+        "$ErrorActionPreference = 'SilentlyContinue'; "
+        f"$recs = @(Get-DnsServerResourceRecord -ZoneName {ps_single_quote(zone)} "
+        f"-Name {ps_single_quote(name)} -RRType {ps_single_quote(record_type)}); "
+    )
+    return get_expr + _PROJECTION_BODY
+
+
+def _child_values(payload: Any, *, record_type: str) -> list[dict[str, Any]]:
+    """Normalise the projection payload into the ``children`` list.
+
+    ``ConvertTo-Json`` renders a single-element array as a bare object and a
+    zero-element array as ``null`` inside the envelope, so the rows field is
+    normalised to a list before projection. Each row's ``rdata`` is coerced to
+    ``str`` and its ``type`` defaulted to the requested ``record_type`` (the
+    read is already RRType-scoped, so every row is that type).
+    """
+    rows = payload.get("rows") if isinstance(payload, dict) else payload
+    if rows is None:
+        rows = []
+    elif isinstance(rows, dict) or not isinstance(rows, list):
+        rows = [rows]
+    children: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        rdata = row.get("rdata")
+        children.append(
+            {
+                "kind": "record_value",
+                "type": str(row.get("type") or record_type),
+                "rdata": "" if rdata is None else str(rdata),
+            }
+        )
+    return children
+
+
+async def _windns_record_remove_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Build the mandatory destructive-tier blast radius for ``record.remove``.
+
+    Read-only. See the module docstring for the shape and the decline contract.
+    Never issues a write — the ``-Force`` clear stays parked until a human
+    approves.
+    """
+    connector = ctx.connector_instance
+    if not isinstance(connector, WindowsDnsConnector) or ctx.target is None:
+        return None
+    zone = ctx.params.get("zone")
+    name = ctx.params.get("name")
+    record_type = ctx.params.get("type")
+    if not (isinstance(zone, str) and isinstance(name, str) and isinstance(record_type, str)):
+        return None
+    record_type = record_type.upper()
+    if record_type not in _REMOVE_SUPPORTED_TYPES:
+        # An out-of-set type declines the preview rather than build a blast
+        # radius the handler would reject at execution time anyway.
+        return None
+
+    script = _build_read_script(zone=zone, name=name, record_type=record_type)
+    operator: Operator | None = ctx.operator
+    try:
+        payload = await pwsh_run(connector, ctx.target, script, operator=operator)
+    except PwshRunError:
+        # Cannot read the current record set → decline → the park is refused
+        # blast_radius_required (fail-closed). Mirrors bind9's decline on a
+        # zonefile read failure.
+        return None
+
+    children = _child_values(payload, record_type=record_type)
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "dns_record",
+                "zone": zone,
+                "name": name,
+                "type": record_type,
+            },
+            "children": children,
+            "irreversibility": "recreatable",
+            "match_count": len(children),
+        },
+    }
+
+
+def _register_windns_remove_preview_builder() -> None:
+    """Wire the ``windns.record.remove`` park-time preview builder. Import-time.
+
+    Idempotent (``register_preview_builder`` overwrites), so a test reload is a
+    no-op-equivalent — same contract as the bind9 / ArgoCD wirings.
+    """
+    register_preview_builder(_REMOVE_OP_ID, _windns_record_remove_preview)
+
+
+_register_windns_remove_preview_builder()

--- a/backend/src/meho_backplane/connectors/winsrv/ops_features.py
+++ b/backend/src/meho_backplane/connectors/winsrv/ops_features.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""winsrv feature ops — ``list`` (safe) + ``install`` / ``remove`` (caution).
+"""winsrv feature ops — ``list`` (safe) + ``install`` (caution) + ``remove`` (dangerous).
 
 The Windows Server role/feature surface is driven by the ``ServerManager``
 module (``Get-WindowsFeature`` / ``Install-WindowsFeature`` /
@@ -10,9 +10,16 @@ This is the c1sql1 ``Install-WindowsFeature`` path
 (evoila-bosnia/claude-rdc-hetzner-dc#2789) — the Failover-Clustering role
 install that today rides ungoverned ``govc guest.run``.
 
-``install`` / ``remove`` are ``caution`` (recoverable — a removed feature can
-be reinstalled). They deliberately **never** pass ``-Restart``: a reboot is a
-``dangerous`` + ``requires_approval`` action, so the handlers return
+``install`` is ``caution`` (additive, recoverable). ``remove`` was promoted to
+``safety_level=dangerous`` + ``requires_approval=True`` by the #3288 operator
+ruling: uninstalling a role is disruptive enough to demand a human decision, so
+it parks for approval (the ``winsrv.localuser.delete`` mould). It is
+**deliberately not** ``destructive`` — removal is reversible by reinstall and
+preserves data, and the destructive tier is reserved for unrecoverable deletes.
+So no blast-radius preview is required at the ``dangerous`` tier (unlike the
+destructive ops governed under #3288); the dispatcher simply parks the dispatch
+at ``awaiting_approval``. Both handlers deliberately **never** pass ``-Restart``:
+a reboot is itself a ``dangerous`` + ``requires_approval`` action, so they return
 ``restart_needed`` and leave the reboot to the approval-gated
 ``winsrv.power.reboot`` op. Batch feature changes, then take one governed
 reboot.
@@ -128,11 +135,18 @@ async def winsrv_feature_remove(
     params: dict[str, Any],
     operator: Operator | None = None,
 ) -> dict[str, Any]:
-    """Handler for ``winsrv.feature.remove`` (caution) — ``Uninstall-WindowsFeature``.
+    """Handler for ``winsrv.feature.remove`` (dangerous, approval-gated).
 
+    ``Uninstall-WindowsFeature``.
     Removes the named feature under ``$ErrorActionPreference = 'Stop'``.
     Never passes ``-Restart`` — returns ``restart_needed`` and leaves the
     reboot to the approval-gated ``winsrv.power.reboot``.
+
+    Governed dangerous tier (#3288): the op is ``safety_level=dangerous`` +
+    ``requires_approval=True``, so a dispatch parks for a human decision before
+    the uninstall runs. Not ``destructive`` (reversible by reinstall,
+    data-preserving), so no blast-radius preview is required — the handler body
+    is unchanged; the tier is enforced upstream in the dispatcher.
     """
     name: str = params["name"]
     mgmt_tools = _ps_bool(params.get("include_management_tools"))
@@ -290,12 +304,16 @@ FEATURE_OPS: tuple[WinsrvOp, ...] = (
     WinsrvOp(
         op_id="winsrv.feature.remove",
         handler_attr="winsrv_feature_remove",
-        summary="Remove a Windows role/feature via ``Uninstall-WindowsFeature`` (caution).",
+        summary="Remove a Windows role/feature via ``Uninstall-WindowsFeature`` (dangerous).",
         description=(
             "Runs ``Uninstall-WindowsFeature -Name <name>`` (optionally with "
             "``-IncludeManagementTools`` to also remove the tools). Never "
-            "auto-restarts — returns ``restart_needed``. safety_level=caution "
-            "(recoverable — the feature can be reinstalled)."
+            "auto-restarts — returns ``restart_needed``. safety_level=dangerous, "
+            "requires_approval=True (#3288): uninstalling a role is disruptive, "
+            "so a dispatch parks for a human decision first. NOT destructive — "
+            "reversible by reinstall and data-preserving, so no blast-radius "
+            "preview is required (the ``winsrv.localuser.delete`` dangerous-tier "
+            "mould)."
         ),
         parameter_schema={
             "type": "object",
@@ -315,13 +333,15 @@ FEATURE_OPS: tuple[WinsrvOp, ...] = (
         response_schema=_FEATURE_WRITE_RESPONSE_SCHEMA,
         group_key="features",
         tags=("write", "feature", "remove"),
-        safety_level="caution",
-        requires_approval=False,
+        safety_level="dangerous",
+        requires_approval=True,
         llm_instructions={
             "when_to_use": (
-                "Remove a Windows role/feature. Recoverable; "
-                "safety_level=caution. Does NOT restart — check "
-                "``restart_needed``. " + SSH_TRANSPORT_NOTE
+                "Remove a Windows role/feature. Disruptive but reversible by "
+                "reinstall; safety_level=dangerous, requires_approval=True "
+                "(#3288) — a dispatch parks for a human decision before the "
+                "uninstall runs. Does NOT restart — check ``restart_needed`` "
+                "and use ``winsrv.power.reboot`` (approval-gated) if set. " + SSH_TRANSPORT_NOTE
             ),
             "parameter_hints": {
                 "name": "Required. The feature short name.",

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -105,6 +105,7 @@ from meho_backplane.db.models import AuditLog
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations._request_preview import compute_preview_hash, preview_dispatch
 from meho_backplane.operations.approval_queue import approve_request
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.reducer import PassThroughReducer
@@ -535,6 +536,68 @@ async def _create_robot_via_approve_resume(
     )
 
 
+async def _delete_robot_via_approve_resume(
+    *,
+    target: _HarborTarget,
+    requester_sub: str,
+    approver_sub: str,
+    project: str,
+    robot_id: int,
+) -> OperationResult:
+    """Drive ``harbor.robot.delete`` through the real governed destructive flow.
+
+    Since #3288 ``harbor.robot.delete`` is ``safety_level=destructive`` +
+    ``requires_approval=True``, so a bare dispatch is refused
+    ``preview_binding_required``. This helper reproduces the governed-delete
+    flow: resolve the park-time preview binding (``preview_dispatch`` →
+    ``compute_preview_hash``), present the bound hash on the parking dispatch,
+    commit the real approval as a **distinct** approver (four-eyes), then resume
+    with ``_approved=True`` against the **live** ``target`` fixture (same
+    live-binding reasoning as :func:`_create_robot_via_approve_resume` — a
+    DB-rehydrated resume would resolve ``no_connector``). Returns the resumed
+    :class:`OperationResult` (``status`` ``"ok"``, ``result["deleted"] is True``).
+    """
+    requester = _make_operator(sub=requester_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
+    params = {"project": project, "id": robot_id}
+
+    # Bind the destructive-tier preview hash (typed op → composite preview).
+    authoritative = await preview_dispatch(
+        operator=requester,
+        connector_id=HARBOR_CONNECTOR_ID,
+        op_id="harbor.robot.delete",
+        target=target,
+        params=params,
+    )
+    assert authoritative["status"] == "ok", authoritative
+    preview_hash = compute_preview_hash(authoritative)
+
+    parked = await dispatch(
+        operator=requester,
+        connector_id=HARBOR_CONNECTOR_ID,
+        op_id="harbor.robot.delete",
+        target=target,
+        params=params,
+        preview_hash=preview_hash,
+    )
+    assert parked.status == "awaiting_approval", parked.error
+    request_id = uuid.UUID(parked.extras["approval_request_id"])
+
+    approver = _make_operator(sub=approver_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await approve_request(session, request_id, operator=approver)
+        await session.commit()
+
+    return await dispatch(
+        operator=requester,
+        connector_id=HARBOR_CONNECTOR_ID,
+        op_id="harbor.robot.delete",
+        target=target,
+        params=params,
+        _approved=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Audit assertion helper
 # ---------------------------------------------------------------------------
@@ -719,7 +782,14 @@ async def test_robot_delete_classified_write(
     harbor_e2e: tuple[_HarborTarget, str],
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """``harbor.robot.delete`` removes the robot; broadcast is classified write."""
+    """``harbor.robot.delete`` removes the robot; broadcast is classified write.
+
+    Since #3288 the op is ``safety_level=destructive`` + ``requires_approval``,
+    so the delete runs through the governed flow (preview-hash-bound park →
+    distinct-human approval → audited resume); a bare dispatch is refused
+    ``preview_binding_required``. The executed (post-approval) op still
+    classifies ``write`` — the tier change is orthogonal to ``classify_op``.
+    """
     target, _ = harbor_e2e
 
     # Create a robot to delete. ``harbor.robot.create`` parks (#147), so the
@@ -736,17 +806,14 @@ async def test_robot_delete_classified_write(
     assert create_result.status == "ok", create_result.error
     robot_id = create_result.result["id"]
 
-    # Now delete it.
-    operator = _make_operator(sub="e2e-robot-delete")
-    result = await dispatch(
-        operator=operator,
-        connector_id=HARBOR_CONNECTOR_ID,
-        op_id="harbor.robot.delete",
+    # Now delete it — governed destructive flow (preview-bound park → approve →
+    # audited resume against the live container).
+    result = await _delete_robot_via_approve_resume(
         target=target,
-        params={
-            "project": _TEST_PROJECT_NAME,
-            "id": robot_id,
-        },
+        requester_sub="e2e-robot-delete",
+        approver_sub="e2e-robot-delete-approver",
+        project=_TEST_PROJECT_NAME,
+        robot_id=robot_id,
     )
     assert result.status == "ok", result.error
     assert result.result.get("deleted") is True, (

--- a/backend/tests/test_broadcast_credential_mint_dispatch.py
+++ b/backend/tests/test_broadcast_credential_mint_dispatch.py
@@ -94,6 +94,7 @@ from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.main import app
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -347,6 +348,36 @@ async def _park_robot_create(
     return UUID(parked.extras["approval_request_id"])
 
 
+async def _park_robot_delete(
+    stub_embedding_service: AsyncMock,
+    *,
+    requester: Operator,
+) -> UUID:
+    """Register the ops, drive the governed destructive flow for ``robot.delete``.
+
+    ``harbor.robot.delete`` is ``safety_level=destructive`` +
+    ``requires_approval=True`` (#3288), so a bare dispatch is refused
+    ``preview_binding_required`` — the caller must present a ``preview_hash``
+    from a prior ``preview_operation`` and the park needs a blast-radius block.
+    This drives the meta-tool path (target resolved by name against the
+    persisted row, so the parked ``ApprovalRequest`` re-hydrates on resume):
+    ``preview_operation`` → bound hash → ``call_operation`` parks. Returns the
+    pending ``approval_request_id``.
+    """
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+    args = {
+        "connector_id": "harbor-rest-2.x",
+        "op_id": "harbor.robot.delete",
+        "target": _TARGET_NAME,
+        "params": {"project": "proj", "id": 7},
+    }
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    parked = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert parked["status"] == "awaiting_approval", parked
+    return UUID(parked["extras"]["approval_request_id"])
+
+
 def _approve_via_decide(
     request_id: UUID,
     mock: respx.MockRouter,
@@ -362,6 +393,11 @@ def _approve_via_decide(
     re-dispatches with ``_approved=True``; returns the decision-response
     body so callers assert ``dispatch_status``.
     """
+    # Re-callable within one test: a fresh keypair is minted each call (same
+    # kid), so clear the in-process JWKS cache first — otherwise a second
+    # /decide verifies its token against the first call's cached key and fails
+    # jws_signature_mismatch.
+    clear_jwks_cache()
     key = make_rsa_keypair("kid-decider")
     mock_discovery_and_jwks(mock, public_jwks(key))
     token = mint_token(
@@ -472,7 +508,7 @@ async def test_robot_create_broadcast_is_aggregate_only(
 
 
 # ---------------------------------------------------------------------------
-# (AC2) harbor.robot.delete stays full-detail (write) — no gate, executes direct
+# (AC2) harbor.robot.delete stays full-detail (write) — governed, executes on resume
 # ---------------------------------------------------------------------------
 
 
@@ -485,28 +521,30 @@ async def test_robot_delete_broadcast_is_full_detail(
     """``harbor.robot.delete`` broadcasts full detail (``write`` class).
 
     Contrast test: ``harbor.robot.delete`` classifies ``write``, not
-    ``credential_mint``, and is left ungated (#147 — a ``caution`` write
-    that revokes, not mints), so a human dispatches it directly (no
-    approval park). Its broadcast carries the full ``params`` block. The
-    divergent behaviour is solely due to :func:`classify_op`.
-    """
-    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+    ``credential_mint``, so its broadcast carries the full ``params`` block.
+    The divergent *redaction* is solely due to :func:`classify_op`.
 
-    operator = _make_operator()
+    Since #3288 the op is ``safety_level=destructive`` + ``requires_approval``,
+    so the write no longer executes on a lone dispatch — it runs on the
+    approve→resume path (preview-bound park → second-operator approval →
+    audited resume). The broadcast redaction is asserted against the
+    **executed** (post-approval) op, exactly as the credential_mint side is.
+    """
+    requester = _make_operator(sub="op-requester")
 
     with respx.mock() as mock:
         mock.delete(_ROBOT_7_URL).mock(return_value=respx.MockResponse(200))
-        result = await dispatch(
-            operator=operator,
-            connector_id="harbor-rest-2.x",
-            op_id="harbor.robot.delete",
-            target=_HarborDispatchTarget(),
-            params={"project": "proj", "id": 7},
-        )
+        request_id = await _park_robot_delete(stub_embedding_service, requester=requester)
+        # Parking must not have broadcast a write event (nothing executed yet).
+        assert not any(e.op_id == "harbor.robot.delete" for e in captured_events)
 
-    assert result.status == "ok", result.error
+        body = _approve_via_decide(request_id, mock, approver_sub="op-approver")
 
-    delete_events = [e for e in captured_events if e.op_id == "harbor.robot.delete"]
+    assert body["dispatch_status"] == "ok", body
+
+    delete_events = [
+        e for e in captured_events if e.op_id == "harbor.robot.delete" and e.result_status == "ok"
+    ]
     assert len(delete_events) == 1
     event = delete_events[0]
     assert event.op_class == "write"
@@ -521,43 +559,39 @@ async def test_credential_mint_and_write_diverge_on_same_dispatch_path(
     captured_events: list[BroadcastEvent],
     _persisted_harbor_target: UUID,
 ) -> None:
-    """Create is aggregate-only (post-approval); delete is full-detail (direct).
+    """Create is aggregate-only; delete is full-detail — both post-approval.
 
-    Both ops flow through the identical dispatch + broadcast infrastructure
-    against the same target. The only variables are the op-id and the
-    #147 gate: create parks then executes via approve→resume; delete
-    executes directly. Divergent redaction proves :func:`classify_op`
-    drives the behaviour, not the handler or target.
+    Both ops flow through the identical dispatch + broadcast + approve→resume
+    infrastructure against the same target. The only variable is the op-id:
+    create classifies ``credential_mint`` (aggregate-only broadcast), delete
+    classifies ``write`` (full-detail). Since #3288 both are approval-gated
+    (create ``credential_mint``/#147, delete ``destructive``/#3288), so the
+    divergent redaction on the executed ops proves :func:`classify_op` drives
+    the behaviour, not the handler, target, or gate.
     """
     requester = _make_operator(sub="op-requester")
-    # Register both ops up front (idempotent — _park_robot_create re-calls it)
-    # so the direct delete dispatch resolves its descriptor.
     await register_harbor_robot_operations(embedding_service=stub_embedding_service)
 
     with respx.mock() as mock:
         _mock_robot_create(mock)
         mock.delete(_ROBOT_7_URL).mock(return_value=respx.MockResponse(200))
 
-        # Ungated write executes directly.
-        delete_result = await dispatch(
-            operator=requester,
-            connector_id="harbor-rest-2.x",
-            op_id="harbor.robot.delete",
-            target=_HarborDispatchTarget(),
-            params={"project": "proj", "id": 7},
-        )
-        assert delete_result.status == "ok", delete_result.error
+        # Governed destructive write: preview-bound park, then execute on approval.
+        delete_request_id = await _park_robot_delete(stub_embedding_service, requester=requester)
+        delete_body = _approve_via_decide(delete_request_id, mock, approver_sub="op-approver")
+        assert delete_body["dispatch_status"] == "ok", delete_body
 
         # Gated credential-mint parks, then executes on second-operator approval.
-        request_id = await _park_robot_create(stub_embedding_service, requester=requester)
-        body = _approve_via_decide(request_id, mock, approver_sub="op-approver")
-
-    assert body["dispatch_status"] == "ok", body
+        create_request_id = await _park_robot_create(stub_embedding_service, requester=requester)
+        create_body = _approve_via_decide(create_request_id, mock, approver_sub="op-approver")
+        assert create_body["dispatch_status"] == "ok", create_body
 
     create_event = next(
         e for e in captured_events if e.op_id == "harbor.robot.create" and e.result_status == "ok"
     )
-    delete_event = next(e for e in captured_events if e.op_id == "harbor.robot.delete")
+    delete_event = next(
+        e for e in captured_events if e.op_id == "harbor.robot.delete" and e.result_status == "ok"
+    )
 
     # Same path, opposite redaction — classifier-driven by construction.
     assert create_event.op_class == "credential_mint"

--- a/backend/tests/test_connectors_harbor_robot_delete.py
+++ b/backend/tests/test_connectors_harbor_robot_delete.py
@@ -1,0 +1,501 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed-tier conformance for ``harbor.robot.delete`` (#3288 operator ruling).
+
+``harbor.robot.delete`` permanently removes a **credential-bearing principal**:
+re-creating the robot mints a BRAND-NEW secret, so every consumer still using
+the old credential breaks silently (the lab signal
+``bind9-harbor-dangerous-writes-bypass-approval-gate.yaml``). It shipped
+caution-tier + approval-free; the #3288 operator ruling promotes it to the
+governed-delete tier: ``safety_level="destructive"`` + ``requires_approval=True``
+with a park-time blast-radius statement naming the robot identity + its project
+association.
+
+These tests prove the promotion holds on every surface, folded via the SINGLE
+SOURCE (``safety_level="destructive"`` + the ``destructive`` tag), never a local
+pattern list:
+
+* **The park-time blast radius names the robot + its project association**, with
+  an honest ``irreversibility="recreatable_new_secret"`` class.
+* **The full governed flow**: preview → parked approval carrying the hash +
+  blast radius → a *distinct human* approves → audited resume runs the DELETE.
+* **The tier holds**: agent ``DENY``, no ``ServicePrincipalGrant``, no
+  self-approval under break-glass, no satellite mint, dispatch refused without a
+  matching preview hash.
+
+The Harbor HTTP transport is mocked by ``_RecordingHarborConnector`` (overriding
+the ``_http_client`` / ``auth_headers`` seams the ``robot_delete`` handler
+reaches). All fixtures are synthetic — no lab names/IDs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+
+import meho_backplane.connectors.harbor  # noqa: F401 -- registers the connector at import
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.harbor import HarborConnector
+from meho_backplane.connectors.harbor.ops import register_harbor_robot_operations
+from meho_backplane.connectors.harbor.ops_robot_delete_preview import (
+    _harbor_robot_delete_preview,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations._preview import PreviewContext
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "harbor-rest-2.x"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003288")
+_OP_ID = "harbor.robot.delete"
+_PROJECT = "team-ci"
+_ROBOT_ID = 7
+_TARGET_NAME = "test-harbor"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def _stub_embedding() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+class _FakeResp:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self, recorder: _RecordingHarborConnector) -> None:
+        self._recorder = recorder
+
+    async def request(self, method: str, path: str, headers: Any = None) -> _FakeResp:
+        self._recorder.delete_calls.append((method, path))
+        return _FakeResp()
+
+
+class _RecordingHarborConnector(HarborConnector):
+    """A HarborConnector whose HTTP transport is canned + recorded.
+
+    Overrides the IO seams the ``robot_delete`` handler reaches — ``_http_client``
+    (the pooled DELETE client) and ``auth_headers`` (credential read) — so the
+    resume path runs offline. A subclass (not a duck type) so the resolver's
+    bound-method rebind + the ``_CONNECTOR_INSTANCE_CACHE`` seeding behave exactly
+    as in production; the base ``robot_delete`` runs unchanged against the fakes.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.delete_calls: list[tuple[str, str]] = []
+
+    async def _http_client(self, target: Any) -> _FakeClient:  # type: ignore[override]
+        return _FakeClient(self)
+
+    async def auth_headers(self, target: Any, operator: Operator) -> dict[str, str]:  # type: ignore[override]
+        return {}
+
+
+def _make_operator(
+    *, sub: str = "op-1", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="harbor delete conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "2.x") -> None:
+        self.version = version
+
+
+class _FakeHarborTarget:
+    """Duck-typed target for direct ``dispatch(...)`` (no DB name-resolve)."""
+
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "harbor"
+        self.fingerprint = _FakeFingerprint()
+        self.preferred_impl_id: str | None = "harbor-rest"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = _TARGET_NAME
+        self.host = "harbor.example.test"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+        self.secret_ref = "meho/testing/harbor/test-harbor"
+
+
+def _seed_instance(recorder: _RecordingHarborConnector) -> None:
+    _CONNECTOR_INSTANCE_CACHE[HarborConnector] = recorder  # type: ignore[assignment]
+
+
+async def _register_ops(stub_embedding: AsyncMock) -> None:
+    await register_harbor_robot_operations(embedding_service=stub_embedding)
+
+
+async def _bootstrap(recorder: _RecordingHarborConnector, stub_embedding: AsyncMock) -> None:
+    await _register_ops(stub_embedding)
+    _seed_instance(recorder)
+
+
+async def _seed_target() -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="harbor",
+                host="harbor.example.test",
+                port=443,
+                fqdn=None,
+                secret_ref="meho/testing/harbor/test-harbor",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "2.x"},
+                preferred_impl_id="harbor-rest",
+                notes="seeded by test_connectors_harbor_robot_delete",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+def _args(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": _TARGET_NAME,
+        "params": {"project": _PROJECT, "id": _ROBOT_ID},
+    }
+    base.update(overrides)
+    return base
+
+
+def _preview_ctx(recorder: _RecordingHarborConnector, *, params: dict[str, Any]) -> PreviewContext:
+    return PreviewContext(
+        descriptor=MagicMock(op_id=_OP_ID),
+        connector_instance=recorder,
+        operator=_make_operator(),
+        target=_FakeHarborTarget(),
+        params=params,
+        connector_id=_CONNECTOR_ID,
+    )
+
+
+# ===========================================================================
+# Preview builder — the robot + project-association blast radius
+# ===========================================================================
+
+
+async def test_preview_names_robot_and_project_association() -> None:
+    recorder = _RecordingHarborConnector()
+    preview = await _harbor_robot_delete_preview(
+        _preview_ctx(recorder, params={"project": _PROJECT, "id": _ROBOT_ID})
+    )
+    assert preview is not None
+    blast = preview["blast_radius"]
+    assert blast["object"] == {
+        "kind": "harbor_robot",
+        "id": _ROBOT_ID,
+        "project": _PROJECT,
+        "level": "project",
+    }
+    assert blast["children"] == [{"kind": "project_association", "project": _PROJECT}]
+    assert blast["irreversibility"] == "recreatable_new_secret"
+    assert blast["match_count"] == 1
+
+
+async def test_preview_declines_on_missing_project() -> None:
+    recorder = _RecordingHarborConnector()
+    assert (
+        await _harbor_robot_delete_preview(_preview_ctx(recorder, params={"id": _ROBOT_ID})) is None
+    )
+
+
+async def test_preview_declines_on_non_int_id() -> None:
+    recorder = _RecordingHarborConnector()
+    assert (
+        await _harbor_robot_delete_preview(
+            _preview_ctx(recorder, params={"project": _PROJECT, "id": "7"})
+        )
+        is None
+    )
+
+
+async def test_preview_declines_without_connector_instance() -> None:
+    ctx = PreviewContext(
+        descriptor=MagicMock(op_id=_OP_ID),
+        connector_instance=None,
+        operator=_make_operator(),
+        target=_FakeHarborTarget(),
+        params={"project": _PROJECT, "id": _ROBOT_ID},
+        connector_id=_CONNECTOR_ID,
+    )
+    assert await _harbor_robot_delete_preview(ctx) is None
+
+
+# ===========================================================================
+# Registration — the op is destructive + requires_approval
+# ===========================================================================
+
+
+async def test_op_registered_destructive_requires_approval(_stub_embedding: AsyncMock) -> None:
+    await _register_ops(_stub_embedding)
+    async with get_sessionmaker()() as s:
+        row = (
+            await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == _OP_ID))
+        ).scalar_one()
+    assert row.safety_level == "destructive"
+    assert row.requires_approval is True
+    assert row.source_kind == "typed"
+    assert "destructive" in (row.tags or [])
+
+
+# ===========================================================================
+# The full governed flow (the keystone)
+# ===========================================================================
+
+
+async def test_full_governed_flow_preview_park_approve_resume(_stub_embedding: AsyncMock) -> None:
+    """preview → park (hash + blast radius) → distinct human → audited DELETE."""
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()
+
+    # 1) Preview binds a param-sensitive hash even for a typed op.
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    bound_hash = preview["preview_hash"]
+    assert isinstance(bound_hash, str) and len(bound_hash) == 64
+
+    # 2) Governed call presenting the bound hash parks; no DELETE ran.
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert recorder.delete_calls == []  # nothing deleted pre-approval
+
+    # 3) The parked row carries the bound hash + the robot blast radius.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    blast = effect["blast_radius"]
+    assert blast["object"]["kind"] == "harbor_robot"
+    assert blast["object"]["id"] == _ROBOT_ID
+    assert blast["object"]["project"] == _PROJECT
+    assert blast["children"] == [{"kind": "project_association", "project": _PROJECT}]
+    assert blast["irreversibility"] == "recreatable_new_secret"
+
+    # 4) A DIFFERENT operator approves (four-eyes) — the binding re-verifies.
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    # 5) Audited resume → the DELETE fires exactly once.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["deleted"] is True
+    assert resume.result["id"] == _ROBOT_ID
+    assert len(recorder.delete_calls) == 1
+    assert recorder.delete_calls[0][0] == "DELETE"
+
+
+# ===========================================================================
+# Requirement 2 — dispatch refused without a matching preview hash
+# ===========================================================================
+
+
+async def test_dispatch_refused_without_preview_hash(_stub_embedding: AsyncMock) -> None:
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeHarborTarget(),
+        params={"project": _PROJECT, "id": _ROBOT_ID},
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert recorder.delete_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
+# No agent execution path — an AGENT principal is DENY'd
+# ===========================================================================
+
+
+async def test_agent_principal_is_denied(_stub_embedding: AsyncMock) -> None:
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeHarborTarget(),
+        params={"project": _PROJECT, "id": _ROBOT_ID},
+    )
+    assert result.status == "denied", result
+    assert recorder.delete_calls == []  # never executed
+    assert await _pending_count() == 0  # never parked either
+
+
+# ===========================================================================
+# No standing-grant path — ServicePrincipalGrant refuses via the single source
+# ===========================================================================
+
+
+async def test_service_grant_refuses_via_single_source_not_pattern_list(
+    _stub_embedding: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The grant is refused by ``safety_level="destructive"`` on the resolved
+    descriptor, not by an op-id pattern list.
+
+    ``harbor.robot.delete`` DOES carry a ``.delete`` suffix, so blank the
+    delete-shaped glob list to prove the tier fold — not the pattern list — is
+    what refuses (the #3213 single-source guard).
+    """
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+    monkeypatch.setattr(get_settings(), "service_grant_delete_shaped_patterns", (), raising=False)
+
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended decommission",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "destructive" in str(exc.value).lower()
+
+
+# ===========================================================================
+# No self-approval, even under APPROVAL_ALLOW_SELF_APPROVAL
+# ===========================================================================
+
+
+async def test_no_self_approval_even_under_break_glass(
+    _stub_embedding: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Break-glass ON — it does NOT reach the destructive tier.
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+# ===========================================================================
+# No satellite mint — the gateway refuses with OP_NOT_SAFE
+# ===========================================================================
+
+
+async def test_satellite_mint_refuses_op_not_safe(_stub_embedding: AsyncMock) -> None:
+    recorder = _RecordingHarborConnector()
+    await _bootstrap(recorder, _stub_embedding)
+
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params={"project": _PROJECT, "id": _ROBOT_ID},
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE

--- a/backend/tests/test_connectors_windows_dns.py
+++ b/backend/tests/test_connectors_windows_dns.py
@@ -476,7 +476,17 @@ def test_op_surface_ids_and_safety_levels() -> None:
     assert by_id["windns.zone.list"].safety_level == "safe"
     assert by_id["windns.record.get"].safety_level == "safe"
     assert by_id["windns.record.add"].safety_level == "caution"
-    assert by_id["windns.record.remove"].safety_level == "caution"
+    # windns.record.remove was promoted to the governed destructive tier
+    # (#3288): destructive + requires_approval + the destructive tag (the
+    # single source the satellite ladder / service-grant guard / flight-recorder
+    # body-exclusion read).
+    remove = by_id["windns.record.remove"]
+    assert remove.safety_level == "destructive"
+    assert remove.requires_approval is True
+    assert "destructive" in remove.tags
+    # record.remove is the ONLY approval-gated windns op; every other op is
+    # approval-free.
+    assert {op.op_id for op in WINDOWS_DNS_OPS if op.requires_approval} == {"windns.record.remove"}
     # Every op declares a curated when_to_use group the registration walk
     # can resolve (identity / zone / record).
     assert {op.group_key for op in WINDOWS_DNS_OPS} == {"identity", "zone", "record"}

--- a/backend/tests/test_connectors_windows_dns_record_remove.py
+++ b/backend/tests/test_connectors_windows_dns_record_remove.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed-tier conformance for ``windns.record.remove`` (#3288 operator ruling).
+
+``windns.record.remove`` clears EVERY value of an RRType at a name in one
+``Remove-DnsServerResourceRecord ... -Force`` write. It shipped caution-tier +
+approval-free; the #3288 operator ruling promotes it to the governed-delete
+tier: ``safety_level="destructive"`` + ``requires_approval=True`` with a
+park-time RRset blast-radius statement (mirroring #3247 for
+``bind9.record.remove``).
+
+These tests prove the promotion holds on every surface, folded via the SINGLE
+SOURCE (``safety_level="destructive"`` + the ``destructive`` tag), never a local
+pattern list:
+
+* **The park-time blast radius names the RRset + enumerates every value that
+  dies**, and declines (→ ``blast_radius_required``, fail-closed) when the
+  current records cannot be read.
+* **The full governed flow**: preview → parked approval carrying the hash +
+  RRset blast radius → a *distinct human* approves → audited resume runs the
+  ``-Force`` clear.
+* **The tier holds**: agent ``DENY``, no ``ServicePrincipalGrant``, no
+  self-approval under break-glass, no satellite mint, dispatch refused without a
+  matching preview hash, park refused without a blast-radius block.
+
+The PowerShell-over-SSH transport is mocked by ``_RecordingWindowsDnsConnector``
+(overriding the ``_run_command`` seam ``pwsh_run`` calls, decoding the
+``-EncodedCommand`` payload to branch Get-vs-Remove). All fixtures are synthetic
+(``example.test`` / RFC 5737 documentation addresses) — no lab names/IPs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+
+import meho_backplane.connectors.windows_dns  # noqa: F401 -- registers the connector at import
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors._shared.pwsh import PwshRunError
+from meho_backplane.connectors.windows_dns import WindowsDnsConnector
+from meho_backplane.connectors.windows_dns.ops_record_remove_preview import (
+    _windns_record_remove_preview,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import typed_register as tr_module
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations._preview import PreviewContext
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "windns-ssh-2016.x"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003288")
+_OP_ID = "windns.record.remove"
+_ZONE = "example.test"
+_TARGET_NAME = "test-windns"
+
+# Two A values at the same name — the RRset the -Force clear removes together.
+_GET_TWO_A = json.dumps(
+    {
+        "rows": [
+            {"type": "A", "rdata": "192.0.2.30"},
+            {"type": "A", "rdata": "192.0.2.31"},
+        ],
+        "total": 2,
+    }
+)
+_GET_EMPTY = json.dumps({"rows": [], "total": 0})
+_REMOVE_OK = json.dumps({"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+def _proc(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    p = MagicMock()
+    p.stdout = stdout
+    p.stderr = stderr
+    p.exit_status = exit_status
+    return p
+
+
+def _decode_encoded_command(cmd: str) -> str:
+    """Recover the PowerShell script text from a ``-EncodedCommand`` invocation."""
+    b64 = cmd.split("-EncodedCommand", 1)[1].strip()
+    return base64.b64decode(b64).decode("utf-16-le")
+
+
+class _RecordingWindowsDnsConnector(WindowsDnsConnector):
+    """A WindowsDnsConnector whose pwsh transport is canned + recorded.
+
+    Overrides the single IO seam the preview builder + the remove handler both
+    reach — ``_run_command`` (which ``pwsh_run`` calls). Decodes the
+    ``-EncodedCommand`` payload to branch the read (``Get-DnsServerResourceRecord``
+    → the RRset) from the write (``Remove-DnsServerResourceRecord`` → ``ok``). A
+    subclass (not a duck type) so the resolver's bound-method rebind + the
+    ``_CONNECTOR_INSTANCE_CACHE`` seeding behave exactly as in production.
+    """
+
+    def __init__(self, *, get_output: str = _GET_TWO_A, get_raises: bool = False) -> None:
+        super().__init__()
+        self._get_output = get_output
+        self._get_raises = get_raises
+        self.run_calls: list[str] = []
+        self.remove_calls: list[str] = []
+
+    async def _run_command(
+        self, target: Any, cmd: str, *, operator: Operator | None = None, timeout: float = 30.0
+    ) -> Any:
+        self.run_calls.append(cmd)
+        script = _decode_encoded_command(cmd)
+        if "Get-DnsServerResourceRecord" in script:
+            if self._get_raises:
+                raise PwshRunError("read failed", exit_status=1, stderr="boom")
+            return _proc(self._get_output)
+        if "Remove-DnsServerResourceRecord" in script:
+            self.remove_calls.append(script)
+            return _proc(_REMOVE_OK)
+        raise AssertionError(f"unexpected pwsh script: {script!r}")
+
+
+def _make_operator(
+    *, sub: str = "op-1", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="windns remove conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "2016.x") -> None:
+        self.version = version
+
+
+class _FakeWindnsTarget:
+    """Duck-typed target for direct ``dispatch(...)`` (no DB name-resolve)."""
+
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "windns"
+        self.fingerprint = _FakeFingerprint()
+        self.preferred_impl_id: str | None = "windns-ssh"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = _TARGET_NAME
+        self.host = "dns.example.test"
+        self.port = 22
+        self.auth_model = "shared_service_account"
+        self.secret_ref = "meho/testing/windns/test-windns"
+
+
+def _seed_instance(recorder: _RecordingWindowsDnsConnector) -> None:
+    _CONNECTOR_INSTANCE_CACHE[WindowsDnsConnector] = recorder  # type: ignore[assignment]
+
+
+async def _register_ops() -> None:
+    with patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)):
+        await WindowsDnsConnector.register_operations()
+
+
+async def _bootstrap(recorder: _RecordingWindowsDnsConnector) -> None:
+    await _register_ops()
+    _seed_instance(recorder)
+
+
+async def _seed_target() -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="windns",
+                host="dns.example.test",
+                port=22,
+                fqdn=None,
+                secret_ref="meho/testing/windns/test-windns",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "2016.x"},
+                preferred_impl_id="windns-ssh",
+                notes="seeded by test_connectors_windows_dns_record_remove",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+def _args(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": _TARGET_NAME,
+        "params": {"zone": _ZONE, "name": "web", "type": "A"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _preview_ctx(
+    recorder: _RecordingWindowsDnsConnector, *, params: dict[str, Any]
+) -> PreviewContext:
+    """A PreviewContext wired to the recording connector for a direct builder call."""
+    return PreviewContext(
+        descriptor=MagicMock(op_id=_OP_ID),
+        connector_instance=recorder,
+        operator=_make_operator(),
+        target=_FakeWindnsTarget(),
+        params=params,
+        connector_id=_CONNECTOR_ID,
+    )
+
+
+# ===========================================================================
+# Preview builder — the RRset blast radius
+# ===========================================================================
+
+
+async def test_preview_enumerates_every_value_at_the_rrset() -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    preview = await _windns_record_remove_preview(
+        _preview_ctx(recorder, params={"zone": _ZONE, "name": "web", "type": "A"})
+    )
+    assert preview is not None
+    blast = preview["blast_radius"]
+    assert blast["object"] == {
+        "kind": "dns_record",
+        "zone": _ZONE,
+        "name": "web",
+        "type": "A",
+    }
+    assert blast["children"] == [
+        {"kind": "record_value", "type": "A", "rdata": "192.0.2.30"},
+        {"kind": "record_value", "type": "A", "rdata": "192.0.2.31"},
+    ]
+    assert blast["irreversibility"] == "recreatable"
+    assert blast["match_count"] == 2
+
+
+async def test_preview_absent_name_is_empty_children_not_decline() -> None:
+    """A name with no matching record is a valid empty blast radius, not a decline."""
+    recorder = _RecordingWindowsDnsConnector(get_output=_GET_EMPTY)
+    preview = await _windns_record_remove_preview(
+        _preview_ctx(recorder, params={"zone": _ZONE, "name": "nope", "type": "A"})
+    )
+    assert preview is not None
+    assert preview["blast_radius"]["children"] == []
+    assert preview["blast_radius"]["match_count"] == 0
+
+
+async def test_preview_declines_on_read_failure() -> None:
+    recorder = _RecordingWindowsDnsConnector(get_raises=True)
+    preview = await _windns_record_remove_preview(
+        _preview_ctx(recorder, params={"zone": _ZONE, "name": "web", "type": "A"})
+    )
+    assert preview is None
+
+
+async def test_preview_declines_on_unsupported_type() -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    preview = await _windns_record_remove_preview(
+        _preview_ctx(recorder, params={"zone": _ZONE, "name": "web", "type": "SOA"})
+    )
+    assert preview is None
+
+
+async def test_preview_declines_without_connector_instance() -> None:
+    ctx = PreviewContext(
+        descriptor=MagicMock(op_id=_OP_ID),
+        connector_instance=None,
+        operator=_make_operator(),
+        target=_FakeWindnsTarget(),
+        params={"zone": _ZONE, "name": "web", "type": "A"},
+        connector_id=_CONNECTOR_ID,
+    )
+    assert await _windns_record_remove_preview(ctx) is None
+
+
+# ===========================================================================
+# Registration — the op is destructive + requires_approval
+# ===========================================================================
+
+
+async def test_op_registered_destructive_requires_approval() -> None:
+    await _register_ops()
+    async with get_sessionmaker()() as s:
+        row = (
+            await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == _OP_ID))
+        ).scalar_one()
+    assert row.safety_level == "destructive"
+    assert row.requires_approval is True
+    assert row.source_kind == "typed"
+    assert "destructive" in (row.tags or [])
+
+
+# ===========================================================================
+# The full governed flow (the keystone)
+# ===========================================================================
+
+
+async def test_full_governed_flow_preview_park_approve_resume() -> None:
+    """preview → park (hash + RRset blast radius) → distinct human → -Force clear."""
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()
+
+    # 1) Preview binds a param-sensitive hash even for a typed op.
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    bound_hash = preview["preview_hash"]
+    assert isinstance(bound_hash, str) and len(bound_hash) == 64
+
+    # 2) Governed call presenting the bound hash parks; no write ran.
+    call = await call_operation(requester, {**args, "preview_hash": bound_hash})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert recorder.remove_calls == []  # nothing cleared pre-approval
+
+    # 3) The parked row carries the bound hash + the RRset blast radius.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        assert row.preview_hash == bound_hash
+        effect = dict(row.proposed_effect)
+    assert effect["safety_level"] == "destructive"
+    blast = effect["blast_radius"]
+    assert blast["object"]["kind"] == "dns_record"
+    assert blast["object"]["name"] == "web"
+    assert blast["object"]["type"] == "A"
+    assert {c["rdata"] for c in blast["children"]} == {"192.0.2.30", "192.0.2.31"}
+    assert blast["irreversibility"] == "recreatable"
+
+    # 4) A DIFFERENT operator approves (four-eyes) — the binding re-verifies.
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    # 5) Audited resume → the -Force clear runs exactly once.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["op_class"] == "write"
+    assert resume.result["type"] == "A"
+    assert len(recorder.remove_calls) == 1
+
+
+# ===========================================================================
+# Requirement 2 — dispatch refused without a matching preview hash
+# ===========================================================================
+
+
+async def test_dispatch_refused_without_preview_hash() -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeWindnsTarget(),
+        params={"zone": _ZONE, "name": "web", "type": "A"},
+    )
+    assert result.status == "denied"
+    assert result.extras["error_code"] == "preview_binding_required"
+    assert recorder.remove_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
+# Requirement 3 — park refused without a blast-radius block
+# ===========================================================================
+
+
+async def test_park_refused_without_blast_radius_on_read_failure() -> None:
+    """A read failure → preview builder declines → park refused (fail-closed)."""
+    recorder = _RecordingWindowsDnsConnector(get_raises=True)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert recorder.remove_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
+# No agent execution path — an AGENT principal is DENY'd
+# ===========================================================================
+
+
+async def test_agent_principal_is_denied() -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeWindnsTarget(),
+        params={"zone": _ZONE, "name": "web", "type": "A"},
+    )
+    assert result.status == "denied", result
+    assert recorder.remove_calls == []  # never executed
+    assert await _pending_count() == 0  # never parked either
+
+
+# ===========================================================================
+# No standing-grant path — ServicePrincipalGrant refuses via the single source
+# ===========================================================================
+
+
+async def test_service_grant_refuses_via_single_source_not_pattern_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The grant is refused by ``safety_level="destructive"`` on the resolved
+    descriptor, not by an op-id pattern list.
+
+    Blank out the delete-shaped op-id glob list so the pattern check cannot
+    fire, register the descriptor, and prove the grant is STILL refused — the
+    #3213 single-source guard. ``record.remove`` has no ``delete``-verb suffix,
+    so without the tier fold a blanked pattern list would let it through.
+    """
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+    monkeypatch.setattr(get_settings(), "service_grant_delete_shaped_patterns", (), raising=False)
+
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    assert "destructive" in str(exc.value).lower()
+
+
+# ===========================================================================
+# No self-approval, even under APPROVAL_ALLOW_SELF_APPROVAL
+# ===========================================================================
+
+
+async def test_no_self_approval_even_under_break_glass(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    args = _args()
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Break-glass ON — it does NOT reach the destructive tier.
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+# ===========================================================================
+# No satellite mint — the gateway refuses with OP_NOT_SAFE
+# ===========================================================================
+
+
+async def test_satellite_mint_refuses_op_not_safe() -> None:
+    recorder = _RecordingWindowsDnsConnector()
+    await _bootstrap(recorder)
+
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params={"zone": _ZONE, "name": "web", "type": "A"},
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE

--- a/backend/tests/test_connectors_winsrv.py
+++ b/backend/tests/test_connectors_winsrv.py
@@ -163,10 +163,15 @@ def test_op_surface_ids_and_safety_tiers() -> None:
         "winsrv.power.reboot",
         "winsrv.power.shutdown",
         "winsrv.localuser.delete",
+        # #3288: uninstalling a role is disruptive-but-reversible → dangerous +
+        # requires_approval (NOT destructive — reinstall recovers it, so no
+        # blast-radius preview is required at this tier).
+        "winsrv.feature.remove",
     }
     # Every dangerous op requires approval; nothing else does.
     assert {k for k, v in by_id.items() if v.requires_approval} == dangerous
     assert "winsrv.feature.install" in caution
+    assert "winsrv.feature.remove" not in caution
     assert "winsrv.storage.disk.format" in caution
     assert {"winsrv.about", "winsrv.service.list", "winsrv.storage.disk.list"} <= safe
 

--- a/backend/tests/test_connectors_winsrv_feature_remove.py
+++ b/backend/tests/test_connectors_winsrv_feature_remove.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed-tier conformance for ``winsrv.feature.remove`` (#3288 operator ruling).
+
+``winsrv.feature.remove`` uninstalls a Windows role/feature. It shipped
+caution-tier + approval-free; the #3288 operator ruling promotes it to
+``safety_level="dangerous"`` + ``requires_approval=True`` — disruptive enough to
+demand a human, but **not** ``destructive`` (reversible by reinstall,
+data-preserving), so the destructive tier's preview-hash binding + mandatory
+blast-radius statement do NOT apply. It mirrors the ``winsrv.localuser.delete``
+dangerous-tier mould.
+
+These tests prove the dangerous tier holds:
+
+* **The full governed flow**: a bare dispatch parks (no preview-hash binding at
+  this tier) → a *distinct human* approves → audited resume runs the uninstall.
+* **The tier holds**: agent ``DENY``, no self-approval under break-glass, no
+  satellite mint (``dangerous`` → EXCLUDED, never runner-minted).
+
+The PowerShell-over-SSH transport is mocked by ``_RecordingWinsrvConnector``
+(overriding the ``_run_command`` seam ``pwsh_run`` calls). Synthetic fixtures.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+
+import meho_backplane.connectors.winsrv  # noqa: F401 -- registers the connector at import
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.winsrv import WinsrvConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import typed_register as tr_module
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.approval_queue import (
+    SelfApprovalForbiddenError,
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.gateway_commands import MintRefusalCode, mint_gateway_command
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "winsrv-ssh-2022.x"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003288")
+_OP_ID = "winsrv.feature.remove"
+_FEATURE = "Failover-Clustering"
+_TARGET_NAME = "test-winsrv"
+
+_UNINSTALL_OK = json.dumps(
+    {
+        "ok": True,
+        "success": True,
+        "exit_code": "Success",
+        "restart_needed": False,
+        "features_changed": [_FEATURE],
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+def _proc(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    p = MagicMock()
+    p.stdout = stdout
+    p.stderr = stderr
+    p.exit_status = exit_status
+    return p
+
+
+def _decode_encoded_command(cmd: str) -> str:
+    b64 = cmd.split("-EncodedCommand", 1)[1].strip()
+    return base64.b64decode(b64).decode("utf-16-le")
+
+
+class _RecordingWinsrvConnector(WinsrvConnector):
+    """A WinsrvConnector whose pwsh transport is canned + recorded.
+
+    Overrides the single IO seam the remove handler reaches — ``_run_command``.
+    A subclass (not a duck type) so the resolver's bound-method rebind + the
+    ``_CONNECTOR_INSTANCE_CACHE`` seeding behave exactly as in production.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.uninstall_calls: list[str] = []
+
+    async def _run_command(
+        self, target: Any, cmd: str, *, operator: Operator | None = None, timeout: float = 30.0
+    ) -> Any:
+        script = _decode_encoded_command(cmd)
+        if "Uninstall-WindowsFeature" in script:
+            self.uninstall_calls.append(script)
+            return _proc(_UNINSTALL_OK)
+        raise AssertionError(f"unexpected pwsh script: {script!r}")
+
+
+def _make_operator(
+    *, sub: str = "op-1", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="winsrv feature.remove conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "2022.x") -> None:
+        self.version = version
+
+
+class _FakeWinsrvTarget:
+    """Duck-typed target for direct ``dispatch(...)`` (no DB name-resolve)."""
+
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "winsrv"
+        self.fingerprint = _FakeFingerprint()
+        self.preferred_impl_id: str | None = "winsrv-ssh"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = _TARGET_NAME
+        self.host = "win.example.test"
+        self.port = 22
+        self.auth_model = "shared_service_account"
+        self.secret_ref = "meho/testing/winsrv/test-winsrv"
+
+
+def _seed_instance(recorder: _RecordingWinsrvConnector) -> None:
+    _CONNECTOR_INSTANCE_CACHE[WinsrvConnector] = recorder  # type: ignore[assignment]
+
+
+async def _register_ops() -> None:
+    with patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)):
+        await WinsrvConnector.register_operations()
+
+
+async def _bootstrap(recorder: _RecordingWinsrvConnector) -> None:
+    await _register_ops()
+    _seed_instance(recorder)
+
+
+async def _seed_target() -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="winsrv",
+                host="win.example.test",
+                port=22,
+                fqdn=None,
+                secret_ref="meho/testing/winsrv/test-winsrv",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "2022.x"},
+                preferred_impl_id="winsrv-ssh",
+                notes="seeded by test_connectors_winsrv_feature_remove",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+def _args(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _OP_ID,
+        "target": _TARGET_NAME,
+        "params": {"name": _FEATURE},
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# Registration — the op is dangerous + requires_approval (NOT destructive)
+# ===========================================================================
+
+
+async def test_op_registered_dangerous_requires_approval() -> None:
+    await _register_ops()
+    async with get_sessionmaker()() as s:
+        row = (
+            await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == _OP_ID))
+        ).scalar_one()
+    assert row.safety_level == "dangerous"
+    assert row.requires_approval is True
+    assert row.source_kind == "typed"
+    # NOT destructive — no destructive tag, no blast-radius preview at this tier.
+    assert "destructive" not in (row.tags or [])
+
+
+# ===========================================================================
+# The full governed flow — a bare park (no preview-hash binding at this tier)
+# ===========================================================================
+
+
+async def test_full_governed_flow_park_approve_resume() -> None:
+    """bare dispatch parks (dangerous tier) → distinct human → uninstall runs."""
+    recorder = _RecordingWinsrvConnector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+
+    # A bare call parks — no preview_hash needed at the dangerous tier.
+    call = await call_operation(requester, _args())
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert recorder.uninstall_calls == []  # nothing uninstalled pre-approval
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["action"] == "remove"
+    assert resume.result["op_class"] == "write"
+    assert len(recorder.uninstall_calls) == 1
+
+
+# ===========================================================================
+# No agent execution path — an AGENT principal is DENY'd
+# ===========================================================================
+
+
+async def test_agent_principal_is_denied() -> None:
+    recorder = _RecordingWinsrvConnector()
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=_FakeWinsrvTarget(),
+        params={"name": _FEATURE},
+    )
+    assert result.status == "denied", result
+    assert recorder.uninstall_calls == []  # never executed
+    assert await _pending_count() == 0  # never parked either
+
+
+# ===========================================================================
+# No self-approval, even under APPROVAL_ALLOW_SELF_APPROVAL
+# ===========================================================================
+
+
+async def test_no_self_approval_even_under_break_glass(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingWinsrvConnector()
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="solo-operator")
+    call = await call_operation(requester, _args())
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    # Break-glass ON — the dangerous tier does NOT permit self-approval either.
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+    async with get_sessionmaker()() as s:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s, request_id, operator=requester, params=None)
+
+
+# ===========================================================================
+# No satellite mint — dangerous → EXCLUDED, the gateway refuses OP_NOT_SAFE
+# ===========================================================================
+
+
+async def test_satellite_mint_refuses_op_not_safe() -> None:
+    recorder = _RecordingWinsrvConnector()
+    await _bootstrap(recorder)
+
+    async with get_sessionmaker()() as s:
+        result = await mint_gateway_command(
+            s,
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params={"name": _FEATURE},
+            runner_id="runner-1",
+        )
+        await s.commit()
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -185,9 +185,23 @@ aggregate-only so the minted secret never appears in the SSE stream — and is
 registered `requires_approval=True` (#147): minting a robot credential is
 privilege issuance, so a human `tenant_admin` dispatch **parks** at
 `awaiting_approval` and a second operator must approve it before the mint
-executes. `robot_delete` (op `harbor.robot.delete`) stays ungated — a
-`caution`-class `write` that revokes access rather than minting a credential
-(mirroring the bind9 #129 precedent). Both forward the dispatched `operator`
+executes. `robot_delete` (op `harbor.robot.delete`) was promoted to the
+governed **destructive** tier by the #3288 operator ruling (superseding the
+#147 "left ungated" posture): `safety_level="destructive"` +
+`requires_approval=True`, tagged `write`/`destructive`. Permanently removing a
+credential-bearing principal is not transparently reversible — re-creating the
+robot mints a BRAND-NEW secret, so every consumer still using the old
+credential breaks silently (the lab signal
+`bind9-harbor-dangerous-writes-bypass-approval-gate.yaml`). So the delete now
+runs only through preview → park (preview-hash-bound, blast-radius statement) →
+distinct-human approval → audited resume; a bare dispatch is refused
+`preview_binding_required`. The park-time blast radius
+(`ops_robot_delete_preview._harbor_robot_delete_preview`, params-derived — no
+live call) names the robot `{id, project, level}` + its project association,
+with `irreversibility="recreatable_new_secret"`. `classify_op` is unchanged —
+`robot.delete` stays `write` (full-detail broadcast), the deliberate contrast
+with `credential_mint` `robot.create` — so the tier change is orthogonal to the
+broadcast redaction. Both forward the dispatched `operator`
 through `auth_headers` → `_load_credentials` for the operator-context Vault
 read and use non-retried HTTP calls (Harbor write endpoints are non-idempotent).
 

--- a/docs/codebase/connectors-windows-dns.md
+++ b/docs/codebase/connectors-windows-dns.md
@@ -39,17 +39,30 @@ Source: `backend/src/meho_backplane/connectors/windows_dns/`.
 | `windns.zone.list` | safe | no | `Get-DnsServerZone` |
 | `windns.record.get` | safe | no | `Get-DnsServerResourceRecord -ZoneName [-Name] [-RRType]` |
 | `windns.record.add` | caution | no | `Add-DnsServerResourceRecordA -IPv4Address` (A) / `Add-DnsServerResourceRecordCName -HostNameAlias` (CNAME), optional `-TimeToLive (New-TimeSpan -Seconds <ttl>)` |
-| `windns.record.remove` | caution | no | `Remove-DnsServerResourceRecord -ZoneName -Name -RRType -Force` |
+| `windns.record.remove` | **destructive** | **yes** | `Remove-DnsServerResourceRecord -ZoneName -Name -RRType -Force` |
 
-The two writes are `safety_level="caution"` (a DNS change is global — no
-per-caller scoping), mirroring bind9's record writes; the production-path
-gate is G7/G10 policy territory keyed on that value, so
-`requires_approval=false` today. `record.get` supports
+`record.add` is `safety_level="caution"` (a DNS change is global — no
+per-caller scoping), mirroring bind9's `record.add`; `requires_approval=false`.
+`record.remove` was promoted to the governed destructive tier by the #3288
+operator ruling (mirroring #3247 for `bind9.record.remove`):
+`safety_level="destructive"` + `requires_approval=True`, tagged
+`delete`/`destructive`. As the `-Force` RRset clear removes **every** value of
+an RRType at a name in one write, it rides the same governed-delete gate as
+`bind9.record.remove` — preview → park → distinct-human approval → audited
+resume. A bare dispatch is refused `preview_binding_required`; a park without a
+resolvable blast radius is refused `blast_radius_required`. The park-time
+blast-radius preview (`ops_record_remove_preview._windns_record_remove_preview`,
+a read-only `Get-DnsServerResourceRecord` projection) names the
+`(zone, name, type)` record-set and enumerates every value that dies
+(`irreversibility="recreatable"`, `match_count`). `record.get` supports
 A/AAAA/CNAME/MX/TXT/PTR/NS/SRV/SOA as `-RRType` filters; `record.remove`
 the same set minus SOA; `record.add` is A + CNAME only (the bind9
 write-surface mirror). `record.remove` deletes **all** records matching
-`(zone, name, RRType)` — the cmdlet default when `-RecordData` is omitted;
-a precision-delete `record_data` parameter is a known follow-up.
+`(zone, name, RRType)` — the cmdlet default when `-RecordData` is omitted; a
+surgical single-value `windns.record.delete` sibling (bind9-style, with
+`-RecordData` disambiguation) is a documented follow-up (see #3288 PR body),
+deferred because `record.remove` is already `(name, type)`-scoped and adding a
+new op meaningfully expands surface beyond this posture sweep.
 
 ## Key types
 
@@ -199,8 +212,13 @@ round-trip + safety-level invariants.
 ## Known issues / scope
 
 - `windns.record.remove` deletes **all** records matching
-  `(zone, name, RRType)`; an optional `record_data` precision-delete
-  parameter (cmdlet `-RecordData`) is a candidate follow-up.
+  `(zone, name, RRType)` and is governed at the destructive tier (#3288:
+  approval-gated, preview-hash-bound, blast-radius-previewed). A surgical
+  single-value `windns.record.delete` sibling (bind9-style, `-RecordData`
+  disambiguation) was evaluated and **deferred** in the #3288 posture sweep —
+  it is a new op with its own schema/preview/tests, and `record.remove` is
+  already `(name, type)`-scoped, so the marginal value is lower than for
+  bind9's whole-name `record.remove`. Tracked as an explicit follow-up.
 - `record.add` supports A + CNAME only (the deliberate bind9
   write-surface mirror); zone create/delete is out of scope.
 - Writes were live-validated against a WS2022 AD-DNS DC via `-WhatIf`

--- a/docs/codebase/connectors-winsrv.md
+++ b/docs/codebase/connectors-winsrv.md
@@ -55,7 +55,7 @@ central-dial / on-site only).
 | `winsrv.service.restart` | caution | no | `Restart-Service` |
 | `winsrv.feature.list` | safe | no | `Get-WindowsFeature` |
 | `winsrv.feature.install` | caution | no | `Install-WindowsFeature` |
-| `winsrv.feature.remove` | caution | no | `Uninstall-WindowsFeature` |
+| `winsrv.feature.remove` | **dangerous** | **yes** | `Uninstall-WindowsFeature` |
 | `winsrv.power.reboot` | **dangerous** | **yes** | `shutdown.exe /r /t <delay>` |
 | `winsrv.power.shutdown` | **dangerous** | **yes** | `shutdown.exe /s /t <delay>` |
 | `winsrv.localuser.list` | safe | no | `Get-LocalUser` |
@@ -68,16 +68,23 @@ central-dial / on-site only).
 | `winsrv.storage.iscsi.connect` | caution | no | `Connect-IscsiTarget` |
 | `winsrv.storage.disk.format` | caution | no | `Initialize-Disk` + `New-Partition` + `Format-Volume` |
 
-The three `dangerous` ops (`power.reboot`, `power.shutdown`, `localuser.delete`)
-are `requires_approval=True` — a dispatch parks at `needs-approval` for a human
-decision (the rke2 write mold; no bespoke `proposed_effect` builder is
-registered — the generic params-echo default (#1856) surfaces the target /
-params redaction-safely to the reviewer). The **agent-principal ceiling**
-therefore applies: an agent session cannot self-approve these — approval is a
-human decision (v0.1-spec §7), so a `winsrv.power.*` / `localuser.delete`
-dispatch from an agent floors at the approval queue until an operator approves in
-the console / CLI. Reads ride satellite runners; the `dangerous` ops are excluded
-from satellites by the tier ladder.
+The four `dangerous` ops (`power.reboot`, `power.shutdown`, `localuser.delete`,
+`feature.remove`) are `requires_approval=True` — a dispatch parks at
+`needs-approval` for a human decision (the rke2 write mold; no bespoke
+`proposed_effect` builder is registered — the generic params-echo default
+(#1856) surfaces the target / params redaction-safely to the reviewer).
+`feature.remove` was promoted from `caution` by the #3288 operator ruling:
+uninstalling a role is disruptive enough to demand a human, but it is
+deliberately **not** `destructive` — removal is reversible by reinstall and
+data-preserving, and the destructive tier is reserved for unrecoverable deletes,
+so no blast-radius preview is required at the `dangerous` tier (unlike the
+destructive `windns.record.remove` / `harbor.robot.delete` governed under
+#3288). The **agent-principal ceiling** therefore applies: an agent session
+cannot self-approve these — approval is a human decision (v0.1-spec §7), so a
+`winsrv.power.*` / `localuser.delete` / `feature.remove` dispatch from an agent
+floors at the approval queue until an operator approves in the console / CLI.
+Reads ride satellite runners; the `dangerous` ops are excluded from satellites
+by the tier ladder.
 
 ## Key types
 


### PR DESCRIPTION
## Summary

Posture sweep governing three caution-tier permanent-removal ops, per the #3288 operator rulings (per-op deliberate postures, mirroring the #3247 `bind9.record.remove` precedent). Each promotion is single-sourced on the op's `safety_level` + tags — the satellite ladder, service-grant guard, and flight-recorder body-exclusion all read from there.

- **`windns.record.remove` → `destructive` + `requires_approval=True`** (tags `delete`/`destructive`). The `-Force` RRset clear removes every value of an RRType at a name in one write, so it now runs only through preview → park → distinct-human approval → audited resume. New read-only park-time blast-radius preview (`ops_record_remove_preview`) runs a `Get-DnsServerResourceRecord` projection to name the `(zone, name, type)` record-set and enumerate every value that dies (`irreversibility="recreatable"`, `match_count`).
- **`harbor.robot.delete` → `destructive` + `requires_approval=True`** (supersedes the #147 "left ungated" posture). Permanent removal of a credential-bearing principal is not transparently reversible — recreation mints a NEW secret and silently breaks every consumer of the old one (lab signal `bind9-harbor-dangerous-writes-bypass-approval-gate.yaml`). New params-derived blast-radius preview (`ops_robot_delete_preview`, no live call) names the robot `{id, project, level}` + its project association (`irreversibility="recreatable_new_secret"`).
- **`winsrv.feature.remove` → `dangerous` + `requires_approval=True`** (deliberately **not** `destructive`). Uninstalling a role is disruptive enough to demand a human, but reversible by reinstall and data-preserving, so no blast-radius preview is required at the dangerous tier (the `winsrv.localuser.delete` mould).

**Orthogonality preserved** (as #3292 established): `broadcast.events.classify_op` is unchanged — all three stay `write` (payload-sensitivity is orthogonal to the safety tier). No `classify_op` list re-declared. The `destructive` tag propagates to the flight-recorder body-exclusion and the service-grant guard automatically. `REMOTE_WRITE_SAFETY_LEVELS` stays `frozenset({"caution"})`; the tier ladder excludes `dangerous`/`destructive` (EXCLUDED, never runner-minted).

## `windns.record.delete` sibling — evaluated, deferred (explicit follow-up)

The ruling asked whether a surgical `windns.record.delete` sibling (bind9-style: exactly one record, `-RecordData` disambiguation) is warranted now. **Decision: deferred.** Rationale:

- It is a genuinely new op — new handler, new parameter schema (`record_data` disambiguation), new preview builder, a 6th op on the windns surface (touching the op-surface conformance pin), and its own governed-delete conformance suite. That meaningfully expands scope beyond a posture sweep.
- Unlike bind9 — where `record.remove` clears the **whole name** across A + AAAA, so `record.delete` was needed to target a single type — `windns.record.remove` is already scoped to a single `(zone, name, type)`. The only extra precision a `delete` sibling adds is single-value disambiguation among multiple values of the same type at the same name (uncommon), so its marginal value is lower.

Tracked as an explicit follow-up in `docs/codebase/connectors-windows-dns.md`. If prioritized, it is a clean lift of the bind9 pattern onto the pwsh transport (`Remove-DnsServerResourceRecord -RecordData`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy` on the five changed source files — clean (pre-existing `net/icmp.py` `MSG_ERRQUEUE` error is a Linux-only symbol absent on the macOS dev box; unrelated, resolves in CI)
- [x] `code-quality.py --diff` — exit 0
- [x] Three new governed conformance suites (29 tests): preview builder shape + decline contract, registration (destructive/dangerous + approval + tag), full governed flow (preview → park → distinct-human approve → audited resume), dispatch refused `preview_binding_required` without a hash, park refused `blast_radius_required` without a resolvable blast radius (windns), agent-principal DENY, no `ServicePrincipalGrant` (single-source, not pattern list), no self-approval under break-glass, no satellite mint (`OP_NOT_SAFE`)
- [x] Per-connector surface pins updated: `test_connectors_windows_dns.py` (record.remove destructive + only approval-gated windns op), `test_connectors_winsrv.py` (feature.remove in the dangerous set)
- [x] `test_broadcast_credential_mint_dispatch.py` reworked — the credential_mint-vs-write broadcast contrast now drives `harbor.robot.delete` through the governed resume (preview-bound park → `/decide` approve → executed full-detail `write` broadcast), keeping the classifier-driven divergence proof intact under the new tier
- [x] Adjacent sweep green (452 tests across the run): satellite tier, service grants, destructive preview binding, MCP surface conformance, harbor spec-reconcile, maturity surface drift, flight-recorder redaction, broadcast events

## Out of scope / notes

- **Snapshot:** CLI OpenAPI snapshot **unchanged** — tier flips carry no per-op safety metadata into the REST surface (#3292 precedent), and no new REST route or op was added (the `windns.record.delete` sibling was deferred, so the windns op surface stays 5).
- **Migrations:** none — the tier is a registration-constant re-applied on startup (single head 0096 untouched).
- **Decision doc:** no stance rewrite (per the #3292 precedent — no adoption list exists to update).

Closes #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
