### PR TITLE
docs(site): client onramps, MCP surface tiers guide, and What's new page

### DIFF
--- a/docs-site/clients/claude-code.md
+++ b/docs-site/clients/claude-code.md
@@ -1,15 +1,56 @@
 # Claude Code
 
-Claude Code speaks MCP over **native HTTP** — no shim. You point a
-project-scoped `.mcp.json` at the backplane's `/mcp` route and pin the
-pre-registered `meho-mcp` public client; Claude Code runs the OAuth 2.1
-authorization-code + PKCE flow itself, listening on a loopback port for
-the callback. This is the pattern both MEHO dogfood repos run daily.
+There are two ways to connect Claude Code to a MEHO backplane:
 
-Like every client in this section, Claude Code must run on a machine
-**on the internal network / VPN** — MEHO is internal-only.
+- **The MEHO plugin (recommended)** — one command installs the MCP
+  wiring and MEHO's operating discipline as skills. Start here.
+- **A manual `.mcp.json`** — native HTTP MCP you configure yourself.
+  Use it for non-plugin clients, CI bots, or when you want the wiring
+  in the repo.
 
-## Configure `.mcp.json`
+Either way, Claude Code must run on a machine **on the internal network
+/ VPN** — MEHO is internal-only — and nothing is exposed to the
+internet.
+
+## The one-command path: the MEHO plugin
+
+MEHO ships an in-repo Claude Code plugin marketplace. Add it and install
+the plugin:
+
+```bash
+claude plugin marketplace add evoila/meho
+/plugin install meho@meho
+```
+
+The plugin carries the MCP server (over the bundled `mcp-remote` stdio
+shim, so no per-project `.mcp.json` editing) and loads the MEHO-first
+operating discipline as skills. Point it at your backplane by setting
+the endpoint once — either an environment variable or a small config
+file the plugin reads:
+
+```bash
+# ~/.config/meho/plugin.env
+MEHO_MCP_URL="https://meho.example.com/mcp"
+# MEHO_CA_CERT="/path/to/internal-ca.pem"   # only on internal-CA deploys
+```
+
+`MEHO_CA_CERT` is only needed on an internal-CA deploy (the plugin's
+shim runs on Node, which does not read the OS trust store). To opt a
+session into the operator planes, set `MEHO_MCP_SCOPES` to add
+`mcp:admin` — see
+[MCP surface and scopes](mcp-surface-and-scopes.md#how-a-client-requests-elevation).
+The realm still needs the public `meho-mcp` client and its loopback
+redirect URI, exactly as the manual path below (see
+[Keycloak realm setup](../install/keycloak-realm.md)).
+
+## The manual path: configure `.mcp.json`
+
+If you are not using the plugin, Claude Code also speaks MCP over
+**native HTTP** — no shim. You point a project-scoped `.mcp.json` at the
+backplane's `/mcp` route and pin the pre-registered `meho-mcp` public
+client; Claude Code runs the OAuth 2.1 authorization-code + PKCE flow
+itself, listening on a loopback port for the callback. This is the
+pattern both MEHO dogfood repos run daily.
 
 Add a `meho` server to the workspace `.mcp.json`. Claude Code reads it
 at session start; restart the session after edits:

--- a/docs-site/clients/claude-desktop.md
+++ b/docs-site/clients/claude-desktop.md
@@ -4,8 +4,19 @@ Claude Desktop reaches an internal MEHO backplane through a **local
 [`mcp-remote`](https://github.com/geelen/mcp-remote) stdio→HTTP shim**
 that runs on your own VPN-connected machine. The shim runs the OAuth
 2.1 + PKCE flow against your internal Keycloak and forwards
-Streamable-HTTP calls to `/mcp`. This is the **only** Desktop path for
-an internal-only backplane.
+Streamable-HTTP calls to `/mcp`. This shim is the **only** Desktop
+transport for an internal-only backplane — but you have two ways to set
+it up:
+
+- **The one-click `.mcpb` bundle (recommended)** — install by opening a
+  file; a dialog asks for your backplane URL and an optional internal-CA
+  bundle, and no JSON editing is involved. Start here.
+- **A manual `claude_desktop_config.json`** — wire the same shim
+  yourself. Use it if you cannot install the bundle, or want to see
+  exactly what it runs.
+
+Either way, everything runs on your own VPN-connected machine and
+nothing is exposed to the internet.
 
 !!! danger "The remote Custom Connector is not applicable"
 
@@ -23,6 +34,30 @@ observed** result of the smoke test run against a standing internal
 deploy over VPN (issue
 [#2666](https://github.com/evoila/meho/issues/2666)) — not a
 design sketch.
+
+## The one-command path: the `.mcpb` bundle
+
+MEHO ships a Claude Desktop bundle in the MCPB format, distributed as an
+asset on each [GitHub Release](https://github.com/evoila/meho/releases).
+Install it by **opening the `.mcpb` file** in Claude Desktop: it wires
+the same `mcp-remote` shim and asks, in a dialog, for the two things
+that differ per deployment —
+
+- **MEHO MCP endpoint** — your backplane's `/mcp` URL (reachable over
+  your VPN).
+- **Internal CA bundle** *(optional)* — the PEM for the CA that signs
+  the backplane's TLS certificate; leave it empty on a public-CA deploy.
+
+Two advanced fields default to the working setup and rarely need
+changing: the OAuth **client id** (default `meho-mcp`) and the OAuth
+**scopes** (default `mcp:read mcp:execute`). To opt the session into the
+operator planes, add `mcp:admin` to the scopes field — see
+[MCP surface and scopes](mcp-surface-and-scopes.md#how-a-client-requests-elevation).
+
+The bundle still expects the realm's public `meho-mcp` client with the
+shim's loopback redirect URIs registered (below), and — on an
+internal-CA deploy — the CA you point it at. If you cannot install the
+bundle, wire the shim by hand with the rest of this page.
 
 ## Prerequisites
 

--- a/docs-site/clients/index.md
+++ b/docs-site/clients/index.md
@@ -32,6 +32,24 @@ install and log in with the [`meho` CLI](cli.md) first. Two reasons:
 - The CLI is the fastest way to prove the realm, TLS trust, and token
   chain are correct before you add an MCP client's moving parts on top.
 
+## The fastest path: one-command onramps
+
+For the two Claude clients, you do not have to hand-write any MCP
+config. Each has a one-step onramp that wires everything for you:
+
+- **Claude Code** — a plugin from an in-repo marketplace:
+  `claude plugin marketplace add evoila/meho`, then
+  `/plugin install meho@meho`. See [Claude Code](claude-code.md).
+- **Claude Desktop** — a one-click `.mcpb` bundle: install by opening
+  the file and answering a short dialog. See
+  [Claude Desktop](claude-desktop.md).
+
+Both onramps still connect **from your VPN-connected machine** and
+expose nothing to the internet. The manual recipes below remain the
+fallback, and the path for every other client. Whichever you pick, an
+agent session lists a small, tiered set of meta-tools — see
+[MCP surface and scopes](mcp-surface-and-scopes.md).
+
 ## The MCP client matrix
 
 All three MCP paths are **internal-only** — the client, or the local
@@ -41,8 +59,8 @@ matches your client:
 
 | Client | How it connects | Page |
 |---|---|---|
-| **Claude Desktop** | A local [`mcp-remote`](https://github.com/geelen/mcp-remote) stdio→HTTP shim runs the OAuth 2.1 + PKCE flow and forwards to `/mcp`. The only Desktop path for an internal-only backplane. | [Claude Desktop](claude-desktop.md) |
-| **Claude Code** | Native HTTP MCP with a loopback PKCE flow, pinned to the pre-registered `meho-mcp` public client. The pattern both dogfood repos run daily. | [Claude Code](claude-code.md) |
+| **Claude Desktop** | One-click `.mcpb` bundle (recommended), or a manual local [`mcp-remote`](https://github.com/geelen/mcp-remote) stdio→HTTP shim running the OAuth 2.1 + PKCE flow and forwarding to `/mcp`. The shim is the only Desktop transport for an internal-only backplane. | [Claude Desktop](claude-desktop.md) |
+| **Claude Code** | One-command MEHO plugin (recommended), or a manual native-HTTP `.mcp.json` with a loopback PKCE flow pinned to the pre-registered `meho-mcp` public client. The pattern both dogfood repos run daily. | [Claude Code](claude-code.md) |
 | **Cursor and other clients that can't carry a `client_id`** | A generic `mcp-remote` stdio shim carrying a CLI-minted bearer token. | [Other MCP clients](mcp-remote-shim.md) |
 
 All three assume the realm already has the public `meho-mcp` OAuth

--- a/docs-site/clients/mcp-surface-and-scopes.md
+++ b/docs-site/clients/mcp-surface-and-scopes.md
@@ -127,7 +127,7 @@ right saves a round of `-32602` errors:
   target name, not the UUID that `list_targets` returns.
 - **The broadcast tools carry the `meho_` prefix** —
   `meho_broadcast_recent`, `meho_broadcast_announce`,
-  `meho_broadcast_watch`. A bare `broadcast_announce` is not a
+  `meho_broadcast_watch`. Drop the prefix and the name is not a
   registered tool.
 
 ## The full tool inventory

--- a/docs-site/clients/mcp-surface-and-scopes.md
+++ b/docs-site/clients/mcp-surface-and-scopes.md
@@ -1,0 +1,139 @@
+# MCP surface and scopes
+
+When an MCP client connects to MEHO, it does **not** see one tool per
+vendor operation. It sees a small, stable set of meta-tools that works
+the same way for every connector and every product version. That set is
+deliberately tiered by trust: a default agent session gets a narrow
+working surface, the operator planes are hidden until a session
+explicitly asks for them, and a few human-decision verbs have no MCP
+path at all.
+
+This page explains the three tiers, how a client opts into the operator
+planes, and why an agent can never approve its own work. It is the same
+model whichever client you wired in [Connect clients](index.md).
+
+## The default working surface (25 tools)
+
+Every session lists the **25-tool working surface** with no elevation —
+enough to discover connectors, run governed operations, page large
+results, and coordinate with other operators. The tools group into ten
+families:
+
+| Family | Tools |
+|---|---|
+| **Health** | `meho_status` |
+| **Connectors** | `meho_connector_list` |
+| **Operation discovery** | `list_operation_groups`, `search_operations` |
+| **Execution** | `call_operation`, `preview_operation` |
+| **Result handles** | `result_query` |
+| **Knowledge** | `search_knowledge`, `add_to_knowledge` (plus the capability-gated docs add-on: `ask_docs`, `search_docs`, `list_doc_collections`) |
+| **Memory** | `search_memory`, `add_to_memory` |
+| **Broadcast** | `meho_broadcast_recent`, `meho_broadcast_announce`, `meho_broadcast_watch` |
+| **Targets and topology** | `list_targets`, `query_topology` |
+| **Runbooks (run family)** | `meho_runbook_start`, `meho_runbook_next`, `meho_runbook_abort`, `meho_runbook_list_runs`, `meho_runbook_list_templates`, `meho_runbook_show_template` |
+
+Three of the 25 — the grounded-documentation add-on tools `ask_docs`,
+`search_docs`, and `list_doc_collections` — appear only when the tenant
+has provisioned the `meho-docs` capability. A session without that
+capability lists the other 22.
+
+The working surface is the same across every connector. An agent picks a
+connector, lists its operation groups, searches for the operation it
+needs, previews it, and calls it — the vendor's own identifiers stay in
+the operation id, never in a tool name.
+
+### The discovery-and-execution ladder
+
+A useful session almost always walks the same rungs:
+
+1. `meho_connector_list` — which connectors can this session reach.
+2. `list_operation_groups` — the enabled operation groups on one
+   connector, each with a "when to use this group" description.
+3. `search_operations` — find the operation, optionally scoped to a
+   group.
+4. `preview_operation` / `call_operation` — preview, then run against a
+   target.
+5. `result_query` — page a large, set-shaped result back from its
+   handle.
+
+## The operator planes (behind `mcp:admin`)
+
+The governance and lifecycle tools — connector lifecycle and ingest,
+agents / principals / grants, scheduler, sensors, broadcast overrides,
+runbook **template authoring**, topology **mutations**, target
+registration, doc-collection create/delete, memory promotion, approvals
+**read**, and audit query — form a second tier of **53 operator-plane
+tools**. They are absent from a default session's tool list and refused
+at call time, and they appear **only** for a session that explicitly
+requested the `mcp:admin` OAuth scope.
+
+Elevation is a per-session, explicit opt-in — not a standing role. A
+session must *choose* to hold the operator planes; it never carries them
+by default on the strength of its identity. That is what keeps a routine
+agent session from reaching the governance controls it does not need.
+
+### How a client requests elevation
+
+The client asks for the extra scope, and your realm mints it into the
+token only on request (the realm grants `mcp:admin` request-only):
+
+- **Claude Code plugin** — set the `MEHO_MCP_SCOPES` environment seam to
+  the space-separated scopes you want, adding `mcp:admin`:
+
+    ```bash
+    MEHO_MCP_SCOPES="mcp:read mcp:execute mcp:admin"
+    ```
+
+- **Claude Desktop `.mcpb` bundle** — set the bundle's **OAuth scopes**
+  (`scopes`) user-config field to the same value in the install dialog.
+
+Requesting a scope your realm does not grant simply degrades to the
+default working surface — it never fails the connection. Leave the scope
+off entirely and the session stays on the 25-tool working surface, which
+is the right default for almost every agent.
+
+## The human-only decision verbs (no MCP path)
+
+Three verbs have **no MCP registration under any scope**, elevated or
+not:
+
+- `meho_approvals_approve`
+- `meho_approvals_reject`
+- `meho_agents_grant_elevate`
+
+Approving an operation, rejecting it, or granting an agent more access
+are human decisions. They are absent from every session's tool list, and
+a direct `tools/call` on any of them is refused **before** the tool
+registry is even consulted, with a remediation that names the human
+path: the operator console approvals queue, or the concrete CLI verb
+(`meho approvals approve <request-id>`, `meho approvals reject
+<request-id> --reason <text>`, `meho agent grant elevate …`).
+
+This is why an agent can never approve its own work. A model session that
+parks a risky operation cannot hold the button that clears its own gate —
+that decision moves to a person at the console or the CLI. Elevating to
+`mcp:admin` does not change this: the three verbs are not "operator-plane
+tools you can unlock", they simply do not exist on MCP.
+
+## Naming that trips people up
+
+A few names on the working surface are easy to get wrong. Getting them
+right saves a round of `-32602` errors:
+
+- **`call_operation`'s operation argument is `op_id`** — the operation
+  identifier from `search_operations`, not a field called `op` or
+  `operation`.
+- **`call_operation`'s `target` resolves by name** — the human-readable
+  target name, not the UUID that `list_targets` returns.
+- **The broadcast tools carry the `meho_` prefix** —
+  `meho_broadcast_recent`, `meho_broadcast_announce`,
+  `meho_broadcast_watch`. A bare `broadcast_announce` is not a
+  registered tool.
+
+## The full tool inventory
+
+This page describes the tiering, not every row. The complete per-tool
+inventory — each tool, its surface tier, and the claim that gates it —
+is published as a generated MCP tool reference in the
+[Reference](../reference/index.md) section, generated from the live
+`tools/list` snapshot so it cannot drift from the product.

--- a/docs-site/project/index.md
+++ b/docs-site/project/index.md
@@ -18,7 +18,9 @@ lives at [Feature maturity index](../reference/maturity.md).
 MEHO follows [SemVer](https://semver.org). The version lives only in
 the release tag; the backplane image, Helm chart, CLI tarballs, and
 this docs site all derive from it
-([release history](https://github.com/evoila/meho/releases)).
+([release history](https://github.com/evoila/meho/releases)). For a
+plain-language summary of what landed recently, see
+[What's new](../reference/whats-new.md).
 
 Pre-1.0, breaking changes still ship in minors — each one carries a
 **migration recipe** in the release notes (the smallest concrete edit

--- a/docs-site/reference/index.md
+++ b/docs-site/reference/index.md
@@ -13,6 +13,8 @@ land incrementally:
 
 ## Available now
 
+- [What's new](whats-new.md) — a plain-language summary of what landed
+  in recent releases, since v0.28.0.
 - [Feature maturity index](maturity.md) — every feature's tier, the
   milestone it targets, and where its road to GA is tracked, generated
   from the codebase registry on every release.

--- a/docs-site/reference/whats-new.md
+++ b/docs-site/reference/whats-new.md
@@ -1,0 +1,84 @@
+# What's new
+
+A plain-language summary of what landed in recent MEHO releases. It
+covers releases **since v0.28.0**; older releases are in the
+[CHANGELOG](https://github.com/evoila/meho/blob/main/CHANGELOG.md),
+which carries the full detail — every change, and the migration recipe
+for each breaking one.
+
+MEHO is under active development. Each release below links to its full
+notes.
+
+## [v0.32.0](https://github.com/evoila/meho/releases/tag/v0.32.0) — 2026-09-02
+
+- **The Microsoft estate gains connectors.** New connectors for Windows
+  Server, Active Directory, SQL Server, failover clustering, and
+  Hyper-V — the Windows and SQL half of the datacenter, behind the same
+  policy and audit as every other connector.
+- **Governed permanent deletes.** A destructive-delete tier previews
+  exactly what would be removed, binds the human approval to that exact
+  preview, and refuses to run until a person approves — so a delete of a
+  VM, a DNS record, a firewall rule, or a secret always has a person who
+  owns it.
+- **Flight recorder.** A complete, redaction-safe record of each
+  dispatch, captured at the vendor-API level with secrets stripped, and
+  readable by operators and by the agent's own session.
+- **Governed in-guest program execution.** Run a program inside a VM's
+  guest operating system as a governed, approval-gated step that keeps
+  secrets out of the preview.
+- **Governed writes on satellite runners.** A remote runner can execute
+  policy-checked, audited writes inside networks the central instance
+  cannot reach — limited to an operator-set allowlist, and never for the
+  destructive or dangerous tiers.
+- **Read result handles from the CLI and REST.** `result_query` reached
+  full parity: a large, set-shaped result can be paged back from the CLI
+  and REST, not only from an MCP client.
+- **A dedicated approve-only role.** A principal who can clear the
+  approval queue without any power to run an operation — separation of
+  duties for regulated teams.
+
+## [v0.31.0](https://github.com/evoila/meho/releases/tag/v0.31.0) — 2026-08-27
+
+- **One-command onboarding.** A Claude Code plugin (`claude plugin
+  marketplace add evoila/meho`, then `/plugin install meho@meho`) and a
+  one-click `.mcpb` bundle for Claude Desktop point a client at your own
+  backplane in a single step. Nothing is exposed to the internet.
+- **Least privilege by default.** A connecting agent now sees only the
+  25-tool working surface; the operator planes list only for a session
+  that explicitly requests the `mcp:admin` scope. See
+  [MCP surface and scopes](../clients/mcp-surface-and-scopes.md).
+- **The AI cannot approve itself.** Approving an action, rejecting it,
+  and granting an agent more access have no path an MCP client can call —
+  those decisions move to the operator console or the CLI.
+- **Two breaking changes for MCP clients.** The default surface dropped
+  to 25 tools, and the approval and grant-elevate verbs left the MCP
+  surface. Each carries a migration recipe in the release notes.
+
+## [v0.30.0](https://github.com/evoila/meho/releases/tag/v0.30.0) — 2026-08-25
+
+- **VMware Cloud Foundation bring-up through the backplane.** Submit and
+  poll a management-domain bring-up as governed, approval-gated steps.
+- **Air-gapped installs.** Govern the depot configuration, TLS-trust,
+  and bundle pre-download steps an air-gapped bring-up depends on.
+- **Recover from a failed bring-up.** Resume a failed management-domain
+  bring-up from where it stopped, under the same approval posture as the
+  original run.
+- **Migration-source connectors for older VMware and Aria versions.** So
+  one estate spanning old and new resolves to the right implementation
+  per system — useful for reading and inventorying an existing estate
+  during onboarding.
+
+## [v0.29.0](https://github.com/evoila/meho/releases/tag/v0.29.0) — 2026-08-19
+
+- **External event ingestion.** An authenticated webhook from your
+  monitoring stack can fire a subscribed agent run on match, through the
+  same policy, approval, and audit path as any other operation.
+- **Checks say which items breached.** A breaching aggregate assertion
+  now carries a sample of the offending rows in its evidence, so a
+  notification names the specific items, not just that the aggregate
+  tripped.
+- **PostgreSQL 12 dropped from the supported range.** The end-of-life
+  release is no longer supported.
+- **More curated read operations across connectors.** Kubernetes,
+  Harbor, and database connectors gained typed read operations that
+  dispatch on a fresh boot with no ingest step.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Local kind quickstart: install/kind-quickstart.md
   - Connect clients:
       - clients/index.md
+      - MCP surface and scopes: clients/mcp-surface-and-scopes.md
       - The meho CLI: clients/cli.md
       - Claude Desktop: clients/claude-desktop.md
       - Claude Code: clients/claude-code.md
@@ -84,6 +85,7 @@ nav:
       - Add-ons: guides/add-ons.md
   - Reference:
       - reference/index.md
+      - What's new: reference/whats-new.md
       # Generated from the feature-maturity registry by
       # backend/scripts/generate_maturity_index.py (#2678); freshness
       # is enforced by backend/tests/test_maturity_surface_drift.py.


### PR DESCRIPTION
## Summary

Public docs-site refresh covering the client-onramp and What's-new copy from the internal public-surfaces refresh plan of 2026-09-03. Three deliverables, all COPY:

- **New MCP surface tiers guide** (`clients/mcp-surface-and-scopes.md`) — the three surface tiers a connecting agent sees: the 25-tool default working surface (ten families, listed), the 53 operator-plane tools behind an explicitly-requested `mcp:admin` scope (via the plugin's `MEHO_MCP_SCOPES` seam / the `.mcpb` `scopes` user_config, granted request-only), and the three human-only decision verbs (approve / reject / grant-elevate) with no MCP path and the remediation a caller gets instead. Includes the naming gotchas (`call_operation` takes `op_id`, `target` resolves by name, broadcast tools carry the `meho_` prefix). The full per-tool inventory is described as a generated reference (links to `reference/index.md`); no hand-curated 78-tool list.
- **One-command client onramps** added to `clients/index.md`, `clients/claude-code.md`, `clients/claude-desktop.md` — the Claude Code plugin (`claude plugin marketplace add evoila/meho` → `/plugin install meho@meho`) and the one-click `.mcpb` bundle for Claude Desktop (both shipped in v0.31.0), led as the primary paths with the manual `.mcp.json` / `mcp-remote` shim kept as the fallback. Nothing exposed to the internet; the shim stays the documented remote path.
- **New What's new page** (`reference/whats-new.md`) — per-release highlights for v0.29.0–v0.32.0 with corrected attributions, each release linked to its GitHub tag and the page linked to the CHANGELOG; "since v0.28.0" marker, older releases in the CHANGELOG.
- Cross-links to the new What's new page from `reference/index.md` and `project/index.md`; nav entries for the two new pages under "Connect clients" and "Reference".

## Per-page sources

- `clients/mcp-surface-and-scopes.md` — `docs/codebase/mcp.md` (§Agent-surface scoping, §Dual-surface tool inventory, working-surface table, the human-only verbs + remediation, the `mcp:admin` / `MEHO_MCP_SCOPES` elevation seam), `CLAUDE.md` (agent-surface families table), CHANGELOG v0.31.0 (25-tool working surface default; approval/grant-elevate verbs no MCP path).
- `clients/claude-code.md`, `clients/claude-desktop.md`, `clients/index.md` — CHANGELOG v0.31.0 (Claude Code plugin + in-repo marketplace; Claude Desktop `.mcpb` bundle; `MEHO_MCP_SCOPES` / `.mcpb` scopes); in-repo `.claude-plugin/marketplace.json`, `clients/claude-code-plugin/` (plugin env seam: `MEHO_MCP_URL`, `MEHO_CA_CERT`, `MEHO_MCP_SCOPES`), `clients/claude-desktop-mcpb/manifest.json` (user_config: backplane URL, CA bundle, client id, scopes).
- `reference/whats-new.md` — CHANGELOG headers and blocks for v0.32.0 (2026-09-02: Microsoft-estate connectors, destructive-delete tier + blast-radius preview, flight recorder, in-guest program execution, satellite write path, `result_query` REST/CLI parity, approve-only role), v0.31.0 (2026-08-27: plugin + `.mcpb` onramps, 25-tool default, approval verbs off MCP), v0.30.0 (2026-08-25: VCF governed bring-up, air-gapped installs, failed-run retry, migration-source connectors), v0.29.0 (2026-08-19: event ingestion, offender-sample, PostgreSQL 12 drop, curated read ops).

Every internal ticket number and internal link stripped from the added prose; no hostnames, IPs, lab code-names, or unreleased items presented as shipped; no seniority self-approval; no `docs/codebase/` raw-embeds.

## Verification

Verification: `mkdocs build --strict` passes locally (docs toolchain via `uv sync --locked --only-group docs`), exit 0, zero warnings, every link resolves.

Source: the internal public-surfaces refresh plan of 2026-09-03 (WP-6 / WP-9 copy parts: P-2 guide, P-4, P-11, P-21 What's-new links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
