### PR TITLE
fix(ui): structure conventions "New convention" dialog (#240)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
@@ -56,28 +56,28 @@
       <div id="conventions-write-result" aria-live="assertive"></div>
 
       <div class="grid gap-3 md:grid-cols-2">
-        <label class="form-control">
-          <span class="label-text">Slug</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Slug</span>
           <input
             type="text"
             name="slug"
             required
             maxlength="{{ slug_max_length }}"
             pattern="[a-z0-9][a-z0-9\-]*"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             placeholder="confirm-before-applying"
             aria-describedby="conventions-create-slug-hint"
           />
-          <span id="conventions-create-slug-hint" class="text-xs opacity-60 mt-1">
+          <span id="conventions-create-slug-hint" class="text-xs opacity-60">
             Lowercase letters, digits, hyphen. The natural key within your tenant.
           </span>
         </label>
 
-        <label class="form-control">
-          <span class="label-text">Kind</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Kind</span>
           <select
             name="kind"
-            class="select select-bordered select-sm"
+            class="select select-bordered select-sm w-full"
             required
             data-action="kind-select"
             hx-post="/ui/conventions/preview"
@@ -93,42 +93,42 @@
         </label>
       </div>
 
-      <label class="form-control">
-        <span class="label-text">Title</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Title</span>
         <input
           type="text"
           name="title"
           required
           maxlength="{{ title_max_length }}"
-          class="input input-bordered input-sm"
+          class="input input-bordered input-sm w-full"
           placeholder="Confirm before applying a destructive change"
         />
       </label>
 
-      <label class="form-control max-w-[12rem]">
-        <span class="label-text">Priority</span>
+      <label class="flex flex-col gap-1 max-w-[12rem]">
+        <span class="text-sm font-medium">Priority</span>
         <input
           type="number"
           name="priority"
           value="0"
           min="{{ priority_min }}"
           max="{{ priority_max }}"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           aria-describedby="conventions-create-priority-hint"
         />
-        <span id="conventions-create-priority-hint" class="text-xs opacity-60 mt-1">
+        <span id="conventions-create-priority-hint" class="text-xs opacity-60">
           Higher wins when the preamble packer drops on overflow.
         </span>
       </label>
 
       <div class="grid gap-3 md:grid-cols-2">
-        <label class="form-control">
-          <span class="label-text">Body (Markdown)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Body (Markdown)</span>
           <textarea
             name="body"
             required
             maxlength="{{ body_max_length }}"
-            class="textarea textarea-bordered min-h-[14rem] font-mono text-sm"
+            class="textarea textarea-bordered min-h-[14rem] w-full font-mono text-sm"
             hx-post="/ui/conventions/preview"
             hx-trigger="keyup changed delay:300ms"
             hx-target="#conventions-token-preview"

--- a/backend/tests/test_ui_conventions_write.py
+++ b/backend/tests/test_ui_conventions_write.py
@@ -327,6 +327,11 @@ def test_create_modal_renders_for_admin() -> None:
     # The debounced preview wiring is present.
     assert 'hx-post="/ui/conventions/preview"' in body
     assert "keyup changed delay:300ms" in body
+    # #240: the create form is migrated off dead daisyUI-v4 classes
+    # (removed in v5 — zero compiled rules — which collapsed the
+    # label-over-input column and misaligned the grids).
+    assert "form-control" not in body
+    assert "label-text" not in body
 
 
 def test_create_end_to_end_returns_hx_redirect() -> None:


### PR DESCRIPTION
## Summary
- The Conventions "New convention" create dialog (`_create_modal.html`) used daisyUI v4 `form-control` + `label-text` on all five fields (Slug, Kind, Title, Priority, Body), both removed in v5 (zero compiled rules), so the label-over-input column collapsed and the two-column Slug/Kind and Body/token-preview grids read misaligned (the Priority label detached from its input, the token-cost preview floated).
- Migrated every field to `flex flex-col gap-1` label wrappers, `text-sm font-medium` labels, helper text as `text-xs opacity-60` blocks below, and `w-full` controls. The `max-w-[12rem]` Priority cap and both `grid md:grid-cols-2` layouts are preserved.
- Presentation only — the create POST, CSRF double-submit, and the debounced token-cost preview (the Kind select's + Body textarea's `hx-post` to `/ui/conventions/preview`) are unchanged.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_conventions_write.py` — 16 passed
- [x] **Aligned dialog** — all 5 fields stack label-over-input via `flex flex-col gap-1`; grids + Priority cap preserved
- [x] **No dead classes** — render-guard asserts `form-control`/`label-text` absent from `/ui/conventions/create`
- [x] **No functional regression** — create POST, CSRF, and both preview `hx-post` wirings covered by the 16 passing tests

## Out of scope
- The detail-view edit modal (`_edit_modal.html`) — sibling task evoila-bosnia/meho-internal#241 under initiative #239.

## Issue
Implements **evoila-bosnia/meho-internal#240** (subtask of initiative **evoila-bosnia/meho-internal#239**). Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#240