### PR TITLE
feat(connectors): pfsense teardown-inverse governed deletes — route.static.delete + gateway.delete + alias.member.remove (#3313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,38 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — pfsense: three teardown-inverse governed deletes (#3313)
+
+- **`pfsense.route.static.delete`** — the inverse of `pfsense.route.static.add`.
+  Deletes ONE static route (`config.xml` `<staticroutes><route>`) by its
+  canonical `network` (CIDR), refusing fail-closed on 0 matches (`not_found`)
+  or >1 (`ambiguous`, two routes canonicalising to the same network). Applies
+  via `pfSsh.php playback` (`write_config()` + `system_routing_configure()`),
+  then reads `config.xml` back and verifies the route is gone and the count
+  dropped by exactly one.
+- **`pfsense.gateway.delete`** — the inverse of `pfsense.gateway.add`. Deletes
+  ONE gateway (`<gateways><gateway_item>`) by exact `name` with a **fail-closed
+  dependency guard** (mirrors `alias.delete`): refuses `referenced` — naming
+  every referrer — when the gateway is still used by any static route, gateway
+  group, or default-gateway setting, so a gateway is never pulled out from
+  under a live route. Also refuses `not_found` / `ambiguous`; read-back
+  verified.
+- **`pfsense.alias.member.remove`** — removes ONE member (host / network entry)
+  from a firewall alias **without deleting the alias** (the shared-alias case:
+  an alias shared across environments keeps its identity and its other members).
+  A read-modify-write on `<address>` (and its positionally-aligned `<detail>`),
+  applied via `filter_configure()`. Refuses `not_found` / `member_not_found` /
+  `ambiguous`, and refuses `last_member` so a shared alias is never emptied into
+  deletion (that is `alias.delete`'s job). Read-back-verifies the member is
+  gone, the alias is retained, and every other member survives.
+- All three are `safety_level="destructive"` / `requires_approval=True` — the
+  governed-delete tier (mandatory human approval, #3197 preview-hash binding,
+  mandatory blast-radius statement, no agent path / standing grant /
+  self-approval / satellite mint). `alias.member.remove` (op-id not ending in
+  `.delete`) folds into the destructive-tier service-grant refusal via its
+  safety level / `destructive` tag rather than the `*.delete` glob. No DB
+  migration; CLI OpenAPI snapshot unchanged (typed ops carry no REST surface).
+
 ## [0.32.0] - 2026-09-02
 
 ### Security — HttpNfcLease device-URL transfers pinned to the lease `sslThumbprint` (#3284)

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -180,13 +180,18 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     ),
     "alias": (
         "Use for pfSense firewall-alias lifecycle: permanently deleting one "
-        "alias (``pfsense.alias.delete``). Call ``pfsense.alias.delete`` to "
-        "retire ONE alias by exact name -- a GOVERNED DESTRUCTIVE delete "
+        "alias (``pfsense.alias.delete``) or trimming ONE member out of a "
+        "shared alias without deleting it (``pfsense.alias.member.remove``). "
+        "Call ``pfsense.alias.delete`` to retire ONE alias by exact name -- it "
+        "refuses fail-closed when the alias is still referenced by any filter "
+        "rule, NAT rule, or other alias, naming every referrer. Call "
+        "``pfsense.alias.member.remove`` to remove one host / network entry "
+        "from an alias shared across environments while keeping the alias and "
+        "its other members -- it refuses ``last_member`` so a shared alias is "
+        "never emptied into deletion. Both are GOVERNED DESTRUCTIVE ops "
         "(safety_level=destructive, mandatory human approval, preview-hash "
-        "binding, blast-radius statement). It refuses fail-closed when the "
-        "alias is still referenced by any filter rule, NAT rule, or other "
-        "alias, naming every referrer. Read the current config first with "
-        "``pfsense.config.show``."
+        "binding, blast-radius statement, read-back verify). Read the current "
+        "config first with ``pfsense.config.show``."
     ),
     "network": (
         "Use for pfSense network-interface operations: listing all "
@@ -213,18 +218,22 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "lease start/end, and effective binding state."
     ),
     "routing": (
-        "Use for pfSense routing-plane provisioning writes: appending a "
-        "named gateway (``pfsense.gateway.add``) or a static route "
-        "(``pfsense.route.static.add``) to ``config.xml``. Call "
-        "``pfsense.gateway.add`` to define a next-hop -- including a "
-        "pre-staged one (``monitor_disable``) whose upstream device does "
-        "not exist yet -- then ``pfsense.route.static.add`` to point a "
-        "CIDR at it. Both are idempotent (re-adding an existing gateway "
-        "name or route network is a reported no-op) and surgical (they "
-        "touch only the gateway / static-route config, never interfaces), "
-        "so they are safe against a perimeter firewall carrying the "
-        "operator's own access path. Read the current state first with "
-        "``pfsense.gateway.list`` / ``pfsense.config.show``."
+        "Use for pfSense routing-plane provisioning and teardown: appending "
+        "a named gateway (``pfsense.gateway.add``) or a static route "
+        "(``pfsense.route.static.add``) to ``config.xml``, or reversing "
+        "either for a governed teardown -- ``pfsense.route.static.delete`` "
+        "(delete one route by canonical network) and ``pfsense.gateway.delete`` "
+        "(delete one gateway by name, refused fail-closed while any static "
+        "route / gateway group / default-gateway setting still uses it). The "
+        "two ``add`` ops are ``caution`` / no-approval and idempotent (re-adding "
+        "an existing gateway name or route network is a reported no-op); the "
+        "two teardown ops are GOVERNED DESTRUCTIVE deletes (``destructive``, "
+        "mandatory human approval, preview-hash binding, blast-radius "
+        "statement, read-back verify). All are surgical (they touch only the "
+        "gateway / static-route config, never interfaces), so they are safe "
+        "against a perimeter firewall carrying the operator's own access path. "
+        "Read the current state first with ``pfsense.gateway.list`` / "
+        "``pfsense.config.show``."
     ),
 }
 
@@ -718,6 +727,68 @@ class PfSenseConnector(SshConnector):
         )
 
         return await _pfsense_alias_delete(self, target, params, operator)
+
+    async def route_static_delete(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.route.static.delete`` (#3313).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_delete.pfsense_route_static_delete`.
+        Governed destructive delete of one static route by canonical network --
+        the inverse of ``pfsense.route.static.add`` (``safety_level=destructive``
+        / ``requires_approval=True``).
+        """
+        from meho_backplane.connectors.pfsense.ops_delete import (
+            pfsense_route_static_delete as _pfsense_route_static_delete,
+        )
+
+        return await _pfsense_route_static_delete(self, target, params, operator)
+
+    async def gateway_delete(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.gateway.delete`` (#3313).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_delete.pfsense_gateway_delete`.
+        Governed destructive delete of one gateway by exact name, fail-closed on
+        any live reference (static route / gateway group / default-gateway
+        setting) -- the inverse of ``pfsense.gateway.add``
+        (``safety_level=destructive`` / ``requires_approval=True``).
+        """
+        from meho_backplane.connectors.pfsense.ops_delete import (
+            pfsense_gateway_delete as _pfsense_gateway_delete,
+        )
+
+        return await _pfsense_gateway_delete(self, target, params, operator)
+
+    async def alias_member_remove(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.alias.member.remove`` (#3313).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_delete.pfsense_alias_member_remove`.
+        Governed destructive removal of ONE member from a firewall alias without
+        deleting the alias (the shared-alias case), fail-closed on
+        ``not_found`` / ``member_not_found`` / ``ambiguous`` / ``last_member``
+        (``safety_level=destructive`` / ``requires_approval=True``).
+        """
+        from meho_backplane.connectors.pfsense.ops_delete import (
+            pfsense_alias_member_remove as _pfsense_alias_member_remove,
+        )
+
+        return await _pfsense_alias_member_remove(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/pfsense/ops.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops.py
@@ -124,8 +124,10 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
     ``pfsense.config.show``, and ``pfsense.dhcp.leases`` (#2849)) +
     ``WRITE_OPS`` (``pfsense.gateway.add`` and
     ``pfsense.route.static.add``, #3090) + ``DELETE_OPS`` (the governed
-    destructive deletes ``pfsense.nat.delete`` and
-    ``pfsense.alias.delete``, #3232). Thirteen ops total.
+    destructive deletes ``pfsense.nat.delete`` / ``pfsense.alias.delete``
+    (#3232), plus the teardown-inverse deletes
+    ``pfsense.route.static.delete`` / ``pfsense.gateway.delete`` /
+    ``pfsense.alias.member.remove`` (#3313)). Sixteen ops total.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -154,8 +156,10 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
 #: ``pfsense.config.show``); #2849 adds ``pfsense.dhcp.leases``; #3090
 #: adds the first write ops (``pfsense.gateway.add``,
 #: ``pfsense.route.static.add``); #3232 adds the first governed
-#: destructive deletes (``pfsense.nat.delete``, ``pfsense.alias.delete``)
-#: -- 13 ops total. The shape of each follow-on PR is "import a new
+#: destructive deletes (``pfsense.nat.delete``, ``pfsense.alias.delete``);
+#: #3313 adds the teardown-inverse deletes (``pfsense.route.static.delete``,
+#: ``pfsense.gateway.delete``, ``pfsense.alias.member.remove``)
+#: -- 16 ops total. The shape of each follow-on PR is "import a new
 #: module-level tuple and splat it into :data:`PFSENSE_OPS` via
 #: :func:`_pfsense_ops`" -- the registration walk in
 #: :meth:`PfSenseConnector.register_operations` does not need to

--- a/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
@@ -4,9 +4,14 @@
 # op metadata / JSON schemas / llm_instructions) mirroring the ops_write.py sibling's
 # single-module-per-op-group convention; all functions are small + low-complexity.
 
-"""pfSense governed destructive deletes -- NAT-rule + alias delete (#3232).
+"""pfSense governed destructive deletes -- NAT / alias / routing teardown.
 
-Adds the connector's first two ``safety_level="destructive"`` typed ops:
+#3232 shipped the connector's first two ``safety_level="destructive"``
+typed ops (``pfsense.nat.delete`` / ``pfsense.alias.delete``); #3313 adds
+the three **teardown-inverse** ops that reverse a governed bring-up --
+retire a static route, retire a gateway, and trim ONE member out of a
+*shared* alias -- so an environment teardown removes what its bring-up
+created, symmetrically and governed, verified by read-back:
 
 * ``pfsense.nat.delete`` -- permanently delete ONE port-forward NAT rule
   (``config.xml`` ``<nat><rule>``) identified by its stable ``<tracker>``
@@ -18,6 +23,25 @@ Adds the connector's first two ``safety_level="destructive"`` typed ops:
   fail-closed (``referenced``) when the alias is still referenced by any
   filter rule, NAT rule (port-forward / outbound / 1:1), or other alias --
   naming the referrers -- exactly as pfSense's own delete guard does.
+* ``pfsense.route.static.delete`` (#3313) -- the inverse of
+  ``pfsense.route.static.add``. Delete ONE static route
+  (``config.xml`` ``<staticroutes><route>``) by its canonical ``network``
+  (CIDR). Refuses ``not_found`` / ``ambiguous``; applies via ``pfSsh.php
+  playback`` (``write_config`` + ``system_routing_configure``).
+* ``pfsense.gateway.delete`` (#3313) -- the inverse of
+  ``pfsense.gateway.add``. Delete ONE ``gateways/gateway_item`` by exact
+  ``name``, with a fail-closed dependency guard (``referenced``, mirroring
+  ``alias.delete``): refuses -- naming every referrer -- when the gateway
+  is still used by any static route, gateway group, or default-gateway
+  setting, so a gateway is never pulled out from under a live route.
+* ``pfsense.alias.member.remove`` (#3313) -- remove ONE member (host /
+  network entry) from a firewall alias **without deleting the alias** (the
+  shared-alias case: an alias shared across environments keeps its other
+  members and its identity). Refuses ``not_found`` / ``member_not_found`` /
+  ``ambiguous``, and refuses ``last_member`` -- never empties a shared
+  alias into deletion (that is ``alias.delete``'s job). A read-modify-write
+  on ``<address>`` (and its positionally-aligned ``<detail>``), applied via
+  ``filter_configure``, verified by read-back.
 
 Governed-delete tier (the whole point of #3232)
 -----------------------------------------------
@@ -94,16 +118,22 @@ References
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import TYPE_CHECKING, Any
 
 from defusedxml.ElementTree import ParseError, fromstring
 
 from meho_backplane.connectors.pfsense.ops import PfSenseOp
+from meho_backplane.connectors.pfsense.ops_read import parse_gateways_xml
 from meho_backplane.connectors.pfsense.ops_write import (
+    _GATEWAY_NAME_RE,
     _apply_playback,
     _php_squote,
     _read_config_xml,
+    _validate_gateway_name,
+    _validate_network_cidr,
+    parse_static_routes_xml,
 )
 from meho_backplane.operations._preview import PreviewContext, register_preview_builder
 
@@ -114,10 +144,14 @@ if TYPE_CHECKING:
 __all__ = [
     "DELETE_OPS",
     "find_alias_references",
+    "find_gateway_references",
     "parse_aliases_xml",
     "parse_nat_port_forwards_xml",
     "pfsense_alias_delete",
+    "pfsense_alias_member_remove",
+    "pfsense_gateway_delete",
     "pfsense_nat_delete",
+    "pfsense_route_static_delete",
     "register_pfsense_delete_preview_builders",
 ]
 
@@ -130,6 +164,15 @@ _TRACKER_RE = re.compile(r"^[0-9]{1,20}$")
 # ``^[a-zA-Z0-9_]+$``). Bounded + metacharacter-free, so the value is safe
 # to emit into the playback fragment and to compare as a reference token.
 _ALIAS_NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,64}$")
+
+# An alias member (one space-separated ``<address>`` token) is an IP, a
+# CIDR, an FQDN host, or a port / port range. This allowlist covers all of
+# those (letters / digits / dot / colon / slash / dash / underscore) and
+# nothing else -- no whitespace (a member is a single token, never a list),
+# no shell metacharacters, no PHP string-literal terminators -- so the value
+# is safe to emit into the playback fragment and to compare as an exact
+# ``<address>`` token.
+_MEMBER_VALUE_RE = re.compile(r"^[A-Za-z0-9_.:/-]{1,255}$")
 
 
 # ---------------------------------------------------------------------------
@@ -157,6 +200,36 @@ def _validate_alias_name(value: Any) -> str:
             f"underscore); got {value!r}"
         )
     return value
+
+
+def _validate_member_value(value: Any) -> str:
+    """Return *value* if it is a valid alias member token, else raise.
+
+    A member is one ``<address>`` token -- an IP, CIDR, FQDN host, or port /
+    port range. Matched exactly against a stored token (never canonicalised),
+    so ``pfsense.alias.member.remove`` removes precisely the entry the caller
+    named. Allowlist: ``^[A-Za-z0-9_.:/-]{1,255}$`` (no whitespace -- a member
+    is a single token, never a space-separated list).
+    """
+    if not isinstance(value, str) or not _MEMBER_VALUE_RE.match(value):
+        raise ValueError(
+            "member value must match ^[A-Za-z0-9_.:/-]{1,255}$ (a single "
+            "IP / CIDR / host / port token, no spaces); "
+            f"got {value!r}"
+        )
+    return value
+
+
+def _alias_members(address: str | None) -> list[str]:
+    """Split an alias ``<address>`` string into its member tokens.
+
+    pfSense stores an alias's members as a whitespace-separated
+    ``<address>`` string. ``str.split()`` (no args) splits on any whitespace
+    run and drops empties -- matching the ``preg_split('/\\s+/', trim(...))``
+    the removal playback uses, so the Python member count and the PHP one
+    agree.
+    """
+    return (address or "").split()
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +500,100 @@ def find_alias_references(xml_text: str, alias_name: str) -> list[dict[str, Any]
     return refs
 
 
+def _match_static_routes_canonical(xml_text: str, network: str) -> list[dict[str, Any]]:
+    """Return the ``<route>`` rows whose canonical network equals *network*.
+
+    Both the stored network and *network* (already canonical) are reduced to
+    their canonical CIDR form before comparison, so a route stored with host
+    bits set (``10.9.0.5/24``) matches a canonical query (``10.9.0.0/24``).
+    Returns every match so the handler can refuse ``ambiguous`` when two
+    routes canonicalise to the same network. A stored value that will not
+    parse as a network is skipped (it cannot be the delete target).
+    """
+    matches: list[dict[str, Any]] = []
+    for row in parse_static_routes_xml(xml_text):
+        stored = row.get("network")
+        if not isinstance(stored, str):
+            continue
+        try:
+            if str(ipaddress.ip_network(stored.strip(), strict=False)) == network:
+                matches.append(row)
+        except ValueError:
+            continue
+    return matches
+
+
+def find_gateway_references(xml_text: str, gateway_name: str) -> list[dict[str, Any]]:
+    """Return the config objects that reference *gateway_name* (fail-closed guard).
+
+    Scans the reference surface pfSense's own gateway-delete guard checks, so a
+    delete that would pull a gateway out from under a live consumer is refused
+    here too -- **before** any mutation:
+
+    * **Static routes** (``<staticroutes><route>``) -- a route whose
+      ``<gateway>`` names this gateway.
+    * **Gateway groups** (``<gateways><gateway_group>``) -- a group whose
+      ``<item>`` (``GATEWAY|tier|vip``) names this gateway in its first
+      pipe-delimited field.
+    * **Default-gateway setting** -- the modern ``<gateways><defaultgw4>`` /
+      ``<defaultgw6>`` pointer, or the legacy per-item ``<defaultgw/>`` flag on
+      the ``gateway_item`` itself.
+
+    Returns one ``{kind, id, descr}`` row per referrer so the refusal can name
+    every one (``id`` is the route's network, the group name, or the
+    default-gateway setting key). An empty list means the gateway is safe to
+    delete. Returns an empty list on parse failure (the handler's own read /
+    parse guards catch a broken config first).
+    """
+    if not xml_text.strip():
+        return []
+    try:
+        root = fromstring(xml_text)
+    except ParseError:
+        return []
+    refs: list[dict[str, Any]] = []
+
+    # Static routes pointing at the gateway.
+    sr_root = root.find(".//staticroutes")
+    if sr_root is not None:
+        for route in sr_root.findall("route"):
+            if _child_text(route, "gateway") == gateway_name:
+                refs.append(
+                    {
+                        "kind": "static_route",
+                        "id": _child_text(route, "network"),
+                        "descr": _child_text(route, "descr"),
+                    }
+                )
+
+    gw_root = root.find(".//gateways")
+    if gw_root is not None:
+        # Gateway groups listing the gateway as a member.
+        for group in gw_root.findall("gateway_group"):
+            for item in group.findall("item"):
+                token = (item.text or "").split("|", 1)[0].strip()
+                if token == gateway_name:
+                    refs.append(
+                        {
+                            "kind": "gateway_group",
+                            "id": _child_text(group, "name"),
+                            "descr": _child_text(group, "descr"),
+                        }
+                    )
+                    break  # one referrer row per group, however many tiers name it
+        # Modern default-gateway pointers.
+        for tag in ("defaultgw4", "defaultgw6"):
+            dgw = gw_root.find(tag)
+            if dgw is not None and (dgw.text or "").strip() == gateway_name:
+                refs.append({"kind": "default_gateway", "id": tag, "descr": None})
+        # Legacy per-item default flag on the gateway being deleted.
+        for item in gw_root.findall("gateway_item"):
+            if _child_text(item, "name") == gateway_name and item.find("defaultgw") is not None:
+                refs.append({"kind": "default_gateway", "id": "gateway_item_flag", "descr": None})
+
+    return refs
+
+
 # ---------------------------------------------------------------------------
 # pfSsh.php playback fragment construction
 # ---------------------------------------------------------------------------
@@ -488,6 +655,130 @@ def _build_alias_delete_playback(name: str) -> str:
         "}",
         "if ($meho_removed === 1) {",
         f"  write_config({_php_squote('meho: delete alias ' + name)});",
+        "  filter_configure();",
+        "}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _build_route_delete_playback(network_exact: str) -> str:
+    """Return the raw-PHP playback fragment that deletes ONE static route.
+
+    Removes only the ``<staticroutes><route>`` whose ``<network>`` matches
+    *network_exact* (the route's exact stored string -- the handler resolves
+    the canonical query to this single stored value first, so a
+    non-canonical-but-equal stored route is deleted by its real key),
+    reindexes, and persists **only when exactly one** entry was removed
+    (``$meho_removed === 1``). Applies via ``system_routing_configure()``
+    (route-table apply only -- never an interface re-enumeration).
+    """
+    lines = [
+        "global $config;",
+        f"$meho_network = {_php_squote(network_exact)};",
+        "$meho_removed = 0;",
+        "if (is_array($config['staticroutes']) && is_array($config['staticroutes']['route'])) {",
+        "  foreach ($config['staticroutes']['route'] as $meho_i => $meho_r) {",
+        "    if (isset($meho_r['network']) && (string)$meho_r['network'] === $meho_network) {",
+        "      unset($config['staticroutes']['route'][$meho_i]);",
+        "      $meho_removed++;",
+        "    }",
+        "  }",
+        "  if ($meho_removed > 0) {",
+        "    $config['staticroutes']['route'] = array_values($config['staticroutes']['route']);",
+        "  }",
+        "}",
+        "if ($meho_removed === 1) {",
+        f"  write_config({_php_squote('meho: delete static route ' + network_exact)});",
+        "  system_routing_configure();",
+        "}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _build_gateway_delete_playback(name: str) -> str:
+    """Return the raw-PHP playback fragment that deletes ONE gateway_item by name.
+
+    Removes only the ``<gateways><gateway_item>`` whose ``<name>`` matches,
+    reindexes, and persists **only when exactly one** entry was removed.
+    Applies via ``system_routing_configure()`` (routing / gateway apply --
+    never an interface re-enumeration that could stun the operator's path).
+    """
+    lines = [
+        "global $config;",
+        f"$meho_name = {_php_squote(name)};",
+        "$meho_removed = 0;",
+        "if (is_array($config['gateways']) && is_array($config['gateways']['gateway_item'])) {",
+        "  foreach ($config['gateways']['gateway_item'] as $meho_i => $meho_g) {",
+        "    if (isset($meho_g['name']) && (string)$meho_g['name'] === $meho_name) {",
+        "      unset($config['gateways']['gateway_item'][$meho_i]);",
+        "      $meho_removed++;",
+        "    }",
+        "  }",
+        "  if ($meho_removed > 0) {",
+        "    $config['gateways']['gateway_item'] = "
+        "array_values($config['gateways']['gateway_item']);",
+        "  }",
+        "}",
+        "if ($meho_removed === 1) {",
+        f"  write_config({_php_squote('meho: delete gateway ' + name)});",
+        "  system_routing_configure();",
+        "}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _build_alias_member_remove_playback(name: str, value: str) -> str:
+    """Return the raw-PHP fragment that removes ONE member from an alias.
+
+    A read-modify-write on the SHARED alias object: split ``<address>`` on
+    whitespace, drop the **first** token equal to *value* (and its
+    positionally-aligned ``<detail>`` entry), and rejoin -- keeping the alias
+    and every other member. Persists **only when** exactly one alias matched
+    the name (``$meho_matched === 1``) *and* the member removal actually
+    applied (``$meho_applied === 1``, which requires exactly one token
+    removed AND at least one member surviving) -- so an empty-out (last
+    member) never persists, defence-in-depth behind the handler's
+    ``last_member`` refusal. Applies via ``filter_configure()`` (aliases
+    compile into pf tables).
+    """
+    lines = [
+        "global $config;",
+        f"$meho_name = {_php_squote(name)};",
+        f"$meho_value = {_php_squote(value)};",
+        "$meho_matched = 0;",
+        "$meho_applied = 0;",
+        "if (is_array($config['aliases']) && is_array($config['aliases']['alias'])) {",
+        "  foreach ($config['aliases']['alias'] as $meho_i => $meho_a) {",
+        "    if (!isset($meho_a['name']) || (string)$meho_a['name'] !== $meho_name) { continue; }",
+        "    $meho_matched++;",
+        "    $meho_addr = array();",
+        "    if (isset($meho_a['address'])) {",
+        "      foreach (preg_split('/\\s+/', trim((string)$meho_a['address'])) as $meho_t) {",
+        "        if ($meho_t !== '') { $meho_addr[] = $meho_t; }",
+        "      }",
+        "    }",
+        "    $meho_det = isset($meho_a['detail']) ? explode('||', (string)$meho_a['detail']) "
+        ": array();",
+        "    $meho_new_addr = array();",
+        "    $meho_new_det = array();",
+        "    $meho_removed = 0;",
+        "    foreach ($meho_addr as $meho_j => $meho_tok) {",
+        "      if ($meho_tok === $meho_value && $meho_removed === 0) {",
+        "        $meho_removed++;",
+        "        continue;",
+        "      }",
+        "      $meho_new_addr[] = $meho_tok;",
+        "      if (isset($meho_det[$meho_j])) { $meho_new_det[] = $meho_det[$meho_j]; }",
+        "    }",
+        "    if ($meho_removed === 1 && count($meho_new_addr) >= 1) {",
+        "      $config['aliases']['alias'][$meho_i]['address'] = implode(' ', $meho_new_addr);",
+        "      $config['aliases']['alias'][$meho_i]['detail'] = implode('||', $meho_new_det);",
+        "      $meho_applied = 1;",
+        "    }",
+        "  }",
+        "}",
+        "if ($meho_matched === 1 && $meho_applied === 1) {",
+        f"  write_config({_php_squote('meho: remove alias member ' + value + ' from ' + name)});",
         "  filter_configure();",
         "}",
     ]
@@ -701,6 +992,351 @@ async def pfsense_alias_delete(
     }
 
 
+async def pfsense_route_static_delete(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.route.static.delete`` -- inverse of the add op.
+
+    Sequence: validate + canonicalise ``network`` -> read ``config.xml`` ->
+    canonical-match static routes. **Fail-closed pre-check:** 0 matches ->
+    ``not_found``, >1 (two routes canonicalising to the same network) ->
+    ``ambiguous`` (never guess). Exactly one -> stage + play back the
+    delete-by-network fragment (keyed on the route's *exact stored* network
+    string, persisting only on a single removal, then
+    ``system_routing_configure()``), then read ``config.xml`` back and verify
+    the route is **absent** *and* the route count dropped by **exactly one**.
+
+    Returns ``{op_class, resource, status, network, matched, removed,
+    routes_before, routes_after, verified, guidance}``.
+    """
+    network = _validate_network_cidr(params.get("network"))
+
+    before = await _read_config_xml(self, target, operator)
+    routes_before = parse_static_routes_xml(before)
+    matches = _match_static_routes_canonical(before, network)
+
+    result: dict[str, Any] = {
+        "op_class": "delete",
+        "resource": "static_route",
+        "network": network,
+        "matched": len(matches),
+        "removed": None,
+        "routes_before": len(routes_before),
+        "routes_after": None,
+        "verified": False,
+    }
+    if not matches:
+        return {
+            **result,
+            "status": "not_found",
+            "guidance": (
+                f"no static route for network {network!r} in config.xml "
+                f"({len(routes_before)} route(s) present); nothing deleted"
+            ),
+        }
+    if len(matches) > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"{len(matches)} static routes canonicalise to {network!r} "
+                "(corrupt config); refusing to delete -- an operator must "
+                "disambiguate the duplicate routes first"
+            ),
+        }
+
+    route = matches[0]
+    stored_network = route["network"]  # exact stored string -- the PHP delete key
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_route_delete_{_script_token(network)}",
+        script_body=_build_route_delete_playback(stored_network),
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    routes_after = parse_static_routes_xml(after)
+    still_present = bool(_match_static_routes_canonical(after, network))
+    removed_exactly_one = len(routes_after) == len(routes_before) - 1
+    if still_present or not removed_exactly_one:
+        raise RuntimeError(
+            f"route.static.delete verification failed for {network!r}: "
+            f"present_after={still_present}, routes {len(routes_before)}->{len(routes_after)} "
+            "(expected exactly one fewer); the pfSsh.php playback did not persist a "
+            "clean single-route delete"
+        )
+    return {
+        **result,
+        "status": "deleted",
+        "removed": route,
+        "routes_after": len(routes_after),
+        "verified": True,
+        "guidance": None,
+    }
+
+
+async def pfsense_gateway_delete(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.gateway.delete`` -- inverse of the add op.
+
+    Sequence: validate ``name`` -> read ``config.xml`` -> match gateways by
+    exact name. **Fail-closed pre-checks:** 0 matches -> ``not_found``, >1 ->
+    ``ambiguous``; then a **dependency check** (mirrors ``alias.delete``) --
+    if any static route, gateway group, or default-gateway setting still uses
+    the gateway, refuse with ``referenced`` and name every referrer, deleting
+    nothing (so a gateway is never pulled out from under a live route). Only a
+    single, unreferenced gateway is deleted: stage + play back the
+    delete-by-name fragment (persists only on a single removal, then
+    ``system_routing_configure()``), then read ``config.xml`` back and verify
+    the gateway is **absent** *and* the count dropped by **exactly one**. Runs
+    at dispatch time (post-approval), so a reference added between park and
+    approval is still caught.
+
+    Returns ``{op_class, resource, status, name, matched, removed,
+    references, reference_count, gateways_before, gateways_after, verified,
+    guidance}``.
+    """
+    name = _validate_gateway_name(params.get("name"))
+
+    before = await _read_config_xml(self, target, operator)
+    gateways_before = parse_gateways_xml(before)
+    matches = [g for g in gateways_before if g.get("name") == name]
+
+    result: dict[str, Any] = {
+        "op_class": "delete",
+        "resource": "gateway",
+        "name": name,
+        "matched": len(matches),
+        "removed": None,
+        "references": [],
+        "reference_count": 0,
+        "gateways_before": len(gateways_before),
+        "gateways_after": None,
+        "verified": False,
+    }
+    if not matches:
+        return {
+            **result,
+            "status": "not_found",
+            "guidance": (
+                f"no gateway named {name!r} in config.xml "
+                f"({len(gateways_before)} gateway(s) present); nothing deleted"
+            ),
+        }
+    if len(matches) > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"{len(matches)} gateways share the name {name!r} (corrupt config); "
+                "refusing to delete -- an operator must disambiguate first"
+            ),
+        }
+
+    references = find_gateway_references(before, name)
+    if references:
+        referrers = ", ".join(
+            f"{r['kind']}({r.get('id') or '?'}{': ' + r['descr'] if r.get('descr') else ''})"
+            for r in references
+        )
+        return {
+            **result,
+            "status": "referenced",
+            "references": references,
+            "reference_count": len(references),
+            "guidance": (
+                f"gateway {name!r} is still referenced by {len(references)} object(s) "
+                f"[{referrers}]; refusing to delete (fail-closed) -- remove or "
+                "repoint those references first"
+            ),
+        }
+
+    gateway = matches[0]
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_gateway_delete_{_script_token(name)}",
+        script_body=_build_gateway_delete_playback(name),
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    gateways_after = parse_gateways_xml(after)
+    still_present = any(g.get("name") == name for g in gateways_after)
+    removed_exactly_one = len(gateways_after) == len(gateways_before) - 1
+    if still_present or not removed_exactly_one:
+        raise RuntimeError(
+            f"gateway.delete verification failed for {name!r}: present_after={still_present}, "
+            f"gateways {len(gateways_before)}->{len(gateways_after)} (expected exactly one "
+            "fewer); the pfSsh.php playback did not persist a clean single-gateway delete"
+        )
+    return {
+        **result,
+        "status": "deleted",
+        "removed": gateway,
+        "gateways_after": len(gateways_after),
+        "verified": True,
+        "guidance": None,
+    }
+
+
+async def pfsense_alias_member_remove(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``pfsense.alias.member.remove`` -- trim one shared-alias member.
+
+    Removes ONE member from a firewall alias **without deleting the alias**:
+    the shared-alias case, where an alias shared across environments must keep
+    its other members and its identity. Sequence: validate ``name`` + ``value``
+    -> read ``config.xml`` -> match aliases by exact name. **Fail-closed
+    pre-checks:** 0 name matches -> ``not_found``, >1 -> ``ambiguous``; then
+    within the single alias, count occurrences of ``value`` among its members:
+    0 -> ``member_not_found``, >1 -> ``ambiguous`` (a degenerate duplicate,
+    refuse); exactly one -> proceed. **Idempotency + safety:** if that member
+    is the alias's *only* member -> ``last_member`` (never empty a shared
+    alias into deletion -- that is ``alias.delete``'s job). Only a valid,
+    non-last member is removed: stage + play back the read-modify-write
+    fragment (drop the token + its aligned ``<detail>`` entry, then
+    ``filter_configure()``), then read ``config.xml`` back and verify the
+    member is **gone**, the alias is **retained**, and every *other* member
+    survives (the residual set is exactly the prior set minus ``value``).
+
+    Returns ``{op_class, resource, status, alias, value, matched,
+    member_matched, removed, members_before, members_after, residual_members,
+    alias_retained, verified, guidance}``.
+    """
+    name = _validate_alias_name(params.get("name"))
+    value = _validate_member_value(params.get("value"))
+
+    before = await _read_config_xml(self, target, operator)
+    aliases_before = parse_aliases_xml(before)
+    matches = [a for a in aliases_before if a.get("name") == name]
+
+    result: dict[str, Any] = {
+        "op_class": "update",
+        "resource": "alias_member",
+        "alias": name,
+        "value": value,
+        "matched": len(matches),
+        "member_matched": 0,
+        "removed": False,
+        "members_before": None,
+        "members_after": None,
+        "residual_members": None,
+        "alias_retained": None,
+        "verified": False,
+    }
+    if not matches:
+        return {
+            **result,
+            "status": "not_found",
+            "guidance": (
+                f"no alias named {name!r} in config.xml "
+                f"({len(aliases_before)} alias(es) present); nothing removed"
+            ),
+        }
+    if len(matches) > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"{len(matches)} aliases share the name {name!r} (corrupt config); "
+                "refusing to modify -- an operator must disambiguate first"
+            ),
+        }
+
+    alias = matches[0]
+    members = _alias_members(alias.get("address"))
+    occurrences = members.count(value)
+    result["member_matched"] = occurrences
+    result["members_before"] = len(members)
+    if occurrences == 0:
+        return {
+            **result,
+            "status": "member_not_found",
+            "guidance": (
+                f"alias {name!r} has no member {value!r} "
+                f"({len(members)} member(s): {members}); nothing removed"
+            ),
+        }
+    if occurrences > 1:
+        return {
+            **result,
+            "status": "ambiguous",
+            "guidance": (
+                f"member {value!r} appears {occurrences} times in alias {name!r} "
+                "(degenerate duplicate); refusing to modify -- an operator must "
+                "disambiguate first"
+            ),
+        }
+    if len(members) == 1:
+        return {
+            **result,
+            "status": "last_member",
+            "guidance": (
+                f"{value!r} is the ONLY member of alias {name!r}; refusing to remove "
+                "it (fail-closed) -- emptying a shared alias into deletion is not this "
+                "op's job. Use pfsense.alias.delete (with its own dependency guard) to "
+                "delete the whole alias."
+            ),
+        }
+
+    expected_residual = sorted(m for m in members if m != value)
+    await _apply_playback(
+        self,
+        target,
+        script_name=f"meho_alias_member_remove_{_script_token(name)}_{_script_token(value)}",
+        script_body=_build_alias_member_remove_playback(name, value),
+        operator=operator,
+    )
+
+    after = await _read_config_xml(self, target, operator)
+    aliases_after = parse_aliases_xml(after)
+    alias_after = next((a for a in aliases_after if a.get("name") == name), None)
+    alias_retained = alias_after is not None
+    members_after = _alias_members(alias_after.get("address")) if alias_after else []
+    value_gone = value not in members_after
+    dropped_exactly_one = len(members_after) == len(members) - 1
+    others_survived = sorted(members_after) == expected_residual
+    same_alias_count = len(aliases_after) == len(aliases_before)
+    if not (
+        alias_retained
+        and value_gone
+        and dropped_exactly_one
+        and others_survived
+        and same_alias_count
+    ):
+        raise RuntimeError(
+            f"alias.member.remove verification failed for {value!r} in {name!r}: "
+            f"alias_retained={alias_retained}, value_gone={value_gone}, "
+            f"members {len(members)}->{len(members_after)} (expected exactly one fewer), "
+            f"others_survived={others_survived}, aliases {len(aliases_before)}->"
+            f"{len(aliases_after)} (expected unchanged); the pfSsh.php playback did not "
+            "persist a clean single-member removal that retained the shared alias"
+        )
+    return {
+        **result,
+        "status": "removed",
+        "removed": True,
+        "members_after": len(members_after),
+        "residual_members": members_after,
+        "alias_retained": True,
+        "verified": True,
+        "guidance": None,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Blast-radius preview builders (#3197 mandatory destructive-tier block)
 # ---------------------------------------------------------------------------
@@ -821,6 +1457,133 @@ async def _alias_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
+async def _route_static_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Blast-radius builder for ``pfsense.route.static.delete`` (#3197 requirement 3).
+
+    Live-reads ``config.xml`` and, when the ``network`` canonicalises to
+    **exactly one** static route, populates the mandatory blast-radius block:
+    the route identity (canonical network -> gateway, descr). A route has no
+    dependents, so there are no children. Declines (``None`` -> park refused
+    ``blast_radius_required``, fail-closed) when the connector can't be read
+    or the network does not resolve to a unique route.
+    """
+    raw = ctx.params.get("network")
+    if not isinstance(raw, str):
+        return None
+    try:
+        network = _validate_network_cidr(raw)
+    except ValueError:
+        return None
+    xml_text = await _read_config_for_preview(ctx)
+    if xml_text is None:
+        return None
+    matches = _match_static_routes_canonical(xml_text, network)
+    if len(matches) != 1:
+        return None
+    route = matches[0]
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "static_route",
+                "network": network,
+                "gateway": route.get("gateway"),
+                "descr": route.get("descr"),
+            },
+            "children": [],
+            "irreversibility": "permanent",
+        },
+    }
+
+
+async def _gateway_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Blast-radius builder for ``pfsense.gateway.delete`` (#3197 requirement 3).
+
+    Live-reads ``config.xml`` and, when the name resolves to **exactly one**
+    gateway, populates the mandatory blast-radius block: the gateway identity
+    (name / interface / gateway IP / descr) plus, as enumerated children,
+    every object that references it -- with ``reference_count`` surfaced so the
+    approver sees at a glance that the delete will be **refused** at execution
+    (fail-closed) unless those references are removed first (mirrors
+    ``alias.delete``). Declines (``None`` -> park refused
+    ``blast_radius_required``) when the connector can't be read or the name
+    does not resolve to a unique gateway.
+    """
+    name = ctx.params.get("name")
+    if not isinstance(name, str) or not _GATEWAY_NAME_RE.match(name):
+        return None
+    xml_text = await _read_config_for_preview(ctx)
+    if xml_text is None:
+        return None
+    matches = [g for g in parse_gateways_xml(xml_text) if g.get("name") == name]
+    if len(matches) != 1:
+        return None
+    gateway = matches[0]
+    references = find_gateway_references(xml_text, name)
+    children = [
+        {"kind": "reference", "ref_kind": r["kind"], "id": r.get("id"), "descr": r.get("descr")}
+        for r in references
+    ]
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "gateway",
+                "name": name,
+                "interface": gateway.get("interface"),
+                "gateway": gateway.get("gateway"),
+                "descr": gateway.get("descr"),
+            },
+            "children": children,
+            "reference_count": len(references),
+            "irreversibility": "permanent",
+        },
+    }
+
+
+async def _alias_member_remove_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Blast-radius builder for ``pfsense.alias.member.remove`` (#3197 requirement 3).
+
+    Live-reads ``config.xml`` and, when the request resolves to a valid
+    single-member removal -- the alias exists (exactly one), the ``value`` is a
+    unique member, and it is **not** the last member -- populates the mandatory
+    blast-radius block: the member identity (alias name + type + the member
+    being removed) and the ``residual_member_count`` that will survive, with
+    ``alias_retained: true`` making explicit that the alias itself is kept.
+    Declines (``None`` -> park refused ``blast_radius_required``, fail-closed)
+    for any non-removable request (absent alias, absent / duplicate / last
+    member) or an unreadable connector, so only a currently-valid removal ever
+    parks.
+    """
+    name = ctx.params.get("name")
+    value = ctx.params.get("value")
+    if not isinstance(name, str) or not _ALIAS_NAME_RE.match(name):
+        return None
+    if not isinstance(value, str) or not _MEMBER_VALUE_RE.match(value):
+        return None
+    xml_text = await _read_config_for_preview(ctx)
+    if xml_text is None:
+        return None
+    matches = [a for a in parse_aliases_xml(xml_text) if a.get("name") == name]
+    if len(matches) != 1:
+        return None
+    members = _alias_members(matches[0].get("address"))
+    if members.count(value) != 1 or len(members) <= 1:
+        return None
+    return {
+        "blast_radius": {
+            "object": {
+                "kind": "alias_member",
+                "alias": name,
+                "type": matches[0].get("type"),
+                "member": value,
+            },
+            "children": [],
+            "residual_member_count": len(members) - 1,
+            "alias_retained": True,
+            "irreversibility": "permanent",
+        },
+    }
+
+
 def register_pfsense_delete_preview_builders() -> None:
     """Wire the destructive-delete blast-radius builders. Import-time.
 
@@ -832,6 +1595,9 @@ def register_pfsense_delete_preview_builders() -> None:
     """
     register_preview_builder("pfsense.nat.delete", _nat_delete_preview)
     register_preview_builder("pfsense.alias.delete", _alias_delete_preview)
+    register_preview_builder("pfsense.route.static.delete", _route_static_delete_preview)
+    register_preview_builder("pfsense.gateway.delete", _gateway_delete_preview)
+    register_preview_builder("pfsense.alias.member.remove", _alias_member_remove_preview)
 
 
 # ---------------------------------------------------------------------------
@@ -988,10 +1754,257 @@ _ALIAS_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
     ),
 }
 
+#: Curated ``when_to_use`` for the ``routing`` group's destructive route delete.
+_ROUTE_DELETE_WHEN_TO_USE = (
+    "Permanently delete ONE pfSense static route by its canonical ``network`` "
+    "(CIDR) -- the inverse of ``pfsense.route.static.add``, for a governed "
+    "environment teardown. GOVERNED DESTRUCTIVE DELETE (same tier + gate as "
+    "``pfsense.nat.delete``). Fail-closed: refuses on 0 matches (``not_found``) "
+    "or >1 (``ambiguous`` -- two routes canonicalising to the same network); "
+    "never guesses. Deletes exactly one route (``write_config`` + "
+    "``system_routing_configure``) and verifies it is gone and the count "
+    "dropped by one."
+)
+
+#: Curated ``when_to_use`` for the ``routing`` group's destructive gateway delete.
+_GATEWAY_DELETE_WHEN_TO_USE = (
+    "Permanently delete ONE pfSense gateway by exact ``name`` -- the inverse "
+    "of ``pfsense.gateway.add``, for a governed environment teardown. GOVERNED "
+    "DESTRUCTIVE DELETE. Fail-closed dependency check (mirrors "
+    "``pfsense.alias.delete``): refuses (``referenced``) when the gateway is "
+    "still used by any static route, gateway group, or default-gateway "
+    "setting, naming every referrer -- remove or repoint those first so a "
+    "gateway is never pulled out from under a live route. Also refuses on 0 "
+    "matches (``not_found``) or >1 (``ambiguous``). Deletes exactly one gateway "
+    "(``write_config`` + ``system_routing_configure``) and verifies the count "
+    "dropped by one."
+)
+
+#: Curated ``when_to_use`` for the ``alias`` group's shared-member removal.
+_ALIAS_MEMBER_REMOVE_WHEN_TO_USE = (
+    "Remove ONE member (host / network entry) from a pfSense firewall alias "
+    "WITHOUT deleting the alias -- the shared-alias teardown case, where an "
+    "alias shared across environments must keep its other members and its "
+    "identity while one environment's entry is trimmed out. GOVERNED "
+    "DESTRUCTIVE op (safety_level=destructive, mandatory human approval, "
+    "preview-hash binding, blast-radius statement). Fail-closed: refuses "
+    "``not_found`` (alias absent), ``member_not_found`` (the value is not a "
+    "member), ``ambiguous`` (duplicate alias name or duplicate member), and "
+    "``last_member`` -- it never empties a shared alias into deletion (deleting "
+    "the whole alias is ``pfsense.alias.delete``'s job, with its own dependency "
+    "guard). Removes exactly the named member (``write_config`` + "
+    "``filter_configure``) and verifies the member is gone, the alias is "
+    "retained, and every other member survives."
+)
+
+_ROUTE_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "network": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Destination network in CIDR form, e.g. ``10.9.0.0/24``. "
+                "Canonicalised to the network address before matching (so "
+                "``10.9.0.5/24`` matches the route stored as ``10.9.0.0/24``). "
+                "A network matching 0 routes is ``not_found``; >1 "
+                "(corrupt config) is ``ambiguous`` and refused."
+            ),
+        },
+    },
+    "required": ["network"],
+    "additionalProperties": False,
+}
+
+_ROUTE_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["delete"]},
+        "resource": {"type": "string", "enum": ["static_route"]},
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_found", "ambiguous"],
+            "description": (
+                "``deleted`` on a verified single-route delete; ``not_found`` "
+                "when no route matches the network; ``ambiguous`` when >1 do "
+                "(refused, fail-closed)."
+            ),
+        },
+        "network": {"type": "string"},
+        "matched": {"type": "integer"},
+        "removed": {"type": ["object", "null"]},
+        "routes_before": {"type": ["integer", "null"]},
+        "routes_after": {"type": ["integer", "null"]},
+        "verified": {"type": "boolean"},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["op_class", "resource", "status", "network", "matched", "verified"],
+    "additionalProperties": False,
+}
+
+_ROUTE_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": _ROUTE_DELETE_WHEN_TO_USE,
+    "parameter_hints": {
+        "network": "Required. Destination CIDR, e.g. ``10.9.0.0/24`` (canonicalised).",
+    },
+    "output_shape": (
+        "``{op_class: 'delete', resource: 'static_route', status, network, "
+        "matched, removed, routes_before, routes_after, verified, guidance}``. "
+        "``status`` is ``deleted`` / ``not_found`` / ``ambiguous``. On "
+        "``deleted``, ``removed`` carries the deleted route (network -> "
+        "gateway) and ``verified`` is true (config read back: route absent, "
+        "count -1)."
+    ),
+}
+
+_GATEWAY_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$",
+            "description": (
+                "Exact name of the ONE gateway to delete. Refused "
+                "(``referenced``) when still used by any static route, gateway "
+                "group, or default-gateway setting; ``not_found`` when absent."
+            ),
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+_GATEWAY_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["delete"]},
+        "resource": {"type": "string", "enum": ["gateway"]},
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_found", "ambiguous", "referenced"],
+            "description": (
+                "``deleted`` on a verified single-gateway delete; ``not_found`` "
+                "when absent; ``ambiguous`` on a duplicate name; ``referenced`` "
+                "when still in use (refused, fail-closed, with the referrers "
+                "named in ``references``)."
+            ),
+        },
+        "name": {"type": "string"},
+        "matched": {"type": "integer"},
+        "removed": {"type": ["object", "null"]},
+        "references": {"type": "array", "items": {"type": "object"}},
+        "reference_count": {"type": "integer"},
+        "gateways_before": {"type": ["integer", "null"]},
+        "gateways_after": {"type": ["integer", "null"]},
+        "verified": {"type": "boolean"},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["op_class", "resource", "status", "name", "matched", "verified"],
+    "additionalProperties": False,
+}
+
+_GATEWAY_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": _GATEWAY_DELETE_WHEN_TO_USE,
+    "parameter_hints": {
+        "name": "Required. Exact gateway name (alphanumeric / dash / underscore).",
+    },
+    "output_shape": (
+        "``{op_class: 'delete', resource: 'gateway', status, name, matched, "
+        "removed, references, reference_count, gateways_before, gateways_after, "
+        "verified, guidance}``. On ``referenced``, ``references`` names every "
+        "static route / gateway group / default-gateway setting still using "
+        "the gateway. On ``deleted``, ``removed`` carries the deleted gateway "
+        "and ``verified`` is true."
+    ),
+}
+
+_ALIAS_MEMBER_REMOVE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_]{1,64}$",
+            "description": (
+                "Exact name of the firewall alias to trim. The alias is "
+                "retained; only the named member is removed. ``not_found`` "
+                "when absent."
+            ),
+        },
+        "value": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.:/-]{1,255}$",
+            "description": (
+                "The exact member entry to remove -- one ``<address>`` token "
+                "(an IP, CIDR, host, or port). Matched exactly (never "
+                "canonicalised). ``member_not_found`` when not a member; "
+                "``last_member`` when it is the alias's only member (refused "
+                "-- use ``pfsense.alias.delete`` to delete the whole alias)."
+            ),
+        },
+    },
+    "required": ["name", "value"],
+    "additionalProperties": False,
+}
+
+_ALIAS_MEMBER_REMOVE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "op_class": {"type": "string", "enum": ["update"]},
+        "resource": {"type": "string", "enum": ["alias_member"]},
+        "status": {
+            "type": "string",
+            "enum": ["removed", "not_found", "member_not_found", "ambiguous", "last_member"],
+            "description": (
+                "``removed`` on a verified single-member removal that retained "
+                "the alias; ``not_found`` when the alias is absent; "
+                "``member_not_found`` when the value is not a member; "
+                "``ambiguous`` on a duplicate alias name or duplicate member; "
+                "``last_member`` when the value is the alias's only member "
+                "(refused, fail-closed)."
+            ),
+        },
+        "alias": {"type": "string"},
+        "value": {"type": "string"},
+        "matched": {"type": "integer"},
+        "member_matched": {"type": "integer"},
+        "removed": {"type": "boolean"},
+        "members_before": {"type": ["integer", "null"]},
+        "members_after": {"type": ["integer", "null"]},
+        "residual_members": {"type": ["array", "null"], "items": {"type": "string"}},
+        "alias_retained": {"type": ["boolean", "null"]},
+        "verified": {"type": "boolean"},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["op_class", "resource", "status", "alias", "value", "matched", "verified"],
+    "additionalProperties": False,
+}
+
+_ALIAS_MEMBER_REMOVE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": _ALIAS_MEMBER_REMOVE_WHEN_TO_USE,
+    "parameter_hints": {
+        "name": "Required. Exact alias name (alphanumeric / underscore).",
+        "value": (
+            "Required. The exact member entry to remove -- one IP / CIDR / host "
+            "/ port token, matched exactly against the alias's members."
+        ),
+    },
+    "output_shape": (
+        "``{op_class: 'update', resource: 'alias_member', status, alias, "
+        "value, matched, member_matched, removed, members_before, "
+        "members_after, residual_members, alias_retained, verified, "
+        "guidance}``. On ``removed``, the alias is retained, "
+        "``residual_members`` lists the surviving members, ``alias_retained`` "
+        "is true, and ``verified`` is true (config read back: member gone, "
+        "others intact, alias count unchanged)."
+    ),
+}
+
 #: The governed destructive-delete ops :class:`PfSenseConnector` registers
-#: alongside the read + additive-write surface. Both are
-#: ``safety_level='destructive'`` / ``requires_approval=True`` (#3232) --
-#: the connector's first ops on the governed-delete tier.
+#: alongside the read + additive-write surface. All are
+#: ``safety_level='destructive'`` / ``requires_approval=True`` -- the
+#: governed-delete tier. #3232 shipped ``nat.delete`` + ``alias.delete``;
+#: #3313 adds the three teardown-inverse ops (``route.static.delete``,
+#: ``gateway.delete``, ``alias.member.remove``).
 DELETE_OPS: tuple[PfSenseOp, ...] = (
     PfSenseOp(
         op_id="pfsense.nat.delete",
@@ -1048,6 +2061,93 @@ DELETE_OPS: tuple[PfSenseOp, ...] = (
         safety_level="destructive",
         requires_approval=True,
         llm_instructions=_ALIAS_DELETE_LLM_INSTRUCTIONS,
+    ),
+    PfSenseOp(
+        op_id="pfsense.route.static.delete",
+        handler_attr="route_static_delete",
+        summary="Permanently delete ONE static route by canonical network (governed).",
+        description=(
+            "Governed destructive delete of a single pfSense static route "
+            "(``config.xml`` ``<staticroutes><route>``) by its canonical "
+            "``network`` (CIDR) -- the inverse of ``pfsense.route.static.add``, "
+            "for a governed environment teardown. safety_level=destructive "
+            "(same tier + gate as ``pfsense.nat.delete``): mandatory human "
+            "approval, a preview-hash binding, and a blast-radius statement "
+            "(the route's network -> gateway). Fail-closed: 0 matches -> "
+            "``not_found``, >1 (two routes canonicalising to the same network) "
+            "-> ``ambiguous`` (never guesses). Deletes exactly one route via "
+            "``pfSsh.php playback`` (``write_config`` + "
+            "``system_routing_configure``) and verifies the route is gone and "
+            "the count dropped by exactly one. Surgical: touches only "
+            "``staticroutes/route``, never interface config."
+        ),
+        parameter_schema=_ROUTE_DELETE_PARAMETER_SCHEMA,
+        response_schema=_ROUTE_DELETE_RESPONSE_SCHEMA,
+        group_key="routing",
+        tags=("write", "routing", "static-route", "delete", "destructive", "pfsense"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=_ROUTE_DELETE_LLM_INSTRUCTIONS,
+    ),
+    PfSenseOp(
+        op_id="pfsense.gateway.delete",
+        handler_attr="gateway_delete",
+        summary="Permanently delete ONE gateway by exact name (governed, fail-closed).",
+        description=(
+            "Governed destructive delete of a single pfSense gateway "
+            "(``config.xml`` ``<gateways><gateway_item>``) by exact ``name`` -- "
+            "the inverse of ``pfsense.gateway.add``, for a governed environment "
+            "teardown. safety_level=destructive (same tier + gate as "
+            "``pfsense.nat.delete``). Fail-closed dependency check (mirrors "
+            "``pfsense.alias.delete``): refuses (``referenced``) when the "
+            "gateway is still used by any static route, gateway group, or "
+            "default-gateway setting -- naming every referrer -- so a gateway is "
+            "never pulled out from under a live route. Also refuses on 0 "
+            "matches (``not_found``) or >1 (``ambiguous``). The blast-radius "
+            "statement names the gateway + its reference count. Deletes exactly "
+            "one gateway via ``pfSsh.php playback`` (``write_config`` + "
+            "``system_routing_configure``) and verifies it is gone and the "
+            "count dropped by exactly one."
+        ),
+        parameter_schema=_GATEWAY_DELETE_PARAMETER_SCHEMA,
+        response_schema=_GATEWAY_DELETE_RESPONSE_SCHEMA,
+        group_key="routing",
+        tags=("write", "routing", "gateway", "delete", "destructive", "pfsense"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=_GATEWAY_DELETE_LLM_INSTRUCTIONS,
+    ),
+    PfSenseOp(
+        op_id="pfsense.alias.member.remove",
+        handler_attr="alias_member_remove",
+        summary="Remove ONE member from a firewall alias, keeping the shared alias (governed).",
+        description=(
+            "Governed destructive removal of ONE member (host / network entry) "
+            "from a pfSense firewall alias (``config.xml`` "
+            "``<aliases><alias>``) WITHOUT deleting the alias -- the shared-alias "
+            "teardown case, where an alias shared across environments keeps its "
+            "other members and its identity while one environment's entry is "
+            "trimmed out. safety_level=destructive (same tier + gate as "
+            "``pfsense.nat.delete``): mandatory human approval, a preview-hash "
+            "binding, and a blast-radius statement (the alias + the member "
+            "being removed + the residual member count). A read-modify-write on "
+            "``<address>`` (and its positionally-aligned ``<detail>``). "
+            "Fail-closed: refuses ``not_found`` (alias absent), "
+            "``member_not_found`` (value not a member), ``ambiguous`` "
+            "(duplicate alias name or duplicate member), and ``last_member`` -- "
+            "never empties a shared alias into deletion (that is "
+            "``pfsense.alias.delete``'s job). Removes exactly the named member "
+            "via ``pfSsh.php playback`` (``write_config`` + ``filter_configure``) "
+            "and verifies the member is gone, the alias is retained, and every "
+            "other member survives."
+        ),
+        parameter_schema=_ALIAS_MEMBER_REMOVE_PARAMETER_SCHEMA,
+        response_schema=_ALIAS_MEMBER_REMOVE_RESPONSE_SCHEMA,
+        group_key="alias",
+        tags=("write", "alias", "member", "delete", "destructive", "pfsense"),
+        safety_level="destructive",
+        requires_approval=True,
+        llm_instructions=_ALIAS_MEMBER_REMOVE_LLM_INSTRUCTIONS,
     ),
 )
 

--- a/backend/tests/test_connectors_pfsense_delete_ops.py
+++ b/backend/tests/test_connectors_pfsense_delete_ops.py
@@ -503,8 +503,8 @@ def test_delete_ops_are_destructive_requires_approval_with_tag() -> None:
     assert seen == delete_ids
 
 
-def test_pfsense_op_count_is_thirteen() -> None:
-    assert len(PFSENSE_OPS) == 13
+def test_pfsense_op_count_is_sixteen() -> None:
+    assert len(PFSENSE_OPS) == 16
 
 
 def test_delete_ops_group_keys() -> None:

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -302,11 +302,21 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
 #: (covered by ``test_connectors_pfsense_write_ops.py``).
 _WRITE_OP_IDS: frozenset[str] = frozenset({"pfsense.gateway.add", "pfsense.route.static.add"})
 
-#: The governed destructive deletes (#3232). Also held separate from the
-#: dispatch/audit sweep: they are ``safety_level='destructive'`` /
-#: ``requires_approval=True`` and take real params, so they park rather than
-#: execute inline (covered by ``test_connectors_pfsense_delete_ops.py``).
-_DELETE_OP_IDS: frozenset[str] = frozenset({"pfsense.nat.delete", "pfsense.alias.delete"})
+#: The governed destructive deletes (#3232 nat/alias; #3313 the three
+#: teardown-inverse ops). Also held separate from the dispatch/audit sweep:
+#: they are ``safety_level='destructive'`` / ``requires_approval=True`` and
+#: take real params, so they park rather than execute inline (covered by
+#: ``test_connectors_pfsense_delete_ops.py`` /
+#: ``test_connectors_pfsense_teardown_ops.py``).
+_DELETE_OP_IDS: frozenset[str] = frozenset(
+    {
+        "pfsense.nat.delete",
+        "pfsense.alias.delete",
+        "pfsense.route.static.delete",
+        "pfsense.gateway.delete",
+        "pfsense.alias.member.remove",
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Target + connector seeding helpers
@@ -418,11 +428,11 @@ async def pfsense_e2e(
 
 
 def test_pfsense_ops_registration_count() -> None:
-    """All 13 pfSense ops registered (9 read/identity + 2 write + 2 delete)."""
+    """All 16 pfSense ops registered (9 read/identity + 2 write + 5 delete)."""
     op_ids = {op.op_id for op in PFSENSE_OPS}
     missing = (set(EXPECTED_OP_IDS) | _WRITE_OP_IDS | _DELETE_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(PFSENSE_OPS) == 13, f"Expected 13 ops, got {len(PFSENSE_OPS)}"
+    assert len(PFSENSE_OPS) == 16, f"Expected 16 ops, got {len(PFSENSE_OPS)}"
 
 
 def test_pfsense_ops_safety_levels_and_approval() -> None:

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -1040,9 +1040,10 @@ async def test_pfsense_dhcp_leases_response_schema_matches_handler_rows() -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_pfsense_ops_has_thirteen_entries() -> None:
-    """canary + 7 reads + dhcp.leases (#2849) + 2 writes (#3090) + 2 deletes (#3232) = 13."""
-    assert len(PFSENSE_OPS) == 13
+def test_pfsense_ops_has_sixteen_entries() -> None:
+    """canary + 7 reads + dhcp.leases (#2849) + 2 writes (#3090) + 2 deletes (#3232)
+    + 3 teardown-inverse deletes (#3313) = 16."""
+    assert len(PFSENSE_OPS) == 16
 
 
 def test_pfsense_ops_about_is_first() -> None:
@@ -1058,9 +1059,16 @@ def test_pfsense_ops_all_have_pfsense_namespace() -> None:
 #: write), unlike the read/identity surface which is ``safe``.
 _WRITE_OP_IDS = {"pfsense.gateway.add", "pfsense.route.static.add"}
 
-#: The governed destructive deletes (#3232) -- classified ``destructive``
-#: and the only ops that require approval.
-_DELETE_OP_IDS = {"pfsense.nat.delete", "pfsense.alias.delete"}
+#: The governed destructive deletes (#3232 nat/alias; #3313 the three
+#: teardown-inverse ops) -- classified ``destructive`` and the only ops that
+#: require approval.
+_DELETE_OP_IDS = {
+    "pfsense.nat.delete",
+    "pfsense.alias.delete",
+    "pfsense.route.static.delete",
+    "pfsense.gateway.delete",
+    "pfsense.alias.member.remove",
+}
 
 
 def test_pfsense_read_ops_safe_write_ops_caution_delete_ops_destructive() -> None:
@@ -1108,6 +1116,9 @@ def test_pfsense_ops_covers_expected_op_ids() -> None:
         "pfsense.route.static.add",
         "pfsense.nat.delete",
         "pfsense.alias.delete",
+        "pfsense.route.static.delete",
+        "pfsense.gateway.delete",
+        "pfsense.alias.member.remove",
     }
     assert op_ids == expected
 

--- a/backend/tests/test_connectors_pfsense_teardown_ops.py
+++ b/backend/tests/test_connectors_pfsense_teardown_ops.py
@@ -1,0 +1,1077 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the pfSense teardown-inverse destructive ops (#3313).
+
+Covers the three ``safety_level="destructive"`` ops that reverse a governed
+bring-up -- ``pfsense.route.static.delete``, ``pfsense.gateway.delete``, and
+``pfsense.alias.member.remove`` -- across three layers:
+
+* **Unit** (mocked ``_run_command``): the canonical route matcher, the
+  fail-closed gateway reference scan, the member-token split, the
+  delete/remove playback fragments, input validation, and the handler happy /
+  refusal / verify-failure paths (0-match ``not_found``, ambiguous, gateway
+  ``referenced``, member ``member_not_found`` / ``last_member`` / duplicate).
+  The ``alias.member.remove`` shared-alias path is tested hardest: a fixture
+  proving the alias identity + every *other* member survive a single-member
+  removal.
+* **Metadata**: registration classification (destructive + requires_approval
+  + ``destructive`` tag + group), response-schema conformance, and proof the
+  ops fold into the destructive-tier service-grant refusal -- including
+  ``alias.member.remove`` whose op-id does **not** end in ``.delete`` yet is
+  still refused via its ``destructive`` safety level / tag.
+* **Governed-flow conformance** (full ``call_operation`` dispatch against a
+  seeded recording connector): preview -> park (hash + blast radius) ->
+  distinct-human approve -> audited resume, plus the fail-closed post-approval
+  re-check (referenced gateway) and the park-refused-without-blast-radius path
+  for a non-resolving target.
+
+All config.xml fixtures are synthetic (RFC 5737 / RFC 1918 addresses, no lab
+hostnames / IPs / VLANs) -- the public repo must never carry lab values.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from jsonschema import Draft202012Validator
+from sqlalchemy import func, select
+
+import meho_backplane.connectors.pfsense  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
+from meho_backplane.connectors.pfsense.ops_delete import (
+    _build_alias_member_remove_playback,
+    _build_gateway_delete_playback,
+    _build_route_delete_playback,
+    _match_static_routes_canonical,
+    find_gateway_references,
+)
+from meho_backplane.connectors.registry import all_connectors_v2, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.approval_queue import (
+    approve_request,
+    resume_dispatch_after_approval,
+)
+from meho_backplane.operations.meta_tools import call_operation, preview_operation
+from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
+from meho_backplane.operations.service_grants import (
+    GrantValidationError,
+    ServicePrincipalGrantService,
+)
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "pfsense-ssh-2.7"
+_TENANT_ID = UUID("00000000-0000-0000-0000-000000003313")
+_ROUTE_OP = "pfsense.route.static.delete"
+_GATEWAY_OP = "pfsense.gateway.delete"
+_MEMBER_OP = "pfsense.alias.member.remove"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic config.xml fixtures (RFC 5737 / RFC 1918 -- no lab values)
+# ---------------------------------------------------------------------------
+
+# Two static routes (both -> LAB_GW), two gateways (LAB_GW referenced,
+# RETIRING_GW unreferenced), a gateway group + default-gateway pointer.
+_CONFIG_ROUTING = (
+    "<pfsense>"
+    "<staticroutes>"
+    "<route><network>10.10.0.0/24</network><gateway>LAB_GW</gateway><descr>lab net</descr></route>"
+    "<route><network>10.20.0.0/24</network><gateway>LAB_GW</gateway><descr>svc net</descr></route>"
+    "</staticroutes>"
+    "<gateways>"
+    "<gateway_item><name>LAB_GW</name><interface>opt1</interface>"
+    "<gateway>192.0.2.1</gateway><descr>lab gw</descr></gateway_item>"
+    "<gateway_item><name>RETIRING_GW</name><interface>opt2</interface>"
+    "<gateway>192.0.2.2</gateway><descr>retiring</descr></gateway_item>"
+    "<gateway_group><name>FAILOVER</name><item>LAB_GW|1</item><item>WAN_DHCP|2</item>"
+    "<descr>failover grp</descr></gateway_group>"
+    "<defaultgw4>WAN_DHCP</defaultgw4>"
+    "</gateways>"
+    "</pfsense>"
+)
+# After deleting route 10.10.0.0/24 (one route remains).
+_CONFIG_ROUTING_NO_ROUTE = _CONFIG_ROUTING.replace(
+    "<route><network>10.10.0.0/24</network><gateway>LAB_GW</gateway><descr>lab net</descr></route>",
+    "",
+)
+# After deleting the unreferenced RETIRING_GW gateway.
+_CONFIG_ROUTING_NO_RETIRING_GW = _CONFIG_ROUTING.replace(
+    "<gateway_item><name>RETIRING_GW</name><interface>opt2</interface>"
+    "<gateway>192.0.2.2</gateway><descr>retiring</descr></gateway_item>",
+    "",
+)
+# Two routes canonicalising to the same network (corrupt -> ambiguous).
+_CONFIG_DUP_ROUTE = (
+    "<pfsense><staticroutes>"
+    "<route><network>10.10.0.0/24</network><gateway>LAB_GW</gateway></route>"
+    "<route><network>10.10.0.5/24</network><gateway>LAB_GW</gateway></route>"
+    "</staticroutes></pfsense>"
+)
+# Two gateways sharing a name (corrupt -> ambiguous).
+_CONFIG_DUP_GW = (
+    "<pfsense><gateways>"
+    "<gateway_item><name>DUP_GW</name><interface>opt1</interface>"
+    "<gateway>192.0.2.1</gateway></gateway_item>"
+    "<gateway_item><name>DUP_GW</name><interface>opt2</interface>"
+    "<gateway>192.0.2.2</gateway></gateway_item>"
+    "</gateways></pfsense>"
+)
+
+# A SHARED host alias with three members (+ aligned detail) and a separate
+# single-member alias (SOLO) that exercises the last_member refusal.
+_CONFIG_SHARED_ALIAS = (
+    "<pfsense><aliases>"
+    "<alias><name>SHARED_HOSTS</name><type>host</type>"
+    "<address>192.0.2.10 192.0.2.11 198.51.100.5</address>"
+    "<detail>env-a||env-b||env-c</detail><descr>shared</descr></alias>"
+    "<alias><name>SOLO</name><type>host</type>"
+    "<address>203.0.113.9</address><detail>only one</detail></alias>"
+    "</aliases></pfsense>"
+)
+# After removing 198.51.100.5 from SHARED_HOSTS: the alias survives with its
+# two other members (and aligned detail); SOLO is untouched; count unchanged.
+_CONFIG_SHARED_ALIAS_AFTER = (
+    "<pfsense><aliases>"
+    "<alias><name>SHARED_HOSTS</name><type>host</type>"
+    "<address>192.0.2.10 192.0.2.11</address>"
+    "<detail>env-a||env-b</detail><descr>shared</descr></alias>"
+    "<alias><name>SOLO</name><type>host</type>"
+    "<address>203.0.113.9</address><detail>only one</detail></alias>"
+    "</aliases></pfsense>"
+)
+# A degenerate alias carrying the same member twice (-> ambiguous).
+_CONFIG_DUP_MEMBER = (
+    "<pfsense><aliases>"
+    "<alias><name>SHARED_HOSTS</name><type>host</type>"
+    "<address>192.0.2.10 198.51.100.5 198.51.100.5</address>"
+    "<detail>env-a||env-c||env-c2</detail></alias>"
+    "</aliases></pfsense>"
+)
+# Two aliases sharing a name (-> ambiguous).
+_CONFIG_DUP_ALIAS = (
+    "<pfsense><aliases>"
+    "<alias><name>SHARED_HOSTS</name><type>host</type><address>192.0.2.10</address></alias>"
+    "<alias><name>SHARED_HOSTS</name><type>host</type><address>192.0.2.11</address></alias>"
+    "</aliases></pfsense>"
+)
+
+
+# ---------------------------------------------------------------------------
+# Environment fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Unit-test stubs
+# ---------------------------------------------------------------------------
+
+
+def _proc(stdout: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.exit_status = exit_status
+    return proc
+
+
+def _cmds(mock_cmd: AsyncMock) -> list[str]:
+    return [call.args[1] for call in mock_cmd.await_args_list]
+
+
+# ===========================================================================
+# Part A -- unit: canonical route matcher + gateway reference scan + members
+# ===========================================================================
+
+
+def test_match_static_routes_canonical_matches_host_bits_set() -> None:
+    # Query is canonical; a stored route with host bits set still matches.
+    assert len(_match_static_routes_canonical(_CONFIG_ROUTING, "10.10.0.0/24")) == 1
+    assert len(_match_static_routes_canonical(_CONFIG_DUP_ROUTE, "10.10.0.0/24")) == 2
+    assert _match_static_routes_canonical(_CONFIG_ROUTING, "10.99.0.0/24") == []
+
+
+def test_find_gateway_references_route_and_group() -> None:
+    refs = find_gateway_references(_CONFIG_ROUTING, "LAB_GW")
+    kinds = sorted(r["kind"] for r in refs)
+    # Two static routes + one gateway group name it.
+    assert kinds == ["gateway_group", "static_route", "static_route"]
+    ids = {(r["kind"], r["id"]) for r in refs}
+    assert ("gateway_group", "FAILOVER") in ids
+    assert ("static_route", "10.10.0.0/24") in ids
+
+
+def test_find_gateway_references_default_gateway_pointer() -> None:
+    # WAN_DHCP is the default-gateway pointer AND a gateway-group member.
+    refs = find_gateway_references(_CONFIG_ROUTING, "WAN_DHCP")
+    kinds = sorted(r["kind"] for r in refs)
+    assert kinds == ["default_gateway", "gateway_group"]
+    assert any(r["kind"] == "default_gateway" and r["id"] == "defaultgw4" for r in refs)
+
+
+def test_find_gateway_references_legacy_defaultgw_flag() -> None:
+    cfg = (
+        "<pfsense><gateways>"
+        "<gateway_item><name>OLD_GW</name><gateway>192.0.2.9</gateway><defaultgw></defaultgw>"
+        "</gateway_item></gateways></pfsense>"
+    )
+    refs = find_gateway_references(cfg, "OLD_GW")
+    assert [(r["kind"], r["id"]) for r in refs] == [("default_gateway", "gateway_item_flag")]
+
+
+def test_find_gateway_references_unreferenced_is_empty() -> None:
+    assert find_gateway_references(_CONFIG_ROUTING, "RETIRING_GW") == []
+    assert find_gateway_references("", "LAB_GW") == []
+    assert find_gateway_references("<broken", "LAB_GW") == []
+
+
+# ===========================================================================
+# Part A -- unit: playback fragments delete/remove exactly one, safely
+# ===========================================================================
+
+
+def test_route_delete_playback_is_single_object_and_safe() -> None:
+    frag = _build_route_delete_playback("10.10.0.0/24")
+    assert "$meho_network = '10.10.0.0/24';" in frag
+    assert "if ($meho_removed === 1) {" in frag
+    assert "write_config('meho: delete static route 10.10.0.0/24');" in frag
+    assert "system_routing_configure();" in frag
+    assert "<?php" not in frag
+    assert "\nexec" not in frag
+
+
+def test_gateway_delete_playback_is_single_object_and_safe() -> None:
+    frag = _build_gateway_delete_playback("RETIRING_GW")
+    assert "$meho_name = 'RETIRING_GW';" in frag
+    assert "if ($meho_removed === 1) {" in frag
+    assert "write_config('meho: delete gateway RETIRING_GW');" in frag
+    assert "system_routing_configure();" in frag
+    assert "<?php" not in frag
+
+
+def test_alias_member_remove_playback_is_surgical_and_safe() -> None:
+    frag = _build_alias_member_remove_playback("SHARED_HOSTS", "198.51.100.5")
+    assert "$meho_name = 'SHARED_HOSTS';" in frag
+    assert "$meho_value = '198.51.100.5';" in frag
+    # Persists only when exactly one alias matched AND the removal applied
+    # (which requires a surviving member -> never empties a shared alias).
+    assert "if ($meho_matched === 1 && $meho_applied === 1) {" in frag
+    assert "count($meho_new_addr) >= 1" in frag
+    # Detail is realigned positionally alongside the address tokens.
+    assert "$meho_new_det[] = $meho_det[$meho_j];" in frag
+    assert "filter_configure();" in frag
+    assert "<?php" not in frag
+
+
+# ===========================================================================
+# Part A -- unit: input validation rejects before any SSH round-trip
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"network": "not-a-cidr"},
+        {"network": "10.0.0.0/24; rm -rf /"},
+        {},  # missing network
+    ],
+)
+async def test_route_delete_rejects_bad_network_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.route_static_delete(None, params)
+    assert mock_cmd.await_count == 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"name": "bad name"},
+        {"name": "gw'; write_config("},
+        {},  # missing name
+    ],
+)
+async def test_gateway_delete_rejects_bad_name_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.gateway_delete(None, params)
+    assert mock_cmd.await_count == 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"name": "SHARED_HOSTS", "value": "has space"},
+        {"name": "SHARED_HOSTS", "value": "1.2.3.4; rm"},
+        {"name": "bad name", "value": "192.0.2.10"},
+        {"name": "SHARED_HOSTS"},  # missing value
+        {"value": "192.0.2.10"},  # missing name
+    ],
+)
+async def test_member_remove_rejects_bad_params_before_ssh(params: dict[str, Any]) -> None:
+    connector = PfSenseConnector()
+    with (
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        pytest.raises(ValueError),
+    ):
+        await connector.alias_member_remove(None, params)
+    assert mock_cmd.await_count == 0
+
+
+# ===========================================================================
+# Part A -- unit: route.static.delete handler paths
+# ===========================================================================
+
+
+async def test_route_delete_happy_path_deletes_one_and_verifies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm cleanup
+            _proc(_CONFIG_ROUTING_NO_ROUTE),  # read-back verify
+        ]
+        result = await connector.route_static_delete(None, {"network": "10.10.0.0/24"})
+    assert result["status"] == "deleted"
+    assert result["verified"] is True
+    assert result["matched"] == 1
+    assert result["routes_before"] == 2
+    assert result["routes_after"] == 1
+    assert result["removed"]["network"] == "10.10.0.0/24"
+    cmds = _cmds(mock_cmd)
+    assert cmds[0] == "cat /cf/conf/config.xml"
+    assert cmds[2] == "pfSsh.php playback meho_route_delete_10_10_0_0_24"
+
+
+async def test_route_delete_canonicalises_host_bits_query() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),
+            _proc("", 0),
+            _proc("", 0),
+            _proc("", 0),
+            _proc(_CONFIG_ROUTING_NO_ROUTE),
+        ]
+        # Host bits set -> canonicalised to 10.10.0.0/24 -> matches.
+        result = await connector.route_static_delete(None, {"network": "10.10.0.5/24"})
+    assert result["status"] == "deleted"
+    assert result["network"] == "10.10.0.0/24"
+
+
+async def test_route_delete_not_found_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_ROUTING)]
+        result = await connector.route_static_delete(None, {"network": "10.99.0.0/24"})
+    assert result["status"] == "not_found"
+    assert result["matched"] == 0
+    assert mock_cmd.await_count == 1
+
+
+async def test_route_delete_ambiguous_refuses_fail_closed() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_DUP_ROUTE)]
+        result = await connector.route_static_delete(None, {"network": "10.10.0.0/24"})
+    assert result["status"] == "ambiguous"
+    assert result["matched"] == 2
+    assert mock_cmd.await_count == 1
+
+
+async def test_route_delete_verification_failure_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),  # guard read (2 routes)
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_ROUTING),  # read-back: route still present
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.route_static_delete(None, {"network": "10.10.0.0/24"})
+
+
+# ===========================================================================
+# Part A -- unit: gateway.delete handler paths
+# ===========================================================================
+
+
+async def test_gateway_delete_happy_path_deletes_one_and_verifies() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_ROUTING_NO_RETIRING_GW),  # read-back verify
+        ]
+        result = await connector.gateway_delete(None, {"name": "RETIRING_GW"})
+    assert result["status"] == "deleted"
+    assert result["verified"] is True
+    assert result["reference_count"] == 0
+    assert result["gateways_before"] == 2
+    assert result["gateways_after"] == 1
+    assert result["removed"]["name"] == "RETIRING_GW"
+
+
+async def test_gateway_delete_referenced_refuses_and_names_referrers() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_ROUTING)]
+        result = await connector.gateway_delete(None, {"name": "LAB_GW"})
+    assert result["status"] == "referenced"
+    assert result["reference_count"] == 3  # 2 routes + 1 gateway group
+    kinds = sorted(r["kind"] for r in result["references"])
+    assert kinds == ["gateway_group", "static_route", "static_route"]
+    assert "still referenced" in result["guidance"]
+    # Fail-closed: refuses after a single guard read, stages nothing.
+    assert mock_cmd.await_count == 1
+
+
+async def test_gateway_delete_not_found_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_ROUTING)]
+        result = await connector.gateway_delete(None, {"name": "NOPE_GW"})
+    assert result["status"] == "not_found"
+    assert result["matched"] == 0
+    assert mock_cmd.await_count == 1
+
+
+async def test_gateway_delete_ambiguous_refuses_fail_closed() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_DUP_GW)]
+        result = await connector.gateway_delete(None, {"name": "DUP_GW"})
+    assert result["status"] == "ambiguous"
+    assert result["matched"] == 2
+    assert mock_cmd.await_count == 1
+
+
+async def test_gateway_delete_verification_failure_raises() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_ROUTING),  # read-back: gateway still present
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.gateway_delete(None, {"name": "RETIRING_GW"})
+
+
+# ===========================================================================
+# Part A -- unit: alias.member.remove handler paths (the delicate one)
+# ===========================================================================
+
+
+async def test_member_remove_happy_path_keeps_shared_alias_and_others() -> None:
+    """Removing one member trims the alias in place: identity + other members survive."""
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_SHARED_ALIAS),  # guard read
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(_CONFIG_SHARED_ALIAS_AFTER),  # read-back verify
+        ]
+        result = await connector.alias_member_remove(
+            None, {"name": "SHARED_HOSTS", "value": "198.51.100.5"}
+        )
+    assert result["status"] == "removed"
+    assert result["verified"] is True
+    assert result["removed"] is True
+    assert result["alias_retained"] is True
+    assert result["members_before"] == 3
+    assert result["members_after"] == 2
+    # The alias identity + the two OTHER members survive; only the named member left.
+    assert result["residual_members"] == ["192.0.2.10", "192.0.2.11"]
+    cmds = _cmds(mock_cmd)
+    body = cmds[1]
+    assert "$meho_value = '198.51.100.5';" in body
+
+
+async def test_member_remove_not_found_alias_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_SHARED_ALIAS)]
+        result = await connector.alias_member_remove(None, {"name": "NOPE", "value": "192.0.2.10"})
+    assert result["status"] == "not_found"
+    assert result["matched"] == 0
+    assert mock_cmd.await_count == 1
+
+
+async def test_member_remove_member_not_found_stages_nothing() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_SHARED_ALIAS)]
+        result = await connector.alias_member_remove(
+            None, {"name": "SHARED_HOSTS", "value": "203.0.113.99"}
+        )
+    assert result["status"] == "member_not_found"
+    assert result["matched"] == 1
+    assert result["member_matched"] == 0
+    assert mock_cmd.await_count == 1
+
+
+async def test_member_remove_last_member_refuses_fail_closed() -> None:
+    """Removing the ONLY member must refuse -- never empty a shared alias into deletion."""
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_SHARED_ALIAS)]
+        result = await connector.alias_member_remove(None, {"name": "SOLO", "value": "203.0.113.9"})
+    assert result["status"] == "last_member"
+    assert result["member_matched"] == 1
+    assert result["members_before"] == 1
+    assert "alias.delete" in result["guidance"]
+    # Fail-closed: refuses after a single guard read, stages nothing.
+    assert mock_cmd.await_count == 1
+
+
+async def test_member_remove_ambiguous_duplicate_alias_name() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_DUP_ALIAS)]
+        result = await connector.alias_member_remove(
+            None, {"name": "SHARED_HOSTS", "value": "192.0.2.10"}
+        )
+    assert result["status"] == "ambiguous"
+    assert result["matched"] == 2
+    assert mock_cmd.await_count == 1
+
+
+async def test_member_remove_ambiguous_duplicate_member_value() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(_CONFIG_DUP_MEMBER)]
+        result = await connector.alias_member_remove(
+            None, {"name": "SHARED_HOSTS", "value": "198.51.100.5"}
+        )
+    assert result["status"] == "ambiguous"
+    assert result["member_matched"] == 2
+    assert mock_cmd.await_count == 1
+
+
+async def test_member_remove_verification_failure_raises_if_alias_deleted() -> None:
+    """A playback that emptied/deleted the shared alias (or dropped an extra member) raises."""
+    connector = PfSenseConnector()
+    empty_aliases = "<pfsense><aliases></aliases></pfsense>"
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_SHARED_ALIAS),  # guard read (2 aliases)
+            _proc("", 0),  # stage
+            _proc("", 0),  # playback
+            _proc("", 0),  # rm
+            _proc(empty_aliases),  # read-back: the alias vanished (bulk over-deletion)
+        ]
+        with pytest.raises(RuntimeError, match="verification failed"):
+            await connector.alias_member_remove(
+                None, {"name": "SHARED_HOSTS", "value": "198.51.100.5"}
+            )
+
+
+# ===========================================================================
+# Part B -- registration classification + schema conformance
+# ===========================================================================
+
+
+def test_teardown_ops_are_destructive_requires_approval_with_tag() -> None:
+    ids = {_ROUTE_OP, _GATEWAY_OP, _MEMBER_OP}
+    seen = set()
+    for op in PFSENSE_OPS:
+        if op.op_id not in ids:
+            continue
+        seen.add(op.op_id)
+        assert op.safety_level == "destructive", op.op_id
+        assert op.requires_approval is True, op.op_id
+        assert "destructive" in op.tags, op.op_id
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+        assert op.llm_instructions and op.llm_instructions.get("when_to_use"), op.op_id
+    assert seen == ids
+
+
+def test_teardown_ops_group_keys() -> None:
+    by_id = {op.op_id: op for op in PFSENSE_OPS}
+    assert by_id[_ROUTE_OP].group_key == "routing"
+    assert by_id[_GATEWAY_OP].group_key == "routing"
+    assert by_id[_MEMBER_OP].group_key == "alias"
+
+
+def test_route_delete_response_schema_accepts_outcomes() -> None:
+    op = next(o for o in PFSENSE_OPS if o.op_id == _ROUTE_OP)
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "delete",
+            "resource": "static_route",
+            "status": "deleted",
+            "network": "10.10.0.0/24",
+            "matched": 1,
+            "removed": {"network": "10.10.0.0/24"},
+            "routes_before": 2,
+            "routes_after": 1,
+            "verified": True,
+            "guidance": None,
+        }
+    )
+
+
+def test_gateway_delete_response_schema_accepts_referenced() -> None:
+    op = next(o for o in PFSENSE_OPS if o.op_id == _GATEWAY_OP)
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "delete",
+            "resource": "gateway",
+            "status": "referenced",
+            "name": "LAB_GW",
+            "matched": 1,
+            "removed": None,
+            "references": [{"kind": "static_route", "id": "10.10.0.0/24", "descr": "lab net"}],
+            "reference_count": 3,
+            "gateways_before": 2,
+            "gateways_after": None,
+            "verified": False,
+            "guidance": "referenced",
+        }
+    )
+
+
+def test_member_remove_response_schema_accepts_outcomes() -> None:
+    op = next(o for o in PFSENSE_OPS if o.op_id == _MEMBER_OP)
+    assert op.response_schema is not None
+    validator = Draft202012Validator(op.response_schema)
+    validator.validate(
+        {
+            "op_class": "update",
+            "resource": "alias_member",
+            "status": "removed",
+            "alias": "SHARED_HOSTS",
+            "value": "198.51.100.5",
+            "matched": 1,
+            "member_matched": 1,
+            "removed": True,
+            "members_before": 3,
+            "members_after": 2,
+            "residual_members": ["192.0.2.10", "192.0.2.11"],
+            "alias_retained": True,
+            "verified": True,
+            "guidance": None,
+        }
+    )
+    validator.validate(
+        {
+            "op_class": "update",
+            "resource": "alias_member",
+            "status": "last_member",
+            "alias": "SOLO",
+            "value": "203.0.113.9",
+            "matched": 1,
+            "member_matched": 1,
+            "removed": False,
+            "members_before": 1,
+            "members_after": None,
+            "residual_members": None,
+            "alias_retained": None,
+            "verified": False,
+            "guidance": "last member",
+        }
+    )
+
+
+# ===========================================================================
+# Part C -- governed-flow conformance (full dispatch)
+# ===========================================================================
+
+
+def _make_operator(
+    *, sub: str = "op-pf", principal_kind: PrincipalKind = PrincipalKind.USER
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="pfSense Teardown Conformance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = "2.7") -> None:
+        self.version = version
+
+
+class _FakePfsenseTarget:
+    def __init__(self) -> None:
+        self.product = "pfsense"
+        self.fingerprint = _FakeFingerprint(version="2.7")
+        self.preferred_impl_id: str | None = "pfsense-ssh"
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT_ID
+        self.name = "pf-perimeter"
+        self.host = "pf.test"
+        self.port = 22
+        self.auth_model = "shared_service_account"
+
+
+class _RecordingPfSense(PfSenseConnector):
+    """A PfSenseConnector whose ``_run_command`` replays canned config.xml.
+
+    Seeded into ``_CONNECTOR_INSTANCE_CACHE`` so the dispatcher (and the
+    blast-radius preview builder) drive real dispatch without SSH. Returns
+    ``config_before`` until a ``pfSsh.php playback`` command runs, then
+    ``config_after`` -- exercising the handler's read-back verification.
+    """
+
+    def __init__(self, *, config_before: str, config_after: str | None = None) -> None:
+        super().__init__()
+        self._config_before = config_before
+        self._config_after = config_after if config_after is not None else config_before
+        self._played = False
+        self.commands: list[str] = []
+
+    async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
+        return {"username": "admin", "client_keys": [], "known_hosts": None}
+
+    async def _run_command(self, target: Any, command: str, operator: Any = None) -> Any:
+        self.commands.append(command)
+        if command == "cat /cf/conf/config.xml":
+            return _proc(self._config_after if self._played else self._config_before)
+        if command.startswith("pfSsh.php playback"):
+            self._played = True
+        return _proc("", 0)
+
+    @property
+    def playback_ran(self) -> bool:
+        return any(c.startswith("pfSsh.php playback") for c in self.commands)
+
+
+async def _seed_target(name: str = "pf-perimeter") -> UUID:
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name=name,
+                aliases=[],
+                product="pfsense",
+                host="pf.test",
+                port=22,
+                fqdn=None,
+                secret_ref="kv/dev/pfsense/perimeter",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "2.7"},
+                preferred_impl_id="pfsense-ssh",
+                notes="seeded by test_connectors_pfsense_teardown_ops",
+            )
+        )
+        await s.commit()
+    return target_id
+
+
+async def _bootstrap(recorder: _RecordingPfSense) -> None:
+    if ("pfsense", "2.7", "pfsense-ssh") not in all_connectors_v2():
+        register_connector_v2(
+            product="pfsense", version="2.7", impl_id="pfsense-ssh", cls=PfSenseConnector
+        )
+    await PfSenseConnector.register_operations()
+    _CONNECTOR_INSTANCE_CACHE[PfSenseConnector] = recorder  # type: ignore[assignment]
+
+
+async def _pending_count() -> int:
+    async with get_sessionmaker()() as s:
+        return int(
+            (await s.execute(select(func.count()).select_from(ApprovalRequest))).scalar_one()
+        )
+
+
+@pytest.mark.asyncio
+async def test_ops_registered_destructive_requires_approval() -> None:
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_ROUTING))
+    async with get_sessionmaker()() as s:
+        for op_id in (_ROUTE_OP, _GATEWAY_OP, _MEMBER_OP):
+            row = (
+                await s.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == op_id))
+            ).scalar_one()
+            assert row.safety_level == "destructive", op_id
+            assert row.requires_approval is True, op_id
+            assert row.source_kind == "typed", op_id
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_route_delete() -> None:
+    """preview -> park (hash + blast radius) -> distinct human approve -> resume delete."""
+    recorder = _RecordingPfSense(
+        config_before=_CONFIG_ROUTING, config_after=_CONFIG_ROUTING_NO_ROUTE
+    )
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _ROUTE_OP,
+        "target": "pf-perimeter",
+        "params": {"network": "10.10.0.0/24"},
+    }
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok", preview
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "awaiting_approval", call
+    request_id = UUID(call["extras"]["approval_request_id"])
+    assert not recorder.playback_ran
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["object"]["kind"] == "static_route"
+    assert blast["object"]["network"] == "10.10.0.0/24"
+    assert blast["object"]["gateway"] == "LAB_GW"
+    assert blast["irreversibility"] == "permanent"
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["verified"] is True
+    assert recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_gateway_delete_unreferenced() -> None:
+    recorder = _RecordingPfSense(
+        config_before=_CONFIG_ROUTING, config_after=_CONFIG_ROUTING_NO_RETIRING_GW
+    )
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _GATEWAY_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "RETIRING_GW"},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["object"]["kind"] == "gateway"
+    assert blast["object"]["name"] == "RETIRING_GW"
+    assert blast["reference_count"] == 0
+    assert blast["children"] == []
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "deleted"
+    assert resume.result["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_referenced_gateway_refused_post_approval_fail_closed() -> None:
+    """A referenced gateway parks (blast radius names the referrers) then is refused
+    at execution (post-approval), fail-closed -- nothing mutates."""
+    recorder = _RecordingPfSense(config_before=_CONFIG_ROUTING)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _GATEWAY_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "LAB_GW"},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["reference_count"] == 3
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "referenced"
+    assert resume.result["reference_count"] == 3
+    assert not recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_full_governed_flow_member_remove_keeps_shared_alias() -> None:
+    """Full dispatch of a shared-alias member removal: the alias + other members survive."""
+    recorder = _RecordingPfSense(
+        config_before=_CONFIG_SHARED_ALIAS, config_after=_CONFIG_SHARED_ALIAS_AFTER
+    )
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _MEMBER_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "SHARED_HOSTS", "value": "198.51.100.5"},
+    }
+    preview = await preview_operation(requester, args)
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    request_id = UUID(call["extras"]["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        blast = dict(row.proposed_effect)["blast_radius"]
+    assert blast["object"]["kind"] == "alias_member"
+    assert blast["object"]["alias"] == "SHARED_HOSTS"
+    assert blast["object"]["member"] == "198.51.100.5"
+    assert blast["residual_member_count"] == 2
+    assert blast["alias_retained"] is True
+
+    approver = _make_operator(sub="op-approver")
+    async with get_sessionmaker()() as s:
+        await approve_request(s, request_id, operator=approver, params=None)
+        await s.commit()
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        resume = await resume_dispatch_after_approval(operator=approver, request=row, params=None)
+    assert resume.status == "ok", resume.error
+    assert resume.result["status"] == "removed"
+    assert resume.result["alias_retained"] is True
+    assert resume.result["residual_members"] == ["192.0.2.10", "192.0.2.11"]
+
+
+@pytest.mark.asyncio
+async def test_park_refused_when_member_would_be_last() -> None:
+    """A last-member removal never resolves a blast radius -> park refused (fail-closed)."""
+    recorder = _RecordingPfSense(config_before=_CONFIG_SHARED_ALIAS)
+    await _bootstrap(recorder)
+    await _seed_target()
+
+    requester = _make_operator(sub="op-requester")
+    args = {
+        "connector_id": _CONNECTOR_ID,
+        "op_id": _MEMBER_OP,
+        "target": "pf-perimeter",
+        "params": {"name": "SOLO", "value": "203.0.113.9"},
+    }
+    preview = await preview_operation(requester, args)
+    assert preview["status"] == "ok"
+    call = await call_operation(requester, {**args, "preview_hash": preview["preview_hash"]})
+    assert call["status"] == "denied", call
+    assert call["extras"]["error_code"] == "blast_radius_required"
+    assert await _pending_count() == 0
+    assert not recorder.playback_ran
+
+
+@pytest.mark.asyncio
+async def test_agent_principal_is_denied() -> None:
+    recorder = _RecordingPfSense(config_before=_CONFIG_ROUTING)
+    await _bootstrap(recorder)
+
+    result = await dispatch(
+        operator=_make_operator(sub="agent-1", principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id=_GATEWAY_OP,
+        target=_FakePfsenseTarget(),
+        params={"name": "RETIRING_GW"},
+    )
+    assert result.status == "denied", result
+    assert not recorder.playback_ran
+    assert await _pending_count() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_id", [_ROUTE_OP, _GATEWAY_OP, _MEMBER_OP])
+async def test_service_grant_refuses_teardown_ops(op_id: str) -> None:
+    """All three fold into the destructive-tier grant refusal -- including
+    ``alias.member.remove``, whose op-id does not end in ``.delete`` (it is
+    refused via its ``destructive`` safety level / tag, not the glob)."""
+    await _bootstrap(_RecordingPfSense(config_before=_CONFIG_ROUTING))
+    svc = ServicePrincipalGrantService()
+    payload = ServiceGrantCreate(
+        principal_sub="svc-runner",
+        op_id=op_id,
+        connector_id=_CONNECTOR_ID,
+        target_id=None,
+        reason="unattended teardown",
+        expires_at=None,
+    )
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, "creator", payload)
+    msg = str(exc.value).lower()
+    assert "delete-shaped" in msg or "destructive" in msg

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -20,6 +20,11 @@ adds the first two write ops (`pfsense.gateway.add`,
 idiom. #3232 adds the first two **governed destructive deletes**
 (`pfsense.nat.delete`, `pfsense.alias.delete`) — `safety_level="destructive"`
 on the governed-delete tier (`docs/decisions/governed-delete-operations.md`).
+#3313 adds the three **teardown-inverse** governed deletes
+(`pfsense.route.static.delete`, `pfsense.gateway.delete`,
+`pfsense.alias.member.remove`) that reverse a governed bring-up — retire a
+static route, retire a gateway (fail-closed on any live referrer), and trim
+ONE member out of a *shared* alias without deleting it.
 
 Source: `backend/src/meho_backplane/connectors/pfsense/`.
 
@@ -32,7 +37,8 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   `probe`, `execute`, `about`, the read-op bound-method shims (the 7 T2 ops
   plus `dhcp_leases`, #2849), the write-op bound-method shims (`gateway_add`,
   `route_static_add`, #3090), and the destructive-delete bound-method shims
-  (`nat_delete`, `alias_delete`, #3232).
+  (`nat_delete`, `alias_delete`, #3232; `route_static_delete`, `gateway_delete`,
+  `alias_member_remove`, #3313).
 
 - **`_auth_config()` override** — the load-bearing auth constraint. Requires
   `ssh_private_key` in the target's **Vault secret** (`target.secret_ref` is a
@@ -45,24 +51,32 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   REPL) instead of a POSIX shell, causing any subsequent command to hang.
 
 - **Op metadata** (`ops.py`) — the `PfSenseOp` dataclass, the `_pfsense_ops()`
-  composition function, and the `PFSENSE_OPS` tuple (13 ops total). T1 shipped
+  composition function, and the `PFSENSE_OPS` tuple (16 ops total). T1 shipped
   `pfsense.about`; T2 (#847) adds 7 read ops via the `ops_read` module; #2849
   appends `pfsense.dhcp.leases`; #3090 appends the two write ops via the
-  `ops_write` module; #3232 appends the two destructive deletes via the
-  `ops_delete` module.
+  `ops_write` module; #3232 appends the first two destructive deletes and #3313
+  the three teardown-inverse deletes, both via the `ops_delete` module.
 
-- **Destructive-delete handlers** (`ops_delete.py`, #3232) — the connector's
-  first `safety_level="destructive"` ops. Config parsers
+- **Destructive-delete handlers** (`ops_delete.py`, #3232 + #3313) — the
+  connector's `safety_level="destructive"` ops. Config parsers
   (`parse_nat_port_forwards_xml` / `parse_aliases_xml`), the fail-closed
-  reference scan (`find_alias_references` — nested aliases + filter / NAT
-  port-forward / outbound / 1:1 rules), the delete-by-identity `pfSsh.php
-  playback` fragment builders (`_build_nat_delete_playback` /
-  `_build_alias_delete_playback`, each persisting only on a single removal),
-  the handlers (`pfsense_nat_delete` / `pfsense_alias_delete`), the mandatory
-  blast-radius preview builders (`_nat_delete_preview` / `_alias_delete_preview`,
-  registered at import via `register_pfsense_delete_preview_builders`), and the
-  `DELETE_OPS` tuple. Both fold into the existing single-source delete-shaped
-  classifier (`*.delete` glob + `destructive` tag) with no new pattern list.
+  reference scans (`find_alias_references` — nested aliases + filter / NAT
+  port-forward / outbound / 1:1 rules; `find_gateway_references` — static
+  routes + gateway groups + default-gateway setting), the canonical route
+  matcher (`_match_static_routes_canonical`) and member-token split
+  (`_alias_members`), the delete/remove-by-identity `pfSsh.php playback`
+  fragment builders (`_build_nat_delete_playback` / `_build_alias_delete_playback`
+  / `_build_route_delete_playback` / `_build_gateway_delete_playback` /
+  `_build_alias_member_remove_playback`, each persisting only on a single
+  clean removal), the handlers (`pfsense_nat_delete` / `pfsense_alias_delete` /
+  `pfsense_route_static_delete` / `pfsense_gateway_delete` /
+  `pfsense_alias_member_remove`), the mandatory blast-radius preview builders
+  (one per op, registered at import via
+  `register_pfsense_delete_preview_builders`), and the `DELETE_OPS` tuple. All
+  fold into the destructive-tier service-grant refusal (safety_level +
+  `destructive` tag; `alias.member.remove`, whose op-id does not end in
+  `.delete`, is refused via the tier rather than the `*.delete` glob) with no
+  new pattern list.
 
 - **Write op handlers** (`ops_write.py`, #3090) — input validators
   (`_validate_gateway_name` / `_validate_interface` / `_validate_gateway_ip` /
@@ -187,7 +201,7 @@ Two-phase registration, identical to the bind9 pattern:
   (`connectors/registry.py`, `operations/typed_register.py`) — registration
   infrastructure.
 
-## Op surface (13 ops)
+## Op surface (16 ops)
 
 | Op ID | Command | Group | Safety |
 |---|---|---|---|
@@ -204,20 +218,31 @@ Two-phase registration, identical to the bind9 pattern:
 | `pfsense.route.static.add` | `cat /cf/conf/config.xml` guard + `pfSsh.php playback` fragment (append `staticroutes/route` + `write_config()` + `system_routing_configure()`) | `routing` | `caution` |
 | `pfsense.nat.delete` | `cat /cf/conf/config.xml` guard (match one `<nat><rule>` by `<tracker>`) + `pfSsh.php playback` fragment (delete-by-tracker + `write_config()` + `filter_configure()`) + read-back verify | `nat` | `destructive` |
 | `pfsense.alias.delete` | `cat /cf/conf/config.xml` guard (match one `<aliases><alias>` by name + fail-closed reference scan) + `pfSsh.php playback` fragment (delete-by-name + `write_config()` + `filter_configure()`) + read-back verify | `alias` | `destructive` |
+| `pfsense.route.static.delete` | `cat /cf/conf/config.xml` guard (canonical-match one `<staticroutes><route>` by network) + `pfSsh.php playback` fragment (delete-by-network + `write_config()` + `system_routing_configure()`) + read-back verify | `routing` | `destructive` |
+| `pfsense.gateway.delete` | `cat /cf/conf/config.xml` guard (match one `<gateways><gateway_item>` by name + fail-closed reference scan) + `pfSsh.php playback` fragment (delete-by-name + `write_config()` + `system_routing_configure()`) + read-back verify | `routing` | `destructive` |
+| `pfsense.alias.member.remove` | `cat /cf/conf/config.xml` guard (match one `<aliases><alias>` by name + locate the member token) + `pfSsh.php playback` fragment (read-modify-write `<address>`/`<detail>` + `write_config()` + `filter_configure()`) + read-back verify | `alias` | `destructive` |
 
 The 9 read / identity ops are `safety_level="safe"`; the 2 write ops (#3090)
 are `safety_level="caution"` / `requires_approval=False` — the same posture
 `bind9.record.add` / `windns.record.add` carry for an additive, recoverable,
-idempotent config write. The 2 delete ops (#3232) are
-`safety_level="destructive"` / `requires_approval=True` — the governed-delete
-tier: mandatory human approval (no agent path, no standing grant, no
-self-approval even under break-glass, no satellite mint), a #3197 preview-hash
-binding, and a mandatory blast-radius statement naming the exact rule / alias.
-Each deletes exactly one object by stable identity (`<tracker>` for a NAT rule,
-exact name for an alias — never by position or description), refuses fail-closed
-on a missing (`not_found`) / duplicated (`ambiguous`) identity or (for an alias)
-a live reference (`referenced`, naming every referrer), and read-back-verifies
-that the object is gone and the count dropped by exactly one.
+idempotent config write. The 5 destructive ops (#3232 nat/alias; #3313 the
+three teardown-inverse ops) are `safety_level="destructive"` /
+`requires_approval=True` — the governed-delete tier: mandatory human approval
+(no agent path, no standing grant, no self-approval even under break-glass, no
+satellite mint), a #3197 preview-hash binding, and a mandatory blast-radius
+statement naming the exact object. Each acts on exactly one object by stable
+identity (`<tracker>` for a NAT rule, exact name for an alias / gateway,
+canonical network for a route, exact member token for an alias member — never
+by position), refuses fail-closed on a missing (`not_found`) / duplicated
+(`ambiguous`) identity or a live reference (`referenced`, naming every
+referrer, for `alias.delete` and `gateway.delete`), and read-back-verifies the
+result. `pfsense.alias.member.remove` is the odd one out: it is a
+**read-modify-write on a shared object**, not a delete — it removes ONE member
+from the alias's `<address>` (and its positionally-aligned `<detail>`) while
+keeping the alias and every other member, refuses `member_not_found` /
+`last_member` (never empties a shared alias into deletion — that is
+`alias.delete`'s job), and verifies the member is gone, the alias is retained,
+and the residual members survive.
 
 `pfsense.firewall.state` and `pfsense.dhcp.leases` both return `{rows, total}`
 and are the JSONFlux reduction candidates: connection-state tables and busy
@@ -312,6 +337,16 @@ applies nothing — a pre-staged gateway is inert config until referenced.
   write ops, via the `pfSsh.php playback` config-mutation idiom. Classification
   mirrors `bind9.record.add` (`caution` / no-approval). pfSense PHP shell:
   https://docs.netgate.com/pfsense/en/latest/development/php-shell.html.
+- Task #3232: `pfsense.nat.delete` + `pfsense.alias.delete` — the first two
+  governed destructive deletes. Decision:
+  `docs/decisions/governed-delete-operations.md`.
+- Task #3313: `pfsense.route.static.delete` + `pfsense.gateway.delete` +
+  `pfsense.alias.member.remove` — the three teardown-inverse governed deletes
+  that reverse a bring-up (retire a route / gateway; trim one member out of a
+  shared alias without deleting it). `gateway.delete` refuses fail-closed while
+  any static route / gateway group / default-gateway setting still uses the
+  gateway; `alias.member.remove` refuses `last_member` so a shared alias is
+  never emptied into deletion.
 - Parent initiative: #370 (G3.7 tier-3 standalone connectors).
 - Bind9 connector (canonical typed-SSH reference): `docs/codebase/connectors-bind9.md`.
 - `SshConnector` adapter: `backend/src/meho_backplane/connectors/adapters/ssh.py`.


### PR DESCRIPTION
## What

Adds the three destructive-tier **teardown-inverse** ops the pfSense connector was missing (`backend/src/meho_backplane/connectors/pfsense/ops_delete.py`), so a governed environment teardown can reverse a bring-up — symmetrically, governed, and read-back verified — instead of relying on out-of-band manual edits on the router (outside audit / policy / approval).

- **`pfsense.route.static.delete`** — inverse of `pfsense.route.static.add`. Deletes one `<staticroutes><route>` by its canonical `network` (CIDR). Refuses `not_found` / `ambiguous` (two routes canonicalising to the same network). Applies `write_config()` + `system_routing_configure()`, then reads `config.xml` back and verifies the route is gone and the count dropped by exactly one.
- **`pfsense.gateway.delete`** — inverse of `pfsense.gateway.add`. Deletes one `<gateways><gateway_item>` by exact `name` with a **fail-closed dependency guard** (`find_gateway_references`, mirroring `alias.delete`): refuses `referenced` — naming every static route / gateway group / default-gateway referrer — so a gateway is never pulled out from under a live route. Also refuses `not_found` / `ambiguous`; read-back verified.
- **`pfsense.alias.member.remove`** — removes ONE member (host/network entry) from a firewall alias **without deleting the alias** (the shared-alias case). A read-modify-write on `<address>` and its positionally-aligned `<detail>`. Refuses `not_found` / `member_not_found` / `ambiguous`, and refuses `last_member` so a shared alias is never emptied into deletion (that is `alias.delete`'s job). Verifies the member is gone, the alias is retained, and every other member survives.

## Governance

All three are `safety_level="destructive"` / `requires_approval=True` — the governed-delete tier: mandatory human approval, a #3197 preview-hash binding, a mandatory blast-radius statement (each op registers a preview builder via `register_pfsense_delete_preview_builders()`), no agent path / standing grant / self-approval / satellite mint. `alias.member.remove` (op-id not ending in `.delete`) folds into the destructive-tier service-grant refusal via its safety level / `destructive` tag rather than the `*.delete` glob.

Each touches only the relevant `config.xml` subtree (`staticroutes/route`, `gateways/gateway_item`, `aliases/alias`), never interface config, and each playback fragment persists only on a single clean removal.

## Tests

New `backend/tests/test_connectors_pfsense_teardown_ops.py` (51 tests): per-op happy path + every refusal (fixtures against the config.xml shape), the shared-alias survival proof (alias identity + other members survive a single-member removal) and `last_member` refusal tested hardest, plus full governed-flow dispatch (preview → park → distinct-human approve → resume) and the referenced-gateway post-approval fail-closed re-check. Op-count assertions updated 13 → 16 across the three existing pfSense test files.

## Docs / hygiene

`docs/codebase/connectors-pfsense.md` + CHANGELOG updated. No DB migration (registration-constant tier). CLI OpenAPI snapshot regenerated — **no diff** (typed ops dispatch through the generic `call_operation` meta-tool and carry no REST surface). All fixtures use RFC 5737 / RFC 1918 addresses and generic names — leak-free.

Closes #3313

🤖 Generated with [Claude Code](https://claude.com/claude-code)