### PR TITLE
docs(site): add flight recorder, event ingestion, and add-ons guides

### DIFF
--- a/docs-site/guides/add-ons.md
+++ b/docs-site/guides/add-ons.md
@@ -21,10 +21,14 @@ that exist today. It is not a setup guide for either product.
 A paired add-on is **not** a connector. A connector is a managed vendor
 system *below* the narrow waist — the agent reaches it through
 `call_operation`. An add-on is a peer control plane *beside* the
-backplane, integrated through the governance planes themselves. The agent
-surface is untouched by pairing: an add-on's name and the surfaces it
-advertises are **data** (rows in the backplane's database), never tool
-names. Pairing an add-on grows no agent tools.
+backplane, integrated through the governance planes themselves. Pairing
+keeps the agent surface narrow: a paired add-on's own entity identifiers
+— blueprint names, workflow names, vendor object names — are **data** in
+results, never tool names, so pairing never adds a per-blueprint or
+per-vendor tool. A tenant that has paired no add-on sees the working
+surface a build that never carried one would; a paired, contract-healthy
+add-on reveals at most a single family-level meta-tool for its family
+(detailed below).
 
 ## The pairing contract
 
@@ -44,10 +48,13 @@ Four things follow from a successful pairing:
   versions realign) rather than half-activating silently.
 - **Advertised surfaces, activated by health.** An add-on declares its
   surfaces — a meta-tool family, a CLI verb family, a console panel, an
-  event kind — as data. A compatible, healthy pairing lights those
-  operator-facing surfaces up, and they disappear cleanly on unpair.
-  Advertising a meta-tool family registers **no** MCP tool: the agent's
-  working surface stays byte-identical whether or not an add-on is paired.
+  event kind — as data. A compatible, healthy pairing activates them, and
+  they disappear cleanly on unpair. The agent's working surface is the
+  conservative case: a tenant with no add-on paired sees it byte-identical
+  to a build that never carried the family, and a paired, contract-healthy
+  add-on reveals **exactly one** family-level meta-tool — a discovery tool
+  for its family, gated on live pairing state. Advertising a family never
+  adds a per-blueprint or per-vendor tool.
 - **Shared governance.** The add-on's own approval outcomes and dispatch
   completions are pushed to a durable, resumable log scoped to its
   lineage, and an out-of-process orchestration's per-step dispatches

--- a/docs-site/guides/add-ons.md
+++ b/docs-site/guides/add-ons.md
@@ -1,0 +1,108 @@
+# Add-ons
+
+An **add-on** is a separate product that runs alongside the backplane and
+shares its policy, approvals, and audit. The backplane is complete on its
+own; an add-on extends what a team can hand to an agent without changing
+the rules an agent works under. This page explains the mechanism — how an
+add-on joins the backplane and stays governed — and names the two add-ons
+that exist today. It is not a setup guide for either product.
+
+!!! note "Maturity"
+
+    Both mechanisms on this page are **experimental** — they sit outside
+    the 1.0 stability promise and may change. See the feature-maturity
+    index for the pairing contract
+    ([`addon_pairing`](../reference/maturity.md#addon_pairing)) and the
+    attached-collection search capability
+    ([`doc_collections`](../reference/maturity.md#doc_collections)).
+
+## What an add-on is (and is not)
+
+A paired add-on is **not** a connector. A connector is a managed vendor
+system *below* the narrow waist — the agent reaches it through
+`call_operation`. An add-on is a peer control plane *beside* the
+backplane, integrated through the governance planes themselves. The agent
+surface is untouched by pairing: an add-on's name and the surfaces it
+advertises are **data** (rows in the backplane's database), never tool
+names. Pairing an add-on grows no agent tools.
+
+## The pairing contract
+
+An add-on becomes a governed peer over a **versioned pairing contract**.
+Four things follow from a successful pairing:
+
+- **Identity.** The add-on gets its own scoped service principal from
+  Keycloak. Everything it does is authorized as that identity — it starts
+  with no blanket access, and every plane below attributes work back to
+  the one pairing.
+- **A negotiated version.** Contract versions are monotonic integers. At
+  pair time both directions are pinned — the backplane refuses an add-on
+  too old for it, and an add-on refuses a backplane too old for it — and
+  the negotiated version is recorded. Compatibility is then re-checked
+  **live**: a pairing that drifts incompatible after an upgrade or
+  downgrade fails safe (its advertised surfaces deactivate until the
+  versions realign) rather than half-activating silently.
+- **Advertised surfaces, activated by health.** An add-on declares its
+  surfaces — a meta-tool family, a CLI verb family, a console panel, an
+  event kind — as data. A compatible, healthy pairing lights those
+  operator-facing surfaces up, and they disappear cleanly on unpair.
+  Advertising a meta-tool family registers **no** MCP tool: the agent's
+  working surface stays byte-identical whether or not an add-on is paired.
+- **Shared governance.** The add-on's own approval outcomes and dispatch
+  completions are pushed to a durable, resumable log scoped to its
+  lineage, and an out-of-process orchestration's per-step dispatches
+  collapse into **one** audit-replay subtree keyed to a shared work
+  reference. A multi-step add-on run therefore reads as a single lineage
+  in the [audit ledger](audit-forensics.md), under the same
+  [approvals](approvals-and-break-glass.md) every operation obeys.
+
+Pairing and unpairing are reversible and audited, and a paired add-on's
+health shows in the backplane's `/status`.
+
+## The two add-ons
+
+### Automation add-on
+
+The backplane governs one operation at a time. The **automation add-on**
+runs whole sequences of them — stand up an environment, retire one, build
+a workload — as a single durable job. It runs as its own service beside
+the backplane, under the scoped identity the pairing establishes, and
+every mutating step it takes goes through the backplane's policy,
+approval, and audit path like any other operation. It is a separate
+product; this page documents only how it attaches, not how to operate it.
+
+### MEHO Knowledge
+
+**MEHO Knowledge** is a separate retrieval service that answers questions
+over a team's own documents with a citation for every claim. The
+backplane does not ingest or store any of those documents — it **attaches
+to and searches** a MEHO Knowledge instance registered as a *doc
+collection*, and forwards the caller's identity so the search is
+authenticated and audited as that operator.
+
+When the capability is granted, an agent gets three meta-tools:
+
+| Tool | What it returns |
+|---|---|
+| `search_docs` | ranked passages from an attached collection, each cited |
+| `ask_docs` | one composed answer over the retrieved passages, with its sources |
+| `list_doc_collections` | the collections the caller is entitled to search |
+
+Two properties make this safe to expose to an agent:
+
+- **The tenant capability gate.** A docs query without a collection is
+  rejected — fail-closed — and a tenant may search only the collections
+  it holds the matching `meho-docs:<collection>` capability for. No caller
+  can run an unscoped query or reach a collection it is not entitled to,
+  and every query lands one audit row (the raw query is hashed, never
+  stored).
+- **Fail-closed grounding.** The grounding contract is enforced in code,
+  not just in a prompt: no claim survives without a citation that resolves
+  to a retrieved passage, and an empty retrieval returns a deterministic
+  *"no grounded answer"* rather than a guess.
+
+The [Memory and knowledge](memory-and-knowledge.md) guide covers how this
+attached-document search differs from MEHO's own memory and knowledge
+base, which live inside the backplane.
+
+**Next:** back to the [Do real work](index.md) index.

--- a/docs-site/guides/audit-forensics.md
+++ b/docs-site/guides/audit-forensics.md
@@ -10,7 +10,9 @@ best-effort.
 
 This guide covers the `query_audit` filter surface, how to correlate an
 audit row with the live broadcast feed, and how to reconstruct an entire
-agent session end to end.
+agent session end to end. For the actual vendor request/response traffic
+behind a single dispatch — one level below the audit row — see the
+[flight recorder](flight-recorder.md).
 
 !!! note "Prerequisites, roles, and maturity"
 

--- a/docs-site/guides/event-ingestion.md
+++ b/docs-site/guides/event-ingestion.md
@@ -122,7 +122,7 @@ body verbatim under `raw`:
 {
   "status": "firing",
   "labels": {"severity": "critical", "alertname": "TargetDown"},
-  "source":     {"slug": "am-prod", "kind": "alertmanager"},
+  "source":     {"slug": "am-prod", "kind": "alertmanager", "id": "<uuid>"},
   "event_type": "firing",
   "received_at": "2026-08-18T10:00:00+00:00",
   "raw":        { "...": "the full sender body, verbatim" }

--- a/docs-site/guides/event-ingestion.md
+++ b/docs-site/guides/event-ingestion.md
@@ -1,0 +1,206 @@
+# Fire agent runs from external events
+
+The [scheduler](scheduler.md) fires agent runs on a clock. Its third
+trigger kind, **event**, fires them on something happening instead — a
+monitoring alert, a registry push, a completed pipeline. This guide
+covers the other half of that story: the authenticated inbound webhook
+surface that turns an external event into a governed agent run, on the
+same policy, approval, and audit path as any other operation.
+
+The shape is: register the sender as an **event source**, point it at the
+ingest URL, and author a scheduler `event` trigger whose filter selects
+the events you care about. A matching event fires an agent run — nothing
+about that run is less governed for having started from a webhook.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane the sender can reach, and a scheduler
+      [`event` trigger](scheduler.md) to fire.
+    - Registering an event source and authoring an `event` trigger both
+      need **tenant_admin**; listing sources is operator-level.
+    - The `event` trigger rides the scheduler, which is **Beta** — see
+      the [feature-maturity index](../reference/maturity.md#scheduler).
+
+## Register an event source
+
+A webhook sender carries no login token, so the **event source** row is
+the whole trust context of an inbound request: it names the tenant the
+event belongs to, how the sender authenticates, and the secret to check
+it against. Registration is an operator action — **REST, CLI, and the
+console, with no MCP tool**.
+
+```bash
+# The slug is the positional argument; the secret is piped in, never
+# passed on the command line.
+printf '%s' "$SHARED_SECRET" | meho event-source add am-prod \
+  --name alertmanager-prod \
+  --kind alertmanager \
+  --auth-strategy static-header \
+  --secret-stdin
+```
+
+Two identifiers matter:
+
+- **`name`** is unique within your tenant — how you refer to the source.
+- The **slug** (`am-prod` above) is unique **globally** and is the
+  routing key in the ingest URL, `POST /api/v1/events/ingest/<slug>`.
+  That URL is JWT-less by design; the slug is a high-entropy routing
+  token, and the sender proves itself with the source's secret, not a
+  login. The secret is held in your secret store; rotating it later is an
+  update with no downtime.
+
+A source registered without a secret has no credential yet, so ingest
+**fails closed** until you set one with a later update. A source can also
+be **paused**: a paused or non-existent slug both return the same `404`,
+so an outsider cannot probe which slugs are real.
+
+## Webhook authentication modes
+
+Each source declares one `auth_strategy`, checked in constant time on
+every delivery. Header names are configurable per source, so a vendor
+whose signature header differs is a configuration detail, not a special
+case.
+
+| Mode | How the sender proves itself |
+|---|---|
+| `hmac-sha256` | An HMAC of the raw request body, in a signature header — optionally binding a timestamp that is checked against a replay window. |
+| `static-header` | A shared secret presented verbatim in a named header. |
+| `basic` | HTTP Basic — the username is configuration, the password is the source's secret. |
+
+Every rejection returns the **same** uniform `401`; the specific reason
+is logged server-side, never in the response, so a probing sender learns
+nothing.
+
+## The shipped source kinds
+
+Five source kinds ship with a per-vendor normalizer (below). Each covers
+a family of senders; the "typical auth" column is the vendor's usual
+story, but auth is per-source configuration, not welded to the kind.
+
+| Kind | Covers | Typical auth |
+|---|---|---|
+| `alertmanager` | Prometheus Alertmanager, the Loki ruler, anything Alertmanager-compatible | `static-header` / `basic` |
+| `grafana` | Grafana Alerting | `hmac-sha256` |
+| `vcf-operations` | vCenter / NSX / vSAN alerts via the VCF Operations outbound webhook plugin | `static-header` |
+| `harbor` | Registry automation — artifact push/pull/delete, scan complete/failed, quota, replication | `static-header` |
+| `generic-json` | Templated senders — Argo CD, Proxmox VE, a Keycloak events plugin, custom scripts | `hmac-sha256` |
+
+## What one delivery does
+
+The ingest endpoint runs a fixed, fail-closed sequence for every
+delivery, and the order is load-bearing:
+
+1. **Resolve** the source by slug (uniform `404` if missing or paused).
+2. **Body cap** (`413`) — enforced before the whole body is buffered, so
+   an understated `Content-Length` cannot smuggle an oversize payload
+   past it. A source may lower the cap, never raise it.
+3. **Authenticate** (`401`) per the source's `auth_strategy`.
+4. **Rate-limit** (`429` with `Retry-After`) per tenant and source.
+5. **De-duplicate** — a delivery id (or a hash of the body) makes a
+   redelivery collide at insert and return an idempotent `200`, so a
+   retry-storming sender never double-fires a subscriber.
+6. **Publish and audit in one transaction.** The event is written to the
+   durable event log and a synchronous audit row is committed in the
+   *same* transaction. As everywhere in MEHO, there is no success without
+   a committed audit row — the ingest itself is on the ledger, recorded
+   under a synthetic ingest identity because the sender has no operator
+   login.
+
+The event log is a transactional outbox: the event row is written in the
+same commit as the state it records, and a background drain claims and
+dispatches it. A pod restart loses nothing — the row is on disk and the
+next drain picks it up.
+
+### Normalization
+
+Before an event is stored, its raw body is reduced to a normalized
+envelope so filters are simple to write. The per-kind normalizer lifts
+the fields you filter on to the **top level** and keeps the full sender
+body verbatim under `raw`:
+
+```json
+{
+  "status": "firing",
+  "labels": {"severity": "critical", "alertname": "TargetDown"},
+  "source":     {"slug": "am-prod", "kind": "alertmanager"},
+  "event_type": "firing",
+  "received_at": "2026-08-18T10:00:00+00:00",
+  "raw":        { "...": "the full sender body, verbatim" }
+}
+```
+
+Untrusted input is handled defensively throughout: a non-JSON body is a
+`400`, a malformed or partially-shaped payload degrades to an empty match
+set rather than crashing, and the raw body always survives under `raw`. A
+bad payload fails closed, never `500`.
+
+## Matching: `payload @> event_filter`
+
+A scheduler `event` trigger carries an **event filter** — a small JSON
+object. An event fires the trigger when the event **payload contains**
+every key and value the filter names. The filter is a *subset* test, and
+the direction is fixed: a filter is matched against the payload, not the
+other way round.
+
+```bash
+# Fire the incident-triage agent on any critical, firing alert.
+meho scheduler create --kind event \
+  --agent-definition incident-triage \
+  --event-filter '{"status": "firing", "labels": {"severity": "critical"}}'
+```
+
+Author filters against the lifted top-level fields:
+
+| Kind | Example `--event-filter` | Matches |
+|---|---|---|
+| `alertmanager` | `{"status": "firing", "labels": {"severity": "critical"}}` | critical alerts, firing |
+| `grafana` | `{"state": "alerting", "labels": {"severity": "warning"}}` | warning alerts still alerting |
+| `vcf-operations` | `{"status": "active", "criticality": "critical"}` | active critical VMware alerts |
+| `vcf-operations` | `{"resource_kind": "VirtualMachine"}` | any alert on a VM |
+| `harbor` | `{"type": "SCANNING_COMPLETED"}` | a completed image scan |
+| `generic-json` | `{"severity": "high"}` | any body with a top-level `severity: high` |
+
+!!! warning "An empty filter matches every event of the tenant"
+
+    `{}` names no constraints, so it matches everything — every source in
+    the tenant shares one event stream. Always scope a filter to the
+    fields (and the source's `kind`) you actually mean, or an unrelated
+    alert will wake your agent.
+
+## What fires, and how it stays governed
+
+A match reuses the scheduler's own fire recipe, so an event-fired run is
+identical to a scheduled one in every way that matters: the bound agent
+definition supplies the identity and credentials, and the run dispatches
+through the same policy, approval, and audit seam. A write it attempts
+still parks for a human if the operation requires approval; every call it
+makes still writes its own audit row.
+
+- **Prompt.** If the trigger carries an `--inputs` prompt, the run uses
+  it. If it does not, the matcher synthesizes a prompt from the matched
+  event — and because the event came from outside, its text is wrapped as
+  untrusted input before the agent sees it.
+- **At-least-once, de-duplicated.** Delivery is at-least-once, but each
+  fired run is keyed so a redelivery of the same event does not fire a
+  second run.
+- **Loop and storm guards.** An `event` trigger never fires from the
+  completion event of the very agent it spawned, one misbehaving
+  subscription never stalls the drain for others, and a run refused by
+  its budget is logged once rather than retried into a storm.
+
+The result is a closed loop: your monitoring stack raises an alert, MEHO
+authenticates and records it, a filter selects it, and a governed agent
+run investigates or remediates — with the whole chain, ingest through
+dispatch, on the audit ledger.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| Every delivery returns `404` | The slug is wrong, or the source is paused — the two are deliberately indistinguishable. | Confirm the slug and that the source's status is active. |
+| Deliveries return `401` | The signature or secret did not verify; the reason is never returned. | Re-check the sender's secret and signature header against the source's `auth_strategy`. |
+| Ingest returns `200` but no agent run fires | The event was accepted but no `event` trigger's filter matched it. | Compare the trigger's `--event-filter` against the lifted top-level fields; test with a broader filter first. |
+| One alert fires many agent runs | A filter is too broad (in the limit, `{}` matches everything). | Tighten the filter to the fields and source `kind` you mean. |
+| A source registered but ingest still fails closed | It was registered without a secret. | Set the secret with an update before pointing the sender at it. |
+
+**Next:** [Satellite gateway](satellite-gateway.md).

--- a/docs-site/guides/flight-recorder.md
+++ b/docs-site/guides/flight-recorder.md
@@ -1,0 +1,173 @@
+# The flight recorder
+
+The [audit ledger](audit-forensics.md) answers *"who did X to Y, and
+when?"* — one durable row per operation. The **flight recorder** answers
+the next question down: *"what did the connector actually send, and what
+came back?"* For a governed dispatch, it captures the real vendor
+request/response traffic as an ordered set of **spans** and attaches them
+to that dispatch's audit row. The audit row stays the slim, append-only
+record of account; the trace is the deeper detail hanging off it, and it
+is captured with secrets stripped so it is safe to read back.
+
+This guide covers what a trace records, how redaction keeps it safe, who
+can read it (operators and the agent itself), and how an operator turns
+capture on — because it is **off by default**.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and a connected client
+      ([Connect clients](../clients/index.md)).
+    - Reading a trace needs the **operator** role. Turning capture on or
+      off — a per-tenant policy or a per-target override — is a
+      governance decision and needs **tenant_admin**.
+    - The flight recorder extends the append-only
+      [audit ledger](audit-forensics.md) (which is **GA**). Capture
+      itself is an operator opt-in: nothing is recorded until you enable
+      it, and it can be turned off globally at any time.
+
+## What a trace records
+
+Each captured dispatch produces one trace: an ordered list of spans, one
+per meaningful step the backplane took. Three kinds of span are
+instrumented, on the **same** single dispatch path the operation already
+runs — there is no parallel execution path:
+
+| Span | What it captures |
+|---|---|
+| **Vendor call** | the outbound request a connector made — method, URL (stripped to its request line so query-string and userinfo secrets never leak), status code, duration, and the **redacted, capped** request/response headers and bodies. Typed connectors are instrumented alongside generic ones. |
+| **Composite sub-step** | a composite that fans out into child dispatches joins the **one** parent trace, so a multi-step operation reads as a single ordered story rather than several disconnected traces. |
+| **JSONFlux reduction** | how a set-shaped response was reduced: input rows, kept fields, output size, and the result-handle id. |
+
+Traces are bounded so a chatty operation can never blow up storage or a
+reader's context. Each span body is capped (oversize **truncates with a
+marker**, it never errors), each trace is capped in total size, and a
+dispatch with very many spans collapses the overflow into counted
+per-kind groups. Capture is also **best-effort by construction**: it can
+never fail, block, or materially slow a dispatch, and the trace is
+persisted only after the audit row has committed. If recording breaks,
+the operation still returns exactly as it would have.
+
+## Redaction is fail-closed
+
+A trace is only safe to read back because a secret never reaches it in
+the first place. Every header and body is redacted **at capture**, before
+a byte is stored, and the engine is built to fail closed:
+
+- **Header allowlist.** Only enumerated known-safe headers survive.
+  Every `Authorization`, `Cookie`, `Set-Cookie`, `X-*-Token`, CSRF,
+  session, and signed-URL header is stripped **unread**. An allowlist is
+  used deliberately over a blocklist, so an unknown vendor header is
+  dropped rather than leaked.
+- **Body-path redaction.** Declarative per-connector path rules scrub
+  known secret-bearing fields from request and response bodies, with the
+  credential-shape detector reused underneath as a second layer.
+- **Hard-excluded operation families.** Credential-read, session-mint,
+  and token operations never record bodies at all, regardless of policy.
+- **Redaction-uncertainty signalling.** Any span the engine cannot
+  *prove* it fully redacted — an unparseable or binary body, malformed
+  JSON, a body truncated mid-value — is flagged uncertain, and the whole
+  trace inherits that flag. Uncertainty always resolves toward **less**
+  exposure, never more (see the read surfaces below).
+
+## Who reads a trace, and how
+
+### Operators — REST and the console
+
+An operator reads the trace for one audit row two ways over the same
+tenant-scoped read:
+
+```bash
+# The audit row id comes from the audit ledger (see the audit guide).
+curl -H "Authorization: Bearer $TOKEN" \
+  https://meho.example.com/api/v1/audit/<audit_id>/trace
+```
+
+…or open the audit row in the console drawer and read its **Flight
+recorder** pane (next to Lineage). Both render exactly what was stored —
+the read surface never re-processes, un-redacts, or writes. Two things
+worth knowing:
+
+- **The operator plane sees everything the tenant captured**, including
+  a redaction-uncertain trace — but the uncertainty is **surfaced**, as a
+  banner in the pane and a `redaction_uncertain` field in the REST body,
+  so you can see when a trace was withheld from agents.
+- **Absence is unambiguous.** An audit row that does not exist, or lives
+  in another tenant, returns `404` (never `403` — existence never leaks
+  across tenants). An audit row that exists but has no captured trace —
+  because capture was off, or best-effort recording skipped it — returns
+  a `200` empty state.
+
+### The agent — its own trace as a result handle
+
+An agent can read the trace of a dispatch it ran, but only through the
+narrow-waist idiom it already uses for any large result: the trace is
+materialized as a set-shaped result handle and paged with the
+**unchanged** `result_query` meta-tool. No new tool is registered, no
+vendor-specific name reaches the agent surface, and no raw payload enters
+agent context.
+
+!!! warning "The agent read is gated separately, and closes on doubt"
+
+    Agent readability is a **per-tenant** setting independent of operator
+    access, and it is the conservative default. A trace whose redaction
+    could not be *proven* complete is withheld from the agent handle
+    **entirely** — while the operator plane keeps full access to it. A
+    secret-bearing or redaction-uncertain span therefore never reaches an
+    agent-visible handle.
+
+## Turning capture on
+
+Capture is a governance decision, so it lives on the operator plane —
+**REST and CLI only, with no MCP tool** — and it is off until an operator
+enables it. Resolution runs per-target first, then per-tenant, then the
+global default.
+
+**Per-tenant policy** (`tenant_admin`):
+
+```bash
+meho tenants flight-recorder-policy set \
+  --enabled \
+  --agent-readable true \
+  --retention-days 14
+```
+
+- `--enabled` flips the tenant's capture default on or off.
+- `--agent-readable true|false|inherit` controls whether agents may read
+  their own traces (`inherit` follows the capture default).
+- `--retention-days N` (bounded **1–365**) or `--clear-retention` sets
+  how long traces are kept before the reaper deletes them.
+
+**Per-target override.** A single target can force capture on or off
+regardless of the tenant default — useful to record just one noisy or
+sensitive system — through the target's own update path (the
+`flight_recorder_capture` field on `meho targets import --update`, or the
+target PATCH route). It is tri-state: force on, force off, or clear back
+to inherit.
+
+**Global kill switch.** `FLIGHT_RECORDER_ENABLED` is read fail-open: set
+it off and the deployment captures nothing, without failing a single
+dispatch. It is the blunt instrument for turning the whole subsystem off.
+
+A policy change takes effect on the **next dispatch** — the resolver
+caches for a minute but each change invalidates that cache, so you never
+wait out a TTL or restart a pod.
+
+## Retention
+
+Traces are transient by design. A reaper deletes expired traces —
+headers and spans together — on a bounded sweep; the default window is
+short and per-tenant configurable through `--retention-days` above. The
+**audit row is never touched** by the reaper: the durable record of
+account outlives the detailed trace hanging off it.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `GET …/trace` returns `200` but an empty trace | Capture was off for that dispatch, or best-effort recording skipped it — not an error. | Enable capture on the tenant (or the target) and re-run; past dispatches cannot be recorded retroactively. |
+| `GET …/trace` returns `404` | The audit row does not exist in your tenant (a wrong id, or a cross-tenant row) — deliberately indistinguishable from a genuinely missing row. | Confirm the `audit_id` and that you are authenticated to the right tenant. |
+| An operator sees a trace but an agent's `result_query` cannot | Either agent-readability is off for the tenant, or the trace was flagged redaction-uncertain and withheld from agents by design. | Check `--agent-readable`; a redaction-uncertain trace stays operator-only on purpose. |
+| A span body ends in a truncation marker | The body exceeded the per-span cap and was truncated — working as designed, and it forces the trace's redaction-uncertain flag. | Nothing; the trace is intact up to the cap, and the truncation is why it is operator-only. |
+| Nothing is ever captured, tenant policy notwithstanding | The global `FLIGHT_RECORDER_ENABLED` kill switch is off. | Set it on at the deployment level; the per-tenant policy applies underneath it. |
+
+**Next:** [Runbooks](runbooks.md).

--- a/docs-site/guides/flight-recorder.md
+++ b/docs-site/guides/flight-recorder.md
@@ -119,8 +119,11 @@ agent context.
 
 Capture is a governance decision, so it lives on the operator plane —
 **REST and CLI only, with no MCP tool** — and it is off until an operator
-enables it. Resolution runs per-target first, then per-tenant, then the
-global default.
+enables it. At dispatch time the resolver checks, highest precedence
+first: the **global kill switch** (below), then any **per-target
+override**, then the **per-tenant default** — which is off unless enabled,
+and is the true fallback. On any error it resolves to *off*: the recorder
+never captures more than it can prove it should.
 
 **Per-tenant policy** (`tenant_admin`):
 
@@ -144,9 +147,11 @@ sensitive system — through the target's own update path (the
 target PATCH route). It is tri-state: force on, force off, or clear back
 to inherit.
 
-**Global kill switch.** `FLIGHT_RECORDER_ENABLED` is read fail-open: set
-it off and the deployment captures nothing, without failing a single
-dispatch. It is the blunt instrument for turning the whole subsystem off.
+**Global kill switch.** `FLIGHT_RECORDER_ENABLED` sits at the top of that
+precedence and is read fail-open: set it off and the deployment captures
+nothing — overriding every tenant and target setting — without failing a
+single dispatch. It is the blunt instrument for turning the whole
+subsystem off.
 
 A policy change takes effect on the **next dispatch** — the resolver
 caches for a minute but each change invalidates that cache, so you never

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -31,9 +31,12 @@ backplane — reach for whichever the task in front of you needs:
 | [Broadcast](broadcast.md) | The cross-operator activity feed — read it, announce intent, watch it live, and the read-before-start discipline. |
 | [Memory and knowledge](memory-and-knowledge.md) | Two durable stores: scoped, TTL'd memory and the tenant knowledge base, and which belongs where. |
 | [Audit forensics](audit-forensics.md) | Reconstructing "who did X to Y and when" from the append-only ledger, and tracing an agent session end to end. |
+| [Flight recorder](flight-recorder.md) | The redacted per-dispatch record of the vendor traffic behind an audit row — what it captures, and who can read it back. |
 | [Runbooks](runbooks.md) | Authoring versioned, multi-step procedures and running them one gated step at a time. |
 | [Scheduler](scheduler.md) | Firing agent runs on cron / one-off triggers, and the durable-credential behavior that keeps them running unattended. |
+| [Event ingestion](event-ingestion.md) | Firing a governed agent run from an authenticated external webhook — a monitoring alert or a registry action. |
 | [Satellite gateway](satellite-gateway.md) | Remote check execution for networks the central instance cannot dial. |
+| [Add-ons](add-ons.md) | How a separate product pairs with the backplane and stays under its policy, approvals, and audit. |
 
 !!! tip "When a guide and your deploy disagree"
 

--- a/docs-site/guides/scheduler.md
+++ b/docs-site/guides/scheduler.md
@@ -73,6 +73,11 @@ event (`--event-filter`) rather than a clock. The knobs worth knowing:
 - `--work-ref` — a change-ticket reference stamped onto the run's audit
   and broadcast lineage.
 
+The external webhook sources that feed these events — Alertmanager,
+Grafana, VCF Operations, Harbor, and generic JSON senders — and how to
+write an `--event-filter` against them are covered in
+[Event ingestion](event-ingestion.md).
+
 List what's scheduled and its state:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,9 +76,12 @@ nav:
       - Broadcast: guides/broadcast.md
       - Memory and knowledge: guides/memory-and-knowledge.md
       - Audit forensics: guides/audit-forensics.md
+      - Flight recorder: guides/flight-recorder.md
       - Runbooks: guides/runbooks.md
       - Scheduler: guides/scheduler.md
+      - Event ingestion: guides/event-ingestion.md
       - Satellite gateway: guides/satellite-gateway.md
+      - Add-ons: guides/add-ons.md
   - Reference:
       - reference/index.md
       # Generated from the feature-maturity registry by


### PR DESCRIPTION
## Description

Adds three new task guides under **Do real work**, plus their nav entries
and cross-links. Every fact is derived from `docs/codebase/` and the code
(not from release notes prose), in the voice of the existing guides. This
is the unblocked slice of the docs-site work in the internal
**public-surfaces refresh plan of 2026-09-03**.

New pages and their sources:

| Page | Source of truth |
|---|---|
| `docs-site/guides/flight-recorder.md` | `docs/codebase/flight-recorder-policy.md` + the v0.32.0 CHANGELOG flight-recorder blocks — what a trace captures (vendor-call / composite / JSONFlux spans, caps), fail-closed redaction, the operator (REST `GET /api/v1/audit/{id}/trace` + console) and agent (reduced result-handle via `result_query`) read surfaces, the tenant/target/global capture policy (`meho tenants flight-recorder-policy set`), and retention. |
| `docs-site/guides/event-ingestion.md` | `docs/codebase/events.md` + `event-source-registry.md` — registering an event source (`meho event-source add`), the webhook auth modes (`hmac-sha256` / `static-header` / `basic`), the shipped source kinds and their normalizers, the `payload @> event_filter` match, and the governed agent run a match fires (through the scheduler `event` trigger) with its synchronous audit row. |
| `docs-site/guides/add-ons.md` | `docs/codebase/addon-contract.md`, `addon-pairing.md`, `addon-parent-linkage.md`, `addon-step-events.md`, `docs-search.md`, `doc-collections.md` — mechanism only: the versioned pairing contract, and the two add-ons (automation add-on; MEHO Knowledge via `search_docs` / `ask_docs` / `list_doc_collections` with the `meho-docs:<collection>` capability gate and fail-closed grounding), both labelled experimental per `reference/maturity.md`. |

Also:

- `mkdocs.yml` — the three pages wired into nav (strict mode requires page + nav together): flight recorder after Audit forensics, event ingestion after Scheduler, add-ons at the end of the guides group.
- Cross-links: one line per new page in `guides/index.md`; audit-forensics → flight recorder; scheduler → event ingestion.

**Verification:** `mkdocs build --strict` passes locally with zero warnings.

## Related issue

Source: internal public-surfaces refresh plan (2026-09-03). No public issue to close.

## Type of change

- [x] Documentation

## Checklist

- [x] Conventional Commits format on every commit
- [x] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable
- [x] Documentation updated where applicable
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
