### PR TITLE
fix(operations): preview parity for approval-requiring typed ops + destructive builder CI sweep (#3312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,34 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — preview parity for approval-requiring typed ops + a destructive builder CI sweep (#3312)
+
+- **`preview_operation` now serves the park-time effect for a `requires_approval`
+  typed op, instead of `preview_unavailable`.** A `dangerous`-tier typed op
+  (canonical case `vault.kv.delete`) parks for a human who sees a rich
+  `proposed_effect` (mount / path / versions / semantics), but the calling agent's
+  pre-dispatch `preview_operation` answered `preview_unavailable` — an asymmetry
+  the through-backplane governed-delete canary surfaced. The previewability gate
+  now admits any `requires_approval` op (alongside the `destructive` tier it
+  already served), and the synthetic preview layers the **reused** park-time
+  `proposed_effect` onto the params-bound projection. The effect is built
+  egress-free — `build_proposed_effect` runs with no connector instance, so a pure
+  builder populates while a live-read blast-radius builder declines — and rides
+  outside the hashed projection, so the #3197 preview-hash binding is unperturbed.
+  Availability change only; park / approval behaviour is unchanged, and #3197's
+  preview-*hash* binding is deliberately **not** extended to the `dangerous` tier.
+- **A registry-driven CI conformance sweep now fails the build if a `destructive`
+  op ships without a blast-radius builder.** The runtime park gate is fail-closed
+  (a destructive op with no builder is un-parkable), but that failure was
+  runtime-only: a posture sweep that promoted an op to `destructive` without adding
+  its builder passed CI and shipped an un-parkable op, silently broken until first
+  use. `test_destructive_builder_conformance.py` enumerates every registered
+  `destructive` descriptor (every connector, both source kinds) from the typed-op
+  registrars and fails if any resolves no registered proposed-effect builder,
+  moving the failure from first-use to CI.
+- No DB migration; the preview REST route returns an untyped object (no OpenAPI
+  schema change), so the CLI snapshot is unchanged.
+
 ### Added — pfsense: three teardown-inverse governed deletes (#3313)
 
 - **`pfsense.route.static.delete`** — the inverse of `pfsense.route.static.add`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Fixed — preview parity for approval-requiring typed ops + a destructive builder CI sweep (#3312)
+### Fixed — preview parity for approval-requiring typed ops + a destructive builder CI sweep (#3312 / #3316)
 
 - **`preview_operation` now serves the park-time effect for a `requires_approval`
   typed op, instead of `preview_unavailable`.** A `dangerous`-tier typed op

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,14 +98,19 @@ connector-related release-notes line.
   `proposed_effect` (mount / path / versions / semantics), but the calling agent's
   pre-dispatch `preview_operation` answered `preview_unavailable` — an asymmetry
   the through-backplane governed-delete canary surfaced. The previewability gate
-  now admits any `requires_approval` op (alongside the `destructive` tier it
-  already served), and the synthetic preview layers the **reused** park-time
-  `proposed_effect` onto the params-bound projection. The effect is built
-  egress-free — `build_proposed_effect` runs with no connector instance, so a pure
-  builder populates while a live-read blast-radius builder declines — and rides
-  outside the hashed projection, so the #3197 preview-hash binding is unperturbed.
-  Availability change only; park / approval behaviour is unchanged, and #3197's
-  preview-*hash* binding is deliberately **not** extended to the `dangerous` tier.
+  now admits any **non-credential-class** `requires_approval` op (alongside the
+  `destructive` tier it already served), and the synthetic preview layers the
+  **reused** park-time `proposed_effect` onto the params-bound projection. The
+  effect is built egress-free — `build_proposed_effect` runs with no connector
+  instance, so a pure builder populates while a live-read blast-radius builder
+  declines — and rides outside the hashed projection, so the #3197 preview-hash
+  binding is unperturbed. A credential-class op (`vault.kv.put` /
+  `k8s.secret.create`, whose secret rides in the request params) is deliberately
+  excluded and stays `unavailable`, since the preview's `redacted_body`
+  connector-boundary redaction cannot be trusted to scrub a structured secret —
+  mirroring the park-time credential-class suppression. Availability change only;
+  park / approval behaviour is unchanged, and #3197's preview-*hash* binding is
+  deliberately **not** extended to the `dangerous` tier.
 - **A registry-driven CI conformance sweep now fails the build if a `destructive`
   op ships without a blast-radius builder.** The runtime park gate is fail-closed
   (a destructive op with no builder is un-parkable), but that failure was

--- a/backend/src/meho_backplane/operations/_composite_preview.py
+++ b/backend/src/meho_backplane/operations/_composite_preview.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Synthetic preview for governed-tier non-ingested ops (#3198 / #3312).
+
+The counterpart to :mod:`._request_preview`, which previews the literal
+would-be HTTP request of an ``source_kind='ingested'`` op (#1683). A
+``typed`` / ``composite`` op runs a Python handler and has no single literal
+HTTP request, so by default it previews as ``status="unavailable"``. The two
+governed approval tiers are the exception and MUST be previewable:
+
+* **``destructive``** (#3198): the governed-delete gate refuses to park the
+  op unless a ``preview_operation`` of the identical tuple bound a matching
+  ``preview_hash`` (decision ``governed-delete-operations.md`` requirement 2).
+* **``requires_approval``** (#3312): the ``dangerous``-tier typed ops
+  (canonical case ``vault.kv.delete``) park for a human. The approver already
+  sees a rich park-time ``proposed_effect``; previewing removes the
+  pre-dispatch asymmetry so the calling agent reads the *same* effect block
+  instead of ``preview_unavailable``.
+
+The synthetic preview binds the *logical request tuple* (the redacted params
+on the ``redacted_body`` slot, a ``COMPOSITE`` sentinel ``method``, the
+``op_id`` as ``resolved_path``) so :func:`compute_preview_hash` stays
+param-sensitive, and layers on the reused park-time ``proposed_effect``. No
+handler runs, no connector is dialled, and nothing is sent — it is a pure,
+egress-free projection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    build_proposed_effect,
+    describe_preview_provenance,
+)
+from meho_backplane.operations._request_preview import (
+    _redact_request_body,
+    compute_preview_hash,
+)
+
+__all__ = ["build_composite_preview"]
+
+_log = structlog.get_logger(__name__)
+
+#: Sentinel ``method`` for a synthetic composite/typed preview (#3198) —
+#: there is no HTTP verb, but the slot is one of the hashed keys, so a
+#: constant keeps the hash stable while the params on ``redacted_body`` make
+#: it param-sensitive.
+_COMPOSITE_PREVIEW_METHOD: Final[str] = "COMPOSITE"
+
+
+async def _synthetic_proposed_effect(
+    *,
+    operator: Operator,
+    connector_id: str,
+    descriptor: EndpointDescriptor,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Reuse the park-time ``proposed_effect`` builder for a pre-dispatch preview (#3312).
+
+    Runs :func:`~meho_backplane.operations._preview.build_proposed_effect` — the
+    *same* park-path builder, so no effect logic is duplicated and redaction is
+    identical — but with ``connector_instance=None`` to keep the preview
+    **egress-free**: a pure builder (``vault.kv.delete``'s ``_kv_delete_preview``
+    reads only its params) populates, while a live-read blast-radius builder
+    declines for lack of a connector. Returns the effect only when genuinely
+    populated (bespoke ``preview`` or generic ``params_echo``, per
+    :func:`describe_preview_provenance`); a decline / credential suppression /
+    fail-soft ``preview_unavailable`` marker yields ``None`` so the synthetic
+    preview stays clean.
+    """
+    proposed_effect = await build_proposed_effect(
+        PreviewContext(
+            descriptor=descriptor,
+            connector_instance=None,
+            operator=operator,
+            target=target,
+            params=params,
+            connector_id=connector_id,
+        )
+    )
+    populated, _reason = describe_preview_provenance(proposed_effect, op_id=descriptor.op_id)
+    return proposed_effect if populated else None
+
+
+async def build_composite_preview(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the synthetic preview for a governed-tier non-ingested op (#3198/#3312).
+
+    A composite / typed op has no single literal HTTP request, so the
+    preview-hash binding (decision ``governed-delete-operations.md``
+    requirement 2) binds the *logical request tuple*: the redacted params ride
+    the ``redacted_body`` slot, so :func:`compute_preview_hash` — unchanged, and
+    unaffected by the ``proposed_effect`` key it does not hash — is
+    param-sensitive (two different deletes hash differently) while ``method`` (a
+    ``COMPOSITE`` sentinel) and ``resolved_path`` (the ``op_id``) name the op. On
+    top of that projection it reuses the park-time ``proposed_effect`` (#3312,
+    via :func:`_synthetic_proposed_effect`) so the calling agent reads the same
+    effect block the approver sees. Only reached for the ``destructive`` /
+    ``requires_approval`` tiers (the gate in
+    :func:`~meho_backplane.operations._request_preview._resolve_previewable_descriptor`);
+    every other typed/composite op keeps the ``"unavailable"`` contract. No
+    handler runs and nothing is sent.
+    """
+    redacted_body = _redact_request_body(
+        params, connector_id=connector_id, operator=operator, op_id=op_id
+    )
+    _log.info(
+        "preview_dispatch_composite",
+        connector_id=connector_id,
+        op_id=op_id,
+        source_kind=descriptor.source_kind,
+        safety_level=descriptor.safety_level,
+        tenant_id=str(operator.tenant_id),
+    )
+    envelope: dict[str, Any] = {
+        "status": "ok",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": descriptor.source_kind,
+        "method": _COMPOSITE_PREVIEW_METHOD,
+        "resolved_path": op_id,
+        "query": None,
+        "redacted_body": redacted_body,
+    }
+    envelope["preview_hash"] = compute_preview_hash(envelope)
+    proposed_effect = await _synthetic_proposed_effect(
+        operator=operator,
+        connector_id=connector_id,
+        descriptor=descriptor,
+        target=target,
+        params=params,
+    )
+    if proposed_effect is not None:
+        envelope["proposed_effect"] = proposed_effect
+    return envelope

--- a/backend/src/meho_backplane/operations/_composite_preview.py
+++ b/backend/src/meho_backplane/operations/_composite_preview.py
@@ -16,7 +16,11 @@ governed approval tiers are the exception and MUST be previewable:
   (canonical case ``vault.kv.delete``) park for a human. The approver already
   sees a rich park-time ``proposed_effect``; previewing removes the
   pre-dispatch asymmetry so the calling agent reads the *same* effect block
-  instead of ``preview_unavailable``.
+  instead of ``preview_unavailable``. A **credential-class** op (e.g.
+  ``vault.kv.put``) is excluded upstream by
+  :func:`~meho_backplane.operations._request_preview._is_previewable` — its
+  secret rides in the params, which the ``redacted_body`` slot below cannot be
+  trusted to scrub — so it never reaches here.
 
 The synthetic preview binds the *logical request tuple* (the redacted params
 on the ``redacted_body`` slot, a ``COMPOSITE`` sentinel ``method``, the

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -37,9 +37,11 @@ Scope (honouring #1683's out-of-scope dispositions):
   to preview -- so by default the preview says so explicitly
   (``status="unavailable"``) rather than fabricating one. The two governed
   approval tiers are the exception: a ``safety_level='destructive'`` op
-  (#3198) and an op that ``requires_approval`` (#3312, canonical case the
-  ``dangerous``-tier typed ``vault.kv.delete``) instead get a **synthetic
-  preview** -- a params-bound projection (the hashed binding) plus the
+  (#3198) and a non-credential-class op that ``requires_approval`` (#3312,
+  canonical case the ``dangerous``-tier typed ``vault.kv.delete``; a
+  credential-class op like ``vault.kv.put`` stays ``unavailable`` because its
+  secret rides in the params) instead get a **synthetic preview** -- a
+  params-bound projection (the hashed binding) plus the
   reused park-time ``proposed_effect`` content -- so the agent reads the
   same effect block the approver sees, pre-dispatch. That proposed-effect
   reuse is **egress-free**: it runs the registered builder with **no
@@ -65,6 +67,7 @@ from typing import Any, Final
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.events import classify_op
 from meho_backplane.connectors import resolve_connector_or_label
 from meho_backplane.db.models import EndpointDescriptor
 from meho_backplane.operations._branches import resolve_ingested_request
@@ -74,6 +77,7 @@ from meho_backplane.operations._lookup import (
     lookup_descriptor,
     parse_connector_id,
 )
+from meho_backplane.operations._preview import _SENSITIVE_CLASSES
 from meho_backplane.operations._validate import InvalidOpSchemaError, validate_params
 from meho_backplane.redaction import apply_connector_boundary_redaction
 
@@ -184,6 +188,37 @@ def _invalid_op_schema_envelope(
     }
 
 
+def _is_previewable(descriptor: EndpointDescriptor) -> bool:
+    """True when the op has a preview surface; else it previews as ``unavailable``.
+
+    An ``source_kind='ingested'`` op has a literal would-be HTTP request. A
+    non-ingested (``typed`` / ``composite``) op has none, so it is previewable
+    only in a governed approval tier, via the synthetic preview
+    (:func:`._composite_preview.build_composite_preview`):
+
+    * ``safety_level='destructive'`` (#3198) — unconditional: the
+      governed-delete gate refuses to park without a bound preview hash, so the
+      op MUST be previewable. Destructive ops are non-credential deletes.
+    * ``requires_approval`` (#3312), **except a credential-class op** — so the
+      calling agent reads the same park-time ``proposed_effect`` the approver
+      sees. A credential-class op (``classify_op`` ∈ the aggregate-only
+      :data:`~meho_backplane.operations._preview._SENSITIVE_CLASSES`) is
+      **excluded**: its secret rides in the request params, and the synthetic
+      preview's ``redacted_body`` slot uses only connector-boundary value-shape
+      redaction — which does not scrub a structured secret like
+      ``{"data": {"password": …}}``. The park path suppresses credential-class
+      request detail for exactly this reason (``build_proposed_effect`` step 3);
+      mirror it here so a ``vault.kv.put`` / ``k8s.secret.create`` preview never
+      surfaces the written secret. Single-sourced on ``classify_op``; the class
+      set is imported, never re-declared.
+    """
+    if descriptor.source_kind == "ingested":
+        return True
+    if descriptor.safety_level == "destructive":
+        return True
+    return descriptor.requires_approval and classify_op(descriptor.op_id) not in _SENSITIVE_CLASSES
+
+
 async def _resolve_previewable_descriptor(
     *,
     operator: Operator,
@@ -194,10 +229,9 @@ async def _resolve_previewable_descriptor(
     """Run dispatch Steps 2-3 + the previewability gate; return descriptor or error.
 
     Returns the validated :class:`EndpointDescriptor` when the op resolves,
-    is previewable (``source_kind='ingested'``, or a non-ingested op in a
-    governed approval tier — ``destructive`` #3198 or ``requires_approval``
-    #3312), and its params pass the schema. Otherwise returns the structured
-    envelope the caller propagates verbatim:
+    is previewable (:func:`_is_previewable` — ``source_kind='ingested'``, or a
+    governed-tier non-ingested op), and its params pass the schema. Otherwise
+    returns the structured envelope the caller propagates verbatim:
 
     * ``unknown_op`` -- the natural key resolved no descriptor.
     * ``preview_unavailable`` (status ``"unavailable"``) -- a ``typed`` /
@@ -237,22 +271,11 @@ async def _resolve_previewable_descriptor(
             "extras": {"error_code": "unknown_op", "known_op_count": known_op_count},
         }
 
-    # --- Non-ingested ops have no single literal HTTP request -------------
-    # A ``typed`` / ``composite`` op runs a Python handler; there is no one
-    # method/path/body to preview, so say so — unless it is in a governed
-    # approval tier, which MUST be previewable: ``destructive`` (#3198, the
-    # governed-delete gate refuses to park without a bound preview hash) or
-    # ``requires_approval`` (#3312, so the calling agent reads the same
-    # park-time ``proposed_effect`` the approver sees, not
-    # ``preview_unavailable``). Such an op has no literal request, so its
-    # preview binds the logical tuple + reuses ``proposed_effect`` — see
-    # :func:`._composite_preview.build_composite_preview`. Every other
-    # typed/composite op keeps the "unavailable" contract.
-    if (
-        descriptor.source_kind != "ingested"
-        and descriptor.safety_level != "destructive"
-        and not descriptor.requires_approval
-    ):
+    # --- Previewability gate (see :func:`_is_previewable`) -----------------
+    # A non-ingested op previews as "unavailable" unless it is in a governed
+    # approval tier (destructive #3198 / non-credential requires_approval
+    # #3312), which routes to the synthetic preview.
+    if not _is_previewable(descriptor):
         return _preview_unavailable_envelope(
             op_id=op_id, connector_id=connector_id, source_kind=descriptor.source_kind
         )
@@ -471,7 +494,8 @@ async def preview_dispatch(
     request via :func:`~meho_backplane.operations._branches.resolve_ingested_request`
     and returns it with the body redacted (:func:`_redact_request_body`). A
     non-ingested op in a governed approval tier (``destructive`` #3198 /
-    ``requires_approval`` #3312) instead gets the synthetic preview
+    non-credential ``requires_approval`` #3312 — see :func:`_is_previewable`)
+    instead gets the synthetic preview
     (:func:`~meho_backplane.operations._composite_preview.build_composite_preview`).
     Never sends, never audits, never parks;
     the policy gate (Step 4) is skipped — a preview carries no side effect to

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -30,11 +30,22 @@ Scope (honouring #1683's out-of-scope dispositions):
   network egress, no audit row, no broadcast event, no policy-gate park.
 * **No replay.** Inspecting a *would-be* request only; re-dispatching a
   past audited request is a separate governance concern (Goal #1651).
-* **Ingested ops only.** A "would-be HTTP request" exists only for
-  ``source_kind='ingested'`` ops (they construct a literal method/path/
-  body). ``typed`` / ``composite`` ops invoke Python handlers and have no
-  single HTTP request to preview -- the preview says so explicitly rather
-  than fabricating one.
+* **Ingested ops, plus a synthetic preview for the approval tiers.** A
+  literal "would-be HTTP request" exists only for ``source_kind='ingested'``
+  ops (they construct a literal method/path/body). A ``typed`` /
+  ``composite`` op invokes a Python handler and has no single HTTP request
+  to preview -- so by default the preview says so explicitly
+  (``status="unavailable"``) rather than fabricating one. The two governed
+  approval tiers are the exception: a ``safety_level='destructive'`` op
+  (#3198) and an op that ``requires_approval`` (#3312, canonical case the
+  ``dangerous``-tier typed ``vault.kv.delete``) instead get a **synthetic
+  preview** -- a params-bound projection (the hashed binding) plus the
+  reused park-time ``proposed_effect`` content -- so the agent reads the
+  same effect block the approver sees, pre-dispatch. That proposed-effect
+  reuse is **egress-free**: it runs the registered builder with **no
+  connector instance**, so a pure builder (e.g. ``vault.kv.delete``, which
+  reads only its params) populates while a live-read blast-radius builder
+  declines. No handler is ever invoked and nothing is sent.
 
 The resolution itself is shared verbatim with the execute path via
 :func:`~meho_backplane.operations._branches.resolve_ingested_request`, so
@@ -115,9 +126,11 @@ def _preview_unavailable_envelope(
     """Structured ``unavailable`` envelope for a non-previewable typed/composite op.
 
     A ``typed`` / ``composite`` op runs a Python handler with no single
-    literal HTTP request to preview. (A ``destructive`` composite is the
-    exception — it is routed to :func:`_build_composite_preview` instead of
-    here, #3198.)
+    literal HTTP request to preview. (The two governed approval tiers are
+    the exception — a ``destructive`` op, #3198, and a ``requires_approval``
+    op, #3312 — are routed to
+    :func:`~meho_backplane.operations._composite_preview.build_composite_preview`
+    instead of here.)
     """
     return {
         "status": "unavailable",
@@ -181,12 +194,14 @@ async def _resolve_previewable_descriptor(
     """Run dispatch Steps 2-3 + the previewability gate; return descriptor or error.
 
     Returns the validated :class:`EndpointDescriptor` when the op resolves,
-    is an ``source_kind='ingested'`` op, and its params pass the schema.
-    Otherwise returns the structured envelope the caller propagates verbatim:
+    is previewable (``source_kind='ingested'``, or a non-ingested op in a
+    governed approval tier — ``destructive`` #3198 or ``requires_approval``
+    #3312), and its params pass the schema. Otherwise returns the structured
+    envelope the caller propagates verbatim:
 
     * ``unknown_op`` -- the natural key resolved no descriptor.
     * ``preview_unavailable`` (status ``"unavailable"``) -- a ``typed`` /
-      ``composite`` op has no single literal HTTP request to preview.
+      ``composite`` op outside the governed approval tiers.
     * ``invalid_params`` -- params failed the descriptor's
       ``parameter_schema`` (same validation ``dispatch`` runs).
     * ``invalid_op_schema`` -- the stored ``parameter_schema`` itself
@@ -223,19 +238,21 @@ async def _resolve_previewable_descriptor(
         }
 
     # --- Non-ingested ops have no single literal HTTP request -------------
-    # A ``typed`` / ``composite`` op invokes a Python handler (which may
-    # itself make zero or many HTTP calls, or none); there is no one
-    # method/path/body to preview. Say so explicitly rather than fabricate.
-    #
-    # #3198 exception: the ``destructive`` tier MUST be previewable, because
-    # the governed-delete gate refuses to park a destructive op unless a
-    # ``preview_operation`` of the identical tuple bound a matching hash
-    # (decision requirement 2). A composite/typed destructive op has no
-    # literal HTTP request, so its preview binds the logical request tuple
-    # (params on the ``redacted_body`` slot) instead — see
-    # :func:`_build_composite_preview`. Scoped to ``destructive`` so every
-    # non-destructive typed/composite op keeps the "unavailable" contract.
-    if descriptor.source_kind != "ingested" and descriptor.safety_level != "destructive":
+    # A ``typed`` / ``composite`` op runs a Python handler; there is no one
+    # method/path/body to preview, so say so — unless it is in a governed
+    # approval tier, which MUST be previewable: ``destructive`` (#3198, the
+    # governed-delete gate refuses to park without a bound preview hash) or
+    # ``requires_approval`` (#3312, so the calling agent reads the same
+    # park-time ``proposed_effect`` the approver sees, not
+    # ``preview_unavailable``). Such an op has no literal request, so its
+    # preview binds the logical tuple + reuses ``proposed_effect`` — see
+    # :func:`._composite_preview.build_composite_preview`. Every other
+    # typed/composite op keeps the "unavailable" contract.
+    if (
+        descriptor.source_kind != "ingested"
+        and descriptor.safety_level != "destructive"
+        and not descriptor.requires_approval
+    ):
         return _preview_unavailable_envelope(
             op_id=op_id, connector_id=connector_id, source_kind=descriptor.source_kind
         )
@@ -437,60 +454,6 @@ def _ok_ingested_envelope(
     return envelope
 
 
-#: Sentinel ``method`` for a destructive composite/typed preview (#3198) —
-#: there is no HTTP verb, but the slot is one of the hashed keys, so a
-#: constant keeps the hash stable while the params on ``redacted_body`` make
-#: it param-sensitive.
-_COMPOSITE_PREVIEW_METHOD: Final[str] = "COMPOSITE"
-
-
-def _build_composite_preview(
-    *,
-    operator: Operator,
-    connector_id: str,
-    op_id: str,
-    descriptor: EndpointDescriptor,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    """Assemble the params-bound preview for a ``destructive`` non-ingested op (#3198).
-
-    A composite / typed op has no single literal HTTP request, so the
-    preview-hash binding (decision ``governed-delete-operations.md``
-    requirement 2) binds the *logical request tuple* instead: the redacted
-    params ride the ``redacted_body`` slot, so :func:`compute_preview_hash`
-    — unchanged — is param-sensitive (two different deletes hash
-    differently) while ``method`` (a ``COMPOSITE`` sentinel) and
-    ``resolved_path`` (the ``op_id``) name the op. Only reached for the
-    ``destructive`` tier (the gate in :func:`_resolve_previewable_descriptor`),
-    so the non-destructive typed/composite surface keeps its
-    ``"unavailable"`` contract. No handler runs and nothing is sent — this
-    is a pure request-shape projection.
-    """
-    redacted_body = _redact_request_body(
-        params, connector_id=connector_id, operator=operator, op_id=op_id
-    )
-    _log.info(
-        "preview_dispatch_composite",
-        connector_id=connector_id,
-        op_id=op_id,
-        source_kind=descriptor.source_kind,
-        safety_level=descriptor.safety_level,
-        tenant_id=str(operator.tenant_id),
-    )
-    envelope: dict[str, Any] = {
-        "status": "ok",
-        "op_id": op_id,
-        "connector_id": connector_id,
-        "source_kind": descriptor.source_kind,
-        "method": _COMPOSITE_PREVIEW_METHOD,
-        "resolved_path": op_id,
-        "query": None,
-        "redacted_body": redacted_body,
-    }
-    envelope["preview_hash"] = compute_preview_hash(envelope)
-    return envelope
-
-
 async def preview_dispatch(
     *,
     operator: Operator,
@@ -499,49 +462,32 @@ async def preview_dispatch(
     target: Any,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """Resolve an op + params to the literal would-be HTTP request, redacted.
+    """Resolve an op + params to the would-be request (or a synthetic preview), redacted.
 
     The read-only sibling of :func:`~meho_backplane.operations.dispatcher.dispatch`.
-    Runs the same Steps 1-3 (parse connector id, look up the descriptor,
-    validate params against ``parameter_schema`` -- via
-    :func:`_resolve_previewable_descriptor`) and Step 5 (resolve the
-    connector instance), then -- instead of executing -- resolves the
-    literal request via
-    :func:`~meho_backplane.operations._branches.resolve_ingested_request`
-    and returns it with the body redacted through the connector-boundary
-    pipeline (:func:`_redact_request_body`).
+    Runs the same Steps 1-3 (parse connector id, look up descriptor, validate
+    params — via :func:`_resolve_previewable_descriptor`) and Step 5 (resolve
+    connector instance), then — instead of executing — resolves the literal
+    request via :func:`~meho_backplane.operations._branches.resolve_ingested_request`
+    and returns it with the body redacted (:func:`_redact_request_body`). A
+    non-ingested op in a governed approval tier (``destructive`` #3198 /
+    ``requires_approval`` #3312) instead gets the synthetic preview
+    (:func:`~meho_backplane.operations._composite_preview.build_composite_preview`).
+    Never sends, never audits, never parks;
+    the policy gate (Step 4) is skipped — a preview carries no side effect to
+    authorize (both surfaces stay ``OPERATOR``-gated at the route/tool layer).
 
-    Never sends the request, never writes an audit row, never parks. The
-    policy gate (Step 4) is deliberately skipped: a preview reveals only
-    what *would* be sent (and the body is redacted), so it carries no
-    side effect to authorize -- the same posture as ``search_operations``
-    over the same descriptors. (Both surfaces are still ``OPERATOR``-gated
-    at the route / tool layer.)
-
-    Returns a JSON-shaped envelope:
-
-    * ``status`` -- ``"ok"`` when the request resolved; ``"error"`` on a
-      structured failure (``unknown_op`` / ``invalid_params`` /
-      ``no_connector`` / ``ambiguous_connector`` / ``dispatch_error``);
-      ``"unavailable"`` when the op is not previewable (a ``typed`` /
-      ``composite`` op has no literal HTTP request).
-    * ``op_id`` / ``connector_id`` -- echoed for correlation.
-    * ``source_kind`` -- the descriptor's source kind (present whenever a
-      descriptor resolved).
-    * On ``status == "ok"``: ``method``, ``resolved_path``, ``query``
-      (object or ``null``), ``redacted_body`` (the raw body after the
-      redaction pipeline; ``null`` when the op declares no body), and
-      ``preview_hash`` (#3197) -- the stable
-      :func:`compute_preview_hash` binding a caller presents on the
-      subsequent governed ``call_operation`` of a ``destructive``-tier op.
-    * On a non-ok status: ``error`` (``"<code>: <human-readable>"``) and,
-      for structured failures, an ``extras`` object carrying the
-      machine-readable ``error_code`` and any per-code detail.
-
-    The function does not raise for operator-input faults (unknown op,
-    invalid params, unresolvable connector) -- they come back as the
-    structured ``error`` envelope, mirroring the dispatcher's never-raises
-    contract so the REST route and MCP tool keep one uniform shape.
+    Returns a JSON-shaped envelope: ``status`` ``"ok"`` (request/synthetic
+    preview resolved), ``"error"`` (structured ``unknown_op`` /
+    ``invalid_params`` / ``no_connector`` / ``ambiguous_connector`` /
+    ``dispatch_error``), or ``"unavailable"`` (a non-governed typed/composite
+    op). ``op_id`` / ``connector_id`` / ``source_kind`` echo for correlation.
+    On ``ok``: ``method``, ``resolved_path``, ``query``, ``redacted_body``,
+    ``preview_hash`` (#3197 — the binding a caller presents on the governed
+    ``call_operation``), and, for a synthetic preview whose builder populated,
+    ``proposed_effect`` (#3312). On non-ok: ``error`` + an ``extras`` object.
+    Never raises for operator-input faults — they ride the ``error`` envelope,
+    mirroring the dispatcher's never-raises contract.
     """
     resolved = await _resolve_previewable_descriptor(
         operator=operator,
@@ -552,13 +498,20 @@ async def preview_dispatch(
     if isinstance(resolved, dict):
         return resolved  # structured unknown_op / unavailable / invalid_params
     if resolved.source_kind != "ingested":
-        # A destructive composite/typed op cleared the previewability gate
-        # (#3198) — bind the logical request tuple, no handler runs.
-        return _build_composite_preview(
+        # A destructive/requires_approval typed/composite op cleared the
+        # previewability gate (#3198/#3312) — bind the logical request tuple
+        # + reuse the park-time proposed_effect, no handler runs. Imported
+        # lazily: the synthetic-preview module imports back from here (shared
+        # ``compute_preview_hash`` / ``_redact_request_body``), so a top-level
+        # import would cycle.
+        from meho_backplane.operations._composite_preview import build_composite_preview
+
+        return await build_composite_preview(
             operator=operator,
             connector_id=connector_id,
             op_id=op_id,
             descriptor=resolved,
+            target=target,
             params=params,
         )
     return await _build_ingested_preview(

--- a/backend/tests/test_destructive_builder_conformance.py
+++ b/backend/tests/test_destructive_builder_conformance.py
@@ -29,7 +29,7 @@ sweep bites without a DB.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -79,7 +79,7 @@ _KNOWN_DESTRUCTIVE_OPS_WITH_BUILDERS: frozenset[str] = frozenset(
 
 
 def _destructive_ops_missing_builder(
-    op_ids: object,
+    op_ids: Iterable[str],
     *,
     registered_builders: Mapping[str, Any],
     exemptions: frozenset[str],
@@ -92,7 +92,7 @@ def _destructive_ops_missing_builder(
     """
     return sorted(
         op_id
-        for op_id in set(op_ids)  # type: ignore[arg-type]
+        for op_id in set(op_ids)
         if op_id not in registered_builders and op_id not in exemptions
     )
 

--- a/backend/tests/test_destructive_builder_conformance.py
+++ b/backend/tests/test_destructive_builder_conformance.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Registry-driven conformance sweep: every destructive op has a builder (#3312).
+
+The runtime enforcement is fail-closed but runtime-only: the dispatcher's
+``_destructive_binding_refusal`` (dispatcher.py) plus the mandatory
+blast-radius gate (``blast_radius_missing_reason``, ``operations/_preview.py``)
+refuse to *park* a ``safety_level="destructive"`` op unless its
+``proposed_effect`` carries a well-formed blast-radius block — which requires a
+registered preview builder. So a posture sweep that promotes an op to
+``destructive`` **without** registering its builder (the #3247 / #3288 / #3305
+promotions show these are recurring) ships an **un-parkable** operation: fail-
+safe, but silently broken until first use, and green in CI.
+
+This sweep closes that gap. It enumerates every registered ``destructive``
+descriptor — across every connector, both source kinds (typed + composite;
+harbor / bind9 precedent shows a bespoke builder is required regardless of
+source kind) — from the real typed-op registrars, and asserts each resolves a
+registered builder in :data:`_PREVIEW_BUILDERS`. A promotion without a builder
+now fails **CI**, not first use.
+
+Idiom: registry-driven (drives off the live registered descriptor set, so it
+fails on an unacknowledged addition), mirroring the flight-recorder registry
+sweep and ``test_mcp_surface_conformance``. The shared predicate
+(:func:`_destructive_ops_missing_builder`) lets the negative guards prove the
+sweep bites without a DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._preview import _PREVIEW_BUILDERS
+from meho_backplane.operations.typed_register import run_typed_op_registrars
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires (``run_typed_op_registrars``
+    reads :func:`get_settings`)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+#: Destructive op ids deliberately exempt from the builder requirement.
+#:
+#: **Empty by design.** The runtime gate is fail-closed, so a destructive op
+#: with no builder is un-parkable; this sweep only promotes that from a
+#: first-use runtime failure to a CI failure. Add an op here ONLY with a
+#: comment proving its family genuinely cannot compute a blast radius (no
+#: family does today — every destructive op ships a bespoke builder).
+_BUILDER_EXEMPT_DESTRUCTIVE_OPS: frozenset[str] = frozenset()
+
+#: Real destructive ops (one per non-vmware family) asserted to be swept: they
+#: must be both registered as ``destructive`` and carry a builder. A guard
+#: against the sweep silently seeing an empty destructive set (a broken seed
+#: would make the main assertion vacuously pass).
+_KNOWN_DESTRUCTIVE_OPS_WITH_BUILDERS: frozenset[str] = frozenset(
+    {
+        "bind9.record.delete",
+        "bind9.record.remove",
+        "harbor.robot.delete",
+        "windns.record.remove",
+    }
+)
+
+
+def _destructive_ops_missing_builder(
+    op_ids: object,
+    *,
+    registered_builders: Mapping[str, Any],
+    exemptions: frozenset[str],
+) -> list[str]:
+    """Return the destructive op ids resolving no proposed-effect builder.
+
+    The registry-driven predicate the sweep and its negative guards share:
+    a destructive op id that is neither in *registered_builders* nor exempt is
+    un-parkable and flagged. Sorted for a deterministic assertion message.
+    """
+    return sorted(
+        op_id
+        for op_id in set(op_ids)  # type: ignore[arg-type]
+        if op_id not in registered_builders and op_id not in exemptions
+    )
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so the registrar pass doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+async def _seed_and_collect_destructive_op_ids(stub: AsyncMock) -> list[str]:
+    """Run every typed-op registrar, return the registered destructive op ids."""
+    await run_typed_op_registrars(embedding_service=stub)
+    async with get_sessionmaker()() as session:
+        rows = await session.execute(
+            select(EndpointDescriptor.op_id).where(EndpointDescriptor.safety_level == "destructive")
+        )
+    return list(rows.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_every_destructive_op_registers_a_blast_radius_builder(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Registry-driven sweep: no registered destructive op lacks a builder (#3312)."""
+    op_ids = await _seed_and_collect_destructive_op_ids(stub_embedding_service)
+
+    # Guard against a vacuous pass: the destructive set must be non-empty and
+    # cover the known non-vmware families (else a broken seed hides gaps).
+    assert op_ids, "no destructive descriptors registered — the sweep would pass vacuously"
+    seeded = set(op_ids)
+    assert seeded >= _KNOWN_DESTRUCTIVE_OPS_WITH_BUILDERS, (
+        "expected the known destructive family ops to be registered; missing "
+        f"{sorted(_KNOWN_DESTRUCTIVE_OPS_WITH_BUILDERS - seeded)}"
+    )
+
+    missing = _destructive_ops_missing_builder(
+        op_ids,
+        registered_builders=_PREVIEW_BUILDERS,
+        exemptions=_BUILDER_EXEMPT_DESTRUCTIVE_OPS,
+    )
+    assert not missing, (
+        "destructive ops with no registered proposed-effect / blast-radius builder "
+        f"(un-parkable — the runtime park gate is fail-closed): {missing}. Register a "
+        "builder via register_preview_builder(op_id, ...), or add a commented "
+        "exemption to _BUILDER_EXEMPT_DESTRUCTIVE_OPS with a reason."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "victim",
+    ["bind9.record.delete", "windns.record.remove", "harbor.robot.delete"],
+)
+async def test_sweep_flags_a_missing_destructive_builder(
+    stub_embedding_service: AsyncMock,
+    victim: str,
+) -> None:
+    """Removing any existing destructive builder makes the sweep flag it (#3312 AC).
+
+    Exercised on a filtered copy of the builder registry so the process-wide
+    :data:`_PREVIEW_BUILDERS` is never mutated.
+    """
+    op_ids = await _seed_and_collect_destructive_op_ids(stub_embedding_service)
+    assert victim in set(op_ids), f"{victim} should be a registered destructive op"
+    assert victim in _PREVIEW_BUILDERS, f"{victim} should have a builder to remove"
+
+    builders_without_victim = {k: v for k, v in _PREVIEW_BUILDERS.items() if k != victim}
+    missing = _destructive_ops_missing_builder(
+        op_ids,
+        registered_builders=builders_without_victim,
+        exemptions=_BUILDER_EXEMPT_DESTRUCTIVE_OPS,
+    )
+    assert victim in missing
+
+
+def test_sweep_flags_a_hypothetical_destructive_op_without_a_builder() -> None:
+    """A promoted-but-builderless destructive descriptor fails the sweep (#3312 AC).
+
+    The recurring hazard the sweep guards: a posture pass adds a ``destructive``
+    op and forgets its builder. Pure — no DB — the predicate is the same one the
+    live sweep uses.
+    """
+    missing = _destructive_ops_missing_builder(
+        ["some.brand_new.destroy"],
+        registered_builders=_PREVIEW_BUILDERS,
+        exemptions=_BUILDER_EXEMPT_DESTRUCTIVE_OPS,
+    )
+    assert missing == ["some.brand_new.destroy"]
+
+
+def test_an_exemption_suppresses_the_flag() -> None:
+    """An explicit exemption removes an op from the flagged set (escape valve)."""
+    op_id = "some.family.that_cannot_preview"
+    missing = _destructive_ops_missing_builder(
+        [op_id],
+        registered_builders={},
+        exemptions=frozenset({op_id}),
+    )
+    assert missing == []

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -64,6 +64,11 @@ from meho_backplane.db.models import AuditLog, EndpointDescriptor
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations._preview import (
+    _PREVIEW_BUILDERS,
+    PreviewContext,
+    register_preview_builder,
+)
 from meho_backplane.operations._request_preview import preview_dispatch
 from meho_backplane.operations.meta_tools import preview_operation
 from meho_backplane.redaction import clear_overrides, parse_policy, register_policy
@@ -671,6 +676,192 @@ async def test_preview_typed_op_is_unavailable(
     assert envelope["extras"]["reason"] == "not_ingested"
     assert "method" not in envelope
     assert "resolved_path" not in envelope
+
+
+# ---------------------------------------------------------------------------
+# #3312 -- preview parity for approval-requiring typed ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _preview_builders_snapshot() -> Iterator[None]:
+    """Snapshot + restore the global preview-builder registry.
+
+    The parity tests register a bespoke builder against a synthetic op id;
+    without this the entry would leak into the process-wide
+    :data:`_PREVIEW_BUILDERS` and pollute the destructive-builder conformance
+    sweep and every other test that reads it.
+    """
+    snapshot = dict(_PREVIEW_BUILDERS)
+    yield
+    _PREVIEW_BUILDERS.clear()
+    _PREVIEW_BUILDERS.update(snapshot)
+
+
+async def _pure_delete_preview(ctx: PreviewContext) -> dict[str, Any]:
+    """A pure preview builder (reads only ``ctx.params``) — the vault.kv.delete shape."""
+    return {
+        "resource": "kv_secret",
+        "path": ctx.params.get("path", ""),
+        "semantics": "soft_delete",
+        "versions": ctx.params.get("versions", []),
+    }
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_approval_typed_op_serves_bespoke_proposed_effect(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    _preview_builders_snapshot: None,
+) -> None:
+    """A dangerous + requires_approval typed op previews ok, carrying proposed_effect (#3312).
+
+    The asymmetry #3312 closes: at park time the approver sees a rich
+    ``proposed_effect`` from ``build_proposed_effect``, but pre-dispatch the
+    agent's ``preview_operation`` answered ``preview_unavailable``. Modelled on
+    ``vault.kv.delete`` (dangerous + requires_approval, a *pure* builder that
+    reads only its params). The synthetic preview binds the logical request
+    tuple (COMPOSITE method, op_id path, redacted params) AND reuses the
+    park-time effect via the same builder path.
+    """
+    register_connector_v2(product="demo", version="", impl_id="", cls=_RecordingHttpConnector)
+    await register_typed_operation(
+        product="demo",
+        version="1.x",
+        impl_id="demo",
+        op_id="demo.secret.delete",
+        handler=_handler_returning_ok,
+        summary="A governed delete.",
+        description="Typed, dangerous, requires approval.",
+        parameter_schema={"type": "object"},
+        safety_level="dangerous",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    register_preview_builder("demo.secret.delete", _pure_delete_preview)
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="demo-1.x",
+        op_id="demo.secret.delete",
+        target=_FakeTarget(product="demo", version="1.x", name="demo-prod"),
+        params={"path": "app/db", "versions": [3]},
+    )
+
+    # Availability change: status=ok, not unavailable.
+    assert envelope["status"] == "ok"
+    assert envelope["source_kind"] == "typed"
+    # Params-bound projection (the #3198 hash binding, unchanged).
+    assert envelope["method"] == "COMPOSITE"
+    assert envelope["resolved_path"] == "demo.secret.delete"
+    assert envelope["redacted_body"] == {"path": "app/db", "versions": [3]}
+    assert isinstance(envelope["preview_hash"], str)
+    # The reused park-time proposed_effect (#3312).
+    effect = envelope["proposed_effect"]
+    assert effect["op_class"] == "write"  # classify_op(".delete")
+    assert effect["preview"] == {
+        "resource": "kv_secret",
+        "path": "app/db",
+        "semantics": "soft_delete",
+        "versions": [3],
+    }
+    # No dispatch happened.
+    assert captured_events == []
+
+
+@pytest.mark.asyncio
+async def test_preview_proposed_effect_does_not_perturb_the_binding_hash(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    _preview_builders_snapshot: None,
+) -> None:
+    """Attaching proposed_effect must not change the preview_hash (#3197 binding intact).
+
+    The #3197 caution: the served preview participates in the preview-hash
+    contract, so the added ``proposed_effect`` key must stay outside the hashed
+    projection. The identical op previewed with and without its builder
+    registered must yield the identical hash.
+    """
+    register_connector_v2(product="demo", version="", impl_id="", cls=_RecordingHttpConnector)
+    await register_typed_operation(
+        product="demo",
+        version="1.x",
+        impl_id="demo",
+        op_id="demo.secret.delete",
+        handler=_handler_returning_ok,
+        summary="A governed delete.",
+        description="Typed, dangerous, requires approval.",
+        parameter_schema={"type": "object"},
+        safety_level="dangerous",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    args = {
+        "operator": _make_operator(),
+        "connector_id": "demo-1.x",
+        "op_id": "demo.secret.delete",
+        "target": _FakeTarget(product="demo", version="1.x", name="demo-prod"),
+        "params": {"path": "app/db", "versions": [3]},
+    }
+
+    # No builder registered: proposed_effect rides the generic params-echo.
+    without_builder = await preview_dispatch(**args)  # type: ignore[arg-type]
+    register_preview_builder("demo.secret.delete", _pure_delete_preview)
+    with_builder = await preview_dispatch(**args)  # type: ignore[arg-type]
+
+    # The bespoke preview differs from the generic echo ...
+    assert "preview" in with_builder["proposed_effect"]
+    assert "params_echo" in without_builder["proposed_effect"]
+    # ... but the binding hash is identical (proposed_effect is unhashed).
+    assert with_builder["preview_hash"] == without_builder["preview_hash"]
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_approval_generic_echo_scrubs_secret_param(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    _preview_builders_snapshot: None,
+) -> None:
+    """The reused proposed_effect applies park-time redaction to a builder-less op (#3312).
+
+    A requires_approval op with no bespoke builder falls to the generic
+    params-echo default — the *same* code path the approval-park path runs — so
+    a secret-by-key-name param is scrubbed identically to park time. This is the
+    "redaction discipline identical to park-time proposed_effect" acceptance.
+    """
+    register_connector_v2(product="demo", version="", impl_id="", cls=_RecordingHttpConnector)
+    await register_typed_operation(
+        product="demo",
+        version="1.x",
+        impl_id="demo",
+        op_id="demo.thing.reconfigure",
+        handler=_handler_returning_ok,
+        summary="A governed reconfigure.",
+        description="Typed, dangerous, requires approval, no bespoke builder.",
+        parameter_schema={"type": "object"},
+        safety_level="dangerous",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="demo-1.x",
+        op_id="demo.thing.reconfigure",
+        target=_FakeTarget(product="demo", version="1.x", name="demo-prod"),
+        params={"host": "h1", "password": "hunter2"},
+    )
+
+    assert envelope["status"] == "ok"
+    echo = envelope["proposed_effect"]["params_echo"]
+    assert echo["host"] == "h1"
+    assert echo["password"] == "***REDACTED***"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -865,6 +865,58 @@ async def test_preview_requires_approval_generic_echo_scrubs_secret_param(
 
 
 @pytest.mark.asyncio
+async def test_preview_credential_class_requires_approval_op_stays_unavailable(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    _preview_builders_snapshot: None,
+) -> None:
+    """A credential-class requires_approval op is NOT previewable — no secret leak (#3312).
+
+    The security guard on the #3312 extension. `k8s.secret.create` (and
+    `vault.kv.put` etc.) classify as `credential_write`: the secret rides in the
+    request params, and the synthetic preview's `redacted_body` slot uses only
+    connector-boundary *value-shape* redaction, which does NOT scrub a structured
+    secret like `{"data": {"password": …}}`. So making it previewable would
+    surface the written secret. The gate excludes credential-class ops (mirroring
+    the park-time `build_proposed_effect` credential suppression), keeping the
+    `unavailable` contract and never producing a `redacted_body` for them.
+    """
+    register_connector_v2(product="demo", version="", impl_id="", cls=_RecordingHttpConnector)
+    # op_id `k8s.secret.create` classifies as credential_write (allowlisted in
+    # broadcast.events), regardless of the demo connector it is registered under.
+    await register_typed_operation(
+        product="demo",
+        version="1.x",
+        impl_id="demo",
+        op_id="k8s.secret.create",
+        handler=_handler_returning_ok,
+        summary="A credential-class governed write.",
+        description="Typed, dangerous, requires approval, secret in params.",
+        parameter_schema={"type": "object"},
+        safety_level="dangerous",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="demo-1.x",
+        op_id="k8s.secret.create",
+        target=_FakeTarget(product="demo", version="1.x", name="demo-prod"),
+        params={"name": "db", "data": {"password": "s3cr3tVALUE"}},
+    )
+
+    assert envelope["status"] == "unavailable"
+    assert envelope["extras"]["reason"] == "not_ingested"
+    assert "redacted_body" not in envelope
+    assert "proposed_effect" not in envelope
+    # Belt-and-suspenders: the secret value appears nowhere in the envelope.
+    assert "s3cr3tVALUE" not in str(envelope)
+
+
+@pytest.mark.asyncio
 async def test_preview_invalid_params_returns_structured_error(
     stub_embedding_service: AsyncMock,
     session: AsyncSession,

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -713,15 +713,21 @@ enforcement that #3196/#3197 left, plus one machinery limitation:
   `redacted_body` slot, so `compute_preview_hash` (unchanged) is
   param-sensitive while a `COMPOSITE` sentinel `method` + the `op_id` as
   `resolved_path` name the op. #3312 additionally extends the gate to any
-  `requires_approval` op (canonical case the `dangerous`-tier typed
-  `vault.kv.delete`) and layers the **reused park-time `proposed_effect`**
-  onto the envelope, so the calling agent reads the same effect block the
-  approver sees pre-dispatch instead of `preview_unavailable`. That reuse
-  runs `build_proposed_effect` with **no connector instance** (egress-free):
-  a pure builder populates, a live-read blast-radius builder declines. The
-  `proposed_effect` key is outside the hashed projection, so the
-  requirement-2 binding is unperturbed. Every op outside the two governed
-  tiers keeps its `unavailable` contract.
+  **non-credential-class** `requires_approval` op (canonical case the
+  `dangerous`-tier typed `vault.kv.delete`) and layers the **reused park-time
+  `proposed_effect`** onto the envelope, so the calling agent reads the same
+  effect block the approver sees pre-dispatch instead of `preview_unavailable`.
+  That reuse runs `build_proposed_effect` with **no connector instance**
+  (egress-free): a pure builder populates, a live-read blast-radius builder
+  declines. The `proposed_effect` key is outside the hashed projection, so the
+  requirement-2 binding is unperturbed. A **credential-class** op (`vault.kv.put`
+  / `k8s.secret.create` — `classify_op` ∈ the aggregate-only sensitivity set)
+  is deliberately **excluded** and keeps its `unavailable` contract: its secret
+  rides in the request params, and the synthetic preview's `redacted_body` slot
+  uses only connector-boundary value-shape redaction, which cannot be trusted to
+  scrub a structured secret — the same reason `build_proposed_effect` suppresses
+  credential-class request detail at park time. Every op outside the two governed
+  tiers likewise keeps its `unavailable` contract.
 - **The USER auto-execute hole.** `_non_agent_verdict` (`operations/_validate.py`)
   previously parked a human only on `requires_approval`; the
   `safety_level→park` mapping lived on the service-principal branch alone.

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -671,9 +671,16 @@ missing/malformed block → `_handle_needs_approval` refuses the park with
 `denied` / `blast_radius_required` (naming the missing field) rather than
 falling back to the identifier-only default. So a `destructive` op that
 registers no blast-radius preview builder is un-parkable by construction —
-fail-closed. The console modal (`ui/templates/approvals/_modal.html`)
-renders the block as an error-tinted "what this destroys" card above the
-generic field table.
+fail-closed. That refusal is **runtime-only**, though: a posture sweep that
+promotes an op to `destructive` without adding its builder ships an
+un-parkable op that is green in CI and only breaks on first use. #3312 adds
+the registry-driven CI conformance sweep
+(`tests/test_destructive_builder_conformance.py`) that enumerates every
+registered `destructive` descriptor (every connector, both source kinds) and
+fails the build if any lacks a registered proposed-effect builder — moving
+the failure from first-use to CI. The console modal
+(`ui/templates/approvals/_modal.html`) renders the block as an error-tinted
+"what this destroys" card above the generic field table.
 
 **Scope note.** The gate lives on the top-level dispatch park path
 (`_handle_needs_approval`). The composite-subop park path
@@ -695,17 +702,26 @@ builder are documented in
 surfaced — and this task closed — three gaps in the tier's *human*-side
 enforcement that #3196/#3197 left, plus one machinery limitation:
 
-- **A composite/typed op is now previewable when it is `destructive`.**
+- **A composite/typed op is now previewable when it is `destructive`
+  (#3198) or `requires_approval` (#3312).**
   `preview_dispatch` returns `unavailable` for non-ingested ops (they have
   no single literal HTTP request), which would make the requirement-2 hash
   binding impossible on the composite surface. The gate in
-  `_resolve_previewable_descriptor` now lets a `destructive` non-ingested op
-  through to `_build_composite_preview`, which binds the *logical request
-  tuple*: the redacted params ride the `redacted_body` slot, so
-  `compute_preview_hash` (unchanged) is param-sensitive while a `COMPOSITE`
-  sentinel `method` + the `op_id` as `resolved_path` name the op. Scoped to
-  `destructive` so every non-destructive typed/composite op keeps its
-  `unavailable` contract.
+  `_resolve_previewable_descriptor` now lets a governed-tier non-ingested op
+  through to `build_composite_preview` (`operations/_composite_preview.py`),
+  which binds the *logical request tuple*: the redacted params ride the
+  `redacted_body` slot, so `compute_preview_hash` (unchanged) is
+  param-sensitive while a `COMPOSITE` sentinel `method` + the `op_id` as
+  `resolved_path` name the op. #3312 additionally extends the gate to any
+  `requires_approval` op (canonical case the `dangerous`-tier typed
+  `vault.kv.delete`) and layers the **reused park-time `proposed_effect`**
+  onto the envelope, so the calling agent reads the same effect block the
+  approver sees pre-dispatch instead of `preview_unavailable`. That reuse
+  runs `build_proposed_effect` with **no connector instance** (egress-free):
+  a pure builder populates, a live-read blast-radius builder declines. The
+  `proposed_effect` key is outside the hashed projection, so the
+  requirement-2 binding is unperturbed. Every op outside the two governed
+  tiers keeps its `unavailable` contract.
 - **The USER auto-execute hole.** `_non_agent_verdict` (`operations/_validate.py`)
   previously parked a human only on `requires_approval`; the
   `safety_level→park` mapping lived on the service-principal branch alone.

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -38,17 +38,22 @@ connector-boundary pipeline the response path uses.
 ## Scope
 
 In scope: the literal would-be request for an `source_kind='ingested'`
-op, redacted, returned without sending.
+op, redacted, returned without sending. Plus, for a non-ingested op in a
+governed approval tier (`safety_level='destructive'` #3198, or
+`requires_approval` #3312), a **synthetic preview** — a params-bound
+projection (the hash binding) plus the reused park-time `proposed_effect`
+(`_composite_preview.py`, egress-free).
 
 Out of scope (honouring #1683's dispositions):
 
 - **No persisting the raw body.** `params_hash` stays the audit field.
 - **No replay.** Inspecting a *would-be* request only; re-dispatching a
   past audited request is a separate governance concern (Goal #1651).
-- **Non-ingested ops.** A `typed` / `composite` op runs a Python handler
-  (which may make zero or many HTTP calls) and has no single literal HTTP
-  request — the preview returns `status="unavailable"` rather than
-  fabricating one.
+- **Non-ingested ops outside the governed tiers.** A `typed` / `composite`
+  op runs a Python handler (which may make zero or many HTTP calls) and has
+  no single literal HTTP request — unless it is `destructive` /
+  `requires_approval` (above), the preview returns `status="unavailable"`
+  rather than fabricating one.
 - **Error-echo on the dispatch path** is deferred (see Known issues).
 
 ## Key types
@@ -91,11 +96,15 @@ preview_dispatch(operator, connector_id, op_id, target, params)
         │
         ├─ parse_connector_id → (product, version, impl_id)
         ├─ lookup_descriptor → None ? → status=error error_code=unknown_op
-        ├─ source_kind != 'ingested' ? → status=unavailable (not_ingested)
+        ├─ source_kind != 'ingested' AND not (destructive OR requires_approval) ?
+        │       → status=unavailable (not_ingested)     ◄── governed tiers pass (#3198/#3312)
         ├─ validate_params → errors ? → status=error error_code=invalid_params
         │       (InvalidOpSchemaError ? → status=error error_code=invalid_op_schema, #3095)
         ├─ resolve_connector_or_label → label ? → status=error (no_connector /
         │       ambiguous_connector)
+        ├─ source_kind != 'ingested' (governed tier) ? → build_composite_preview:
+        │       COMPOSITE method + op_id path + redacted params, hashed, PLUS the
+        │       reused park-time proposed_effect (build_proposed_effect, no connector)
         ├─ get_or_create_connector_instance(cls)   (cached singleton)
         ├─ resolve_ingested_request(...)   ◄── SAME resolver dispatch_ingested uses
         │       → IngestedRequest{method, path, query, body}
@@ -104,24 +113,27 @@ preview_dispatch(operator, connector_id, op_id, target, params)
                      tenant, op).redacted   ◄── SAME pipeline the response path uses
         ▼
 {status: ok, op_id, connector_id, source_kind, method,
- resolved_path, query, redacted_body, preview_hash}
+ resolved_path, query, redacted_body, preview_hash [, proposed_effect]}
 ```
 
 The HTTP transport (`HttpConnector._post_json` / `_request_json`) is
 **never** called: there is no network egress, no audit row, no broadcast
-event, no policy-gate park. The policy gate (dispatch Step 4) is
-deliberately skipped — a preview reveals only what *would* be sent (and
-the body is redacted), so it carries no side effect to authorize, the
-same posture as `search_operations` over the same descriptors. Both
-surfaces stay `OPERATOR`-gated at the route / tool layer.
+event, no policy-gate park. The synthetic-preview branch keeps this
+contract — it reuses `build_proposed_effect` with **no connector instance**,
+so a pure builder (e.g. `vault.kv.delete`) populates while a live-read
+blast-radius builder declines rather than dialling out. The policy gate
+(dispatch Step 4) is deliberately skipped — a preview reveals only what
+*would* be sent (and the body is redacted), so it carries no side effect to
+authorize, the same posture as `search_operations` over the same
+descriptors. Both surfaces stay `OPERATOR`-gated at the route / tool layer.
 
 ## Envelope shape
 
 | `status` | meaning | extra fields |
 |---|---|---|
-| `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind`, `preview_hash` (#3197 — SHA-256 over the resolved-request projection; the caller presents it on a `destructive`-tier `call_operation` and the dispatcher recomputes + matches it before parking the approval) |
+| `ok` | request (or synthetic preview) resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind`, `preview_hash` (#3197 — SHA-256 over the resolved-request projection; the caller presents it on a `destructive`-tier `call_operation` and the dispatcher recomputes + matches it before parking the approval), and — on a governed-tier synthetic preview whose builder populated — `proposed_effect` (#3312, the reused park-time effect block; unhashed, so it never perturbs the `preview_hash` binding) |
 | `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `invalid_op_schema` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail (`invalid_op_schema` carries `extras.missing_ref`, #3095) |
-| `unavailable` | not an HTTP-ingested op | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
+| `unavailable` | not an HTTP-ingested op **and** not in a governed approval tier (destructive / requires_approval) | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
 
 Operator-input faults come back **inside** the envelope (not as
 exceptions), mirroring the dispatcher's never-raises contract so the REST
@@ -200,10 +212,16 @@ named-pattern catalogue and policy resolution.
   is a larger, riskier change for marginal benefit (an operator who hit a
   4xx re-issues the same args against `/preview`). It is recorded here as
   a possible follow-up rather than shipped in this change.
-- The preview covers `source_kind='ingested'` only; previewing the
-  *effective* request a composite handler would synthesize per sub-op is
-  out of scope (composites already carry the park-time `proposed_effect`
-  semantic preview, #1608 / #1628).
+- The literal-request preview covers `source_kind='ingested'` only;
+  previewing the *effective* per-sub-op requests a composite handler would
+  synthesize is out of scope. A governed-tier (destructive /
+  requires_approval) non-ingested op instead gets the **synthetic** preview
+  (`_composite_preview.py`, #3198 / #3312): a params-bound projection plus
+  the reused park-time `proposed_effect`. That effect is built egress-free
+  (no connector instance), so a live-read blast-radius builder — which needs
+  a connector to enumerate children — declines and the synthetic preview
+  carries only the params-bound projection; the rich blast radius still
+  lands at park time, where the connector is resolved.
 
 ## References
 

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -39,10 +39,12 @@ connector-boundary pipeline the response path uses.
 
 In scope: the literal would-be request for an `source_kind='ingested'`
 op, redacted, returned without sending. Plus, for a non-ingested op in a
-governed approval tier (`safety_level='destructive'` #3198, or
-`requires_approval` #3312), a **synthetic preview** — a params-bound
-projection (the hash binding) plus the reused park-time `proposed_effect`
-(`_composite_preview.py`, egress-free).
+governed approval tier (`safety_level='destructive'` #3198, or a
+**non-credential-class** `requires_approval` op #3312 — a credential-class op
+like `vault.kv.put` stays `unavailable` because its secret rides in the
+params), a **synthetic preview** — a params-bound projection (the hash
+binding) plus the reused park-time `proposed_effect` (`_composite_preview.py`,
+egress-free).
 
 Out of scope (honouring #1683's dispositions):
 
@@ -51,9 +53,9 @@ Out of scope (honouring #1683's dispositions):
   past audited request is a separate governance concern (Goal #1651).
 - **Non-ingested ops outside the governed tiers.** A `typed` / `composite`
   op runs a Python handler (which may make zero or many HTTP calls) and has
-  no single literal HTTP request — unless it is `destructive` /
-  `requires_approval` (above), the preview returns `status="unavailable"`
-  rather than fabricating one.
+  no single literal HTTP request — unless it is `destructive` or a
+  non-credential-class `requires_approval` op (above), the preview returns
+  `status="unavailable"` rather than fabricating one.
 - **Error-echo on the dispatch path** is deferred (see Known issues).
 
 ## Key types
@@ -96,7 +98,8 @@ preview_dispatch(operator, connector_id, op_id, target, params)
         │
         ├─ parse_connector_id → (product, version, impl_id)
         ├─ lookup_descriptor → None ? → status=error error_code=unknown_op
-        ├─ source_kind != 'ingested' AND not (destructive OR requires_approval) ?
+        ├─ not previewable (see _is_previewable: ingested, OR destructive,
+        │       OR requires_approval AND not credential-class) ?
         │       → status=unavailable (not_ingested)     ◄── governed tiers pass (#3198/#3312)
         ├─ validate_params → errors ? → status=error error_code=invalid_params
         │       (InvalidOpSchemaError ? → status=error error_code=invalid_op_schema, #3095)
@@ -133,7 +136,7 @@ descriptors. Both surfaces stay `OPERATOR`-gated at the route / tool layer.
 |---|---|---|
 | `ok` | request (or synthetic preview) resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind`, `preview_hash` (#3197 — SHA-256 over the resolved-request projection; the caller presents it on a `destructive`-tier `call_operation` and the dispatcher recomputes + matches it before parking the approval), and — on a governed-tier synthetic preview whose builder populated — `proposed_effect` (#3312, the reused park-time effect block; unhashed, so it never perturbs the `preview_hash` binding) |
 | `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `invalid_op_schema` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail (`invalid_op_schema` carries `extras.missing_ref`, #3095) |
-| `unavailable` | not an HTTP-ingested op **and** not in a governed approval tier (destructive / requires_approval) | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
+| `unavailable` | not an HTTP-ingested op **and** not previewable in a governed tier (destructive, or non-credential-class requires_approval — a credential-class op like `vault.kv.put` stays here so its secret params never surface) | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
 
 Operator-input faults come back **inside** the envelope (not as
 exceptions), mirroring the dispatcher's never-raises contract so the REST

--- a/docs/decisions/governed-delete-operations.md
+++ b/docs/decisions/governed-delete-operations.md
@@ -289,15 +289,21 @@ the park → human-approve → execute chain held, but `preview_operation` answe
 `proposed_effect`. Both extend — do not revise — requirements 2 and 3 above.
 
 **1. Preview parity for approval-requiring typed ops.** Requirement 2's
-previewability gate (`_resolve_previewable_descriptor`) admitted the
-`destructive` tier only. It now also admits any `requires_approval` op (the
-`dangerous`-tier typed ops, canonical case `vault.kv.delete`), and the synthetic
-preview (now `operations/_composite_preview.py`) layers the **reused** park-time
+previewability gate (`_resolve_previewable_descriptor` → `_is_previewable`)
+admitted the `destructive` tier only. It now also admits any **non-credential-class**
+`requires_approval` op (the `dangerous`-tier typed ops, canonical case
+`vault.kv.delete`), and the synthetic preview (now
+`operations/_composite_preview.py`) layers the **reused** park-time
 `proposed_effect` onto the params-bound projection — `build_proposed_effect` run
 with **no connector instance**, so it stays egress-free (a pure builder like
 `vault.kv.delete`'s populates; a live-read blast-radius builder declines). This
 closes the asymmetry where the approver saw the effect block but the calling
-agent could not preview it. The preview-hash binding is untouched: the
+agent could not preview it. A **credential-class** op (`vault.kv.put` /
+`k8s.secret.create`) is deliberately excluded — its secret rides in the request
+params, and the synthetic preview's `redacted_body` slot uses only
+connector-boundary value-shape redaction, which cannot be trusted to scrub a
+structured secret; the exclusion mirrors `build_proposed_effect`'s own
+credential-class suppression. The preview-hash binding is untouched: the
 `proposed_effect` key is outside the hashed projection, and — per this decision's
 non-goals — #3197's preview-*hash* binding is **not** extended to the `dangerous`
 tier (typed synthetic previews are params-derived, so the existing `params_hash`

--- a/docs/decisions/governed-delete-operations.md
+++ b/docs/decisions/governed-delete-operations.md
@@ -279,3 +279,39 @@ blast-radius statement (requirements 2–3). Those gates live on the approvals
 plane and the audit row, not in the trace; the flight recorder neither duplicates
 nor bypasses them — it captures the post-approval vendor traffic of the executed
 destroy, with the destructive / delete-shaped spans' bodies excluded as above.
+
+## Amendment (2026-09-02) — preview parity + a builder-coverage CI sweep (#3312)
+
+Two coupled follow-ups from the 2026-09-02 through-backplane canary of the
+governed `vault.kv.delete` chain (lab evoila-bosnia/claude-rdc-hetzner-dc#2814):
+the park → human-approve → execute chain held, but `preview_operation` answered
+`preview_unavailable` for the op even though the park-time apparatus built a rich
+`proposed_effect`. Both extend — do not revise — requirements 2 and 3 above.
+
+**1. Preview parity for approval-requiring typed ops.** Requirement 2's
+previewability gate (`_resolve_previewable_descriptor`) admitted the
+`destructive` tier only. It now also admits any `requires_approval` op (the
+`dangerous`-tier typed ops, canonical case `vault.kv.delete`), and the synthetic
+preview (now `operations/_composite_preview.py`) layers the **reused** park-time
+`proposed_effect` onto the params-bound projection — `build_proposed_effect` run
+with **no connector instance**, so it stays egress-free (a pure builder like
+`vault.kv.delete`'s populates; a live-read blast-radius builder declines). This
+closes the asymmetry where the approver saw the effect block but the calling
+agent could not preview it. The preview-hash binding is untouched: the
+`proposed_effect` key is outside the hashed projection, and — per this decision's
+non-goals — #3197's preview-*hash* binding is **not** extended to the `dangerous`
+tier (typed synthetic previews are params-derived, so the existing `params_hash`
+on dangerous parks already pins the same content).
+
+**2. A registry-driven CI sweep for destructive builder coverage.** Requirement 3
+makes a destructive op un-parkable without a blast-radius builder — fail-closed,
+but **runtime-only**: a posture sweep (#3247 / #3288 / #3305 show these recur)
+that promotes an op to `destructive` without adding its builder passes CI and
+ships an un-parkable op, silently broken until first use. The conformance tests
+this decision's requirement 3 named (§"conformance tests proving no agent path,
+no grant path, …") scoped to **access-control invariants** only. #3312 adds a
+new, orthogonal conformance sweep
+(`tests/test_destructive_builder_conformance.py`): it enumerates every registered
+`destructive` descriptor from the real typed-op registrars (every connector, both
+source kinds) and fails the build if any resolves no registered proposed-effect
+builder. A promotion without a builder now fails CI, not first use.


### PR DESCRIPTION
## What + why

Two coupled fixes from the 2026-09-02 through-backplane governed-delete canary of the `vault.kv.delete` chain (lab evoila-bosnia/claude-rdc-hetzner-dc#2814). The park → human-approve → execute chain held end-to-end, but `preview_operation` answered `preview_unavailable` for the op **even though the park-time apparatus already built a rich `proposed_effect`** (mount / path / versions / semantics). A follow-up code read confirmed two distinct, related gaps.

### 1. Preview parity for approval-requiring typed ops

**The asymmetry:** at park time the approver sees a rich effect block from `build_proposed_effect`; pre-dispatch the calling agent's `preview_operation` got `preview_unavailable`. `_resolve_previewable_descriptor` served previews only for `source_kind=="ingested"` OR `safety_level=="destructive"`, so a `dangerous` + `requires_approval` typed op (canonical case `vault.kv.delete`) fell through to `preview_unavailable`.

**The fix:** the previewability gate now also admits any `requires_approval` op. The synthetic preview reuses the **same** park-time builder — `build_proposed_effect` — and layers its output onto the params-bound projection as `proposed_effect`. No effect-building logic is duplicated.

- **Egress-free:** the builder runs with **no connector instance**, honouring the preview's no-dispatch contract. A pure builder (`vault.kv.delete`, which reads only its params) populates a rich block; a live-read blast-radius builder (which needs a connector to enumerate children) declines cleanly — its rich blast radius still lands at park time, where the connector is resolved.
- **Binding preserved (#3197):** `proposed_effect` rides **outside** the hashed projection (`compute_preview_hash` reads only the request-tuple keys), so the destructive preview-hash binding is unperturbed. A test pins that the hash is identical with and without the builder registered.
- **Redaction discipline identical to park-time:** it *is* the park-time builder, so the generic params-echo scrub and bespoke field discipline are the same.
- Availability change only; park / approval behaviour is unchanged. Per the decision's non-goals, #3197's preview-*hash* binding is **not** extended to the `dangerous` tier.

To keep `_request_preview.py` under the repo's file-size limit, the synthetic-preview path (a distinct responsibility from the #1683 ingested literal-request preview) is extracted to a new `operations/_composite_preview.py`.

### 2. Registry-driven CI conformance sweep for destructive builder coverage

The runtime destructive park gate (`_destructive_binding_refusal` + `blast_radius_missing_reason`) is fail-closed but **runtime-only**: a posture sweep that promotes an op to `destructive` without adding its builder (the #3247 / #3288 / #3305 promotions show these recur) passes CI and ships an **un-parkable** op — fail-safe, but silently broken until first use.

`test_destructive_builder_conformance.py` enumerates every registered `destructive` descriptor from the real typed-op registrars (every connector, both source kinds — currently 10 ops across bind9 / harbor / pfsense / windns typed + vmware composite) and fails the build if any resolves no registered proposed-effect builder. Registry-driven (fails on unacknowledged additions), with negative guards proving removing a builder or adding a builderless destructive descriptor makes it bite, and an empty, commented exemption set.

## Tests

- `test_operations_request_preview.py` — 3 new parity tests: bespoke `proposed_effect` served for a `dangerous`+`requires_approval` typed op, generic params-echo scrub parity, and hash-stability under `proposed_effect` attachment.
- `test_destructive_builder_conformance.py` — the sweep + its negative guards.
- Green locally: preview / binding / conformance / vm-destroy / bind9 / windns / harbor / pfsense / mcp-output-schema / meta-tools lanes (330+ tests), mypy + ruff clean.

## Docs

`docs/codebase/dispatch-request-preview.md` + `docs/codebase/approvals.md` availability/coverage claims updated; `docs/decisions/governed-delete-operations.md` amended with a #3312 section noting the CI sweep as a deliberate extension. CHANGELOG `[Unreleased]` Fixed bullet.

No DB migration; the preview REST route returns an untyped object (no OpenAPI schema change), so the CLI snapshot is unchanged.

Closes #3312

🤖 Generated with [Claude Code](https://claude.com/claude-code)