### PR TITLE
feat(net): tls_inspect returns the presented leaf certificate PEM and SANs (#3375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — net.tls_inspect returns the presented certificate PEM, closing the probe → `tls_ca_pin` loop (#3375)
+
+- `net.tls_inspect` now emits a `pem` field on every presented chain entry
+  (and so on `leaf`, its `chain[0]` alias) — the certificate serialised as
+  PEM, alongside the metadata it already returned. This closes the governed
+  **probe → pin** path for target registration: `register_target` accepts a
+  `tls_ca_pin` (PEM, fed verbatim to `ssl.SSLContext.load_verify_locations`)
+  to pin a target's identity when hostname verification can never match — an
+  appliance dialled through a NAT alias, say — but until now the only governed
+  way to observe a target's certificate returned every fact *about* the cert
+  except the bytes the pin needs. An operator now probes the endpoint and pins
+  the right trust anchor from the result: `leaf.pem` directly for a self-signed
+  appliance (the leaf is its own anchor), or an issuer/root from a later
+  `chain[]` entry for a CA-signed one — paired with `tls_server_name` from the
+  emitted SAN. The PEM is the **public** certificate material the server
+  presents in the handshake — never a secret, never any private key. Response
+  stays inline (a certificate is a few KB; no JSONFlux handle-threshold change);
+  `san` (DNS + IP) is unchanged. Typed-op response-schema addition only — no
+  CLI OpenAPI-snapshot change.
+
 ## [0.33.2] - 2026-09-05
 
 ### Fixed — vmware-rest: standalone ESXi host ops now speak SOAP over `/sdk` (#3363)

--- a/backend/src/meho_backplane/connectors/net/tls.py
+++ b/backend/src/meho_backplane/connectors/net/tls.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — a single cohesive typed op (schemas +
+# helpers + blocking handler + async wrapper + registrar) that was already
+# over the 600-line block limit before #3375's surgical field addition;
+# splitting it is out of scope for this change (precedent: bff30915).
 
 """Network-diagnostics typed op ``net.tls_inspect`` + its registrar.
 
@@ -53,6 +57,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from cryptography import x509
+from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import NameOID
 from OpenSSL import SSL
 
@@ -146,6 +151,15 @@ _CHAIN_ITEM_SCHEMA: dict[str, Any] = {
             "type": "boolean",
             "description": "True iff subject == issuer (a root or self-signed leaf).",
         },
+        "pem": {
+            "type": "string",
+            "description": (
+                "The presented certificate as PEM (public handshake material, "
+                "never a private key). Load leaf.pem as a register_target "
+                "tls_ca_pin for a self-signed appliance; for a CA-signed one "
+                "pin the issuer/root PEM from a later chain[] entry."
+            ),
+        },
     },
     "required": [
         "subject",
@@ -156,6 +170,7 @@ _CHAIN_ITEM_SCHEMA: dict[str, Any] = {
         "days_to_expiry",
         "serial",
         "self_signed",
+        "pem",
     ],
     "additionalProperties": False,
 }
@@ -404,6 +419,12 @@ def _cert_to_dict(cert: x509.Certificate, now: datetime) -> dict[str, Any]:
     can bite on for cert-expiry early warning, computed against a single
     probe-time *now* the caller injects so every cert in one chain shares
     the same reference instant.
+
+    ``pem`` is the presented certificate serialised as PEM — public
+    handshake material, never a secret and never any private key. It lets
+    a consumer turn a governed probe into a ``register_target``
+    ``tls_ca_pin`` (the leaf for a self-signed appliance; the issuer/root
+    from ``chain[]`` for a CA-signed one).
     """
     return {
         "subject": cert.subject.rfc4514_string(),
@@ -414,6 +435,7 @@ def _cert_to_dict(cert: x509.Certificate, now: datetime) -> dict[str, Any]:
         "days_to_expiry": (cert.not_valid_after_utc - now).total_seconds() / 86400.0,
         "serial": str(cert.serial_number),
         "self_signed": cert.subject == cert.issuer,
+        "pem": cert.public_bytes(serialization.Encoding.PEM).decode("ascii"),
     }
 
 

--- a/backend/tests/test_connectors_net_tls_inspect.py
+++ b/backend/tests/test_connectors_net_tls_inspect.py
@@ -57,6 +57,7 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, EndpointDescriptor
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
+from meho_backplane.targets.schemas import validate_ca_pin_pem
 
 _CONNECTOR_ID = "net-probe-1.x"
 _OP_ID = "net.tls_inspect"
@@ -744,3 +745,108 @@ async def test_days_to_expiry_threshold_sensor_bands_end_to_end(
     outcome = evaluate_assertion(spec, body, now=datetime.datetime.now(datetime.UTC))
     assert outcome.state == expected_state
     assert outcome.value == body["days_to_expiry"]
+
+
+# ---------------------------------------------------------------------------
+# pem — the presented certificate material, for probe -> tls_ca_pin (#3375)
+# ---------------------------------------------------------------------------
+
+
+async def test_leaf_pem_round_trips_to_the_minted_cert(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """``leaf.pem`` is the exact PEM the server presented and parses back identically."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    key = _new_key()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _LEAF_CN)])
+    cert = _sign(_LEAF_CN, key, name, key, san_dns=[_LEAF_CN])
+    server = _TLSServer(tmp_path, _pem(cert), _key_pem(key))
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+    leaf_pem = body["leaf"]["pem"]
+    # Byte-for-byte the certificate the server presented.
+    assert leaf_pem == _pem(cert).decode("ascii")
+    # Parseable, and the *same* certificate (fingerprint identity).
+    parsed = x509.load_pem_x509_certificate(leaf_pem.encode("ascii"))
+    assert parsed.fingerprint(hashes.SHA256()) == cert.fingerprint(hashes.SHA256())
+    assert str(parsed.serial_number) == body["leaf"]["serial"]
+
+
+async def test_pem_present_on_every_chain_entry_no_private_material(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """Each chain[] entry carries a public-only PEM matching its metadata, leaf-first."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": _LEAF_CN}
+    )
+    assert result.status == "ok", result.error
+    body = result.result
+    assert len(body["chain"]) == 3
+    for entry in body["chain"]:
+        pem = entry["pem"]
+        # Public certificate material only — never a private key.
+        assert pem.startswith("-----BEGIN CERTIFICATE-----")
+        assert "PRIVATE KEY" not in pem
+        # The PEM parses back to the cert whose metadata this entry reports,
+        # so leaf-first ordering is preserved through the pem field too.
+        parsed = x509.load_pem_x509_certificate(pem.encode("ascii"))
+        assert parsed.subject.rfc4514_string() == entry["subject"]
+        assert str(parsed.serial_number) == entry["serial"]
+    # leaf is the convenience alias for chain[0], pem included.
+    assert body["leaf"]["pem"] == body["chain"][0]["pem"]
+
+
+async def test_self_signed_leaf_pem_loads_as_target_tls_ca_pin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A self-signed appliance's leaf.pem is directly usable as a tls_ca_pin.
+
+    The probe -> pin path the #2907 backplane-first coverage needs: the leaf
+    PEM a governed ``net.tls_inspect`` returns is accepted verbatim by the
+    target contract's ``validate_ca_pin_pem`` (ssl load_verify_locations
+    cadata=...), paired with a ``tls_server_name`` from the emitted SAN.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    server = _self_signed_server(tmp_path)
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["leaf"]["self_signed"] is True
+    # The probed leaf PEM passes the target's tls_ca_pin validator unchanged.
+    assert validate_ca_pin_pem(body["leaf"]["pem"]) == body["leaf"]["pem"]
+    # tls_server_name pairs with the already-emitted leaf SAN (no new field).
+    assert _LEAF_CN in body["leaf"]["san"]
+
+
+def test_cert_to_dict_pem_is_public_material_only() -> None:
+    """``_cert_to_dict`` emits a parseable certificate PEM and no private key."""
+    now = datetime.datetime.now(datetime.UTC)
+    key = _new_key()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _LEAF_CN)])
+    cert = _sign(_LEAF_CN, key, name, key, san_dns=[_LEAF_CN])
+    flat = net_tls._cert_to_dict(cert, now)
+    pem = flat["pem"]
+    assert pem == _pem(cert).decode("ascii")
+    assert pem.startswith("-----BEGIN CERTIFICATE-----")
+    assert "PRIVATE KEY" not in pem
+    # Round-trips to the same certificate.
+    parsed = x509.load_pem_x509_certificate(pem.encode("ascii"))
+    assert parsed.fingerprint(hashes.SHA256()) == cert.fingerprint(hashes.SHA256())

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -415,7 +415,7 @@ Control flow (`connectors/net/tls.py`):
    clamped timeout, so a stalled peer cannot pin the worker thread.
 4. Each presented cert is flattened to
    `{subject, issuer, san, not_before, not_after, days_to_expiry, serial,
-   self_signed}` (leaf-first). `serial` is stringified (a serial is a
+   self_signed, pem}` (leaf-first). `serial` is stringified (a serial is a
    large integer a JSON number consumer would truncate); timestamps use
    the tz-aware `not_valid_*_utc` accessors. `days_to_expiry` is
    `(not_valid_after_utc - now) / 86400` as a float (negative once
@@ -475,6 +475,49 @@ every chain entry, `{"select": {"path": "$.chain[*].days_to_expiry",
 (an intermediate included) with the same comparator. `FreshnessCompare`
 stays untouched and past-oriented; the two are complementary, not
 alternatives.
+
+### Probe → `tls_ca_pin` — the presented certificate PEM (#3375)
+
+Every chain entry (and so `leaf`, its `chain[0]` alias) carries a `pem`
+field: the presented certificate serialised as PEM
+(`cert.public_bytes(serialization.Encoding.PEM)`), alongside the metadata.
+
+**Safety — public, not a secret.** `pem` is the public certificate
+material the server *presents in the TLS handshake* to every client that
+connects; it is not confidential and carries **no private key**. Only the
+certificate is serialised — no private material is ever returned, on any
+path. It is safe to log, store in the audit row, and hand to an agent.
+
+This closes the governed **probe → pin** loop for target registration.
+`register_target` accepts a `tls_ca_pin` (PEM) that is fed verbatim to
+`ssl.SSLContext.load_verify_locations(cadata=...)` (validated at the API
+boundary by `targets/schemas.py::validate_ca_pin_pem`), which is how an
+operator pins a target's identity when hostname verification can never
+match — e.g. an appliance dialled through a NAT alias. Before this field
+the only governed way to observe a target's certificate (`net.tls_inspect`)
+returned every fact *about* the cert but not the bytes the pin needs. Now:
+
+1. Probe the endpoint: `net.tls_inspect(host, port, server_name?)`.
+2. Pick the trust anchor from the result and register the target with it
+   as `tls_ca_pin`, plus `tls_server_name` = the name to verify against
+   (a SAN entry from `leaf.san`, since the dialled alias won't match).
+
+Which entry to pin depends on how the appliance's cert is issued:
+
+- **Self-signed appliance** (the common case; `leaf.self_signed == true`):
+  the leaf is its own trust anchor — `leaf.pem` loads directly as
+  `tls_ca_pin`.
+- **CA-signed appliance**: the leaf is *not* a CA and cannot validate
+  itself via `cadata`; pin the issuer/root instead — a later `chain[]`
+  entry's `pem` (whichever CA the operator wants to trust). Per-chain-item
+  `pem` (not leaf-only) is exactly why the field lives on every entry:
+  the consumer picks the right anchor from the already-returned chain.
+
+Behaviour for chains: `pem` is present on the **leaf and each presented
+chain entry** (leaf, intermediates, and the root when the server sends
+one) — leaf-only when the server presents only the leaf. The response
+stays inline (a certificate is a few KB; no JSONFlux handle threshold
+changes).
 
 ## ICMP cohort — `net.ping` / `net.trace` / `net.path_mtu` (T6, #2411)
 


### PR DESCRIPTION
## Problem

`net.tls_inspect` — the backplane's own governed TLS diagnostic — returns per-cert
metadata (`subject`, `issuer`, `serial`, `not_before` / `not_after` /
`days_to_expiry`, `san`, `self_signed`) but not the certificate material itself.
`register_target` accepts a `tls_ca_pin` (PEM, fed verbatim to
`ssl.SSLContext.load_verify_locations(cadata=...)`) to pin a target's identity when
hostname verification can never match — e.g. an automation consumer registering
alias-fronted appliances dialled through a NAT alias. But the only governed way to
observe a target's presented certificate returned every fact *about* the cert
except the bytes the pin needs, so there was no governed path from "probe the
target" to "pin its identity" — the missing link in a fully backplane-dispatchable
target-registration path (parent initiative #2907).

## Fix

Add a `pem` field to the per-cert chain-item schema, emitted by `_cert_to_dict` as
`cert.public_bytes(serialization.Encoding.PEM).decode("ascii")`.

- `backend/src/meho_backplane/connectors/net/tls.py`: import `serialization`;
  emit `pem` in `_cert_to_dict`; add `pem` (`type: string`) to
  `_CHAIN_ITEM_SCHEMA` properties **and** its `required` list. The top-level
  `leaf` field is a spread of the chain-item schema, so `leaf.pem` (the common
  case) is inherited for free, and every `chain[]` entry carries its `pem` too.
- Per-chain-item `pem` (not leaf-only): a self-signed appliance's leaf is its own
  trust anchor (`leaf.pem` loads directly as `tls_ca_pin`); a CA-signed appliance's
  leaf cannot validate itself via `cadata`, so the operator pins the issuer/root
  from a later `chain[]` entry. `pem` is present on the leaf and each presented
  chain entry — leaf-only when the server presents only the leaf.
- `san` (DNS + IP) was already emitted and `required`; no change there.
- Response stays inline (a certificate is a few KB; no JSONFlux handle-threshold
  change).

## Tests

- `leaf.pem` byte-equals the certificate the server presented and round-trips to
  the same SHA-256 fingerprint and serial.
- Every `chain[]` entry carries a public-only PEM (`BEGIN CERTIFICATE`, no
  `PRIVATE KEY`) that parses back to the cert whose metadata the entry reports —
  leaf-first ordering preserved; `leaf.pem == chain[0].pem`.
- A self-signed `leaf.pem` passes the target contract's `validate_ca_pin_pem`
  verbatim, paired with a `tls_server_name` drawn from the emitted SAN — the
  probe → pin loop, end to end.
- `_cert_to_dict` emits parseable, public-only PEM; the existing schema
  round-trip test now exercises `pem` as a required field.
- Verified once at the end: net connector suite, MCP surface + output-schema
  conformance, destructive-builder + addon-pairing conformance, OpenAPI target
  product enum, operations-ingest OpenAPI. `ruff check` / `ruff format --check` /
  `mypy` clean on the changed files.
- No `cli/api/openapi.json` regen: `net.tls_inspect` is a typed synthetic op whose
  response schema lives in `endpoint_descriptor`, not the CLI OpenAPI snapshot
  (direct precedent: the `days_to_expiry` addition, `bff30915`). Confirmed by
  re-running `make snapshot-openapi` — no diff.

## Safety note

`pem` is the **public** certificate material the server presents in the TLS
handshake to every client that connects — not confidential, and carrying **no
private key**. Only the certificate is serialised; no private material is ever
returned, on any path. It is safe to log, store in the audit row, and hand to an
agent.

## Docs

`docs/codebase/connectors-net-diagnostics.md`: the new `pem` field, the
leaf-vs-chain behaviour, the probe → `tls_ca_pin` recipe, and the
public-not-a-secret safety note.

Closes #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
