### PR TITLE
fix(ui): structure conventions detail-view edit modal (#241)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
@@ -37,66 +37,66 @@
       <div id="conventions-write-result" aria-live="assertive"></div>
 
       <div class="grid gap-3 md:grid-cols-2">
-        <label class="form-control">
-          <span class="label-text">Slug <span class="opacity-60">(read-only)</span></span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Slug <span class="opacity-60 font-normal">(read-only)</span></span>
           <input
             type="text"
             value="{{ convention.slug }}"
             readonly
-            class="input input-bordered input-sm font-mono opacity-70"
+            class="input input-bordered input-sm font-mono opacity-70 w-full"
             data-readonly-slug
           />
         </label>
 
-        <label class="form-control">
-          <span class="label-text">Kind <span class="opacity-60">(read-only)</span></span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Kind <span class="opacity-60 font-normal">(read-only)</span></span>
           <input
             type="text"
             value="{{ convention.kind }}"
             readonly
-            class="input input-bordered input-sm font-mono opacity-70"
+            class="input input-bordered input-sm font-mono opacity-70 w-full"
             data-readonly-kind
           />
-          <span class="text-xs opacity-60 mt-1">
+          <span class="text-xs opacity-60">
             Delete + recreate to change the kind.
           </span>
         </label>
       </div>
 
-      <label class="form-control">
-        <span class="label-text">Title</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Title</span>
         <input
           type="text"
           name="title"
           required
           maxlength="{{ title_max_length }}"
           value="{{ convention.title }}"
-          class="input input-bordered input-sm"
+          class="input input-bordered input-sm w-full"
         />
       </label>
 
-      <label class="form-control max-w-[12rem]">
-        <span class="label-text">Priority</span>
+      <label class="flex flex-col gap-1 max-w-[12rem]">
+        <span class="text-sm font-medium">Priority</span>
         <input
           type="number"
           name="priority"
           value="{{ convention.priority }}"
           min="{{ priority_min }}"
           max="{{ priority_max }}"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
         />
       </label>
 
       <input type="hidden" name="kind" value="{{ convention.kind }}" data-preview-kind />
 
       <div class="grid gap-3 md:grid-cols-2">
-        <label class="form-control">
-          <span class="label-text">Body (Markdown)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Body (Markdown)</span>
           <textarea
             name="body"
             required
             maxlength="{{ body_max_length }}"
-            class="textarea textarea-bordered min-h-[14rem] font-mono text-sm"
+            class="textarea textarea-bordered min-h-[14rem] w-full font-mono text-sm"
             hx-post="/ui/conventions/preview"
             hx-trigger="keyup changed delay:300ms"
             hx-target="#conventions-token-preview"

--- a/backend/tests/test_ui_conventions_write.py
+++ b/backend/tests/test_ui_conventions_write.py
@@ -598,6 +598,11 @@ def test_edit_modal_shows_kind_and_slug_readonly() -> None:
     # The title/priority/body editable fields are pre-filled.
     assert 'value="Editable"' in body
     assert "original body" in body
+    # #241: the edit form is migrated off dead daisyUI-v4 classes (removed
+    # in v5 — zero compiled rules — which collapsed the label-over-input
+    # column and misaligned the grids).
+    assert "form-control" not in body
+    assert "label-text" not in body
 
 
 def test_edit_patch_updates_title_priority_body() -> None:


### PR DESCRIPTION
## Summary
- The Conventions detail-view edit modal (`_edit_modal.html`) used daisyUI v4 `form-control` + `label-text` on all five fields (read-only Slug and Kind, Title, Priority, Body), both removed in v5 (zero compiled rules) — the same collapsed-layout regression as the create dialog (#240 / PR #3309).
- Migrated every field to `flex flex-col gap-1` label wrappers, `text-sm font-medium` labels ("(read-only)" qualifiers inline as `opacity-60 font-normal`), the kind hint as a `text-xs opacity-60` block, and `w-full` controls. The `max-w-[12rem]` Priority cap and both `grid md:grid-cols-2` layouts are preserved.
- Presentation only — the edit PATCH, CSRF, the read-only slug/kind contract (`data-readonly-slug` / `data-readonly-kind`, hidden `data-preview-kind`), and the Body textarea's debounced token-cost preview are unchanged. Completes round-7 initiative evoila-bosnia/meho-internal#239 together with #240.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_conventions_write.py` — 16 passed
- [x] **Aligned dialog** — all 5 fields stack label-over-input; grids + Priority cap preserved
- [x] **No dead classes** — render-guard asserts `form-control`/`label-text` absent from the edit-modal fragment
- [x] **No functional regression** — edit PATCH, read-only fields, and the preview wiring covered by the 16 passing tests

## Out of scope
- The create dialog — sibling task evoila-bosnia/meho-internal#240 (PR #3309).

## Issue
Implements **evoila-bosnia/meho-internal#241** (subtask of initiative **evoila-bosnia/meho-internal#239**). Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#241