### PR TITLE
fix(ci): scope TruffleHog scan to merge_group diff so queue entries pass

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -55,4 +55,22 @@ jobs:
       - name: TruffleHog Scan
         uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b  # v3.97.1
         with:
+          # Pin the scan range on merge_group refs. The action derives its
+          # BASE/HEAD from the event payload, but its dispatch only handles
+          # push / pull_request / workflow_dispatch / schedule — there is NO
+          # merge_group branch. On a merge_group event COMMIT_IDS is [] and
+          # both inputs stay empty, so the action falls back to a
+          # full-filesystem scan of the whole tree; with
+          # --results=verified,unknown below that surfaces pre-existing
+          # UNVERIFIED findings living in repo test fixtures and --fail exits
+          # non-zero, ejecting every merge-queue entry `failed_checks` (#3307;
+          # the #3253 merge_group trigger made the context report but not pass).
+          #
+          # Passing base/head from the merge_group payload scopes the scan to
+          # the base..head diff — matching PR semantics, so those historical
+          # fixture findings are out of scope. On pull_request / push
+          # github.event.merge_group is null so both expressions are empty and
+          # the action keeps its own derivation: PR/push behaviour is identical.
+          base: ${{ github.event.merge_group.base_sha }}
+          head: ${{ github.event.merge_group.head_sha }}
           extra_args: --results=verified,unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,34 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `TruffleHog Secret Scan` fails on `merge_group` refs, ejecting every merge-queue entry (#3307)
+
+- The `merge_group` trigger #3253 added to `secret-scan.yml` made the
+  required `TruffleHog Secret Scan` context *report* on queue refs, but
+  the trufflehog action's own scan-range derivation has no `merge_group`
+  branch (it handles only `push` / `pull_request` / `workflow_dispatch` /
+  `schedule`). On a `merge_group` event its `BASE`/`HEAD` stayed empty, so
+  it fell back to a **full-filesystem scan** of the whole tree; with
+  `--results=verified,unknown` that surfaced pre-existing unverified
+  Postgres false-positives living in repo test fixtures and `--fail`
+  exited non-zero — so the first real queue entry (#3306) was ejected
+  `failed_checks` in ~86 s and the merge queue was dead on arrival.
+- The scan is now pinned to the merge-group diff via
+  `base: ${{ github.event.merge_group.base_sha }}` /
+  `head: ${{ github.event.merge_group.head_sha }}`, matching PR
+  `base..head` semantics so the historical fixture findings are out of
+  scope and a clean queue entry passes. Off the queue
+  `github.event.merge_group` is null, both inputs are empty, and the
+  action keeps its own PR/push derivation — behaviour there is identical.
+- `docs/codebase/devops.md` gains a load-bearing note: a `merge_group`
+  trigger makes a workflow *run*, but any action that derives its own
+  scan range from the event payload must be handed the `merge_group`
+  range explicitly — the trigger alone is not enough. (Secondary
+  observation on the #3306 canary: the external `DCO` App posts no
+  check-run on `merge_group` refs; non-blocking under the queue's
+  `ALLGREEN` strategy since the ruleset carries no `required_status_checks`
+  rule — tracked as the next required-set decision, not fixed here.)
+
 ### Fixed — self-approval break-glass no longer permits dangerous-tier deletes (#3290 / #3198)
 
 - The unconditional self-approval refusal (#3198 — "no self-approval, even

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -862,7 +862,7 @@ hangs the queue forever:
 | `Go (golangci-lint + go test)` | `ci.yml` | yes (#769) |
 | `Helm (lint + template + kubeconform)` | `ci.yml` | yes (#769) |
 | `Semgrep SAST` | `security-scan.yml` | yes (#769) |
-| `TruffleHog Secret Scan` | `secret-scan.yml` | yes (#769) |
+| `TruffleHog Secret Scan` | `secret-scan.yml` | yes (#769 trigger; #3307 scan-range fix) — see caveat below |
 | `Python License Check` | `dependency-license-check.yml` | yes — `changes` + job-level `if:` |
 | `NPM License Check` | `dependency-license-check.yml` | yes — same shape |
 | `helm install + helm test (pgvector preflight)` | `chart.yml` | **yes (#3253)** — the `helm-test-gate` aggregator (`if: always()`) is the required context and fails closed |
@@ -889,6 +889,21 @@ these workflows:
   cancelled queue check fails the merge attempt and drops the PR out of
   the queue, so `merge_group` runs are never cancelled; `pull_request` /
   `push` runs still cancel their own predecessors as before.
+- **Third-party actions that derive their own scan range must be told
+  the `merge_group` range explicitly.** A `merge_group` trigger makes the
+  workflow *run*, but an action that computes its diff from the event
+  payload can still misfire: the TruffleHog action's dispatch handles
+  only `push` / `pull_request` / `workflow_dispatch` / `schedule`, so on a
+  `merge_group` event its `BASE`/`HEAD` stay empty and it falls back to a
+  full-filesystem scan of the whole tree — which, with
+  `--results=verified,unknown`, trips `--fail` on pre-existing unverified
+  fixture findings and ejected the first real queue entry `failed_checks`
+  (#3306 → #3307). The fix passes `base: ${{ github.event.merge_group.base_sha }}`
+  / `head: ${{ github.event.merge_group.head_sha }}` so the queue ref is
+  scanned as a `base..head` diff; both expressions are empty off the
+  queue, preserving PR/push behaviour. When adding any range-deriving
+  action to a required-check workflow, check its `merge_group` handling —
+  the trigger alone is not enough.
 
 `chart.yml` additionally guards its `publish` and `verify-anonymous-pull`
 jobs to `github.event_name == 'push'` (was `!= 'pull_request'`), so a


### PR DESCRIPTION
## What & why

The merge queue is non-functional: the first real queue entry (#3306)
was ejected `failed_checks` in ~86 s because the required
**`TruffleHog Secret Scan`** check fails on `merge_group` refs.

#3253 added the `merge_group` trigger to `secret-scan.yml` so the context
*reports* on queue refs — but the trufflehog action's own scan-range
derivation has **no `merge_group` branch** (it handles only `push` /
`pull_request` / `workflow_dispatch` / `schedule`). On a `merge_group`
event `COMMIT_IDS` is `[]` and both `BASE`/`HEAD` inputs stay empty, so
the action falls back to a **full-filesystem scan** of the whole tree
(`unit_kind=dir`, ~56k chunks). With `--results=verified,unknown` that
surfaces 10 pre-existing **unverified** Postgres false-positives living in
repo test fixtures (already on `main`, never in a PR diff), and `--fail`
exits **183** → check failure → the queue ejects the entry.

## The fix

Pass the action's `base` / `head` inputs from the merge_group payload so
the queue ref is scanned as a `base..head` diff — matching PR semantics,
which is why PR/push runs were always green (the fixture findings are
never in a PR diff):

```yaml
base: ${{ github.event.merge_group.base_sha }}
head: ${{ github.event.merge_group.head_sha }}
```

On `pull_request` / `push`, `github.event.merge_group` is null so both
expressions are **empty** and the action keeps its own derivation —
PR/push behaviour is byte-for-byte identical. `--results=verified,unknown`
is unchanged, so the DIFF-scan posture matches the PR path.

This is a real scan, not a gate/skip — the security signal is preserved
on queue refs.

## Self-proving

The fix takes effect **on the `merge_group` ref that contains it**, so
this PR's own queue run is the test: `TruffleHog Secret Scan` must report
**success** on the merge ref.

## Notes / follow-ups (in #3307)

- The 10 fixture false-positives are pre-existing and out of scope here.
- **Secondary canary observation:** the external `DCO` App posts no
  check-run on `merge_group` refs. Non-blocking under the queue's
  `ALLGREEN` strategy (the `protect main` ruleset has no
  `required_status_checks` rule, so only checks that actually report are
  gated — corroborated by #3306 ejecting on the failure in ~86 s, not a
  60-min timeout). Tracked in #3307 as the next required-set decision.
- All other required-context **workflows** already fire on `merge_group`
  (`ci.yml`, `chart.yml`, `security-scan.yml`,
  `dependency-license-check.yml`); `image.yml` / `pr-smoke.yml` lack the
  trigger but carry no required context, so they do not block the queue.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on `secret-scan.yml` —
  parses; `with` = `{base, head, extra_args}`; triggers =
  `push, pull_request, merge_group`.

Closes #3307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
