### PR TITLE
docs(changelog): roll [Unreleased] into v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ connector-related release-notes line.
 
 ## [0.33.0] - 2026-09-04
 
-### Added — docs site: new guide pages, client onramps + MCP surface tiers, and a What's new page (#3334 / #3335 / #3342 / #3343)
+### Added — docs site: new guide pages, client onramps + MCP surface tiers, and a What's new page (#3334 / #3335 / #3342 / #3343 / #3346)
 
 - New Do-real-work guides on the docs site: **flight recorder**, **event
   ingestion**, and **add-ons** (#3334); a **Windows estate and in-guest
@@ -104,6 +104,10 @@ connector-related release-notes line.
   approvals, the docs add-on, sensors, and upgrades — with the shipped v0.32.0
   surface (#3335). Docs-site only; no code, schema, or CLI OpenAPI-snapshot
   change.
+- **Generated reference pages** — the connector inventory, the MCP tool
+  reference, and the CLI command reference are now generated straight from the
+  code, published on the docs site under **Reference**, with a CI freshness
+  gate that fails the build if a published page drifts from the source (#3346).
 
 ### Added — standalone-ESXi host resolution (pre-vCenter) + a governed host storage-device read (#3332)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-09-04
+
+### Added — docs site: new guide pages, client onramps + MCP surface tiers, and a What's new page (#3334 / #3335 / #3342 / #3343)
+
+- New Do-real-work guides on the docs site: **flight recorder**, **event
+  ingestion**, and **add-ons** (#3334); a **Windows estate and in-guest
+  execution** guide (#3342); a **client onramps** section (Claude Code, Claude
+  Desktop) with an **MCP surface-and-scopes** reference explaining the default
+  25-tool working surface vs the `mcp:admin` operator planes, and a new
+  **What's new** page summarising recent releases in plain language (#3343). A
+  truthfulness sweep also reconciled the existing guides — banners, CLI verbs,
+  approvals, the docs add-on, sensors, and upgrades — with the shipped v0.32.0
+  surface (#3335). Docs-site only; no code, schema, or CLI OpenAPI-snapshot
+  change.
+
 ### Added — standalone-ESXi host resolution (pre-vCenter) + a governed host storage-device read (#3332)
 
 - **The host-domain write composites now dispatch against a standalone
@@ -132,6 +147,19 @@ connector-related release-notes line.
   large). No DB migration; the op registers at runtime, so the CLI OpenAPI
   snapshot is unchanged. (Follow-up to verify the boot-key format on real
   hardware: #3336.)
+
+### Fixed — operator console: Conventions create + edit dialogs miscompiled under daisyUI v5 (#240 / #3309, #241 / #3321)
+
+- **The Conventions "New convention" create dialog and the detail-view edit
+  modal rendered with collapsed, misaligned fields.** Both used daisyUI v4
+  `form-control` / `label-text` classes, removed in v5 (zero compiled rules),
+  so the label-over-input columns collapsed and the two-column Slug/Kind and
+  Body/token-preview grids read misaligned. Both dialogs migrated to
+  `flex flex-col gap-1` label wrappers with `w-full` controls, preserving the
+  `max-w-[12rem]` Priority cap and the `md:grid-cols-2` layouts. Presentation
+  only — the create POST, edit PATCH, CSRF double-submit, the read-only
+  slug/kind contract, and the debounced token-cost preview are unchanged. No DB
+  migration; no CLI OpenAPI-snapshot change.
 
 ### Fixed — CLI credential store: reconcile the keyring/file split-brain (#3320)
 

--- a/docs-site/reference/whats-new.md
+++ b/docs-site/reference/whats-new.md
@@ -9,6 +9,39 @@ for each breaking one.
 MEHO is under active development. Each release below links to its full
 notes.
 
+## [v0.33.0](https://github.com/evoila/meho/releases/tag/v0.33.0) — 2026-09-04
+
+- **A much bigger documentation site.** New do-real-work guides for the flight
+  recorder, external event ingestion, and add-ons; a guide to the Windows
+  estate and governed in-guest program execution; a client-onramp section for
+  Claude Code and Claude Desktop; an explainer of the MCP surface tiers — the
+  default working surface versus the operator planes behind the `mcp:admin`
+  scope; and this What's new page. An accuracy sweep also brought the existing
+  guides back in line with what the last release actually ships.
+- **Generated, always-current references.** The connector catalogue, the full
+  MCP tool inventory, and every CLI command are published as reference pages
+  generated straight from the code, with a CI check that fails the build if
+  they drift out of date.
+- **Standalone ESXi hosts, before any vCenter exists.** The host-setup
+  composites — mount an NFS datastore, mark a disk as flash, control a service
+  — now run directly against a freshly provisioned ESXi host that no vCenter
+  manages yet, the exact state you are in early in a management-domain
+  bring-up. A new read lists a host's raw storage devices so the disk it
+  flash-marks is chosen from real data.
+- **More governed deletes for pfSense.** Removing a static route, a gateway,
+  or a single member of a shared firewall alias each became a governed,
+  approval-gated delete that previews exactly what goes and refuses to strand a
+  route behind a gateway or empty a shared alias.
+- **Preview parity for approval-gated actions.** An agent can now preview the
+  exact effect of an approval-requiring action before it parks for a human,
+  matching what the approver sees — while actions that carry a secret in their
+  request stay deliberately un-previewable.
+- **Steadier CLI sign-in.** A stale system-keyring entry can no longer shadow
+  a newer saved token, and expiry messages now say plainly when a session has
+  ended and point at how to sign back in.
+- **Operator console polish.** The Conventions create and edit dialogs render
+  correctly again after a UI-framework upgrade.
+
 ## [v0.32.0](https://github.com/evoila/meho/releases/tag/v0.32.0) — 2026-09-02
 
 - **The Microsoft estate gains connectors.** New connectors for Windows


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
<!-- Copyright (c) 2026 evoila Group -->

## Description

Release-cutting PR for **v0.33.0** (target date 2026-09-04). Rolls the
`## [Unreleased]` CHANGELOG section into `## [0.33.0] - 2026-09-04` and adds the
docs-site What's new section for the release.

**CHANGELOG completeness audit** (`git log v0.32.0..origin/main`) — every merged
PR since v0.32.0 now has a bullet:

- Rolled as-is (already had bullets): standalone-ESXi host resolution +
  `vmware.host.storage_devices` read (#3332 / #3333); CLI credential keyring/file
  split-brain fix (#3320 / #3324); preview parity for approval-requiring typed
  ops + destructive-builder CI sweep (#3312 / #3316); pfSense three
  teardown-inverse governed deletes (#3313 / #3314).
- **Backfilled** (surfaced by the audit, no prior bullet):
  - Fixed — operator console Conventions create + edit dialogs miscompiled under
    daisyUI v5 (#3309, #3321).
  - Added — docs site: new guide pages, client onramps + MCP surface tiers, and a
    What's new page (#3334, #3335, #3342, #3343).

**What's new page** — added a `v0.33.0` section at the top of
`docs-site/reference/whats-new.md` in the page's existing per-release
plain-language format (public-safe: no internal ticket numbers, hostnames, or
lab names in prose).

**No version-file edits** — the git tag is the sole version source
(`backend/pyproject.toml` stays `0.1.0-dev`; chart `version`/`appVersion` are
calver-bumped by `chart.yml`; the CLI bakes `{{.Tag}}`). No DB migration and no
CLI OpenAPI-snapshot change in the rolled work, so no `deploying.md`
upgrade-notes row is required.

### Gates run locally

- `uv run --project backend --no-sync mkdocs build --strict` → clean (exit 0).
- Release-body path-freshness gate (`scripts/release/check_release_body_paths.py`)
  → OK, 0 cited paths.

### Sequencing

The generated-references docs PR (#3346) must merge **before** the tag so the
docs deploy includes it; this PR is independent of it (different files). The tag
is held until the orchestrator gives the go.

## Related issue

Release v0.33.0.

## Type of change

- [x] Documentation

## Checklist

- [x] Conventional Commits format on every commit
- [x] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable (n/a — CHANGELOG + docs only)
- [x] Documentation updated where applicable
- [ ] CI green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)