### PR TITLE
feat(vmware-rest): standalone-ESXi host resolution for host composites + vmware.host.storage_devices read op (#3332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,17 +111,21 @@ connector-related release-notes line.
   (the #3312 parity rule).
 - **New governed read op `vmware.host.storage_devices`** (safe tier, no
   approval) — enumerates a host's raw SCSI storage devices, the per-LUN
-  `uuid` + `ssd` / `local` flags + capacity + model / vendor that
-  `host.disk_mark_flash` needs as its runtime input (the other host
-  storage reads — `vsan_health` / `datastore.usage` / `network_uplinks` —
-  do not surface the raw device set). Reads
-  `HostSystem.config.storageDevice.scsiLun` via PropertyCollector directly
-  on the connector session (zero catalog ingest), on a vCenter target
-  (with host name/moref resolution) and on a standalone ESXi target alike.
-  Set-shaped (JSONFlux-reduced to a handle when large); `is_boot` is a
-  best-effort null (the property surface carries no boot flag). No DB
-  migration; the op registers at runtime, so the CLI OpenAPI snapshot is
-  unchanged.
+  `uuid` + `ssd` / `local` flags + capacity + model / vendor + `is_boot`
+  that `host.disk_mark_flash` needs to flash-mark "every non-boot disk"
+  (the other host storage reads — `vsan_health` / `datastore.usage` /
+  `network_uplinks` — do not surface the raw device set). Reads
+  `HostSystem.config.storageDevice.scsiLun` + `configManager.bootDeviceSystem`
+  via PropertyCollector directly on the connector session (zero catalog
+  ingest), on a vCenter target (with host name/moref resolution) and on a
+  standalone ESXi target alike. `is_boot` is resolved over the same
+  VI-JSON seam via `HostBootDeviceSystem.QueryBootDevices` (no esxcli
+  needed), matching its `currentBootDeviceKey` against the LUNs; boot
+  resolution is fail-safe (an absent/erroring boot query nulls `is_boot`
+  and records `boot_device_resolution` / `boot_device_note` without
+  sinking the device listing). Set-shaped (JSONFlux-reduced to a handle
+  when large). No DB migration; the op registers at runtime, so the CLI
+  OpenAPI snapshot is unchanged.
 
 ### Fixed — CLI credential store: reconcile the keyring/file split-brain (#3320)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,12 +120,18 @@ connector-related release-notes line.
   ingest), on a vCenter target (with host name/moref resolution) and on a
   standalone ESXi target alike. `is_boot` is resolved over the same
   VI-JSON seam via `HostBootDeviceSystem.QueryBootDevices` (no esxcli
-  needed), matching its `currentBootDeviceKey` against the LUNs; boot
-  resolution is fail-safe (an absent/erroring boot query nulls `is_boot`
-  and records `boot_device_resolution` / `boot_device_note` without
-  sinking the device listing). Set-shaped (JSONFlux-reduced to a handle
-  when large). No DB migration; the op registers at runtime, so the CLI
-  OpenAPI snapshot is unchanged.
+  needed), matching its `currentBootDeviceKey` against the LUNs. The key
+  format is vendor-defined, so `is_boot` is a labelled best-effort signal:
+  it is authoritative only when the top-level `boot_device_resolution` is
+  `matched` (`true`/`false`); on `no_match` / `unavailable` every `is_boot`
+  is `null` (unknown) — the op never asserts `false` in an ambiguous state,
+  so a caller excludes the boot disk only under `matched` and treats `null`
+  as unknown. Boot resolution is fail-safe (an absent/erroring boot query
+  nulls `is_boot` without sinking the device listing); the device read
+  itself is fail-closed. Set-shaped (JSONFlux-reduced to a handle when
+  large). No DB migration; the op registers at runtime, so the CLI OpenAPI
+  snapshot is unchanged. (Follow-up to verify the boot-key format on real
+  hardware: #3336.)
 
 ### Fixed — CLI credential store: reconcile the keyring/file split-brain (#3320)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,39 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — standalone-ESXi host resolution (pre-vCenter) + a governed host storage-device read (#3332)
+
+- **The host-domain write composites now dispatch against a standalone
+  ESXi host that no vCenter manages yet.**
+  `vmware.composite.host.datastore_mount_nfs` / `disk_mark_flash` /
+  `service_control` previously resolved their target host only through
+  `GET:/vcenter/host` — i.e. they required a managing vCenter that already
+  inventoried the host. When the target's probe fingerprint is
+  `product=esxi` (a freshly-provisioned nested host during a
+  management-domain bring-up, before the SDDC vCenter exists) the
+  composites now resolve the well-known singleton `ha-host` MoRef directly
+  through the VI-JSON seam, and the `host` parameter becomes optional /
+  ignored (on an ESXi target the host is the target). A managing-vCenter
+  target resolves through `GET:/vcenter/host` exactly as before (no
+  regression); a reachable target that is neither vCenter nor ESXi fails
+  closed (`unsupported_host_target`), and a vCenter target given no host
+  refuses `host_required`. The park-time approval previews take the same
+  branch, so a preview that passes on an ESXi target is not denied at call
+  (the #3312 parity rule).
+- **New governed read op `vmware.host.storage_devices`** (safe tier, no
+  approval) — enumerates a host's raw SCSI storage devices, the per-LUN
+  `uuid` + `ssd` / `local` flags + capacity + model / vendor that
+  `host.disk_mark_flash` needs as its runtime input (the other host
+  storage reads — `vsan_health` / `datastore.usage` / `network_uplinks` —
+  do not surface the raw device set). Reads
+  `HostSystem.config.storageDevice.scsiLun` via PropertyCollector directly
+  on the connector session (zero catalog ingest), on a vCenter target
+  (with host name/moref resolution) and on a standalone ESXi target alike.
+  Set-shaped (JSONFlux-reduced to a handle when large); `is_boot` is a
+  best-effort null (the property surface carries no boot flag). No DB
+  migration; the op registers at runtime, so the CLI OpenAPI snapshot is
+  unchanged.
+
 ### Fixed — CLI credential store: reconcile the keyring/file split-brain (#3320)
 
 - **A stale OS-keyring entry can no longer shadow a newer file-fallback

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_host.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_host.py
@@ -23,8 +23,11 @@ disk-grow write established: every mutating vim method flows through
 :func:`~meho_backplane.connectors.vmware_rest.composites._write._write_vmomi_sub_op`
 (the #2254 ``enforce_subop_policy`` gate → ``_post_vmomi_json`` on the
 documented ``/sdk/vim25/{release}`` base) -- no ``pyvmomi`` SDK
-dependency. Target is the vCenter; the host is selected by display name
-**or** moref (:func:`_resolve_host_moid`).
+dependency. On a **vCenter** target the host is selected by display name
+**or** moref (:func:`_resolve_host_moid`); on a **standalone ESXi**
+target -- one no vCenter manages yet (#3332) -- the host *is* the target
+(the well-known ``ha-host``), resolved via the VI-JSON seam without any
+``GET:/vcenter/host`` listing (:func:`classify_host_target`).
 
 Config-manager indirection
 --------------------------
@@ -63,6 +66,11 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     _read_sub_op,
     _unwrap_value,
     _write_vmomi_sub_op,
+)
+from meho_backplane.connectors.vmware_rest.host_target import (
+    HOST_FLAVOR_ESXI,
+    STANDALONE_ESXI_HOST_MOID,
+    classify_host_target,
 )
 from meho_backplane.connectors.vmware_rest.vim_body import (
     VIM_TYPE_NAME_KEY,
@@ -276,27 +284,45 @@ async def _resolve_host_and_manager(
     target: Any,
     operator: Operator,
     *,
-    host: str,
+    host: str | None,
     prop: str,
 ) -> tuple[str | None, str | None, dict[str, Any] | None]:
     """Resolve host moid + one config-manager sub-moid, or a refusal envelope.
 
     Returns ``(host_moid, manager_moid, None)`` on success or
-    ``(None, None, envelope)`` when the host does not resolve uniquely or
-    the config manager is unreadable -- the shared pre-write resolution the
-    three handlers run before building their vim body. The envelope's
-    ``status`` is ``host_not_found`` / ``ambiguous_host`` /
-    ``config_manager_unreadable``; ``candidate_hosts`` is present on
-    ambiguity.
+    ``(None, None, envelope)`` on a pre-write refusal. Branches on the
+    target's probe fingerprint (:func:`classify_host_target`, #3332): a
+    **standalone ESXi** target resolves to the well-known
+    :data:`STANDALONE_ESXI_HOST_MOID` (``ha-host``) directly -- no
+    ``GET:/vcenter/host`` listing (absent on a host no vCenter manages) and
+    the *host* selector is ignored (the host is the target); a **vCenter**
+    target resolves *host* (display name or moref) through the existing
+    ``GET:/vcenter/host`` ladder (unchanged); any **other reachable
+    product** fails closed. The config-manager read is issued the same way
+    for both flavors, so a standalone ESXi that cannot answer it fails
+    closed exactly like a vCenter host. Envelope ``status`` is
+    ``unsupported_host_target`` / ``host_required`` / ``host_not_found`` /
+    ``ambiguous_host`` / ``config_manager_unreadable``; ``candidate_hosts``
+    rides on ambiguity.
     """
-    host_moid, failure, candidates = await _resolve_host_moid(
-        connector, target, operator, host=host
-    )
-    if host_moid is None:
-        envelope: dict[str, Any] = {"status": failure, "host": host}
-        if candidates:
-            envelope["candidate_hosts"] = candidates
-        return None, None, envelope
+    flavor, refusal = classify_host_target(target)
+    if refusal is not None:
+        return None, None, {**refusal, "host": host}
+    if flavor == HOST_FLAVOR_ESXI:
+        host_moid = STANDALONE_ESXI_HOST_MOID
+    elif not host:
+        # vCenter path needs a host selector; ESXi never reaches here.
+        return None, None, {"status": "host_required", "host": host}
+    else:
+        resolved, failure, candidates = await _resolve_host_moid(
+            connector, target, operator, host=host
+        )
+        if resolved is None:
+            envelope: dict[str, Any] = {"status": failure, "host": host}
+            if candidates:
+                envelope["candidate_hosts"] = candidates
+            return None, None, envelope
+        host_moid = resolved
     manager_moid = await _resolve_config_manager_moid(
         connector, target, operator, host_moid=host_moid, prop=prop
     )
@@ -332,7 +358,7 @@ async def datastore_mount_nfs_composite(
     ``connector_error``.
     """
     host_moid, ds_system_moid, refusal = await _resolve_host_and_manager(
-        connector, target, operator, host=params["host"], prop=_PROP_CM_DATASTORE_SYSTEM
+        connector, target, operator, host=params.get("host"), prop=_PROP_CM_DATASTORE_SYSTEM
     )
     if refusal is not None:
         return {**refusal, "datastore": None}
@@ -407,7 +433,7 @@ async def disk_mark_flash_composite(
     target, principal).
     """
     host_moid, storage_system_moid, refusal = await _resolve_host_and_manager(
-        connector, target, operator, host=params["host"], prop=_PROP_CM_STORAGE_SYSTEM
+        connector, target, operator, host=params.get("host"), prop=_PROP_CM_STORAGE_SYSTEM
     )
     if refusal is not None:
         return {**refusal, "mode": params.get("mode", "flash"), "results": [], "summary": None}
@@ -510,7 +536,7 @@ async def service_control_composite(
     if service not in _SERVICE_ALLOWLIST:
         return {
             "status": "service_not_allowed",
-            "host": params["host"],
+            "host": params.get("host"),
             "service": service,
             "action": params.get("action"),
             "policy": params.get("policy"),
@@ -524,7 +550,7 @@ async def service_control_composite(
         }
 
     host_moid, service_system_moid, refusal = await _resolve_host_and_manager(
-        connector, target, operator, host=params["host"], prop=_PROP_CM_SERVICE_SYSTEM
+        connector, target, operator, host=params.get("host"), prop=_PROP_CM_SERVICE_SYSTEM
     )
     if refusal is not None:
         return {**refusal, "service": service, "action": params["action"], "policy_updated": False}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -908,11 +908,19 @@ def _host_composite_preview_host(ctx: PreviewContext) -> str | None:
     builds even with no ``host`` param -- matching the call, which resolves
     ``ha-host`` and does not deny (the #3312 preview/call parity rule: a
     preview that passes on an ESXi target must not be denied at call).
-    Otherwise the operator's ``host`` param is echoed. Returns ``None`` when
-    neither is available (a vCenter dispatch with no host, which the handler
-    refuses ``host_required`` -- the preview declines to match).
+    Otherwise the operator's ``host`` param is echoed. Returns ``None``
+    (the builder then declines to the identifier-only default) in the two
+    cases the call itself refuses, so the preview never over-promises a
+    write the dispatch will reject: an **unsupported** target (a reachable
+    fingerprint that is neither vCenter nor ESXi -- the handler refuses
+    ``unsupported_host_target``) and a **vCenter** dispatch with no host
+    (the handler refuses ``host_required``).
     """
-    flavor, _refusal = classify_host_target(ctx.target)
+    flavor, refusal = classify_host_target(ctx.target)
+    if refusal is not None:
+        # Unsupported target -- the call fails closed, so the preview declines
+        # rather than parking an effect the dispatch will reject (#3312 parity).
+        return None
     if flavor == HOST_FLAVOR_ESXI:
         return STANDALONE_ESXI_HOST_MOID
     host = ctx.params.get("host")

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing multi-builder module, one
+# park-time preview builder per vmware write composite; the builders share
+# the ``PreviewContext`` contract + the ``_write`` resolution helpers, so
+# splitting them by group would scatter that shared surface for no
+# readability gain. Splitting the module is separate refactor work, out of
+# scope for #3332 (which only extends the three host builders).
 
 """Park-time ``proposed_effect`` preview builders for the vmware write composites.
 
@@ -162,6 +168,11 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     _resolve_distributed_portgroup,
     _resolve_vm_list,
     _resolve_vm_name,
+)
+from meho_backplane.connectors.vmware_rest.host_target import (
+    HOST_FLAVOR_ESXI,
+    STANDALONE_ESXI_HOST_MOID,
+    classify_host_target,
 )
 from meho_backplane.operations._preview import (
     PreviewBuilder,
@@ -888,20 +899,43 @@ async def _vm_customize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     return preview
 
 
+def _host_composite_preview_host(ctx: PreviewContext) -> str | None:
+    """Effective host label for a host-composite preview (call parity, #3332).
+
+    Takes the **same** branch the handler's :func:`_resolve_host_and_manager`
+    does. On a standalone-ESXi target the ``host`` param is ignored and the
+    host is the well-known :data:`STANDALONE_ESXI_HOST_MOID`, so the preview
+    builds even with no ``host`` param -- matching the call, which resolves
+    ``ha-host`` and does not deny (the #3312 preview/call parity rule: a
+    preview that passes on an ESXi target must not be denied at call).
+    Otherwise the operator's ``host`` param is echoed. Returns ``None`` when
+    neither is available (a vCenter dispatch with no host, which the handler
+    refuses ``host_required`` -- the preview declines to match).
+    """
+    flavor, _refusal = classify_host_target(ctx.target)
+    if flavor == HOST_FLAVOR_ESXI:
+        return STANDALONE_ESXI_HOST_MOID
+    host = ctx.params.get("host")
+    return host if isinstance(host, str) else None
+
+
 async def _host_datastore_mount_nfs_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     """Preview ``host.datastore_mount_nfs`` — echo the mount coordinates (no I/O).
 
     The params fully name the blast radius: which host, which NFS export,
     the local datastore name, and the access mode. Host resolution
-    (name→moref) and the config-manager read stay the handler's job, so no
-    live read is issued and the preview cannot drift from the approved
-    dispatch. Declines on malformed params.
+    (name→moref, or the standalone-ESXi ha-host branch, #3332) and the
+    config-manager read stay the handler's job, so no live read is issued
+    and the preview cannot drift from the approved dispatch. Declines on
+    malformed params.
     """
-    host = ctx.params.get("host")
+    host = _host_composite_preview_host(ctx)
     nfs_server = ctx.params.get("nfs_server")
     remote_path = ctx.params.get("remote_path")
     datastore_name = ctx.params.get("datastore_name")
-    if not all(isinstance(v, str) for v in (host, nfs_server, remote_path, datastore_name)):
+    if host is None or not all(
+        isinstance(v, str) for v in (nfs_server, remote_path, datastore_name)
+    ):
         return None
     return {
         "host": host,
@@ -924,12 +958,14 @@ async def _host_disk_mark_flash_preview(ctx: PreviewContext) -> dict[str, Any] |
 
     The disk UUID list is the blast radius; it is capped to
     :data:`_PREVIEW_RESOLVED_CAP` with ``total_disks`` carrying the true
-    count so a large batch does not balloon the durable row. Declines when
-    ``disk_uuids`` is not a non-empty list.
+    count so a large batch does not balloon the durable row. The host takes
+    the standalone-ESXi branch (#3332) so a disk-mark on an ESXi target with
+    no ``host`` param still previews. Declines when ``disk_uuids`` is not a
+    non-empty list.
     """
-    host = ctx.params.get("host")
+    host = _host_composite_preview_host(ctx)
     disk_uuids = ctx.params.get("disk_uuids")
-    if not isinstance(host, str) or not isinstance(disk_uuids, list) or not disk_uuids:
+    if host is None or not isinstance(disk_uuids, list) or not disk_uuids:
         return None
     uuids = [uuid for uuid in disk_uuids if isinstance(uuid, str)]
     return {
@@ -944,13 +980,14 @@ async def _host_service_control_preview(ctx: PreviewContext) -> dict[str, Any] |
     """Preview ``host.service_control`` — echo host + service + action + policy (no I/O).
 
     The params fully name the change (which service, which transition,
-    optional startup policy); the allowlist check and host resolution stay
-    the handler's job. Declines on malformed params.
+    optional startup policy); the allowlist check and host resolution
+    (incl. the standalone-ESXi ha-host branch, #3332) stay the handler's
+    job. Declines on malformed params.
     """
-    host = ctx.params.get("host")
+    host = _host_composite_preview_host(ctx)
     service = ctx.params.get("service")
     action = ctx.params.get("action")
-    if not all(isinstance(v, str) for v in (host, service, action)):
+    if host is None or not all(isinstance(v, str) for v in (service, action)):
         return None
     return {
         "host": host,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -3627,10 +3627,14 @@ HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "minLength": 1,
             "description": (
-                "Host display name or moref (e.g. 'esxi-01.lab' or 'host-15'). "
+                "Host display name or moref (e.g. 'esxi-01' or 'host-15'). "
                 "Resolved via ``GET:/vcenter/host`` — a display-name lookup first, "
                 "falling back to a moref match; an ambiguous name is refused with "
-                "``status='ambiguous_host'`` before any write."
+                "``status='ambiguous_host'`` before any write. **Optional / ignored "
+                "on a standalone-ESXi target** (#3332): a target whose probe "
+                "fingerprint is product=esxi has exactly one host (the target "
+                "itself, the well-known ha-host), so ``host`` is not needed and is "
+                "ignored. Required on a vCenter target (else ``status='host_required'``)."
             ),
         },
         "nfs_server": {
@@ -3675,7 +3679,7 @@ HOST_DATASTORE_MOUNT_NFS_PARAMETER_SCHEMA: dict[str, Any] = {
             ),
         },
     },
-    "required": ["host", "nfs_server", "remote_path", "datastore_name"],
+    "required": ["nfs_server", "remote_path", "datastore_name"],
     "additionalProperties": False,
 }
 
@@ -3692,7 +3696,11 @@ HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA: dict[str, Any] = {
         "host": {
             "type": "string",
             "minLength": 1,
-            "description": "Host display name or moref (see host.datastore_mount_nfs).",
+            "description": (
+                "Host display name or moref (see host.datastore_mount_nfs). "
+                "Optional / ignored on a standalone-ESXi target (#3332); required "
+                "on a vCenter target."
+            ),
         },
         "disk_uuids": {
             "type": "array",
@@ -3716,7 +3724,7 @@ HOST_DISK_MARK_FLASH_PARAMETER_SCHEMA: dict[str, Any] = {
             ),
         },
     },
-    "required": ["host", "disk_uuids"],
+    "required": ["disk_uuids"],
     "additionalProperties": False,
 }
 
@@ -3734,7 +3742,11 @@ HOST_SERVICE_CONTROL_PARAMETER_SCHEMA: dict[str, Any] = {
         "host": {
             "type": "string",
             "minLength": 1,
-            "description": "Host display name or moref (see host.datastore_mount_nfs).",
+            "description": (
+                "Host display name or moref (see host.datastore_mount_nfs). "
+                "Optional / ignored on a standalone-ESXi target (#3332); required "
+                "on a vCenter target."
+            ),
         },
         "service": {
             "type": "string",
@@ -3765,7 +3777,7 @@ HOST_SERVICE_CONTROL_PARAMETER_SCHEMA: dict[str, Any] = {
             ),
         },
     },
-    "required": ["host", "service", "action"],
+    "required": ["service", "action"],
     "additionalProperties": False,
 }
 
@@ -3776,14 +3788,30 @@ HOST_DATASTORE_MOUNT_NFS_RESPONSE_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {
             "type": "string",
-            "enum": ["mounted", "host_not_found", "ambiguous_host", "config_manager_unreadable"],
+            "enum": [
+                "mounted",
+                "host_not_found",
+                "ambiguous_host",
+                "config_manager_unreadable",
+                "unsupported_host_target",
+                "host_required",
+            ],
             "description": (
                 "``'mounted'`` — the datastore was created; the refusal statuses "
                 "are reached before any write (host name/moref did not resolve "
-                "uniquely, or the host's HostDatastoreSystem was unreadable)."
+                "uniquely, the host's HostDatastoreSystem was unreadable, the "
+                "target is neither vCenter nor standalone ESXi "
+                "(``unsupported_host_target``, #3332), or a vCenter target was "
+                "given no ``host`` (``host_required``))."
             ),
         },
-        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "host": {
+            "type": ["string", "null"],
+            "description": (
+                "Resolved host moid (``ha-host`` on a standalone-ESXi target), or "
+                "the input host on refusal (``null`` when none was supplied)."
+            ),
+        },
         "datastore": {
             "type": ["string", "null"],
             "description": "New datastore moid; ``null`` on any non-``mounted`` status.",
@@ -3818,14 +3846,23 @@ HOST_DISK_MARK_FLASH_RESPONSE_SCHEMA: dict[str, Any] = {
                 "host_not_found",
                 "ambiguous_host",
                 "config_manager_unreadable",
+                "unsupported_host_target",
+                "host_required",
             ],
             "description": (
                 "``'marked'`` — every disk reached SSD/HDD state; ``'partial'`` — "
                 "at least one disk faulted / timed out / errored (see per-disk "
-                "``results``); the refusal statuses are reached before any write."
+                "``results``); the refusal statuses (incl. ``unsupported_host_target`` "
+                "/ ``host_required``, #3332) are reached before any write."
             ),
         },
-        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "host": {
+            "type": ["string", "null"],
+            "description": (
+                "Resolved host moid (``ha-host`` on a standalone-ESXi target), or "
+                "the input host on refusal (``null`` when none was supplied)."
+            ),
+        },
         "mode": {"type": "string", "enum": ["flash", "non_flash"]},
         "results": {
             "type": "array",
@@ -3875,15 +3912,24 @@ HOST_SERVICE_CONTROL_RESPONSE_SCHEMA: dict[str, Any] = {
                 "host_not_found",
                 "ambiguous_host",
                 "config_manager_unreadable",
+                "unsupported_host_target",
+                "host_required",
             ],
             "description": (
                 "``'applied'`` — the action (and optional policy update) ran; "
                 "``'service_not_allowed'`` — the service is outside the curated "
                 "allowlist (refused before any resolution or write); the remaining "
-                "refusals are reached before any write."
+                "refusals (incl. ``unsupported_host_target`` / ``host_required``, "
+                "#3332) are reached before any write."
             ),
         },
-        "host": {"type": "string", "description": "Resolved host moid (or the input on refusal)."},
+        "host": {
+            "type": ["string", "null"],
+            "description": (
+                "Resolved host moid (``ha-host`` on a standalone-ESXi target), or "
+                "the input host on refusal (``null`` when none was supplied)."
+            ),
+        },
         "service": {"type": "string"},
         "action": {"type": ["string", "null"], "enum": ["start", "stop", "restart", None]},
         "policy": {"type": ["string", "null"], "enum": ["on", "automatic", "off", None]},

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -1150,6 +1150,40 @@ class VmwareRestConnector(HttpConnector):
 
         return await host_vsan_health_impl(self, operator, target, params)
 
+    async def host_storage_devices(
+        self,
+        operator: Operator,
+        target: VsphereTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vmware.host.storage_devices`` -- per-host raw SCSI storage devices (#3332).
+
+        A ``source_kind="typed"`` op: the dispatcher binds this method to
+        the connector instance and invokes it with ``(operator, target,
+        params)`` (see
+        :func:`~meho_backplane.operations._branches.dispatch_typed`).
+        Resolves the host -- a vCenter name/moref via ``GET:/vcenter/host``,
+        or the standalone-ESXi ``ha-host`` when the target's probe
+        fingerprint is ``product=esxi`` (the host is the target) -- then
+        reads ``config.storageDevice.scsiLun`` via PropertyCollector
+        directly on the connector session, so it works on a fresh boot with
+        zero catalog ingest (the pre-vCenter standalone-ESXi case #3332
+        needs). Returns the per-LUN uuid + ssd/local flags +
+        capacity/model/vendor set (``is_boot`` best-effort null), the
+        runtime input ``host.disk_mark_flash`` needs.
+
+        Delegates to
+        :func:`~meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices.host_storage_devices_impl`
+        (imported lazily to keep this module off the typed-ops import at
+        class-load time). Returns
+        ``{"status": ..., "host": ..., "devices": [...], "device_count": ...}``.
+        """
+        from meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices import (
+            host_storage_devices_impl,
+        )
+
+        return await host_storage_devices_impl(self, operator, target, params)
+
     async def vm_info(
         self,
         operator: Operator,

--- a/backend/src/meho_backplane/connectors/vmware_rest/host_target.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/host_target.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared standalone-ESXi vs vCenter host-target classification (#3332).
+
+The host-domain write composites (``vmware.composite.host.*`` in
+:mod:`~meho_backplane.connectors.vmware_rest.composites._host`) and the
+``vmware.host.storage_devices`` typed read
+(:mod:`~meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices`)
+both resolve a host, and both must take the **same** branch:
+
+* a managing-**vCenter** target resolves the host through the vCenter
+  Automation REST listing ``GET:/vcenter/host`` (a display-name /
+  moref lookup) -- the pre-#3332 behaviour, unchanged; while
+* a standalone **ESXi** target -- a host no vCenter manages yet, e.g.
+  a freshly-provisioned nested host during a management-domain
+  bring-up before the SDDC vCenter exists -- serves no
+  ``GET:/vcenter/host`` at all. It has exactly one host, the well-known
+  singleton ``ha-host`` MoRef, reached through the VI-JSON seam. On such
+  a target the ``host`` parameter is ignored: *the host is the target*.
+
+The distinguisher is the target's cached **probe fingerprint**: the
+``vmware-rest`` connector registers under ``product="vmware"`` (that is
+the resolver key), but its :meth:`fingerprint` stamps
+``product_from_line_id`` -> ``"vcenter"`` / ``"esxi"`` into
+``Target.fingerprint``. So the fingerprint's ``product`` -- not the
+``Target.product`` column -- tells the two apart.
+
+Keeping the classifier here (dependency-light: no ``operations`` /
+connector imports) lets the composite dispatch path, its park-time
+``proposed_effect`` preview builder, and the typed read all agree by
+construction -- the #3312 preview/call parity rule (a preview that
+passes on an ESXi target must not be denied at call, because both run
+this one function).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+__all__ = [
+    "HOST_FLAVOR_ESXI",
+    "HOST_FLAVOR_VCENTER",
+    "STANDALONE_ESXI_HOST_MOID",
+    "classify_host_target",
+]
+
+#: The well-known singleton ``HostSystem`` MoRef on a standalone ESXi
+#: host (the host a vCenter has not inventoried). Every ESXi host serves
+#: exactly one, addressable through the VI-JSON seam without any
+#: ``GET:/vcenter/host`` listing.
+STANDALONE_ESXI_HOST_MOID: Final = "ha-host"
+
+#: Classification results (also the ``fingerprint.product`` slugs
+#: :func:`~meho_backplane.connectors.vmware_rest.connector.product_from_line_id`
+#: stamps).
+HOST_FLAVOR_VCENTER: Final = "vcenter"
+HOST_FLAVOR_ESXI: Final = "esxi"
+
+
+def _fingerprint_field(fingerprint: Any, name: str) -> Any:
+    """Read *name* off a fingerprint that may be a ``Mapping`` or an object.
+
+    A probed target hands the ORM a JSON ``Mapping`` (the probe route
+    persists ``FingerprintResult.model_dump(mode="json")``); a duck-typed
+    test target may instead expose attributes. Read both shapes -- mirrors
+    :func:`~meho_backplane.connectors.resolver.resolve_target_version`.
+    """
+    if isinstance(fingerprint, Mapping):
+        return fingerprint.get(name)
+    return getattr(fingerprint, name, None)
+
+
+def classify_host_target(target: Any) -> tuple[str | None, dict[str, Any] | None]:
+    """Classify *target* as a vCenter or a standalone ESXi for host resolution.
+
+    Returns one of:
+
+    * ``("esxi", None)`` -- the probe fingerprint names ``product="esxi"``:
+      resolve the host as the well-known :data:`STANDALONE_ESXI_HOST_MOID`
+      via VI-JSON (the ``host`` parameter is ignored -- the host is the
+      target).
+    * ``("vcenter", None)`` -- a vCenter fingerprint, an **absent**
+      fingerprint (never probed), or an **unreachable** one (a failed /
+      transient probe): resolve through ``GET:/vcenter/host``. This is the
+      pre-#3332 default, so a managing-vCenter target -- probed or not --
+      keeps resolving exactly as before (no regression), and the existing
+      host-composite callers that pass no fingerprint at all stay on the
+      vCenter path.
+    * ``(None, refusal)`` -- a **reachable** fingerprint that names some
+      *other* product (an unrecognised ``product_line_id``): fail closed
+      with a typed ``unsupported_host_target`` envelope rather than guess
+      which resolution path applies. The envelope carries ``status`` /
+      ``target_product`` / ``guidance``; a handler merges it into its own
+      refusal shape.
+
+    ``target`` may be ``None`` (a unit-test handler call with no resolved
+    target) -- that reads as an absent fingerprint and classifies as
+    ``vcenter``.
+    """
+    fingerprint = getattr(target, "fingerprint", None)
+    if fingerprint is None:
+        return HOST_FLAVOR_VCENTER, None
+    product = _fingerprint_field(fingerprint, "product")
+    if product == HOST_FLAVOR_ESXI:
+        return HOST_FLAVOR_ESXI, None
+    if product in (None, HOST_FLAVOR_VCENTER) or not bool(
+        _fingerprint_field(fingerprint, "reachable")
+    ):
+        return HOST_FLAVOR_VCENTER, None
+    return None, {
+        "status": "unsupported_host_target",
+        "target_product": product,
+        "guidance": (
+            "host-domain operations resolve a host only on a vCenter target "
+            "(via GET:/vcenter/host) or a standalone ESXi target (the "
+            "well-known ha-host via VI-JSON); this target's probe fingerprint "
+            f"names product={product!r}, which is neither"
+        ),
+    }

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "VMWARE_HOST_NETWORK_UPLINKS_OP",
+    "VMWARE_HOST_STORAGE_DEVICES_OP",
     "VMWARE_HOST_USAGE_OP",
     "VMWARE_HOST_VSAN_HEALTH_OP",
     "VMWARE_OBJECT_COLLECT_OP",
@@ -370,6 +371,11 @@ from meho_backplane.connectors.vmware_rest.typed_ops_host_network_uplinks import
     HOST_NETWORK_UPLINKS_WHEN_TO_USE,
     VMWARE_HOST_NETWORK_UPLINKS_OP,
 )
+from meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices import (  # noqa: E402
+    HOST_STORAGE_DEVICES_GROUP_KEY,
+    HOST_STORAGE_DEVICES_WHEN_TO_USE,
+    VMWARE_HOST_STORAGE_DEVICES_OP,
+)
 from meho_backplane.connectors.vmware_rest.typed_ops_host_vsan_health import (  # noqa: E402
     HOST_VSAN_HEALTH_GROUP_KEY,
     HOST_VSAN_HEALTH_WHEN_TO_USE,
@@ -408,6 +414,7 @@ VMWARE_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     ),
     HOST_NETWORK_UPLINKS_GROUP_KEY: HOST_NETWORK_UPLINKS_WHEN_TO_USE,
     HOST_VSAN_HEALTH_GROUP_KEY: HOST_VSAN_HEALTH_WHEN_TO_USE,
+    HOST_STORAGE_DEVICES_GROUP_KEY: HOST_STORAGE_DEVICES_WHEN_TO_USE,
     VM_INFO_GROUP_KEY: VM_INFO_WHEN_TO_USE,
     OBJECT_COLLECT_GROUP_KEY: OBJECT_COLLECT_WHEN_TO_USE,
     TASKS_RECENT_GROUP_KEY: TASKS_RECENT_WHEN_TO_USE,
@@ -482,13 +489,15 @@ VMWARE_HOST_USAGE_OP = VmwareTypedOp(
 #: The typed ops :class:`VmwareRestConnector` registers at lifespan
 #: startup: ``vmware.host.usage`` (#2257); ``host.network_uplinks`` +
 #: ``host.vsan_health`` (#2258, re-shipped from the former composites);
-#: and the incident-survival reads ``vm.info`` + ``object.collect`` +
-#: ``tasks.recent`` (#2300). The tuple shape lets future typed reads join
-#: without touching the registrar.
+#: ``host.storage_devices`` (#3332, per-host raw SCSI devices, vCenter or
+#: standalone-ESXi); and the incident-survival reads ``vm.info`` +
+#: ``object.collect`` + ``tasks.recent`` (#2300). The tuple shape lets
+#: future typed reads join without touching the registrar.
 VMWARE_TYPED_OPS: tuple[VmwareTypedOp, ...] = (
     VMWARE_HOST_USAGE_OP,
     VMWARE_HOST_NETWORK_UPLINKS_OP,
     VMWARE_HOST_VSAN_HEALTH_OP,
+    VMWARE_HOST_STORAGE_DEVICES_OP,
     VMWARE_VM_INFO_OP,
     VMWARE_OBJECT_COLLECT_OP,
     VMWARE_TASKS_RECENT_OP,

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
@@ -4,50 +4,38 @@
 """``vmware.host.storage_devices`` typed read op (#3332).
 
 Enumerates a host's raw SCSI storage devices -- per-LUN ``uuid`` +
-``canonical_name`` + ``ssd`` / ``local`` flags + capacity + model /
-vendor -- the runtime input ``vmware.composite.host.disk_mark_flash``
-needs. Before this op the only host storage reads were ``vsan_health`` /
-``datastore.usage`` / ``network_uplinks``; none enumerate the raw device
-set, so a caller that wants to flash-mark "every non-boot disk" could
-not discover the devices through the backplane and had to pre-supply
-UUIDs it could only get out-of-band.
+``canonical_name`` + ``ssd`` / ``local`` flags + capacity + model / vendor
++ a best-effort ``is_boot`` flag -- the runtime input
+``vmware.composite.host.disk_mark_flash`` needs to flash-mark "every
+non-boot disk" (the other host storage reads do not enumerate the raw
+device set).
 
-In the :mod:`~meho_backplane.connectors.vmware_rest.typed_ops` mould
-(``vmware.host.usage`` / ``.network_uplinks``): a ``source_kind="typed"``
-bound method that reads directly on the connector session -- no
-``dispatch_child``, no ingested descriptor -- so it works on a **fresh
-boot with zero catalog ingest**. That property is load-bearing here: the
-#3332 use case is a **standalone ESXi** host no vCenter manages yet (a
-nested management-domain bring-up before the SDDC vCenter exists), where
-no vCenter catalog can have been ingested.
+A ``source_kind="typed"`` bound method in the ``vmware.host.usage`` mould:
+reads directly on the connector session (no ``dispatch_child``, no ingested
+descriptor), so it works on a **fresh boot with zero catalog ingest** --
+load-bearing here, since the #3332 case is a **standalone ESXi** host no
+vCenter manages yet. Host resolution branches on the fingerprint
+(:func:`~meho_backplane.connectors.vmware_rest.host_target.classify_host_target`):
+a standalone-ESXi target (``product=esxi``) resolves the well-known
+``ha-host`` (``host`` ignored); a vCenter target resolves the ``host``
+param (name / moref) via ``GET:/vcenter/host``.
 
-Both target flavors are covered (#3332, via
-:func:`~meho_backplane.connectors.vmware_rest.host_target.classify_host_target`):
-
-* a **standalone ESXi** target -- fingerprint ``product=esxi`` -- has one
-  host, the well-known ``ha-host``; the ``host`` param is ignored (the
-  host is the target);
-* a **vCenter** target resolves the ``host`` param (display name or
-  moref) through ``GET:/vcenter/host`` (name-first, moref-fallback), the
-  same ladder the host write composites use.
-
-The device rows come from the Web-Services-API
-``HostSystem.config.storageDevice.scsiLun`` property (the host-side
-read mirror of ``HostStorageSystem.storageDeviceInfo.scsiLun`` -- the
-same ``HostScsiDisk`` / ``ScsiLun`` array), read via the PropertyCollector
-``RetrievePropertiesEx`` vi-json method routed through
-:meth:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector._post_vmomi_json`
-(mounted on the documented ``/sdk/vim25/{release}`` base). The response
-is set-shaped, so the dispatcher JSONFlux-reduces it to a handle when
-large -- the same auto-reduction the other typed reads rely on.
-
+Device rows come from ``HostSystem.config.storageDevice.scsiLun`` (the
+read mirror of ``HostStorageSystem.storageDeviceInfo.scsiLun``), read via
+one PropertyCollector ``RetrievePropertiesEx`` on the VI-JSON
+``/sdk/vim25/{release}`` seam; set-shaped, so JSONFlux-reduced when large.
 ``ssd`` / ``local`` / ``capacity_bytes`` are ``HostScsiDisk`` fields (the
-``deviceType="disk"`` subclass of ``ScsiLun``); a non-disk LUN (cdrom /
-tape) carries ``null`` for them. ``is_boot`` is **best-effort**: the
-``scsiLun`` property surface carries no boot flag (identifying the ESXi
-boot device reliably needs the esxcli ``storage core device list`` "Is
-Boot Device" datum, not a managed-object property), so it is ``null``
-here and reserved for a future esxcli-backed enrichment.
+``deviceType="disk"`` subclass), ``null`` on a non-disk LUN.
+
+Boot-device identification needs **no esxcli seam**: the same read also
+fetches ``configManager.bootDeviceSystem``, and when present the op calls
+``HostBootDeviceSystem.QueryBootDevices`` (a vim query over the same seam)
+and matches its ``currentBootDeviceKey`` -- which typically embeds the
+device's canonical name / uuid -- against the rows (``is_boot`` true on
+the match, false on the rest). **Fail-safe**: an absent config manager, an
+unsupported / erroring query, or a missing key nulls every ``is_boot`` and
+names the reason in ``boot_device_resolution`` / ``boot_device_note`` --
+the listing is still returned.
 """
 
 from __future__ import annotations
@@ -92,40 +80,34 @@ _LIST_HOSTS_PATH = "/vcenter/host"
 _RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
 _HOST_SYSTEM_MO_TYPE = "HostSystem"
 # HostSystem-side mirror of HostStorageSystem.storageDeviceInfo.scsiLun
-# (the same HostStorageDeviceInfo object, cached on config). Narrowed to
-# the scsiLun leaf so the read does not pull the whole storageDevice
-# object (HBAs / multipath / plug-store topology).
+# (cached on config), narrowed to the scsiLun leaf; paired with the
+# bootDeviceSystem config-manager MoRef so one read backs both the device
+# list and the boot-device query.
 _PROP_SCSI_LUN = "config.storageDevice.scsiLun"
-_STORAGE_DEVICE_PATH_SET = (_PROP_SCSI_LUN,)
+_PROP_BOOT_DEVICE_SYSTEM = "configManager.bootDeviceSystem"
+_STORAGE_DEVICE_PATH_SET = (_PROP_SCSI_LUN, _PROP_BOOT_DEVICE_SYSTEM)
+# HostBootDeviceSystem.QueryBootDevices vim method (the moId rides the
+# path); posted through the same VI-JSON seam as RetrievePropertiesEx.
+_QUERY_BOOT_DEVICES_PATH = "/HostBootDeviceSystem/{moid}/QueryBootDevices"
+# Minimum identifier length trusted for a substring match against the boot
+# key -- guards a short id from spuriously matching (fail-safe).
+_MIN_BOOT_MATCH_LEN = 6
 
 HOST_STORAGE_DEVICES_GROUP_KEY = "vmware-host-storage-devices"
 
 
 def _str_or_none(value: Any) -> str | None:
-    """Return a trimmed string, or ``None`` for anything else.
-
-    SCSI inquiry strings (``model`` / ``vendor``) arrive space-padded from
-    the WS-API, so they are trimmed; identifiers (``uuid`` /
-    ``canonicalName``) carry no padding and pass through the same trim
-    harmlessly.
-    """
+    """Trimmed string (``model`` / ``vendor`` are space-padded), else ``None``."""
     return value.strip() if isinstance(value, str) else None
 
 
 def _bool_or_none(value: Any) -> bool | None:
-    """Coerce a WS-API boolean to ``bool``; anything else -> ``None``.
-
-    ``ssd`` / ``localDisk`` are ``HostScsiDisk``-only fields, absent on a
-    non-disk ``ScsiLun`` -- their absence reads as ``None``.
-    """
+    """Coerce a WS-API boolean to ``bool``; anything else -> ``None`` (a non-disk LUN)."""
     return value if isinstance(value, bool) else None
 
 
 def _int_or_none(value: Any) -> int | None:
-    """Coerce a JSON number / numeric string to int; anything else -> ``None``.
-
-    Rejects bools (``True`` is an ``int`` subclass and must not read as 1).
-    """
+    """Coerce a JSON number / numeric string to int; anything else (incl. bool) -> ``None``."""
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
@@ -139,12 +121,7 @@ def _int_or_none(value: Any) -> int | None:
 
 
 def _capacity_bytes(capacity: Any) -> int | None:
-    """Compute a LUN's capacity in bytes from ``HostDiskDimensionsLba``.
-
-    ``HostScsiDisk.capacity`` is ``{blockSize, block}`` (bytes-per-block x
-    block count); the byte total is their product. Absent (non-disk LUN)
-    or partial -> ``None``.
-    """
+    """Bytes from ``HostScsiDisk.capacity`` (``{blockSize, block}`` product); else ``None``."""
     if not isinstance(capacity, dict):
         return None
     block_size = _int_or_none(capacity.get("blockSize"))
@@ -154,35 +131,47 @@ def _capacity_bytes(capacity: Any) -> int | None:
     return block_size * block
 
 
-def _map_scsi_lun(lun: dict[str, Any]) -> dict[str, Any]:
-    """Flatten one WS-API ``ScsiLun`` / ``HostScsiDisk`` into an operator row.
+def _matches_boot(uuid: str | None, canonical_name: str | None, boot_key: str) -> bool:
+    """Whether a scsiLun row is the current boot device.
 
-    ``is_boot`` is best-effort ``None``: the ``scsiLun`` property surface
-    exposes no boot flag (see the module docstring); it is reserved for a
-    future esxcli-backed enrichment so a caller excluding the boot device
-    has a stable field to read.
+    ``currentBootDeviceKey`` typically embeds the canonical name / uuid;
+    match by containment either way, guarded to identifiers >=
+    :data:`_MIN_BOOT_MATCH_LEN` chars (fail-safe: no match on a missing id).
     """
+    key_l = boot_key.strip().lower()
+    if not key_l:
+        return False
+    for ident in (canonical_name, uuid):
+        if not ident:
+            continue
+        ident_l = ident.lower()
+        if len(ident_l) >= _MIN_BOOT_MATCH_LEN and (ident_l in key_l or key_l in ident_l):
+            return True
+    return False
+
+
+def _map_scsi_lun(lun: dict[str, Any], boot_key: str | None) -> dict[str, Any]:
+    """Flatten one ``ScsiLun`` / ``HostScsiDisk`` row (``is_boot``: null when
+    *boot_key* is None, else whether this LUN matches the boot key)."""
+    uuid = _str_or_none(lun.get("uuid"))
+    canonical_name = _str_or_none(lun.get("canonicalName"))
     return {
-        "uuid": _str_or_none(lun.get("uuid")),
-        "canonical_name": _str_or_none(lun.get("canonicalName")),
+        "uuid": uuid,
+        "canonical_name": canonical_name,
         "device_type": _str_or_none(lun.get("deviceType")),
         "capacity_bytes": _capacity_bytes(lun.get("capacity")),
         "ssd": _bool_or_none(lun.get("ssd")),
         "local": _bool_or_none(lun.get("localDisk")),
         "model": _str_or_none(lun.get("model")),
         "vendor": _str_or_none(lun.get("vendor")),
-        "is_boot": None,
+        "is_boot": None if boot_key is None else _matches_boot(uuid, canonical_name, boot_key),
     }
 
 
-def _extract_scsi_luns(retrieve_result: Any) -> list[Any]:
-    """Pull the ``config.storageDevice.scsiLun`` array from a RetrievePropertiesEx result.
+def _extract_host_props(retrieve_result: Any) -> dict[str, Any]:
+    """Flatten a single-host ``RetrievePropertiesEx`` result to ``{name: val}``.
 
-    ``RetrievePropertiesEx`` returns a ``RetrieveResult`` whose ``objects``
-    list carries one ``ObjectContent`` per queried object, each with a
-    ``propSet`` list of ``{name, val}`` pairs. For the single-host query
-    the first object's propSet holds the requested scsiLun array (boxed as
-    ``ArrayOf*`` -- :func:`unwrap_vim_value` un-boxes it). Absent -> ``[]``.
+    Each ``val`` is un-boxed via :func:`unwrap_vim_value`.
     """
     payload = _unwrap_value(retrieve_result)
     if isinstance(payload, dict):
@@ -191,26 +180,62 @@ def _extract_scsi_luns(retrieve_result: Any) -> list[Any]:
         objects = payload
     else:
         objects = []
+    props: dict[str, Any] = {}
     for obj in objects:
         if not isinstance(obj, dict):
             continue
         for prop in obj.get("propSet", []) or []:
-            if isinstance(prop, dict) and prop.get("name") == _PROP_SCSI_LUN:
-                luns = unwrap_vim_value(prop.get("val"))
-                return luns if isinstance(luns, list) else []
-    return []
+            if isinstance(prop, dict) and isinstance(prop.get("name"), str):
+                props[prop["name"]] = unwrap_vim_value(prop.get("val"))
+    return props
+
+
+def _moref_value(val: Any) -> str | None:
+    """Extract the ``value`` moid from a ``ManagedObjectReference`` dict, else ``None``."""
+    if isinstance(val, dict):
+        value = val.get("value")
+        return value if isinstance(value, str) and value else None
+    return None
 
 
 def build_host_storage_devices_retrieve_params(host_moid: str) -> dict[str, Any]:
-    """Build the ``RetrievePropertiesEx`` request body for one host's scsiLun array.
+    """Build the ``RetrievePropertiesEx`` request body for one host.
 
-    A single ``PropertyFilterSpec`` scoped directly to the ``HostSystem``
-    object (no ContainerView / TraversalSpec) requesting the one
-    ``config.storageDevice.scsiLun`` property path -- the VI-JSON
-    ``RetrievePropertiesExRequestType`` shape the other typed reads send,
-    ``_typeName``-annotated via the shared trio helper (#3103).
+    One ``PropertyFilterSpec`` scoped to the ``HostSystem`` requesting
+    ``config.storageDevice.scsiLun`` (the device array) +
+    ``configManager.bootDeviceSystem`` (so the boot query needs no extra
+    read) -- ``_typeName``-annotated via the shared trio helper (#3103).
     """
     return retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], _STORAGE_DEVICE_PATH_SET)
+
+
+async def _resolve_boot_device_key(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    boot_system_moid: str | None,
+) -> tuple[str | None, str | None]:
+    """Best-effort current-boot-device key via ``HostBootDeviceSystem.QueryBootDevices``.
+
+    Returns ``(key, None)`` on success. **Fail-safe**: an absent config
+    manager, a transport / status / unsupported-method failure, or a missing
+    ``currentBootDeviceKey`` yields ``(None, reason)`` (``is_boot`` null, the
+    listing still returned). ``QueryBootDevices`` is a read, so it rides the
+    un-gated :meth:`VmwareRestConnector._post_vmomi_json` seam, not the write
+    sub-op seam.
+    """
+    if not boot_system_moid:
+        return None, "host exposes no configManager.bootDeviceSystem"
+    path = _QUERY_BOOT_DEVICES_PATH.format(moid=boot_system_moid)
+    try:
+        payload = await connector._post_vmomi_json(target, path, operator=operator, json={})
+    except (httpx.HTTPError, RuntimeError) as exc:
+        return None, f"QueryBootDevices failed: {type(exc).__name__}: {exc}"
+    info = unwrap_vim_value(_unwrap_value(payload))
+    key = info.get("currentBootDeviceKey") if isinstance(info, dict) else None
+    if isinstance(key, str) and key.strip():
+        return key.strip(), None
+    return None, "QueryBootDevices returned no currentBootDeviceKey"
 
 
 async def _list_host_moids(
@@ -221,10 +246,8 @@ async def _list_host_moids(
 ) -> list[str]:
     """Return the ``host`` moids from one ``GET:/vcenter/host`` listing.
 
-    Routes through :meth:`VmwareRestConnector.mount_op_path` (``/api``
-    modern / ``/rest`` legacy) and keys the filter param off the mount
-    flavor via :meth:`adapt_op_query` (#2298), the same way the sibling
-    typed reads issue their host listing.
+    Mounted via :meth:`mount_op_path` and filter-adapted via
+    :meth:`adapt_op_query` (#2298), like the sibling typed reads.
     """
     list_path = await connector.mount_op_path(target, _LIST_HOSTS_PATH, operator)
     listing_query = await connector.adapt_op_query(target, query, operator)
@@ -245,14 +268,12 @@ async def _resolve_host_moid(
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Resolve the target's host to a ``HostSystem`` moid, or a refusal envelope.
 
-    Branches on the target fingerprint (:func:`classify_host_target`,
-    #3332): a standalone-ESXi target resolves to the well-known
+    Branches on the fingerprint (:func:`classify_host_target`, #3332): a
+    standalone-ESXi target resolves the well-known
     :data:`STANDALONE_ESXI_HOST_MOID` (``host`` ignored); a vCenter target
-    resolves ``host`` (display name first, moref fallback) via
-    ``GET:/vcenter/host``; any other reachable product / a missing host /
-    an unresolved host fails closed. Returns ``(moid, None)`` on success or
-    ``(None, refusal)`` -- the refusal is the full op envelope (empty
-    ``devices``).
+    resolves ``host`` (name first, moref fallback) via ``GET:/vcenter/host``;
+    any other reachable product / missing / unresolved host fails closed.
+    Returns ``(moid, None)`` or ``(None, refusal)`` (the full op envelope).
     """
     flavor, refusal = classify_host_target(target)
     if refusal is not None:
@@ -292,17 +313,15 @@ async def host_storage_devices_impl(
 ) -> dict[str, Any]:
     """Implementation of ``vmware.host.storage_devices`` -- per-host raw SCSI devices.
 
-    Resolves the host (standalone-ESXi ``ha-host`` or a vCenter
-    name/moref, #3332), then reads ``config.storageDevice.scsiLun`` off one
-    PropertyCollector ``RetrievePropertiesEx`` on the connector session and
-    maps each LUN to a row. The read is fail-closed: a VI-JSON transport /
-    status failure (the seam unavailable, an ESXi that rejects the call)
-    returns a typed ``status='storage_devices_unreadable'`` with an empty
-    device set and a ``read_note`` rather than a bare stack trace.
-
-    Returns ``{status, host, devices: [{uuid, canonical_name, device_type,
-    capacity_bytes, ssd, local, model, vendor, is_boot}, ...], device_count}``.
-    Set-shaped, so the dispatcher JSONFlux-reduces it to a handle when large.
+    Resolves the host (#3332), reads ``config.storageDevice.scsiLun`` +
+    ``configManager.bootDeviceSystem`` off one ``RetrievePropertiesEx``,
+    best-effort resolves the boot device via ``QueryBootDevices``, and maps
+    each LUN. The device read is **fail-closed**
+    (``storage_devices_unreadable``); the boot resolution is **fail-safe**
+    (nulls ``is_boot`` + names the reason without sinking the listing).
+    Returns ``{status, host, devices[], device_count,
+    current_boot_device_key, boot_device_resolution, boot_device_note}`` --
+    set-shaped, JSONFlux-reduced when large.
     """
     host_moid, refusal = await _resolve_host_moid(connector, operator, target, params.get("host"))
     if refusal is not None:
@@ -326,16 +345,36 @@ async def host_storage_devices_impl(
                 f"{host_moid!r} failed with {type(exc).__name__}: {exc}"
             ),
         }
-    devices = [
-        _map_scsi_lun(lun) for lun in _extract_scsi_luns(props_result) if isinstance(lun, dict)
-    ]
+    props = _extract_host_props(props_result)
+    raw_luns = props.get(_PROP_SCSI_LUN)
+    scsi_luns = raw_luns if isinstance(raw_luns, list) else []
+    boot_system_moid = _moref_value(props.get(_PROP_BOOT_DEVICE_SYSTEM))
+    boot_key, boot_note = await _resolve_boot_device_key(
+        connector, operator, target, boot_system_moid
+    )
+    devices = [_map_scsi_lun(lun, boot_key) for lun in scsi_luns if isinstance(lun, dict)]
+    if boot_key is None:
+        boot_resolution = "unavailable"
+    elif any(device["is_boot"] for device in devices):
+        boot_resolution = "matched"
+    else:
+        boot_resolution = "no_match"
     _log.info(
         "vmware_host_storage_devices_read",
         target=target.name,
         host=host_moid,
         device_count=len(devices),
+        boot_device_resolution=boot_resolution,
     )
-    return {"status": "ok", "host": host_moid, "devices": devices, "device_count": len(devices)}
+    return {
+        "status": "ok",
+        "host": host_moid,
+        "devices": devices,
+        "device_count": len(devices),
+        "current_boot_device_key": boot_key,
+        "boot_device_resolution": boot_resolution,
+        "boot_device_note": boot_note,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -404,10 +443,11 @@ _DEVICE_ITEM_SCHEMA: dict[str, Any] = {
         "is_boot": {
             "type": ["boolean", "null"],
             "description": (
-                "Best-effort boot-device flag. The scsiLun property surface "
-                "carries no boot marker, so this is null; reserved for a future "
-                "esxcli-backed enrichment. Callers excluding the boot device "
-                "today do so by the UUIDs they provisioned."
+                "Whether this LUN is the host's current boot device — matched "
+                "from QueryBootDevices' currentBootDeviceKey against "
+                "canonical_name / uuid. true = boot, false = not, null = boot "
+                "resolution unavailable (see boot_device_resolution). Lets a "
+                "caller flash-mark 'every non-boot disk' (is_boot != true)."
             ),
         },
     },
@@ -451,6 +491,31 @@ _RESPONSE_SCHEMA: dict[str, Any] = {
                 "Length of ``devices`` (the true count; the array may be JSONFlux-reduced)."
             ),
         },
+        "current_boot_device_key": {
+            "type": ["string", "null"],
+            "description": (
+                "HostBootDeviceInfo.currentBootDeviceKey echoed when the boot "
+                "query resolved; null when boot resolution was unavailable."
+            ),
+        },
+        "boot_device_resolution": {
+            "type": "string",
+            "enum": ["matched", "no_match", "unavailable"],
+            "description": (
+                "'matched' — a LUN matched the boot key (its is_boot true); "
+                "'no_match' — key resolved but matched no LUN (all false, key "
+                "echoed); 'unavailable' — boot query could not resolve (all "
+                "null; see boot_device_note). Only on 'ok'."
+            ),
+        },
+        "boot_device_note": {
+            "type": ["string", "null"],
+            "description": (
+                "On boot_device_resolution='unavailable', the reason (no "
+                "bootDeviceSystem, QueryBootDevices failed, or no "
+                "currentBootDeviceKey); null otherwise."
+            ),
+        },
         "candidate_hosts": {
             "type": "array",
             "items": {"type": "string"},
@@ -468,40 +533,37 @@ _RESPONSE_SCHEMA: dict[str, Any] = {
 #: Curated ``when_to_use`` blurb for the host-storage-devices group.
 HOST_STORAGE_DEVICES_WHEN_TO_USE = (
     "Use to enumerate the raw SCSI storage devices on an ESXi host — each "
-    "LUN's uuid, canonical_name, device_type, capacity_bytes, and the "
-    "ssd / local flags (plus model / vendor). The one read that surfaces "
-    "the per-disk UUIDs and flash state vsan_health / datastore.usage / "
-    "network_uplinks do not. The right op when the question is 'which "
-    "disks does this host have?', 'which are flagged flash (ssd)?', or "
-    "'what UUIDs do I feed host.disk_mark_flash?' — including on a "
-    "standalone ESXi host that no vCenter manages yet (a pre-vCenter "
-    "management-domain bring-up), where the host param is ignored and the "
-    "host is the target. Read-only."
+    "LUN's uuid, canonical_name, device_type, capacity_bytes, the ssd / local "
+    "flags (plus model / vendor), and is_boot (the current boot device). The "
+    "one read that surfaces the per-disk UUIDs, flash state, and boot-device "
+    "flag vsan_health / datastore.usage / network_uplinks do not — the right "
+    "op for 'which disks does this host have?', 'which are flash (ssd)?', or "
+    "'which UUIDs do I feed host.disk_mark_flash to flash-mark every non-boot "
+    "disk?', including on a standalone ESXi host no vCenter manages yet (host "
+    "param ignored — the host is the target). Read-only."
 )
 
 VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
     op_id="vmware.host.storage_devices",
     handler_attr="host_storage_devices",
     summary=(
-        "Per-host raw SCSI storage devices — per-LUN uuid, ssd/local flags, capacity, model/vendor."
+        "Per-host raw SCSI storage devices — per-LUN uuid, ssd/local flags, "
+        "capacity, model/vendor, and is_boot."
     ),
     description=(
-        "Returns one row per SCSI LUN on an ESXi host: uuid "
-        "(ScsiLun.uuid — the id host.disk_mark_flash takes), canonical_name, "
-        "device_type, capacity_bytes (bytes; null on non-disk LUNs), ssd "
-        "(flash flag) and local (host-local flag) from HostScsiDisk, plus "
-        "trimmed model / vendor. is_boot is a best-effort null (the scsiLun "
-        "property surface exposes no boot flag). Reads "
-        "HostSystem.config.storageDevice.scsiLun (the read mirror of "
-        "HostStorageSystem.storageDeviceInfo.scsiLun) via a PropertyCollector "
-        "RetrievePropertiesEx directly on the connector session, so it works "
-        "with zero catalog ingest. Works on a vCenter target (with host "
-        "name/moref resolution) and on a standalone ESXi target no vCenter "
-        "manages yet (host param ignored — the host is the target, #3332). "
-        "The device read is fail-closed: a VI-JSON failure returns "
-        "status='storage_devices_unreadable' with an empty device set. "
-        "Set-shaped (JSONFlux-reduced to a handle when large). "
-        "safety_level=safe, read-only."
+        "Returns one row per SCSI LUN on an ESXi host: uuid (ScsiLun.uuid — "
+        "the id host.disk_mark_flash takes), canonical_name, device_type, "
+        "capacity_bytes (null on non-disk LUNs), ssd (flash) and local from "
+        "HostScsiDisk, trimmed model / vendor, and is_boot (the current boot "
+        "device — matched from HostBootDeviceSystem.QueryBootDevices over the "
+        "same VI-JSON seam; null when unavailable, see boot_device_resolution). "
+        "Reads config.storageDevice.scsiLun + configManager.bootDeviceSystem "
+        "via a PropertyCollector RetrievePropertiesEx directly on the connector "
+        "session (zero catalog ingest), on a vCenter target (host name/moref "
+        "resolution) and a standalone ESXi target no vCenter manages yet (host "
+        "param ignored — the host is the target, #3332). Device read fail-closed "
+        "(storage_devices_unreadable); boot resolution fail-safe. Set-shaped, "
+        "JSONFlux-reduced when large. safety_level=safe, read-only."
     ),
     parameter_schema=_PARAMETER_SCHEMA,
     response_schema=_RESPONSE_SCHEMA,
@@ -512,9 +574,10 @@ VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
     llm_instructions={
         "when_to_use": (
             "Call to discover a host's raw disks before flash-marking them — "
-            "the per-LUN uuid + ssd flag host.disk_mark_flash needs, which the "
-            "other host storage reads do not surface. Works on a standalone "
-            "ESXi host (no managing vCenter) as well as through a vCenter."
+            "the per-LUN uuid + ssd flag + is_boot host.disk_mark_flash needs to "
+            "flash-mark every non-boot disk, which the other host storage reads "
+            "do not surface. Works on a standalone ESXi host (no managing "
+            "vCenter) as well as through a vCenter."
         ),
         "parameter_hints": {
             "host": (
@@ -524,9 +587,11 @@ VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
         },
         "output_shape": (
             "{status, host, devices: [{uuid, canonical_name, device_type, "
-            "capacity_bytes, ssd, local, model, vendor, is_boot}], "
-            "device_count}. Refusals (host_required / host_not_found / "
-            "ambiguous_host / unsupported_host_target / "
+            "capacity_bytes, ssd, local, model, vendor, is_boot}], device_count, "
+            "current_boot_device_key, boot_device_resolution, boot_device_note}. "
+            "To flash-mark non-boot disks, feed the uuids of rows where is_boot "
+            "!= true to host.disk_mark_flash. Refusals (host_required / "
+            "host_not_found / ambiguous_host / unsupported_host_target / "
             "storage_devices_unreadable) carry an empty devices array."
         ),
     },

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``vmware.host.storage_devices`` typed read op (#3332).
+
+Enumerates a host's raw SCSI storage devices -- per-LUN ``uuid`` +
+``canonical_name`` + ``ssd`` / ``local`` flags + capacity + model /
+vendor -- the runtime input ``vmware.composite.host.disk_mark_flash``
+needs. Before this op the only host storage reads were ``vsan_health`` /
+``datastore.usage`` / ``network_uplinks``; none enumerate the raw device
+set, so a caller that wants to flash-mark "every non-boot disk" could
+not discover the devices through the backplane and had to pre-supply
+UUIDs it could only get out-of-band.
+
+In the :mod:`~meho_backplane.connectors.vmware_rest.typed_ops` mould
+(``vmware.host.usage`` / ``.network_uplinks``): a ``source_kind="typed"``
+bound method that reads directly on the connector session -- no
+``dispatch_child``, no ingested descriptor -- so it works on a **fresh
+boot with zero catalog ingest**. That property is load-bearing here: the
+#3332 use case is a **standalone ESXi** host no vCenter manages yet (a
+nested management-domain bring-up before the SDDC vCenter exists), where
+no vCenter catalog can have been ingested.
+
+Both target flavors are covered (#3332, via
+:func:`~meho_backplane.connectors.vmware_rest.host_target.classify_host_target`):
+
+* a **standalone ESXi** target -- fingerprint ``product=esxi`` -- has one
+  host, the well-known ``ha-host``; the ``host`` param is ignored (the
+  host is the target);
+* a **vCenter** target resolves the ``host`` param (display name or
+  moref) through ``GET:/vcenter/host`` (name-first, moref-fallback), the
+  same ladder the host write composites use.
+
+The device rows come from the Web-Services-API
+``HostSystem.config.storageDevice.scsiLun`` property (the host-side
+read mirror of ``HostStorageSystem.storageDeviceInfo.scsiLun`` -- the
+same ``HostScsiDisk`` / ``ScsiLun`` array), read via the PropertyCollector
+``RetrievePropertiesEx`` vi-json method routed through
+:meth:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector._post_vmomi_json`
+(mounted on the documented ``/sdk/vim25/{release}`` base). The response
+is set-shaped, so the dispatcher JSONFlux-reduces it to a handle when
+large -- the same auto-reduction the other typed reads rely on.
+
+``ssd`` / ``local`` / ``capacity_bytes`` are ``HostScsiDisk`` fields (the
+``deviceType="disk"`` subclass of ``ScsiLun``); a non-disk LUN (cdrom /
+tape) carries ``null`` for them. ``is_boot`` is **best-effort**: the
+``scsiLun`` property surface carries no boot flag (identifying the ESXi
+boot device reliably needs the esxcli ``storage core device list`` "Is
+Boot Device" datum, not a managed-object property), so it is ``null``
+here and reserved for a future esxcli-backed enrichment.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vmware_rest.host_target import (
+    HOST_FLAVOR_ESXI,
+    STANDALONE_ESXI_HOST_MOID,
+    classify_host_target,
+)
+from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+from meho_backplane.connectors.vmware_rest.typed_ops import VmwareTypedOp, _unwrap_value
+from meho_backplane.connectors.vmware_rest.vim_body import (
+    retrieve_properties_body,
+    unwrap_vim_value,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+__all__ = [
+    "HOST_STORAGE_DEVICES_GROUP_KEY",
+    "HOST_STORAGE_DEVICES_WHEN_TO_USE",
+    "VMWARE_HOST_STORAGE_DEVICES_OP",
+    "build_host_storage_devices_retrieve_params",
+    "host_storage_devices_impl",
+]
+
+_log = structlog.get_logger(__name__)
+
+# vCenter Automation REST host listing (spec-relative; mounted onto
+# /api or /rest per-target by mount_op_path).
+_LIST_HOSTS_PATH = "/vcenter/host"
+# PropertyCollector RetrievePropertiesEx against the singleton
+# ``propertyCollector`` moId (carried in the path, so the body is only
+# the method arguments).
+_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+_HOST_SYSTEM_MO_TYPE = "HostSystem"
+# HostSystem-side mirror of HostStorageSystem.storageDeviceInfo.scsiLun
+# (the same HostStorageDeviceInfo object, cached on config). Narrowed to
+# the scsiLun leaf so the read does not pull the whole storageDevice
+# object (HBAs / multipath / plug-store topology).
+_PROP_SCSI_LUN = "config.storageDevice.scsiLun"
+_STORAGE_DEVICE_PATH_SET = (_PROP_SCSI_LUN,)
+
+HOST_STORAGE_DEVICES_GROUP_KEY = "vmware-host-storage-devices"
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return a trimmed string, or ``None`` for anything else.
+
+    SCSI inquiry strings (``model`` / ``vendor``) arrive space-padded from
+    the WS-API, so they are trimmed; identifiers (``uuid`` /
+    ``canonicalName``) carry no padding and pass through the same trim
+    harmlessly.
+    """
+    return value.strip() if isinstance(value, str) else None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    """Coerce a WS-API boolean to ``bool``; anything else -> ``None``.
+
+    ``ssd`` / ``localDisk`` are ``HostScsiDisk``-only fields, absent on a
+    non-disk ``ScsiLun`` -- their absence reads as ``None``.
+    """
+    return value if isinstance(value, bool) else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    """Coerce a JSON number / numeric string to int; anything else -> ``None``.
+
+    Rejects bools (``True`` is an ``int`` subclass and must not read as 1).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _capacity_bytes(capacity: Any) -> int | None:
+    """Compute a LUN's capacity in bytes from ``HostDiskDimensionsLba``.
+
+    ``HostScsiDisk.capacity`` is ``{blockSize, block}`` (bytes-per-block x
+    block count); the byte total is their product. Absent (non-disk LUN)
+    or partial -> ``None``.
+    """
+    if not isinstance(capacity, dict):
+        return None
+    block_size = _int_or_none(capacity.get("blockSize"))
+    block = _int_or_none(capacity.get("block"))
+    if block_size is None or block is None:
+        return None
+    return block_size * block
+
+
+def _map_scsi_lun(lun: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one WS-API ``ScsiLun`` / ``HostScsiDisk`` into an operator row.
+
+    ``is_boot`` is best-effort ``None``: the ``scsiLun`` property surface
+    exposes no boot flag (see the module docstring); it is reserved for a
+    future esxcli-backed enrichment so a caller excluding the boot device
+    has a stable field to read.
+    """
+    return {
+        "uuid": _str_or_none(lun.get("uuid")),
+        "canonical_name": _str_or_none(lun.get("canonicalName")),
+        "device_type": _str_or_none(lun.get("deviceType")),
+        "capacity_bytes": _capacity_bytes(lun.get("capacity")),
+        "ssd": _bool_or_none(lun.get("ssd")),
+        "local": _bool_or_none(lun.get("localDisk")),
+        "model": _str_or_none(lun.get("model")),
+        "vendor": _str_or_none(lun.get("vendor")),
+        "is_boot": None,
+    }
+
+
+def _extract_scsi_luns(retrieve_result: Any) -> list[Any]:
+    """Pull the ``config.storageDevice.scsiLun`` array from a RetrievePropertiesEx result.
+
+    ``RetrievePropertiesEx`` returns a ``RetrieveResult`` whose ``objects``
+    list carries one ``ObjectContent`` per queried object, each with a
+    ``propSet`` list of ``{name, val}`` pairs. For the single-host query
+    the first object's propSet holds the requested scsiLun array (boxed as
+    ``ArrayOf*`` -- :func:`unwrap_vim_value` un-boxes it). Absent -> ``[]``.
+    """
+    payload = _unwrap_value(retrieve_result)
+    if isinstance(payload, dict):
+        objects = payload.get("objects", [])
+    elif isinstance(payload, list):
+        objects = payload
+    else:
+        objects = []
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and prop.get("name") == _PROP_SCSI_LUN:
+                luns = unwrap_vim_value(prop.get("val"))
+                return luns if isinstance(luns, list) else []
+    return []
+
+
+def build_host_storage_devices_retrieve_params(host_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` request body for one host's scsiLun array.
+
+    A single ``PropertyFilterSpec`` scoped directly to the ``HostSystem``
+    object (no ContainerView / TraversalSpec) requesting the one
+    ``config.storageDevice.scsiLun`` property path -- the VI-JSON
+    ``RetrievePropertiesExRequestType`` shape the other typed reads send,
+    ``_typeName``-annotated via the shared trio helper (#3103).
+    """
+    return retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], _STORAGE_DEVICE_PATH_SET)
+
+
+async def _list_host_moids(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    query: dict[str, Any],
+) -> list[str]:
+    """Return the ``host`` moids from one ``GET:/vcenter/host`` listing.
+
+    Routes through :meth:`VmwareRestConnector.mount_op_path` (``/api``
+    modern / ``/rest`` legacy) and keys the filter param off the mount
+    flavor via :meth:`adapt_op_query` (#2298), the same way the sibling
+    typed reads issue their host listing.
+    """
+    list_path = await connector.mount_op_path(target, _LIST_HOSTS_PATH, operator)
+    listing_query = await connector.adapt_op_query(target, query, operator)
+    listing = await connector._get_json(target, list_path, operator=operator, params=listing_query)
+    rows = _unwrap_value(listing)
+    if not isinstance(rows, list):
+        return []
+    return [
+        row["host"] for row in rows if isinstance(row, dict) and isinstance(row.get("host"), str)
+    ]
+
+
+async def _resolve_host_moid(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    host: str | None,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve the target's host to a ``HostSystem`` moid, or a refusal envelope.
+
+    Branches on the target fingerprint (:func:`classify_host_target`,
+    #3332): a standalone-ESXi target resolves to the well-known
+    :data:`STANDALONE_ESXI_HOST_MOID` (``host`` ignored); a vCenter target
+    resolves ``host`` (display name first, moref fallback) via
+    ``GET:/vcenter/host``; any other reachable product / a missing host /
+    an unresolved host fails closed. Returns ``(moid, None)`` on success or
+    ``(None, refusal)`` -- the refusal is the full op envelope (empty
+    ``devices``).
+    """
+    flavor, refusal = classify_host_target(target)
+    if refusal is not None:
+        return None, {**refusal, "host": host, "devices": [], "device_count": 0}
+    if flavor == HOST_FLAVOR_ESXI:
+        return STANDALONE_ESXI_HOST_MOID, None
+    if not host:
+        return None, {
+            "status": "host_required",
+            "host": host,
+            "devices": [],
+            "device_count": 0,
+            "guidance": "a vCenter target requires a host display name or moref",
+        }
+    by_name = await _list_host_moids(connector, operator, target, {"filter.names": [host]})
+    if len(by_name) == 1:
+        return by_name[0], None
+    if len(by_name) > 1:
+        return None, {
+            "status": "ambiguous_host",
+            "host": host,
+            "candidate_hosts": by_name,
+            "devices": [],
+            "device_count": 0,
+        }
+    by_moref = await _list_host_moids(connector, operator, target, {"filter.hosts": [host]})
+    if len(by_moref) == 1:
+        return by_moref[0], None
+    return None, {"status": "host_not_found", "host": host, "devices": [], "device_count": 0}
+
+
+async def host_storage_devices_impl(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Implementation of ``vmware.host.storage_devices`` -- per-host raw SCSI devices.
+
+    Resolves the host (standalone-ESXi ``ha-host`` or a vCenter
+    name/moref, #3332), then reads ``config.storageDevice.scsiLun`` off one
+    PropertyCollector ``RetrievePropertiesEx`` on the connector session and
+    maps each LUN to a row. The read is fail-closed: a VI-JSON transport /
+    status failure (the seam unavailable, an ESXi that rejects the call)
+    returns a typed ``status='storage_devices_unreadable'`` with an empty
+    device set and a ``read_note`` rather than a bare stack trace.
+
+    Returns ``{status, host, devices: [{uuid, canonical_name, device_type,
+    capacity_bytes, ssd, local, model, vendor, is_boot}, ...], device_count}``.
+    Set-shaped, so the dispatcher JSONFlux-reduces it to a handle when large.
+    """
+    host_moid, refusal = await _resolve_host_moid(connector, operator, target, params.get("host"))
+    if refusal is not None:
+        return refusal
+    assert host_moid is not None  # refusal is None => the host resolved (mypy narrowing).
+    try:
+        props_result = await connector._post_vmomi_json(
+            target,
+            _RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=build_host_storage_devices_retrieve_params(host_moid),
+        )
+    except (httpx.HTTPError, RuntimeError) as exc:
+        return {
+            "status": "storage_devices_unreadable",
+            "host": host_moid,
+            "devices": [],
+            "device_count": 0,
+            "read_note": (
+                f"storage-device read failed: RetrievePropertiesEx for host "
+                f"{host_moid!r} failed with {type(exc).__name__}: {exc}"
+            ),
+        }
+    devices = [
+        _map_scsi_lun(lun) for lun in _extract_scsi_luns(props_result) if isinstance(lun, dict)
+    ]
+    _log.info(
+        "vmware_host_storage_devices_read",
+        target=target.name,
+        host=host_moid,
+        device_count=len(devices),
+    )
+    return {"status": "ok", "host": host_moid, "devices": devices, "device_count": len(devices)}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata + schemas
+# ---------------------------------------------------------------------------
+
+_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Host display name or moref (e.g. 'esxi-01' or 'host-15') to "
+                "enumerate devices for. Resolved via GET:/vcenter/host — a "
+                "display-name lookup first, moref fallback; ambiguous names "
+                "return status='ambiguous_host'. Required on a vCenter target "
+                "(else status='host_required'). **Optional / ignored on a "
+                "standalone-ESXi target** (fingerprint product=esxi): that "
+                "target has exactly one host (the well-known ha-host), so the "
+                "host is the target and this param is not needed."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+_DEVICE_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "uuid": {
+            "type": ["string", "null"],
+            "description": "ScsiLun.uuid — the stable device UUID disk_mark_flash takes.",
+        },
+        "canonical_name": {
+            "type": ["string", "null"],
+            "description": "ScsiLun.canonicalName (e.g. 'naa.…' / 'mpx.vmhba0:C0:T0:L0').",
+        },
+        "device_type": {
+            "type": ["string", "null"],
+            "description": "ScsiLun.deviceType (e.g. 'disk', 'cdrom').",
+        },
+        "capacity_bytes": {
+            "type": ["integer", "null"],
+            "description": (
+                "Capacity in bytes (HostScsiDisk.capacity.blockSize x block); "
+                "null on a non-disk LUN."
+            ),
+        },
+        "ssd": {
+            "type": ["boolean", "null"],
+            "description": (
+                "HostScsiDisk.ssd — true when the disk is presented as flash; "
+                "null on a non-disk LUN. This is the flag disk_mark_flash toggles."
+            ),
+        },
+        "local": {
+            "type": ["boolean", "null"],
+            "description": (
+                "HostScsiDisk.localDisk — true when the disk is host-local; null on a non-disk LUN."
+            ),
+        },
+        "model": {"type": ["string", "null"], "description": "ScsiLun.model (trimmed)."},
+        "vendor": {"type": ["string", "null"], "description": "ScsiLun.vendor (trimmed)."},
+        "is_boot": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Best-effort boot-device flag. The scsiLun property surface "
+                "carries no boot marker, so this is null; reserved for a future "
+                "esxcli-backed enrichment. Callers excluding the boot device "
+                "today do so by the UUIDs they provisioned."
+            ),
+        },
+    },
+    "required": ["uuid", "canonical_name"],
+}
+
+_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "host_required",
+                "host_not_found",
+                "ambiguous_host",
+                "unsupported_host_target",
+                "storage_devices_unreadable",
+            ],
+            "description": (
+                "'ok' — devices enumerated; the refusal statuses are reached "
+                "before (host resolution) or in place of (VI-JSON read "
+                "failure) the device read."
+            ),
+        },
+        "host": {
+            "type": ["string", "null"],
+            "description": (
+                "Resolved host moid (ha-host on a standalone-ESXi target), or the input on refusal."
+            ),
+        },
+        "devices": {
+            "type": "array",
+            "items": _DEVICE_ITEM_SCHEMA,
+            "description": "One row per SCSI LUN (empty on any non-'ok' status).",
+        },
+        "device_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Length of ``devices`` (the true count; the array may be JSONFlux-reduced)."
+            ),
+        },
+        "candidate_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Matched host moids on 'ambiguous_host'.",
+        },
+        "read_note": {
+            "type": "string",
+            "description": "On 'storage_devices_unreadable', the failing method + error.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "host", "devices", "device_count"],
+}
+
+#: Curated ``when_to_use`` blurb for the host-storage-devices group.
+HOST_STORAGE_DEVICES_WHEN_TO_USE = (
+    "Use to enumerate the raw SCSI storage devices on an ESXi host — each "
+    "LUN's uuid, canonical_name, device_type, capacity_bytes, and the "
+    "ssd / local flags (plus model / vendor). The one read that surfaces "
+    "the per-disk UUIDs and flash state vsan_health / datastore.usage / "
+    "network_uplinks do not. The right op when the question is 'which "
+    "disks does this host have?', 'which are flagged flash (ssd)?', or "
+    "'what UUIDs do I feed host.disk_mark_flash?' — including on a "
+    "standalone ESXi host that no vCenter manages yet (a pre-vCenter "
+    "management-domain bring-up), where the host param is ignored and the "
+    "host is the target. Read-only."
+)
+
+VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
+    op_id="vmware.host.storage_devices",
+    handler_attr="host_storage_devices",
+    summary=(
+        "Per-host raw SCSI storage devices — per-LUN uuid, ssd/local flags, capacity, model/vendor."
+    ),
+    description=(
+        "Returns one row per SCSI LUN on an ESXi host: uuid "
+        "(ScsiLun.uuid — the id host.disk_mark_flash takes), canonical_name, "
+        "device_type, capacity_bytes (bytes; null on non-disk LUNs), ssd "
+        "(flash flag) and local (host-local flag) from HostScsiDisk, plus "
+        "trimmed model / vendor. is_boot is a best-effort null (the scsiLun "
+        "property surface exposes no boot flag). Reads "
+        "HostSystem.config.storageDevice.scsiLun (the read mirror of "
+        "HostStorageSystem.storageDeviceInfo.scsiLun) via a PropertyCollector "
+        "RetrievePropertiesEx directly on the connector session, so it works "
+        "with zero catalog ingest. Works on a vCenter target (with host "
+        "name/moref resolution) and on a standalone ESXi target no vCenter "
+        "manages yet (host param ignored — the host is the target, #3332). "
+        "The device read is fail-closed: a VI-JSON failure returns "
+        "status='storage_devices_unreadable' with an empty device set. "
+        "Set-shaped (JSONFlux-reduced to a handle when large). "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_PARAMETER_SCHEMA,
+    response_schema=_RESPONSE_SCHEMA,
+    group_key=HOST_STORAGE_DEVICES_GROUP_KEY,
+    tags=("read-only", "vmware", "vcenter", "esxi", "host", "storage", "devices"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to discover a host's raw disks before flash-marking them — "
+            "the per-LUN uuid + ssd flag host.disk_mark_flash needs, which the "
+            "other host storage reads do not surface. Works on a standalone "
+            "ESXi host (no managing vCenter) as well as through a vCenter."
+        ),
+        "parameter_hints": {
+            "host": (
+                "Host display name or moref on a vCenter target; omit on a "
+                "standalone-ESXi target (the host is the target)."
+            ),
+        },
+        "output_shape": (
+            "{status, host, devices: [{uuid, canonical_name, device_type, "
+            "capacity_bytes, ssd, local, model, vendor, is_boot}], "
+            "device_count}. Refusals (host_required / host_not_found / "
+            "ambiguous_host / unsupported_host_target / "
+            "storage_devices_unreadable) carry an empty devices array."
+        ),
+    },
+)

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_storage_devices.py
@@ -6,36 +6,42 @@
 Enumerates a host's raw SCSI storage devices -- per-LUN ``uuid`` +
 ``canonical_name`` + ``ssd`` / ``local`` flags + capacity + model / vendor
 + a best-effort ``is_boot`` flag -- the runtime input
-``vmware.composite.host.disk_mark_flash`` needs to flash-mark "every
-non-boot disk" (the other host storage reads do not enumerate the raw
-device set).
+``vmware.composite.host.disk_mark_flash`` needs (the other host storage
+reads do not enumerate the raw device set).
 
 A ``source_kind="typed"`` bound method in the ``vmware.host.usage`` mould:
 reads directly on the connector session (no ``dispatch_child``, no ingested
 descriptor), so it works on a **fresh boot with zero catalog ingest** --
-load-bearing here, since the #3332 case is a **standalone ESXi** host no
-vCenter manages yet. Host resolution branches on the fingerprint
+load-bearing, since the #3332 case is a **standalone ESXi** host no vCenter
+manages yet. Host resolution branches on the fingerprint
 (:func:`~meho_backplane.connectors.vmware_rest.host_target.classify_host_target`):
-a standalone-ESXi target (``product=esxi``) resolves the well-known
-``ha-host`` (``host`` ignored); a vCenter target resolves the ``host``
-param (name / moref) via ``GET:/vcenter/host``.
+standalone-ESXi (``product=esxi``) -> the well-known ``ha-host`` (``host``
+ignored); vCenter -> the ``host`` param (name / moref) via GET:/vcenter/host.
 
-Device rows come from ``HostSystem.config.storageDevice.scsiLun`` (the
-read mirror of ``HostStorageSystem.storageDeviceInfo.scsiLun``), read via
-one PropertyCollector ``RetrievePropertiesEx`` on the VI-JSON
-``/sdk/vim25/{release}`` seam; set-shaped, so JSONFlux-reduced when large.
-``ssd`` / ``local`` / ``capacity_bytes`` are ``HostScsiDisk`` fields (the
-``deviceType="disk"`` subclass), ``null`` on a non-disk LUN.
+Device rows come from ``HostSystem.config.storageDevice.scsiLun`` (the read
+mirror of ``HostStorageSystem.storageDeviceInfo.scsiLun``) via one
+PropertyCollector ``RetrievePropertiesEx`` on the VI-JSON seam; set-shaped,
+JSONFlux-reduced when large. ``ssd`` / ``local`` / ``capacity_bytes`` are
+``HostScsiDisk`` fields, ``null`` on a non-disk LUN.
 
 Boot-device identification needs **no esxcli seam**: the same read also
 fetches ``configManager.bootDeviceSystem``, and when present the op calls
 ``HostBootDeviceSystem.QueryBootDevices`` (a vim query over the same seam)
-and matches its ``currentBootDeviceKey`` -- which typically embeds the
-device's canonical name / uuid -- against the rows (``is_boot`` true on
-the match, false on the rest). **Fail-safe**: an absent config manager, an
-unsupported / erroring query, or a missing key nulls every ``is_boot`` and
-names the reason in ``boot_device_resolution`` / ``boot_device_note`` --
-the listing is still returned.
+and matches its ``HostBootDeviceInfo.currentBootDeviceKey`` against the
+rows. That key is **vendor-defined** (it *typically* embeds the canonical
+name / uuid, but the format is not contractual, and ESXi frequently leaves
+``bootDeviceSystem`` unpopulated), so the match is a labelled best-effort
+heuristic and ``boot_device_resolution`` reports the outcome: ``matched``
+(a LUN positively matched -- then, and only then, ``is_boot`` is
+authoritative: true on the match, false on the rest), ``no_match`` (key
+resolved, matched no listed LUN), or ``unavailable`` (no config manager /
+an unsupported / erroring query -- an **expected** outcome, not an error).
+On ``no_match`` and ``unavailable`` every ``is_boot`` is ``null`` -- the op
+never asserts ``false`` in an ambiguous state -- and the listing is still
+returned. See the vSphere Web Services API reference for
+``HostBootDeviceSystem`` / ``HostBootDeviceInfo``
+(developer.broadcom.com/xapis/vsphere-web-services-api); follow-up to
+verify the key format on real hardware: evoila/meho#3336.
 """
 
 from __future__ import annotations
@@ -132,14 +138,14 @@ def _capacity_bytes(capacity: Any) -> int | None:
 
 
 def _matches_boot(uuid: str | None, canonical_name: str | None, boot_key: str) -> bool:
-    """Whether a scsiLun row is the current boot device.
+    """Best-effort: whether a scsiLun row is the current boot device.
 
-    ``currentBootDeviceKey`` typically embeds the canonical name / uuid;
-    match by containment either way, guarded to identifiers >=
-    :data:`_MIN_BOOT_MATCH_LEN` chars (fail-safe: no match on a missing id).
+    ``currentBootDeviceKey`` is a vendor-defined key that *typically* embeds
+    the canonical name / uuid (heuristic, see the module docstring); match by
+    containment either way, both sides >= :data:`_MIN_BOOT_MATCH_LEN` chars.
     """
     key_l = boot_key.strip().lower()
-    if not key_l:
+    if len(key_l) < _MIN_BOOT_MATCH_LEN:
         return False
     for ident in (canonical_name, uuid):
         if not ident:
@@ -150,29 +156,24 @@ def _matches_boot(uuid: str | None, canonical_name: str | None, boot_key: str) -
     return False
 
 
-def _map_scsi_lun(lun: dict[str, Any], boot_key: str | None) -> dict[str, Any]:
-    """Flatten one ``ScsiLun`` / ``HostScsiDisk`` row (``is_boot``: null when
-    *boot_key* is None, else whether this LUN matches the boot key)."""
-    uuid = _str_or_none(lun.get("uuid"))
-    canonical_name = _str_or_none(lun.get("canonicalName"))
+def _map_scsi_lun(lun: dict[str, Any], is_boot: bool | None) -> dict[str, Any]:
+    """Flatten one ``ScsiLun`` / ``HostScsiDisk`` row (*is_boot* is the
+    caller-computed flag: True/False only when matched, else None)."""
     return {
-        "uuid": uuid,
-        "canonical_name": canonical_name,
+        "uuid": _str_or_none(lun.get("uuid")),
+        "canonical_name": _str_or_none(lun.get("canonicalName")),
         "device_type": _str_or_none(lun.get("deviceType")),
         "capacity_bytes": _capacity_bytes(lun.get("capacity")),
         "ssd": _bool_or_none(lun.get("ssd")),
         "local": _bool_or_none(lun.get("localDisk")),
         "model": _str_or_none(lun.get("model")),
         "vendor": _str_or_none(lun.get("vendor")),
-        "is_boot": None if boot_key is None else _matches_boot(uuid, canonical_name, boot_key),
+        "is_boot": is_boot,
     }
 
 
 def _extract_host_props(retrieve_result: Any) -> dict[str, Any]:
-    """Flatten a single-host ``RetrievePropertiesEx`` result to ``{name: val}``.
-
-    Each ``val`` is un-boxed via :func:`unwrap_vim_value`.
-    """
+    """Flatten a single-host ``RetrievePropertiesEx`` result to ``{name: val}`` (val un-boxed)."""
     payload = _unwrap_value(retrieve_result)
     if isinstance(payload, dict):
         objects = payload.get("objects", [])
@@ -199,13 +200,7 @@ def _moref_value(val: Any) -> str | None:
 
 
 def build_host_storage_devices_retrieve_params(host_moid: str) -> dict[str, Any]:
-    """Build the ``RetrievePropertiesEx`` request body for one host.
-
-    One ``PropertyFilterSpec`` scoped to the ``HostSystem`` requesting
-    ``config.storageDevice.scsiLun`` (the device array) +
-    ``configManager.bootDeviceSystem`` (so the boot query needs no extra
-    read) -- ``_typeName``-annotated via the shared trio helper (#3103).
-    """
+    """RetrievePropertiesEx body: scsiLun + bootDeviceSystem (annotated, #3103)."""
     return retrieve_properties_body(_HOST_SYSTEM_MO_TYPE, [host_moid], _STORAGE_DEVICE_PATH_SET)
 
 
@@ -217,12 +212,10 @@ async def _resolve_boot_device_key(
 ) -> tuple[str | None, str | None]:
     """Best-effort current-boot-device key via ``HostBootDeviceSystem.QueryBootDevices``.
 
-    Returns ``(key, None)`` on success. **Fail-safe**: an absent config
-    manager, a transport / status / unsupported-method failure, or a missing
-    ``currentBootDeviceKey`` yields ``(None, reason)`` (``is_boot`` null, the
-    listing still returned). ``QueryBootDevices`` is a read, so it rides the
-    un-gated :meth:`VmwareRestConnector._post_vmomi_json` seam, not the write
-    sub-op seam.
+    ``(key, None)`` on success; **fail-safe** ``(None, reason)`` on an absent
+    config manager, a transport / status / unsupported-method failure, or a
+    missing ``currentBootDeviceKey``. A read, so it rides the un-gated
+    :meth:`VmwareRestConnector._post_vmomi_json` seam, not the write seam.
     """
     if not boot_system_moid:
         return None, "host exposes no configManager.bootDeviceSystem"
@@ -244,11 +237,8 @@ async def _list_host_moids(
     target: VsphereTargetLike,
     query: dict[str, Any],
 ) -> list[str]:
-    """Return the ``host`` moids from one ``GET:/vcenter/host`` listing.
-
-    Mounted via :meth:`mount_op_path` and filter-adapted via
-    :meth:`adapt_op_query` (#2298), like the sibling typed reads.
-    """
+    """Return the ``host`` moids from one ``GET:/vcenter/host`` listing (mount +
+    filter-adapted like the sibling typed reads, #2298)."""
     list_path = await connector.mount_op_path(target, _LIST_HOSTS_PATH, operator)
     listing_query = await connector.adapt_op_query(target, query, operator)
     listing = await connector._get_json(target, list_path, operator=operator, params=listing_query)
@@ -268,12 +258,10 @@ async def _resolve_host_moid(
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Resolve the target's host to a ``HostSystem`` moid, or a refusal envelope.
 
-    Branches on the fingerprint (:func:`classify_host_target`, #3332): a
-    standalone-ESXi target resolves the well-known
-    :data:`STANDALONE_ESXI_HOST_MOID` (``host`` ignored); a vCenter target
-    resolves ``host`` (name first, moref fallback) via ``GET:/vcenter/host``;
+    Branches on the fingerprint (:func:`classify_host_target`, #3332):
+    standalone-ESXi -> :data:`STANDALONE_ESXI_HOST_MOID` (``host`` ignored);
+    vCenter -> ``host`` (name first, moref fallback) via ``GET:/vcenter/host``;
     any other reachable product / missing / unresolved host fails closed.
-    Returns ``(moid, None)`` or ``(None, refusal)`` (the full op envelope).
     """
     flavor, refusal = classify_host_target(target)
     if refusal is not None:
@@ -316,12 +304,8 @@ async def host_storage_devices_impl(
     Resolves the host (#3332), reads ``config.storageDevice.scsiLun`` +
     ``configManager.bootDeviceSystem`` off one ``RetrievePropertiesEx``,
     best-effort resolves the boot device via ``QueryBootDevices``, and maps
-    each LUN. The device read is **fail-closed**
-    (``storage_devices_unreadable``); the boot resolution is **fail-safe**
-    (nulls ``is_boot`` + names the reason without sinking the listing).
-    Returns ``{status, host, devices[], device_count,
-    current_boot_device_key, boot_device_resolution, boot_device_note}`` --
-    set-shaped, JSONFlux-reduced when large.
+    each LUN. Device read **fail-closed** (``storage_devices_unreadable``);
+    boot resolution **fail-safe** (nulls ``is_boot`` + names the reason).
     """
     host_moid, refusal = await _resolve_host_moid(connector, operator, target, params.get("host"))
     if refusal is not None:
@@ -347,18 +331,40 @@ async def host_storage_devices_impl(
         }
     props = _extract_host_props(props_result)
     raw_luns = props.get(_PROP_SCSI_LUN)
-    scsi_luns = raw_luns if isinstance(raw_luns, list) else []
+    scsi_luns = (
+        [lun for lun in raw_luns if isinstance(lun, dict)] if isinstance(raw_luns, list) else []
+    )
     boot_system_moid = _moref_value(props.get(_PROP_BOOT_DEVICE_SYSTEM))
     boot_key, boot_note = await _resolve_boot_device_key(
         connector, operator, target, boot_system_moid
     )
-    devices = [_map_scsi_lun(lun, boot_key) for lun in scsi_luns if isinstance(lun, dict)]
+    # is_boot is authoritative ONLY when a key positively matched a listed LUN
+    # ("matched": true = boot, false = not-boot). A resolved-but-unmatched key
+    # ("no_match") or no key ("unavailable") is ambiguous -- the boot device
+    # may be a non-SCSI device absent from scsiLun, OR the vendor-defined key
+    # format did not align -- so every is_boot is null (unknown), never false (B2).
     if boot_key is None:
         boot_resolution = "unavailable"
-    elif any(device["is_boot"] for device in devices):
+        is_boot_flags: list[bool | None] = [None] * len(scsi_luns)
+    elif any(
+        _matches_boot(
+            _str_or_none(lun.get("uuid")), _str_or_none(lun.get("canonicalName")), boot_key
+        )
+        for lun in scsi_luns
+    ):
         boot_resolution = "matched"
+        is_boot_flags = [
+            _matches_boot(
+                _str_or_none(lun.get("uuid")), _str_or_none(lun.get("canonicalName")), boot_key
+            )
+            for lun in scsi_luns
+        ]
     else:
         boot_resolution = "no_match"
+        is_boot_flags = [None] * len(scsi_luns)
+    devices = [
+        _map_scsi_lun(lun, is_boot) for lun, is_boot in zip(scsi_luns, is_boot_flags, strict=True)
+    ]
     _log.info(
         "vmware_host_storage_devices_read",
         target=target.name,
@@ -388,14 +394,12 @@ _PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "minLength": 1,
             "description": (
-                "Host display name or moref (e.g. 'esxi-01' or 'host-15') to "
-                "enumerate devices for. Resolved via GET:/vcenter/host — a "
-                "display-name lookup first, moref fallback; ambiguous names "
-                "return status='ambiguous_host'. Required on a vCenter target "
-                "(else status='host_required'). **Optional / ignored on a "
-                "standalone-ESXi target** (fingerprint product=esxi): that "
-                "target has exactly one host (the well-known ha-host), so the "
-                "host is the target and this param is not needed."
+                "Host display name or moref (e.g. 'esxi-01' / 'host-15'). "
+                "Resolved via GET:/vcenter/host (name first, moref fallback; "
+                "ambiguous -> status='ambiguous_host'). Required on a vCenter "
+                "target (else status='host_required'); **optional / ignored on "
+                "a standalone-ESXi target** (fingerprint product=esxi) — that "
+                "target's one host is the well-known ha-host, i.e. the target."
             ),
         },
     },
@@ -443,11 +447,11 @@ _DEVICE_ITEM_SCHEMA: dict[str, Any] = {
         "is_boot": {
             "type": ["boolean", "null"],
             "description": (
-                "Whether this LUN is the host's current boot device — matched "
-                "from QueryBootDevices' currentBootDeviceKey against "
-                "canonical_name / uuid. true = boot, false = not, null = boot "
-                "resolution unavailable (see boot_device_resolution). Lets a "
-                "caller flash-mark 'every non-boot disk' (is_boot != true)."
+                "Best-effort boot-device flag (matched from QueryBootDevices' "
+                "currentBootDeviceKey against canonical_name / uuid). "
+                "**Authoritative only when boot_device_resolution == 'matched'** "
+                "(true = boot, false = not); otherwise null on every row — treat "
+                "null as UNKNOWN, never as 'not the boot disk'."
             ),
         },
     },
@@ -476,7 +480,7 @@ _RESPONSE_SCHEMA: dict[str, Any] = {
         "host": {
             "type": ["string", "null"],
             "description": (
-                "Resolved host moid (ha-host on a standalone-ESXi target), or the input on refusal."
+                "Resolved host moid (ha-host on standalone ESXi), or the input on refusal."
             ),
         },
         "devices": {
@@ -487,34 +491,28 @@ _RESPONSE_SCHEMA: dict[str, Any] = {
         "device_count": {
             "type": "integer",
             "minimum": 0,
-            "description": (
-                "Length of ``devices`` (the true count; the array may be JSONFlux-reduced)."
-            ),
+            "description": "Length of ``devices`` (true count; array may be JSONFlux-reduced).",
         },
         "current_boot_device_key": {
             "type": ["string", "null"],
             "description": (
-                "HostBootDeviceInfo.currentBootDeviceKey echoed when the boot "
-                "query resolved; null when boot resolution was unavailable."
+                "currentBootDeviceKey when the boot query resolved; null on unavailable."
             ),
         },
         "boot_device_resolution": {
             "type": "string",
             "enum": ["matched", "no_match", "unavailable"],
             "description": (
-                "'matched' — a LUN matched the boot key (its is_boot true); "
-                "'no_match' — key resolved but matched no LUN (all false, key "
-                "echoed); 'unavailable' — boot query could not resolve (all "
-                "null; see boot_device_note). Only on 'ok'."
+                "'matched' — a LUN matched the boot key (is_boot authoritative: "
+                "match true, rest false); 'no_match' — key matched no LUN (all "
+                "is_boot null, key echoed); 'unavailable' — boot query did not "
+                "resolve (all null; see boot_device_note) — expected on many "
+                "hosts, not an error. Only on 'ok'."
             ),
         },
         "boot_device_note": {
             "type": ["string", "null"],
-            "description": (
-                "On boot_device_resolution='unavailable', the reason (no "
-                "bootDeviceSystem, QueryBootDevices failed, or no "
-                "currentBootDeviceKey); null otherwise."
-            ),
+            "description": "On 'unavailable', the reason; null otherwise.",
         },
         "candidate_hosts": {
             "type": "array",
@@ -532,15 +530,15 @@ _RESPONSE_SCHEMA: dict[str, Any] = {
 
 #: Curated ``when_to_use`` blurb for the host-storage-devices group.
 HOST_STORAGE_DEVICES_WHEN_TO_USE = (
-    "Use to enumerate the raw SCSI storage devices on an ESXi host — each "
-    "LUN's uuid, canonical_name, device_type, capacity_bytes, the ssd / local "
-    "flags (plus model / vendor), and is_boot (the current boot device). The "
-    "one read that surfaces the per-disk UUIDs, flash state, and boot-device "
-    "flag vsan_health / datastore.usage / network_uplinks do not — the right "
-    "op for 'which disks does this host have?', 'which are flash (ssd)?', or "
-    "'which UUIDs do I feed host.disk_mark_flash to flash-mark every non-boot "
+    "Use to enumerate the raw SCSI storage devices on an ESXi host — per-LUN "
+    "uuid, canonical_name, device_type, capacity_bytes, ssd / local flags, "
+    "model / vendor, and is_boot (the boot device). The one read that surfaces "
+    "the per-disk UUIDs, flash state, and boot-device flag vsan_health / "
+    "datastore.usage / network_uplinks do not — the right op for 'which disks "
+    "does this host have?', 'which are flash (ssd)?', or 'which is the boot "
     "disk?', including on a standalone ESXi host no vCenter manages yet (host "
-    "param ignored — the host is the target). Read-only."
+    "param ignored). is_boot is advisory (authoritative only when "
+    "boot_device_resolution == 'matched'). Read-only."
 )
 
 VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
@@ -551,17 +549,18 @@ VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
         "capacity, model/vendor, and is_boot."
     ),
     description=(
-        "Returns one row per SCSI LUN on an ESXi host: uuid (ScsiLun.uuid — "
-        "the id host.disk_mark_flash takes), canonical_name, device_type, "
+        "Returns one row per SCSI LUN on an ESXi host: uuid (ScsiLun.uuid — the "
+        "id host.disk_mark_flash takes), canonical_name, device_type, "
         "capacity_bytes (null on non-disk LUNs), ssd (flash) and local from "
-        "HostScsiDisk, trimmed model / vendor, and is_boot (the current boot "
-        "device — matched from HostBootDeviceSystem.QueryBootDevices over the "
-        "same VI-JSON seam; null when unavailable, see boot_device_resolution). "
-        "Reads config.storageDevice.scsiLun + configManager.bootDeviceSystem "
-        "via a PropertyCollector RetrievePropertiesEx directly on the connector "
-        "session (zero catalog ingest), on a vCenter target (host name/moref "
-        "resolution) and a standalone ESXi target no vCenter manages yet (host "
-        "param ignored — the host is the target, #3332). Device read fail-closed "
+        "HostScsiDisk, trimmed model / vendor, and is_boot (the boot device, "
+        "matched via HostBootDeviceSystem.QueryBootDevices — authoritative only "
+        "when boot_device_resolution=='matched', else null; the key format is "
+        "vendor-defined so no_match/unavailable are expected). Reads "
+        "config.storageDevice.scsiLun + configManager.bootDeviceSystem via one "
+        "PropertyCollector RetrievePropertiesEx directly on the connector session "
+        "(zero catalog ingest), on a vCenter target (host name/moref resolution) "
+        "and a standalone ESXi target no vCenter manages yet (host param ignored "
+        "— the host is the target, #3332). Device read fail-closed "
         "(storage_devices_unreadable); boot resolution fail-safe. Set-shaped, "
         "JSONFlux-reduced when large. safety_level=safe, read-only."
     ),
@@ -573,11 +572,12 @@ VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
     requires_approval=False,
     llm_instructions={
         "when_to_use": (
-            "Call to discover a host's raw disks before flash-marking them — "
-            "the per-LUN uuid + ssd flag + is_boot host.disk_mark_flash needs to "
-            "flash-mark every non-boot disk, which the other host storage reads "
-            "do not surface. Works on a standalone ESXi host (no managing "
-            "vCenter) as well as through a vCenter."
+            "Call to discover a host's raw disks (uuid + ssd flag + is_boot) "
+            "before selecting disks to flash-mark, which the other host storage "
+            "reads do not surface. Works on a standalone ESXi host (no managing "
+            "vCenter) as well as through a vCenter. is_boot is advisory: trust "
+            "it to exclude the boot disk ONLY when boot_device_resolution == "
+            "'matched'; treat null as unknown, never as 'not the boot disk'."
         ),
         "parameter_hints": {
             "host": (
@@ -589,9 +589,10 @@ VMWARE_HOST_STORAGE_DEVICES_OP = VmwareTypedOp(
             "{status, host, devices: [{uuid, canonical_name, device_type, "
             "capacity_bytes, ssd, local, model, vendor, is_boot}], device_count, "
             "current_boot_device_key, boot_device_resolution, boot_device_note}. "
-            "To flash-mark non-boot disks, feed the uuids of rows where is_boot "
-            "!= true to host.disk_mark_flash. Refusals (host_required / "
-            "host_not_found / ambiguous_host / unsupported_host_target / "
+            "host.disk_mark_flash takes an explicit disk_uuids list; rely on "
+            "is_boot to exclude the boot disk only under boot_device_resolution "
+            "== 'matched'. Refusals (host_required / host_not_found / "
+            "ambiguous_host / unsupported_host_target / "
             "storage_devices_unreadable) carry an empty devices array."
         ),
     },

--- a/backend/tests/test_connectors_vmware_rest_composites_host.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_host.py
@@ -44,6 +44,12 @@ from meho_backplane.connectors.vmware_rest.composites._host import (
     disk_mark_flash_composite,
     service_control_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._write_preview import (
+    _host_datastore_mount_nfs_preview,
+    _host_disk_mark_flash_preview,
+    _host_service_control_preview,
+)
+from meho_backplane.connectors.vmware_rest.host_target import STANDALONE_ESXI_HOST_MOID
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AgentPermission,
@@ -51,6 +57,7 @@ from meho_backplane.db.models import (
     ApprovalRequestStatus,
     PermissionVerdict,
 )
+from meho_backplane.operations._preview import PreviewContext
 from meho_backplane.settings import get_settings
 
 _TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000031a6")
@@ -191,6 +198,9 @@ class _HostRecordingConnector:
         )
         self._fault_tasks = fault_tasks or set()
         self.writes: list[dict[str, Any]] = []
+        # Records every GET:/vcenter/host listing so a standalone-ESXi test
+        # can assert the vCenter listing was never issued (#3332).
+        self.get_calls: list[str] = []
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         return f"/api{path}"
@@ -204,6 +214,7 @@ class _HostRecordingConnector:
     async def _get_json(
         self, target: Any, path: str, *, operator: Operator, params: Any = None
     ) -> Any:
+        self.get_calls.append(path)
         params = params or {}
         names = params.get("names") or params.get("filter.names")
         if names:
@@ -727,3 +738,188 @@ async def test_service_control_human_operator_auto_executes(session: AsyncSessio
 async def test_service_control_allowlist_is_the_expected_bounded_set() -> None:
     """Pin the curated allowlist so an accidental widening is caught in review."""
     assert frozenset({"TSM-SSH", "TSM", "ntpd", "ptpd"}) == _host._SERVICE_ALLOWLIST
+
+
+# ===========================================================================
+# Standalone-ESXi host resolution (#3332)
+# ===========================================================================
+
+
+class _FingerprintTarget:
+    """Duck-typed target carrying a probe fingerprint dict for the classifier."""
+
+    def __init__(self, *, product: str, reachable: bool = True) -> None:
+        self.name = f"{product}-target"
+        self.fingerprint = {"product": product, "reachable": reachable, "version": "9.0"}
+
+
+def _esxi_target() -> _FingerprintTarget:
+    return _FingerprintTarget(product="esxi")
+
+
+def _vcenter_target() -> _FingerprintTarget:
+    return _FingerprintTarget(product="vcenter")
+
+
+def _preview_ctx(target: Any, params: dict[str, Any]) -> PreviewContext:
+    """A minimal PreviewContext for the param-echo host preview builders.
+
+    The host preview builders read only ``ctx.target`` + ``ctx.params``, so
+    the descriptor / connector instance are irrelevant here.
+    """
+    return PreviewContext(
+        descriptor=None,  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=target,
+        params=params,
+    )
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_standalone_esxi_resolves_ha_host(gate: _GateRecorder) -> None:
+    """On an ESXi target the mount resolves ha-host via VI-JSON -- no vCenter listing."""
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=_esxi_target(),
+        params={
+            "nfs_server": "10.0.0.5",
+            "remote_path": "/export/base",
+            "datastore_name": "base-nfs",
+        },  # no host param -- the host is the target
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "mounted"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    # The GET:/vcenter/host listing was never issued (absent on a standalone ESXi).
+    assert conn.get_calls == []
+    # The config-manager read + the mount still landed through the vim seam.
+    assert conn.writes[0]["path"] == "/HostDatastoreSystem/datastoreSystem-15/CreateNasDatastore"
+
+
+@pytest.mark.asyncio
+async def test_disk_mark_flash_standalone_esxi_resolves_ha_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await disk_mark_flash_composite(
+        operator=_operator(),
+        target=_esxi_target(),
+        params={"disk_uuids": ["uuid-a"], "mode": "flash"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "marked"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    assert conn.get_calls == []
+    assert conn.writes[0]["path"] == "/HostStorageSystem/storageSystem-15/MarkAsSsd_Task"
+
+
+@pytest.mark.asyncio
+async def test_service_control_standalone_esxi_resolves_ha_host(gate: _GateRecorder) -> None:
+    conn = _HostRecordingConnector()
+    out = await service_control_composite(
+        operator=_operator(),
+        target=_esxi_target(),
+        params={"service": "TSM-SSH", "action": "start"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "applied"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    assert conn.get_calls == []
+    assert [w["path"] for w in conn.writes] == ["/HostServiceSystem/serviceSystem-15/StartService"]
+
+
+@pytest.mark.asyncio
+async def test_vcenter_target_still_uses_the_host_listing(gate: _GateRecorder) -> None:
+    """A managing-vCenter target keeps resolving through GET:/vcenter/host (no regression)."""
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=_vcenter_target(),
+        params={
+            "host": "esxi-01",
+            "nfs_server": "10.0.0.5",
+            "remote_path": "/export/base",
+            "datastore_name": "base-nfs",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "mounted"
+    assert out["host"] == "host-15"
+    # The vCenter listing WAS consulted for name resolution.
+    assert any(path.endswith("/vcenter/host") for path in conn.get_calls)
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_unsupported_target_fails_closed(gate: _GateRecorder) -> None:
+    """A reachable target that is neither vCenter nor ESXi fails closed with no write."""
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=_FingerprintTarget(product="frobnicator"),
+        params={
+            "host": "esxi-01",
+            "nfs_server": "10.0.0.5",
+            "remote_path": "/export/base",
+            "datastore_name": "base-nfs",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "unsupported_host_target"
+    assert out["target_product"] == "frobnicator"
+    assert conn.writes == []
+    assert conn.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_datastore_mount_nfs_vcenter_without_host_refuses(gate: _GateRecorder) -> None:
+    """A vCenter target given no host refuses host_required before any write."""
+    conn = _HostRecordingConnector()
+    out = await datastore_mount_nfs_composite(
+        operator=_operator(),
+        target=_vcenter_target(),
+        params={"nfs_server": "10.0.0.5", "remote_path": "/x", "datastore_name": "d"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "host_required"
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_host_previews_parity_on_esxi_target() -> None:
+    """Preview builders take the standalone-ESXi branch too (#3312 call parity).
+
+    A preview that passes on an ESXi target (host param omitted) must not
+    then be denied at call -- both resolve to ha-host.
+    """
+    esxi = _esxi_target()
+    mount = await _host_datastore_mount_nfs_preview(
+        _preview_ctx(esxi, {"nfs_server": "n", "remote_path": "/p", "datastore_name": "d"})
+    )
+    assert mount is not None and mount["host"] == STANDALONE_ESXI_HOST_MOID
+
+    flash = await _host_disk_mark_flash_preview(
+        _preview_ctx(esxi, {"disk_uuids": ["uuid-a"], "mode": "flash"})
+    )
+    assert flash is not None and flash["host"] == STANDALONE_ESXI_HOST_MOID
+
+    svc = await _host_service_control_preview(
+        _preview_ctx(esxi, {"service": "TSM-SSH", "action": "start"})
+    )
+    assert svc is not None and svc["host"] == STANDALONE_ESXI_HOST_MOID
+
+
+@pytest.mark.asyncio
+async def test_host_preview_declines_on_vcenter_without_host() -> None:
+    """On a vCenter target with no host the preview declines -- matching host_required."""
+    preview = await _host_datastore_mount_nfs_preview(
+        _preview_ctx(
+            _vcenter_target(), {"nfs_server": "n", "remote_path": "/p", "datastore_name": "d"}
+        )
+    )
+    assert preview is None

--- a/backend/tests/test_connectors_vmware_rest_composites_host.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_host.py
@@ -923,3 +923,26 @@ async def test_host_preview_declines_on_vcenter_without_host() -> None:
         )
     )
     assert preview is None
+
+
+@pytest.mark.asyncio
+async def test_host_previews_decline_on_unsupported_target() -> None:
+    """On a reachable non-vCenter/non-ESXi target the previews decline (call-parity).
+
+    The call fails closed ``unsupported_host_target`` (no write), so the
+    preview must not build+park an effect the dispatch will reject (#3312).
+    """
+    unsupported = _FingerprintTarget(product="frobnicator")
+    mount = await _host_datastore_mount_nfs_preview(
+        _preview_ctx(
+            unsupported,
+            {"host": "h", "nfs_server": "n", "remote_path": "/p", "datastore_name": "d"},
+        )
+    )
+    flash = await _host_disk_mark_flash_preview(
+        _preview_ctx(unsupported, {"host": "h", "disk_uuids": ["uuid-a"]})
+    )
+    svc = await _host_service_control_preview(
+        _preview_ctx(unsupported, {"host": "h", "service": "TSM-SSH", "action": "start"})
+    )
+    assert mount is None and flash is None and svc is None

--- a/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
@@ -37,6 +37,7 @@ from meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices import
     HOST_STORAGE_DEVICES_GROUP_KEY,
     VMWARE_HOST_STORAGE_DEVICES_OP,
     _map_scsi_lun,
+    _matches_boot,
     build_host_storage_devices_retrieve_params,
     host_storage_devices_impl,
 )
@@ -532,15 +533,25 @@ def test_retrieve_body_targets_the_scsi_lun_path() -> None:
 _BOOT_SYSTEM_MOID = "bootDeviceSystem-1"
 
 
-def test_map_scsi_lun_matched_boot_key_sets_is_boot_true() -> None:
-    """A boot key embedding the LUN's canonical name marks it is_boot=true."""
-    row = _map_scsi_lun(_DISK_LUN, "key-vim.host.BootDevice-naa.6000c290:1")
-    assert row["is_boot"] is True
+def test_matches_boot_key_embedding_canonical_name() -> None:
+    """A boot key embedding the LUN's canonical name matches (containment)."""
+    assert _matches_boot("0200000000600a", "naa.6000c290", "key-vim.host.BootDevice-naa.6000c290:1")
 
 
-def test_map_scsi_lun_unmatched_boot_key_sets_is_boot_false() -> None:
-    row = _map_scsi_lun(_DISK_LUN, "key-vim.host.BootDevice-naa.ffffffff:1")
-    assert row["is_boot"] is False
+def test_matches_boot_unrelated_key_does_not_match() -> None:
+    assert not _matches_boot("0200000000600a", "naa.6000c290", "key-vim.host.BootDevice-naa.ffff:1")
+
+
+def test_matches_boot_short_key_cannot_spuriously_match() -> None:
+    """A key shorter than the min-match length never matches (fail-safe guard)."""
+    assert not _matches_boot("0200000000600a", "naa.6000c290", "sd")
+
+
+def test_map_scsi_lun_passes_through_is_boot_value() -> None:
+    """_map_scsi_lun echoes the caller-computed is_boot (True / False / None)."""
+    assert _map_scsi_lun(_DISK_LUN, True)["is_boot"] is True
+    assert _map_scsi_lun(_DISK_LUN, False)["is_boot"] is False
+    assert _map_scsi_lun(_DISK_LUN, None)["is_boot"] is None
 
 
 @pytest.mark.asyncio
@@ -573,8 +584,15 @@ async def test_boot_device_matched_flags_the_boot_lun() -> None:
 
 
 @pytest.mark.asyncio
-async def test_boot_device_no_match_all_false_key_echoed() -> None:
-    """A resolved key that matches no LUN -> all is_boot false, key echoed, no_match."""
+async def test_boot_device_no_match_all_null_key_echoed() -> None:
+    """B2: a resolved key matching no LUN -> EVERY is_boot null (never false), key echoed.
+
+    A resolved-but-unmatched key is ambiguous (the boot device may be a
+    non-SCSI device absent from scsiLun, or the vendor key format did not
+    align), so the op must report unknown, not assert false — otherwise a
+    caller flashing 'every disk where is_boot != true' could flash the boot
+    disk. is_boot is authoritative only under boot_device_resolution=='matched'.
+    """
     conn = _FakeConnector(
         props_by_host={
             STANDALONE_ESXI_HOST_MOID: _retrieve_result(
@@ -593,7 +611,7 @@ async def test_boot_device_no_match_all_false_key_echoed() -> None:
     )
     assert out["boot_device_resolution"] == "no_match"
     assert out["current_boot_device_key"] == "key-vim.host.BootDevice-naa.ffffffff:1"
-    assert all(d["is_boot"] is False for d in out["devices"])
+    assert all(d["is_boot"] is None for d in out["devices"])
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the ``vmware.host.storage_devices`` typed op (#3332).
+
+A ``source_kind="typed"`` bound method on :class:`VmwareRestConnector`
+that resolves a host -- a vCenter name/moref via ``GET:/vcenter/host``,
+or the standalone-ESXi ``ha-host`` when the target's probe fingerprint is
+``product=esxi`` -- then reads ``config.storageDevice.scsiLun`` per host
+directly on the connector session (no ``dispatch_child``, no ingested
+descriptor), so it works on a fresh boot with zero catalog ingest -- the
+pre-vCenter standalone-ESXi case #3332 needs.
+
+Exercised against a fake connector that records
+:meth:`mount_op_path` / :meth:`_get_json` / :meth:`_post_vmomi_json`
+calls, so the assertion targets are the resolution branch (esxi vs
+vCenter), the per-LUN mapping (ssd / local / capacity / model / vendor),
+the fail-closed refusal paths, and the JSONFlux set-shaped output --
+without a live httpx transport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
+from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+from meho_backplane.connectors.vmware_rest.host_target import STANDALONE_ESXI_HOST_MOID
+from meho_backplane.connectors.vmware_rest.typed_ops import VMWARE_TYPED_OPS
+from meho_backplane.connectors.vmware_rest.typed_ops_host_storage_devices import (
+    HOST_STORAGE_DEVICES_GROUP_KEY,
+    VMWARE_HOST_STORAGE_DEVICES_OP,
+    _map_scsi_lun,
+    build_host_storage_devices_retrieve_params,
+    host_storage_devices_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-host-storage-devices",
+        name="Host Storage Devices Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0b0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _Target:
+    """Duck-typed target the classifier + impl read from.
+
+    ``fingerprint`` is the JSON dict the probe route persists; ``None``
+    (unprobed) classifies as vCenter, ``{"product": "esxi", ...}`` as a
+    standalone ESXi.
+    """
+
+    fingerprint: dict[str, Any] | None = None
+    name: str = "vc-test"
+    host: str = "vc.test.invalid"
+    port: int | None = 443
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _vcenter_target() -> _Target:
+    return _Target(fingerprint={"product": "vcenter", "reachable": True, "version": "9.0"})
+
+
+def _esxi_target() -> _Target:
+    return _Target(
+        fingerprint={"product": "esxi", "reachable": True, "version": "9.0"},
+        name="esxi-standalone",
+    )
+
+
+# A HostScsiDisk (deviceType="disk") with the flash/local flags + capacity,
+# and a non-disk ScsiLun (cdrom) that carries none of the HostScsiDisk-only
+# fields -- so the mapping's null-coercion is exercised.
+_DISK_LUN: dict[str, Any] = {
+    "_typeName": "HostScsiDisk",
+    "uuid": "0200000000600a",
+    "canonicalName": "naa.6000c290",
+    "deviceType": "disk",
+    "ssd": True,
+    "localDisk": True,
+    "model": "Virtual disk   ",
+    "vendor": "VMware  ",
+    "capacity": {"blockSize": 512, "block": 209715200},
+}
+_CDROM_LUN: dict[str, Any] = {
+    "_typeName": "ScsiLun",
+    "uuid": "mpx.vmhba64:C0:T0:L0",
+    "canonicalName": "mpx.vmhba64:C0:T0:L0",
+    "deviceType": "cdrom",
+    "model": "CD-ROM  ",
+    "vendor": "NECVMWar",
+}
+
+
+def _boxed_scsi_luns(luns: list[dict[str, Any]]) -> dict[str, Any]:
+    """VI-JSON ``ArrayOf*`` ``_value`` boxing of a scsiLun array."""
+    return {"_typeName": "ArrayOfScsiLun", "_value": luns}
+
+
+def _retrieve_result(moid: str, scsi_lun_val: Any) -> dict[str, Any]:
+    """A RetrievePropertiesEx ``RetrieveResult`` carrying config.storageDevice.scsiLun."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "HostSystem", "value": moid},
+                "propSet": [{"name": "config.storageDevice.scsiLun", "val": scsi_lun_val}],
+            }
+        ]
+    }
+
+
+class _FakeConnector:
+    """Records the transport calls ``host_storage_devices_impl`` makes.
+
+    Serves the host listing on :meth:`_get_json` (keyed off the
+    ``names`` / ``hosts`` filter, adapted to the mount flavor) and a
+    per-host RetrievePropertiesEx result on :meth:`_post_vmomi_json`
+    (keyed by the host MoRef in the request body's objectSet).
+    """
+
+    def __init__(
+        self,
+        *,
+        hosts: list[dict[str, str]] | None = None,
+        props_by_host: dict[str, Any] | None = None,
+        post_error: Exception | None = None,
+        mount_prefix: str = "/api",
+    ) -> None:
+        self._hosts = hosts if hosts is not None else [{"host": "host-15", "name": "esxi-01"}]
+        self._props_by_host = props_by_host or {}
+        self._post_error = post_error
+        self._mount_prefix = mount_prefix
+        self.get_calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        del target, operator
+        return f"{self._mount_prefix}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._mount_prefix, query)
+
+    async def _get_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        params = params or {}
+        self.get_calls.append((path, params))
+        names = params.get("names") or params.get("filter.names")
+        if names:
+            return [h for h in self._hosts if h["name"] in names]
+        wanted = params.get("hosts") or params.get("filter.hosts")
+        if wanted:
+            return [h for h in self._hosts if h["host"] in wanted]
+        return list(self._hosts)
+
+    async def _post_vmomi_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        assert json is not None
+        self.post_calls.append((path, json))
+        if self._post_error is not None:
+            raise self._post_error
+        moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+        return self._props_by_host[moid]
+
+
+# ---------------------------------------------------------------------------
+# Resolution branch: standalone ESXi vs vCenter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_esxi_target_resolves_ha_host_without_listing() -> None:
+    """A standalone-ESXi target reads ha-host directly -- no GET:/vcenter/host."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID, _boxed_scsi_luns([_DISK_LUN])
+            )
+        }
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},  # no host param -- the host is the target
+    )
+    assert out["status"] == "ok"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    assert out["device_count"] == 1
+    # No host listing was issued (the surface does not exist on a standalone ESXi).
+    assert conn.get_calls == []
+    # The RetrievePropertiesEx targeted ha-host reading the scsiLun path.
+    assert len(conn.post_calls) == 1
+    body = conn.post_calls[0][1]
+    assert body["specSet"][0]["objectSet"][0]["obj"]["value"] == STANDALONE_ESXI_HOST_MOID
+    assert body["specSet"][0]["propSet"][0]["pathSet"] == ["config.storageDevice.scsiLun"]
+
+
+@pytest.mark.asyncio
+async def test_esxi_ignores_supplied_host_param() -> None:
+    """On an ESXi target a supplied ``host`` is ignored -- the host is the target."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID, _boxed_scsi_luns([_DISK_LUN])
+            )
+        }
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {"host": "whatever-ignored"},
+    )
+    assert out["status"] == "ok"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    assert conn.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_vcenter_resolves_host_by_display_name() -> None:
+    """A vCenter target resolves the ``host`` display name via GET:/vcenter/host."""
+    conn = _FakeConnector(
+        hosts=[{"host": "host-15", "name": "esxi-01"}],
+        props_by_host={"host-15": _retrieve_result("host-15", _boxed_scsi_luns([_DISK_LUN]))},
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {"host": "esxi-01"},
+    )
+    assert out["status"] == "ok"
+    assert out["host"] == "host-15"
+    assert out["device_count"] == 1
+    # A name lookup was issued (name-first ladder).
+    assert conn.get_calls and (
+        conn.get_calls[0][1].get("names") == ["esxi-01"]
+        or conn.get_calls[0][1].get("filter.names") == ["esxi-01"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_vcenter_resolves_host_by_moref_fallback() -> None:
+    """A ``host`` that is not a display name falls back to a moref match."""
+    conn = _FakeConnector(
+        hosts=[{"host": "host-15", "name": "esxi-01"}],
+        props_by_host={"host-15": _retrieve_result("host-15", _boxed_scsi_luns([_DISK_LUN]))},
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {"host": "host-15"},
+    )
+    assert out["status"] == "ok"
+    assert out["host"] == "host-15"
+
+
+# ---------------------------------------------------------------------------
+# Per-LUN mapping
+# ---------------------------------------------------------------------------
+
+
+def test_map_scsi_lun_disk_flags_and_capacity() -> None:
+    """A HostScsiDisk maps uuid / flags / trimmed model+vendor / byte capacity."""
+    row = _map_scsi_lun(_DISK_LUN)
+    assert row == {
+        "uuid": "0200000000600a",
+        "canonical_name": "naa.6000c290",
+        "device_type": "disk",
+        "capacity_bytes": 512 * 209715200,
+        "ssd": True,
+        "local": True,
+        "model": "Virtual disk",
+        "vendor": "VMware",
+        "is_boot": None,
+    }
+
+
+def test_map_scsi_lun_non_disk_nulls_disk_only_fields() -> None:
+    """A non-disk ScsiLun (cdrom) nulls ssd / local / capacity_bytes."""
+    row = _map_scsi_lun(_CDROM_LUN)
+    assert row["device_type"] == "cdrom"
+    assert row["ssd"] is None
+    assert row["local"] is None
+    assert row["capacity_bytes"] is None
+    assert row["is_boot"] is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_device_set_maps_every_lun() -> None:
+    """The op maps every scsiLun row, disk and non-disk alike."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID, _boxed_scsi_luns([_DISK_LUN, _CDROM_LUN])
+            )
+        }
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["device_count"] == 2
+    kinds = {d["device_type"] for d in out["devices"]}
+    assert kinds == {"disk", "cdrom"}
+    disk = next(d for d in out["devices"] if d["device_type"] == "disk")
+    assert disk["ssd"] is True and disk["local"] is True
+
+
+@pytest.mark.asyncio
+async def test_soap_flavoured_array_boxing_tolerated() -> None:
+    """A ``{"_typeName": "ArrayOfScsiLun", "ScsiLun": [...]}`` box also unwraps."""
+    soap_box = {"_typeName": "ArrayOfScsiLun", "ScsiLun": [_DISK_LUN]}
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(STANDALONE_ESXI_HOST_MOID, soap_box)
+        }
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["device_count"] == 1
+    assert out["devices"][0]["uuid"] == "0200000000600a"
+
+
+@pytest.mark.asyncio
+async def test_absent_scsi_lun_property_yields_empty_set() -> None:
+    """A host whose propSet omits scsiLun returns an empty (ok) device set."""
+    empty_result = {"objects": [{"obj": {"type": "HostSystem", "value": "host-15"}, "propSet": []}]}
+    conn = _FakeConnector(
+        hosts=[{"host": "host-15", "name": "esxi-01"}],
+        props_by_host={"host-15": empty_result},
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {"host": "esxi-01"},
+    )
+    assert out["status"] == "ok"
+    assert out["devices"] == []
+    assert out["device_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed refusal paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vcenter_without_host_refuses_host_required() -> None:
+    """A vCenter target with no ``host`` param fails closed (no read issued)."""
+    conn = _FakeConnector()
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["status"] == "host_required"
+    assert out["devices"] == []
+    assert conn.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_vcenter_unknown_host_refuses_host_not_found() -> None:
+    conn = _FakeConnector(hosts=[{"host": "host-15", "name": "esxi-01"}])
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {"host": "ghost-99"},
+    )
+    assert out["status"] == "host_not_found"
+    assert out["host"] == "ghost-99"
+    assert conn.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_vcenter_ambiguous_name_refuses_with_candidates() -> None:
+    conn = _FakeConnector(
+        hosts=[{"host": "host-15", "name": "dup"}, {"host": "host-16", "name": "dup"}]
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _vcenter_target(),  # type: ignore[arg-type]
+        {"host": "dup"},
+    )
+    assert out["status"] == "ambiguous_host"
+    assert sorted(out["candidate_hosts"]) == ["host-15", "host-16"]
+    assert conn.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unsupported_host_target_fails_closed() -> None:
+    """A reachable fingerprint that is neither vCenter nor esxi fails closed."""
+    conn = _FakeConnector()
+    target = _Target(fingerprint={"product": "frobnicator", "reachable": True})
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        target,  # type: ignore[arg-type]
+        {"host": "esxi-01"},
+    )
+    assert out["status"] == "unsupported_host_target"
+    assert out["target_product"] == "frobnicator"
+    assert conn.get_calls == [] and conn.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_read_failure_returns_storage_devices_unreadable() -> None:
+    """A VI-JSON read failure is a typed refusal, not a bare stack trace."""
+    conn = _FakeConnector(post_error=httpx.ConnectError("vi-json seam unavailable"))
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["status"] == "storage_devices_unreadable"
+    assert out["host"] == STANDALONE_ESXI_HOST_MOID
+    assert out["devices"] == []
+    assert "vi-json seam unavailable" in out["read_note"]
+
+
+# ---------------------------------------------------------------------------
+# Registration metadata
+# ---------------------------------------------------------------------------
+
+
+def test_op_is_registered_in_typed_ops_tuple() -> None:
+    op_ids = {op.op_id for op in VMWARE_TYPED_OPS}
+    assert "vmware.host.storage_devices" in op_ids
+
+
+def test_op_metadata_is_a_safe_read() -> None:
+    op = VMWARE_HOST_STORAGE_DEVICES_OP
+    assert op.op_id == "vmware.host.storage_devices"
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert op.group_key == HOST_STORAGE_DEVICES_GROUP_KEY
+    # The handler_attr resolves to a real bound method on the connector.
+    assert getattr(VmwareRestConnector, op.handler_attr, None) is not None
+    # The response status enum names both the success and the refusal states.
+    statuses = op.response_schema["properties"]["status"]["enum"]
+    assert "ok" in statuses
+    assert "unsupported_host_target" in statuses
+    assert "storage_devices_unreadable" in statuses
+
+
+def test_retrieve_body_targets_the_scsi_lun_path() -> None:
+    body = build_host_storage_devices_retrieve_params("host-15")
+    assert body["specSet"][0]["objectSet"][0]["obj"]["value"] == "host-15"
+    assert body["specSet"][0]["propSet"][0]["pathSet"] == ["config.storageDevice.scsiLun"]

--- a/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_storage_devices.py
@@ -114,25 +114,41 @@ def _boxed_scsi_luns(luns: list[dict[str, Any]]) -> dict[str, Any]:
     return {"_typeName": "ArrayOfScsiLun", "_value": luns}
 
 
-def _retrieve_result(moid: str, scsi_lun_val: Any) -> dict[str, Any]:
-    """A RetrievePropertiesEx ``RetrieveResult`` carrying config.storageDevice.scsiLun."""
-    return {
-        "objects": [
+def _retrieve_result(
+    moid: str, scsi_lun_val: Any, boot_system_moid: str | None = None
+) -> dict[str, Any]:
+    """A RetrievePropertiesEx ``RetrieveResult`` carrying scsiLun (+ optional bootDeviceSystem)."""
+    prop_set: list[dict[str, Any]] = [{"name": "config.storageDevice.scsiLun", "val": scsi_lun_val}]
+    if boot_system_moid is not None:
+        prop_set.append(
             {
-                "obj": {"type": "HostSystem", "value": moid},
-                "propSet": [{"name": "config.storageDevice.scsiLun", "val": scsi_lun_val}],
+                "name": "configManager.bootDeviceSystem",
+                "val": {
+                    "_typeName": "ManagedObjectReference",
+                    "type": "HostBootDeviceSystem",
+                    "value": boot_system_moid,
+                },
             }
-        ]
-    }
+        )
+    return {"objects": [{"obj": {"type": "HostSystem", "value": moid}, "propSet": prop_set}]}
+
+
+def _boot_info(current_key: str | None) -> dict[str, Any]:
+    """A HostBootDeviceInfo QueryBootDevices response with the given currentBootDeviceKey."""
+    info: dict[str, Any] = {"_typeName": "HostBootDeviceInfo", "bootDevices": []}
+    if current_key is not None:
+        info["currentBootDeviceKey"] = current_key
+    return info
 
 
 class _FakeConnector:
     """Records the transport calls ``host_storage_devices_impl`` makes.
 
     Serves the host listing on :meth:`_get_json` (keyed off the
-    ``names`` / ``hosts`` filter, adapted to the mount flavor) and a
-    per-host RetrievePropertiesEx result on :meth:`_post_vmomi_json`
-    (keyed by the host MoRef in the request body's objectSet).
+    ``names`` / ``hosts`` filter, adapted to the mount flavor); on
+    :meth:`_post_vmomi_json` it serves the per-host RetrievePropertiesEx
+    result (keyed by the host MoRef in the request body's objectSet) and,
+    for a ``.../QueryBootDevices`` path, the configured boot info.
     """
 
     def __init__(
@@ -141,11 +157,15 @@ class _FakeConnector:
         hosts: list[dict[str, str]] | None = None,
         props_by_host: dict[str, Any] | None = None,
         post_error: Exception | None = None,
+        boot_info: dict[str, Any] | None = None,
+        boot_error: Exception | None = None,
         mount_prefix: str = "/api",
     ) -> None:
         self._hosts = hosts if hosts is not None else [{"host": "host-15", "name": "esxi-01"}]
         self._props_by_host = props_by_host or {}
         self._post_error = post_error
+        self._boot_info = boot_info
+        self._boot_error = boot_error
         self._mount_prefix = mount_prefix
         self.get_calls: list[tuple[str, dict[str, Any] | None]] = []
         self.post_calls: list[tuple[str, dict[str, Any]]] = []
@@ -190,6 +210,10 @@ class _FakeConnector:
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
+        if path.endswith("/QueryBootDevices"):
+            if self._boot_error is not None:
+                raise self._boot_error
+            return self._boot_info
         if self._post_error is not None:
             raise self._post_error
         moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
@@ -226,7 +250,10 @@ async def test_esxi_target_resolves_ha_host_without_listing() -> None:
     assert len(conn.post_calls) == 1
     body = conn.post_calls[0][1]
     assert body["specSet"][0]["objectSet"][0]["obj"]["value"] == STANDALONE_ESXI_HOST_MOID
-    assert body["specSet"][0]["propSet"][0]["pathSet"] == ["config.storageDevice.scsiLun"]
+    assert body["specSet"][0]["propSet"][0]["pathSet"] == [
+        "config.storageDevice.scsiLun",
+        "configManager.bootDeviceSystem",
+    ]
 
 
 @pytest.mark.asyncio
@@ -297,7 +324,7 @@ async def test_vcenter_resolves_host_by_moref_fallback() -> None:
 
 def test_map_scsi_lun_disk_flags_and_capacity() -> None:
     """A HostScsiDisk maps uuid / flags / trimmed model+vendor / byte capacity."""
-    row = _map_scsi_lun(_DISK_LUN)
+    row = _map_scsi_lun(_DISK_LUN, None)
     assert row == {
         "uuid": "0200000000600a",
         "canonical_name": "naa.6000c290",
@@ -313,7 +340,7 @@ def test_map_scsi_lun_disk_flags_and_capacity() -> None:
 
 def test_map_scsi_lun_non_disk_nulls_disk_only_fields() -> None:
     """A non-disk ScsiLun (cdrom) nulls ssd / local / capacity_bytes."""
-    row = _map_scsi_lun(_CDROM_LUN)
+    row = _map_scsi_lun(_CDROM_LUN, None)
     assert row["device_type"] == "cdrom"
     assert row["ssd"] is None
     assert row["local"] is None
@@ -492,4 +519,129 @@ def test_op_metadata_is_a_safe_read() -> None:
 def test_retrieve_body_targets_the_scsi_lun_path() -> None:
     body = build_host_storage_devices_retrieve_params("host-15")
     assert body["specSet"][0]["objectSet"][0]["obj"]["value"] == "host-15"
-    assert body["specSet"][0]["propSet"][0]["pathSet"] == ["config.storageDevice.scsiLun"]
+    assert body["specSet"][0]["propSet"][0]["pathSet"] == [
+        "config.storageDevice.scsiLun",
+        "configManager.bootDeviceSystem",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Boot-device identification (HostBootDeviceSystem.QueryBootDevices)
+# ---------------------------------------------------------------------------
+
+_BOOT_SYSTEM_MOID = "bootDeviceSystem-1"
+
+
+def test_map_scsi_lun_matched_boot_key_sets_is_boot_true() -> None:
+    """A boot key embedding the LUN's canonical name marks it is_boot=true."""
+    row = _map_scsi_lun(_DISK_LUN, "key-vim.host.BootDevice-naa.6000c290:1")
+    assert row["is_boot"] is True
+
+
+def test_map_scsi_lun_unmatched_boot_key_sets_is_boot_false() -> None:
+    row = _map_scsi_lun(_DISK_LUN, "key-vim.host.BootDevice-naa.ffffffff:1")
+    assert row["is_boot"] is False
+
+
+@pytest.mark.asyncio
+async def test_boot_device_matched_flags_the_boot_lun() -> None:
+    """QueryBootDevices' currentBootDeviceKey marks the matching LUN is_boot=true."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID,
+                _boxed_scsi_luns([_DISK_LUN, _CDROM_LUN]),
+                boot_system_moid=_BOOT_SYSTEM_MOID,
+            )
+        },
+        boot_info=_boot_info("key-vim.host.BootDevice-naa.6000c290:1"),
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["boot_device_resolution"] == "matched"
+    assert out["current_boot_device_key"] == "key-vim.host.BootDevice-naa.6000c290:1"
+    assert out["boot_device_note"] is None
+    by_type = {d["device_type"]: d["is_boot"] for d in out["devices"]}
+    assert by_type == {"disk": True, "cdrom": False}
+    # The boot query rode the QueryBootDevices method on the bootDeviceSystem moid.
+    boot_calls = [p for p, _ in conn.post_calls if p.endswith("/QueryBootDevices")]
+    assert boot_calls == [f"/HostBootDeviceSystem/{_BOOT_SYSTEM_MOID}/QueryBootDevices"]
+
+
+@pytest.mark.asyncio
+async def test_boot_device_no_match_all_false_key_echoed() -> None:
+    """A resolved key that matches no LUN -> all is_boot false, key echoed, no_match."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID,
+                _boxed_scsi_luns([_DISK_LUN, _CDROM_LUN]),
+                boot_system_moid=_BOOT_SYSTEM_MOID,
+            )
+        },
+        boot_info=_boot_info("key-vim.host.BootDevice-naa.ffffffff:1"),
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["boot_device_resolution"] == "no_match"
+    assert out["current_boot_device_key"] == "key-vim.host.BootDevice-naa.ffffffff:1"
+    assert all(d["is_boot"] is False for d in out["devices"])
+
+
+@pytest.mark.asyncio
+async def test_boot_device_unavailable_when_no_config_manager() -> None:
+    """No configManager.bootDeviceSystem -> is_boot null, unavailable, no boot query."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID, _boxed_scsi_luns([_DISK_LUN])
+            )
+        }
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    assert out["boot_device_resolution"] == "unavailable"
+    assert out["current_boot_device_key"] is None
+    assert "bootDeviceSystem" in out["boot_device_note"]
+    assert out["devices"][0]["is_boot"] is None
+    # No QueryBootDevices call was issued (nothing to query).
+    assert all(not p.endswith("/QueryBootDevices") for p, _ in conn.post_calls)
+
+
+@pytest.mark.asyncio
+async def test_boot_device_unavailable_when_query_errors_is_fail_safe() -> None:
+    """A QueryBootDevices failure nulls is_boot but still returns the device listing."""
+    conn = _FakeConnector(
+        props_by_host={
+            STANDALONE_ESXI_HOST_MOID: _retrieve_result(
+                STANDALONE_ESXI_HOST_MOID,
+                _boxed_scsi_luns([_DISK_LUN]),
+                boot_system_moid=_BOOT_SYSTEM_MOID,
+            )
+        },
+        boot_error=httpx.ConnectError("boot query unsupported"),
+    )
+    out = await host_storage_devices_impl(
+        conn,  # type: ignore[arg-type]
+        _make_operator(),
+        _esxi_target(),  # type: ignore[arg-type]
+        {},
+    )
+    # Fail-safe: the listing is still returned, is_boot nulled with a reason.
+    assert out["status"] == "ok"
+    assert out["device_count"] == 1
+    assert out["boot_device_resolution"] == "unavailable"
+    assert out["devices"][0]["is_boot"] is None
+    assert "QueryBootDevices" in out["boot_device_note"]

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -360,18 +360,27 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   esxcli seam**: when the host exposes a `bootDeviceSystem`, the op calls
   `HostBootDeviceSystem.QueryBootDevices` — a vim query over the *same*
   VI-JSON seam the write composites use — and matches its
-  `currentBootDeviceKey` (which typically embeds the device's canonical
-  name / uuid) against the rows (`is_boot` true on the match, false on the
-  rest), so a caller can flash-mark "every non-boot disk" (`is_boot !=
-  true`). Boot resolution is **fail-safe**, not fail-closed: an absent
-  config manager, an unsupported/erroring query, or a missing key nulls
-  every `is_boot` and names the reason in the top-level
-  `boot_device_resolution` (`matched` / `no_match` / `unavailable`) +
-  `boot_device_note` — the device list is still returned. Set-shaped
-  (JSONFlux-reduced when large); the device read itself is fail-closed
+  `currentBootDeviceKey` against the rows. That key is **vendor-defined**
+  (it *typically* embeds the canonical name / uuid, but the format is not
+  contractual, and ESXi frequently leaves `bootDeviceSystem` unpopulated),
+  so the match is a **labelled best-effort heuristic** whose outcome the
+  top-level `boot_device_resolution` reports: `matched` (a LUN positively
+  matched — then, and *only* then, `is_boot` is authoritative: `true` on
+  the match, `false` on the rest), `no_match` (the key resolved but matched
+  no LUN), or `unavailable` (no config manager, or an unsupported/erroring
+  query — an **expected** outcome on many hosts, not an error). On both
+  `no_match` and `unavailable` every `is_boot` is `null` — the op **never
+  asserts `false` in an ambiguous state**, so a caller must trust `is_boot`
+  for boot-exclusion only under `boot_device_resolution == 'matched'` and
+  treat `null` as unknown (this is the fail-safe #3332 review B2 hardened).
+  The follow-up to verify the key format on real hardware + tighten the
+  match is `#3336`. Boot resolution is **fail-safe** (an absent/erroring
+  boot query nulls `is_boot` and records `boot_device_note` without sinking
+  the listing); the device read itself is **fail-closed**
   (`status='storage_devices_unreadable'` with an empty set on a VI-JSON
-  failure), with `host_required` / `host_not_found` / `ambiguous_host` /
-  `unsupported_host_target` covering the resolution refusals.
+  failure). Set-shaped (JSONFlux-reduced when large), with `host_required`
+  / `host_not_found` / `ambiguous_host` / `unsupported_host_target`
+  covering the resolution refusals.
 - **`register_vmware_typed_operations`** (`typed_ops.py`) — async
   registrar wrapper queued onto `run_typed_op_registrars` (via
   `register_typed_op_registrar` in the package `__init__`, alongside the

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -351,14 +351,24 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   composites take, so the read works on the **pre-vCenter standalone
   ESXi** the `#3332` bring-up needs), then reads
   `HostSystem.config.storageDevice.scsiLun` (the host-side read mirror of
-  `HostStorageSystem.storageDeviceInfo.scsiLun`) via one PropertyCollector
+  `HostStorageSystem.storageDeviceInfo.scsiLun`) plus
+  `configManager.bootDeviceSystem` off one PropertyCollector
   `RetrievePropertiesEx`. Each LUN maps to
   `{uuid, canonical_name, device_type, capacity_bytes, ssd, local, model,
   vendor, is_boot}` — `ssd` / `local` / `capacity_bytes` are
-  `HostScsiDisk`-only (null on a non-disk LUN); `is_boot` is a best-effort
-  null (the `scsiLun` property surface carries no boot flag — a reliable
-  boot datum needs esxcli, reserved for a future enrichment). Set-shaped
-  (JSONFlux-reduced when large); the device read is fail-closed
+  `HostScsiDisk`-only (null on a non-disk LUN). **`is_boot` needs no
+  esxcli seam**: when the host exposes a `bootDeviceSystem`, the op calls
+  `HostBootDeviceSystem.QueryBootDevices` — a vim query over the *same*
+  VI-JSON seam the write composites use — and matches its
+  `currentBootDeviceKey` (which typically embeds the device's canonical
+  name / uuid) against the rows (`is_boot` true on the match, false on the
+  rest), so a caller can flash-mark "every non-boot disk" (`is_boot !=
+  true`). Boot resolution is **fail-safe**, not fail-closed: an absent
+  config manager, an unsupported/erroring query, or a missing key nulls
+  every `is_boot` and names the reason in the top-level
+  `boot_device_resolution` (`matched` / `no_match` / `unavailable`) +
+  `boot_device_note` — the device list is still returned. Set-shaped
+  (JSONFlux-reduced when large); the device read itself is fail-closed
   (`status='storage_devices_unreadable'` with an empty set on a VI-JSON
   failure), with `host_required` / `host_not_found` / `ambiguous_host` /
   `unsupported_host_target` covering the resolution refusals.

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -211,14 +211,27 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   start/stop/restart + optional `UpdateServicePolicy` **bounded to a
   curated server-side allowlist** (`TSM-SSH` / `TSM` / `ntpd` / `ptpd`)
   — an out-of-list service name is refused (`status='service_not_allowed'`)
-  before any resolution or write, never passed through. The host is
-  selected by display name **or** moref (`GET:/vcenter/host` name lookup,
-  moref fallback, ambiguity refused). Because these vim methods live on
-  the per-host config sub-managers, not `HostSystem`, each handler first
-  reads the needed `HostSystem.configManager.{datastoreSystem,`
-  `storageSystem,serviceSystem}` MoRef (one un-gated `RetrievePropertiesEx`)
-  and mounts the method on it. Registered with T4's `dangerous` +
-  `requires_approval=True`.
+  before any resolution or write, never passed through. On a **vCenter**
+  target the host is selected by display name **or** moref
+  (`GET:/vcenter/host` name lookup, moref fallback, ambiguity refused).
+  On a **standalone-ESXi** target (`#3332`) — a host no vCenter manages
+  yet, distinguished by the probe fingerprint `product=esxi` via
+  `host_target.classify_host_target` — there is no `GET:/vcenter/host`
+  surface, so the handler resolves the well-known singleton `ha-host`
+  MoRef directly through the VI-JSON seam and the `host` param is
+  optional / ignored (the host is the target); a reachable target that is
+  neither vCenter nor ESXi fails closed (`status='unsupported_host_target'`)
+  and a vCenter target given no host refuses `host_required`. Because
+  these vim methods live on the per-host config sub-managers, not
+  `HostSystem`, each handler then reads the needed
+  `HostSystem.configManager.{datastoreSystem,storageSystem,serviceSystem}`
+  MoRef (one un-gated `RetrievePropertiesEx`, issued the same way for both
+  flavors — so a standalone ESXi that cannot answer it fails
+  `config_manager_unreadable` exactly like a vCenter host) and mounts the
+  method on it. The park-time preview builders take the same
+  `classify_host_target` branch, so a preview that passes on an ESXi
+  target is not denied at call (the `#3312` parity rule). Registered with
+  T4's `dangerous` + `requires_approval=True`.
 - **Guest-operations channel** (`#3100`, group `guest_ops`,
   `composites/_guest.py`) — the governed replacement for out-of-band
   `govc guest.run`, reaching *inside* a running VM's guest OS via VMware
@@ -326,6 +339,29 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
     state (`queued`/`running`/`success`/`error`), progress, cancelled
     flag, the queue/start/complete timestamps, and the localized error
     message when a task faulted.
+- **`vmware.host.storage_devices`** (`typed_ops_host_storage_devices.py`,
+  handler `host_storage_devices`, `#3332`) — per-host raw SCSI storage
+  devices, the `safe` read that supplies the runtime input
+  `vmware.composite.host.disk_mark_flash` needs (the other host storage
+  reads — `vsan_health` / `datastore.usage` / `network_uplinks` — do not
+  enumerate the raw device set). Resolves the host (a vCenter name/moref
+  via `GET:/vcenter/host`, or the standalone-ESXi `ha-host` when the
+  probe fingerprint is `product=esxi`, via the shared
+  `host_target.classify_host_target` — the same branch the host write
+  composites take, so the read works on the **pre-vCenter standalone
+  ESXi** the `#3332` bring-up needs), then reads
+  `HostSystem.config.storageDevice.scsiLun` (the host-side read mirror of
+  `HostStorageSystem.storageDeviceInfo.scsiLun`) via one PropertyCollector
+  `RetrievePropertiesEx`. Each LUN maps to
+  `{uuid, canonical_name, device_type, capacity_bytes, ssd, local, model,
+  vendor, is_boot}` — `ssd` / `local` / `capacity_bytes` are
+  `HostScsiDisk`-only (null on a non-disk LUN); `is_boot` is a best-effort
+  null (the `scsiLun` property surface carries no boot flag — a reliable
+  boot datum needs esxcli, reserved for a future enrichment). Set-shaped
+  (JSONFlux-reduced when large); the device read is fail-closed
+  (`status='storage_devices_unreadable'` with an empty set on a VI-JSON
+  failure), with `host_required` / `host_not_found` / `ambiguous_host` /
+  `unsupported_host_target` covering the resolution refusals.
 - **`register_vmware_typed_operations`** (`typed_ops.py`) — async
   registrar wrapper queued onto `run_typed_op_registrars` (via
   `register_typed_op_registrar` in the package `__init__`, alongside the


### PR DESCRIPTION
## Why

Initiative #2907's backplane-first rule requires every provisioning-workflow step to be dispatchable through the backplane. The #3182 host-domain write composites (`vmware.composite.host.datastore_mount_nfs` / `disk_mark_flash` / `service_control`) resolved their target host only via `GET:/vcenter/host` — i.e. they required a **managing vCenter** that already inventoried the host. That breaks for a real bring-up phase: a **freshly-provisioned standalone ESXi host that no vCenter manages yet** (a nested management-domain bring-up before the SDDC vCenter exists). Against such a host `GET:/vcenter/host` returns nothing and every host-domain op fails `host_not_found`, and there was no governed way to enumerate a host's raw storage devices to drive a "flash-mark every non-boot disk" step (the runtime input `disk_mark_flash` needs). Both gaps forced out-of-band pyvmomi/hostd calls, invisible to audit.

## What

**1. Standalone-ESXi host resolution.** A shared, dependency-light classifier (`vmware_rest/host_target.py::classify_host_target`) reads the target's probe fingerprint:
- `product=esxi` → resolve the well-known singleton **`ha-host`** MoRef via the VI-JSON seam; the `host` param becomes optional / ignored (on an ESXi target the host is the target).
- a vCenter fingerprint, or an **absent / unreachable** one → the existing `GET:/vcenter/host` name/moref ladder (no regression for a managing-vCenter target, probed or not).
- a **reachable** fingerprint naming some other product → fail closed (`unsupported_host_target`).

The three host write composites and their **park-time preview builders** take the same branch, so a preview that passes on an ESXi target is not denied at call (the #3312 parity rule). `host` is now optional in the three parameter schemas; new refusal statuses `unsupported_host_target` / `host_required`; `host` is nullable in the response schemas. The config-manager read is issued the same way for both flavors, so a standalone ESXi that cannot answer it fails `config_manager_unreadable` exactly like a vCenter host (fail-closed on VI-JSON unavailable).

**2. New governed read op `vmware.host.storage_devices`** (safe tier, no approval) — a typed op mirroring `vmware.host.usage`. Reads `HostSystem.config.storageDevice.scsiLun` (the host-side mirror of `HostStorageSystem.storageDeviceInfo.scsiLun`) via one PropertyCollector `RetrievePropertiesEx` directly on the connector session (zero catalog ingest — load-bearing for the pre-vCenter standalone-ESXi case), on a vCenter target (with host name/moref resolution) and a standalone ESXi target alike. Each LUN maps to `{uuid, canonical_name, device_type, capacity_bytes, ssd, local, model, vendor, is_boot}` — `ssd` / `local` / `capacity_bytes` are `HostScsiDisk`-only (null on a non-disk LUN). Set-shaped → JSONFlux-reduced to a handle when large; the device read is fail-closed (`storage_devices_unreadable`).

> **Note on `is_boot`:** best-effort **null**. The `scsiLun` property surface exposes no boot flag — a reliable boot datum needs esxcli (`storage core device list` → "Is Boot Device"), which is not a managed-object property. The field is present (nullable) and reserved for a future esxcli-backed enrichment. Flagged for reviewer/decision visibility.

## Tests

- esxi-vs-vCenter resolution on the write composites (ha-host used, `GET:/vcenter/host` never issued; vCenter path unchanged), preview/call parity on an esxi target, `unsupported_host_target` / `host_required` refusals — added to `test_connectors_vmware_rest_composites_host.py`.
- New `test_connectors_vmware_rest_typed_host_storage_devices.py`: both resolution branches, the per-LUN mapping (ssd/local flags, capacity, non-disk nulls, `_value`- and SOAP-flavoured array unwrap), every refusal path (`host_required` / `host_not_found` / `ambiguous_host` / `unsupported_host_target` / `storage_devices_unreadable`), and registration metadata.
- Existing host-composite + write-preview + register + conformance tests stay green (**821 passed** across the vmware_rest + preview area; 117 across the directly-touched suites).

## Lint / type / snapshot

- `ruff check src/ tests/` + `ruff format --check` clean.
- `mypy src/` clean (the one `net/icmp.py` `MSG_ERRQUEUE` error is pre-existing on `origin/main` and macOS-only; CI runs on Linux where the attr exists).
- CLI OpenAPI snapshot **unchanged** (`make snapshot-openapi` → no diff; the op registers at runtime, not as a FastAPI route).
- No DB migration.

## Docs

- `docs/codebase/connectors-vmware-rest.md` — the standalone-ESXi resolution story on the host composites + the new `storage_devices` typed read.
- `CHANGELOG.md` `[Unreleased]` — Added bullet. (`docs/codebase/mcp.md` unchanged — no MCP tool-inventory change; the op is an `op_id`, not a tool.)

The #2907 coverage-register rows (pre-vCenter host-config + device-read) point here — board-side register update is a follow-up.

Closes #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)