### PR TITLE
fix(cli): reconcile keyring/file credential store to end the split-brain (#3320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,35 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — CLI credential store: reconcile the keyring/file split-brain (#3320)
+
+- **A stale OS-keyring entry can no longer shadow a newer file-fallback
+  token.** On macOS the Keychain caps a single value at ~4 KiB, so a full
+  OIDC bundle (access + refresh + id token) is transparently written to
+  `~/.config/meho/credentials.json` instead. The two backends could then
+  diverge: `Load` read the keyring first and returned whatever it found
+  there, so a smaller earlier login left in the keyring — even one with an
+  empty or already-consumed `refresh_token` — shadowed the fresh, refresh-
+  token-bearing file token. The next command tripped the refresh guard and
+  failed with `auth_expired: ... no refresh_token present` despite a valid
+  token on disk. The credential store now keeps the backends consistent:
+  `Load` reads **both** and returns the more usable entry (the one that
+  still carries a `refresh_token`, then the more recently written by a new
+  `saved_at` stamp); a size-triggered `Save` **evicts** the now-stale
+  keyring entry after falling back to the file; and `Delete` clears
+  **both** backends so no copy can be stranded to shadow a later login.
+- **Clearer auth-expiry messages.** When a refresh fails because the IdP
+  rejected the refresh token as `invalid_grant` (an expired/ended session),
+  `meho status` now exits `auth_expired` and says the session expired —
+  pointing at `meho login` (and `--offline` for a durable session) —
+  instead of the misleading `unreachable`. When no refresh token is present
+  at all, the remediation now also names the `MEHO_KEYRING_DISABLE=1`
+  escape hatch for the keyring/file-mismatch case.
+- A failed refresh never deletes or degrades the stored credential — the
+  still-valid refresh token is preserved. Backwards-compatible: an entry
+  written by an older CLI (no `saved_at`) sorts as oldest. No DB migration
+  and no CLI OpenAPI-snapshot change.
+
 ### Fixed — preview parity for approval-requiring typed ops + a destructive builder CI sweep (#3312 / #3316)
 
 - **`preview_operation` now serves the park-time effect for a `requires_approval`

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -270,6 +270,16 @@ func IsNoRefreshToken(err error) bool {
 	return errors.Is(err, errNoRefreshToken)
 }
 
+// IsRefreshRejected reports whether err is the "the IdP rejected the
+// refresh exchange as invalid_grant" sentinel — the refresh token was
+// present but is expired / consumed / the session ended. Lets the
+// cobra command surface a "your session expired, rerun `meho login`"
+// message (distinct from IsNoRefreshToken's "there was no session to
+// refresh") and still route to output.AuthExpired (#3320).
+func IsRefreshRejected(err error) bool {
+	return errors.Is(err, errRefreshRejected)
+}
+
 // capRoundTripper wraps an http.RoundTripper so every response body
 // is re-bound to an http.MaxBytesReader before the typed-client
 // parsers (oapi-codegen's generated `Parse*Response` helpers, which

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -239,3 +239,55 @@ func TestTokenBox_Refresh_OmitsScopeToPreserveGrant(t *testing.T) {
 		t.Errorf("access token after refresh = %q, want fresh-access", got)
 	}
 }
+
+// TestTokenBox_Refresh_InvalidGrant_IsRefreshRejected pins the #3320
+// error-UX classification: when the IdP rejects the refresh exchange as
+// invalid_grant (Keycloak's "Token is not active" for a dead session),
+// refresh returns an error matched by IsRefreshRejected — so the command
+// layer can say "session expired, rerun `meho login`" — and NOT
+// IsNoRefreshToken (a refresh_token WAS present). The stored token must
+// survive: a failed refresh never wipes the credential.
+func TestTokenBox_Refresh_InvalidGrant_IsRefreshRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant",` +
+			`"error_description":"Token is not active"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	box := &tokenBox{
+		current: auth.StoredToken{
+			AccessToken:  "stale-access",
+			RefreshToken: "dead-refresh",
+			TokenType:    "Bearer",
+			ClientID:     "meho-cli",
+			Issuer:       "https://kc.example/realms/evba",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+		httpClient: srv.Client(),
+		refreshDiscoverer: func(_ context.Context, _ *http.Client, _ string) (*auth.DiscoveryDocument, error) {
+			return &auth.DiscoveryDocument{TokenEndpoint: srv.URL + "/token"}, nil
+		},
+	}
+
+	err := box.refresh(context.Background())
+	if err == nil {
+		t.Fatal("expected refresh to fail on invalid_grant")
+	}
+	if !IsRefreshRejected(err) {
+		t.Errorf("expected IsRefreshRejected, got %v", err)
+	}
+	if IsNoRefreshToken(err) {
+		t.Errorf("invalid_grant must not classify as no-refresh-token: %v", err)
+	}
+	// The credential must be preserved — no delete-on-failure (#3320).
+	box.mu.Lock()
+	surviving := box.current.RefreshToken
+	box.mu.Unlock()
+	if surviving != "dead-refresh" {
+		t.Errorf("stored refresh_token must survive a failed refresh; got %q", surviving)
+	}
+}

--- a/cli/internal/api/refresh.go
+++ b/cli/internal/api/refresh.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"golang.org/x/oauth2"
@@ -20,6 +21,15 @@ import (
 // cobra command surfaces this as output.AuthExpired (the operator
 // must rerun `meho login`).
 var errNoRefreshToken = errors.New("meho: no refresh_token persisted; rerun `meho login`")
+
+// errRefreshRejected signals that a refresh_token *was* present but the
+// IdP rejected the exchange as invalid_grant (the refresh token is
+// expired, was consumed, or the session was ended) — Keycloak reports
+// this with error_description "Token is not active". Distinct from
+// errNoRefreshToken so the cobra command can tell "your session
+// expired, log in again" apart from "there was no session to refresh"
+// (#3320).
+var errRefreshRejected = errors.New("meho: refresh token rejected by identity provider; session expired, rerun `meho login`")
 
 // tokenBox holds the current access bearer plus enough state for a
 // best-effort 401-retry refresh. Encapsulated in a struct so the
@@ -107,6 +117,15 @@ func (b *tokenBox) refresh(ctx context.Context) error {
 	src := cfg.TokenSource(flowCtx, stale)
 	fresh, err := src.Token()
 	if err != nil {
+		if isInvalidGrant(err) {
+			// The refresh token itself is dead (expired / consumed /
+			// session ended). Wrap the sentinel so the command layer
+			// surfaces "session expired, rerun `meho login`" rather
+			// than a generic transport failure (#3320). The in-memory
+			// and on-disk tokens are left untouched — we never delete
+			// on a failed refresh.
+			return fmt.Errorf("%w: %v", errRefreshRejected, err)
+		}
 		return fmt.Errorf("meho: refresh exchange: %w", err)
 	}
 
@@ -144,6 +163,32 @@ func authorizationHeader(accessToken string) string {
 		return ""
 	}
 	return "Bearer " + accessToken
+}
+
+// isInvalidGrant reports whether a failed refresh exchange was
+// rejected by the IdP as invalid_grant — the RFC 6749 §5.2 error for
+// an expired, revoked, or already-consumed refresh token. golang.org/
+// x/oauth2 surfaces a token-endpoint error as *oauth2.RetrieveError,
+// whose ErrorCode carries RFC 6749's `error` parameter. Keycloak
+// returns error_description "Token is not active" for a dead offline/
+// refresh session, so we also match that description as a belt-and-
+// braces check for providers that don't set a clean ErrorCode. Network
+// / discovery failures don't produce a RetrieveError, so they fall
+// through as ordinary (retryable-looking) errors (#3320).
+func isInvalidGrant(err error) bool {
+	var re *oauth2.RetrieveError
+	if !errors.As(err, &re) {
+		return false
+	}
+	if strings.EqualFold(re.ErrorCode, "invalid_grant") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(re.ErrorDescription), "token is not active") {
+		return true
+	}
+	// Older/newer oauth2 releases may leave ErrorCode/ErrorDescription
+	// unparsed; fall back to the raw response body.
+	return strings.Contains(strings.ToLower(string(re.Body)), "token is not active")
 }
 
 // fetchDiscovery is the production bridge from refreshDiscoverer

--- a/cli/internal/auth/store.go
+++ b/cli/internal/auth/store.go
@@ -66,6 +66,14 @@ type StoredToken struct {
 	// when the IdP omitted expires_in (treat as "unknown — try and
 	// see"). Compared via time.Now().After() at request time.
 	Expiry time.Time `json:"expiry,omitempty"`
+	// SavedAt is the moment this entry was last persisted, in UTC.
+	// Stamped by fallbackStore.Save on every write so Load can
+	// reconcile a keyring/file split-brain by recency when both
+	// backends hold a usable token (#3320). Backwards-compatible: an
+	// entry written by a CLI that predates this field deserialises to
+	// the zero value, which sorts as "oldest" — so a freshly-written,
+	// timestamped entry always wins over a legacy un-timestamped one.
+	SavedAt time.Time `json:"saved_at,omitempty"`
 }
 
 // TokenStore is the storage backend for credentials persisted across
@@ -404,21 +412,22 @@ func NewTokenStore() (TokenStore, error) {
 // so a future go-keyring release that rewords the error string can't
 // silently change which failures route to the file fallback.
 //
-// Load bridges to the secondary on ErrTokenNotFound only. A previous
-// CLI invocation that hit the size-rejection path on Save lands the
-// token in the secondary (file) store; the next invocation constructs
-// a fresh fallbackStore whose primary still reports "no entry" for
-// that (service, user) pair, and AC #1 ("a subsequent `meho status`
-// reads the bearer") would regress without this bridge. Every other
-// primary error — locked Keychain, D-Bus unreachable, malformed JSON,
-// etc. — surfaces unchanged so a real keyring outage still produces
-// the expected error rather than masking it with a stale file entry.
+// The two backends are kept from diverging into a split-brain (#3320):
 //
-// Delete goes to the primary only. After a size-triggered fallback,
-// the secondary still holds the token; an operator running `meho
-// logout` after re-login (which overwrites the secondary) won't see
-// a stale entry, and the asymmetry is documented for the rare case
-// where they need to scrub the credentials file by hand.
+//   - On a size-triggered fallback, Save also *evicts* any entry the
+//     keyring still holds for the same (service, user) — a smaller,
+//     now-stale login that fit under the cap — so a later Load can't
+//     hand back that shadow instead of the fresh file token.
+//   - Load reads *both* backends and returns the more usable one:
+//     the entry that still carries a refresh_token wins (it's the one
+//     that can silently renew the session), and when that doesn't
+//     decide it, the more recently written entry (by SavedAt) wins.
+//     It no longer unconditionally trusts the keyring. A non-not-found
+//     primary error (locked Keychain, D-Bus unreachable, malformed
+//     entry) still surfaces unchanged so a real keyring outage isn't
+//     masked by a possibly-stale file entry.
+//   - Delete clears *both* backends so no entry can be stranded to
+//     shadow a later login.
 type fallbackStore struct {
 	primary   TokenStore
 	secondary TokenStore
@@ -450,6 +459,13 @@ func newFallbackStore(primary, secondary TokenStore) *fallbackStore {
 // propagates unchanged so unrelated keyring failures (locked Keychain,
 // D-Bus down) still surface to the operator.
 func (s *fallbackStore) Save(service, user string, tok StoredToken) error {
+	// Stamp the write time so Load can reconcile a keyring/file split
+	// by recency when both backends carry a usable token (#3320). Every
+	// Save is a fresh persistence event — including the post-refresh
+	// re-save, whose token is derived from an entry that already carries
+	// an older SavedAt — so the stamp is unconditional, not zero-guarded.
+	tok.SavedAt = time.Now().UTC()
+
 	err := s.primary.Save(service, user, tok)
 	if err == nil {
 		s.mu.Lock()
@@ -467,37 +483,106 @@ func (s *fallbackStore) Save(service, user string, tok StoredToken) error {
 		// the file store at all.
 		return fmt.Errorf("meho: keyring rejected token by size (%v) and file fallback also failed: %w", err, ferr)
 	}
+	// The keyring can't hold this bundle (too big), but it may still
+	// hold a smaller, now-stale entry for the same (service, user) from
+	// an earlier login that fit under the cap. Evict it so a later Load
+	// can't return that shadow instead of the fresh file token (#3320).
+	// Best-effort: keyringStore.Delete already maps ErrNotFound to nil,
+	// and a delete failure must not fail a Save that already succeeded
+	// on the file backend.
+	_ = s.primary.Delete(service, user)
 	s.mu.Lock()
 	s.lastBackend = s.secondary
 	s.mu.Unlock()
 	return nil
 }
 
-// Load reads from the primary store, and bridges to the secondary
-// only when the primary reports ErrTokenNotFound. The bridge closes
-// the cross-invocation gap: a previous run that hit the size-fallback
-// path on Save persisted the token in the secondary, and a fresh
-// fallbackStore in the next process must surface that token rather
-// than report "please log in". Every other primary error (locked
-// Keychain, D-Bus unreachable, malformed entry) propagates unchanged
-// so a real keyring outage isn't masked by a stale file-store entry.
+// Load reconciles the two backends instead of blindly trusting the
+// keyring (#3320). It reads both and returns the more usable entry:
+//
+//   - A non-not-found error from the primary (locked Keychain, D-Bus
+//     unreachable, malformed entry) surfaces immediately — a real
+//     keyring outage must not be masked by a possibly-stale file entry,
+//     and the secondary is not even consulted.
+//   - When both backends hold an entry, preferUsable picks the one that
+//     still carries a refresh_token (the session it can silently renew),
+//     falling back to the more recently written (SavedAt) entry.
+//   - When only one backend holds an entry, that entry is returned. This
+//     also closes the cross-invocation gap: a previous run that hit the
+//     size-fallback path on Save left the token in the secondary, and a
+//     fresh fallbackStore in the next process finds it there.
+//   - When neither backend holds an entry, ErrTokenNotFound propagates.
+//
+// A malformed / unreadable secondary is tolerated when the primary
+// held a usable token; otherwise its error surfaces.
 func (s *fallbackStore) Load(service, user string) (StoredToken, error) {
-	tok, err := s.primary.Load(service, user)
-	if err == nil {
-		return tok, nil
+	primaryTok, primaryErr := s.primary.Load(service, user)
+	if primaryErr != nil && !errors.Is(primaryErr, ErrTokenNotFound) {
+		return StoredToken{}, primaryErr
 	}
-	if !errors.Is(err, ErrTokenNotFound) {
-		return StoredToken{}, err
+
+	secondaryTok, secondaryErr := s.secondary.Load(service, user)
+	if secondaryErr != nil && !errors.Is(secondaryErr, ErrTokenNotFound) {
+		// The file backend is genuinely broken. Prefer the primary's
+		// token if it had one rather than failing the command; only
+		// surface the secondary error when the primary had nothing.
+		if primaryErr == nil {
+			return primaryTok, nil
+		}
+		return StoredToken{}, secondaryErr
 	}
-	return s.secondary.Load(service, user)
+
+	primaryHas := primaryErr == nil
+	secondaryHas := secondaryErr == nil
+	switch {
+	case primaryHas && secondaryHas:
+		return preferUsable(primaryTok, secondaryTok), nil
+	case primaryHas:
+		return primaryTok, nil
+	case secondaryHas:
+		return secondaryTok, nil
+	default:
+		return StoredToken{}, ErrTokenNotFound
+	}
 }
 
-// Delete removes the entry from the primary store only. The secondary
-// is only ever written to after a Save fell back; if a previous run
-// produced a file-store entry, the operator should clean it up
-// explicitly (or re-run `meho login`, which will overwrite it).
+// preferUsable chooses between a keyring (primary) and file (secondary)
+// entry that both exist for the same (service, user). The entry that
+// still carries a refresh_token wins, because that is the one the CLI
+// can silently renew from after the short access-token lifetime; an
+// empty refresh_token is the stale-shadow signature this bug is about
+// (#3320). When both or neither carry a refresh_token, the more
+// recently written entry (by SavedAt) wins; ties — including two zero
+// timestamps from pre-#3320 CLIs — resolve to the primary, preserving
+// the keyring's status as the canonical backend.
+func preferUsable(primary, secondary StoredToken) StoredToken {
+	primaryRenewable := primary.RefreshToken != ""
+	secondaryRenewable := secondary.RefreshToken != ""
+	if primaryRenewable != secondaryRenewable {
+		if primaryRenewable {
+			return primary
+		}
+		return secondary
+	}
+	if secondary.SavedAt.After(primary.SavedAt) {
+		return secondary
+	}
+	return primary
+}
+
+// Delete clears the entry from BOTH backends so no copy can be
+// stranded to shadow a later login (#3320). Delete is idempotent in
+// each backend (absence maps to nil), so the combined result is nil
+// unless both backends returned a real error — in which case the
+// primary's is surfaced. A failure in one backend still lets the other
+// removal stand.
 func (s *fallbackStore) Delete(service, user string) error {
-	return s.primary.Delete(service, user)
+	primaryErr := s.primary.Delete(service, user)
+	secondaryErr := s.secondary.Delete(service, user)
+	if primaryErr != nil && secondaryErr != nil {
+		return primaryErr
+	}
+	return nil
 }
 
 // Describe names the backend that received the most recent Save. The

--- a/cli/internal/auth/store.go
+++ b/cli/internal/auth/store.go
@@ -67,8 +67,9 @@ type StoredToken struct {
 	// see"). Compared via time.Now().After() at request time.
 	Expiry time.Time `json:"expiry,omitempty"`
 	// SavedAt is the moment this entry was last persisted, in UTC.
-	// Stamped by fallbackStore.Save on every write so Load can
-	// reconcile a keyring/file split-brain by recency when both
+	// Stamped by every backend's Save (via stampSavedAt) on every
+	// write — keyring, file, and the fallback wrapper alike — so Load
+	// can reconcile a keyring/file split-brain by recency when both
 	// backends hold a usable token (#3320). Backwards-compatible: an
 	// entry written by a CLI that predates this field deserialises to
 	// the zero value, which sorts as "oldest" — so a freshly-written,
@@ -131,11 +132,26 @@ const DefaultService = "meho"
 // condition up front and falls back to fileStore.
 type keyringStore struct{}
 
+// stampSavedAt records the current time as the entry's persistence
+// moment. Called by every concrete backend's Save so a token carries a
+// fresh saved_at no matter which store wrote it — the reconciliation in
+// fallbackStore.Load compares this to break a keyring/file tie by
+// recency (#3320). Keeping it in one helper means every Save path agrees
+// on the stamp; single-backend semantics are unchanged (a bare
+// keyringStore / fileStore simply timestamps its own writes, and a
+// login performed under MEHO_KEYRING_DISABLE=1 no longer persists a zero
+// saved_at that a later stamped keyring entry could out-rank).
+func stampSavedAt(tok StoredToken) StoredToken {
+	tok.SavedAt = time.Now().UTC()
+	return tok
+}
+
 // Save serialises tok as JSON and stores it as a single keyring
 // secret. The serialisation keeps every field round-trippable, which
 // matters because the file fallback writes the identical JSON shape
 // and we want the two backends to be transparent to callers.
 func (keyringStore) Save(service, user string, tok StoredToken) error {
+	tok = stampSavedAt(tok)
 	blob, err := json.Marshal(tok)
 	if err != nil {
 		return fmt.Errorf("meho: marshal token: %w", err)
@@ -215,6 +231,7 @@ func fileKey(service, user string) string {
 }
 
 func (s *fileStore) Save(service, user string, tok StoredToken) error {
+	tok = stampSavedAt(tok)
 	blob, err := s.read()
 	if err != nil {
 		return err
@@ -459,13 +476,12 @@ func newFallbackStore(primary, secondary TokenStore) *fallbackStore {
 // propagates unchanged so unrelated keyring failures (locked Keychain,
 // D-Bus down) still surface to the operator.
 func (s *fallbackStore) Save(service, user string, tok StoredToken) error {
-	// Stamp the write time so Load can reconcile a keyring/file split
-	// by recency when both backends carry a usable token (#3320). Every
-	// Save is a fresh persistence event — including the post-refresh
-	// re-save, whose token is derived from an entry that already carries
-	// an older SavedAt — so the stamp is unconditional, not zero-guarded.
-	tok.SavedAt = time.Now().UTC()
-
+	// The saved_at stamp is applied by whichever concrete backend
+	// (keyringStore / fileStore) ends up writing — see stampSavedAt —
+	// so every Save path, wrapped or bare, records a fresh timestamp
+	// (#3320). Each Save is a fresh persistence event, including the
+	// post-refresh re-save whose token was derived from an entry that
+	// already carried an older SavedAt.
 	err := s.primary.Save(service, user, tok)
 	if err == nil {
 		s.mu.Lock()

--- a/cli/internal/auth/store_test.go
+++ b/cli/internal/auth/store_test.go
@@ -177,6 +177,35 @@ func TestFileStoreSupportsMultipleEntries(t *testing.T) {
 	}
 }
 
+// TestFileStoreSaveStampsSavedAt pins that a BARE fileStore.Save stamps
+// saved_at (#3320). Before the stamp was hoisted into every concrete
+// backend it lived only in fallbackStore.Save, so a login performed
+// under MEHO_KEYRING_DISABLE=1 (bare fileStore) persisted a zero
+// saved_at — which a later, stamped keyring entry could out-rank in the
+// reconciliation tie-break even when the file token was the newer one.
+func TestFileStoreSaveStampsSavedAt(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStoreAt(filepath.Join(dir, "credentials.json"))
+
+	before := time.Now().UTC().Add(-time.Second)
+	// Save an entry that carries NO saved_at — the store must stamp it.
+	if err := store.Save(DefaultService, "https://a.example", StoredToken{AccessToken: "tok"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	after := time.Now().UTC().Add(time.Second)
+
+	got, err := store.Load(DefaultService, "https://a.example")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.SavedAt.IsZero() {
+		t.Fatal("bare fileStore.Save must stamp saved_at, got zero")
+	}
+	if got.SavedAt.Before(before) || got.SavedAt.After(after) {
+		t.Errorf("saved_at %v not within [%v, %v]", got.SavedAt, before, after)
+	}
+}
+
 // TestFileStoreDeleteAbsentIsNoop matches the documented
 // idempotency contract: deleting a non-existent entry returns nil
 // rather than a sentinel — callers don't have to special-case
@@ -717,6 +746,48 @@ func TestFallbackStoreLoadPrefersNewerWhenBothHaveRefreshTokens(t *testing.T) {
 	}
 	if got2.AccessToken != "keyring" {
 		t.Errorf("newer keyring entry should win; got %q", got2.AccessToken)
+	}
+}
+
+// TestFallbackStoreLoadNewerRealFileWinsOverOlderStampedKeyring is the
+// end-to-end proof of the every-Save-stamps fix (#3320): the file entry
+// is written through a REAL fileStore.Save (so its saved_at is stamped
+// "now", not hand-set), while the keyring holds an OLDER stamped entry.
+// Both carry a refresh_token, so the tie-break falls to recency — and
+// because the file save is now genuinely stamped, the newer file token
+// wins. Before the stamp was hoisted into the leaf stores this file
+// entry would have persisted a zero saved_at and LOST to the older
+// keyring stamp, which is the exact disable-mode-then-re-enable hazard.
+func TestFallbackStoreLoadNewerRealFileWinsOverOlderStampedKeyring(t *testing.T) {
+	// Keyring: an older, still-refreshable entry (hand-stamped in the past).
+	keyringSide := &fakeStore{label: "OS keyring"}
+	if err := keyringSide.Save(DefaultService, "https://x", StoredToken{
+		AccessToken:  "old-keyring",
+		RefreshToken: "kr",
+		SavedAt:      time.Now().UTC().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+
+	// File: written through the REAL fileStore, which stamps saved_at=now.
+	dir := t.TempDir()
+	fileSide := NewFileStoreAt(filepath.Join(dir, "credentials.json"))
+	if err := fileSide.Save(DefaultService, "https://x", StoredToken{
+		AccessToken:  "new-file",
+		RefreshToken: "fr",
+		// No SavedAt set — the store stamps it (the previously-unstamped
+		// disable-mode shape, now correctly timestamped).
+	}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	store := newFallbackStore(keyringSide, fileSide)
+	got, err := store.Load(DefaultService, "https://x")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.AccessToken != "new-file" {
+		t.Errorf("newer real-stamped file entry should win over older keyring entry; got %q", got.AccessToken)
 	}
 }
 

--- a/cli/internal/auth/store_test.go
+++ b/cli/internal/auth/store_test.go
@@ -271,6 +271,7 @@ type fakeStore struct {
 	label       string
 	saveErr     error
 	loadErr     error
+	deleteErr   error
 	saveCalls   int
 	loadCalls   int
 	deleteCalls int
@@ -301,6 +302,14 @@ func (f *fakeStore) Load(_, _ string) (StoredToken, error) {
 
 func (f *fakeStore) Delete(_, _ string) error {
 	f.deleteCalls++
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	// Actually evict so a subsequent Load reports ErrTokenNotFound —
+	// the reconciliation tests assert an evicted keyring entry can no
+	// longer shadow the file token.
+	f.last = StoredToken{}
+	f.hasToken = false
 	return nil
 }
 
@@ -426,19 +435,20 @@ func TestFallbackStoreSurfacesBothFailures(t *testing.T) {
 	}
 }
 
-// TestFallbackStoreLoadHappyPathStaysOnPrimary pins the contract
-// that Load returns the primary's token directly when the primary has
-// one. The secondary is only consulted to close the cross-invocation
-// gap (primary returns ErrTokenNotFound); on the happy path it must
-// stay completely untouched so a routine `meho status` never opens
-// the credentials file on hosts where the keyring is healthy.
-func TestFallbackStoreLoadHappyPathStaysOnPrimary(t *testing.T) {
+// TestFallbackStoreLoadReturnsPrimaryWhenOnlyPrimaryHasEntry pins the
+// reconciled contract (#3320): Load now reads BOTH backends so a fresher
+// file entry can never be shadowed by a stale keyring one. When only the
+// primary holds an entry it still wins, but the secondary IS consulted
+// (that read is what makes the reconciliation possible). This replaces
+// the old "stays on primary / never touches the file" contract, which
+// was the exact behaviour that let the split-brain go undetected.
+func TestFallbackStoreLoadReturnsPrimaryWhenOnlyPrimaryHasEntry(t *testing.T) {
 	primary := &fakeStore{label: "OS keyring"}
 	secondary := &fakeStore{label: "credentials file at /tmp/x"}
 	store := newFallbackStore(primary, secondary)
 
 	// Seed the primary so its Load returns a token (not ErrTokenNotFound).
-	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "from-primary"}); err != nil {
+	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "from-primary", RefreshToken: "r"}); err != nil {
 		t.Fatalf("seed primary: %v", err)
 	}
 	primary.saveCalls = 0 // ignore seed call in assertions
@@ -453,20 +463,27 @@ func TestFallbackStoreLoadHappyPathStaysOnPrimary(t *testing.T) {
 	if primary.loadCalls != 1 {
 		t.Errorf("primary load calls: got %d, want 1", primary.loadCalls)
 	}
-	if secondary.loadCalls != 0 {
-		t.Errorf("secondary must not be touched on primary hit; got %d Load calls", secondary.loadCalls)
+	if secondary.loadCalls != 1 {
+		t.Errorf("secondary must be consulted so a fresher file entry can't be shadowed; got %d Load calls, want 1", secondary.loadCalls)
 	}
 }
 
-// TestFallbackStoreDeleteGoesToPrimaryOnly pins the documented
-// asymmetry: Delete touches only the primary even though Load may
-// bridge to the secondary. A previous size-fallback run that
-// persisted to the file store leaves an entry that re-login
-// overwrites in the normal case; operators who need to scrub by hand
-// do so explicitly.
-func TestFallbackStoreDeleteGoesToPrimaryOnly(t *testing.T) {
+// TestFallbackStoreDeleteClearsBothBackends pins the reconciled Delete
+// contract (#3320): Delete must clear the entry from BOTH backends so a
+// copy left by an earlier size-fallback (or any other divergence) can't
+// be stranded to shadow a later login. This replaces the old
+// primary-only asymmetry, which was one of the ways the two stores could
+// drift out of sync.
+func TestFallbackStoreDeleteClearsBothBackends(t *testing.T) {
 	primary := &fakeStore{label: "OS keyring"}
 	secondary := &fakeStore{label: "credentials file at /tmp/x"}
+	// Seed both so we can assert both entries are actually gone.
+	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "p"}); err != nil {
+		t.Fatalf("seed primary: %v", err)
+	}
+	if err := secondary.Save(DefaultService, "user", StoredToken{AccessToken: "s"}); err != nil {
+		t.Fatalf("seed secondary: %v", err)
+	}
 	store := newFallbackStore(primary, secondary)
 
 	if err := store.Delete(DefaultService, "user"); err != nil {
@@ -475,8 +492,41 @@ func TestFallbackStoreDeleteGoesToPrimaryOnly(t *testing.T) {
 	if primary.deleteCalls != 1 {
 		t.Errorf("primary delete calls: got %d, want 1", primary.deleteCalls)
 	}
-	if secondary.deleteCalls != 0 {
-		t.Errorf("secondary must not be touched on Delete; got %d calls", secondary.deleteCalls)
+	if secondary.deleteCalls != 1 {
+		t.Errorf("secondary delete calls: got %d, want 1", secondary.deleteCalls)
+	}
+	if primary.hasToken {
+		t.Error("primary entry should be gone after Delete")
+	}
+	if secondary.hasToken {
+		t.Error("secondary entry should be gone after Delete")
+	}
+	// Idempotent: with nothing left, Load reports the not-found sentinel.
+	if _, err := store.Load(DefaultService, "user"); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("after Delete, Load should report ErrTokenNotFound; got %v", err)
+	}
+}
+
+// TestFallbackStoreDeleteSurfacesErrorOnlyWhenBothFail confirms the
+// best-effort posture: a failure in one backend still lets the other
+// removal stand and returns success; only when BOTH backends error does
+// Delete surface an error (#3320).
+func TestFallbackStoreDeleteSurfacesErrorOnlyWhenBothFail(t *testing.T) {
+	// Primary errors, secondary succeeds → overall success.
+	primary := &fakeStore{label: "OS keyring", deleteErr: errors.New("keychain locked")}
+	secondary := &fakeStore{label: "credentials file at /tmp/x"}
+	if err := newFallbackStore(primary, secondary).Delete(DefaultService, "user"); err != nil {
+		t.Errorf("one-backend delete failure must not fail the overall delete; got %v", err)
+	}
+
+	// Both error → surface the primary's error.
+	pErr := errors.New("keychain locked")
+	sErr := errors.New("permission denied")
+	primary2 := &fakeStore{label: "OS keyring", deleteErr: pErr}
+	secondary2 := &fakeStore{label: "credentials file at /tmp/x", deleteErr: sErr}
+	err := newFallbackStore(primary2, secondary2).Delete(DefaultService, "user")
+	if !errors.Is(err, pErr) {
+		t.Errorf("both-fail delete should surface the primary error; got %v", err)
 	}
 }
 
@@ -553,6 +603,120 @@ func TestFallbackStoreLoadCrossInvocationAfterSizeFallback(t *testing.T) {
 	}
 	if secondary.loadCalls != 1 {
 		t.Errorf("secondary load calls: got %d, want 1", secondary.loadCalls)
+	}
+}
+
+// TestFallbackStoreLoadPrefersFileWhenKeyringShadowLacksRefreshToken is
+// the core #3320 regression: the keyring holds a stale entry with an
+// empty refresh_token (an older/smaller login the size cap accepted)
+// while the file holds the fresh, refresh-token-bearing token from a
+// later size-rejected login. The old Load returned the keyring shadow —
+// which trips the "no refresh_token present" guard on the next refresh.
+// The reconciled Load must return the file entry instead.
+func TestFallbackStoreLoadPrefersFileWhenKeyringShadowLacksRefreshToken(t *testing.T) {
+	primary := &fakeStore{label: "OS keyring"}
+	secondary := &fakeStore{label: "credentials file at /tmp/x"}
+	// Stale keyring shadow: has an access token but NO refresh_token.
+	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "stale-keyring"}); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	// Fresh file token: carries the refresh_token that can renew the session.
+	if err := secondary.Save(DefaultService, "user", StoredToken{AccessToken: "fresh-file", RefreshToken: "fresh-refresh"}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	store := newFallbackStore(primary, secondary)
+
+	got, err := store.Load(DefaultService, "user")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.AccessToken != "fresh-file" {
+		t.Errorf("Load must return the refresh-token-bearing file entry, not the keyring shadow: got %q", got.AccessToken)
+	}
+	if got.RefreshToken != "fresh-refresh" {
+		t.Errorf("Load must carry the file entry's refresh_token; got %q", got.RefreshToken)
+	}
+}
+
+// TestFallbackStoreSaveEvictsStaleKeyringEntryOnSizeFallback is the
+// #3320 Save-side regression: a size-rejected Save writes the fresh
+// token to the file AND evicts the smaller, now-stale keyring entry the
+// cap previously accepted, so a later Load can't hand back that shadow.
+func TestFallbackStoreSaveEvictsStaleKeyringEntryOnSizeFallback(t *testing.T) {
+	primary := &fakeStore{label: "OS keyring"}
+	secondary := &fakeStore{label: "credentials file at /tmp/x"}
+	// Pre-seed the keyring with a smaller earlier login (fit under the cap).
+	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "old-small"}); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	primary.saveCalls = 0
+	// Now the keyring rejects the next (oversized) bundle by size.
+	primary.saveErr = keyring.ErrSetDataTooBig
+
+	store := newFallbackStore(primary, secondary)
+	fresh := StoredToken{AccessToken: "new-big", RefreshToken: "new-refresh"}
+	if err := store.Save(DefaultService, "user", fresh); err != nil {
+		t.Fatalf("size-fallback save should succeed: %v", err)
+	}
+
+	if secondary.saveCalls != 1 || secondary.last.AccessToken != "new-big" {
+		t.Errorf("fresh token must land in the file backend; saveCalls=%d last=%q", secondary.saveCalls, secondary.last.AccessToken)
+	}
+	if primary.deleteCalls != 1 {
+		t.Errorf("stale keyring entry must be evicted on size fallback; deleteCalls=%d, want 1", primary.deleteCalls)
+	}
+	if primary.hasToken {
+		t.Error("stale keyring entry should be gone after the eviction")
+	}
+	// End-to-end: a fresh process now Loads the file token, not the shadow.
+	got, err := newFallbackStore(primary, secondary).Load(DefaultService, "user")
+	if err != nil {
+		t.Fatalf("post-fallback load: %v", err)
+	}
+	if got.AccessToken != "new-big" || got.RefreshToken != "new-refresh" {
+		t.Errorf("post-fallback Load returned the wrong token: %+v", got)
+	}
+}
+
+// TestFallbackStoreLoadPrefersNewerWhenBothHaveRefreshTokens covers the
+// recency tie-break (#3320): when both backends carry a usable
+// refresh_token, the more recently written entry (by SavedAt) wins.
+func TestFallbackStoreLoadPrefersNewerWhenBothHaveRefreshTokens(t *testing.T) {
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(24 * time.Hour)
+
+	// Case 1: the file entry is newer → it wins.
+	primary := &fakeStore{label: "OS keyring"}
+	secondary := &fakeStore{label: "credentials file at /tmp/x"}
+	if err := primary.Save(DefaultService, "user", StoredToken{AccessToken: "keyring", RefreshToken: "r1", SavedAt: older}); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	if err := secondary.Save(DefaultService, "user", StoredToken{AccessToken: "file", RefreshToken: "r2", SavedAt: newer}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	got, err := newFallbackStore(primary, secondary).Load(DefaultService, "user")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.AccessToken != "file" {
+		t.Errorf("newer file entry should win; got %q", got.AccessToken)
+	}
+
+	// Case 2: the keyring entry is newer → it wins.
+	primary2 := &fakeStore{label: "OS keyring"}
+	secondary2 := &fakeStore{label: "credentials file at /tmp/x"}
+	if err := primary2.Save(DefaultService, "user", StoredToken{AccessToken: "keyring", RefreshToken: "r1", SavedAt: newer}); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	if err := secondary2.Save(DefaultService, "user", StoredToken{AccessToken: "file", RefreshToken: "r2", SavedAt: older}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	got2, err := newFallbackStore(primary2, secondary2).Load(DefaultService, "user")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got2.AccessToken != "keyring" {
+		t.Errorf("newer keyring entry should win; got %q", got2.AccessToken)
 	}
 }
 

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -124,9 +124,18 @@ func runOneShot(cmd *cobra.Command, backplaneURL string, jsonOut bool) error {
 
 	resp, err := client.GetHealth(cmd.Context())
 	if err != nil {
+		if api.IsRefreshRejected(err) {
+			// A refresh_token was present but the IdP rejected it as
+			// invalid_grant — the session genuinely expired. Say so
+			// (exit auth_expired), and point at --offline for a session
+			// that survives a workday (#3320).
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf("session expired (refresh token rejected); run `meho login %s` (add --offline for a durable session)", backplaneURL)),
+				jsonOut)
+		}
 		if api.IsNoRefreshToken(err) {
 			return output.RenderError(cmd.ErrOrStderr(),
-				output.AuthExpired(fmt.Sprintf("stored token rejected and no refresh_token present; run `meho login %s`", backplaneURL)),
+				output.AuthExpired(fmt.Sprintf("stored token rejected and no refresh_token present; run `meho login %s`; if you believe you are logged in, try MEHO_KEYRING_DISABLE=1 (keyring/file mismatch — see #3320)", backplaneURL)),
 				jsonOut)
 		}
 		return output.RenderError(cmd.ErrOrStderr(),

--- a/cli/internal/cmd/status_test.go
+++ b/cli/internal/cmd/status_test.go
@@ -232,6 +232,90 @@ func TestStatus_NoCreds_JSON_EmitsEnvelope(t *testing.T) {
 	}
 }
 
+// TestStatus_NoRefreshToken_AppendsKeyringDisableHint pins the #3320
+// error-UX: when the stored token carries no refresh_token and the
+// backplane rejects the bearer, the auth_expired remediation appends
+// the MEHO_KEYRING_DISABLE escape-hatch hint so a dogfooder hitting a
+// keyring/file mismatch is pointed at the workaround. Refresh
+// short-circuits on the empty refresh_token, so no IdP is needed.
+func TestStatus_NoRefreshToken_AppendsKeyringDisableHint(t *testing.T) {
+	xdg := withTempXDG(t)
+	url, _ := fakeBackplane(t, nil, http.StatusUnauthorized)
+	seedCreds(t, xdg, url, auth.StoredToken{
+		BackplaneURL: url,
+		AccessToken:  jwtMarker,
+		// No RefreshToken → refresh returns the no-refresh sentinel.
+		Expiry: time.Now().Add(time.Hour),
+	})
+
+	_, stderr, err := runStatus(t)
+	if err == nil {
+		t.Fatal("expected auth_expired error")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) || coder.ExitCode() != output.ExitAuthExpired {
+		t.Fatalf("expected auth_expired exit (%d), got %v (err=%v)", output.ExitAuthExpired, coder, err)
+	}
+	if !strings.Contains(stderr.String(), "MEHO_KEYRING_DISABLE=1") {
+		t.Errorf("expected keyring/file mismatch hint in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "#3320") {
+		t.Errorf("expected #3320 reference in stderr; got %q", stderr.String())
+	}
+}
+
+// TestStatus_RefreshRejected_ExitsAuthExpiredWithSessionMessage pins the
+// #3320 error-UX for a genuinely-expired session: the token carries a
+// refresh_token but the IdP rejects the exchange as invalid_grant. The
+// command must exit auth_expired (NOT unreachable, which is what the
+// pre-fix code returned) and say the session expired. A fake IdP serves
+// discovery + a token endpoint that returns invalid_grant.
+func TestStatus_RefreshRejected_ExitsAuthExpiredWithSessionMessage(t *testing.T) {
+	xdg := withTempXDG(t)
+
+	var idp *httptest.Server
+	idpMux := http.NewServeMux()
+	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(mustJSON(map[string]any{
+			"token_endpoint":                idp.URL + "/token",
+			"device_authorization_endpoint": idp.URL + "/device",
+		}))
+	})
+	idpMux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Token is not active"}`))
+	})
+	idp = httptest.NewServer(idpMux)
+	t.Cleanup(idp.Close)
+
+	url, _ := fakeBackplane(t, nil, http.StatusUnauthorized)
+	seedCreds(t, xdg, url, auth.StoredToken{
+		BackplaneURL: url,
+		AccessToken:  jwtMarker,
+		RefreshToken: "dead-refresh",
+		Issuer:       idp.URL,
+		ClientID:     "meho-cli",
+		Expiry:       time.Now().Add(-time.Hour),
+	})
+
+	_, stderr, err := runStatus(t)
+	if err == nil {
+		t.Fatal("expected auth_expired error")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) || coder.ExitCode() != output.ExitAuthExpired {
+		t.Fatalf("expected auth_expired exit (%d), got %v (err=%v)", output.ExitAuthExpired, coder, err)
+	}
+	if !strings.Contains(stderr.String(), "session expired") {
+		t.Errorf("expected 'session expired' in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--offline") {
+		t.Errorf("expected '--offline' durable-session hint in stderr; got %q", stderr.String())
+	}
+}
+
 func TestStatus_BackplaneUnreachable_ExitsUnreachable(t *testing.T) {
 	xdg := withTempXDG(t)
 	// Point the config at an unrouteable URL.

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -593,7 +593,11 @@ backend and remembers that fact so `Describe()` — which the success
 message prints — names the credentials file the operator can
 actually inspect. Every other keyring failure (locked Keychain,
 D-Bus unreachable, Wincred ACL denial) is left to surface unchanged
-so unrelated outages don't silently route tokens to disk.
+so unrelated outages don't silently route tokens to disk. On a
+size fallback the wrapper also **evicts** any entry the keyring
+still holds for the same `(service, user)` — a smaller earlier
+login that fit under the cap — so it can't linger as a stale shadow
+(#3320).
 
 An `offline_access` refresh token (from `meho login --offline`, #2902)
 is not time-boxed and rides in the same bundle, so on macOS it makes
@@ -603,21 +607,35 @@ then converges with gcloud's long-lived-refresh-token model. Keep the
 credentials file 0600 and the per-client offline-session idle bound
 tight.
 
-`Load` bridges to the secondary only on `ErrTokenNotFound` from the
-primary — the case where a previous invocation hit the size-fallback
-path on `Save` and the token sits in the file store. AC #1 ("a
-subsequent `meho status` reads the bearer") would regress without
-this bridge, because a fresh `fallbackStore` in the next process
-starts with the primary reporting "no entry" for that
-`(service, user)`. Every other primary error (locked Keychain, D-Bus
-unreachable, malformed entry) propagates unchanged, so a real
-keyring outage still surfaces as an error instead of masking it with
-a stale file-store entry.
+`Load` **reconciles** the two backends rather than blindly trusting
+the keyring (#3320). It reads both and returns the more usable
+entry: the one that still carries a `refresh_token` wins (it's the
+one the CLI can silently renew from), and when that doesn't decide
+it, the more recently written entry (by the `saved_at` stamp) wins.
+This is what stops a stale keyring entry — including one left with
+an empty/consumed `refresh_token`, or by a wholly different earlier
+backplane URL — from shadowing the fresh, refresh-token-bearing
+file token and tripping the "no refresh_token present" guard. It
+also closes the cross-invocation gap the old ErrTokenNotFound bridge
+covered: when only one backend holds an entry, that entry is
+returned. A non-not-found primary error (locked Keychain, D-Bus
+unreachable, malformed entry) still surfaces unchanged, so a real
+keyring outage isn't masked by a possibly-stale file entry.
 
-`Delete` goes to the primary store only. After a size-triggered
-fallback the secondary still holds the token, and an operator who
-needs to scrub the credentials file by hand is expected to do so
-explicitly — re-running `meho login` overwrites it in the normal
+`Delete` clears **both** backends so no copy can be stranded to
+shadow a later login (#3320). It is idempotent per backend (absence
+maps to nil), so the combined result is success unless both backends
+returned a real error — in which case the primary's is surfaced; a
+failure in one still lets the other removal stand.
+
+A failed refresh never deletes or degrades the stored credential:
+the still-valid refresh token is preserved and the command surfaces
+a `meho login` prompt. When the IdP rejects the refresh as
+`invalid_grant` (session expired / ended), `meho status` exits
+`auth_expired` with a "session expired, rerun `meho login`" message
+(and a `--offline` hint) rather than the misleading `unreachable`;
+when no refresh token is present, the remediation also names the
+`MEHO_KEYRING_DISABLE=1` escape hatch for the keyring/file-mismatch
 case.
 
 ### What's persisted
@@ -637,6 +655,11 @@ canonicalised backplane URL. Field set:
 * `id_token` — OIDC id_token, when issued.
 * `token_type` — almost always `Bearer`.
 * `expiry` — RFC3339 UTC expiration moment.
+* `saved_at` — RFC3339 UTC moment the entry was last persisted.
+  Stamped on every write so `Load` can reconcile a keyring/file
+  split by recency (#3320). Backwards-compatible: an entry from a
+  CLI that predates the field deserialises to the zero time, which
+  sorts as oldest.
 
 Field names are stable across CLI releases — renaming them would be
 a wire-compat break for tokens persisted by older CLI versions.

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -612,11 +612,15 @@ the keyring (#3320). It reads both and returns the more usable
 entry: the one that still carries a `refresh_token` wins (it's the
 one the CLI can silently renew from), and when that doesn't decide
 it, the more recently written entry (by the `saved_at` stamp) wins.
-This is what stops a stale keyring entry — including one left with
-an empty/consumed `refresh_token`, or by a wholly different earlier
-backplane URL — from shadowing the fresh, refresh-token-bearing
-file token and tripping the "no refresh_token present" guard. It
-also closes the cross-invocation gap the old ErrTokenNotFound bridge
+This is what stops a stale keyring entry left for the same
+`(service, URL)` — e.g. one whose `refresh_token` is empty or already
+consumed — from shadowing the fresh, refresh-token-bearing file token
+and tripping the "no refresh_token present" guard. Entries for a
+*different* backplane URL don't shadow it in the first place: the store
+is keyed by `(service, URL)`, so `Load` only ever reads the current
+URL's key — the reconciliation is defence-in-depth for the case where
+the OS keyring hands back a mismatched-account blob. It also closes the
+cross-invocation gap the old ErrTokenNotFound bridge
 covered: when only one backend holds an entry, that entry is
 returned. A non-not-found primary error (locked Keychain, D-Bus
 unreachable, malformed entry) still surfaces unchanged, so a real


### PR DESCRIPTION
## Why

On macOS the OS keyring caps a single value at ~4 KiB, so `meho login`
transparently writes the full OIDC bundle (access + refresh + id token)
to `~/.config/meho/credentials.json` instead. The credential store's two
backends could then diverge into a **split-brain**:

- `Save` fell back to the file on `keyring.ErrSetDataTooBig` but left any
  smaller earlier keyring entry in place.
- `Load` read the **keyring first** and returned whatever it found there,
  only consulting the file on `ErrTokenNotFound`.
- `Delete` touched the keyring only.

So a stale keyring entry — even one with an empty or already-consumed
`refresh_token`, or one left by a wholly different earlier backplane URL —
shadowed the fresh, refresh-token-bearing file token. The very next
command tripped the empty-`RefreshToken` refresh guard and failed with:

```
auth_expired: stored token rejected and no refresh_token present; run `meho login <url>`
```

despite a valid refresh token sitting on disk. `MEHO_KEYRING_DISABLE=1`
(file backend only) restored correct behaviour — the clean before/after
proof that the split-brain is the root cause.

## What changed

Make the two backends consistent (`cli/internal/auth/store.go`):

- **`fallbackStore.Load` reconciles** instead of blindly trusting the
  keyring: it reads **both** backends and returns the more usable entry —
  the one that still carries a `refresh_token` wins (it's the one the CLI
  can silently renew from); when that doesn't decide it, the more recently
  written entry (by a new `saved_at` stamp) wins. A real keyring outage
  (a non-not-found error) still surfaces rather than being masked by a
  possibly-stale file entry.
- **`fallbackStore.Save` evicts** any now-stale keyring entry for the same
  `(service, user)` after a size fallback, and stamps `saved_at` on every
  write.
- **`fallbackStore.Delete` clears both backends** (idempotent,
  best-effort per backend) so no copy can be stranded to shadow a later
  login.

Error UX:

- A refresh the IdP rejects as `invalid_grant` ("Token is not active")
  now exits `auth_expired` with a "session expired, rerun `meho login`"
  message (plus an `--offline` hint) instead of the misleading
  `unreachable` (new `api.IsRefreshRejected` classifier).
- The no-refresh-token remediation also names the `MEHO_KEYRING_DISABLE=1`
  escape hatch for the keyring/file-mismatch case.
- A failed refresh never deletes or degrades the stored credential — the
  still-valid refresh token is preserved.

Backwards-compatible: an entry written by an older CLI (no `saved_at`)
sorts as oldest. No DB migration; the CLI OpenAPI snapshot is unchanged.

Docs: `docs/codebase/cli.md` (Load/Save/Delete reconciliation + the
`saved_at` field); `CHANGELOG.md` `[Unreleased]`.

## Tests

- Revised the two tests that locked the diverging behaviour
  (`...LoadHappyPathStaysOnPrimary` → `...LoadReturnsPrimaryWhenOnlyPrimaryHasEntry`;
  `...DeleteGoesToPrimaryOnly` → `...DeleteClearsBothBackends`).
- Added regression tests: stale keyring shadow (empty refresh_token) +
  valid file entry → Load returns the file entry; size-fallback Save
  evicts the keyring entry (end-to-end re-Load); Delete clears both;
  newer-`saved_at` tie-break; both-fail Delete surfacing; and the
  `invalid_grant` → `IsRefreshRejected` classification (not
  `IsNoRefreshToken`, credential preserved).
- Added `meho status` UX tests: `invalid_grant` refresh → `auth_expired`
  exit + "session expired"/"--offline"; no-refresh-token →
  `MEHO_KEYRING_DISABLE=1`/#3320 hint.

Commands (run in `cli/`), all green:

- `go build ./...`
- `go vet ./...`
- `go test ./...` (and `go test -race` on the changed packages)
- `golangci-lint run ./...` (v2.12.2, matching CI) — 0 issues
- `gofmt -l` — clean

Closes #3320

🤖 Generated with [Claude Code](https://claude.com/claude-code)