### PR TITLE
docs(site): generated connector, MCP tool, and CLI reference pages with freshness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1839,27 +1839,32 @@ jobs:
         working-directory: backend
         run: uv sync --locked --all-groups
 
-      - name: Regenerate OpenAPI snapshot + Go client
+      - name: Regenerate OpenAPI snapshot + Go client + CLI reference doc
         # Run the same Make targets the maintainer runs so the drift check
         # compares like-for-like. snapshot-openapi writes cli/api/openapi.json
         # (downgrading OpenAPI 3.1->3.0 for oapi-codegen v2, see the script
         # header); generate (which depends on `tools`) rebuilds
-        # cli/internal/api/client.gen.go from it. The regen is idempotent,
-        # so a clean tree means the committed artifacts are already current.
+        # cli/internal/api/client.gen.go from it; cli-docs re-renders the
+        # committed docs-site/reference/cli.md from the cobra command tree
+        # (cmd/docgen, discovery disabled — deterministic + offline). All
+        # three regens are idempotent, so a clean tree means the committed
+        # artifacts are already current.
         working-directory: cli
         run: |
           make snapshot-openapi
           make generate
+          make cli-docs
 
-      - name: Fail if the committed snapshot / client are stale
-        # The snapshot + generated client are checked-in artifacts derived
-        # from the backend OpenAPI document. If a backend route changed
-        # without re-running the two targets above, the working tree now
-        # differs from HEAD — fail with the remediation command. Same
-        # rationale as a `go mod tidy` / `uv.lock --locked` drift gate.
+      - name: Fail if the committed snapshot / client / CLI reference are stale
+        # The snapshot, generated client, and CLI reference are checked-in
+        # artifacts derived from the backend OpenAPI document and the cobra
+        # command tree. If a backend route or a CLI command changed without
+        # re-running the targets above, the working tree now differs from
+        # HEAD — fail with the remediation command. Same rationale as a
+        # `go mod tidy` / `uv.lock --locked` drift gate.
         run: |
-          if ! git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go; then
-            echo "::error title=CLI API snapshot stale::cli/api/openapi.json and/or cli/internal/api/client.gen.go are out of date relative to the backend OpenAPI document. Run 'cd cli && make snapshot-openapi && make generate' and commit the result."
+          if ! git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go docs-site/reference/cli.md; then
+            echo "::error title=CLI artifacts stale::cli/api/openapi.json, cli/internal/api/client.gen.go, and/or docs-site/reference/cli.md are out of date. Run 'cd cli && make snapshot-openapi && make generate && make cli-docs' and commit the result."
             exit 1
           fi
 

--- a/backend/scripts/generate_reference_docs.py
+++ b/backend/scripts/generate_reference_docs.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Render the docs-site connector-inventory and MCP-tool reference pages.
+
+Two committed reference pages are generated from the in-process backend
+registries — no database, no live backplane:
+
+* ``docs-site/reference/connectors.md`` — the per-connector inventory,
+  from the v2 connector registry
+  (:func:`meho_backplane.connectors.registry.all_connectors_v2`) joined
+  with the committed connector-spec catalog
+  (:func:`meho_backplane.operations.ingest.catalog.load_catalog`).
+* ``docs-site/reference/mcp-tools.md`` — the MCP tool surface, from the
+  MCP tool registry (:data:`meho_backplane.mcp.registry._TOOLS`, populated
+  by :func:`~meho_backplane.mcp.registry.eager_import_mcp_modules`) plus
+  the human-only decision verbs
+  (:data:`meho_backplane.mcp.human_only.HUMAN_ONLY_MCP_TOOLS`).
+
+Both pages are **committed**, not built on the fly: the docs-site CI job
+installs only the ``docs`` dependency group (``uv sync --locked
+--only-group docs``, see ``.github/workflows/docs-site.yml``), so an
+mkdocs hook importing ``meho_backplane`` would drag the whole backend
+dependency tree into every docs build and tag deploy. Instead this script
+regenerates the pages inside the backend env, and the freshness gate in
+:mod:`tests.test_reference_docs_drift` fails the unit lane whenever a
+committed page and its registry disagree — the same committed-derived-
+artifact shape as ``docs-site/reference/maturity.md`` /
+``backend/scripts/generate_maturity_index.py`` and ``cli/api/openapi.json``.
+
+**Public-safety.** Tool descriptions are the agent-facing contract text
+and several carry bare ``#NNNN`` planning-issue references; :func:`_redact`
+strips every such token (and any parenthetical that only exists to hold
+one) so no internal ticket number reaches the public page. The pages
+never restate a maturity or readiness stage beyond what a public,
+machine-readable source states — connector *kind* comes only from the
+committed catalog (blank where the catalog is silent), and per-connector
+readiness is deliberately not asserted (no machine-readable public
+per-connector stage exists; the page links the maturity reference and the
+CHANGELOG ship-state convention instead).
+
+Run from ``backend/``::
+
+    uv run python scripts/generate_reference_docs.py
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from meho_backplane.connectors.registry import (
+    _eager_import_connectors,
+    all_connectors_v2,
+)
+from meho_backplane.features import FEATURE_MATURITY
+from meho_backplane.mcp.human_only import HUMAN_ONLY_MCP_TOOLS
+from meho_backplane.mcp.registry import ToolSurface, eager_import_mcp_modules
+from meho_backplane.operations.ingest.catalog import load_catalog
+
+#: Where the rendered pages land, relative to the repo root.
+CONNECTORS_RELPATH = "docs-site/reference/connectors.md"
+MCP_TOOLS_RELPATH = "docs-site/reference/mcp-tools.md"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Sentence-ending abbreviations the first-sentence extractor must not
+#: split on (``"... e.g. this"`` is one sentence, not two).
+_ABBREVIATIONS = ("e.g.", "i.e.", "etc.", "cf.", "vs.")
+
+# ---------------------------------------------------------------------------
+# Public-safety text helpers
+# ---------------------------------------------------------------------------
+
+
+#: Internal planning identifiers that must never reach a public page:
+#: GitHub issue numbers (``#3153``), Goal/Initiative/Task identifiers
+#: (``G11.2-T6``, ``G0.7``), and internal design-doc section markers
+#: (``§6``). Tool descriptions are the agent-facing contract text and
+#: several embed these; the published reference must strip them.
+_INTERNAL_REF = r"(?:#\d+|G\d[\dA-Za-z.]*(?:-T\d+)?|§\d+)"
+
+
+def _redact(text: str) -> str:
+    """Strip internal planning references from public-facing text.
+
+    Removes any parenthetical group that exists only to carry an internal
+    reference (``"(Initiative #3153)"``, ``"(G11.2-T6)"``), then any bare
+    internal-reference token left behind, then collapses the resulting
+    whitespace.
+    """
+    text = re.sub(rf"\s*\([^()]*{_INTERNAL_REF}[^()]*\)", "", text)
+    text = re.sub(rf"\s*{_INTERNAL_REF}", "", text)
+    return re.sub(r"\s{2,}", " ", text).strip()
+
+
+def _first_sentence(text: str) -> str:
+    """Return the first sentence of *text*, abbreviation-aware."""
+    for match in re.finditer(r"\.\s", text):
+        head = text[: match.start() + 1]
+        if not any(head.endswith(abbr) for abbr in _ABBREVIATIONS):
+            return head
+    return text
+
+
+def _one_liner(description: str) -> str:
+    """Reduce a full MCP tool description to a redacted one-line summary."""
+    body = re.sub(r"^\[(?:beta|experimental)\]\s*", "", description)
+    return _redact(_first_sentence(body.split("\n", 1)[0]))
+
+
+def _md_escape(text: str) -> str:
+    """Escape the pipe character so cell text cannot break a Markdown table."""
+    return text.replace("|", r"\|")
+
+
+def _generated_header(script_note: str, freshness_note: str) -> list[str]:
+    """The ``do not edit by hand`` banner every generated page carries."""
+    return [
+        "<!--",
+        "  GENERATED FILE — do not edit by hand.",
+        f"  Regenerate from backend/ with: {script_note}",
+        f"  {freshness_note}",
+        "-->",
+        "",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Connector inventory
+# ---------------------------------------------------------------------------
+
+
+def _catalog_kind_by_triple() -> dict[tuple[str, str, str], str]:
+    """Map each catalogued connector triple to ``"generic"`` / ``"typed"``.
+
+    The committed connector-spec catalog is the only DB-free public
+    statement of a connector's ingest kind: a row that names an
+    ``upstream`` spec URL or ships a bundled ``spec_resource`` is a
+    generic (spec-ingested) connector; a row with neither is a typed
+    (hand-coded) one. The mechanism-fixture row (``product="_fixture"``)
+    is not a shippable connector and is skipped.
+    """
+    kinds: dict[tuple[str, str, str], str] = {}
+    for entry in load_catalog().entries:
+        if entry.product == "_fixture":
+            continue
+        generic = bool(getattr(entry, "upstream", None)) or bool(
+            getattr(entry, "spec_resource", None)
+        )
+        kinds[(entry.product, entry.version, entry.impl_id)] = "generic" if generic else "typed"
+    return kinds
+
+
+def render_connector_index() -> str:
+    """Render the connector-inventory page from the v2 registry + catalog."""
+    _eager_import_connectors()
+    kinds = _catalog_kind_by_triple()
+
+    rows: list[tuple[str, str, str, str]] = []
+    for (product, version, impl_id), cls in all_connectors_v2().items():
+        # Skip the wildcard / v1-compat padding rows (empty version /
+        # impl_id): they are resolver-internal, never operator-addressable.
+        if not version or not impl_id:
+            continue
+        connector_id = f"{impl_id}-{version}"
+        supported = cls.supported_version_range or "—"
+        kind = kinds.get((product, version, impl_id), "—")
+        rows.append((product, connector_id, supported, kind))
+    rows.sort(key=lambda row: (row[0], row[1]))
+
+    lines = _generated_header(
+        "uv run python scripts/generate_reference_docs.py",
+        "The freshness gate in backend/tests/test_reference_docs_drift.py "
+        "fails CI when this page and the registry disagree.",
+    )
+    lines += [
+        "# Connector inventory",
+        "",
+        "Every connector MEHO can resolve a target to, generated from the "
+        "in-process connector registry. Each row is one registered "
+        "implementation: agents and operators drive them all through the "
+        "same governed surface — pick a connector, list its operation "
+        "groups, search operations, then call — so the vendor never leaks "
+        "into the tool names.",
+        "",
+        "MEHO has two kinds of connector, both first-class and "
+        "indistinguishable to an agent. **Generic** connectors are built by "
+        "ingesting a vendor's protocol spec (OpenAPI, GraphQL, WSDL, proto); "
+        "**typed** connectors are hand-coded against a vendor SDK or "
+        "transport where no usable spec exists. The **Kind** column is "
+        "populated only where MEHO's published connector-spec catalog states "
+        "it, and is blank otherwise — it is a property of how a connector's "
+        "operations are sourced, not something this table infers.",
+        "",
+        "| Connector | Product | Supported versions | Kind |",
+        "| --- | --- | --- | --- |",
+    ]
+    for product, connector_id, supported, kind in rows:
+        lines.append(
+            f"| `{_md_escape(connector_id)}` | `{_md_escape(product)}` "
+            f"| {_md_escape(supported)} | {kind} |"
+        )
+    lines += [
+        "",
+        "## Versions and how a connector is chosen",
+        "",
+        "**Supported versions** is the product-version range an "
+        "implementation advertises. Where a product has more than one "
+        "implementation — a modern and a legacy one, say — both are "
+        "registered and MEHO resolves the right one per target from the "
+        "target's fingerprint, so one estate spanning old and new versions "
+        "just works.",
+        "",
+        "## Maturity and readiness",
+        "",
+        "This inventory lists what is *registered*; it does not restate a "
+        "ship-state. Feature-level maturity — GA, beta, or experimental — is "
+        "published in the [feature maturity index](maturity.md). "
+        "Per-release, per-connector ship-state (dispatch + catalog, "
+        "loader-wired, or production-ready) is stated in the "
+        "[changelog](https://github.com/evoila/meho/blob/main/CHANGELOG.md) "
+        "under the connector release-notes convention. The two-connector "
+        "model is described in the "
+        "[architecture overview](../architecture.md).",
+        "",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# MCP tool surface
+# ---------------------------------------------------------------------------
+
+
+def _tool_maturity(feature: str | None) -> str:
+    """Resolve a tool's maturity tier from its owning feature key."""
+    if feature is None:
+        return "—"
+    return FEATURE_MATURITY[feature]["maturity"]
+
+
+def _tool_rows(definitions: list) -> list[tuple[str, str, str, str]]:
+    """Build ``(name, maturity, gating, summary)`` rows, sorted by name."""
+    rows: list[tuple[str, str, str, str]] = []
+    for defn in sorted(definitions, key=lambda d: d.name):
+        gating: list[str] = []
+        if defn.required_capability is not None:
+            gating.append(f"capability `{defn.required_capability}`")
+        if defn.required_addon_family is not None:
+            gating.append(f"add-on `{defn.required_addon_family}`")
+        rows.append(
+            (
+                defn.name,
+                _tool_maturity(defn.feature),
+                ", ".join(gating) or "—",
+                _one_liner(defn.description),
+            )
+        )
+    return rows
+
+
+def _tool_table(rows: list[tuple[str, str, str, str]]) -> list[str]:
+    """Render tool rows as a Markdown table."""
+    lines = [
+        "| Tool | Maturity | Extra gate | Summary |",
+        "| --- | --- | --- | --- |",
+    ]
+    for name, maturity, gating, summary in rows:
+        lines.append(f"| `{name}` | {maturity} | {gating} | {_md_escape(summary)} |")
+    return lines
+
+
+def render_mcp_tool_index() -> str:
+    """Render the MCP tool-surface page from the in-process tool registry."""
+    eager_import_mcp_modules()
+    from meho_backplane.mcp.registry import _TOOLS
+
+    definitions = [defn for defn, _handler in _TOOLS.values()]
+    working_default = [
+        d
+        for d in definitions
+        if d.surface is ToolSurface.WORKING and d.required_addon_family is None
+    ]
+    working_addon = [
+        d
+        for d in definitions
+        if d.surface is ToolSurface.WORKING and d.required_addon_family is not None
+    ]
+    operator = [d for d in definitions if d.surface is ToolSurface.OPERATOR]
+
+    lines = _generated_header(
+        "uv run python scripts/generate_reference_docs.py",
+        "The freshness gate in backend/tests/test_reference_docs_drift.py "
+        "fails CI when this page and the registry disagree.",
+    )
+    lines += [
+        "# MCP tool surface",
+        "",
+        "MEHO exposes one narrow, stable surface of meta-tools over MCP — "
+        "the same tools across every connector and product version, so an "
+        "agent never has to route through a vendor's thousands of "
+        "operations. The surface has three tiers, generated here from the "
+        "in-process tool registry.",
+        "",
+        "- **Working surface** — what every MCP session lists by default.",
+        "- **Operator plane** — governance tools a session lists only after "
+        "requesting the `mcp:admin` OAuth scope (request-only; the realm "
+        "grants it on ask).",
+        "- **Human-only** — decision verbs with no MCP path under any claim "
+        "set; a human makes these at the console or CLI.",
+        "",
+        "Each tool also exists as a `meho` CLI command against the same "
+        "dispatch path — see the [CLI reference](cli.md). Maturity labels "
+        "(`beta` / `experimental`) come from the "
+        "[feature maturity registry](maturity.md); a `—` maturity is "
+        "deliberately unclassified infrastructure.",
+        "",
+        "## Working surface",
+        "",
+        "The default agent surface. No elevation required.",
+        "",
+    ]
+    lines += _tool_table(_tool_rows(working_default))
+    if working_addon:
+        lines += [
+            "",
+            "### Add-on working tools",
+            "",
+            "Listed on the working surface only while a paired add-on "
+            "advertising the named family is active for the tenant; a "
+            "backplane with no such add-on paired never lists them.",
+            "",
+        ]
+        lines += _tool_table(_tool_rows(working_addon))
+    lines += [
+        "",
+        "## Operator plane (`mcp:admin`)",
+        "",
+        "Connector lifecycle, principals and grants, scheduler, sensors, "
+        "topology mutations, audit admin, and the other governance planes. "
+        "A session lists and can call these only when it holds the "
+        "`mcp:admin` scope.",
+        "",
+    ]
+    lines += _tool_table(_tool_rows(operator))
+    lines += [
+        "",
+        "## Human-only (no MCP path)",
+        "",
+        "Approving or rejecting a parked operation, and granting an agent a "
+        "privilege elevation, are human decisions with no agent-facing path "
+        "under any claim set. An agent that reaches for one is told where "
+        "the human makes the decision instead.",
+        "",
+        "| Tool | Where the decision is made |",
+        "| --- | --- |",
+    ]
+    for name in sorted(HUMAN_ONLY_MCP_TOOLS):
+        lines.append(f"| `{name}` | operator console approvals queue, or the `meho` CLI |")
+    lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    """Write both rendered reference pages."""
+    for relpath, render in (
+        (CONNECTORS_RELPATH, render_connector_index),
+        (MCP_TOOLS_RELPATH, render_mcp_tool_index),
+    ):
+        target = _REPO_ROOT / relpath
+        target.write_text(render(), encoding="utf-8")
+        print(f"wrote {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_reference_docs_drift.py
+++ b/backend/tests/test_reference_docs_drift.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Freshness + public-safety gate for the generated docs-site reference pages.
+
+``docs-site/reference/connectors.md`` and
+``docs-site/reference/mcp-tools.md`` are rendered from the in-process
+backend registries by ``backend/scripts/generate_reference_docs.py`` and
+**committed** (the docs-site CI job installs only the ``docs`` dependency
+group and must not import the backend — see
+``.github/workflows/docs-site.yml``). This module is the drift guard: a
+registry or catalog edit that changes either page without regeneration
+turns the unit lane red — the same committed-derived-artifact shape as
+``docs-site/reference/maturity.md`` /
+``backend/tests/test_maturity_surface_drift.py`` and
+``cli/api/openapi.json`` / its ``cli-api-snapshot-freshness`` CI job.
+
+It also asserts the rendered pages carry no internal planning reference
+(GitHub issue numbers, Goal/Task identifiers, internal design-doc section
+markers, or a private-repo slug) — the redaction contract the public
+surface depends on, checked against freshly rendered output so a new tool
+description that smuggles a reference in fails here even while the
+committed page stays "fresh".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from scripts.generate_reference_docs import (
+    CONNECTORS_RELPATH,
+    MCP_TOOLS_RELPATH,
+    render_connector_index,
+    render_mcp_tool_index,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Tokens that must never appear in a published reference page.
+_FORBIDDEN_PATTERNS = (
+    r"#\d+",  # GitHub issue / PR numbers
+    r"\bG\d[\dA-Za-z.]*-T\d+\b",  # Goal/Task identifiers, e.g. G11.2-T6
+    r"§\d+",  # internal design-doc section markers
+    r"meho-internal",  # private planning repo slug
+    r"evoila-bosnia",  # private org slug
+)
+
+
+@pytest.mark.parametrize(
+    ("relpath", "render"),
+    [
+        (CONNECTORS_RELPATH, render_connector_index),
+        (MCP_TOOLS_RELPATH, render_mcp_tool_index),
+    ],
+)
+def test_reference_page_is_fresh(relpath: str, render) -> None:
+    """The committed page must equal freshly rendered output."""
+    committed = (_REPO_ROOT / relpath).read_text(encoding="utf-8")
+    assert committed == render(), (
+        f"{relpath} is stale relative to the backend registry. Regenerate "
+        "with `uv run python scripts/generate_reference_docs.py` from "
+        "backend/ and commit the result."
+    )
+
+
+@pytest.mark.parametrize(
+    ("relpath", "render"),
+    [
+        (CONNECTORS_RELPATH, render_connector_index),
+        (MCP_TOOLS_RELPATH, render_mcp_tool_index),
+    ],
+)
+def test_reference_page_carries_no_internal_reference(relpath: str, render) -> None:
+    """No internal planning reference may leak into a public reference page."""
+    rendered = render()
+    leaks = {
+        pattern: re.findall(pattern, rendered)
+        for pattern in _FORBIDDEN_PATTERNS
+        if re.search(pattern, rendered)
+    }
+    assert not leaks, (
+        f"{relpath} would leak internal references {leaks}; extend "
+        "`_redact` / `_INTERNAL_REF` in "
+        "backend/scripts/generate_reference_docs.py to strip them."
+    )

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -6,7 +6,7 @@
 # (which delegates here) or run targets directly from this directory.
 
 .PHONY: help build test lint tidy install clean generate snapshot-openapi tools \
-        release-check release-dry-run goreleaser
+        cli-docs release-check release-dry-run goreleaser
 
 # Version metadata gets baked into the binary via -ldflags -X.
 # Override on the command line for release builds:
@@ -86,6 +86,9 @@ $(OAPI_CODEGEN):
 
 generate: tools ## Regenerate the typed API client from api/openapi.json.
 	$(OAPI_CODEGEN) --config api/oapi.config.yaml api/openapi.json
+
+cli-docs: ## Regenerate the committed docs-site CLI reference from the command tree.
+	go run ./cmd/docgen ../docs-site/reference/cli.md
 
 snapshot-openapi: ## Re-snapshot api/openapi.json from the running backplane source.
 	@command -v uv >/dev/null 2>&1 || { echo "snapshot-openapi requires uv (see backend/README.md)"; exit 2; }

--- a/cli/cmd/docgen/main.go
+++ b/cli/cmd/docgen/main.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Command docgen renders the docs-site CLI reference page
+// (docs-site/reference/cli.md) from the meho cobra command tree.
+//
+// It is NOT part of the shipped meho binary (goreleaser builds only
+// ./cmd/meho); it is a build tool driven by `make cli-docs`, and its
+// output is committed. The freshness gate in the `cli-api-snapshot-
+// freshness` CI job regenerates it and fails on a working-tree diff —
+// the same committed-derived-artifact shape as cli/api/openapi.json.
+//
+// The command tree is built with backplane discovery disabled
+// (cmd.NewRootCmdForDocs), so generation is deterministic and offline:
+// the page documents the built-in verbs, and a connected backplane may
+// additionally surface discovered operations at runtime.
+//
+// Public-safety: cobra help strings are operator-facing but a few embed
+// internal planning references (GitHub issue numbers, Goal/Task IDs,
+// design-doc section markers). redact() strips them so none reach the
+// published page — the Go twin of _redact in
+// backend/scripts/generate_reference_docs.py.
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/evoila/meho/cli/internal/cmd"
+)
+
+// defaultOutPath is relative to cli/ (where `make cli-docs` runs), so it
+// resolves to the repo's docs-site tree.
+const defaultOutPath = "../docs-site/reference/cli.md"
+
+// Public-safety redaction patterns. Cobra help strings are operator-facing
+// but a few embed internal planning references — GitHub issue numbers
+// (#3153), Goal/Task identifiers (G11.2-T6, G0.7), design-doc section
+// markers (§5) — or lab-specific example coordinates (a `.lab` hostname,
+// an IPv4 literal). None may reach the published page.
+var (
+	internalRefParen = regexp.MustCompile(`\s*\([^()]*(?:#\d+|G\d[\dA-Za-z.]*(?:-T\d+)?|§\d+)[^()]*\)`)
+	internalRefBare  = regexp.MustCompile(`\s*(?:#\d+|G\d[\dA-Za-z.]*(?:-T\d+)?|§\d+)`)
+	labHostname      = regexp.MustCompile(`\b[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*\.lab\b`)
+	ipv4Literal      = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	multiSpace       = regexp.MustCompile(`[ \t]{2,}`)
+)
+
+// redact strips internal planning references and lab-specific example
+// coordinates from operator-facing text.
+func redact(text string) string {
+	text = internalRefParen.ReplaceAllString(text, "")
+	text = internalRefBare.ReplaceAllString(text, "")
+	text = labHostname.ReplaceAllString(text, "example.com")
+	text = ipv4Literal.ReplaceAllString(text, "<ip>")
+	lines := strings.Split(text, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(multiSpace.ReplaceAllString(ln, " "), " ")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// documented reports whether a command belongs in the reference: not
+// hidden, and not cobra's auto-added help / completion scaffolding.
+func documented(c *cobra.Command) bool {
+	if c.Hidden || c.Name() == "help" || c.Name() == "completion" {
+		return false
+	}
+	return c.IsAvailableCommand() || c.HasAvailableSubCommands()
+}
+
+func sortedSubcommands(c *cobra.Command) []*cobra.Command {
+	subs := make([]*cobra.Command, 0, len(c.Commands()))
+	for _, sub := range c.Commands() {
+		if documented(sub) {
+			subs = append(subs, sub)
+		}
+	}
+	sort.Slice(subs, func(i, j int) bool { return subs[i].Name() < subs[j].Name() })
+	return subs
+}
+
+// localFlagLines renders a command's own flags (skipping the globals and
+// help), one bullet each, sorted by name (pflag VisitAll is sorted).
+func localFlagLines(c *cobra.Command) []string {
+	var lines []string
+	c.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		switch f.Name {
+		case "help", "config", "verbose":
+			return
+		}
+		name := "`--" + f.Name
+		if f.Shorthand != "" {
+			name += "`, `-" + f.Shorthand
+		}
+		name += "`"
+		usage := redact(f.Usage)
+		lines = append(lines, fmt.Sprintf("- %s — %s", name, usage))
+	})
+	return lines
+}
+
+// headingPrefix caps Markdown heading depth at level 6.
+func headingPrefix(depth int) string {
+	level := depth + 2 // top-level command == "##"
+	if level > 6 {
+		level = 6
+	}
+	return strings.Repeat("#", level)
+}
+
+func renderCommand(sb *strings.Builder, c *cobra.Command, depth int) {
+	fmt.Fprintf(sb, "%s `%s`\n\n", headingPrefix(depth), c.CommandPath())
+	if short := redact(c.Short); short != "" {
+		fmt.Fprintf(sb, "%s\n\n", short)
+	}
+	// The multi-paragraph `Long` help is deliberately omitted: it carries
+	// contributor-facing jargon and lab-recipe examples not suited to the
+	// public reference, and mechanical ref-redaction of mid-sentence
+	// references leaves grammar artifacts. The usage line + flags below
+	// document the command shape P-10 needs.
+	fmt.Fprintf(sb, "```\n%s\n```\n\n", c.UseLine())
+	if flags := localFlagLines(c); len(flags) > 0 {
+		fmt.Fprintf(sb, "%s\n\n", strings.Join(flags, "\n"))
+	}
+	for _, sub := range sortedSubcommands(c) {
+		renderCommand(sb, sub, depth+1)
+	}
+}
+
+func render(root *cobra.Command) string {
+	var sb strings.Builder
+	sb.WriteString("<!--\n")
+	sb.WriteString("  GENERATED FILE — do not edit by hand.\n")
+	sb.WriteString("  Regenerate from cli/ with: make cli-docs\n")
+	sb.WriteString("  Source of truth: the meho cobra command tree (cli/internal/cmd).\n")
+	sb.WriteString("  Freshness is enforced by the cli-api-snapshot-freshness CI job.\n")
+	sb.WriteString("-->\n\n")
+	sb.WriteString("# CLI reference\n\n")
+	sb.WriteString("`meho` is the operator CLI for the MEHO governance backplane. " +
+		"It dispatches through the same policy, audit, and approval path as the " +
+		"MCP tool surface — the CLI and the agent are dual front-ends on one " +
+		"backplane, not wrappers of each other.\n\n")
+	sb.WriteString("This page is generated from the built-in command tree. Further " +
+		"operations are discovered from a connected backplane at runtime, so a " +
+		"logged-in `meho` may list more commands than appear here.\n\n")
+	sb.WriteString("Every command accepts the global flags below.\n\n")
+	sb.WriteString("## Global flags\n\n")
+	sb.WriteString("- `--config` — path to the meho config file " +
+		"(default: `$XDG_CONFIG_HOME/meho/config.json`).\n")
+	sb.WriteString("- `--verbose`, `-v` — enable verbose output.\n\n")
+	for _, sub := range sortedSubcommands(root) {
+		renderCommand(&sb, sub, 0)
+	}
+	out := strings.TrimRight(sb.String(), "\n") + "\n"
+	return out
+}
+
+func main() {
+	outPath := defaultOutPath
+	if len(os.Args) > 1 && os.Args[1] != "" {
+		outPath = os.Args[1]
+	}
+	root := cmd.NewRootCmdForDocs()
+	if err := os.WriteFile(outPath, []byte(render(root)), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "docgen: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %s\n", outPath)
+}

--- a/cli/internal/cmd/docgen.go
+++ b/cli/internal/cmd/docgen.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+// NewRootCmdForDocs builds the full static command tree with backplane
+// discovery disabled, for offline documentation generation.
+//
+// The shipped `meho` binary never calls this — the docgen tool under
+// cmd/docgen does, to render docs-site/reference/cli.md from the local
+// command set. Discovery is disabled (setDynamicRegistrar to a no-op) so
+// generation is deterministic and needs no live backplane: the committed
+// reference documents the built-in verbs, and a connected backplane may
+// additionally surface discovered operations at runtime.
+func NewRootCmdForDocs() *cobra.Command {
+	restore := setDynamicRegistrar(func(*cobra.Command) {})
+	defer restore()
+	return newRootCmd()
+}

--- a/docs-site/reference/cli.md
+++ b/docs-site/reference/cli.md
@@ -1,0 +1,5512 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate from cli/ with: make cli-docs
+  Source of truth: the meho cobra command tree (cli/internal/cmd).
+  Freshness is enforced by the cli-api-snapshot-freshness CI job.
+-->
+
+# CLI reference
+
+`meho` is the operator CLI for the MEHO governance backplane. It dispatches through the same policy, audit, and approval path as the MCP tool surface — the CLI and the agent are dual front-ends on one backplane, not wrappers of each other.
+
+This page is generated from the built-in command tree. Further operations are discovered from a connected backplane at runtime, so a logged-in `meho` may list more commands than appear here.
+
+Every command accepts the global flags below.
+
+## Global flags
+
+- `--config` — path to the meho config file (default: `$XDG_CONFIG_HOME/meho/config.json`).
+- `--verbose`, `-v` — enable verbose output.
+
+## `meho admin`
+
+Deployer-side install-time provisioning verbs
+
+```
+meho admin
+```
+
+### `meho admin keycloak`
+
+Provision Keycloak realm resources for the MEHO auth onramp
+
+```
+meho admin keycloak
+```
+
+#### `meho admin keycloak bootstrap-clients`
+
+Idempotently provision the public CLI + MCP clients in a Keycloak realm
+
+```
+meho admin keycloak bootstrap-clients [flags]
+```
+
+- `--admin-group-name` — top-level group the admin user joins (drives group-gated tools)
+- `--admin-user-email` — optional email for the new admin user
+- `--admin-user-username` — username of the admin user to provision (required unless --skip-user-provisioning)
+- `--admin-username` — master-realm admin username (or set KEYCLOAK_ADMIN_USER)
+- `--backplane-audience` — audience claim the `audience-meho-backplane` mapper emits (matches chart's `config.keycloakAudience`)
+- `--cli-client-id` — public client_id for the device-code flow (matches chart's `config.keycloakCliClientId`)
+- `--cli-offline-access` — opt the device-code CLI client into the long-lived offline-token path: assign `offline_access` as an optional client scope and bound its per-client offline-session idle timeout to the given number of seconds. Off by default. A bare `--cli-offline-access` uses 172800 seconds (48h); to pass a custom value use the equals form, e.g. `--cli-offline-access=86400`. Pairs with `meho login --offline`. Security: this enables a long-lived refresh token on the operator's disk — keep the bound tight and prefer the OS keyring for storage
+- `--dry-run` — print what would be provisioned without making any API calls
+- `--insecure-skip-tls-verify` — skip TLS verification when calling Keycloak (one-time bootstrap convenience; do not use in CI against untrusted Keycloaks)
+- `--keycloak-base-url` — Keycloak base URL, e.g. https://keycloak.example.com
+- `--mcp-client-id` — public client_id for the MCP browser-flow client
+- `--mcp-redirect-uri` — redirect URI(s) for the MCP browser-flow client (default: loopback localhost + <ip>, any port/path)
+- `--mcp-resource-uri` — audience the `meho-mcp-audience` mapper emits, e.g. https://meho.example.com/mcp (no trailing slash)
+- `--mcp-web-origin` — CORS web origin(s) for the MCP browser-flow client (default: `+` — allow the redirect-URI origins)
+- `--realm` — target realm name (NOT the master realm — that's where the admin token is minted)
+- `--skip-user-provisioning` — skip the group + user creation steps (use when users are externally-managed via federation / SCIM)
+- `--tenant-id` — hardcoded value for the `tenant_id` claim mapper (UUID; the lab convention is one tenant per realm)
+- `--tenant-role` — hardcoded value for the `tenant_role` claim mapper (one of tenant_admin / operator / read_only)
+
+## `meho agent`
+
+Manage agent definitions (list / show / create / edit / delete)
+
+```
+meho agent
+```
+
+### `meho agent create`
+
+Create one agent definition (tenant_admin)
+
+```
+meho agent create <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--disabled` — create the definition parked (enabled=false; default is enabled)
+- `--identity-ref` — reference to the agent principal whose permissions bound the toolset
+- `--json` — emit raw AgentDefinitionRead JSON instead of the human summary
+- `--model-tier` — logical model tier: standard | fast | deep
+- `--output-schema` — optional structured-output JSON Schema as a JSON object: inline JSON, @<path>, or @-
+- `--system-prompt` — the agent's system prompt
+- `--toolset` — allowed-tools spec as a JSON object: inline JSON, @<path>, or @- (default {})
+- `--turn-budget` — max model turns the runtime allows (1..1000)
+
+### `meho agent delete`
+
+Delete one agent definition by name (tenant_admin)
+
+```
+meho agent delete <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable success envelope instead of the human line
+
+### `meho agent edit`
+
+Apply a partial update to one agent definition (tenant_admin)
+
+```
+meho agent edit <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--disabled` — disable (park) the definition
+- `--enabled` — enable the definition
+- `--identity-ref` — new identity reference
+- `--json` — emit raw AgentDefinitionRead JSON instead of the human summary
+- `--model-tier` — new model tier: standard | fast | deep
+- `--output-schema` — new output schema as a JSON object: inline JSON, @<path>, or @-
+- `--system-prompt` — new system prompt
+- `--toolset` — new toolset spec as a JSON object: inline JSON, @<path>, or @-
+- `--turn-budget` — new turn budget (1..1000)
+
+### `meho agent grant`
+
+Manage agent permission grants (tenant_admin)
+
+```
+meho agent grant
+```
+
+#### `meho agent grant create`
+
+Create a permission grant for an agent principal (tenant_admin)
+
+```
+meho agent grant create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--expires` — ISO 8601 UTC expiry for a time-bounded elevation, e.g. 2026-05-25T18:00:00Z
+- `--json` — emit raw AgentGrantRead JSON
+- `--op` — fnmatch op-pattern, e.g. '*' or 'vault.kv.*' (required)
+- `--principal` — JWT sub of the agent principal (required)
+- `--target` — target UUID or '*' for any target (default: any)
+- `--verdict` — auto-execute | needs-approval | deny (required)
+
+#### `meho agent grant elevate`
+
+Create a time-bounded elevation grant (tenant_admin)
+
+```
+meho agent grant elevate [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--expires` — required ISO 8601 UTC expiry, e.g. 2026-06-01T00:00:00Z
+- `--json` — emit raw AgentGrantRead JSON
+- `--op` — fnmatch op-pattern (required)
+- `--principal` — JWT sub of the agent principal (required)
+- `--target` — target UUID or '*' for any target (optional)
+- `--verdict` — auto-execute | needs-approval | deny (required)
+
+#### `meho agent grant list`
+
+List agent permission grants in your tenant (tenant_admin)
+
+```
+meho agent grant list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--include-expired` — include expired elevations (default: active only)
+- `--json` — emit raw AgentGrantListResponse JSON
+- `--limit` — max grants per page (1..500, server default 100)
+- `--offset` — page offset (default 0)
+- `--principal` — filter by agent principal JWT sub
+
+#### `meho agent grant revoke`
+
+Revoke a permission grant by id (tenant_admin)
+
+```
+meho agent grant revoke <grant-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable result JSON
+
+#### `meho agent grant show`
+
+Fetch one permission grant by id (tenant_admin)
+
+```
+meho agent grant show <grant-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--json` — emit raw AgentGrantRead JSON
+
+### `meho agent list`
+
+List agent definitions in your tenant
+
+```
+meho agent list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AgentDefinitionListResponse JSON instead of the human table
+- `--limit` — max definitions per page (1..500, server default 100 when omitted)
+- `--offset` — offset into the name-sorted result set (default 0)
+
+### `meho agent run`
+
+Run an agent (sync block-and-return, or --async for a handle)
+
+```
+meho agent run <name> [flags]
+```
+
+- `--async` — return a run handle immediately instead of blocking for the result
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--input` — the user prompt to run the agent on (required)
+- `--json` — emit the raw run response JSON instead of the human summary
+- `--work-ref` — external change-ticket reference to bind the run to; filterable via `meho agent run-list --work-ref`
+
+### `meho agent run-cancel`
+
+Cancel a non-terminal agent run by handle
+
+```
+meho agent run-cancel <handle> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw AgentRunSummaryResponse JSON instead of the human summary
+
+### `meho agent run-events`
+
+Stream a fresh agent run's events over SSE
+
+```
+meho agent run-events <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--input` — the user prompt to run the agent on (required)
+- `--json` — emit one raw JSON object per event instead of a compact human line
+
+### `meho agent run-list`
+
+List agent runs (filter by --work-ref / --status)
+
+```
+meho agent run-list [flags]
+```
+
+- `--agent-name` — filter by agent definition name (exact match); an unknown name returns an empty list
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw []AgentRunSummaryResponse JSON instead of the table
+- `--limit` — max runs per page (1..500, server default 100 when omitted)
+- `--offset` — rows to skip for paging into the result set (default 0)
+- `--status` — filter by lifecycle status: pending, running, awaiting_approval, succeeded, failed, or cancelled
+- `--work-ref` — filter by external change-ticket reference
+
+### `meho agent run-status`
+
+Poll an agent run's status by handle
+
+```
+meho agent run-status <handle> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw AgentRunStatusResponse JSON instead of the human summary
+
+### `meho agent show`
+
+Fetch one agent definition by name
+
+```
+meho agent show <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AgentDefinitionRead JSON instead of the human summary
+
+## `meho agent-principal`
+
+Manage agent principals (register / list / revoke)
+
+```
+meho agent-principal
+```
+
+### `meho agent-principal list`
+
+List agent principals in your tenant
+
+```
+meho agent-principal list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--include-revoked` — include revoked principals in the listing (default false)
+- `--json` — emit raw ListResponse JSON instead of the human table
+
+### `meho agent-principal register`
+
+Register a new agent principal (tenant_admin)
+
+```
+meho agent-principal register <name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AgentPrincipalRead JSON instead of the human summary
+- `--owner-sub` — OIDC sub of the kill-switch owner (defaults to the caller's sub)
+
+### `meho agent-principal revoke`
+
+Revoke an agent principal — kill switch (tenant_admin)
+
+```
+meho agent-principal revoke <name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AgentPrincipalRead JSON instead of the human summary
+
+## `meho approvals`
+
+Manage approval requests (list / show / approve / reject)
+
+```
+meho approvals
+```
+
+### `meho approvals approve`
+
+Approve a pending approval request
+
+```
+meho approvals approve <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--json` — emit raw JSON response instead of summary
+- `--reason` — optional rationale for the approval
+
+### `meho approvals list`
+
+List approval requests in your tenant
+
+```
+meho approvals list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--json` — emit raw JSON array instead of the human table
+- `--limit` — max requests per page (1..500, server default 50 when omitted)
+- `--offset` — offset into the result set (default 0)
+- `--status` — filter by status: pending, approved, rejected, expired (default: all)
+- `--work-ref` — filter by external change-ticket reference, exact match
+
+### `meho approvals reject`
+
+Reject a pending approval request
+
+```
+meho approvals reject <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--json` — emit raw JSON response instead of summary
+- `--reason` — optional rationale for the rejection
+
+### `meho approvals show`
+
+Inspect a pending approval request
+
+```
+meho approvals show <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from `meho login`)
+- `--json` — emit raw JSON instead of the human-readable view
+
+## `meho argocd`
+
+Pre-scoped CLI verbs for the argocd-api-3.x connector
+
+```
+meho argocd
+```
+
+### `meho argocd app`
+
+ArgoCD Application sub-verbs (list, get, diff, resource-tree; sync, rollback, set, refresh, delete)
+
+```
+meho argocd app
+```
+
+#### `meho argocd app delete`
+
+Delete an ArgoCD Application with cascade (approval-gated)
+
+```
+meho argocd app delete [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--no-cascade` — leave managed cluster resources orphaned
+- `--propagation-policy` — deletion propagation policy (foreground|background|orphan)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app diff`
+
+Show the desired-vs-live drift for an ArgoCD Application
+
+```
+meho argocd app diff [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--project` — optional AppProject to scope the lookup
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app get`
+
+Read one ArgoCD Application's full spec and status by name
+
+```
+meho argocd app get [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--project` — optional AppProject to scope the lookup
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app list`
+
+List ArgoCD Applications with their sync and health status
+
+```
+meho argocd app list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--project` — filter to one or more AppProjects (repeatable)
+- `--selector` — Kubernetes label selector (e.g. team=payments,env=prod)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app refresh`
+
+Force an immediate reconcile of an ArgoCD Application (approval-gated)
+
+```
+meho argocd app refresh [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--no-hard` — do a normal refresh instead of a hard refresh
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app resource-tree`
+
+Show an ArgoCD Application's reconciled resource tree
+
+```
+meho argocd app resource-tree [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--project` — optional AppProject to scope the lookup
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app rollback`
+
+Roll an ArgoCD Application back to a prior deployed revision (approval-gated)
+
+```
+meho argocd app rollback [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--dry-run` — render + validate without applying
+- `--id` — deployment history id to roll back to (required)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--poll-timeout` — seconds to poll operationState (default 300 backend-side)
+- `--prune` — delete resources no longer defined at that revision
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app set`
+
+Update an ArgoCD Application's spec / target revision (approval-gated)
+
+```
+meho argocd app set [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--no-validate` — skip server-side spec validation
+- `--spec-file` — JSON file with the full ApplicationSpec (required)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd app sync`
+
+Sync an ArgoCD Application and wait for a terminal phase (approval-gated)
+
+```
+meho argocd app sync [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--dry-run` — render + validate without applying
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — the Application's metadata.name (required)
+- `--poll-timeout` — seconds to poll operationState (default 300 backend-side)
+- `--prune` — delete resources no longer defined in Git
+- `--revision` — Git revision to sync to (default: app target revision)
+- `--target` — target slug to dispatch against (required)
+
+### `meho argocd appproject`
+
+ArgoCD AppProject sub-verbs (list; create, update)
+
+```
+meho argocd appproject
+```
+
+#### `meho argocd appproject create`
+
+Create an ArgoCD AppProject (approval-gated)
+
+```
+meho argocd appproject create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--project-file` — JSON file with the AppProject object (required)
+- `--target` — target slug to dispatch against (required)
+- `--upsert` — update the project if it already exists
+
+#### `meho argocd appproject list`
+
+List ArgoCD AppProjects and their source/destination allow-lists
+
+```
+meho argocd appproject list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho argocd appproject update`
+
+Update an ArgoCD AppProject (approval-gated)
+
+```
+meho argocd appproject update [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--project-file` — JSON file with the AppProject object (required)
+- `--target` — target slug to dispatch against (required)
+
+### `meho argocd repo`
+
+ArgoCD repository sub-verbs (list)
+
+```
+meho argocd repo
+```
+
+#### `meho argocd repo list`
+
+List configured ArgoCD repositories and their connection state
+
+```
+meho argocd repo list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+## `meho audit`
+
+Query the MEHO audit log (query / recent / show / who-touched / my-recent / replay / reflex)
+
+```
+meho audit
+```
+
+### `meho audit my-recent`
+
+Show your own recent audit activity
+
+```
+meho audit my-recent [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw {items, next_cursor} envelope JSON instead of the human table
+- `--limit` — max rows (1..1000, server default 100 when omitted)
+- `--since` — earliest occurred_at; defaults server-side to 24h when omitted
+
+### `meho audit query`
+
+Query the audit log with arbitrary filter combinations
+
+```
+meho audit query [flags]
+```
+
+- `--audit-id` — exact audit-id lookup (UUID)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cursor` — opaque forward-pagination cursor from a prior page's NEXT line
+- `--json` — emit raw AuditQueryResult JSON instead of the human table
+- `--limit` — max rows per page (1..1000, server default 100 when omitted)
+- `--op-class` — narrow to one op-class (read|write|credential_read|audit_query|other)
+- `--op-id` — narrow to one op-id (glob with * wildcards)
+- `--parent-audit-id` — narrow to the composite-op subtree under this audit-id
+- `--principal` — narrow to one operator (JWT subject; partial-match supported)
+- `--result-status` — narrow to one result-status (ok|error|denied)
+- `--session-id` — narrow to one agent session (UUID); the flat companion to `meho audit replay`
+- `--since` — earliest occurred_at; accepts 24h / 7d / 30m / 2w shorthand or ISO-8601
+- `--target` — narrow to one target (name or alias; server-side resolution)
+- `--until` — latest occurred_at; accepts the same shorthand as --since
+- `--work-ref` — narrow to one external change-ticket reference — "show every write authorised by ticket X"
+
+### `meho audit recent`
+
+Show the most recent audit rows in the operator's tenant
+
+```
+meho audit recent [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw QueryResult JSON instead of the human table
+- `--limit` — max rows (1..1000, server default 100 when omitted)
+
+### `meho audit reflex`
+
+Read reflex-adoption KPIs (read-before-act / announce coverage / write-back)
+
+```
+meho audit reflex [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw ReflexReport on stdout instead of the human table
+- `--since` — window start; accepts relative (`7d`, `24h`) or ISO-8601 date (`2026-08-01`)
+- `--tenant` — tenant UUID filter (platform_admin only; other tokens get a 403)
+- `--until` — window end; same grammar as --since; defaults to now when omitted
+
+### `meho audit replay`
+
+Replay one agent session as a parent/child audit tree
+
+```
+meho audit replay <session-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AuditReplayResult JSON instead of the human ASCII tree
+- `--max-depth` — fold tree nodes deeper than this level (rendering only; default 20)
+
+### `meho audit show`
+
+Fetch a single audit row by id
+
+```
+meho audit show <audit-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho audit who-touched`
+
+Show every audit row that touched a specific target
+
+```
+meho audit who-touched <target> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AuditQueryResult JSON instead of the human table
+- `--limit` — max rows (1..1000, server default 100 when omitted)
+- `--since` — earliest occurred_at; defaults server-side to 24h when omitted
+
+## `meho automation`
+
+Inspect the paired automation add-on surface
+
+```
+meho automation
+```
+
+### `meho automation list`
+
+List the paired automation add-on surface
+
+```
+meho automation list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+
+## `meho bind9`
+
+Pre-scoped CLI verbs for the bind9-ssh-9.x connector
+
+```
+meho bind9
+```
+
+### `meho bind9 about`
+
+Show bind9 vendor / product / version / OS for a target
+
+```
+meho bind9 about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required for ops that read a target)
+
+### `meho bind9 config`
+
+bind9 config verbs (show / apply-views / apply-file / backup / reload)
+
+```
+meho bind9 config
+```
+
+#### `meho bind9 config apply-file`
+
+Replace a bind9 config fragment from a local file (atomic)
+
+```
+meho bind9 config apply-file <name> <local-src> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho bind9 config apply-views`
+
+Apply a views fragment + zonefile tree (atomic; rollback on failure)
+
+```
+meho bind9 config apply-views <local-views.conf> <zones-dir> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--primary-path` — which staged file's content the audit row captures (defaults to first key sorted)
+- `--target` — target slug to dispatch against
+- `--verify-fqdn` — sample FQDN to dig-verify post-reload (optional)
+
+#### `meho bind9 config backup`
+
+Snapshot /etc/bind/ into /var/backups/meho-bind9/<timestamp>-<tag>.tar.gz
+
+```
+meho bind9 config backup [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--tag` — friendly tag embedded in the backup filename ([A-Za-z0-9._-]{1,64})
+- `--target` — target slug to dispatch against
+
+#### `meho bind9 config reload`
+
+rndc reload — re-read the active bind9 configuration
+
+```
+meho bind9 config reload [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho bind9 config show`
+
+Read a bind9 config file from the target
+
+```
+meho bind9 config show <file> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho bind9 record`
+
+bind9 record verbs (get / add / remove)
+
+```
+meho bind9 record
+```
+
+#### `meho bind9 record add`
+
+Add an A/AAAA record (atomic-apply; rollback on failure)
+
+```
+meho bind9 record add <fqdn> <ip> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+- `--type` — record type (A / AAAA). Omitted → handler default (A).
+- `--view` — split-horizon view owning the zone. Required only when the zone is in multiple views.
+- `--zone` — owning zone (e.g. example.com). Omitted → handler resolves via longest-suffix match.
+
+#### `meho bind9 record get`
+
+Resolve an FQDN through the local bind9 (dig @localhost)
+
+```
+meho bind9 record get <fqdn> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+- `--type` — record type (A / AAAA / CNAME / MX / TXT). Omitted → handler default (A).
+
+#### `meho bind9 record remove`
+
+Remove the A/AAAA records at an FQDN (atomic-apply)
+
+```
+meho bind9 record remove <fqdn> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+- `--view` — split-horizon view owning the zone. Required only when the zone is in multiple views.
+- `--zone` — owning zone (e.g. example.com). Omitted → handler resolves via longest-suffix match.
+
+### `meho bind9 zone`
+
+bind9 zone verbs (list / read)
+
+```
+meho bind9 zone
+```
+
+#### `meho bind9 zone list`
+
+List zones declared in the active bind9 configuration
+
+```
+meho bind9 zone list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho bind9 zone read`
+
+Read the records of a zone (name / ttl / class / type / rdata rows)
+
+```
+meho bind9 zone read <zone> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+## `meho broadcast`
+
+Manage broadcast-detail overrides (overrides list / set / remove)
+
+```
+meho broadcast
+```
+
+### `meho broadcast overrides`
+
+List, create, and delete broadcast-detail override rules
+
+```
+meho broadcast overrides
+```
+
+#### `meho broadcast overrides list`
+
+List broadcast-detail override rules for the operator's tenant
+
+```
+meho broadcast overrides list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw JSON array instead of the human table
+- `--op-id-pattern` — exact-match filter on op_id_pattern (the rule's stored pattern, not a glob match)
+
+#### `meho broadcast overrides remove`
+
+Delete a broadcast-detail override rule by id
+
+```
+meho broadcast overrides remove <override-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit JSON error envelope on failure (success is still silent)
+
+#### `meho broadcast overrides set`
+
+Create a broadcast-detail override rule
+
+```
+meho broadcast overrides set [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--detail` — override detail (full | aggregate)
+- `--json` — emit the created row as JSON instead of the human summary
+- `--op-id-pattern` — op_id glob (e.g. "vault.kv.*" or "k8s.configmap.info"); regex chars are rejected
+- `--scope-field` — scope field (one of: namespace, target_name); leave empty for an op-wide rule
+- `--scope-value` — scope value (e.g. "kube-system"); required when --scope-field is set
+
+## `meho connector`
+
+spec-ingestion + review workflow (ingest / list / catalog / review / edit / enable / enable-reads / disable)
+
+```
+meho connector
+```
+
+### `meho connector catalog`
+
+Curated connector-spec catalog (the raw-REST ingest on-ramp)
+
+```
+meho connector catalog
+```
+
+#### `meho connector catalog list`
+
+List curated connector-spec catalog entries
+
+```
+meho connector catalog list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+
+### `meho connector disable`
+
+Flip an enabled connector back to disabled (rollback; per-op overrides preserved)
+
+```
+meho connector disable <connector_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the interactive confirmation prompt
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho connector edit-group`
+
+Patch a group's when_to_use hint or display name
+
+```
+meho connector edit-group <connector_id> <group_key> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+- `--name` — replacement display name; supports `@<path>` to read from a file
+- `--when-to-use` — replacement when_to_use text; supports `@<path>` to read from a file
+
+### `meho connector edit-op`
+
+Patch a per-op override (custom_description, safety, approval, enabled)
+
+```
+meho connector edit-op <connector_id> <op_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--custom-description` — replacement custom_description; supports `@<path>` to read from a file
+- `--disable` — set is_enabled=false on this op
+- `--enable` — set is_enabled=true on this op
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+- `--no-requires-approval` — clear the requires_approval flag
+- `--requires-approval` — mark the op as requiring an approval workflow
+- `--safety` — replacement safety_level: safe | caution | dangerous
+
+### `meho connector enable`
+
+Flip a staged or disabled connector to enabled (operations dispatchable)
+
+```
+meho connector enable <connector_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the interactive confirmation prompt
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho connector enable-reads`
+
+Bulk-enable every read-class (GET/HEAD) op; writes stay default-deny
+
+```
+meho connector enable-reads <connector_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the interactive confirmation prompt
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho connector ingest`
+
+Ingest one or more vendor specs into a new connector (staged state)
+
+```
+meho connector ingest [flags]
+```
+
+- `--auth-scheme` — manual mode: select a named auth scheme (closed catalog) so the connector is stamped DISPATCHABLE (a profiled connector, still staged behind review) instead of a non-dispatchable shim. One of: basic, static_header, session_login, session_login_basic, session_login_token, oauth2_mint. Selection only — no free-form auth config. Mutually exclusive with --catalog
+- `--auth-secret-field` — manual mode: override a secret-field NAME the --auth-scheme reads at dispatch (never the value — that stays in the target's secret_ref); repeat for multiple. Omit for the per-scheme defaults. Requires --auth-scheme
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--catalog` — catalog mode: ingest the curated entry for <product>/<version> (e.g. vmware/9.0); mutually exclusive with --product/--version/--impl/--spec
+- `--dry-run` — parse and plan without writing to the DB; the response carries an IngestionResult with counts but no GroupingResult
+- `--impl` — impl identifier (e.g. vmware-rest, k8s-go); manual mode
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+- `--no-wait` — on an async 202 answer, exit 0 with the job handle (job_id + poll URL) instead of polling the job to completion; no effect when the backplane answers synchronously (HTTP 200)
+- `--product` — product name (e.g. vmware, kubernetes); manual mode (required with --version/--impl/--spec)
+- `--spec` — spec URI; repeat for multi-spec merge under one connector_id; manual mode
+- `--spec-info-versions-compatible` — manual mode: declare that the spec's info.version is compatible with --version even when they differ (e.g. a vendor /api/v2 surface self-versioning as info.version=v2 ingested under --version 9.0). Each entry is a glob (2.x, 9.0.x) or a PEP 440 specifier set (>=2,<3); repeatable or comma-separated. Without it, a spec/label major mismatch is rejected; mutually exclusive with --catalog (the catalog row carries its own band)
+- `--tenant-id` — write scope for the ingested rows (works with both modes): omit for the built-in / global scope (tenant_id left unset — visible to every tenant); pass your own tenant UUID for a tenant-curated ingest (another tenant's UUID is rejected with HTTP 403)
+- `--version` — product version (e.g. 9.0, 1.x); manual mode
+
+### `meho connector ingest-status`
+
+Poll or inspect an async ingest job by id (after `ingest --no-wait`)
+
+```
+meho connector ingest-status <job-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human render (the raw IngestJobStatusResponse for a snapshot, the assembled IngestResponse on success)
+- `--wait` — poll the job (2s cadence) until it reaches a terminal status, then render the result; without it, read one snapshot and exit (a running job exits 0 with its current state)
+
+### `meho connector list`
+
+List ingested connectors filtered by review status
+
+```
+meho connector list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--status` — filter by review status: staged | enabled | disabled | all (default all)
+
+### `meho connector review`
+
+Show the per-group + per-op review payload for one connector
+
+```
+meho connector review <connector_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human render
+
+## `meho conventions`
+
+Manage tenant conventions (list / show / create / edit / delete / history)
+
+```
+meho conventions
+```
+
+### `meho conventions create`
+
+Create one convention (tenant_admin)
+
+```
+meho conventions create [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--body` — convention body: inline text, @<path> to read a file, or @- to read from stdin
+- `--json` — emit raw Convention JSON instead of the human summary
+- `--kind` — convention kind: operational | workflow | reference
+- `--priority` — ranking key (default 0; range -32768..32767; higher wins on over-budget drops)
+- `--slug` — operator-visible identifier (lowercase ASCII, digits, hyphen; max 128 chars)
+- `--title` — short display label
+
+### `meho conventions delete`
+
+Delete one convention by slug (tenant_admin)
+
+```
+meho conventions delete <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable success envelope instead of the human line
+
+### `meho conventions edit`
+
+Edit one convention via flags or $EDITOR (tenant_admin)
+
+```
+meho conventions edit <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--body` — new body: inline text, @<path>, or @- (omit for $EDITOR mode)
+- `--json` — emit raw Convention JSON instead of the human summary
+- `--priority` — new ranking key (range -32768..32767)
+- `--title` — new short display label
+
+### `meho conventions history`
+
+Show the edit history of one convention
+
+```
+meho conventions history <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw history rows as JSON instead of the unified-diff view
+- `--limit` — cap the number of history rows rendered (default: all)
+
+### `meho conventions list`
+
+List tenant conventions, optionally filtered by kind
+
+```
+meho conventions list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw ConventionListResponse JSON instead of the human table
+- `--kind` — narrow entries by kind: operational | workflow | reference
+
+### `meho conventions show`
+
+Fetch one convention by slug
+
+```
+meho conventions show <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw Convention JSON instead of the Markdown body
+
+## `meho dashboard`
+
+Manage deterministic-check dashboards (list / show / create / delete)
+
+```
+meho dashboard
+```
+
+### `meho dashboard create`
+
+Create one dashboard (tenant_admin)
+
+```
+meho dashboard create [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--description` — optional free-form description
+- `--investigator-prompt` — operator context appended to the investigator's briefing (max 4096 chars)
+- `--json` — emit raw DashboardDetail JSON instead of the human summary
+- `--name` — operator-facing dashboard name (unique per tenant)
+- `--notify-email` — comma-separated recipient(s) for transition mail (unset = notifications off)
+- `--notify-min-state` — notification floor: degraded or critical (server default: critical)
+- `--sensor-id` — member sensor UUID (repeatable; empty set rolls up 'unknown')
+- `--tenant` — target tenant UUID (platform_admin cross-tenant create)
+
+### `meho dashboard delete`
+
+Delete one dashboard by id (tenant_admin)
+
+```
+meho dashboard delete <dashboard_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a structured JSON result instead of plain text
+- `--tenant` — target tenant UUID (platform_admin cross-tenant delete)
+
+### `meho dashboard list`
+
+List dashboards in your tenant
+
+```
+meho dashboard list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw ListResponse JSON instead of the human table
+- `--limit` — max dashboards per page (1..500, server default 100 when omitted)
+- `--offset` — offset into the result set (default 0)
+- `--tenant` — target tenant UUID (platform_admin only; operator role is locked to its own tenant)
+
+### `meho dashboard show`
+
+Show one dashboard with its member breakdown
+
+```
+meho dashboard show <dashboard_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw DashboardDetail JSON instead of the human summary
+- `--tenant` — target tenant UUID (platform_admin cross-tenant read)
+
+## `meho docs`
+
+Search the meho-docs vendor-document add-on
+
+```
+meho docs
+```
+
+### `meho docs collections`
+
+List, create, delete, and probe / toggle doc collections
+
+```
+meho docs collections
+```
+
+#### `meho docs collections create`
+
+Register a new doc collection (tenant_admin)
+
+```
+meho docs collections create <collection-key> [flags]
+```
+
+- `--backend-ref` — backend config as a JSON object (e.g. '{"endpoint":"https://corpus/v1/search"}')
+- `--backend-type` — search-backend type to route to (e.g. corpus-http)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--description` — optional free-text description
+- `--from-file` — read the full create body from a JSON file instead of the flags
+- `--json` — emit the created collection as JSON instead of a confirmation line
+- `--product` — product the corpus covers (repeatable, e.g. --product vsphere --product nsx)
+- `--vendor` — vendor the corpus covers (e.g. 'VMware by Broadcom')
+- `--when-to-use` — optional 'pick this collection when…' blurb surfaced to agents
+
+#### `meho docs collections delete`
+
+Deregister a disabled, tenant-owned doc collection (tenant_admin)
+
+```
+meho docs collections delete <collection-key> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a JSON status envelope
+
+#### `meho docs collections disable`
+
+Hide a collection from search service
+
+```
+meho docs collections disable <collection-key> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a JSON status envelope
+
+#### `meho docs collections enable`
+
+Return a disabled collection to search service
+
+```
+meho docs collections enable <collection-key> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a JSON status envelope
+
+#### `meho docs collections list`
+
+List the doc collections you are entitled to search
+
+```
+meho docs collections list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cursor` — keyset pagination cursor (the last collection key from the previous page)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--limit` — max collections per page (1..500, server default 100 when omitted)
+- `--vendor` — filter by vendor (exact match)
+
+#### `meho docs collections probe`
+
+Probe a collection's backend and refresh its cached liveness
+
+```
+meho docs collections probe <collection-key> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw BackendReadiness JSON
+
+### `meho docs search`
+
+Search vendor-document collection(s) (mandatory --collection)
+
+```
+meho docs search <query> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--collection` — collection key to search (required; e.g. vmware). Repeat for a cross-collection fan-out, or pass 'all' to fan out across every entitled collection.
+- `--json` — emit raw SearchDocsResponse JSON (full DocsChunk shape)
+- `--limit` — max chunks to return (1..50, server default 10 when omitted)
+- `--product` — optional vendor-product refinement within a single collection
+- `--version` — optional product-version refinement within a single collection
+
+## `meho event-source`
+
+Operate the MEHO event_source registry (add / list / describe / update / delete)
+
+```
+meho event-source
+```
+
+### `meho event-source add`
+
+Register a single event source (alias `create`)
+
+```
+meho event-source add <slug> [flags]
+```
+
+- `--auth-strategy` — auth strategy: hmac-sha256 | static-header | basic (required)
+- `--backplane` — backplane URL (defaults to the URL recorded by `meho login`)
+- `--extras` — per-source tuning as a JSON object (body cap, rate limit, replay window, dedupe)
+- `--json` — emit the created event source as JSON
+- `--kind` — producer kind: alertmanager | grafana | vcf-operations | harbor | generic-json (required)
+- `--name` — human-readable name, unique within the tenant (required)
+- `--secret-stdin` — read the auth secret from stdin (else MEHO_EVENT_SOURCE_SECRET); never a flag value
+- `--status` — initial status: active | paused
+
+### `meho event-source delete`
+
+Soft-delete one event source by slug (tenant_admin)
+
+```
+meho event-source delete <slug> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to `meho login`'s)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable envelope instead of the human line
+
+### `meho event-source describe`
+
+Describe a single event source by slug
+
+```
+meho event-source describe <slug> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to `meho login`'s)
+- `--json` — emit machine-readable JSON instead of the summary
+
+### `meho event-source list`
+
+List event sources in your tenant
+
+```
+meho event-source list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to `meho login`'s)
+- `--cursor` — keyset cursor (the last name from the previous page)
+- `--json` — emit machine-readable JSON instead of the table
+- `--limit` — max sources per page (1..500, server default 100)
+- `--status` — filter by status: active | paused
+
+### `meho event-source update`
+
+Apply a partial update to one event source (tenant_admin)
+
+```
+meho event-source update <slug> [flags]
+```
+
+- `--auth-strategy` — new auth strategy
+- `--backplane` — backplane URL (defaults to `meho login`'s)
+- `--extras` — replace per-source tuning with this JSON object
+- `--json` — emit the updated event source as JSON
+- `--kind` — new producer kind
+- `--secret-stdin` — rotate the auth secret, reading it from stdin (else MEHO_EVENT_SOURCE_SECRET)
+- `--status` — new status: active | paused
+
+## `meho forget`
+
+Delete one memory by natural key (DELETE /api/v1/memory)
+
+```
+meho forget <scope>/<slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by `meho login`)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable success envelope instead of the human line
+- `--target` — target name (required when --scope=target or user-target)
+
+## `meho gcloud`
+
+Pre-scoped CLI verbs for the gcloud-rest-1.0 connector
+
+```
+meho gcloud
+```
+
+### `meho gcloud about`
+
+Show GCP project identity (project_id, lifecycle_state, organization)
+
+```
+meho gcloud about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required for ops that read a target)
+
+### `meho gcloud compute`
+
+GCP Compute Engine verbs (instances, networks, subnets)
+
+```
+meho gcloud compute
+```
+
+#### `meho gcloud compute instances`
+
+Compute Engine instance verbs (list)
+
+```
+meho gcloud compute instances
+```
+
+##### `meho gcloud compute instances list`
+
+List Compute Engine instances (all zones or a specific zone)
+
+```
+meho gcloud compute instances list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+- `--zone` — optional zone filter (e.g. europe-west3-a); omit to list all zones via aggregatedList
+
+#### `meho gcloud compute networks`
+
+VPC network verbs (list)
+
+```
+meho gcloud compute networks
+```
+
+##### `meho gcloud compute networks list`
+
+List VPC networks in the project
+
+```
+meho gcloud compute networks list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho gcloud compute subnets`
+
+VPC subnet verbs (list)
+
+```
+meho gcloud compute subnets
+```
+
+##### `meho gcloud compute subnets list`
+
+List VPC subnets (all regions or a specific region)
+
+```
+meho gcloud compute subnets list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--region` — optional region filter (e.g. europe-west3); omit to list all regions via aggregatedList
+- `--target` — target slug to dispatch against
+
+### `meho gcloud iam`
+
+GCP IAM verbs (service-account list, policy read)
+
+```
+meho gcloud iam
+```
+
+#### `meho gcloud iam policy`
+
+GCP IAM policy verbs (read)
+
+```
+meho gcloud iam policy
+```
+
+##### `meho gcloud iam policy read`
+
+Read the project-level IAM policy (all role bindings)
+
+```
+meho gcloud iam policy read [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho gcloud iam sa`
+
+GCP service-account verbs (list)
+
+```
+meho gcloud iam sa
+```
+
+##### `meho gcloud iam sa list`
+
+List IAM service accounts in the project
+
+```
+meho gcloud iam sa list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho gcloud project`
+
+GCP project verbs (describe)
+
+```
+meho gcloud project
+```
+
+#### `meho gcloud project describe`
+
+Return the full Cloud Resource Manager project resource
+
+```
+meho gcloud project describe [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho gcloud services`
+
+GCP services (APIs) verbs (list)
+
+```
+meho gcloud services
+```
+
+#### `meho gcloud services list`
+
+List GCP services (APIs) enabled on the project
+
+```
+meho gcloud services list [flags]
+```
+
+- `--all` — include disabled services in addition to enabled ones
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+## `meho harbor`
+
+Pre-scoped CLI verbs for the harbor-rest-2.x connector
+
+```
+meho harbor
+```
+
+### `meho harbor about`
+
+Show Harbor version, auth mode, and registry URL
+
+```
+meho harbor about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+### `meho harbor artifact`
+
+List or inspect Harbor artifacts within a repository
+
+```
+meho harbor artifact
+```
+
+#### `meho harbor artifact info`
+
+Show full metadata for a Harbor artifact by tag or digest
+
+```
+meho harbor artifact info <project_name> <repository_name> <reference> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+#### `meho harbor artifact list`
+
+List artifacts (tags + digests) in a Harbor repository
+
+```
+meho harbor artifact list <project_name> <repository_name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+### `meho harbor health`
+
+Show Harbor composite health across all subsystems
+
+```
+meho harbor health [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+### `meho harbor operation`
+
+Pre-scoped meta-tool wrappers (search / call) for harbor-rest-2.x
+
+```
+meho harbor operation
+```
+
+#### `meho harbor operation call`
+
+Dispatch any harbor-rest-2.x op_id (escape hatch for ops without aliases)
+
+```
+meho harbor operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — Harbor target slug
+
+#### `meho harbor operation search`
+
+Hybrid BM25 + cosine RRF search across harbor-rest-2.x operations
+
+```
+meho harbor operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho harbor project`
+
+List or inspect Harbor projects
+
+```
+meho harbor project
+```
+
+#### `meho harbor project info`
+
+Show full details for a Harbor project
+
+```
+meho harbor project info <project_name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+#### `meho harbor project list`
+
+List all Harbor projects
+
+```
+meho harbor project list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+### `meho harbor repository`
+
+List or inspect Harbor repositories within a project
+
+```
+meho harbor repository
+```
+
+#### `meho harbor repository info`
+
+Show full details for a Harbor repository
+
+```
+meho harbor repository info <project_name> <repository_name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+#### `meho harbor repository list`
+
+List repositories within a Harbor project
+
+```
+meho harbor repository list <project_name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+### `meho harbor robot`
+
+List, create, or delete Harbor robot accounts
+
+```
+meho harbor robot
+```
+
+#### `meho harbor robot create`
+
+Create a project-scoped robot account in Harbor
+
+```
+meho harbor robot create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--duration` — validity in days (-1 = never expires)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--name` — robot account name (alphanumeric, hyphens, underscores)
+- `--project` — Harbor project to scope the robot to
+- `--target` — Harbor target slug
+
+#### `meho harbor robot delete`
+
+Delete a project-scoped robot account from Harbor
+
+```
+meho harbor robot delete [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--id` — numeric robot account ID
+- `--json` — emit the full OperationResult envelope as JSON
+- `--project` — Harbor project that scopes the robot account
+- `--target` — Harbor target slug
+
+#### `meho harbor robot list`
+
+List Harbor system-level robot accounts
+
+```
+meho harbor robot list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Harbor target slug
+
+## `meho hetzner-robot`
+
+Pre-scoped CLI verbs for the hetzner-rest-2026.04 connector
+
+```
+meho hetzner-robot
+```
+
+### `meho hetzner-robot failover`
+
+List failover IPs in the Hetzner Robot account
+
+```
+meho hetzner-robot failover
+```
+
+#### `meho hetzner-robot failover list`
+
+List all failover IPs and their active routing targets
+
+```
+meho hetzner-robot failover list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot firewall`
+
+Read the packet-filter firewall of a dedicated server
+
+```
+meho hetzner-robot firewall
+```
+
+#### `meho hetzner-robot firewall get`
+
+Show the packet-filter firewall for one dedicated server by its primary IP
+
+```
+meho hetzner-robot firewall get <server-ip> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot ip`
+
+List IP addresses assigned to the Hetzner Robot account
+
+```
+meho hetzner-robot ip
+```
+
+#### `meho hetzner-robot ip list`
+
+List all IPs assigned to the Hetzner Robot account
+
+```
+meho hetzner-robot ip list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot operation`
+
+Pre-scoped meta-tool wrappers (search / call) for hetzner-rest-2026.04
+
+```
+meho hetzner-robot operation
+```
+
+#### `meho hetzner-robot operation call`
+
+Dispatch any hetzner-rest-2026.04 op_id (escape hatch for ops without aliases)
+
+```
+meho hetzner-robot operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — Hetzner Robot target slug
+
+#### `meho hetzner-robot operation search`
+
+Hybrid BM25 + cosine RRF search across hetzner-rest-2026.04 operations
+
+```
+meho hetzner-robot operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho hetzner-robot rdns`
+
+List reverse DNS (PTR record) entries for the Hetzner Robot account
+
+```
+meho hetzner-robot rdns
+```
+
+#### `meho hetzner-robot rdns list`
+
+List all reverse DNS (PTR) entries set on the account's IPs
+
+```
+meho hetzner-robot rdns list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot server`
+
+List or inspect dedicated servers in the Hetzner Robot account
+
+```
+meho hetzner-robot server
+```
+
+#### `meho hetzner-robot server info`
+
+Show full detail for one dedicated server by its primary IP
+
+```
+meho hetzner-robot server info <server-ip> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+#### `meho hetzner-robot server list`
+
+List all dedicated servers in the Hetzner Robot account
+
+```
+meho hetzner-robot server list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot ssh-key`
+
+List SSH public keys registered in the Hetzner Robot portal
+
+```
+meho hetzner-robot ssh-key
+```
+
+#### `meho hetzner-robot ssh-key list`
+
+List all SSH public keys registered in the Hetzner Robot portal
+
+```
+meho hetzner-robot ssh-key list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot subnet`
+
+List subnets assigned to the Hetzner Robot account
+
+```
+meho hetzner-robot subnet
+```
+
+#### `meho hetzner-robot subnet list`
+
+List all subnets assigned to the Hetzner Robot account
+
+```
+meho hetzner-robot subnet list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+### `meho hetzner-robot vswitch`
+
+List or inspect vSwitches in the Hetzner Robot account
+
+```
+meho hetzner-robot vswitch
+```
+
+#### `meho hetzner-robot vswitch info`
+
+Show full detail for one vSwitch by its numeric ID
+
+```
+meho hetzner-robot vswitch info <vswitch-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+#### `meho hetzner-robot vswitch list`
+
+List all vSwitches in the Hetzner Robot account
+
+```
+meho hetzner-robot vswitch list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — Hetzner Robot target slug
+
+## `meho holodeck`
+
+Pre-scoped CLI verbs for the holodeck-ssh-9.0 connector
+
+```
+meho holodeck
+```
+
+### `meho holodeck about`
+
+Show Holodeck product / version / Photon OS for a target
+
+```
+meho holodeck about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck config`
+
+Holodeck appliance config sub-verbs (show)
+
+```
+meho holodeck config
+```
+
+#### `meho holodeck config show`
+
+Return the full Holodeck appliance configuration dict
+
+```
+meho holodeck config show [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck k8s`
+
+In-appliance K8s sub-verbs (exec — read-only)
+
+```
+meho holodeck k8s
+```
+
+#### `meho holodeck k8s exec`
+
+Run a read-only kubectl command on the in-appliance K8s cluster
+
+```
+meho holodeck k8s exec <kubectl-command> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck logs`
+
+Holodeck runtime log sub-verbs (tail)
+
+```
+meho holodeck logs
+```
+
+#### `meho holodeck logs tail`
+
+Tail Holodeck runtime log files for a given component
+
+```
+meho holodeck logs tail <component> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--lines` — number of trailing lines to return per file (backend clamps to [1, 5000])
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck networking`
+
+Holodeck networking sub-verbs (show)
+
+```
+meho holodeck networking
+```
+
+#### `meho holodeck networking show`
+
+Composite FRR/BGP + DNS + DHCP snapshot for the appliance
+
+```
+meho holodeck networking show [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck pod`
+
+Holodeck nested-pod sub-verbs (list, info)
+
+```
+meho holodeck pod
+```
+
+#### `meho holodeck pod info`
+
+Return per-pod detail (state, networking, VMs) for a Holodeck pod
+
+```
+meho holodeck pod info <pod-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho holodeck pod list`
+
+List active Holodeck nested pods (Get-HoloDeckPod)
+
+```
+meho holodeck pod list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho holodeck service`
+
+Holodeck Photon service sub-verbs (list)
+
+```
+meho holodeck service
+```
+
+#### `meho holodeck service list`
+
+List Holodeck Photon services and their status
+
+```
+meho holodeck service list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+## `meho k8s`
+
+Pre-scoped CLI verbs for the k8s-1.x connector
+
+```
+meho k8s
+```
+
+### `meho k8s about`
+
+Identify the cluster (product / version / platform)
+
+```
+meho k8s about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s configmap`
+
+ConfigMap verbs (list keys-only / info full data)
+
+```
+meho k8s configmap
+```
+
+#### `meho k8s configmap info`
+
+Fetch one ConfigMap including all key=value data
+
+```
+meho k8s configmap info <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace the configmap lives in (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+#### `meho k8s configmap list`
+
+List ConfigMaps in a namespace - KEY NAMES ONLY, no values
+
+```
+meho k8s configmap list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace to list within (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s deployment`
+
+Deployment verbs (list / info)
+
+```
+meho k8s deployment
+```
+
+#### `meho k8s deployment info`
+
+Full detail for one deployment (kubectl describe deployment)
+
+```
+meho k8s deployment info <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace the deployment lives in (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+#### `meho k8s deployment list`
+
+List deployments (kubectl get deployments)
+
+```
+meho k8s deployment list [flags]
+```
+
+- `--all-namespaces` — list across every namespace (mutually exclusive with --namespace)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--continue-token` — pagination cursor from a prior response's next_continue field
+- `--field-selector` — k8s field selector forwarded server-side (e.g. status.phase=Running)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--label-selector` — k8s label selector forwarded server-side (e.g. app=argocd-server)
+- `--limit` — server-side ?limit= for paginated reads (1..1000)
+- `--namespace` — namespace to list within (mutually exclusive with --all-namespaces)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s event`
+
+Event verbs (list)
+
+```
+meho k8s event
+```
+
+#### `meho k8s event list`
+
+List recent events in a namespace (kubectl get events)
+
+```
+meho k8s event list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--field-selector` — k8s field selector forwarded server-side (e.g. type=Warning)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--limit` — maximum rows to return (server default 100, capped at 500)
+- `--namespace` — namespace to list within (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s ingress`
+
+Ingress verbs (list)
+
+```
+meho k8s ingress
+```
+
+#### `meho k8s ingress list`
+
+List Ingresses in a namespace (kubectl get ingress)
+
+```
+meho k8s ingress list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace to list within (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s logs`
+
+Fetch a chunk of pod logs (kubectl logs - non-streaming)
+
+```
+meho k8s logs <pod> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--container` — container name within the pod (required for multi-container pods)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace the pod lives in (required)
+- `--previous` — fetch logs from the previous container instance (after a restart)
+- `--since` — duration string for time-bounded fetch (e.g. 5m, 1h, 24h, 7d)
+- `--tail` — lines from the end of the log (default 100, capped at 5000)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s ls`
+
+Inventory walker (cluster root / namespace summary / kind list)
+
+```
+meho k8s ls [path] [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s namespace`
+
+Namespace verbs (list)
+
+```
+meho k8s namespace
+```
+
+#### `meho k8s namespace list`
+
+List Kubernetes namespaces (name / status / age / labels)
+
+```
+meho k8s namespace list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s node`
+
+Node verbs (list)
+
+```
+meho k8s node
+```
+
+#### `meho k8s node list`
+
+List cluster nodes (status / roles / version / taints)
+
+```
+meho k8s node list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s pod`
+
+Pod verbs (list / info)
+
+```
+meho k8s pod
+```
+
+#### `meho k8s pod info`
+
+Full detail for one pod (kubectl describe pod)
+
+```
+meho k8s pod info <name> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace the pod lives in (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+#### `meho k8s pod list`
+
+List pods (kubectl get pods)
+
+```
+meho k8s pod list [flags]
+```
+
+- `--all-namespaces` — list across every namespace (mutually exclusive with --namespace)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--continue-token` — pagination cursor from a prior response's next_continue field
+- `--field-selector` — k8s field selector forwarded server-side (e.g. status.phase=Running)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--label-selector` — k8s label selector forwarded server-side (e.g. app=argocd-server)
+- `--limit` — server-side ?limit= for paginated reads (1..1000)
+- `--namespace` — namespace to list within (mutually exclusive with --all-namespaces)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+### `meho k8s service`
+
+Service verbs (list)
+
+```
+meho k8s service
+```
+
+#### `meho k8s service list`
+
+List Services in a namespace (kubectl get svc)
+
+```
+meho k8s service list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--namespace` — namespace to list within (required)
+- `--target` — K8s target slug to dispatch against (resolved server-side)
+
+## `meho kb`
+
+Operate the MEHO knowledge base (ingest / search / list / show / add / delete)
+
+```
+meho kb
+```
+
+### `meho kb add`
+
+Create or re-index one kb entry (tenant_admin)
+
+```
+meho kb add <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--body` — entry body: inline text, @<path> to read a file, or @- to read from stdin
+- `--json` — emit raw KbEntry JSON instead of the human summary
+- `--metadata` — comma-separated key=value pairs to attach as entry metadata (e.g. owner=ops,source=runbook)
+
+### `meho kb delete`
+
+Delete one kb entry by slug (tenant_admin)
+
+```
+meho kb delete <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--confirm` — skip the stdin confirmation prompt
+- `--json` — emit a machine-readable success envelope instead of the human line
+
+### `meho kb ingest`
+
+Bulk-ingest a kb/ directory on the backplane host (tenant_admin)
+
+```
+meho kb ingest <directory> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--dry-run` — resolve the plan without writing to the substrate (counters reflect intent only)
+- `--json` — emit raw KbIngestionResult JSON instead of the human summary
+
+### `meho kb list`
+
+List kb entries in your tenant
+
+```
+meho kb list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--filter` — narrow entries by a SQL LIKE pattern (e.g. `vcenter%`)
+- `--json` — emit raw KbListResponse JSON instead of the human table
+- `--limit` — max entries per page (1..500, server default 100 when omitted)
+- `--offset` — offset into the slug-sorted result set (default 0)
+
+### `meho kb search`
+
+Search kb entries via hybrid BM25 + cosine retrieval
+
+```
+meho kb search <query> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RetrieveResponse JSON (full RetrievalHit shape)
+- `--limit` — max hits to return (1..50, server default 10 when omitted)
+
+### `meho kb show`
+
+Fetch a kb entry by slug
+
+```
+meho kb show <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw KbEntry JSON instead of the Markdown body
+
+## `meho keycloak`
+
+Pre-scoped CLI verbs for the keycloak-admin-26.x connector
+
+```
+meho keycloak
+```
+
+### `meho keycloak client`
+
+Keycloak client sub-verbs (list, get, create, update)
+
+```
+meho keycloak client
+```
+
+#### `meho keycloak client create`
+
+Create a Keycloak client (approval-gated)
+
+```
+meho keycloak client create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--representation-file`, `-f` — path to a JSON file with the ClientRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak client get`
+
+Read one Keycloak client's full config by internal UUID (secret redacted)
+
+```
+meho keycloak client get [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--id` — the client's internal UUID (from `meho keycloak client list`) (required)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak client list`
+
+List Keycloak clients in the managed realm (secrets redacted)
+
+```
+meho keycloak client list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--client-id` — filter to a single client by its human clientId (Keycloak ?clientId=)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--max` — cap on the number of clients returned (0 = no cap)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak client update`
+
+Update a Keycloak client by UUID or clientId (approval-gated)
+
+```
+meho keycloak client update [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--client-id` — the human clientId (resolved to UUID when --id is absent)
+- `--id` — the client's internal UUID (skips name→UUID resolution)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--representation-file`, `-f` — path to a JSON file with the partial ClientRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+### `meho keycloak client-scope`
+
+Keycloak client-scope sub-verbs (list, create)
+
+```
+meho keycloak client-scope
+```
+
+#### `meho keycloak client-scope create`
+
+Create a Keycloak client scope (approval-gated)
+
+```
+meho keycloak client-scope create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--representation-file`, `-f` — path to a JSON file with the ClientScopeRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak client-scope list`
+
+List Keycloak client scopes in the managed realm
+
+```
+meho keycloak client-scope list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho keycloak protocol-mapper`
+
+Keycloak protocol-mapper sub-verbs (create)
+
+```
+meho keycloak protocol-mapper
+```
+
+#### `meho keycloak protocol-mapper create`
+
+Add a protocol mapper to a Keycloak client (approval-gated)
+
+```
+meho keycloak protocol-mapper create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--client-id` — the human clientId (resolved to UUID when --id is absent)
+- `--id` — the client's internal UUID (skips name→UUID resolution)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--representation-file`, `-f` — path to a JSON file with the ProtocolMapperRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+### `meho keycloak realm`
+
+Keycloak realm sub-verbs (get, create, update)
+
+```
+meho keycloak realm
+```
+
+#### `meho keycloak realm create`
+
+Create a Keycloak realm (approval-gated)
+
+```
+meho keycloak realm create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--representation-file`, `-f` — path to a JSON file with the RealmRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak realm get`
+
+Read the managed realm's top-level configuration
+
+```
+meho keycloak realm get [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho keycloak realm update`
+
+Update a Keycloak realm's top-level config (approval-gated)
+
+```
+meho keycloak realm update [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--realm` — realm to update (defaults to the target's managed realm)
+- `--representation-file`, `-f` — path to a JSON file with the partial RealmRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+
+### `meho keycloak role-mapping`
+
+Keycloak role-mapping sub-verbs (get, assign)
+
+```
+meho keycloak role-mapping
+```
+
+#### `meho keycloak role-mapping assign`
+
+Grant realm roles to a Keycloak user (approval-gated, privilege grant)
+
+```
+meho keycloak role-mapping assign [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--id` — the user's internal UUID (skips name→UUID resolution)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--role` — realm role name to grant (repeatable)
+- `--target` — target slug to dispatch against (required)
+- `--username` — the username (resolved to UUID when --id is absent)
+
+#### `meho keycloak role-mapping get`
+
+Read a Keycloak user's realm + client role mappings by UUID
+
+```
+meho keycloak role-mapping get [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--id` — the user's internal UUID (from `meho keycloak user list`) (required)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho keycloak user`
+
+Keycloak user sub-verbs (list, create, reset-password)
+
+```
+meho keycloak user
+```
+
+#### `meho keycloak user create`
+
+Create a Keycloak user with a Vault-sourced password (approval-gated)
+
+```
+meho keycloak user create [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--password-secret-key` — field within the Vault secret payload (default 'password')
+- `--password-secret-mount` — Vault KV-v2 mount point (default 'secret')
+- `--password-secret-ref` — Vault KV-v2 path the password is read from (the password is never passed inline)
+- `--representation-file`, `-f` — path to a JSON file with the UserRepresentation body (required)
+- `--target` — target slug to dispatch against (required)
+- `--temporary` — force a password change on first login
+
+#### `meho keycloak user list`
+
+List Keycloak users in the managed realm (credentials redacted)
+
+```
+meho keycloak user list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--max` — cap on the number of users returned (0 = no cap)
+- `--target` — target slug to dispatch against (required)
+- `--username` — filter to matching users by username (Keycloak ?username=)
+
+#### `meho keycloak user reset-password`
+
+Reset a Keycloak user's password from Vault (approval-gated)
+
+```
+meho keycloak user reset-password [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--id` — the user's internal UUID (skips name→UUID resolution)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--password-secret-key` — field within the Vault secret payload (default 'password')
+- `--password-secret-mount` — Vault KV-v2 mount point (default 'secret')
+- `--password-secret-ref` — Vault KV-v2 path the password is read from (the password is never passed inline)
+- `--target` — target slug to dispatch against (required)
+- `--temporary` — force a password change on first login
+- `--username` — the username (resolved to UUID when --id is absent)
+
+## `meho list`
+
+List memories visible to the operator (GET /api/v1/memory)
+
+```
+meho list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by `meho login`)
+- `--include-expired` — include memories past their expires_at (omitted: expired entries filtered out)
+- `--json` — emit raw MemoryListResponse JSON instead of the human table
+- `--limit` — max memories per page (1..500, server default 100 when omitted)
+- `--scope` — filter by memory scope: user|user-tenant|user-target|tenant|target
+- `--slug-pattern` — filter by substring match on slug (forwarded to MemoryService.list_memories)
+- `--tag` — filter by tag (memories whose metadata.tags contains this string)
+
+## `meho login`
+
+Authenticate against the MEHO backplane via Keycloak device-code flow
+
+```
+meho login <backplane-url> [flags]
+```
+
+- `--client-id` — OAuth client_id to use for the device-code flow (auto-discovered when blank)
+- `--insecure-allow-http` — permit a plaintext http:// backplane URL for a localhost backplane only (local-dev convenience; the bearer token is sent in the clear — never use against a remote host)
+- `--issuer` — Keycloak realm issuer URL (auto-discovered from the backplane when blank)
+- `--offline` — request a long-lived offline refresh token (adds the OIDC `offline_access` scope) so you stay logged in across SSO idle timeouts instead of re-running the device dance. Requires the backplane's meho-cli client to allow offline_access (provision via `meho admin keycloak bootstrap-clients --cli-offline-access`). The refresh token is stored like any credential (OS keyring first, 0600 file fallback) — treat it as a long-lived secret
+- `--print-token` — after a successful login, print ONLY the access token to stdout (every other line — the device-code prompt, the success message, warnings — goes to stderr) so it can be captured with 'TOKEN=$(meho login --print-token <backplane-url>)'. WARNING: the value is a live bearer credential — never log it or paste it into shared channels
+- `--resolve` — pin a host to an IP for the flow, mirroring `curl --resolve <host>:<port>:<ip>` (split-DNS escape hatch when the Keycloak host doesn't resolve). Repeat for multiple hosts. TLS SNI/Host use the real hostname, so certificate validation is unaffected
+- `--scope` — OAuth scopes to request (default: openid). Repeat or comma-separate for multiple.
+
+## `meho migrate`
+
+Migrate laptop-local data to the MEHO backplane
+
+```
+meho migrate
+```
+
+### `meho migrate memory`
+
+Migrate laptop-local memory entries to the backplane
+
+```
+meho migrate memory [flags]
+```
+
+- `--backplane` — backplane URL override (default: from meho login config)
+- `--dry-run` — preview entries that would be migrated without submitting
+- `--include-machine-local` — include machine-local entries (default: skip them)
+- `--mark-migrated` — touch the migration-complete marker after successful submission
+- `--non-interactive` — skip the interactive picker; migrates only user/feedback entries
+- `--source` — path to the local memory directory to scan (default: XDG-resolved)
+
+## `meho nsx`
+
+Pre-scoped CLI verbs for the nsx-rest-4.2 connector
+
+```
+meho nsx
+```
+
+### `meho nsx about`
+
+Show NSX Manager version, hostname, and node UUID
+
+```
+meho nsx about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx cluster`
+
+NSX management cluster verbs (status)
+
+```
+meho nsx cluster
+```
+
+#### `meho nsx cluster status`
+
+Show NSX management cluster health
+
+```
+meho nsx cluster status [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx firewall`
+
+NSX distributed-firewall verbs (policy list / rule list)
+
+```
+meho nsx firewall
+```
+
+#### `meho nsx firewall policy`
+
+NSX distributed-firewall policy verbs (list)
+
+```
+meho nsx firewall policy
+```
+
+##### `meho nsx firewall policy list`
+
+List distributed-firewall security policies in a domain
+
+```
+meho nsx firewall policy list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--scope` — NSX policy domain-id (default "default")
+- `--target` — NSX target slug
+
+#### `meho nsx firewall rule`
+
+NSX distributed-firewall rule verbs (list)
+
+```
+meho nsx firewall rule
+```
+
+##### `meho nsx firewall rule list`
+
+List rules in a distributed-firewall security policy
+
+```
+meho nsx firewall rule list <policy-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--scope` — NSX policy domain-id (default "default")
+- `--target` — NSX target slug
+
+### `meho nsx node`
+
+NSX transport-node verbs (list)
+
+```
+meho nsx node
+```
+
+#### `meho nsx node list`
+
+List NSX transport nodes (ESXi + edge)
+
+```
+meho nsx node list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx operation`
+
+Pre-scoped meta-tool wrappers (search / call) for nsx-rest-4.2
+
+```
+meho nsx operation
+```
+
+#### `meho nsx operation call`
+
+Dispatch any nsx-rest-4.2 op_id (escape hatch for ops without aliases)
+
+```
+meho nsx operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — NSX target slug
+
+#### `meho nsx operation search`
+
+Hybrid BM25 + cosine RRF search across nsx-rest-4.2 operations
+
+```
+meho nsx operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho nsx segment`
+
+NSX segment verbs (list)
+
+```
+meho nsx segment
+```
+
+#### `meho nsx segment list`
+
+List NSX policy-API segments (logical + DVS-backed portgroups)
+
+```
+meho nsx segment list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx tier0`
+
+NSX tier-0 gateway verbs (list)
+
+```
+meho nsx tier0
+```
+
+#### `meho nsx tier0 list`
+
+List NSX tier-0 (provider edge) gateways
+
+```
+meho nsx tier0 list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx tier1`
+
+NSX tier-1 gateway verbs (list)
+
+```
+meho nsx tier1
+```
+
+#### `meho nsx tier1 list`
+
+List NSX tier-1 (per-tenant) gateways
+
+```
+meho nsx tier1 list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+### `meho nsx transport-zone`
+
+NSX transport-zone verbs (list)
+
+```
+meho nsx transport-zone
+```
+
+#### `meho nsx transport-zone list`
+
+List NSX transport zones under the default enforcement point
+
+```
+meho nsx transport-zone list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — NSX target slug
+
+## `meho operation`
+
+operation meta-tool surface (groups / search / call)
+
+```
+meho operation
+```
+
+### `meho operation call`
+
+Invoke an operation through the dispatcher
+
+```
+meho operation call <connector_id> <op_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--params` — operation params as inline JSON or @<file>; omitted means no params
+- `--preview-hash` — preview_hash from a prior `meho operation preview` — required for a destructive-tier op
+- `--target` — target slug to dispatch against (required for ops that read a target)
+
+### `meho operation groups`
+
+List enabled operation groups for a connector
+
+```
+meho operation groups <connector_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+
+### `meho operation preview`
+
+Resolve an op to its would-be request + preview_hash, without sending
+
+```
+meho operation preview <connector_id> <op_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full preview envelope as JSON instead of the human render
+- `--params` — operation params as inline JSON or @<file>; omitted means no params
+- `--target` — target slug to resolve against (required for ops that read a target)
+
+### `meho operation result-query`
+
+Page rows back from a JSONFlux result handle
+
+```
+meho operation result-query <handle_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full result-query envelope as JSON instead of the human render
+- `--limit` — page size; default 50, max 500 (matches the result_query MCP tool)
+- `--offset` — zero-based index of the first row to return (page by advancing this by --limit)
+
+### `meho operation search`
+
+Hybrid BM25 + cosine RRF search across enabled operations
+
+```
+meho operation search <connector_id> <query> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key within the connector
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--limit` — max hits to return (1..50, clamped by the API at 50)
+
+## `meho pfsense`
+
+Pre-scoped CLI verbs for the pfsense-ssh-2.7 connector
+
+```
+meho pfsense
+```
+
+### `meho pfsense about`
+
+Show pfSense product / version / build for a target
+
+```
+meho pfsense about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense config`
+
+pfSense config sub-verbs (show)
+
+```
+meho pfsense config
+```
+
+#### `meho pfsense config show`
+
+Return the full pfSense configuration as XML (/cf/conf/config.xml)
+
+```
+meho pfsense config show [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense dhcp`
+
+pfSense DHCP sub-verbs (leases)
+
+```
+meho pfsense dhcp
+```
+
+#### `meho pfsense dhcp leases`
+
+List live pfSense DHCPv4 leases (ISC dhcpd lease DB)
+
+```
+meho pfsense dhcp leases [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense firewall`
+
+pfSense firewall sub-verbs (rules, state)
+
+```
+meho pfsense firewall
+```
+
+#### `meho pfsense firewall rules`
+
+List active pfSense firewall filter rules (pfctl -sr)
+
+```
+meho pfsense firewall rules [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho pfsense firewall state`
+
+List active pfSense connection-state table entries (pfctl -ss)
+
+```
+meho pfsense firewall state [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense nat`
+
+pfSense NAT sub-verbs (rules)
+
+```
+meho pfsense nat
+```
+
+#### `meho pfsense nat rules`
+
+List active pfSense NAT ruleset (pfctl -sn)
+
+```
+meho pfsense nat rules [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense network`
+
+pfSense network sub-verbs (interface, gateway)
+
+```
+meho pfsense network
+```
+
+#### `meho pfsense network gateway`
+
+List pfSense routing gateways (from config.xml)
+
+```
+meho pfsense network gateway [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+#### `meho pfsense network interface`
+
+List pfSense network interfaces (ifconfig -a)
+
+```
+meho pfsense network interface [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against (required)
+
+### `meho pfsense version`
+
+Show pfSense version / build / kernel for a target
+
+```
+meho pfsense version [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required)
+
+## `meho promote`
+
+Promote one memory to a strictly broader scope (POST /api/v1/memory/{scope}/{slug}/promote)
+
+```
+meho promote <scope>/<slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by `meho login`)
+- `--json` — emit raw MemoryEntry JSON instead of the human summary
+- `--move` — delete the source row in the same transaction (broadens-and-leaves vs. broadens-and-rewires)
+- `--to` — target scope: user-tenant|user-target|tenant|target (required)
+
+## `meho recall`
+
+Fetch a memory by natural key or via retrieval (GET /api/v1/memory or /api/v1/retrieve)
+
+```
+meho recall <scope>/<slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by `meho login`)
+- `--json` — emit raw MemoryEntry / RetrieveResponse JSON instead of human output
+- `--limit` — max hits to return in --query mode (1..50, server default 10 when omitted)
+- `--query` — run hybrid retrieval against memories with this query; mutually exclusive with the <scope>/<slug> positional
+- `--scope` — narrow --query mode to one scope: user|user-tenant|user-target|tenant|target
+- `--target` — target name for user-target / target scopes (positional mode only)
+
+## `meho remember`
+
+Persist one memory in the backplane (POST /api/v1/memory)
+
+```
+meho remember <body> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by `meho login`)
+- `--json` — emit raw MemoryEntry JSON instead of the human summary
+- `--persist` — persist forever — opt out of the backend's default-7-day TTL on memory-user writes (sends expires_at=null)
+- `--scope` — memory scope: user|user-tenant|user-target|tenant|target
+- `--slug` — override the auto-generated slug with an operator-supplied identifier
+- `--tag` — tag to attach to the memory; repeat for multiple tags
+- `--target` — target name (required when --scope=target or user-target)
+- `--ttl` — time-to-live shorthand (e.g. `7d`, `36h`, `30m`) — set expires_at
+
+## `meho retrieval`
+
+Retrieval-quality + migration-decision tooling
+
+```
+meho retrieval
+```
+
+### `meho retrieval eval`
+
+Run the checked-in eval corpus + report precision@5 / MRR / coverage
+
+```
+meho retrieval eval [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--baseline` — baseline kind to also run; only `grep` is supported in v0.2 (kb surface only)
+- `--compare-baseline` — compare today's eval against this saved baseline; exit 1 on any per-metric regression
+- `--json` — emit a machine-readable JSON envelope on stdout instead of the human table
+- `--save-baseline` — write the eval result to this file for future regression comparison
+- `--surface` — retrieval surface to evaluate (kb|memory|operations|all)
+
+### `meho retrieval retire-checklist`
+
+Run the 5-criterion retire-decision checklist per retrieval surface
+
+```
+meho retrieval retire-checklist [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--baseline-file` — JSON file containing per-surface baseline metrics (output of `meho retrieval eval --baseline grep --save-baseline ...`); without it, criterion 4 stays yellow
+- `--gh-repo` — GitHub repo to query for `retrieval-migration-blocker` issues
+- `--json` — emit the structured RetireChecklistReport on stdout instead of the human table
+- `--no-blockers` — skip the gh lookup; the backplane reports criterion 5 as REVIEW MANUALLY
+- `--surface` — retrieval surface to evaluate (kb|memory|operations|all)
+
+### `meho retrieval usage`
+
+Read audit-log-backed retrieval usage telemetry (daily buckets per surface)
+
+```
+meho retrieval usage [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the raw UsageReport on stdout instead of the human table
+- `--since` — window start; accepts relative (`30d`, `7d`, `24h`) or ISO-8601 date (`2026-04-01`)
+- `--surface` — retrieval surface to report (kb|memory|operations|all)
+- `--tenant` — tenant UUID filter (tenant_admin only; operator-role tokens get a 403)
+
+## `meho runbook`
+
+Author and operate runbook templates and runs
+
+```
+meho runbook
+```
+
+### `meho runbook abort`
+
+Abort an in-progress runbook run (assignee or tenant_admin)
+
+```
+meho runbook abort <run_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw AbortRunResponse JSON instead of the human confirmation
+- `--reason` — non-empty reason persisted to audit_log (required; prompts if omitted on a TTY)
+
+### `meho runbook deprecate-template`
+
+Mark a published version as deprecated (tenant_admin)
+
+```
+meho runbook deprecate-template <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw DeprecateTemplateResponse JSON instead of the human confirmation
+- `--version` — template version to deprecate (required; positive integer)
+
+### `meho runbook draft-template`
+
+Create the first draft of a new runbook template (tenant_admin)
+
+```
+meho runbook draft-template <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--from` — path to the YAML file describing the template body (required)
+- `--json` — emit raw DraftTemplateResponse JSON instead of the human summary
+
+### `meho runbook edit-template`
+
+Edit a draft template — in-place or fork-on-publish (tenant_admin)
+
+```
+meho runbook edit-template <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--from` — path to the YAML file describing the template body (required)
+- `--json` — emit raw EditTemplateResponse JSON instead of the human summary
+
+### `meho runbook list-templates`
+
+List runbook templates in your tenant
+
+```
+meho runbook list-templates [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RunbookTemplateListResponse JSON instead of the human table
+- `--limit` — max templates per page (1..500, server default 100 when omitted)
+- `--status` — filter by lifecycle status: draft, published, or deprecated
+- `--target-kind` — filter by target_kind (free-form connector kind like `vmware-rest`)
+
+### `meho runbook next`
+
+Advance an in-progress runbook run by one step
+
+```
+meho runbook next <run_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw NextStepResponse JSON instead of the human block
+- `--verify-response` — answer for a confirm-typed verify: yes|no|escalate (omit to prompt interactively)
+
+### `meho runbook publish-template`
+
+Flip a draft template to published (tenant_admin)
+
+```
+meho runbook publish-template <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw PublishTemplateResponse JSON instead of the human confirmation
+- `--version` — template version to publish (required; the value returned by draft-template / edit-template)
+
+### `meho runbook reassign`
+
+Transfer ownership of an in-progress run (tenant_admin)
+
+```
+meho runbook reassign <run_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw ReassignRunResponse JSON instead of the human confirmation
+- `--to` — required: operator subject identifier (`sub`) to transfer ownership to
+
+### `meho runbook runs`
+
+List runbook runs in your tenant
+
+```
+meho runbook runs [flags]
+```
+
+- `--assignee` — filter by assignee subject (tenant_admin only; operators see own regardless)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RunbookListRunsResponse JSON instead of the human table
+- `--limit` — max runs per page (1..500, server default 100 when omitted)
+- `--status` — filter by run state: in_progress, completed, or abandoned
+- `--template-slug` — filter by template slug
+- `--work-ref` — filter by external change-ticket reference
+
+### `meho runbook show-template`
+
+Read the full body of a runbook template, including step contents
+
+```
+meho runbook show-template <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw ShowTemplateResponse JSON instead of the human-readable block
+- `--version` — pin to a specific template version (default: latest non-deprecated)
+
+### `meho runbook start`
+
+Start a new runbook run (operator)
+
+```
+meho runbook start <slug> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw CurrentStepResponse JSON instead of the human block
+- `--param` — k=v substitution context entry for ${run.params.k}; repeat for multiple params
+- `--target` — required: run subject (host, cluster, cert thumbprint) -- substituted as ${run.target}
+- `--work-ref` — optional external change-ticket reference the run executes under; inherited by every operation_call step's audit row
+
+## `meho runner-principal`
+
+Manage runner principals (register / list / show / revoke)
+
+```
+meho runner-principal
+```
+
+### `meho runner-principal list`
+
+List runner principals in your tenant
+
+```
+meho runner-principal list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--include-revoked` — include revoked principals in the listing (default false)
+- `--json` — emit raw ListResponse JSON instead of the human table
+
+### `meho runner-principal register`
+
+Register a new runner principal (tenant_admin)
+
+```
+meho runner-principal register <name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RunnerPrincipalRead JSON instead of the human summary
+- `--owner-sub` — OIDC sub of the kill-switch owner (defaults to the caller's sub)
+
+### `meho runner-principal revoke`
+
+Revoke a runner principal — kill switch (tenant_admin)
+
+```
+meho runner-principal revoke <name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RunnerPrincipalRead JSON instead of the human summary
+
+### `meho runner-principal show`
+
+Show one runner principal by name (operator)
+
+```
+meho runner-principal show <name> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw RunnerPrincipalRead JSON instead of the human summary
+
+## `meho scheduler`
+
+Manage scheduled triggers (list / create / cancel)
+
+```
+meho scheduler
+```
+
+### `meho scheduler cancel`
+
+Cancel one scheduled trigger by id (tenant_admin)
+
+```
+meho scheduler cancel <trigger_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a structured JSON result instead of plain text
+- `--tenant` — target tenant UUID (tenant_admin cross-tenant cancel)
+
+### `meho scheduler create`
+
+Create one scheduled trigger (tenant_admin)
+
+```
+meho scheduler create [flags]
+```
+
+- `--agent-definition` — UUID of the agent definition to fire
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cron-expr` — 5-field cron expression (required when --kind=cron)
+- `--event-filter` — event-match filter JSON object (required when --kind=event; inline JSON, @<path>, or @-)
+- `--fire-at` — ISO 8601 fire time (required when --kind=one_off)
+- `--identity-sub` — identity sub the scheduler impersonates at fire time (default '__scheduler__')
+- `--in-flight-policy` — killed-mid-flight policy: fail_into_audit | resume (default fail_into_audit)
+- `--inputs` — optional inputs JSON object forwarded as the agent run's input (inline JSON, @<path>, or @-)
+- `--json` — emit raw Trigger JSON instead of the human summary
+- `--kind` — trigger kind: cron | one_off | event
+- `--tenant` — target tenant UUID (tenant_admin cross-tenant create)
+- `--timezone` — IANA timezone name for cron evaluation (default 'UTC')
+- `--work-ref` — external change-ticket reference inherited by every dispatched run
+
+### `meho scheduler list`
+
+List scheduled triggers in your tenant
+
+```
+meho scheduler list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit raw ListResponse JSON instead of the human table
+- `--kind` — filter by trigger kind: cron | one_off | event
+- `--limit` — max triggers per page (1..500, server default 100 when omitted)
+- `--offset` — offset into the result set (default 0)
+- `--status` — filter by trigger status: active | paused | cancelled | fired
+- `--tenant` — target tenant UUID (tenant_admin only; operator role is locked to its own tenant)
+- `--work-ref` — filter by external change-ticket reference
+
+## `meho sddc-manager`
+
+Pre-scoped CLI verbs for the sddc-rest-9.0 connector
+
+```
+meho sddc-manager
+```
+
+### `meho sddc-manager about`
+
+Show SDDC Manager VCF release version, build date, and component BOM
+
+```
+meho sddc-manager about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager bundle`
+
+VCF LCM bundle operations
+
+```
+meho sddc-manager bundle
+```
+
+#### `meho sddc-manager bundle list`
+
+List LCM bundles (VCF update packages, async patches)
+
+```
+meho sddc-manager bundle list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager cluster`
+
+VCF cluster operations
+
+```
+meho sddc-manager cluster
+```
+
+#### `meho sddc-manager cluster list`
+
+List vSphere clusters across all or one VCF domain
+
+```
+meho sddc-manager cluster list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--domain` — filter to a specific domain id
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager domain`
+
+VCF domain operations (list / info)
+
+```
+meho sddc-manager domain
+```
+
+#### `meho sddc-manager domain info`
+
+Show full detail for one VCF domain
+
+```
+meho sddc-manager domain info <domain-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+#### `meho sddc-manager domain list`
+
+List VCF domains (management + workload)
+
+```
+meho sddc-manager domain list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager host`
+
+VCF ESXi host operations
+
+```
+meho sddc-manager host
+```
+
+#### `meho sddc-manager host list`
+
+List ESXi hosts across all or one VCF domain or cluster
+
+```
+meho sddc-manager host list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--cluster` — filter to a specific cluster id
+- `--domain` — filter to a specific domain id
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager manager`
+
+SDDC Manager appliance operations
+
+```
+meho sddc-manager manager
+```
+
+#### `meho sddc-manager manager list`
+
+List SDDC Manager appliances (FQDN, IP, version, management domain)
+
+```
+meho sddc-manager manager list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager network-pool`
+
+VCF network pool operations (list / get)
+
+```
+meho sddc-manager network-pool
+```
+
+#### `meho sddc-manager network-pool get`
+
+Show one network pool's networks with free/used IP capacity
+
+```
+meho sddc-manager network-pool get <network-pool-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+#### `meho sddc-manager network-pool list`
+
+List VCF network pools (IP ranges and VLANs for host commission)
+
+```
+meho sddc-manager network-pool list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — SDDC Manager target slug
+
+### `meho sddc-manager operation`
+
+Pre-scoped meta-tool wrappers (search / call) for sddc-rest-9.0
+
+```
+meho sddc-manager operation
+```
+
+#### `meho sddc-manager operation call`
+
+Dispatch any sddc-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho sddc-manager operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — SDDC Manager target slug
+
+#### `meho sddc-manager operation search`
+
+Hybrid BM25 + cosine RRF search across sddc-rest-9.0 operations
+
+```
+meho sddc-manager operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho sddc-manager workflow`
+
+VCF workflow task operations
+
+```
+meho sddc-manager workflow
+```
+
+#### `meho sddc-manager workflow list`
+
+List in-flight or recent VCF workflow tasks
+
+```
+meho sddc-manager workflow list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--status` — filter by task status: Successful, Failed, In_Progress, Pending, Cancelled
+- `--target` — SDDC Manager target slug
+
+## `meho secret`
+
+Secret-broker verbs for the secret-broker-1.x connector
+
+```
+meho secret
+```
+
+### `meho secret move`
+
+Move a credential between stores server-side (references only, approval-gated)
+
+```
+meho secret move [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--from` — source '<kind>:<ref>' reference the credential is read from (required)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--reason` — justification recorded for the approver and the audit trail (required)
+- `--to` — sink '<kind>:<ref>' reference the credential is written to (required)
+
+### `meho secret read`
+
+Pipe a single raw secret field to stdout (pipe-only, audited)
+
+```
+meho secret read <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL from the most recent `meho login`)
+- `--field` — key within the secret's data map whose raw value is written to stdout (required)
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+## `meho sensor`
+
+Manage deterministic-check sensors (list / create / delete)
+
+```
+meho sensor
+```
+
+### `meho sensor create`
+
+Create one sensor (tenant_admin)
+
+```
+meho sensor create [flags]
+```
+
+- `--assertion` — bounded select->compare assertion spec JSON object (inline JSON, @<path>, or @-)
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cadence-kind` — cadence kind: interval | cron
+- `--connector-id` — connector id of the operation to evaluate
+- `--cron-expr` — 5-field cron expression (required when --cadence-kind=cron)
+- `--for-seconds` — hold-time hysteresis in seconds a failing state must persist (default 0)
+- `--identity-sub` — identity sub the runner dispatches under (default '__sensor__')
+- `--interval-seconds` — interval in seconds, 5..86400 (required when --cadence-kind=interval)
+- `--json` — emit raw Sensor JSON instead of the human summary
+- `--name` — operator-facing sensor name (unique per tenant)
+- `--op-id` — operation id (must be safety_level='safe')
+- `--params` — optional op-params JSON object (inline JSON, @<path>, or @-)
+- `--retry-backoff-seconds` — accelerated re-check spacing in seconds while a state change is pending, 5..300 (omitted when unset; the server then applies its default of 15)
+- `--retry-times` — consecutive confirming re-checks required before a state change commits, 0..5 (default 0 = off)
+- `--severity` — worst rollup state a failing assertion drives: degraded | critical (default critical)
+- `--target` — optional dispatch-target JSON object (inline JSON, @<path>, or @-)
+- `--tenant` — target tenant UUID (platform_admin cross-tenant create)
+- `--timezone` — IANA timezone name for cron evaluation (default 'UTC')
+
+### `meho sensor delete`
+
+Delete one sensor by id (tenant_admin)
+
+```
+meho sensor delete <sensor_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a structured JSON result instead of plain text
+- `--tenant` — target tenant UUID (platform_admin cross-tenant delete)
+
+### `meho sensor list`
+
+List sensors in your tenant
+
+```
+meho sensor list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cadence-kind` — filter by cadence kind: interval | cron
+- `--json` — emit raw ListResponse JSON instead of the human table
+- `--limit` — max sensors per page (1..500, server default 100 when omitted)
+- `--offset` — offset into the result set (default 0)
+- `--status` — filter by sensor status: active | paused
+- `--tenant` — target tenant UUID (platform_admin only; operator role is locked to its own tenant)
+
+### `meho sensor results`
+
+Show a sensor's per-tick evidence history (trend query)
+
+```
+meho sensor results <sensor_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cursor` — opaque keyset pagination token (echo the printed next cursor to continue)
+- `--from` — inclusive lower bound on evaluated_at (RFC 3339, e.g. 2026-08-01T00:00:00Z)
+- `--json` — emit the raw {items, next_cursor} JSON envelope instead of the human table
+- `--limit` — max rows per page (1..500, server default 100 when omitted)
+- `--state` — filter by state: ok | degraded | critical | unknown | skip
+- `--to` — inclusive upper bound on evaluated_at (RFC 3339, e.g. 2026-08-02T00:00:00Z)
+
+## `meho status`
+
+Show operator identity + backplane health; --watch streams live activity
+
+```
+meho status [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit a single JSON document on stdout instead of the human summary
+- `--op-class` — filter --watch events by op_class (read, write, credential_read, audit_query)
+- `--principal` — filter --watch events by principal_sub (JWT subject claim)
+- `--target` — filter --watch events by target_name (the connector instance name)
+- `--watch`, `-w` — stream a live SSE feed of broadcast events (one line per event; Ctrl-C to exit)
+
+## `meho targets`
+
+Operate the MEHO targets registry (add / list / describe / probe / import / discover)
+
+```
+meho targets
+```
+
+### `meho targets add`
+
+Register a single target (alias `create`)
+
+```
+meho targets add <name> [flags]
+```
+
+- `--alias` — additional name the target resolves by (repeatable)
+- `--auth-model` — per-target identity model (default: shared_service_account)
+- `--backplane` — backplane URL to create the target in (defaults to the URL recorded by `meho login`)
+- `--fqdn` — fully-qualified domain name, when distinct from --host
+- `--host` — host or IP the connector dials (required)
+- `--json` — emit the created target as JSON instead of the human summary
+- `--note` — free-form operator note stored on the target
+- `--port` — connection port (default: the connector's product default)
+- `--preferred-impl` — connector impl_id override for the resolver's tie-break
+- `--product` — connector product slug (required; must match a registered connector — see `meho connector list`)
+- `--secret-ref` — Vault path of the target's credential (omit to derive the per-tenant default)
+- `--tls-ca-pin` — PEM CA bundle to pin for this target (mutually exclusive with --verify-tls=false)
+- `--tls-server-name` — TLS SNI / certificate-verification hostname, decoupled from --host
+- `--verify-tls` — verify the target's TLS certificate; pass --verify-tls=false to opt out
+- `--version` — operator-asserted product version (e.g. 9.0) the resolver consults before the first probe
+
+### `meho targets describe`
+
+Describe a single target (alias-aware)
+
+```
+meho targets describe <name-or-alias> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho targets discover`
+
+Discover candidate targets a connector can reach for a product
+
+```
+meho targets discover <product> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human tables
+- `--seed-target` — scope discovery to one already-registered target's reach (resolved tenant-scoped)
+
+### `meho targets import`
+
+Bulk-import targets from a targets.yaml file
+
+```
+meho targets import <file> [flags]
+```
+
+- `--backplane` — backplane URL to import into (defaults to the URL recorded by `meho login`)
+- `--dry-run` — print the plan (read-only: one GET, no writes); does not apply
+- `--json` — output the plan as JSON (use with --dry-run)
+- `--update` — PATCH existing targets instead of erroring on duplicate names
+
+### `meho targets list`
+
+List targets in your tenant
+
+```
+meho targets list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cursor` — keyset pagination cursor (the last name from the previous page)
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--limit` — max targets per page (1..500, server default 100 when omitted)
+- `--product`, `-p` — filter by product slug (exact match)
+
+### `meho targets probe`
+
+Probe a target's connector and refresh its fingerprint
+
+```
+meho targets probe <name-or-alias> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+## `meho tenants`
+
+Operate per-tenant policy (flight-recorder capture policy)
+
+```
+meho tenants
+```
+
+### `meho tenants flight-recorder-policy`
+
+Manage the tenant's flight-recorder capture policy (tenant_admin)
+
+```
+meho tenants flight-recorder-policy
+```
+
+#### `meho tenants flight-recorder-policy set`
+
+Update the tenant flight-recorder capture policy (tenant_admin)
+
+```
+meho tenants flight-recorder-policy set [flags]
+```
+
+- `--agent-readable` — agent-read override (F5): true | false | inherit (inherit clears to the capture default)
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--clear-retention` — clear the retention override back to the global default
+- `--enabled` — per-tenant capture default (F1); send true or false
+- `--json` — emit the resolved policy as JSON instead of the human summary
+- `--retention-days` — per-tenant trace retention window in days (F4; 1..365)
+
+## `meho topology`
+
+Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / timeline / diff / history / annotate / unannotate / list-edges)
+
+```
+meho topology
+```
+
+### `meho topology annotate`
+
+Assert a curated topology edge (operator-curated cross-system relationship)
+
+```
+meho topology annotate <from> <kind> <to> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--evidence-url` — URL pointing at evidence for the asserted relationship (max 2000 chars)
+- `--from-kind` — pin the `from` endpoint to one node kind when its name is ambiguous
+- `--json` — emit the raw TopologyEdge response to stdout instead of the human summary
+- `--note` — free-form operator note (max 2000 chars) attached to the edge
+- `--to-kind` — pin the `to` endpoint to one node kind when its name is ambiguous
+
+### `meho topology bulk-import`
+
+Annotate a list of curated topology edges from one file in a single transaction
+
+```
+meho topology bulk-import <file> [flags]
+```
+
+- `--backplane` — backplane URL to import into (defaults to the URL recorded by the most recent `meho login`)
+- `--dry-run` — compute the plan without applying any annotation (no writes, no audit, no broadcast events)
+- `--json` — emit the raw POST /edges/bulk response JSON instead of the human table
+
+### `meho topology dependencies`
+
+Walk what a node depends on (forward closure)
+
+```
+meho topology dependencies <name|alias> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--depth` — max traversal depth (1..64, server default 16 when omitted)
+- `--include-stale` — include soft-deleted (stale) nodes and edges in the walk (last-refresh-wins); pass --include-stale=false for live rows only
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--kind` — restrict the walk to edges of this kind (e.g. runs-on, mounts, routes-through, belongs-to)
+- `--node-kind` — pin the anchor to one node kind when the name is ambiguous across kinds
+
+### `meho topology dependents`
+
+Walk what depends on a node (reverse closure)
+
+```
+meho topology dependents <name|alias> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--depth` — max traversal depth (1..64, server default 16 when omitted)
+- `--include-stale` — include soft-deleted (stale) nodes and edges in the walk (last-refresh-wins); pass --include-stale=false for live rows only
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--kind` — restrict the walk to edges of this kind (e.g. runs-on, mounts, routes-through, belongs-to)
+- `--node-kind` — pin the anchor to one node kind when the name is ambiguous across kinds
+
+### `meho topology diff`
+
+Diff the topology graph between two timestamps
+
+```
+meho topology diff <ts1> <ts2> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--changed-only` — suppress `updated` entries whose only mutation was a `last_seen` bump
+- `--json` — emit raw TopologyDiffResult JSON instead of the human summary
+- `--kind` — narrow to one resource kind (node kind like `vm` or edge kind like `runs-on`)
+
+### `meho topology history`
+
+Walk the per-resource history of one node
+
+```
+meho topology history <node-name|alias> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--include-edges` — also walk history rows for edges incident to the anchor node
+- `--json` — emit raw TopologyHistoryResult JSON instead of the human table
+- `--limit` — max rows returned (1..5000, server-side cap when omitted)
+- `--node-kind` — pin the anchor to one node kind when the name is ambiguous across kinds
+- `--since` — earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand, RFC3339, or YYYY-MM-DD
+- `--until` — latest valid_from; accepts the same shorthand as --since
+
+### `meho topology list-edges`
+
+List curated + auto topology edges (filterable, tenant-scoped)
+
+```
+meho topology list-edges [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--conflicts` — surface only edges flagged by the conflict detector (recoverability listing)
+- `--from` — filter to edges whose `from` endpoint matches this node name
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--kind` — restrict to one edge kind (run `meho topology annotate --help` for the closed 10-kind vocabulary)
+- `--limit` — max edges to return (1..1000, server default 200 when omitted)
+- `--offset` — pagination offset (default 0)
+- `--source` — restrict by source: `curated` (operator-asserted) or `auto` (probe-derived)
+- `--to` — filter to edges whose `to` endpoint matches this node name
+
+### `meho topology path`
+
+Find the shortest path between two nodes
+
+```
+meho topology path <from> <to> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--from-kind` — pin the `from` endpoint to one node kind when its name is ambiguous
+- `--include-stale` — include soft-deleted (stale) nodes and edges in the search (last-refresh-wins); pass --include-stale=false for live rows only
+- `--json` — emit machine-readable JSON to stdout instead of the human chain
+- `--max-hops` — max path length in hops (1..32, server default 8 when omitted)
+- `--to-kind` — pin the `to` endpoint to one node kind when its name is ambiguous
+
+### `meho topology refresh`
+
+Rediscover one target's topology and reconcile it into the graph
+
+```
+meho topology refresh <target> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit machine-readable JSON to stdout instead of the human summary
+
+### `meho topology timeline`
+
+Walk the tenant timeline of graph changes
+
+```
+meho topology timeline [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cursor` — opaque forward-pagination cursor from a prior page's NEXT line
+- `--json` — emit raw TopologyTimelineResult JSON instead of the human table
+- `--limit` — max rows per page (1..1000, server default 50 when omitted)
+- `--since` — earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand, RFC3339, or YYYY-MM-DD
+- `--target` — narrow to one target (name or alias; server-side resolution)
+- `--until` — latest valid_from; accepts the same shorthand as --since
+
+### `meho topology unannotate`
+
+Delete a curated topology edge (by id or by from/kind/to tuple)
+
+```
+meho topology unannotate <edge-id> | <from> <kind> <to> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--from-kind` — pin the `from` endpoint to one node kind when its name is ambiguous (tuple form only)
+- `--json` — emit machine-readable JSON ({"deleted": "<edge_id>"}) instead of the human line
+- `--to-kind` — pin the `to` endpoint to one node kind when its name is ambiguous (tuple form only)
+
+## `meho vault`
+
+Pre-scoped CLI verbs for the vault-1.x connector
+
+```
+meho vault
+```
+
+### `meho vault auth`
+
+Vault identity verbs (userpass / approle, read-only)
+
+```
+meho vault auth
+```
+
+#### `meho vault auth approle-list`
+
+List configured approle role names
+
+```
+meho vault auth approle-list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault auth approle-read`
+
+Read one approle role (policies, ttls)
+
+```
+meho vault auth approle-read <role> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault auth userpass-list`
+
+List configured userpass users
+
+```
+meho vault auth userpass-list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault auth userpass-read`
+
+Read one userpass user (policies, ttl)
+
+```
+meho vault auth userpass-read <user> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+### `meho vault kv`
+
+KV-v2 secret verbs (read / list / put / versions / delete)
+
+```
+meho vault kv
+```
+
+#### `meho vault kv delete`
+
+Soft-delete specific versions of a KV-v2 secret
+
+```
+meho vault kv delete <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+- `--versions` — comma-separated version numbers to soft-delete (e.g. 3,4,5); required
+
+#### `meho vault kv list`
+
+List keys at a KV-v2 path
+
+```
+meho vault kv list <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault kv put`
+
+Write a new version of a KV-v2 secret
+
+```
+meho vault kv put <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--cas` — check-and-set: only write if the current version equals this value
+- `--data` — secret body as inline JSON object or @<file>; required
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault kv read`
+
+Read the latest version of a KV-v2 secret
+
+```
+meho vault kv read <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault kv versions`
+
+List the version history of a KV-v2 secret
+
+```
+meho vault kv versions <mount> <path> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+### `meho vault sys`
+
+Vault system diagnostics (health / seal-status / mounts-list / auth-list)
+
+```
+meho vault sys
+```
+
+#### `meho vault sys auth-list`
+
+List enabled auth backends
+
+```
+meho vault sys auth-list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault sys health`
+
+Report Vault health (initialized / sealed / standby)
+
+```
+meho vault sys health [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault sys mounts-list`
+
+List enabled secret backends
+
+```
+meho vault sys mounts-list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+#### `meho vault sys seal-status`
+
+Read the Vault seal state
+
+```
+meho vault sys seal-status [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — Vault target slug to dispatch against (resolved server-side)
+
+## `meho vcf-automation`
+
+Pre-scoped CLI verbs for the vcfa-rest-9.0 dual-plane connector
+
+```
+meho vcf-automation
+```
+
+- `--fqdn` — per-call vhost override (target.fqdn); honoured by the connector for vhost routing
+- `--plane` — VCFA plane to target: 'provider' (cloudapi/*) or 'tenant' (iaas/api/*)
+
+### `meho vcf-automation about`
+
+Show VCFA appliance identity (plane-specific)
+
+```
+meho vcf-automation about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation blueprint`
+
+Tenant-plane VCFA catalog blueprints (list)
+
+```
+meho vcf-automation blueprint
+```
+
+#### `meho vcf-automation blueprint list`
+
+List tenant-plane catalog blueprints
+
+```
+meho vcf-automation blueprint list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation deployment`
+
+Tenant-plane VCFA catalog deployments (list / get)
+
+```
+meho vcf-automation deployment
+```
+
+#### `meho vcf-automation deployment get`
+
+Read one tenant-plane deployment by id
+
+```
+meho vcf-automation deployment get <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+#### `meho vcf-automation deployment list`
+
+List tenant-plane catalog deployments
+
+```
+meho vcf-automation deployment list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation operation`
+
+Pre-scoped meta-tool wrappers (search / call) for vcfa-rest-9.0
+
+```
+meho vcf-automation operation
+```
+
+#### `meho vcf-automation operation call`
+
+Dispatch any vcfa-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho vcf-automation operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — VCFA target slug
+
+#### `meho vcf-automation operation search`
+
+Hybrid BM25 + cosine RRF search across vcfa-rest-9.0 operations
+
+```
+meho vcf-automation operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho vcf-automation org`
+
+Provider-plane VCFA organizations (list / get)
+
+```
+meho vcf-automation org
+```
+
+#### `meho vcf-automation org get`
+
+Read one provider-plane organization by id
+
+```
+meho vcf-automation org get <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+#### `meho vcf-automation org list`
+
+List provider-plane organizations on a VCFA appliance
+
+```
+meho vcf-automation org list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation project`
+
+Tenant-plane VCFA projects (list)
+
+```
+meho vcf-automation project
+```
+
+#### `meho vcf-automation project list`
+
+List tenant-plane projects on a VCFA appliance
+
+```
+meho vcf-automation project list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation region`
+
+Provider-plane VCFA regions (list / get)
+
+```
+meho vcf-automation region
+```
+
+#### `meho vcf-automation region get`
+
+Read one provider-plane region by id
+
+```
+meho vcf-automation region get <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+#### `meho vcf-automation region list`
+
+List provider-plane regions on a VCFA appliance
+
+```
+meho vcf-automation region list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+### `meho vcf-automation user`
+
+Provider-plane VCFA system users (list)
+
+```
+meho vcf-automation user
+```
+
+#### `meho vcf-automation user list`
+
+List provider-plane system users on a VCFA appliance
+
+```
+meho vcf-automation user list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCFA target slug
+
+## `meho vcf-fleet`
+
+Pre-scoped CLI verbs for the fleet-rest-9.0 connector
+
+```
+meho vcf-fleet
+```
+
+### `meho vcf-fleet about`
+
+Show vRSLCM appliance identity (apiVersion + productVersion + build)
+
+```
+meho vcf-fleet about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+### `meho vcf-fleet datacenter`
+
+VCF Fleet datacenter operations (list)
+
+```
+meho vcf-fleet datacenter
+```
+
+#### `meho vcf-fleet datacenter list`
+
+List Fleet-managed datacenters (wrapper-verified reachability probe)
+
+```
+meho vcf-fleet datacenter list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+### `meho vcf-fleet environment`
+
+VCF Fleet environment operations (list / info)
+
+```
+meho vcf-fleet environment
+```
+
+#### `meho vcf-fleet environment info`
+
+Show the full detail of one Fleet environment
+
+```
+meho vcf-fleet environment info <environment-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+#### `meho vcf-fleet environment list`
+
+List Fleet-managed environments (the primary inventory unit)
+
+```
+meho vcf-fleet environment list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+### `meho vcf-fleet operation`
+
+Pre-scoped meta-tool wrappers (search / call) for fleet-rest-9.0
+
+```
+meho vcf-fleet operation
+```
+
+#### `meho vcf-fleet operation call`
+
+Dispatch any fleet-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho vcf-fleet operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — VCF Fleet target slug
+
+#### `meho vcf-fleet operation search`
+
+Hybrid BM25 + cosine RRF search across fleet-rest-9.0 operations
+
+```
+meho vcf-fleet operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho vcf-fleet product`
+
+VCF Fleet product operations (list)
+
+```
+meho vcf-fleet product
+```
+
+#### `meho vcf-fleet product list`
+
+List products deployed under a Fleet environment
+
+```
+meho vcf-fleet product list <environment-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+### `meho vcf-fleet request`
+
+VCF Fleet lifecycle request operations (list / info)
+
+```
+meho vcf-fleet request
+```
+
+#### `meho vcf-fleet request info`
+
+Show the full detail of one Fleet lifecycle request
+
+```
+meho vcf-fleet request info <request-id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+#### `meho vcf-fleet request list`
+
+List Fleet lifecycle requests (deploy / patch / upgrade workflows)
+
+```
+meho vcf-fleet request list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+### `meho vcf-fleet vcenter`
+
+VCF Fleet vCenter operations (list)
+
+```
+meho vcf-fleet vcenter
+```
+
+#### `meho vcf-fleet vcenter list`
+
+List vCenters registered under a Fleet datacenter
+
+```
+meho vcf-fleet vcenter list <datacenter-vmid> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — VCF Fleet target slug
+
+## `meho vcf-logs`
+
+Pre-scoped CLI verbs for the vrli-rest-9.0 connector (VCF Operations for Logs)
+
+```
+meho vcf-logs
+```
+
+### `meho vcf-logs about`
+
+Show vRLI appliance version, release name, and build
+
+```
+meho vcf-logs about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+
+### `meho vcf-logs aggregated`
+
+Run a vRLI aggregated event query (group-by / count / time-bin)
+
+```
+meho vcf-logs aggregated [constraints] [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+- `--time-range` — aggregation time window (e.g. 5m, 1h, 24h, 7d); empty = appliance default
+
+### `meho vcf-logs alert`
+
+vRLI alert-definition verbs (list)
+
+```
+meho vcf-logs alert
+```
+
+#### `meho vcf-logs alert list`
+
+List vRLI alert definitions
+
+```
+meho vcf-logs alert list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+
+### `meho vcf-logs content-pack`
+
+vRLI content-pack inventory verbs (list)
+
+```
+meho vcf-logs content-pack
+```
+
+#### `meho vcf-logs content-pack list`
+
+List installed vRLI content packs
+
+```
+meho vcf-logs content-pack list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+
+### `meho vcf-logs field`
+
+vRLI indexer-field catalog verbs (list)
+
+```
+meho vcf-logs field
+```
+
+#### `meho vcf-logs field list`
+
+List vRLI indexer fields (static + extracted)
+
+```
+meho vcf-logs field list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+
+### `meho vcf-logs host`
+
+vRLI host-inventory verbs (list)
+
+```
+meho vcf-logs host
+```
+
+#### `meho vcf-logs host list`
+
+List hosts currently reporting log events to this vRLI cluster
+
+```
+meho vcf-logs host list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vRLI target slug
+
+### `meho vcf-logs operation`
+
+Pre-scoped meta-tool wrappers (search / call) for vrli-rest-9.0
+
+```
+meho vcf-logs operation
+```
+
+#### `meho vcf-logs operation call`
+
+Dispatch any vrli-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho vcf-logs operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — vRLI target slug
+
+#### `meho vcf-logs operation search`
+
+Hybrid BM25 + cosine RRF search across vrli-rest-9.0 operations
+
+```
+meho vcf-logs operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho vcf-logs query`
+
+Run a vRLI event query (constraints, optional limit)
+
+```
+meho vcf-logs query [constraints] [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--limit` — max events to return (0 = appliance default)
+- `--target` — vRLI target slug
+
+## `meho vcf-operations`
+
+Pre-scoped CLI verbs for the vrops-rest-9.0 connector
+
+```
+meho vcf-operations
+```
+
+### `meho vcf-operations about`
+
+Show vROps appliance release name and build number
+
+```
+meho vcf-operations about [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vROps target slug
+
+### `meho vcf-operations alert`
+
+vROps alert verbs (list)
+
+```
+meho vcf-operations alert
+```
+
+#### `meho vcf-operations alert list`
+
+List vROps alerts (currently firing or recently resolved)
+
+```
+meho vcf-operations alert list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+### `meho vcf-operations alertdefinition`
+
+vROps alert-definition verbs (list)
+
+```
+meho vcf-operations alertdefinition
+```
+
+#### `meho vcf-operations alertdefinition list`
+
+List vROps alert definitions (the policy surface)
+
+```
+meho vcf-operations alertdefinition list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+### `meho vcf-operations operation`
+
+Pre-scoped meta-tool wrappers (search / call) for vrops-rest-9.0
+
+```
+meho vcf-operations operation
+```
+
+#### `meho vcf-operations operation call`
+
+Dispatch any vrops-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho vcf-operations operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+#### `meho vcf-operations operation search`
+
+Hybrid BM25 + cosine RRF search across vrops-rest-9.0 operations
+
+```
+meho vcf-operations operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key
+- `--json` — emit machine-readable JSON
+- `--limit` — max hits (1..50, clamped by the API)
+
+### `meho vcf-operations recommendation`
+
+vROps recommendation verbs (list)
+
+```
+meho vcf-operations recommendation
+```
+
+#### `meho vcf-operations recommendation list`
+
+List vROps recommendations (remediation hints attached to alerts/symptoms)
+
+```
+meho vcf-operations recommendation list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+### `meho vcf-operations resource`
+
+vROps resource verbs (list, get)
+
+```
+meho vcf-operations resource
+```
+
+#### `meho vcf-operations resource get`
+
+Get one vROps resource by identifier (UUID)
+
+```
+meho vcf-operations resource get <id> [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — vROps target slug
+
+#### `meho vcf-operations resource list`
+
+List vROps resources (VMs, hosts, datastores, adapter instances)
+
+```
+meho vcf-operations resource list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+### `meho vcf-operations supermetric`
+
+vROps super-metric verbs (list)
+
+```
+meho vcf-operations supermetric
+```
+
+#### `meho vcf-operations supermetric list`
+
+List vROps super metrics (user-defined metric formulae)
+
+```
+meho vcf-operations supermetric list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+### `meho vcf-operations symptom`
+
+vROps symptom verbs (list)
+
+```
+meho vcf-operations symptom
+```
+
+#### `meho vcf-operations symptom list`
+
+List vROps symptoms (per-condition signals beneath alerts)
+
+```
+meho vcf-operations symptom list [flags]
+```
+
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--params` — filter params as inline JSON or @<file>
+- `--target` — vROps target slug
+
+## `meho version`
+
+Print CLI version and build metadata
+
+```
+meho version
+```
+
+## `meho vmware`
+
+Pre-scoped CLI verbs for the vmware-rest-9.0 connector
+
+```
+meho vmware
+```
+
+### `meho vmware about`
+
+Show vSphere product, version, and build for a target
+
+```
+meho vmware about [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--target` — target slug to dispatch against (required for ops that read a target)
+
+### `meho vmware cluster`
+
+vSphere cluster verbs (list / patch)
+
+```
+meho vmware cluster
+```
+
+#### `meho vmware cluster list`
+
+List vSphere clusters on a vCenter target
+
+```
+meho vmware cluster list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho vmware cluster patch`
+
+Patch a vSphere cluster (composite: lifecycle-managed)
+
+```
+meho vmware cluster patch <name-or-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--spec` — patch spec as inline JSON or @<file>; optional
+- `--target` — target slug to dispatch against
+
+### `meho vmware datacenter`
+
+vSphere datacenter verbs (list)
+
+```
+meho vmware datacenter
+```
+
+#### `meho vmware datacenter list`
+
+List vSphere datacenters on a vCenter target
+
+```
+meho vmware datacenter list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho vmware datastore`
+
+vSphere datastore verbs (list)
+
+```
+meho vmware datastore
+```
+
+#### `meho vmware datastore list`
+
+List vSphere datastores on a vCenter target
+
+```
+meho vmware datastore list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho vmware host`
+
+vSphere host verbs (list / evacuate)
+
+```
+meho vmware host
+```
+
+#### `meho vmware host evacuate`
+
+Evacuate a host (composite: vMotion all VMs off then maintenance-mode)
+
+```
+meho vmware host evacuate <name-or-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho vmware host list`
+
+List ESXi hosts on a vCenter target
+
+```
+meho vmware host list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho vmware network`
+
+vSphere network verbs (list)
+
+```
+meho vmware network
+```
+
+#### `meho vmware network list`
+
+List vSphere networks on a vCenter target
+
+```
+meho vmware network list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+### `meho vmware operation`
+
+Pre-scoped meta-tool wrappers (search / call) for vmware-rest-9.0
+
+```
+meho vmware operation
+```
+
+#### `meho vmware operation call`
+
+Dispatch any vmware-rest-9.0 op_id (escape hatch for ops without aliases)
+
+```
+meho vmware operation call <op_id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON instead of the human render
+- `--params` — operation params as inline JSON or @<file>; omitted means no params
+- `--target` — target slug to dispatch against (required for ops that read a target)
+
+#### `meho vmware operation search`
+
+Hybrid BM25 + cosine RRF search across vmware-rest-9.0 operations
+
+```
+meho vmware operation search <query> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--group` — narrow the search to one group_key within the connector
+- `--json` — emit machine-readable JSON to stdout instead of the human table
+- `--limit` — max hits to return (1..50, clamped by the API at 50)
+
+### `meho vmware vm`
+
+vSphere VM verbs (list / info / create)
+
+```
+meho vmware vm
+```
+
+#### `meho vmware vm create`
+
+Create a VM via the composite create flow
+
+```
+meho vmware vm create [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--spec` — vSphere CreateSpec as inline JSON or @<file>; required
+- `--target` — target slug to dispatch against
+
+#### `meho vmware vm info`
+
+Show details for one VM by name or moid
+
+```
+meho vmware vm info <name-or-id> [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--target` — target slug to dispatch against
+
+#### `meho vmware vm list`
+
+List VMs on a vCenter target
+
+```
+meho vmware vm list [flags]
+```
+
+- `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--filter` — raw vSphere filter as k=v; repeat for multiple filters (e.g. --filter clusters=domain-c1)
+- `--json` — emit the full OperationResult envelope as JSON
+- `--names` — filter by VM name; repeat for multiple matches
+- `--power-state` — filter by powered_states (POWERED_ON / POWERED_OFF / SUSPENDED); repeat for OR
+- `--target` — target slug to dispatch against

--- a/docs-site/reference/connectors.md
+++ b/docs-site/reference/connectors.md
@@ -1,0 +1,61 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate from backend/ with: uv run python scripts/generate_reference_docs.py
+  The freshness gate in backend/tests/test_reference_docs_drift.py fails CI when this page and the registry disagree.
+-->
+
+# Connector inventory
+
+Every connector MEHO can resolve a target to, generated from the in-process connector registry. Each row is one registered implementation: agents and operators drive them all through the same governed surface — pick a connector, list its operation groups, search operations, then call — so the vendor never leaks into the tool names.
+
+MEHO has two kinds of connector, both first-class and indistinguishable to an agent. **Generic** connectors are built by ingesting a vendor's protocol spec (OpenAPI, GraphQL, WSDL, proto); **typed** connectors are hand-coded against a vendor SDK or transport where no usable spec exists. The **Kind** column is populated only where MEHO's published connector-spec catalog states it, and is blank otherwise — it is a property of how a connector's operations are sourced, not something this table infers.
+
+| Connector | Product | Supported versions | Kind |
+| --- | --- | --- | --- |
+| `argocd-api-3.x` | `argocd` | >=2.0,<4.0 | — |
+| `bind9-ssh-9.x` | `bind9` | — | typed |
+| `fleet-lcm-9.0` | `fleet` | >=9.0,<10.0 | — |
+| `fleet-rest-9.0` | `fleet` | >=8.0,<10.0 | — |
+| `gcloud-rest-1.0` | `gcloud` | — | — |
+| `gh-rest-3` | `gh` | — | generic |
+| `harbor-rest-2.x` | `harbor` | >=2.0,<3.0 | generic |
+| `hetzner-rest-2026.04` | `hetzner` | — | — |
+| `holodeck-ssh-9.0` | `holodeck` | — | — |
+| `hyperv-ssh-2022.x` | `hyperv` | — | — |
+| `installer-rest-9.1` | `installer` | >=9.1,<10.0 | — |
+| `k8s-1.x` | `k8s` | — | typed |
+| `keycloak-admin-26.x` | `keycloak` | >=26.0,<27.0 | — |
+| `loki-api-3.x` | `loki` | >=2.9,<4.0 | — |
+| `mongodb-wire-7` | `mongodb` | >=5,<9 | — |
+| `msad-ssh-2022.x` | `msad` | — | — |
+| `mssql-tds-2022.x` | `mssql` | >=13,<17 | — |
+| `nsx-rest-9.0` | `nsx` | >=4.0,<10.0 | generic |
+| `pfsense-ssh-2.7` | `pfsense` | — | — |
+| `postgres-wire-16` | `postgres` | >=13,<18 | — |
+| `prometheus-api-2.x` | `prometheus` | — | — |
+| `proxmox-api-8.x` | `proxmox` | >=7.0,<9.0 | — |
+| `rabbitmq-management-3.x` | `rabbitmq` | >=3.8,<5.0 | — |
+| `rke2-ssh-1.x` | `rke2` | — | — |
+| `sddc-rest-9.0` | `sddc` | >=9.0,<10.0 | generic |
+| `sddc-vcf5-5.0` | `sddc` | >=5.0,<9.0 | — |
+| `tempo-api-2.x` | `tempo` | >=2.0,<3.0 | — |
+| `vault-1.x` | `vault` | — | typed |
+| `vcd-rest-10.6` | `vcd` | >=10.0,<11.0 | — |
+| `vcfa-rest-9.0` | `vcfa` | >=9.0,<10.0 | — |
+| `vcfa-vra8-8.0` | `vcfa` | >=8.0,<9.0 | — |
+| `vmware-rest-9.0` | `vmware` | >=8.5,<10.0 | generic |
+| `vrli-rest-9.0` | `vrli` | >=9.0,<10.0 | — |
+| `vrli-vrli8-8.0` | `vrli` | >=8.0,<9.0 | — |
+| `vrops-rest-9.0` | `vrops` | >=9.0,<10.0 | — |
+| `vrops-vrops8-8.0` | `vrops` | >=8.0,<9.0 | — |
+| `windns-ssh-2016.x` | `windns` | — | — |
+| `winsrv-ssh-2022.x` | `winsrv` | — | — |
+| `wsfc-ssh-2022.x` | `wsfc` | — | — |
+
+## Versions and how a connector is chosen
+
+**Supported versions** is the product-version range an implementation advertises. Where a product has more than one implementation — a modern and a legacy one, say — both are registered and MEHO resolves the right one per target from the target's fingerprint, so one estate spanning old and new versions just works.
+
+## Maturity and readiness
+
+This inventory lists what is *registered*; it does not restate a ship-state. Feature-level maturity — GA, beta, or experimental — is published in the [feature maturity index](maturity.md). Per-release, per-connector ship-state (dispatch + catalog, loader-wired, or production-ready) is stated in the [changelog](https://github.com/evoila/meho/blob/main/CHANGELOG.md) under the connector release-notes convention. The two-connector model is described in the [architecture overview](../architecture.md).

--- a/docs-site/reference/index.md
+++ b/docs-site/reference/index.md
@@ -1,20 +1,27 @@
 # Reference
 
-This section is **generated from contract snapshots**, so it cannot drift
-from the product without a red build. The pages are being filled in and
-land incrementally:
-
-- MCP tools — from the `tools/list` snapshot.
-- REST API — from the public OpenAPI snapshot.
-- CLI — from the server-driven command manifest.
-- Environment variables — from the backplane settings model.
-- Helm values — from `values.schema.json`.
-- Connector catalog — with per-connector maturity badges.
+This section is **generated from the codebase**, so it cannot drift from
+the product without a red build. Each page is rendered from a registry,
+command tree, or contract snapshot and committed, with a CI freshness gate
+that fails the moment the source and the committed page disagree.
 
 ## Available now
 
 - [What's new](whats-new.md) — a plain-language summary of what landed
   in recent releases, since v0.28.0.
+- [Connectors](connectors.md) — the per-connector inventory: connector
+  id, product, supported version range, and kind, from the connector
+  registry.
+- [MCP tools](mcp-tools.md) — the three-tier MCP tool surface (working,
+  operator, human-only) with per-tool maturity, from the tool registry.
+- [CLI](cli.md) — the `meho` command tree: every verb, its usage, and its
+  flags, from the cobra command tree.
 - [Feature maturity index](maturity.md) — every feature's tier, the
-  milestone it targets, and where its road to GA is tracked, generated
-  from the codebase registry on every release.
+  milestone it targets, and where its road to GA is tracked, from the
+  codebase registry.
+
+## Landing incrementally
+
+- REST API — from the public OpenAPI snapshot.
+- Environment variables — from the backplane settings model.
+- Helm values — from `values.schema.json`.

--- a/docs-site/reference/mcp-tools.md
+++ b/docs-site/reference/mcp-tools.md
@@ -1,0 +1,125 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate from backend/ with: uv run python scripts/generate_reference_docs.py
+  The freshness gate in backend/tests/test_reference_docs_drift.py fails CI when this page and the registry disagree.
+-->
+
+# MCP tool surface
+
+MEHO exposes one narrow, stable surface of meta-tools over MCP — the same tools across every connector and product version, so an agent never has to route through a vendor's thousands of operations. The surface has three tiers, generated here from the in-process tool registry.
+
+- **Working surface** — what every MCP session lists by default.
+- **Operator plane** — governance tools a session lists only after requesting the `mcp:admin` OAuth scope (request-only; the realm grants it on ask).
+- **Human-only** — decision verbs with no MCP path under any claim set; a human makes these at the console or CLI.
+
+Each tool also exists as a `meho` CLI command against the same dispatch path — see the [CLI reference](cli.md). Maturity labels (`beta` / `experimental`) come from the [feature maturity registry](maturity.md); a `—` maturity is deliberately unclassified infrastructure.
+
+## Working surface
+
+The default agent surface. No elevation required.
+
+| Tool | Maturity | Extra gate | Summary |
+| --- | --- | --- | --- |
+| `add_to_knowledge` | ga | — | Add a new entry to the tenant's knowledge base. |
+| `add_to_memory` | ga | — | Add a new memory entry. |
+| `ask_docs` | experimental | capability `meho-docs` | Answer a vendor-reference question with a SYNTHESIZED, CITED answer composed over a vendor-document collection (product manuals, KB articles, design / reference guides) — e.g. 'What are the NSX 9.0 config maximums for logical switches?'. |
+| `call_operation` | ga | — | Invoke an operation. |
+| `list_doc_collections` | experimental | capability `meho-docs` | List the documentation collections you are entitled to search — the catalogue an agent reads to learn WHICH `collection` to pass to `search_docs` / `ask_docs` before searching. |
+| `list_operation_groups` | ga | — | List enabled operation groups for a connector. |
+| `list_targets` | ga | — | List the operator's accessible infrastructure targets, optionally filtered by connector. |
+| `meho_broadcast_announce` | beta | — | Publish an agent-authored announcement to the operator's tenant broadcast stream. |
+| `meho_broadcast_recent` | beta | — | Read the operator's tenant's recent broadcast events from meho:feed:{tenant_id}. |
+| `meho_broadcast_watch` | beta | — | Long-poll the operator's tenant broadcast stream for new events past 'cursor'. |
+| `meho_connector_list` | ga | — | List ingested connectors visible to the operator's tenant (plus built-in / global). |
+| `meho_runbook_abort` | beta | — | Abort an in-progress run. |
+| `meho_runbook_list_runs` | beta | — | List runs in the tenant. |
+| `meho_runbook_list_templates` | beta | — | List runbook templates in the operator's tenant. |
+| `meho_runbook_next` | beta | — | Advance one step in an in-progress runbook run. |
+| `meho_runbook_show_template` | beta | — | Read the full body of a runbook template, including step contents. |
+| `meho_runbook_start` | beta | — | Start a new runbook run. |
+| `meho_status` | — | — | Returns the operator's identity (sub, name, email, tenant_id, tenant_role) plus the MEHO backplane's dependency status: Vault federation chain (reachable + KV read OK?) and DB migration state. |
+| `preview_operation` | ga | — | Preview an operation WITHOUT running it. |
+| `query_topology` | beta | — | Query the topology graph. |
+| `result_query` | ga | — | Read rows back from a JSONFlux result handle. |
+| `search_docs` | experimental | capability `meho-docs` | Search a vendor-document collection (product manuals, KB articles, design / reference guides) for an authoritative vendor fact — e.g. 'NSX config maximums for 9.0' or 'vCenter 8.0 supported snapshot depth'. |
+| `search_knowledge` | ga | — | Search the tenant's knowledge base for distilled operator knowledge: vendor API patterns, lab conventions, known-good runbooks, post-incident learnings. |
+| `search_memory` | ga | — | Search the operator's accessible memories (own user-scoped entries + tenant-shared + target-shared entries visible to this operator). |
+| `search_operations` | ga | — | Hybrid BM25 + cosine retrieval over a connector's enabled operations. |
+
+### Add-on working tools
+
+Listed on the working surface only while a paired add-on advertising the named family is active for the tenant; a backplane with no such add-on paired never lists them.
+
+| Tool | Maturity | Extra gate | Summary |
+| --- | --- | --- | --- |
+| `meho_automation_list` | experimental | add-on `automation` | List the surface a paired automation add-on advertises — the automation analogue of `meho_connector_list`. |
+
+## Operator plane (`mcp:admin`)
+
+Connector lifecycle, principals and grants, scheduler, sensors, topology mutations, audit admin, and the other governance planes. A session lists and can call these only when it holds the `mcp:admin` scope.
+
+| Tool | Maturity | Extra gate | Summary |
+| --- | --- | --- | --- |
+| `create_doc_collections` | experimental | capability `meho-docs` | Register a new documentation collection in your tenant so `search_docs` / `ask_docs` can route to it — the write half of the doc-collection registry (tenant_admin only). |
+| `delete_doc_collections` | experimental | capability `meho-docs` | Deregister a disabled, tenant-owned documentation collection and free its `collection_key` for re-registration — the delete half of the doc-collection registry (tenant_admin only). |
+| `meho_agent_principals_list` | experimental | — | List agent principals registered for the operator's tenant. |
+| `meho_agent_principals_register` | experimental | — | Register a new agent principal for the operator's tenant. |
+| `meho_agent_principals_revoke` | experimental | — | Revoke an agent principal — kill switch. |
+| `meho_agents_create` | experimental | — | Create an agent definition for the operator's tenant. |
+| `meho_agents_delete` | experimental | — | Delete an agent definition by name for the operator's tenant. |
+| `meho_agents_edit` | experimental | — | Apply a partial update to an agent definition by name. |
+| `meho_agents_grant_create` | experimental | — | Grant a permission to an agent principal. |
+| `meho_agents_grant_list` | experimental | — | List agent permission grants for the operator's tenant. |
+| `meho_agents_grant_revoke` | experimental | — | Revoke (delete) a permission grant by id. |
+| `meho_agents_grant_show` | experimental | — | Fetch one agent permission grant by id. |
+| `meho_agents_list` | experimental | — | List agent definitions for the operator's tenant. |
+| `meho_agents_list_runs` | experimental | — | List the operator's tenant's agent runs, newest first. |
+| `meho_agents_run` | experimental | — | Run a named agent for the operator's tenant. |
+| `meho_agents_run_status` | experimental | — | Poll an agent run's durable status by run_id. |
+| `meho_agents_show` | experimental | — | Fetch one agent definition by name for the operator's tenant. |
+| `meho_approvals_get` | ga | — | Inspect a single approval request by id. |
+| `meho_approvals_list` | ga | — | List approval requests for your tenant. |
+| `meho_audit_replay` | ga | — | Reconstruct the full trace of one agent session — every operation, its result, and the parent/child graph between them — as a chronological ReplayNode forest. |
+| `meho_broadcast_overrides_list` | beta | — | List broadcast-detail override rules for the operator's tenant. |
+| `meho_broadcast_overrides_remove` | beta | — | Delete a broadcast-detail override rule by id for the operator's tenant. |
+| `meho_broadcast_overrides_set` | beta | — | Create a broadcast-detail override rule for the operator's tenant. |
+| `meho_connector_delete` | ga | — | Delete one connector (tenant_admin only): remove its operation_group + endpoint_descriptor rows under the target scope and, when no rows remain for the triple anywhere, deregister the auto-registered ingest shim from the v2 registry. |
+| `meho_connector_disable` | ga | — | Flip every group of a connector to review_status='disabled' (tenant_admin only). |
+| `meho_connector_edit_group` | experimental | — | Edit one operation group's when_to_use prose or display name (tenant_admin only). |
+| `meho_connector_edit_op` | experimental | — | Edit one operation's per-op overrides (tenant_admin only). |
+| `meho_connector_enable` | ga | — | Flip every group of a connector to review_status='enabled' (tenant_admin only). |
+| `meho_connector_enable_reads` | ga | — | Bulk-enable every read-class operation of a connector in one pass (tenant_admin only). |
+| `meho_connector_ingest` | experimental | — | Ingest one or more OpenAPI specs into a MEHO connector (tenant_admin only). |
+| `meho_connector_ingest_status` | experimental | — | Poll the durable status of an async connector-ingest job by handle (operator-level). |
+| `meho_connector_review` | experimental | — | Get the full review payload for one connector (groups + per-group operations + per-op flags). |
+| `meho_memory_promote` | ga | — | Promote one memory to a strictly broader scope along the ladder: user -> user-tenant -> tenant, OR user -> user-target -> target. |
+| `meho_runbook_deprecate_template` | beta | — | Mark a published version as deprecated. |
+| `meho_runbook_discard_template` | beta | — | Delete an UNPUBLISHED DRAFT version of a template. |
+| `meho_runbook_draft_template` | beta | — | Create the first draft of a new runbook template. |
+| `meho_runbook_edit_template` | beta | — | Edit a runbook template. |
+| `meho_runbook_publish_template` | beta | — | Flip a draft template to published. |
+| `meho_runbook_reassign` | beta | — | Reassign an in-progress run to a different operator. |
+| `meho_scheduler_cancel` | beta | — | Cancel one scheduled trigger by id. |
+| `meho_scheduler_create` | beta | — | Create one scheduled trigger under the operator's tenant. |
+| `meho_scheduler_list` | beta | — | List scheduled triggers for the operator's tenant. |
+| `meho_sensor_create` | beta | — | Create one sensor under the operator's tenant. |
+| `meho_sensor_delete` | beta | — | Hard-delete one sensor by id. |
+| `meho_sensor_list` | beta | — | List sensors for the operator's tenant. |
+| `meho_sensor_results` | beta | — | Per-tick evidence trend query for one sensor. |
+| `meho_targets_register` | ga | — | Register a new target in the operator's tenant (tenant_admin only). |
+| `meho_topology_annotate` | beta | — | Assert a curated `graph_edge` that auto-discovery cannot infer (tenant_admin only). |
+| `meho_topology_bulk_import` | beta | — | Batch-assert curated `graph_edge` rows in one atomic pass (tenant_admin only). |
+| `meho_topology_create_node` | beta | — | Manually seed a `graph_node` row in the operator's tenant (tenant_admin only). |
+| `meho_topology_delete_node` | beta | — | Hard-delete a manually-seeded `graph_node` row by `node_id` (tenant_admin only), writing a `removed` history tombstone so the delete stays visible in `query_topology {kind: timeline}`. |
+| `meho_topology_unannotate` | beta | — | Hard-delete a curated `graph_edge` and clear its reciprocal markers (tenant_admin only). |
+| `query_audit` | ga | — | Query the audit log for forensic reconstruction. |
+
+## Human-only (no MCP path)
+
+Approving or rejecting a parked operation, and granting an agent a privilege elevation, are human decisions with no agent-facing path under any claim set. An agent that reaches for one is told where the human makes the decision instead.
+
+| Tool | Where the decision is made |
+| --- | --- |
+| `meho_agents_grant_elevate` | operator console approvals queue, or the `meho` CLI |
+| `meho_approvals_approve` | operator console approvals queue, or the `meho` CLI |
+| `meho_approvals_reject` | operator console approvals queue, or the `meho` CLI |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,14 @@ nav:
   - Reference:
       - reference/index.md
       - What's new: reference/whats-new.md
+      # Generated from the connector registry + MCP tool registry by
+      # backend/scripts/generate_reference_docs.py; freshness is enforced
+      # by backend/tests/test_reference_docs_drift.py.
+      - Connectors: reference/connectors.md
+      - MCP tools: reference/mcp-tools.md
+      # Generated from the cobra command tree by cli/cmd/docgen; freshness
+      # is enforced by the cli-api-snapshot-freshness CI job.
+      - CLI: reference/cli.md
       # Generated from the feature-maturity registry by
       # backend/scripts/generate_maturity_index.py (#2678); freshness
       # is enforced by backend/tests/test_maturity_surface_drift.py.


### PR DESCRIPTION
## Summary

Adds three docs-site **reference pages, each generated from the codebase and committed with a CI freshness gate**, plus their `Reference` nav entries. This is the generator slice of the internal public-surfaces refresh plan (2026-09-03): the published Reference section stops promising generated pages and starts shipping them, drift-proof.

## Design

Each page is rendered from the cheapest **reliable, DB-free** source (in-process registries; no live backplane, no database):

- **Connectors** ← the v2 connector registry (`all_connectors_v2()`), joined with the committed connector-spec catalog for `kind`.
- **MCP tools** ← the in-process MCP tool registry (`tools/list` contract) + the human-only decision verbs; deliberately **not** embedding `docs/codebase/mcp.md` (it carries internal refs + a private link).
- **CLI** ← the cobra command tree, via a small Go tool (`cli/cmd/docgen`) that walks the tree offline with discovery disabled (deterministic). No new Go dependencies.

Both generators strip internal planning references (issue numbers, Goal/Task ids, section markers) and lab-specific example coordinates (`.lab` hostnames, IPs) from the source text; every page carries a "generated — do not edit" header.

## The three generated pages

- `docs-site/reference/connectors.md` — per-connector inventory: connector id, product, supported version range, kind (39 rows).
- `docs-site/reference/mcp-tools.md` — the three-tier MCP tool surface (working 25 · operator 53 · human-only 3) with per-tool maturity and gating.
- `docs-site/reference/cli.md` — the `meho` command tree: every verb, its usage line, and its flags.

## The two freshness gates (each mirrors an existing repo precedent)

- **connectors.md + mcp-tools.md** → `backend/tests/test_reference_docs_drift.py` (backend unit lane) — regenerate-and-compare + a public-safety assertion; same shape as `maturity.md` / `test_maturity_surface_drift.py`.
- **cli.md** → a `make cli-docs` regen + `git diff --exit-code` step in the existing `cli-api-snapshot-freshness` CI job; same shape as `cli/api/openapi.json`.

Not added to `docs-site.yml`'s `mkdocs build --strict` job on purpose: that job installs only the `docs` dependency group and must not import the backend.

## Deviations (surfaced for review)

- **No `Readiness` column.** The plan lists it "blank where no public statement exists"; there is no machine-readable *current* per-connector public readiness source (the readiness doc's State map is a stale v0.3.0 snapshot — mechanically parsing it risks the over/understatement that doc exists to prevent). Rather than a 39-row all-`—` column, the page carries a prose "Maturity and readiness" section linking the maturity index + the CHANGELOG ship-state convention. The literal all-`—` column is a one-line add if wanted.
- **`Kind` is populated for only 8 of 39 rows** (the catalogued connectors). Kind is a DB/runtime property for the rest; the connector-spec catalog is the only DB-free public statement, so the other rows render `—`.
- **`holodeck-ssh-9.0` is included** as a real registered connector ("Holodeck" is a public VMware toolkit name, not a lab identifier).
- **No `auth models` / `docs link` columns** — the plan gated both ("if cheaply available" / "where a docs-site page exists"); neither is cheaply/reliably available.

## Verification

- Verification: `mkdocs build --strict` → exit 0, zero warnings.
- Verification: `pytest tests/test_reference_docs_drift.py` → 4 passed (freshness + no-internal-reference guard).
- Verification: generators deterministic ×2 and idempotent (regenerate → no git diff); `make cli-docs` + `git diff --exit-code` clean.
- Verification: `ruff check`/`ruff format --check` clean on the new Python; `gofmt`/`go build ./...`/`go vet`/`go test ./internal/cmd/` OK.
- Verification: safety scan across all three pages found no internal ids, lab names, or IPs.

Source: the internal public-surfaces refresh plan (2026-09-03), WP-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
