### PR TITLE
docs(changelog): roll [Unreleased] into v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-09-04
+
 ### Fixed — service-principal grants: literal query-string op ids (`?action=…`) were refused as wildcards (#3350)
 
 - A standing grant whose `op_id` carried a literal query string (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ connector-related release-notes line.
 
 ## [0.33.1] - 2026-09-04
 
+### Added — docs site: the satellite gateway guide now documents the opt-in remote-write tier (#3354)
+
+- The **satellite runner / gateway** guide previously told operators a satellite
+  had no path to write; it now documents the opt-in remote-write tier — the
+  composed approval-and-allowlist gate that lets a remote runner perform
+  governed, policy-checked, audited writes inside networks the central instance
+  cannot reach (never the destructive or dangerous tiers). Docs-site only; no
+  code, schema, or CLI OpenAPI-snapshot change.
+
 ### Fixed — service-principal grants: literal query-string op ids (`?action=…`) were refused as wildcards (#3350)
 
 - A standing grant whose `op_id` carried a literal query string (e.g.

--- a/docs-site/reference/whats-new.md
+++ b/docs-site/reference/whats-new.md
@@ -16,6 +16,11 @@ notes.
   verb — such as a vCenter power action or an OVF deploy. Before, these were
   wrongly refused as wildcards, so an agent could never be granted them and the
   power-on and deploy-from-library flows always had to park for a human.
+- **The satellite gateway guide now covers remote writes.** The guide for
+  running checks and operations through a remote runner used to say a satellite
+  had no way to write; it now documents the opt-in tier that lets that runner
+  perform governed, approval-gated, audited writes inside networks the central
+  instance cannot reach.
 
 ## [v0.33.0](https://github.com/evoila/meho/releases/tag/v0.33.0) — 2026-09-04
 

--- a/docs-site/reference/whats-new.md
+++ b/docs-site/reference/whats-new.md
@@ -9,6 +9,14 @@ for each breaking one.
 MEHO is under active development. Each release below links to its full
 notes.
 
+## [v0.33.1](https://github.com/evoila/meho/releases/tag/v0.33.1) — 2026-09-04
+
+- **Standing grants for query-string actions.** A service principal can now
+  hold a standing grant for an operation whose id carries a literal `?action=`
+  verb — such as a vCenter power action or an OVF deploy. Before, these were
+  wrongly refused as wildcards, so an agent could never be granted them and the
+  power-on and deploy-from-library flows always had to park for a human.
+
 ## [v0.33.0](https://github.com/evoila/meho/releases/tag/v0.33.0) — 2026-09-04
 
 - **A much bigger documentation site.** New do-real-work guides for the flight


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
<!-- Copyright (c) 2026 evoila Group -->

## Description

Release-cutting PR for **v0.33.1** (patch). Rolls the `[Unreleased]` CHANGELOG
section into `## [0.33.1] - 2026-09-04`, leaves a fresh empty `[Unreleased]`
above it, and adds the matching `v0.33.1` section to the docs-site What's new
page. No version-file bumps — the git tag is the sole version source
(`backend/pyproject.toml` stays `0.1.0-dev`; `Chart.yaml` version/appVersion are
calver-bumped by `chart.yml` at publish; the CLI bakes `{{.Tag}}` via GoReleaser).

**Tag is HELD.** Do not tag on merge — the orchestrator tags the merge commit by
SHA once its main CI run is green, per `docs/RELEASING.md` §4.

### Rolled entries (`[0.33.1]`)

- **Fixed** — service-principal grants: literal query-string op ids
  (`?action=…`) were refused as wildcards (#3350). Rolled verbatim from
  `[Unreleased]` (shipped by #3352).

### Completeness audit

`git log v0.33.0..origin/main --oneline` = exactly one merged PR since the
v0.33.0 tag: #3352 (the grants fix, PR-half of planning issue #3350) — covered
by the rolled bullet. No docs-site-only PRs merged in the window (#3354 was
still open at PR-open time, so no consolidated docs-site bullet).

### Upgrade notes

None required — the grants fix carries no DB migration, no chart field, and no
default-on guard, so no `deploying.md` upgrade-notes row was appended.

### Docs build

`uv run --project backend --no-sync mkdocs build --strict` → exit 0, clean (only
the vendor Material MkDocs-2.0 banner on stderr).

## Related issue

Rolls #3350 / #3352.

## Type of change

- [x] Documentation

## Checklist

- [x] Conventional Commits format on every commit
- [x] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable (N/A — CHANGELOG + docs only)
- [x] Documentation updated where applicable
- [ ] CI green (awaiting)
