### PR TITLE
test(connectors): widen phantom read-back guard to descriptors, docs, and CLI

### DIFF
--- a/backend/tests/test_connectors_no_phantom_readback_tool.py
+++ b/backend/tests/test_connectors_no_phantom_readback_tool.py
@@ -1,58 +1,459 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""G0.19-T1 (#1479) grep gate: no agent-facing phantom read-back tool refs.
+"""G0.19-T1 (#1479, widened by #3370) grep gate: agent- and operator-facing
+text must not point at a phantom result-handle read-back surface, nor
+describe SQL / filter / aggregate guidance against the paging-only
+``result_query`` meta-tool.
 
-Several connectors' ``llm_instructions`` / ``when_to_use`` / ``when_to_call``
-/ ``next_step`` strings used to instruct the LLM to "use ``result_query`` /
-``result_describe`` to navigate the handle" or to spill "through the shared
-``HandleStore``". Neither the read-back meta-tools nor the ``HandleStore``
-exist in this version (G3.1-T4 #304 was closed-superseded), so the guidance
-sent the agent at a tool it can never call.
+Background
+----------
+When this gate was first written (#1479) *no* result-handle read-back
+meta-tool existed, so every ``result_*`` reference was a phantom. Since
+then ``result_query`` has shipped (#1507 / #3179) as a **paging-only**
+tool -- ``result_query(handle_id, offset, limit)`` reads a window of a
+set-shaped response spilled to the Valkey-backed
+:class:`~meho_backplane.connectors.result_handle_store.ResultHandleStore`.
+Two drift classes remain, and #3369 removed 36 live instances of them
+across connector descriptors, dev docs, and CLI help; this widened gate
+keeps them from returning:
 
-This gate walks the connectors source tree and fails if any **action
-phrase** directing the agent at a phantom read-back surface reappears. It
-deliberately matches *instruction* phrasing (``use result_query``,
-``navigate via …``, ``through the shared HandleStore``) rather than every
-mention of the token — module docstrings that *document the absence*
-(``#304 was closed as superseded; no HandleStore landed``) are legitimate
-historical context and must stay.
+1. **Phantom read-back names.** ``result_aggregate`` / ``result_describe``
+   / ``result_export`` (and their hyphenated CLI-verb spellings
+   ``result-aggregate`` etc.) were never registered. The name set is
+   sourced from ``scripts/ci/check_consumer_tool_names.py``'s
+   ``FORBIDDEN_NONEXISTENT`` (its ``result_*`` subset), so the two guards
+   share one denylist rather than drifting apart.
+2. **SQL / filter / aggregate guidance against paging-only
+   ``result_query``.** ``SELECT ... FROM`` / ``WHERE`` / ``GROUP BY`` /
+   ``filter on`` / ``count by`` / ``sum ... by`` / ``aggregate over the
+   handle`` / a jq-style positional argument passed to ``result-query``
+   all imply a query surface the tool does not have. The legal argument
+   set is read from the *registered* tool's ``inputSchema`` (today
+   ``handle_id`` / ``offset`` / ``limit``); if #3366 later adds a real
+   query argument the paging-only drift rules relax automatically, with no
+   change to this guard (issue #3370, "Out of scope").
+
+The historical phantom **HandleStore** phrasing (``through the shared
+HandleStore`` / ``via the HandleStore``) stays flagged too: the store that
+shipped is ``ResultHandleStore``, and no descriptor should send the agent
+at a bare "HandleStore".
+
+Scope
+-----
+The surfaces where this guidance lives: connector descriptor source
+(``backend/src/meho_backplane/connectors``), the ``docs/codebase`` +
+``docs/cross-repo`` pages, and the Cobra ``Long`` help strings under
+``cli/internal/cmd``. ``docs/decisions`` and ``docs/architecture`` are
+deliberately out of scope -- their historical registers name the phantom
+tools on purpose.
+
+Negative mentions -- text that names a phantom in order to say it is *not*
+callable -- stay legal via an explicit per-site ``(path, phrase)``
+allow-list, mirroring ``check_consumer_tool_names.py``'s identifier
+allow-list rather than a natural-language negation heuristic.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import re
 from pathlib import Path
+from types import ModuleType
+from typing import NamedTuple
 
-_CONNECTORS_ROOT = Path(__file__).resolve().parent.parent / "src" / "meho_backplane" / "connectors"
+import pytest
 
-#: Action phrases that direct the agent at a read-back surface that does not
-#: exist. Case-insensitive. Each is an *instruction* ("use X", "navigate via
-#: X", "reads it back via X", "through the shared HandleStore") — not a bare
-#: mention of the token, which can legitimately document the tool's absence.
-_PHANTOM_ACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"use\s+result_(?:describe|query|aggregate|export)", re.IGNORECASE),
-    re.compile(r"navigate\s+(?:via|the\s+handle\s+via)\s+result_", re.IGNORECASE),
-    re.compile(r"drills?\s+in(?:to)?\s+via\b[^.]*result_", re.IGNORECASE),
-    re.compile(r"reads?\s+(?:them|it)?\s*back\s+via\s+result_", re.IGNORECASE),
-    re.compile(r"paging\s+via\s+result_", re.IGNORECASE),
-    re.compile(r"available\s+for\s+paging\s+via\s+result_", re.IGNORECASE),
-    re.compile(r"through\s+the\s+shared\s+handlestore", re.IGNORECASE),
-    re.compile(r"via\s+the\s+handlestore", re.IGNORECASE),
+from meho_backplane.mcp.registry import get_tool
+
+#: Repo root, resolved from ``backend/tests/<this>`` -> ``parents[2]``.
+_REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+
+
+def _load_consumer_name_guard() -> ModuleType:
+    """Import ``scripts/ci/check_consumer_tool_names.py`` as a module.
+
+    The phantom read-back names live there (in ``FORBIDDEN_NONEXISTENT``);
+    importing the script rather than restating the names keeps the two
+    guards' denylist single-sourced.
+    """
+    path = _REPO_ROOT / "scripts" / "ci" / "check_consumer_tool_names.py"
+    spec = importlib.util.spec_from_file_location("_meho_consumer_tool_name_guard", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _result_query_input_schema() -> dict[str, object]:
+    """Return the *registered* ``result_query`` tool's ``inputSchema``.
+
+    Reading it from the registry (rather than a hand-kept list) means the
+    legal-argument set tracks the tool: when #3366 adds a query argument,
+    the schema -- and this guard's view of it -- widens on its own.
+    """
+    registered = get_tool("result_query")
+    if registered is None:
+        # Not yet imported in this test session -- importing the module
+        # runs its ``register_mcp_tool`` side effect.
+        import meho_backplane.mcp.tools.result_query  # noqa: F401  (registers result_query)
+
+        registered = get_tool("result_query")
+    if registered is None:
+        raise RuntimeError(
+            "result_query MCP tool is not registered; cannot derive its legal argument set"
+        )
+    definition, _handler = registered
+    return definition.inputSchema
+
+
+_name_guard = _load_consumer_name_guard()
+
+#: The result-handle read-back names that were never registered, sourced
+#: from the sibling markdown guard's denylist (its ``result_*`` subset).
+_PHANTOM_READBACK_NAMES: tuple[str, ...] = tuple(
+    sorted(name for name in _name_guard.FORBIDDEN_NONEXISTENT if name.startswith("result_"))
+)
+
+#: ``result_query``'s legal argument names, derived from its registered
+#: ``inputSchema``. Today: ``handle_id`` / ``offset`` / ``limit``.
+_LEGAL_RESULT_QUERY_ARGS: frozenset[str] = frozenset(
+    _result_query_input_schema()["properties"]  # type: ignore[arg-type]
+)
+
+#: The shipped v0.1-spec §4 paging contract (#1507 / #3179). This is a
+#: fixed historical baseline, NOT a second copy of the legal-arg list: it
+#: never grows. When the registered arg set (above) advertises anything
+#: beyond it, ``result_query`` has gained a real query surface and the
+#: SQL/aggregate/jq drift rules stop applying (issue #3370, "Out of scope"
+#: -- Task A widens the derived set, no guard change needed).
+_SHIPPED_PAGING_CONTRACT_ARGS: frozenset[str] = frozenset({"handle_id", "offset", "limit"})
+
+#: True while ``result_query`` exposes only paging arguments. Gates the
+#: SQL/aggregate/jq drift rules so they relax automatically once a query
+#: surface ships.
+_RESULT_QUERY_IS_PAGING_ONLY: bool = _LEGAL_RESULT_QUERY_ARGS <= _SHIPPED_PAGING_CONTRACT_ARGS
+
+# --- rule patterns -----------------------------------------------------------
+
+#: Rule A -- a phantom read-back **name** (underscore or hyphen spelling),
+#: e.g. ``result_aggregate`` / ``result-export``. Built from the shared
+#: denylist so it can never mention ``result_query`` (a real tool).
+_PHANTOM_NAME_RE: re.Pattern[str] = re.compile(
+    r"(?<![\w-])result[_-](?:"
+    + "|".join(sorted(name.removeprefix("result_") for name in _PHANTOM_READBACK_NAMES))
+    + r")(?![\w-])",
+    re.IGNORECASE,
+)
+
+#: Rule H -- the phantom "HandleStore" spill surface. ``ResultHandleStore``
+#: (the real class) does not match: the phrase requires ``the [shared]
+#: handlestore`` with nothing between ``the`` and ``handlestore``.
+_HANDLESTORE_RE: re.Pattern[str] = re.compile(
+    r"(?:through|via)\s+the\s+(?:shared\s+)?handlestore", re.IGNORECASE
+)
+
+#: A result-handle context anchor -- Rule-B SQL phrases only count as drift
+#: when one sits near them on the same line.
+_HANDLE_ANCHOR_RE: re.Pattern[str] = re.compile(
+    r"result[_-]query|result[_-]handle|result\s+handle|resulthandle|jsonflux\s+handle",
+    re.IGNORECASE,
+)
+
+#: Rule B -- ``aggregate over a/the handle`` is self-anchored (it names the
+#: handle itself), so it needs no separate anchor.
+_AGG_OVER_HANDLE_RE: re.Pattern[str] = re.compile(
+    r"aggregate\s+over\s+(?:a|the)\s+handle", re.IGNORECASE
+)
+
+#: A bare ``result_query`` / ``result-query`` mention -- the start of a
+#: (possible) invocation whose trailing argument text is inspected.
+_RESULT_QUERY_VERB_RE: re.Pattern[str] = re.compile(r"result[_-]query", re.IGNORECASE)
+
+#: A jq-style positional expression: a quote immediately opening a filter
+#: (``'.[]``, ``'.foo``, ``"[0]"``).
+_JQ_POSITIONAL_RE: re.Pattern[str] = re.compile(r"""['"]\s*[.\[]""")
+
+#: How close (in characters, same line) a SQL phrase must sit to a handle
+#: anchor to count as drift -- tight enough that an unrelated "select"
+#: dropdown a paragraph away from a "ResultHandle" mention is not flagged.
+_PROXIMITY: int = 50
+
+#: Rule B -- SQL / filter / aggregate phrases. Each fires only when a
+#: handle anchor sits within ``_PROXIMITY`` characters on the same line.
+_SQL_PHRASE_RES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("SELECT ... FROM", re.compile(r"\bSELECT\b.{0,80}?\bFROM\b", re.IGNORECASE)),
+    ("WHERE", re.compile(r"\bWHERE\b", re.IGNORECASE)),
+    ("GROUP BY", re.compile(r"\bGROUP\s+BY\b", re.IGNORECASE)),
+    ("filter on", re.compile(r"\bfilter on\b", re.IGNORECASE)),
+    ("count by", re.compile(r"\bcount by\b", re.IGNORECASE)),
+    ("sum ... by", re.compile(r"\bsum\b.{0,30}?\bby\b", re.IGNORECASE)),
+)
+
+#: Files walked, as ``(root, glob)`` pairs, all relative to the repo root.
+_SCAN_ROOTS: tuple[tuple[Path, str], ...] = (
+    (_REPO_ROOT / "backend" / "src" / "meho_backplane" / "connectors", "*.py"),
+    (_REPO_ROOT / "docs" / "codebase", "*.md"),
+    (_REPO_ROOT / "docs" / "cross-repo", "*.md"),
+    (_REPO_ROOT / "cli" / "internal" / "cmd", "*.go"),
+)
+
+#: Per-site negative-mention allow-list: ``(path suffix, line substring)``.
+#: An offending line is legal when its path ends with the suffix AND the
+#: line contains the substring -- both scoped tightly to the one sentence
+#: that documents a phantom's *absence*. Re-confirmed against the tree on
+#: 2026-09-05: ``docs/codebase/mcp.md`` L410-413 ("a nonexistent
+#: ``search_connectors`` / ``result_aggregate``"). ``docs-site`` is not a
+#: scan root here, so ``first-operations.md`` needs no entry.
+_NEGATIVE_MENTION_ALLOWLIST: tuple[tuple[str, str], ...] = (
+    ("docs/codebase/mcp.md", "reciprocal, not divergent"),
 )
 
 
-def test_no_connector_string_points_at_a_phantom_readback_tool() -> None:
-    """No connector source line directs the agent at a non-existent read-back tool."""
-    offenders: list[str] = []
-    for path in sorted(_CONNECTORS_ROOT.rglob("*.py")):
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            for pattern in _PHANTOM_ACTION_PATTERNS:
-                if pattern.search(line):
-                    rel = path.relative_to(_CONNECTORS_ROOT)
-                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+class Offense(NamedTuple):
+    """One flagged line: 1-based line number, the rule id, the line text."""
 
-    assert not offenders, (
-        "agent-facing strings must not instruct the LLM to use a read-back "
-        "meta-tool / HandleStore that does not exist in this version:\n" + "\n".join(offenders)
+    lineno: int
+    rule: str
+    text: str
+
+
+def _invocation_window(line: str, start: int) -> str:
+    """Text from ``start`` to the invocation's end (a backtick or ``;``).
+
+    Bounds argument inspection to the ``result_query`` call itself so a
+    sibling suggestion later on the line (``... ; or pass ``--json```) is
+    not read as an argument to the tool.
+    """
+    end = len(line)
+    for terminator in ("`", ";"):
+        idx = line.find(terminator, start)
+        if idx != -1:
+            end = min(end, idx)
+    return line[start:end]
+
+
+def _near_anchor(line: str, span: tuple[int, int]) -> bool:
+    """True when a handle anchor sits within ``_PROXIMITY`` of ``span``."""
+    lo, hi = span
+    return any(
+        anchor.start() <= hi + _PROXIMITY and lo <= anchor.end() + _PROXIMITY
+        for anchor in _HANDLE_ANCHOR_RE.finditer(line)
     )
+
+
+def _scan_line(line: str) -> list[str]:
+    """Return the rule ids a single line trips (empty when clean)."""
+    rules: list[str] = []
+
+    if _PHANTOM_NAME_RE.search(line):
+        rules.append("phantom-readback-name")
+    if _HANDLESTORE_RE.search(line):
+        rules.append("phantom-handlestore")
+
+    if not _RESULT_QUERY_IS_PAGING_ONLY:
+        # A real query surface shipped -- SQL/aggregate/jq guidance is no
+        # longer necessarily drift; leave those rules dormant.
+        return rules
+
+    if _AGG_OVER_HANDLE_RE.search(line):
+        rules.append("aggregate-over-handle")
+
+    for verb in _RESULT_QUERY_VERB_RE.finditer(line):
+        if _JQ_POSITIONAL_RE.search(_invocation_window(line, verb.end())):
+            rules.append("jq-argument-to-result_query")
+            break
+
+    for label, pattern in _SQL_PHRASE_RES:
+        match = pattern.search(line)
+        if match and _near_anchor(line, match.span()):
+            rules.append(f"sql-guidance:{label}")
+
+    return rules
+
+
+def _is_allowed(rel_path: str, line: str) -> bool:
+    """True when ``(rel_path, line)`` matches a negative-mention allow entry."""
+    return any(
+        rel_path.endswith(suffix) and substring.lower() in line.lower()
+        for suffix, substring in _NEGATIVE_MENTION_ALLOWLIST
+    )
+
+
+def find_offenses(rel_path: str, text: str) -> list[Offense]:
+    """Scan *text* (attributed to *rel_path*) for phantom read-back drift."""
+    offenses: list[Offense] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        rules = _scan_line(line)
+        if not rules or _is_allowed(rel_path, line):
+            continue
+        offenses.extend(Offense(lineno, rule, line.strip()) for rule in rules)
+    return offenses
+
+
+def _scan_tree() -> list[str]:
+    """Scan every file under the scan roots; return ``path:line [rule]`` lines."""
+    hits: list[str] = []
+    for root, glob in _SCAN_ROOTS:
+        for path in sorted(root.rglob(glob)):
+            rel = str(path.relative_to(_REPO_ROOT))
+            for offense in find_offenses(rel, path.read_text(encoding="utf-8")):
+                hits.append(f"{rel}:{offense.lineno} [{offense.rule}] {offense.text}")
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def test_no_agent_facing_string_points_at_a_phantom_readback_surface() -> None:
+    """No scanned file points the agent at a phantom read-back surface.
+
+    Fails when a connector descriptor, a ``docs/codebase`` / ``docs/cross-repo``
+    page, or a CLI ``Long`` help string reintroduces a phantom read-back
+    name, a phantom HandleStore reference, or SQL/aggregate/jq guidance
+    against the paging-only ``result_query``.
+    """
+    offenders = _scan_tree()
+    assert not offenders, (
+        "agent-facing text must not name a phantom read-back tool / HandleStore, "
+        "nor describe a query surface result_query does not have "
+        f"(legal args: {sorted(_LEGAL_RESULT_QUERY_ARGS)}):\n" + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard-the-guard invariants
+# ---------------------------------------------------------------------------
+
+
+def test_phantom_name_set_is_sourced_from_the_shared_denylist() -> None:
+    """The phantom-name set is the ``result_*`` subset of the sibling guard."""
+    assert set(_PHANTOM_READBACK_NAMES) == {
+        "result_aggregate",
+        "result_describe",
+        "result_export",
+    }
+    # Sourced, not restated: every name is in the sibling guard's denylist.
+    for name in _PHANTOM_READBACK_NAMES:
+        assert name in _name_guard.FORBIDDEN_NONEXISTENT
+
+
+def test_legal_result_query_args_are_derived_from_the_registered_schema() -> None:
+    """The legal-arg set comes from the registered tool and is paging-only today."""
+    assert "handle_id" in _LEGAL_RESULT_QUERY_ARGS
+    assert sorted(_LEGAL_RESULT_QUERY_ARGS) == ["handle_id", "limit", "offset"]
+    assert _RESULT_QUERY_IS_PAGING_ONLY is True
+
+
+def test_paging_only_gate_relaxes_when_a_query_arg_ships() -> None:
+    """A simulated query-surface widening disables the SQL/aggregate rules."""
+    widened = _LEGAL_RESULT_QUERY_ARGS | {"query"}
+    assert not (widened <= _SHIPPED_PAGING_CONTRACT_ARGS)
+
+
+# ---------------------------------------------------------------------------
+# Negative fixtures -- one (or a family) per rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "result_aggregate",
+        "result_describe",
+        "result_export",
+        "result-aggregate",
+        "result-describe",
+        "result-export",
+    ],
+)
+def test_phantom_readback_name_is_flagged(name: str) -> None:
+    """Each phantom name (underscore and hyphen spelling) trips Rule A."""
+    offenses = find_offenses("connectors/x.py", f"drill in with {name} for the rows")
+    assert [o.rule for o in offenses] == ["phantom-readback-name"]
+
+
+@pytest.mark.parametrize(
+    ("label", "text"),
+    [
+        (
+            "SELECT ... FROM",
+            "page with result_query, e.g. SELECT id, severity FROM result WHERE id = 'x'",
+        ),
+        ("WHERE", "a ``result_query`` ``WHERE id = ...`` away."),
+        ("GROUP BY", "against the result handle, GROUP BY guestOs to flag OSes"),
+        ("filter on", "drill in with result_query (e.g. filter on used.storage)."),
+        ("count by", "narrow with result_query (e.g. count by projectId or status)."),
+        ("sum ... by", "reduced to a result handle; sum memoryMB by org."),
+    ],
+)
+def test_sql_guidance_near_a_handle_anchor_is_flagged(label: str, text: str) -> None:
+    """Each SQL/aggregate phrase near a handle anchor trips Rule B."""
+    offenses = find_offenses("connectors/x.py", text)
+    assert any(o.rule == f"sql-guidance:{label}" for o in offenses), offenses
+
+
+def test_aggregate_over_the_handle_is_flagged() -> None:
+    """The self-anchored ``aggregate over the handle`` phrase trips Rule B."""
+    offenses = find_offenses(
+        "connectors/x.py", "aggregate over the handle for host/version counts."
+    )
+    assert [o.rule for o in offenses] == ["aggregate-over-handle"]
+
+
+def test_jq_positional_argument_to_result_query_is_flagged() -> None:
+    """A jq-style positional passed to ``result-query`` trips Rule B."""
+    offenses = find_offenses(
+        "docs/cross-repo/x.md",
+        "meho operation result-query <handle_id> '.[] | .server.server_ip'",
+    )
+    assert any(o.rule == "jq-argument-to-result_query" for o in offenses), offenses
+
+
+def test_phantom_handlestore_phrase_is_flagged() -> None:
+    """A ``through the shared HandleStore`` reference trips Rule H."""
+    offenses = find_offenses(
+        "cli/internal/cmd/x.go",
+        '"through the shared HandleStore — page the result handle"',
+    )
+    assert any(o.rule == "phantom-handlestore" for o in offenses), offenses
+
+
+# ---------------------------------------------------------------------------
+# Positive controls -- shipped-contract phrasing must NOT be flagged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "page it with result_query(handle_id, offset, limit) and read rows per row.",
+        "the result handle the agent drills into via `result_query`.",
+        "meho operation result-query <handle_id> --offset 0 --limit 50",
+        "Optional. The owner name to filter on. Omit to return every record.",  # no anchor
+        "a ResultHandle metadata field, plus a Write scope select for the mode",  # UI select
+    ],
+)
+def test_shipped_contract_phrasing_is_not_flagged(text: str) -> None:
+    """Correct paging phrasing and unrelated ``select``/``filter on`` stay clean."""
+    assert find_offenses("connectors/x.py", text) == []
+
+
+# ---------------------------------------------------------------------------
+# Allow-list is path-scoped and load-bearing
+# ---------------------------------------------------------------------------
+
+
+def test_negative_mention_is_allowed_only_at_its_registered_path() -> None:
+    """The mcp.md negative mention is legal there, flagged anywhere else."""
+    line = (
+        "a nonexistent `search_connectors` / `result_aggregate`). "
+        "The two are reciprocal, not divergent — names are"
+    )
+    assert find_offenses("docs/codebase/mcp.md", line) == []
+    # Same text under any other path is a real offense (proves scoping).
+    elsewhere = find_offenses("docs/cross-repo/other.md", line)
+    assert [o.rule for o in elsewhere] == ["phantom-readback-name"]


### PR DESCRIPTION
## Summary

- Widens the G0.19-T1 (#1479) phantom-read-back grep gate
  (`backend/tests/test_connectors_no_phantom_readback_tool.py`) so it runs
  in the required backend pytest lane against the **full agent- and
  operator-facing surface**: connector descriptors
  (`backend/src/meho_backplane/connectors/**/*.py`), `docs/codebase/**`,
  `docs/cross-repo/**`, and the Cobra `Long` help under
  `cli/internal/cmd/**/*.go`. `docs/decisions` and `docs/architecture`
  stay out of scope (their historical registers name the phantom tools on
  purpose).
- Catches **two drift classes** that the old 8 action-phrase regexes let
  through (they anchored on `use result_` / `navigate via` / `paging via`,
  missing `drill in with` / `narrow with` / jq-SQL args, and never scanned
  docs/CLI):
  1. **Phantom read-back names** — `result_aggregate` / `result_describe`
     / `result_export` and their hyphenated CLI spellings, sourced from
     `scripts/ci/check_consumer_tool_names.py`'s `FORBIDDEN_NONEXISTENT`
     (its `result_*` subset) so the denylist is single-sourced; plus the
     phantom `HandleStore` spill surface.
  2. **SQL/filter/aggregate guidance against paging-only `result_query`**
     — `SELECT…FROM` / `WHERE` / `GROUP BY` / `filter on` / `count by` /
     `sum…by` / `aggregate over the handle` / a jq positional to
     `result-query`, **scoped to a result-handle anchor** so unrelated
     `filter on` prose (topology, audit, scheduler, windows_dns, tempo)
     does not red.
- The legal `result_query` argument set is read from the **registered
  tool's `inputSchema`** (today `handle_id` / `offset` / `limit`), so the
  paging-only drift rules relax automatically if #3366 later ships a query
  surface — no guard change needed.
- Negative mentions stay legal via an explicit per-site `(path, phrase)`
  allow-list (`docs/codebase/mcp.md` L410-413 "a nonexistent
  `search_connectors` / `result_aggregate`"), not an NL negation
  heuristic. `docs-site` is not a scan root here, so
  `first-operations.md` needs no entry.

Only the one test file changes; no connector/doc/CLI source is touched
(this Task adds the guard; Task B #3369 removed the drift and is merged).

## Test plan

- [x] `cd backend && .venv/bin/python -m pytest tests/test_connectors_no_phantom_readback_tool.py tests/test_consumer_doc_tool_names.py -q` — **42 passed** (required backend lane; AC 3).
- [x] `ruff check` + `ruff format --check` on the touched file — clean.
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0.
- [x] **AC 1** — synthetic fixtures fail on both drift kinds: one per phantom name (× underscore/hyphen), and `SELECT`/`WHERE`/`GROUP BY`/`filter on`/`count by`/`sum…by`/`aggregate over the handle`/jq-arg near a `result_query` mention; positive controls confirm shipped `result_query(handle_id, offset, limit)` phrasing stays clean.
- [x] **AC 2** — scanned surface covers connector `.py` **and** `docs/codebase` + `docs/cross-repo` + `cli/internal/cmd`; the mcp.md negative mention is allow-listed and green, and a path-scope test proves the same text under any other path is still flagged.
- [x] **AC 4** — passes on this (post-Task-B) tree; **fails on the pre-#3369 tree** (see regression proof).

## Regression proof (AC 4)

Ran the widened guard's own `find_offenses` against the entire pre-#3369
scan surface at `11e28678` (the commit before #3369/PR #3372 landed), from
the worktree:

```bash
cd backend
ROOT=$(git rev-parse --show-toplevel)
SHA=11e28678 ROOT="$ROOT" .venv/bin/python - <<'PY'
import os, subprocess, sys
sys.path.insert(0, "tests")
import test_connectors_no_phantom_readback_tool as g
sha, root = os.environ["SHA"], os.environ["ROOT"]
roots = {"backend/src/meho_backplane/connectors": ".py", "docs/codebase": ".md",
         "docs/cross-repo": ".md", "cli/internal/cmd": ".go"}
files = subprocess.check_output(
    ["git", "-C", root, "ls-tree", "--full-name", "-r", "--name-only", sha], text=True
).splitlines()
targets = [p for p in files
           if any(p.startswith(r + "/") and p.endswith(ext) for r, ext in roots.items())]
hits = []
for p in targets:
    text = subprocess.check_output(["git", "-C", root, "show", f"{sha}:{p}"], text=True)
    for off in g.find_offenses(p, text):
        hits.append(f"{p}:{off.lineno} [{off.rule}]")
print(f"{len(targets)} files scanned; FLAGGED {len(hits)} sites")
print("\n".join(hits))
PY
```

Result: **916 files scanned, 42 sites flagged** across all four roots
(guard would have RED on the pre-#3369 tree). The flagged sites are
exactly the drift #3369 removed, e.g.:

```
backend/src/meho_backplane/connectors/harbor/connector.py:706 [sql-guidance:WHERE]
backend/src/meho_backplane/connectors/harbor/ops.py:517 [sql-guidance:SELECT ... FROM]
backend/src/meho_backplane/connectors/harbor/ops.py:777 [sql-guidance:filter on]
backend/src/meho_backplane/connectors/sddc_vcf5/typed_ops.py:240 [aggregate-over-handle]
backend/src/meho_backplane/connectors/vcd/_llm_instructions.py:93 [phantom-readback-name]
backend/src/meho_backplane/connectors/vra8/_llm_instructions.py:62 [sql-guidance:count by]
cli/internal/cmd/vault/kv.go:136 [phantom-readback-name]           (result_export)
cli/internal/cmd/vcf-fleet/environment.go:46 [phantom-handlestore]
docs/cross-repo/hetzner-robot-onboarding.md:301 [jq-argument-to-result_query]
docs/cross-repo/hetzner-robot-onboarding.md:302 [phantom-readback-name] (result-aggregate)
docs/codebase/connectors-vault.md:597-598 [phantom-readback-name]
… 42 total (11 connector .py, 9 CLI .go, 22 docs), every rule exercised.
```

On the current tree the same scan of the live roots yields **0** offenders
(the gate is green).

## Out of scope

- Correcting the drift itself — Task B (#3369, merged as c133f9ff).
- The `result_query` query surface — Task A (#3366); the derived legal-arg
  set widens automatically when it lands.
- Changing `FORBIDDEN_NONEXISTENT` entries.

<!-- auto-implement-issue: fresh, iteration 1 -->

Depends-on: #3369

Closes #3370
