### PR TITLE
fix(connectors): bind9 zone resolution walks to owning zone for parent-hosted subdomain records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,26 @@ connector-related release-notes line.
   `ALLGREEN` strategy since the ruleset carries no `required_status_checks`
   rule — tracked as the next required-set decision, not fixed here.)
 
+### Fixed — bind9 destructive-delete resolves records in parent-hosted subdomains (#3304)
+
+- `bind9.record.delete` / `bind9.record.remove` (destructive tier) fail-closed
+  with `blast_radius_required` at park time for a record that lives flat in a
+  configured parent zone's zonefile (`host.sub.example.com` written into the
+  `example.com` zone, where `sub.example.com` is not itself a zone) whenever a
+  `zone` context naming that unserved subdomain reached the op. Zone resolution
+  (`resolve_zone_target`) honoured a supplied `zone` verbatim and refused it when
+  it was not an exactly-configured zone, instead of walking up to the configured
+  ancestor that actually owns the record — so governed teardowns could not delete
+  any such record even though the delete is fully computable. Resolution now
+  treats an unserved `zone` the same as an omitted one: it walks the configured
+  zones longest-first for the record's FQDN and selects the longest suffix the
+  server actually serves, failing closed only when **no** configured zone is a
+  suffix of the FQDN. Deletion params (`fqdn` / `type`) are untouched — only the
+  resolved zone context changes, so the blast radius names the true owning zone
+  and the exact record, and the shared resolver keeps park-time preview and
+  post-approval execution in agreement. A genuinely-configured subzone still wins
+  by longest suffix; a record under no configured zone still parks refused.
+
 ### Fixed — self-approval break-glass no longer permits dangerous-tier deletes (#3290 / #3198)
 
 - The unconditional self-approval refusal (#3198 — "no self-approval, even

--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -549,12 +549,20 @@ def resolve_zone_target(
 
     Zone selection:
 
-    * ``explicit_zone`` set -> that zone name (trailing-dot / case
-      normalised).
-    * otherwise -> longest-suffix match via :func:`resolve_zone_for_fqdn`
-      over the **distinct** zone names, so a zone declared in N views no
-      longer ties with itself and spuriously reports ``ambiguous`` (the
-      #2897 failure mode).
+    * ``explicit_zone`` set **and configured on this server** -> that zone
+      name (trailing-dot / case normalised).
+    * otherwise (no ``explicit_zone``, **or** an ``explicit_zone`` this
+      server does not serve) -> longest-suffix match via
+      :func:`resolve_zone_for_fqdn` over the **distinct** configured zone
+      names, so a zone declared in N views no longer ties with itself and
+      spuriously reports ``ambiguous`` (the #2897 failure mode). Walking on
+      an unserved ``explicit_zone`` (rather than refusing it verbatim) lets a
+      record that lives flat in a configured ancestor's zonefile -- e.g.
+      ``host.sub.example.com`` written into the ``example.com`` zone, where
+      ``sub.example.com`` is not itself a zone -- resolve to that ancestor
+      instead of failing closed (#3304). The FQDN is authoritative for a
+      record op, so the walk can only ever land on a zone the FQDN belongs
+      to; a truly-outside FQDN still raises ``unresolvable``.
 
     View disambiguation, over the rows whose name matches the zone and
     that carry a ``file`` directive:
@@ -575,10 +583,22 @@ def resolve_zone_target(
     def _name(row: dict[str, Any]) -> str:
         return str(row["name"]).rstrip(".").lower()
 
-    if explicit_zone is not None:
+    configured_zone_names = {_name(row) for row in rows}
+    if explicit_zone is not None and explicit_zone.rstrip(".").lower() in configured_zone_names:
         zone_name = explicit_zone.rstrip(".").lower()
     else:
-        zone_name = resolve_zone_for_fqdn(sorted({_name(row) for row in rows}), fqdn)
+        # No ``explicit_zone`` -- OR an ``explicit_zone`` this server does
+        # not serve (e.g. a parent-hosted subdomain like ``sub.example.com``
+        # whose records live flat in a configured ancestor's zonefile, not a
+        # delegated child zone). In both cases walk the configured zones
+        # longest-first for the record's FQDN and pick the longest suffix the
+        # server actually serves; ``resolve_zone_for_fqdn`` fails closed
+        # (``unresolvable``) only when NO configured zone is a suffix of the
+        # FQDN. Honouring an unserved ``explicit_zone`` verbatim would wrongly
+        # refuse a computable delete whose record lives in a configured
+        # ancestor (#3304); the FQDN is authoritative for a record op, so the
+        # walk cannot resolve into a zone the FQDN does not belong to.
+        zone_name = resolve_zone_for_fqdn(sorted(configured_zone_names), fqdn)
 
     candidates = [row for row in rows if _name(row) == zone_name and row.get("file")]
     if not candidates:

--- a/backend/tests/test_connectors_bind9_atomic.py
+++ b/backend/tests/test_connectors_bind9_atomic.py
@@ -324,6 +324,88 @@ class TestResolveZoneTarget:
             resolve_zone_target(rows, fqdn="api.evba.lab", explicit_zone=None, explicit_view=None)
         assert exc_info.value.reason == "unresolvable"
 
+    def test_unserved_explicit_zone_walks_to_configured_parent(self) -> None:
+        """#3304: an ``explicit_zone`` this server does not serve walks up.
+
+        A record written flat into a configured parent's zonefile
+        (``host.sub.evba.lab`` under ``evba.lab``, where ``sub.evba.lab`` is
+        not itself a zone) must resolve to the configured ancestor rather than
+        fail closed. Before the fix, honouring the unserved ``sub.evba.lab``
+        verbatim raised ``unresolvable`` and the destructive-delete park was
+        refused ``blast_radius_required`` for a computable delete.
+        """
+        zone, path, view = resolve_zone_target(
+            _NO_VIEW_ROWS,
+            fqdn="host.sub.evba.lab",
+            explicit_zone="sub.evba.lab",
+            explicit_view=None,
+        )
+        assert (zone, path, view) == ("evba.lab", "/etc/bind/db.evba.lab", None)
+
+    def test_configured_subzone_wins_over_parent_longest_suffix(self) -> None:
+        """#3304: a genuinely-configured subzone resolves to the subzone.
+
+        When ``sub.evba.lab`` really is a served zone, the longest suffix
+        wins over the parent -- whether the caller omits ``zone`` (walk) or
+        names the subzone explicitly (served -> honoured verbatim).
+        """
+        rows = [
+            {"name": "evba.lab", "file": "/etc/bind/db.evba.lab", "type": "master", "view": None},
+            {
+                "name": "sub.evba.lab",
+                "file": "/etc/bind/db.sub.evba.lab",
+                "type": "master",
+                "view": None,
+            },
+        ]
+        expected = ("sub.evba.lab", "/etc/bind/db.sub.evba.lab", None)
+        assert (
+            resolve_zone_target(
+                rows, fqdn="host.sub.evba.lab", explicit_zone=None, explicit_view=None
+            )
+            == expected
+        )
+        assert (
+            resolve_zone_target(
+                rows,
+                fqdn="host.sub.evba.lab",
+                explicit_zone="sub.evba.lab",
+                explicit_view=None,
+            )
+            == expected
+        )
+
+    def test_unserved_explicit_zone_with_no_configured_ancestor_is_unresolvable(self) -> None:
+        """#3304: the walk fails closed when no configured zone owns the FQDN.
+
+        An unserved ``explicit_zone`` does not lower the bar -- if no
+        configured zone is a suffix of the FQDN, resolution still raises
+        ``unresolvable`` (the destructive-delete park stays refused
+        ``blast_radius_required``).
+        """
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                _NO_VIEW_ROWS,
+                fqdn="host.other.example",
+                explicit_zone="sub.other.example",
+                explicit_view=None,
+            )
+        assert exc_info.value.reason == "unresolvable"
+
+    def test_configured_but_file_less_explicit_zone_unchanged(self) -> None:
+        """#3304 regression guard: a configured file-less explicit zone is
+
+        still refused verbatim (not walked). The fix only changes the
+        behaviour for zones this server does not serve *at all*; a configured
+        forward / hint zone named explicitly keeps failing ``unresolvable``.
+        """
+        rows = [{"name": "evba.lab", "file": None, "type": "forward", "view": None}]
+        with pytest.raises(ZoneResolutionError) as exc_info:
+            resolve_zone_target(
+                rows, fqdn="api.evba.lab", explicit_zone="evba.lab", explicit_view=None
+            )
+        assert exc_info.value.reason == "unresolvable"
+
 
 # ---------------------------------------------------------------------------
 # View-aware verify predicate builders (#2897)

--- a/backend/tests/test_connectors_bind9_record_delete.py
+++ b/backend/tests/test_connectors_bind9_record_delete.py
@@ -658,6 +658,103 @@ async def test_park_refused_without_blast_radius_unmanaged_zone() -> None:
 
 
 # ===========================================================================
+# #3304 — records in parent-hosted subdomains resolve to the owning zone
+# ===========================================================================
+
+# A zonefile for ``example.test`` that carries a record written flat under a
+# subdomain (``host.sub`` -> ``host.sub.example.test.``) — ``sub.example.test``
+# is NOT a separate zone, the record lives in the parent zonefile.
+_ZONEFILE_PARENT_HOSTED_SUB = """$TTL 3600
+@ IN SOA ns1.example.test. admin.example.test. (
+    2026080101 3600 600 604800 86400 )
+@        IN NS ns1.example.test.
+ns1      IN A 192.0.2.1
+host.sub IN A 192.0.2.55
+"""
+
+
+async def test_park_resolves_parent_hosted_subdomain_to_owning_zone() -> None:
+    """#3304: a delete for a record that lives flat in a configured parent's
+
+    zonefile — behind an unserved ``zone=sub.example.test`` context — parks
+    with a blast radius naming the *parent* zone + the exact record, and the
+    approved resume deletes it. Before the fix the park was refused
+    ``blast_radius_required`` because the unserved subdomain was honoured
+    verbatim.
+    """
+    recorder = _RecordingBind9Connector(zonefile=_ZONEFILE_PARENT_HOSTED_SUB)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    # The caller supplies the subdomain as the zone context (what an operator
+    # or the consumer write flow passes when treating ``sub`` as a zone).
+    args = _args(params={"fqdn": "host.sub.example.test", "type": "A", "zone": "sub.example.test"})
+
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert recorder.sudo_calls == []
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        effect = dict(row.proposed_effect)
+    blast = effect["blast_radius"]
+    # The blast radius names the RESOLVED owning zone (the parent), not the
+    # unserved subdomain, and the exact record.
+    assert blast["object"] == {
+        "kind": "dns_record",
+        "zone": _ZONE,
+        "name": "host.sub.example.test.",
+        "type": "A",
+        "view": None,
+    }
+    assert blast["children"] == [{"kind": "record_value", "type": "A", "rdata": "192.0.2.55"}]
+
+    # Post-approval resume deletes it — the shared resolver means execution
+    # walks to the same parent zone the park named.
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    assert approved.status == "approved"
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["zone"] == _ZONE
+    assert len(recorder.sudo_calls) == 1
+
+
+async def test_park_still_refused_when_no_configured_zone_owns_fqdn() -> None:
+    """#3304 guard: an unserved ``zone`` does not lower the bar. When no
+
+    configured zone is a suffix of the FQDN the preview still declines and the
+    park stays refused ``blast_radius_required`` (fail-closed preserved).
+    """
+    recorder = _RecordingBind9Connector(checkconf=_CHECKCONF_OTHER)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = _args(params={"fqdn": "host.sub.example.test", "type": "A", "zone": "sub.example.test"})
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert recorder.sudo_calls == []
+    assert await _pending_count() == 0
+
+
+# ===========================================================================
 # No agent execution path — an AGENT principal is DENY'd
 # ===========================================================================
 

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -350,10 +350,19 @@ explicit_zone, explicit_view)` (in `ops_record.py`) walks the
 `{name, file, type, view}` rows T2's `parse_named_checkconf_zones`
 emits and returns `(zone_name, zonefile_path, view)`:
 
-* **Zone name** -- `explicit_zone` when given, else longest-suffix match
-  (`resolve_zone_for_fqdn`) over the **distinct** zone names. The FQDN's
-  label sequence must end with the zone's (`api.evba.lab` matches
-  `evba.lab`, not `ba.lab`); the root zone (`.`) is excluded.
+* **Zone name** -- `explicit_zone` when it names a zone this server
+  serves; otherwise (no `explicit_zone`, **or** an `explicit_zone` this
+  server does not serve) longest-suffix match (`resolve_zone_for_fqdn`)
+  over the **distinct** zone names. The FQDN's label sequence must end
+  with the zone's (`api.evba.lab` matches `evba.lab`, not `ba.lab`); the
+  root zone (`.`) is excluded. Walking on an unserved `explicit_zone`
+  (rather than refusing it verbatim) lets a record that lives flat in a
+  configured ancestor's zonefile -- e.g. `host.sub.evba.lab` written into
+  the `evba.lab` zone, where `sub.evba.lab` is not itself a zone --
+  resolve to that ancestor instead of failing closed (#3304); the FQDN is
+  authoritative for a record op, so the walk can only land on a zone the
+  FQDN belongs to. A genuinely-configured subzone still wins by longest
+  suffix.
 * **View** -- the candidate rows are the zone's rows that carry a `file`
   directive:
   * `view` given -> restrict to that view; no match raises


### PR DESCRIPTION
## What

Fixes a fail-closed bug in the bind9 destructive-delete governed tier found while dogfooding a governed teardown: `bind9.record.delete` (and `bind9.record.remove`) refuse to park (`blast_radius_required`) for a record that lives flat in a configured parent zone's zonefile — e.g. `host.sub.example.com` written into the `example.com` zone, where `sub.example.com` is **not** itself a configured zone — whenever a `zone` context naming that unserved subdomain reaches the op.

## Root cause (confirmed with file:line + a direct repro)

The park-time blast-radius builders (`backend/src/meho_backplane/connectors/bind9/ops_record_delete_preview.py`) resolve the owning zone through the shared `resolve_zone_target` in `ops_record.py`, forwarding `explicit_zone = ctx.params.get("zone")`.

The naive-resolution hypothesis was **partially refuted / partially confirmed**:

- Refuted: there is no strip-first-label default. With **no** `zone` supplied, `resolve_zone_target` already walks configured zones longest-first (`resolve_zone_for_fqdn`) and resolves `host.sub.example.com` → `example.com` correctly.
- Confirmed (the real gap): with a `zone` supplied, `resolve_zone_target` trusted it verbatim and required it to be an exactly-configured zone; if not, it raised `ZoneResolutionError("unresolvable")` immediately — never walking up to the configured ancestor that actually owns the record. The preview catches that → returns `None` → the park is refused `blast_radius_required` (fail-closed, but wrong resolution).

The delete is fully computable (`bind9.record.get` and `bind9.zone.read` of the parent both work), so the refusal blocks governed teardowns from deleting any record under a subdomain that is not itself a configured zone.

## Fix

`resolve_zone_target` now treats an **unserved** `zone` the same as an omitted one: walk the configured zones longest-first for the record's FQDN and select the longest suffix the server actually serves; fail closed only when **no** configured zone is a suffix of the FQDN. The FQDN is authoritative for a record op, so the walk can only ever land on a zone the FQDN belongs to.

- Deletion params (`fqdn` / `type`) stay verbatim — only the resolved zone context changes. The blast radius names the true owning zone + the exact record.
- The change lives in the shared resolver, so park-time preview and post-approval execution stay in agreement (a parked delete that resolves to the parent also executes against the parent).
- A configured-but-file-less explicit zone is unchanged (still `unresolvable`); a genuinely-configured subzone still wins by longest suffix.

## Tests

Pure-resolver (`test_connectors_bind9_atomic.py`):

- unserved explicit subdomain walks to the configured parent
- genuinely-configured subzone wins by longest suffix (both omitted and explicit `zone`)
- unserved explicit zone with no configured ancestor → still `unresolvable`
- configured-but-file-less explicit zone → still `unresolvable` (regression guard)

Builder / end-to-end dispatch (`test_connectors_bind9_record_delete.py`):

- a delete for a parent-hosted subdomain record (behind `zone=sub.example.test`) parks with a blast radius naming the parent zone + the exact record, and the approved resume deletes it
- an unserved `zone` whose FQDN is under no configured zone → park still refused `blast_radius_required`

Local gates green: `ruff format --check`, `ruff check`, `mypy` (src), and the full bind9 test suites (atomic / record_delete / record_remove / reads / config / connector + destructive-preview-binding).

Closes #3304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
