### PR TITLE
fix(grants): accept literal query-string op ids (?action=…) in standing grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — service-principal grants: literal query-string op ids (`?action=…`) were refused as wildcards (#3350)
+
+- A standing grant whose `op_id` carried a literal query string (e.g.
+  `POST:/vcenter/vm/{vm}/power?action=start`,
+  `POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy`) was
+  rejected with a 422 "wildcards are not permitted", because `_reject_wildcards`
+  treated every `?` as a glob. Several governed vCenter ops key each `?action=`
+  verb as its own exact op id, so a service principal could never hold a grant
+  for them and the `vm.power` / `vm.create` power-on / `vm.deploy_from_library`
+  composites always parked. Grant creation now accepts a well-formed literal
+  query string on an HTTP-style op id (exactly one `?`, no `*`, `key=value`
+  pairs joined by `&`) and matches it by exact string equality; `*` anywhere and
+  a malformed `?` are still refused.
+
 ## [0.33.0] - 2026-09-04
 
 ### Added — docs site: new guide pages, client onramps + MCP surface tiers, and a What's new page (#3334 / #3335 / #3342 / #3343 / #3346)

--- a/backend/src/meho_backplane/operations/service_grants.py
+++ b/backend/src/meho_backplane/operations/service_grants.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: cohesive CRUD + enforcement unit (create-time review,
+# lookup, dispatch-time consult) that predates this change at ~650 lines;
+# splitting the grant service from its enforcement path is out of scope for a
+# surgical bug fix.
 
 """Standing scoped auto-approval grants for service principals (#3151 / #3152).
 
@@ -43,6 +47,7 @@ tag.
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -99,25 +104,67 @@ class GrantValidationError(Exception):
 # ---------------------------------------------------------------------------
 
 
+#: A well-formed HTTP-style ``op_id`` ending in a **literal** query string.
+#:
+#: Several governed vCenter operations carry a ``?action=<verb>`` (or a
+#: multi-param) query string as a literal part of their canonical op id — the
+#: ``vm.power`` / ``vm.deploy_from_library`` / host-software composite sub-ops
+#: (``POST:/vcenter/vm/{vm}/power?action=start``,
+#: ``POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy``,
+#: ``POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true``) and
+#: every ``?action=`` endpoint the ingest parser emits. That ``?`` is part of
+#: the exact op id, not a glob — grant matching is exact string equality (see
+#: :func:`find_live_grant`), so the literal is safe. This matches exactly one
+#: ``?`` (no ``*``), followed by one or more ``key=value`` pairs joined by
+#: ``&`` (keys / values are ``[A-Za-z0-9_.-]``, covering ``vmw-task``).
+_LITERAL_QUERY_STRING_OP_ID: re.Pattern[str] = re.compile(
+    r"^[A-Z]+:/[^?*]+\?[A-Za-z0-9_.-]+=[A-Za-z0-9_.-]+"
+    r"(?:&[A-Za-z0-9_.-]+=[A-Za-z0-9_.-]+)*$"
+)
+
+
 def _reject_wildcards(payload: ServiceGrantCreate) -> None:
-    """Refuse any glob metacharacter in the exact-scope fields (#3151).
+    """Refuse glob metacharacters in the exact-scope fields (#3151).
 
     Creating a grant is the operator's explicit per-op review, so
     ``op_id``, ``connector_id``, and ``principal_sub`` must each name one
-    exact value — a ``*`` / ``?`` would silently widen the unattended
-    surface past what the operator reviewed.
+    exact value — a ``*`` (or a bare ``?``) would silently widen the
+    unattended surface past what the operator reviewed. ``*`` is never
+    permitted anywhere.
+
+    The one exception is a **literal** query string on an HTTP-style
+    ``op_id`` (e.g. ``POST:/vcenter/vm/{vm}/power?action=start``): several
+    governed vCenter ops carry a ``?action=`` key as a literal part of their
+    exact op id, and grant matching is exact string equality, so such an op
+    id is accepted verbatim (see :data:`_LITERAL_QUERY_STRING_OP_ID`). A
+    ``?`` anywhere else — a malformed op id, or a ``connector_id`` /
+    ``principal_sub`` — is still a rejected glob.
     """
+
+    def _wildcard_error(field: str, value: str) -> GrantValidationError:
+        return GrantValidationError(
+            f"{field} must be an exact value; wildcards are not permitted "
+            f"(got {value!r}). A standing grant is the operator's explicit "
+            "per-op review, not a pattern."
+        )
+
     for field, value in (
         ("op_id", payload.op_id),
         ("connector_id", payload.connector_id),
         ("principal_sub", payload.principal_sub),
     ):
-        if "*" in value or "?" in value:
-            raise GrantValidationError(
-                f"{field} must be an exact value; wildcards are not permitted "
-                f"(got {value!r}). A standing grant is the operator's explicit "
-                "per-op review, not a pattern."
-            )
+        if "*" in value:
+            raise _wildcard_error(field, value)
+        if "?" in value:
+            if field == "op_id" and _LITERAL_QUERY_STRING_OP_ID.match(value):
+                continue
+            if field == "op_id":
+                raise GrantValidationError(
+                    "op_id may contain a literal query string like "
+                    f"'?action=start' (got {value!r}); glob wildcards are not "
+                    "permitted."
+                )
+            raise _wildcard_error(field, value)
 
 
 def _validate_expires_at(expires_at: datetime | None) -> None:

--- a/backend/tests/test_service_grants.py
+++ b/backend/tests/test_service_grants.py
@@ -25,6 +25,7 @@ from meho_backplane.operations.service_grant_schemas import ServiceGrantCreate
 from meho_backplane.operations.service_grants import (
     GrantValidationError,
     ServicePrincipalGrantService,
+    find_live_grant,
 )
 from meho_backplane.settings import get_settings
 
@@ -103,6 +104,76 @@ async def test_create_refuses_wildcards(field: str, payload_kwargs: dict[str, st
         await svc.create(_TENANT_ID, _CREATOR, _payload(**payload_kwargs))
     assert field in str(exc.value)
     assert "wildcard" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op_id",
+    [
+        # vCenter ?action= governance keys carry a literal query string as
+        # part of their exact op id (vm.power / vm.deploy / host-software).
+        "POST:/vcenter/vm/{vm}/power?action=start",
+        "POST:/vcenter/vm/{vm}/guest/power?action=shutdown",
+        "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy",
+        # multi-param, including a hyphenated param name (vmw-task).
+        "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true",
+    ],
+)
+async def test_create_accepts_literal_query_string_op_id(op_id: str) -> None:
+    """A literal ``?action=`` query string on an op_id is exact, not a glob."""
+    svc = ServicePrincipalGrantService()
+    entry = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op_id))
+    assert entry.op_id == op_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op_id",
+    [
+        "POST:/vcenter/vm/*",  # glob in the path
+        "POST:/vcenter/vm/{vm}/power?action=*",  # glob in the value
+        "POST:/vcenter/vm/?",  # bare ? (no key=value)
+        "POST:/x?",  # ? with nothing after it
+        "POST:/x?a",  # key with no '='
+        "POST:/x?a=b?c=d",  # a second '?' (not '&')
+        "*.delete",  # typed-op glob
+    ],
+)
+async def test_create_refuses_malformed_query_or_glob_op_id(op_id: str) -> None:
+    """A malformed ``?`` use or any ``*`` in op_id is still refused."""
+    svc = ServicePrincipalGrantService()
+    with pytest.raises(GrantValidationError) as exc:
+        await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op_id))
+    assert "op_id" in str(exc.value)
+    assert "wildcard" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_query_string_grant_round_trips_to_find_live_grant(
+    session: AsyncSession,
+) -> None:
+    """A query-param op id is created and matched by an exact-string dispatch.
+
+    Regression for the defect where ``?action=`` op ids were refused as
+    wildcards: without a creatable grant, the power/deploy composite sub-ops
+    always parked for service principals. Grant matching is exact string
+    equality, so the same string used to create must match at dispatch.
+    """
+    op_id = "POST:/vcenter/vm/{vm}/power?action=start"
+    svc = ServicePrincipalGrantService()
+    created = await svc.create(_TENANT_ID, _CREATOR, _payload(op_id=op_id))
+
+    matched = await find_live_grant(
+        session,
+        tenant_id=_TENANT_ID,
+        principal_sub=_PRINCIPAL,
+        op_id=op_id,
+        connector_id=_CONNECTOR,
+        target_id=None,
+    )
+    assert matched is not None
+    assert matched.id == created.id
+    assert matched.op_id == op_id
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/service-principal-grants.md
+++ b/docs/codebase/service-principal-grants.md
@@ -89,6 +89,17 @@ model). `target_id` is matched **exactly**, including the targetless
 (`NULL`) case — no any-target wildcard. Creating the grant IS the
 operator's upfront review, deny-by-default absent a match.
 
+An `op_id` **may** carry a literal query string (e.g.
+`POST:/vcenter/vm/{vm}/power?action=start`,
+`POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy`): several
+governed vCenter ops key each `?action=` verb as its own exact op id, so the
+`?` there is a literal part of the id, not a glob. Such an op id is accepted
+verbatim and matched by exact string equality; a `*` anywhere — or a
+malformed `?` (no `key=value`) — is still refused as a wildcard. Without
+this, a service principal could never hold a standing grant for the
+`vm.power` / `vm.deploy_from_library` / host-software composite sub-ops, so
+those composites always parked for service principals.
+
 - **`reason` is required** (the review flow — the body carries the
   operator's justification).
 - **`expires_at`** optional (a standing grant is permanent by default).


### PR DESCRIPTION
## Why

Creating a service-principal standing grant whose `op_id` carried a literal
query string was rejected with HTTP 422:

```
op_id must be an exact value; wildcards are not permitted (got
'POST:/vcenter/vm/{vm}/power?action=start').
```

`_reject_wildcards` (`operations/service_grants.py`) treated every `?` as a
glob. But several governed vCenter op ids carry a literal `?action=` query
string as a part of their **exact** id — the `vm.power` / guest-power
composite sub-ops, `POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy`,
`POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true`, and
every `?action=` endpoint the ingest parser emits (`op_id = f"{method}:{path}"`).
A service principal could therefore never hold a standing grant for them, so
the `vm.power` / `vm.create` power-on / `vm.deploy_from_library` composites
always parked for service principals — even after an operator reviewed and
granted the op. Grant matching is exact string equality (`find_live_grant`),
so allowing the literal `?` is safe.

## Change

- `_reject_wildcards`: still reject `*` anywhere; reject `?` only when it is
  not a well-formed literal query string on an HTTP-style op id (exactly one
  `?`, no `*`, one or more `key=value` pairs joined by `&`; keys/values allow
  `-`/`.` so `?action=apply&vmw-task=true` is covered). A malformed `?` gets a
  distinct message; real wildcards keep the existing message.
- No pydantic `pattern` constraint exists on `op_id` (only length), and the
  REST route / CLI do no separate op-id validation, so nothing else in the
  grants path needed aligning and the **CLI OpenAPI snapshot is unaffected**.
- Docs (`docs/codebase/service-principal-grants.md`) + CHANGELOG `[Unreleased]`
  Fixed bullet.

## Tests

- `test_service_grants.py`: new parametrized accept cases (power/guest-power,
  OVF deploy, multi-param with hyphenated key), new reject cases (`*` in
  path/value, bare `?`, `?a`, `?a=b?c=d`, `*.delete`), and a round-trip test
  that a query-param grant is created and then matched by `find_live_grant`
  keyed by the same string.
- Green locally: `test_service_grants.py`, `test_service_principal_grant_gate.py`,
  `test_api_v1_service_grants.py` (68) + the approvals suites (122). ruff +
  mypy clean.

Closes #3350
Refs #3349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
