### PR TITLE
feat(jsonflux): bounded validated query surface over result_query handles (#3366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — result_query: a bounded, validated server-side query surface over JSONFlux handles (#3366 / #3377)
+
+- `result_query` gains a second read-back mode alongside paging: pass a `query` object and the backplane returns just the matching rows or the per-group counts instead of forcing the agent to page the whole set into context and filter client-side. The `query` grammar is filter predicates (≤10; operators `=, !=, <, <=, >, >=, IN, IS NULL`), a `select` projection, `group_by` (≤4), aggregates (`COUNT/SUM/MIN/MAX/AVG`), `order_by` (≤4), and `limit` — compiled into **exactly one parameterized, read-only `SELECT`** over the single handle table; every referenced field is validated against the handle's known columns (unknown field → rejected), operators and aggregate functions are fixed allow-lists, and caller values bind as DuckDB prepared-statement parameters. There is **no raw-SQL argument** on any transport: the unsafe forms (writes, DDL, multi-statement input) are not expressible, a stronger property than sanitizing a caller SQL string. The MCP `inputSchema` and the REST `ResultQueryBody` gain the same optional `query` arg in lockstep and both dispatch through one shared core; paging (`handle_id`/`offset`/`limit`) is unchanged and backward-compatible, and the CLI grows matching `--where/--select/--group-by/--aggregate/--order-by/--query-limit` flags on `meho operation result-query`. Every query is bounded — output rows capped at `RESULT_QUERY_MAX_OUTPUT_ROWS` (500) with an explicit `truncated` flag, serialized output capped at `RESULT_QUERY_MAX_OUTPUT_BYTES` (256 KB) with an actionable over-budget error, and each `SELECT` run under a `RESULT_QUERY_TIMEOUT_SECONDS` (5 s) wall-time budget via a worker-thread `conn.interrupt()` — and every result carries a `coverage` label so a `COUNT` over a capped spill is reported as covering the stored subset only, never a whole-inventory total.
+
 ## [0.33.3] - 2026-09-05
 
 ### Added — net.tls_inspect returns the presented certificate PEM, closing the probe → `tls_ca_pin` loop (#3375)

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -67,8 +67,13 @@ from meho_backplane.operations.meta_tools import (
 from meho_backplane.operations.operation_run_service import get_operation_run_service
 from meho_backplane.operations.result_query import (
     MAX_LIMIT,
+    QueryContractError,
     ResultHandleNotFoundError,
+    ResultQueryOutputTooLargeError,
+    ResultQuerySpec,
+    ResultQueryTimeoutError,
     read_result_window,
+    run_result_query,
 )
 
 #: Shared OpenAPI metadata for the ``connector_id`` query param on the
@@ -326,8 +331,13 @@ class ResultQueryBody(BaseModel):
     validate identically. ``extra="forbid"`` rejects unknown body fields with
     a 422, matching the sibling ``CallOperationBody`` posture.
 
-    Filtering / projection is out of scope (issue #3179 non-goal): parity is
-    the same offset/limit window the MCP tool serves, not more.
+    ``query`` (#3366) is the optional structured query: when present, the
+    handle is queried server-side as one bounded read-only ``SELECT``
+    (filter / project / group / aggregate) and ``offset`` / ``limit`` are
+    ignored. It mirrors the MCP tool's ``query`` argument exactly (the same
+    :class:`~meho_backplane.jsonflux.query.contract.ResultQuerySpec`), so the
+    two surfaces stay in lockstep; there is deliberately no raw-SQL argument
+    on either.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -343,8 +353,8 @@ class ResultQueryBody(BaseModel):
         default=0,
         ge=0,
         description=(
-            "Zero-based index of the first row to return. Page by advancing "
-            "this by the previous `limit`."
+            "Zero-based index of the first row to return (paging mode). Page "
+            "by advancing this by the previous `limit`."
         ),
     )
     limit: int = Field(
@@ -352,8 +362,18 @@ class ResultQueryBody(BaseModel):
         ge=1,
         le=MAX_LIMIT,
         description=(
-            f"Page size. Default 50; max {MAX_LIMIT}. Matches the "
-            "`result_query` MCP tool's upper bound."
+            f"Page size (paging mode). Default 50; max {MAX_LIMIT}. Matches "
+            "the `result_query` MCP tool's upper bound."
+        ),
+    )
+    query: ResultQuerySpec | None = Field(
+        default=None,
+        description=(
+            "Optional structured query. When present, the handle is queried "
+            "server-side (filter / select / group_by / aggregate / order_by / "
+            "limit) as one bounded read-only SELECT and `offset` / `limit` are "
+            "ignored. Every referenced field must be a column on the handle; "
+            "there is no raw-SQL argument."
         ),
     )
 
@@ -387,6 +407,8 @@ async def post_result_query(
     UUID) or an out-of-range ``offset`` / ``limit`` is a ``422`` at the
     Pydantic layer before the handler runs.
     """
+    if body.query is not None:
+        return await _run_result_query_body(operator, body)
     try:
         return await read_result_window(operator, body.handle_id, body.offset, body.limit)
     except ResultHandleNotFoundError as exc:
@@ -397,6 +419,50 @@ async def post_result_query(
                 "reason": "handle_not_found",
                 "handle_id": str(body.handle_id),
             },
+        ) from exc
+
+
+async def _run_result_query_body(
+    operator: Operator,
+    body: ResultQueryBody,
+) -> dict[str, Any]:
+    """Run the structured-query branch of ``POST /result-query`` (#3366).
+
+    The Pydantic layer already validated ``body.query`` shape (caps,
+    operator/aggregate allow-lists, unknown sub-keys → 422). Field-vs-schema,
+    time-budget, and output-byte violations surface from the core here: a
+    contract violation is a ``422`` (``reason=invalid_query``), a timeout a
+    ``422`` (``reason=query_timeout``), an over-budget result a ``422``
+    (``reason=output_too_large``), and a missing handle the same ``404`` as
+    the paging branch. Each carries a structured ``detail`` so the caller can
+    narrow and retry.
+    """
+    assert body.query is not None  # guarded by the caller's branch (mypy narrowing)
+    try:
+        return await run_result_query(operator, body.handle_id, body.query)
+    except ResultHandleNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "message": str(exc),
+                "reason": "handle_not_found",
+                "handle_id": str(body.handle_id),
+            },
+        ) from exc
+    except QueryContractError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": str(exc), "reason": "invalid_query"},
+        ) from exc
+    except ResultQueryTimeoutError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": str(exc), "reason": "query_timeout"},
+        ) from exc
+    except ResultQueryOutputTooLargeError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": str(exc), "reason": "output_too_large"},
         ) from exc
 
 

--- a/backend/src/meho_backplane/connectors/result_handle_store.py
+++ b/backend/src/meho_backplane/connectors/result_handle_store.py
@@ -77,6 +77,7 @@ import structlog
 
 __all__ = [
     "ResultHandleStore",
+    "SpilledRowSet",
     "SpilledWindow",
     "get_result_handle_store",
     "reset_result_handle_store_for_testing",
@@ -121,6 +122,22 @@ class SpilledWindow(msgspec.Struct, frozen=True):
     total_rows: int
     stored_rows: int
     truncated: bool
+
+
+class SpilledRowSet(msgspec.Struct, frozen=True):
+    """The full authorized row set served by :meth:`ResultHandleStore.fetch_rows`.
+
+    ``rows`` is every row actually retrievable from the store — the reduce's
+    normalized set, capped at spill time to ``stored_rows``. ``total_rows``
+    is the full collection size the reducer saw; when ``stored_rows <
+    total_rows`` the spill was capped and a query over ``rows`` covers only
+    the stored subset (the ``result_query`` core labels that coverage so a
+    capped aggregate is never presented as a whole-inventory total).
+    """
+
+    rows: list[dict[str, Any]]
+    total_rows: int
+    stored_rows: int
 
 
 class _StoredPayload(msgspec.Struct):
@@ -261,6 +278,61 @@ class ResultHandleStore:
             total_rows=payload.total_rows,
             stored_rows=payload.stored_rows,
             truncated=payload.stored_rows < payload.total_rows,
+        )
+
+    async def fetch_rows(
+        self,
+        *,
+        tenant_id: UUID,
+        operator_sub: str,
+        handle_id: UUID,
+    ) -> SpilledRowSet | None:
+        """Return the **full** authorized row set of a spilled handle.
+
+        The sibling of :meth:`fetch_window` for the ``result_query`` query
+        surface (#3366): where ``fetch_window`` serves an
+        ``[offset:offset+limit]`` slice for paging, this returns every stored
+        row so the core can register them in a hardened DuckDB engine and run
+        one bounded, compiled ``SELECT`` over the set.
+
+        Reuses ``fetch_window``'s isolation and non-disclosure model exactly:
+        the tenant scopes the key, the stored ``operator_sub`` is checked so
+        another operator in the same tenant gets the same miss (``None``) as a
+        stranger, and an unknown / expired / cross-operator handle or an
+        unreachable store all return ``None`` — the four cases the read tools
+        surface as one typed "handle not found or expired", leaking no
+        existence signal across the operator boundary.
+        """
+        try:
+            raw = await self._client.get(_key(tenant_id, handle_id))
+        except (redis.RedisError, OSError) as exc:
+            _log.warning(
+                "result_handle_fetch_failed",
+                handle_id=str(handle_id),
+                tenant_id=str(tenant_id),
+                error=str(exc),
+            )
+            return None
+        if raw is None:
+            return None
+        try:
+            payload = msgspec.json.decode(_to_bytes(raw), type=_StoredPayload)
+        except (msgspec.DecodeError, msgspec.ValidationError) as exc:
+            _log.warning(
+                "result_handle_decode_failed",
+                handle_id=str(handle_id),
+                tenant_id=str(tenant_id),
+                error=str(exc),
+            )
+            return None
+        if payload.operator_sub != operator_sub:
+            # Cross-operator access within the same tenant: a miss, not
+            # another operator's rows. Mirrors #304's isolation contract.
+            return None
+        return SpilledRowSet(
+            rows=payload.rows,
+            total_rows=payload.total_rows,
+            stored_rows=payload.stored_rows,
         )
 
 

--- a/backend/src/meho_backplane/jsonflux/query/contract.py
+++ b/backend/src/meho_backplane/jsonflux/query/contract.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Bounded, validated query contract for the ``result_query`` read-back surface.
+
+This module turns a small, typed argument grammar
+(:class:`ResultQuerySpec`) into **exactly one parameterized, read-only
+``SELECT``** over the single Arrow-registered handle table
+(:data:`RESULT_TABLE`) inside the hardened JSONFlux
+:class:`~meho_backplane.jsonflux.query.engine.QueryEngine`.
+
+Why compile, not sanitize (#3366)
+=================================
+
+The alternative — accept a caller SQL string and try to prove it safe —
+was rejected against the locked ``duckdb==1.5.5``: a ``:memory:`` database
+cannot be opened ``read_only`` (raises ``CatalogException``); with
+``enable_external_access=false`` an in-memory ``CREATE TABLE ... AS SELECT``
+still succeeds; and ``execute("A; B")`` silently runs both statements. A
+raw-SQL contract would therefore force MEHO to build and maintain a SQL
+parser to close holes that compiling from a fixed template avoids by
+construction. Here the unsafe forms are simply **not expressible**: there
+is no ``sql=`` field, every referenced field is checked against the
+handle's known column set (unknown field → rejected, Kubernetes
+field-selector style), operators and aggregate functions are fixed
+allow-lists, and every caller value is bound as a DuckDB prepared-statement
+parameter — never string-interpolated. The only value ever interpolated
+into the SQL text is the ``LIMIT`` (a validated, bounded integer) and the
+column identifiers (each an exact match of a real column, double-quoted
+with embedded quotes escaped).
+
+Bounds
+======
+
+Filter predicates ≤ 10, ``group_by`` ≤ 4, ``order_by`` ≤ 4 (rejected at
+model construction). Operator allow-list ``=, !=, <, <=, >, >=, IN, IS
+NULL``; aggregate allow-list ``COUNT, SUM, MIN, MAX, AVG``. The output-row
+ceiling (``MAX_LIMIT``) is single-sourced in
+:mod:`meho_backplane.operations.result_query` and passed to
+:func:`compile_query` as ``max_limit`` — this module never imports it, to
+keep the vendored ``jsonflux`` package free of an ``operations`` back-edge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "RESULT_TABLE",
+    "Aggregate",
+    "CompiledQuery",
+    "FilterPredicate",
+    "OrderBy",
+    "QueryContractError",
+    "ResultQuerySpec",
+    "compile_query",
+]
+
+#: The in-memory table the handle's rows are registered under. Must match
+#: the reducer's ``_TABLE`` (``meho_backplane.operations.jsonflux_reducer``)
+#: — a fixed wire constant, kept as a literal here so the vendored
+#: ``jsonflux`` package needs no ``operations`` import.
+RESULT_TABLE = "result"
+
+#: Filter operators the compiler will emit. A fixed allow-list: a value
+#: outside it is rejected at model construction (``Literal``), so an
+#: injection attempt via the operator slot is not expressible.
+FilterOperator = Literal["=", "!=", "<", "<=", ">", ">=", "IN", "IS NULL"]
+
+#: Aggregate functions the compiler will emit. Fixed allow-list, same
+#: reasoning as :data:`FilterOperator`.
+AggregateFunc = Literal["COUNT", "SUM", "MIN", "MAX", "AVG"]
+
+#: Sort directions. Compiled to the literal ``ASC`` / ``DESC`` keyword, so
+#: this slot can never carry arbitrary text either.
+SortDirection = Literal["asc", "desc"]
+
+#: Operators that take no value (the value slot must be omitted).
+_VALUELESS_OPERATORS: frozenset[str] = frozenset({"IS NULL"})
+
+#: Operators whose value must be a non-empty list (expanded to one bound
+#: placeholder per element).
+_LIST_OPERATORS: frozenset[str] = frozenset({"IN"})
+
+
+class QueryContractError(ValueError):
+    """A structured query cannot be compiled against this handle's schema.
+
+    Raised by :func:`compile_query` for violations that need the handle's
+    actual column set to detect — an unknown field, an aggregate over a
+    missing column, an order-by column not covered by ``group_by`` in a
+    grouped query, a malformed predicate value. Model-shape violations
+    (caps, operator/aggregate allow-lists, ``extra="forbid"``) are caught
+    earlier, at :class:`ResultQuerySpec` construction, as a pydantic
+    ``ValidationError``. Each transport maps this to its own recoverable
+    error (MCP ``-32602``; REST ``422``) so the caller can narrow and retry.
+    """
+
+
+class FilterPredicate(BaseModel):
+    """One ``WHERE`` clause term: ``field op value``.
+
+    ``value`` is omitted for ``IS NULL``, a list for ``IN`` (each element
+    bound as its own placeholder), and a scalar otherwise. The value is
+    always bound as a DuckDB prepared-statement parameter — never
+    interpolated — so it cannot alter the statement's structure.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(min_length=1, description="Column to test; must exist on the handle.")
+    op: FilterOperator = Field(description="Comparison operator (fixed allow-list).")
+    value: Any = Field(
+        default=None,
+        description=(
+            "The comparison value, bound as a parameter. Omit for `IS NULL`; "
+            "a list for `IN`; a scalar for the ordering/equality operators."
+        ),
+    )
+
+
+class Aggregate(BaseModel):
+    """One aggregate output column: ``func(field)`` (``COUNT`` may omit field).
+
+    ``COUNT`` with no ``field`` compiles to ``COUNT(*)``; every other
+    function requires a field. The output alias is derived deterministically
+    (``count`` / ``sum_<field>`` / ...) and quoted, so callers never inject
+    an alias identifier.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    func: AggregateFunc = Field(description="Aggregate function (fixed allow-list).")
+    field: str | None = Field(
+        default=None,
+        description="Column to aggregate; omit only for COUNT (compiles to COUNT(*)).",
+    )
+
+
+class OrderBy(BaseModel):
+    """One ``ORDER BY`` term: a known column plus a direction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(min_length=1, description="Column to sort by; must exist on the handle.")
+    direction: SortDirection = Field(default="asc", description="Sort direction.")
+
+
+class ResultQuerySpec(BaseModel):
+    """The structured, validated query arguments for a single handle.
+
+    Every field is optional: an empty spec compiles to ``SELECT * FROM
+    result LIMIT <max>`` — a full read-back capped at the output ceiling.
+    The list caps (``filter`` ≤ 10, ``group_by`` ≤ 4, ``order_by`` ≤ 4)
+    and the operator/aggregate allow-lists are enforced here, at
+    construction; field-vs-schema validation needs the handle's columns and
+    happens in :func:`compile_query`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    filter: list[FilterPredicate] = Field(
+        default_factory=list,
+        max_length=10,
+        description="Predicates AND-ed into the WHERE clause (max 10).",
+    )
+    select: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Projection: columns to return. Omit for all columns. Not allowed "
+            "together with `aggregate` (the output is then the group keys plus "
+            "the aggregates)."
+        ),
+    )
+    group_by: list[str] = Field(
+        default_factory=list,
+        max_length=4,
+        description="Columns to group by (max 4).",
+    )
+    aggregate: list[Aggregate] = Field(
+        default_factory=list,
+        description="Aggregate output columns (COUNT/SUM/MIN/MAX/AVG).",
+    )
+    order_by: list[OrderBy] = Field(
+        default_factory=list,
+        max_length=4,
+        description="Sort terms (max 4).",
+    )
+    limit: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Max output rows. Omitted or above the server ceiling clamps to "
+            "the ceiling (500); the result flags `truncated` when more rows existed."
+        ),
+    )
+
+    def is_empty(self) -> bool:
+        """True when no query dimension is set (a pure full read-back)."""
+        return not (self.filter or self.select or self.group_by or self.aggregate or self.order_by)
+
+
+class CompiledQuery(BaseModel):
+    """The output of :func:`compile_query`: one SELECT + its bound params.
+
+    ``effective_limit`` is the output-row ceiling actually applied (after
+    clamping ``spec.limit`` to ``max_limit``); the core caps the returned
+    rows to it and reports ``truncated`` when the underlying result had more.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sql: str
+    params: list[Any]
+    effective_limit: int
+
+
+def _quote_ident(name: str) -> str:
+    """Double-quote a SQL identifier, escaping embedded double quotes.
+
+    The name is always an exact match of a real column (validated before
+    this is called) or a compiler-generated alias, so quoting here is
+    belt-and-suspenders that also handles pathological column names
+    (spaces, dots, embedded quotes) correctly.
+    """
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _require_known(field: str, known: set[str]) -> None:
+    """Reject a field that is not a column on the handle's schema."""
+    if field not in known:
+        raise QueryContractError(
+            f"unknown field {field!r}: not a column on this result handle. "
+            f"Known columns: {sorted(known)}."
+        )
+
+
+def _build_where(
+    predicates: Sequence[FilterPredicate],
+    known: set[str],
+    params: list[Any],
+) -> str:
+    """Compile the predicate list into a parameterized ``WHERE`` body."""
+    terms: list[str] = []
+    for pred in predicates:
+        _require_known(pred.field, known)
+        ident = _quote_ident(pred.field)
+        if pred.op in _VALUELESS_OPERATORS:
+            if pred.value is not None:
+                raise QueryContractError(
+                    f"operator {pred.op!r} on field {pred.field!r} takes no value; omit `value`."
+                )
+            terms.append(f"{ident} IS NULL")
+        elif pred.op in _LIST_OPERATORS:
+            if not isinstance(pred.value, list) or not pred.value:
+                raise QueryContractError(
+                    f"operator 'IN' on field {pred.field!r} needs a non-empty list value."
+                )
+            placeholders = ", ".join("?" for _ in pred.value)
+            terms.append(f"{ident} IN ({placeholders})")
+            params.extend(pred.value)
+        else:
+            if pred.value is None or isinstance(pred.value, (list, dict)):
+                raise QueryContractError(
+                    f"operator {pred.op!r} on field {pred.field!r} needs a scalar value."
+                )
+            terms.append(f"{ident} {pred.op} ?")
+            params.append(pred.value)
+    return " AND ".join(terms)
+
+
+def _aggregate_alias(agg: Aggregate) -> str:
+    """Deterministic output name for an aggregate (``count`` / ``sum_field``)."""
+    if agg.field is None:
+        return agg.func.lower()
+    return f"{agg.func.lower()}_{agg.field}"
+
+
+def _build_aggregate_projection(spec: ResultQuerySpec, known: set[str]) -> tuple[str, str]:
+    """Compile the SELECT list + GROUP BY body for an aggregate query.
+
+    Output columns are the ``group_by`` keys followed by the aggregate
+    expressions; ``select`` is not allowed alongside ``aggregate`` (the
+    output shape is fully determined by the keys + aggregates).
+    """
+    if spec.select:
+        raise QueryContractError(
+            "`select` is not allowed with `aggregate`: the output columns are the "
+            "`group_by` keys plus the aggregates."
+        )
+    select_parts: list[str] = []
+    seen_aliases: set[str] = set()
+    for col in spec.group_by:
+        _require_known(col, known)
+        select_parts.append(_quote_ident(col))
+    for agg in spec.aggregate:
+        if agg.func == "COUNT" and agg.field is None:
+            expr = "COUNT(*)"
+        else:
+            if agg.field is None:
+                raise QueryContractError(
+                    f"aggregate {agg.func} requires a `field` (only COUNT may omit it)."
+                )
+            _require_known(agg.field, known)
+            expr = f"{agg.func}({_quote_ident(agg.field)})"
+        alias = _aggregate_alias(agg)
+        if alias in seen_aliases:
+            raise QueryContractError(
+                f"duplicate aggregate output {alias!r}; each aggregate must be distinct."
+            )
+        seen_aliases.add(alias)
+        select_parts.append(f"{expr} AS {_quote_ident(alias)}")
+    group_sql = ", ".join(_quote_ident(col) for col in spec.group_by)
+    return ", ".join(select_parts), group_sql
+
+
+def _build_projection(spec: ResultQuerySpec, known: set[str]) -> tuple[str, str]:
+    """Compile the SELECT list and GROUP BY body for any spec.
+
+    Three shapes: aggregate (keys + aggregates), plain ``group_by`` (the
+    distinct key combinations), or a flat projection (``select`` columns, or
+    ``*`` when omitted).
+    """
+    if spec.aggregate:
+        return _build_aggregate_projection(spec, known)
+    if spec.group_by:
+        for col in spec.group_by:
+            _require_known(col, known)
+        cols = ", ".join(_quote_ident(col) for col in spec.group_by)
+        return cols, cols
+    if spec.select:
+        for col in spec.select:
+            _require_known(col, known)
+        return ", ".join(_quote_ident(col) for col in spec.select), ""
+    return "*", ""
+
+
+def _build_order(spec: ResultQuerySpec, known: set[str]) -> str:
+    """Compile the ``ORDER BY`` body, validating each term against the schema.
+
+    In a grouped/aggregated query, an order-by column must be one of the
+    ``group_by`` keys (ordering by a non-grouped raw column is not valid
+    SQL); the check is done here so the caller gets a clear contract error
+    rather than an opaque DuckDB binder error.
+    """
+    if not spec.order_by:
+        return ""
+    grouped = bool(spec.group_by or spec.aggregate)
+    group_cols = set(spec.group_by)
+    parts: list[str] = []
+    for term in spec.order_by:
+        _require_known(term.field, known)
+        if grouped and term.field not in group_cols:
+            raise QueryContractError(
+                f"cannot order by {term.field!r} in a grouped query: order only by a "
+                "`group_by` key."
+            )
+        parts.append(f"{_quote_ident(term.field)} {'DESC' if term.direction == 'desc' else 'ASC'}")
+    return ", ".join(parts)
+
+
+def compile_query(
+    spec: ResultQuerySpec,
+    columns: Sequence[str],
+    *,
+    max_limit: int,
+) -> CompiledQuery:
+    """Compile *spec* into one parameterized, read-only ``SELECT``.
+
+    *columns* is the handle's known column set (from the registered table's
+    ``DESCRIBE``); every referenced field is checked against it. *max_limit*
+    is the output-row ceiling (single-sourced in
+    :mod:`meho_backplane.operations.result_query`); ``spec.limit`` is clamped
+    to it. The statement selects one extra row over the ceiling so the core
+    can set ``truncated`` when the underlying result had more rows than fit.
+
+    Raises :class:`QueryContractError` on any field-vs-schema or
+    value-shape violation. The returned SQL is always a single ``SELECT``
+    over :data:`RESULT_TABLE` with no trailing statement separator.
+    """
+    known = set(columns)
+    params: list[Any] = []
+
+    where_sql = _build_where(spec.filter, known, params)
+    select_sql, group_sql = _build_projection(spec, known)
+    order_sql = _build_order(spec, known)
+
+    effective_limit = max_limit if spec.limit is None else min(spec.limit, max_limit)
+    # +1 so the core can detect "more rows existed than the ceiling admits"
+    # and flag ``truncated`` without a second count query. The value is a
+    # validated, bounded int — the only integer ever interpolated here.
+    fetch_limit = effective_limit + 1
+
+    sql = f"SELECT {select_sql} FROM {_quote_ident(RESULT_TABLE)}"
+    if where_sql:
+        sql += f" WHERE {where_sql}"
+    if group_sql:
+        sql += f" GROUP BY {group_sql}"
+    if order_sql:
+        sql += f" ORDER BY {order_sql}"
+    sql += f" LIMIT {fetch_limit}"
+
+    return CompiledQuery(sql=sql, params=params, effective_limit=effective_limit)

--- a/backend/src/meho_backplane/jsonflux/query/engine.py
+++ b/backend/src/meho_backplane/jsonflux/query/engine.py
@@ -175,12 +175,25 @@ class QueryEngine:
         (``conn.register``); DuckDB never reads files or URLs itself. These
         settings make that contract enforced rather than incidental, closing
         the latent arbitrary-file-read / SSRF / untrusted-extension surface
-        that arbitrary SQL (e.g. a future ``result_query`` drill-in) would
-        otherwise expose. ``lock_configuration`` must be applied last because
-        it freezes all further configuration changes.
+        that arbitrary SQL (e.g. the ``result_query`` drill-in, #3366) would
+        otherwise expose.
+
+        Resource ceilings (``max_memory`` / ``threads``) and the
+        extension-autoload switches are applied here too so every engine — in
+        particular the ``result_query`` compiler running a caller-shaped
+        ``SELECT`` — is bounded in memory and single-threaded and can neither
+        auto-install nor auto-load an extension. These are ``SET`` statements,
+        so they MUST precede ``lock_configuration=true`` (a post-lock ``SET``
+        raises ``InvalidInputException`` on the pinned duckdb 1.5.5).
+        ``lock_configuration`` is therefore applied **last** — it freezes all
+        further configuration changes.
         """
         self.conn.execute("SET enable_external_access=false")
         self.conn.execute("SET allow_community_extensions=false")
+        self.conn.execute("SET autoinstall_known_extensions=false")
+        self.conn.execute("SET autoload_known_extensions=false")
+        self.conn.execute("SET max_memory='256MB'")
+        self.conn.execute("SET threads=1")
         self.conn.execute("SET lock_configuration=true")
 
     def register(  # NOSONAR (cognitive complexity)

--- a/backend/src/meho_backplane/mcp/tools/result_query.py
+++ b/backend/src/meho_backplane/mcp/tools/result_query.py
@@ -38,13 +38,20 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from pydantic import ValidationError
+
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, ToolSurface, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.result_query import (
     MAX_LIMIT,
+    QueryContractError,
     ResultHandleNotFoundError,
+    ResultQueryOutputTooLargeError,
+    ResultQuerySpec,
+    ResultQueryTimeoutError,
     read_result_window,
+    run_result_query,
 )
 
 __all__: list[str] = []
@@ -60,14 +67,22 @@ async def _result_query_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    """Return a ``[offset : offset+limit]`` window of a spilled handle.
+    """Read back from a spilled handle: page a window, or run a bounded query.
 
     The MCP dispatcher has already validated ``arguments`` against the
-    tool's ``inputSchema`` (``handle_id`` required, ``offset`` / ``limit``
-    bounded), so the body parses the UUID and delegates the windowed read
-    to the shared :func:`read_result_window` core (the same core the REST
-    ``POST /api/v1/operations/result-query`` route wraps). The tenant comes
-    from ``operator.tenant_id`` — the arguments carry no tenant, by design.
+    tool's ``inputSchema``, so the body parses the UUID and branches on the
+    optional ``query`` argument:
+
+    * absent → paging mode: delegate the ``[offset : offset+limit]`` window
+      to the shared :func:`read_result_window` core (unchanged, #3179).
+    * present → query mode: validate it into a
+      :class:`~meho_backplane.jsonflux.query.contract.ResultQuerySpec` and
+      delegate to :func:`run_result_query`, which compiles it to one bounded
+      read-only ``SELECT`` over the handle (#3366).
+
+    Both branches wrap the same tenant/principal scoping and not-found
+    semantics. The tenant comes from ``operator.tenant_id`` — the arguments
+    carry no tenant, by design.
     """
     raw_handle = arguments["handle_id"]
     try:
@@ -78,6 +93,10 @@ async def _result_query_handler(
             data={"reason": "invalid_handle_id", "handle_id": str(raw_handle)},
         ) from exc
 
+    raw_query = arguments.get("query")
+    if raw_query is not None:
+        return await _run_query(operator, handle_id, raw_query)
+
     offset = int(arguments.get("offset", 0))
     limit = int(arguments.get("limit", 50))
 
@@ -85,6 +104,39 @@ async def _result_query_handler(
         return await read_result_window(operator, handle_id, offset, limit)
     except ResultHandleNotFoundError as exc:
         raise _handle_not_found(handle_id) from exc
+
+
+async def _run_query(
+    operator: Operator,
+    handle_id: UUID,
+    raw_query: Any,
+) -> dict[str, Any]:
+    """Validate the ``query`` argument and run the bounded structured query.
+
+    Model-shape violations (caps, operator/aggregate allow-lists, unknown
+    sub-keys) surface as a pydantic ``ValidationError``; field-vs-schema,
+    time-budget, and output-byte violations surface from the core. All map
+    to a recoverable ``-32602`` with a machine-readable ``data.reason`` so
+    the agent can narrow and retry.
+    """
+    try:
+        spec = ResultQuerySpec.model_validate(raw_query)
+    except ValidationError as exc:
+        raise McpInvalidParamsError(
+            f"invalid query spec: {exc.error_count()} validation error(s); "
+            f"first: {exc.errors()[0].get('msg', 'invalid')}",
+            data={"reason": "invalid_query"},
+        ) from exc
+    try:
+        return await run_result_query(operator, handle_id, spec)
+    except ResultHandleNotFoundError as exc:
+        raise _handle_not_found(handle_id) from exc
+    except QueryContractError as exc:
+        raise McpInvalidParamsError(str(exc), data={"reason": "invalid_query"}) from exc
+    except ResultQueryTimeoutError as exc:
+        raise McpInvalidParamsError(str(exc), data={"reason": "query_timeout"}) from exc
+    except ResultQueryOutputTooLargeError as exc:
+        raise McpInvalidParamsError(str(exc), data={"reason": "output_too_large"}) from exc
 
 
 def _handle_not_found(handle_id: UUID) -> McpInvalidParamsError:
@@ -108,19 +160,28 @@ register_mcp_tool(
             "Read rows back from a JSONFlux result handle. After "
             "`call_operation` reduces a large list response, you get an "
             "inline sample plus a handle (`result.handle.handle_id`); call "
-            "this tool to page through the FULL set beyond that sample. "
-            "Arguments: `handle_id` (required, the UUID from the reduced "
+            "this tool to read the FULL set beyond that sample, either by "
+            "paging or by running a bounded server-side query. "
+            "Paging: pass `handle_id` (required, the UUID from the reduced "
             "response's `handle.handle_id` / the `fetch_more.drill_in."
-            "example_call`), `offset` (default 0), `limit` (default 50, "
-            "max 500). Returns the requested window plus `total_rows` "
-            "(the full collection size), `stored_rows` (how many rows are "
-            "retrievable — may be less than `total_rows` if the spill was "
-            "capped), and `truncated`. Page by re-calling with a higher "
-            "`offset`; an empty `rows` with `offset >= stored_rows` is the "
-            "end. A handle that does not exist, has expired (TTL elapsed), "
-            "or belongs to another operator is a recoverable error "
-            "(`-32602`, `data.reason=handle_not_found`) — re-run the "
-            "original operation to get a fresh handle. Only use this when "
+            "example_call`) plus `offset` (default 0) and `limit` (default "
+            "50, max 500); page by re-calling with a higher `offset`, and an "
+            "empty `rows` with `offset >= stored_rows` is the end. "
+            "Query: pass `handle_id` plus a `query` object to filter, "
+            "project (`select`), `group_by`, and `aggregate` "
+            "(COUNT/SUM/MIN/MAX/AVG) server-side — so you fetch just the one "
+            "row you need or the counts by group, not the whole set. The "
+            "query runs as one bounded read-only SELECT over the handle "
+            "(no raw SQL); every referenced field must be a column on the "
+            "handle. Results carry `total_rows`, `stored_rows` (retrievable "
+            "rows — may be below `total_rows` if the spill was capped), "
+            "`truncated` (more rows existed than returned), and, for a "
+            "query, `coverage` (`complete`/`partial`): a `partial` result "
+            "aggregated only the stored subset, not the whole inventory. "
+            "A handle that does not exist, has expired (TTL elapsed), or "
+            "belongs to another operator is a recoverable error (`-32602`, "
+            "`data.reason=handle_not_found`) — re-run the original operation "
+            "to get a fresh handle. Only use this when "
             "`fetch_more.drill_in.available` is `true` on the handle; when "
             "it is `false` the full set was not spilled and you must "
             "re-call the operation with narrower params instead."
@@ -152,9 +213,106 @@ register_mcp_tool(
                     "maximum": _MAX_LIMIT,
                     "default": 50,
                     "description": (
-                        f"Page size. Default 50; max {_MAX_LIMIT}. Matches "
-                        "the sibling list tools' upper bound."
+                        f"Page size (paging mode). Default 50; max {_MAX_LIMIT}. "
+                        "Matches the sibling list tools' upper bound."
                     ),
+                },
+                "query": {
+                    "type": "object",
+                    "description": (
+                        "Optional structured query (query mode). When present, "
+                        "`offset`/`limit` are ignored and the handle is queried "
+                        "server-side as one bounded read-only SELECT. Every "
+                        "referenced field must be a column on the handle."
+                    ),
+                    "additionalProperties": False,
+                    "properties": {
+                        "filter": {
+                            "type": "array",
+                            "maxItems": 10,
+                            "description": "Predicates AND-ed into the WHERE clause (max 10).",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "properties": {
+                                    "field": {"type": "string", "minLength": 1},
+                                    "op": {
+                                        "type": "string",
+                                        "enum": ["=", "!=", "<", "<=", ">", ">=", "IN", "IS NULL"],
+                                    },
+                                    "value": {
+                                        "description": (
+                                            "Bound as a parameter. Omit for `IS NULL`; "
+                                            "a list for `IN`; a scalar otherwise."
+                                        ),
+                                    },
+                                },
+                                "required": ["field", "op"],
+                            },
+                        },
+                        "select": {
+                            "type": "array",
+                            "items": {"type": "string", "minLength": 1},
+                            "description": (
+                                "Columns to return. Omit for all columns. Not allowed "
+                                "with `aggregate`."
+                            ),
+                        },
+                        "group_by": {
+                            "type": "array",
+                            "maxItems": 4,
+                            "items": {"type": "string", "minLength": 1},
+                            "description": "Columns to group by (max 4).",
+                        },
+                        "aggregate": {
+                            "type": "array",
+                            "description": "Aggregate output columns (COUNT/SUM/MIN/MAX/AVG).",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "properties": {
+                                    "func": {
+                                        "type": "string",
+                                        "enum": ["COUNT", "SUM", "MIN", "MAX", "AVG"],
+                                    },
+                                    "field": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "description": (
+                                            "Column to aggregate; omit only for COUNT (COUNT(*))."
+                                        ),
+                                    },
+                                },
+                                "required": ["func"],
+                            },
+                        },
+                        "order_by": {
+                            "type": "array",
+                            "maxItems": 4,
+                            "description": "Sort terms (max 4).",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "properties": {
+                                    "field": {"type": "string", "minLength": 1},
+                                    "direction": {
+                                        "type": "string",
+                                        "enum": ["asc", "desc"],
+                                        "default": "asc",
+                                    },
+                                },
+                                "required": ["field"],
+                            },
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": (
+                                f"Max output rows; clamps to {_MAX_LIMIT}. "
+                                "The result flags `truncated` when more rows existed."
+                            ),
+                        },
+                    },
                 },
             },
             "required": ["handle_id"],
@@ -171,6 +329,19 @@ register_mcp_tool(
                 "total_rows": {"type": "integer", "minimum": 0},
                 "stored_rows": {"type": "integer", "minimum": 0},
                 "truncated": {"type": "boolean"},
+                "coverage": {
+                    "type": "string",
+                    "enum": ["complete", "partial"],
+                    "description": (
+                        "Query mode only. `partial` when the spill was capped "
+                        "(`stored_rows < total_rows`) so the query covered only the "
+                        "stored subset — a count/aggregate is not a whole-inventory total."
+                    ),
+                },
+                "coverage_note": {
+                    "type": ["string", "null"],
+                    "description": "Query mode only. Human-readable coverage caveat when partial.",
+                },
             },
             "required": [
                 "handle_id",

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -150,7 +150,10 @@ def _drill_in_available_rationale(handle_id: UUID, stored_rows: int, total_rows:
         f"via the ``{_RESULT_QUERY_TOOL}`` tool or over REST via "
         f"``{_RESULT_QUERY_REST_ROUTE}``. Call either with "
         f"``handle_id={handle_id}`` plus ``offset`` / ``limit`` to page "
-        f"beyond the inline sample.{tail_note}"
+        f"beyond the inline sample, or pass a ``query`` (``filter`` / "
+        f"``select`` / ``group_by`` / ``aggregate`` / ``order_by`` / "
+        f"``limit``) to have the backplane return just the matching rows or "
+        f"the per-group counts instead of the whole set.{tail_note}"
     )
 
 

--- a/backend/src/meho_backplane/operations/result_query.py
+++ b/backend/src/meho_backplane/operations/result_query.py
@@ -39,13 +39,35 @@ rather than getting an opaque internal error.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import Any
 from uuid import UUID
 
+import msgspec
+
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.result_handle_store import get_result_handle_store
+from meho_backplane.jsonflux.query.contract import (
+    RESULT_TABLE,
+    CompiledQuery,
+    QueryContractError,
+    ResultQuerySpec,
+    compile_query,
+)
+from meho_backplane.jsonflux.query.engine import QueryEngine
+from meho_backplane.settings import get_settings
 
-__all__ = ["MAX_LIMIT", "ResultHandleNotFoundError", "read_result_window"]
+__all__ = [
+    "MAX_LIMIT",
+    "QueryContractError",
+    "ResultHandleNotFoundError",
+    "ResultQueryOutputTooLargeError",
+    "ResultQuerySpec",
+    "ResultQueryTimeoutError",
+    "read_result_window",
+    "run_result_query",
+]
 
 #: Upper bound on a single read-back page: one call returns at most this many
 #: rows so a reader can't pull an unbounded slice in one request. Matches the
@@ -115,4 +137,191 @@ async def read_result_window(
         "total_rows": window.total_rows,
         "stored_rows": window.stored_rows,
         "truncated": window.truncated,
+    }
+
+
+class ResultQueryTimeoutError(Exception):
+    """A compiled ``result_query`` ``SELECT`` exceeded its wall-time budget.
+
+    DuckDB has no native Python query timeout, so the core runs
+    ``conn.execute()`` on a worker thread and calls ``conn.interrupt()`` when
+    the ``result_query_timeout_seconds`` budget elapses. Recoverable: the
+    caller narrows the query (a tighter ``filter``, fewer ``group_by`` keys,
+    a lower ``limit``) and retries. Each transport maps it to its own
+    recoverable-error shape.
+    """
+
+    def __init__(self, handle_id: UUID, timeout_seconds: int) -> None:
+        self.handle_id = handle_id
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"query over handle {handle_id} exceeded the {timeout_seconds}s time "
+            "budget and was aborted. Narrow the query (a tighter filter, fewer "
+            "group_by keys, or a lower limit) and retry."
+        )
+
+
+class ResultQueryOutputTooLargeError(Exception):
+    """A ``result_query`` result exceeded the serialized-output byte budget.
+
+    Applied **after** the row cap: even ≤ ``MAX_LIMIT`` rows can overflow the
+    ``result_query_max_output_bytes`` budget when they are wide or deeply
+    nested. Recoverable: the caller narrows the projection (a smaller
+    ``select``), filters harder, or lowers ``limit`` and retries.
+    """
+
+    def __init__(self, handle_id: UUID, output_bytes: int, max_bytes: int) -> None:
+        self.handle_id = handle_id
+        self.output_bytes = output_bytes
+        self.max_bytes = max_bytes
+        super().__init__(
+            f"query result for handle {handle_id} is {output_bytes} serialized "
+            f"bytes, over the {max_bytes}-byte output budget. Narrow the result: "
+            "project fewer columns with `select`, add a `filter`, or lower `limit`."
+        )
+
+
+def _known_columns(engine: QueryEngine) -> list[str]:
+    """Return the registered handle table's column names (its known schema).
+
+    The contract compiler validates every referenced field against this set,
+    so an unknown field is rejected before any SQL runs.
+    """
+    described = engine.conn.execute(f"DESCRIBE {RESULT_TABLE}").fetchall()
+    return [str(row[0]) for row in described]
+
+
+def _execute_sync(engine: QueryEngine, compiled: CompiledQuery) -> tuple[list[str], list[Any]]:
+    """Run the compiled SELECT on the engine's connection (worker thread).
+
+    Returns the result column names and the raw fetched rows. Runs on a
+    worker thread so :func:`run_result_query` can call
+    ``engine.conn.interrupt()`` from the event loop on timeout.
+    """
+    cursor = engine.conn.execute(compiled.sql, compiled.params)
+    columns = [desc[0] for desc in cursor.description]
+    return columns, cursor.fetchall()
+
+
+async def _run_compiled_query(
+    rows: list[dict[str, Any]],
+    spec: ResultQuerySpec,
+    handle_id: UUID,
+    *,
+    max_output_rows: int,
+    timeout_seconds: int,
+) -> tuple[list[dict[str, Any]], bool, int]:
+    """Compile *spec*, run it under the time budget; return rows + flags.
+
+    The engine is created + the rows registered + the contract compiled
+    inline (bounded work), then only the ``SELECT`` execution runs on a
+    worker thread so the event loop can interrupt it on timeout. The result
+    is capped to ``max_output_rows`` and ``truncated`` is ``True`` when the
+    underlying result had more rows than the cap admits.
+    """
+    engine = QueryEngine()
+    try:
+        engine.register(RESULT_TABLE, rows, unwrap="auto")
+        columns = _known_columns(engine)
+        compiled = compile_query(spec, columns, max_limit=max_output_rows)
+
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, _execute_sync, engine, compiled)
+        try:
+            result_columns, fetched = await asyncio.wait_for(
+                asyncio.shield(future), timeout_seconds
+            )
+        except TimeoutError as exc:  # asyncio.TimeoutError aliases this on 3.11+
+            with contextlib.suppress(Exception):
+                engine.conn.interrupt()
+            with contextlib.suppress(BaseException):
+                await future
+            raise ResultQueryTimeoutError(handle_id, timeout_seconds) from exc
+    finally:
+        engine.close()
+
+    truncated = len(fetched) > compiled.effective_limit
+    capped = fetched[: compiled.effective_limit]
+    result_rows = [dict(zip(result_columns, row, strict=False)) for row in capped]
+    return result_rows, truncated, compiled.effective_limit
+
+
+async def run_result_query(
+    operator: Operator,
+    handle_id: UUID,
+    spec: ResultQuerySpec,
+) -> dict[str, Any]:
+    """Run a bounded, validated structured query over a spilled handle (#3366).
+
+    Loads the full authorized row set (same tenant + ``operator_sub``
+    isolation and None-on-miss non-disclosure as the paging read), registers
+    it in a fresh hardened :class:`QueryEngine`, compiles *spec* into one
+    parameterized read-only ``SELECT`` (:func:`compile_query`), and runs it
+    under the output-row / output-byte / wall-time bounds from settings.
+
+    The result carries coverage metadata: when the spill was capped
+    (``stored_rows < total_rows``) the query ran over the stored subset only,
+    so it is labelled ``coverage="partial"`` and an aggregate over it is
+    never presented as a whole-inventory total.
+
+    Raises :class:`ResultHandleNotFoundError` (unknown / expired /
+    cross-operator handle, or no tenant), :class:`QueryContractError` (a
+    field-vs-schema or value-shape violation), :class:`ResultQueryTimeoutError`
+    (time budget exceeded), or :class:`ResultQueryOutputTooLargeError` (byte
+    budget exceeded). Each transport maps these to its own recoverable-error
+    shape.
+    """
+    if operator.tenant_id is None:
+        raise ResultHandleNotFoundError(handle_id)
+
+    row_set = await get_result_handle_store().fetch_rows(
+        tenant_id=operator.tenant_id,
+        operator_sub=operator.sub,
+        handle_id=handle_id,
+    )
+    if row_set is None:
+        raise ResultHandleNotFoundError(handle_id)
+
+    settings = get_settings()
+    result_rows, truncated, effective_limit = await _run_compiled_query(
+        row_set.rows,
+        spec,
+        handle_id,
+        max_output_rows=settings.result_query_max_output_rows,
+        timeout_seconds=settings.result_query_timeout_seconds,
+    )
+
+    # Byte cap applied AFTER the row cap: wide/nested rows can overflow the
+    # token budget even under the row ceiling. Encoding also normalizes any
+    # non-JSON-native value (datetime, Decimal) to a JSON-safe form for the
+    # transport layer, in one pass.
+    encoded_rows = msgspec.json.encode(result_rows)
+    if len(encoded_rows) > settings.result_query_max_output_bytes:
+        raise ResultQueryOutputTooLargeError(
+            handle_id, len(encoded_rows), settings.result_query_max_output_bytes
+        )
+    json_safe_rows: list[dict[str, Any]] = msgspec.json.decode(encoded_rows)
+
+    partial = row_set.stored_rows < row_set.total_rows
+    coverage_note = (
+        (
+            f"This query ran over the {row_set.stored_rows} stored rows only; the "
+            f"full result had {row_set.total_rows} rows (the spill was capped). "
+            "Counts and aggregates cover the stored subset, not the whole inventory."
+        )
+        if partial
+        else None
+    )
+
+    return {
+        "handle_id": str(handle_id),
+        "rows": json_safe_rows,
+        "offset": 0,
+        "limit": effective_limit,
+        "returned_rows": len(json_safe_rows),
+        "total_rows": row_set.total_rows,
+        "stored_rows": row_set.stored_rows,
+        "truncated": truncated,
+        "coverage": "partial" if partial else "complete",
+        "coverage_note": coverage_note,
     }

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -563,6 +563,30 @@ class Settings(BaseModel):
         genuinely larger sets raise it via
         ``RESULT_HANDLE_MAX_SPILL_ROWS``. Read once per reduce through
         :func:`get_settings`'s cache.
+    result_query_max_output_rows:
+        Output-row ceiling on the ``result_query`` structured query surface
+        (#3366): a compiled ``SELECT`` over a handle returns at most this many
+        rows (grouped results capped identically), and the result flags
+        ``truncated`` when the underlying result had more. Default 500 — the
+        same page ceiling as the paging read-back and the sibling list tools.
+        Env ``RESULT_QUERY_MAX_OUTPUT_ROWS``. Distinct from
+        ``result_handle_max_spill_rows`` (how many rows are *stored*): this
+        bounds how many a single query *returns*.
+    result_query_max_output_bytes:
+        Serialized-output ceiling, in JSON bytes, applied to a
+        ``result_query`` query result **after** the row cap. A wide or
+        deeply-nested projection can blow the MCP result token budget even
+        under 500 rows, so an over-budget result fails closed with an
+        actionable error (narrow ``select``, add a ``filter``, or lower
+        ``limit``) rather than returning a giant envelope. Default 262144
+        (256 KB). Env ``RESULT_QUERY_MAX_OUTPUT_BYTES``.
+    result_query_timeout_seconds:
+        Wall-time budget for a single ``result_query`` compiled ``SELECT``.
+        DuckDB exposes no native Python query timeout, so the core runs
+        ``conn.execute()`` on a worker thread and calls ``conn.interrupt()``
+        on expiry (raising ``InterruptException``), surfaced to the caller as
+        a recoverable "narrow and retry" error. Default 5 seconds. Env
+        ``RESULT_QUERY_TIMEOUT_SECONDS``.
     jsonflux_sample_byte_budget:
         Upper bound, in serialized JSON bytes, on the inline sample the
         JSONFlux reducer carries on a reduced ``ResultHandle`` (#134).
@@ -1229,6 +1253,12 @@ class Settings(BaseModel):
     checks_evidence_prune_interval_seconds: int = Field(default=604800, ge=60, le=604800)
     checks_evidence_prune_enabled: bool = True
     result_handle_max_spill_rows: int = Field(default=10000, gt=0)
+    # #3366 -- bounds on the ``result_query`` structured query surface. These
+    # are the query interface's own resource ceilings; it inherits neither the
+    # spill row cap above nor the reducer's hardcoded TTL.
+    result_query_max_output_rows: int = Field(default=500, gt=0)
+    result_query_max_output_bytes: int = Field(default=262144, gt=0)
+    result_query_timeout_seconds: int = Field(default=5, gt=0)
     jsonflux_sample_byte_budget: int = Field(default=4096, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
     agent_invoke_max_depth: int = Field(default=4, gt=0)
@@ -2053,6 +2083,15 @@ def get_settings() -> Settings:
         ),
         result_handle_max_spill_rows=int(
             os.environ.get("RESULT_HANDLE_MAX_SPILL_ROWS", "10000"),
+        ),
+        result_query_max_output_rows=int(
+            os.environ.get("RESULT_QUERY_MAX_OUTPUT_ROWS", "500"),
+        ),
+        result_query_max_output_bytes=int(
+            os.environ.get("RESULT_QUERY_MAX_OUTPUT_BYTES", "262144"),
+        ),
+        result_query_timeout_seconds=int(
+            os.environ.get("RESULT_QUERY_TIMEOUT_SECONDS", "5"),
         ),
         jsonflux_sample_byte_budget=int(
             os.environ.get("JSONFLUX_SAMPLE_BYTE_BUDGET", "4096"),

--- a/backend/tests/test_api_v1_operations.py
+++ b/backend/tests/test_api_v1_operations.py
@@ -45,7 +45,7 @@ from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
-from meho_backplane.connectors.result_handle_store import SpilledWindow
+from meho_backplane.connectors.result_handle_store import SpilledRowSet, SpilledWindow
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.middleware import RequestContextMiddleware
@@ -876,6 +876,18 @@ class _FakeResultStore:
             truncated=False,
         )
 
+    async def fetch_rows(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        handle_id: uuid.UUID,
+    ) -> SpilledRowSet | None:
+        rows = self._rows.get((str(tenant_id), operator_sub, str(handle_id)))
+        if rows is None:
+            return None
+        return SpilledRowSet(rows=rows, total_rows=len(rows), stored_rows=len(rows))
+
 
 @pytest.fixture
 def fake_result_store(monkeypatch: pytest.MonkeyPatch) -> _FakeResultStore:
@@ -1118,13 +1130,117 @@ def test_post_result_query_rejects_extra_body_field(
     client: TestClient,
     fake_result_store: _FakeResultStore,
 ) -> None:
-    """extra='forbid' rejects an unknown body field with a 422 (typo-loud)."""
+    """#3366 relaxed this to reject only *genuinely* unknown body fields.
+
+    A bogus top-level field is still a 422 (``extra="forbid"``), but the
+    newly-legal ``query`` field is accepted — the schema widened for the real
+    query surface, not for arbitrary fields.
+    """
+    handle = uuid.uuid4()
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=[{"id": 1}],
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        bogus = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(uuid.uuid4()), "bogus": 1},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+        assert bogus.status_code == 422
+        ok = client.post(
+            "/api/v1/operations/result-query",
+            json={"handle_id": str(handle), "query": {"select": ["id"]}},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert ok.status_code == 200
+
+
+def test_post_result_query_query_mode_filters_server_side(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A ``query`` body filters + aggregates server-side (REST twin of MCP)."""
+    handle = uuid.uuid4()
+    rows = [
+        {"id": i, "severity": "high" if i % 2 else "low", "project": f"p{i % 3}"} for i in range(30)
+    ]
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=rows,
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        filtered = client.post(
+            "/api/v1/operations/result-query",
+            json={
+                "handle_id": str(handle),
+                "query": {"filter": [{"field": "severity", "op": "=", "value": "high"}]},
+            },
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+        grouped = client.post(
+            "/api/v1/operations/result-query",
+            json={
+                "handle_id": str(handle),
+                "query": {"group_by": ["project"], "aggregate": [{"func": "COUNT"}]},
+            },
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert filtered.status_code == 200
+    fbody = filtered.json()
+    assert fbody["returned_rows"] == 15
+    assert fbody["coverage"] == "complete"
+    assert grouped.status_code == 200
+    counts = {r["project"]: r["count"] for r in grouped.json()["rows"]}
+    assert counts == {"p0": 10, "p1": 10, "p2": 10}
+
+
+def test_post_result_query_query_mode_unknown_field_is_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """A field not on the handle's schema is a 422 with reason=invalid_query."""
+    handle = uuid.uuid4()
+    fake_result_store.seed(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        operator_sub="op-1",
+        handle_id=handle,
+        rows=[{"id": 1}],
+    )
     key = make_rsa_keypair("kid-A")
     with respx.mock as mock_router:
         mock_discovery_and_jwks(mock_router, public_jwks(key))
         response = client.post(
             "/api/v1/operations/result-query",
-            json={"handle_id": str(uuid.uuid4()), "bogus": 1},
+            json={"handle_id": str(handle), "query": {"select": ["nope"]}},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 422
+    assert response.json()["detail"]["reason"] == "invalid_query"
+
+
+def test_post_result_query_query_mode_bad_operator_is_422(
+    client: TestClient,
+    fake_result_store: _FakeResultStore,
+) -> None:
+    """An operator outside the allow-list fails Pydantic body validation (422)."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/operations/result-query",
+            json={
+                "handle_id": str(uuid.uuid4()),
+                "query": {"filter": [{"field": "id", "op": "LIKE", "value": 1}]},
+            },
             headers={"Authorization": f"Bearer {_operator_token(key)}"},
         )
     assert response.status_code == 422

--- a/backend/tests/test_connectors_no_phantom_readback_tool.py
+++ b/backend/tests/test_connectors_no_phantom_readback_tool.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import NamedTuple
@@ -342,16 +343,36 @@ def test_phantom_name_set_is_sourced_from_the_shared_denylist() -> None:
 
 
 def test_legal_result_query_args_are_derived_from_the_registered_schema() -> None:
-    """The legal-arg set comes from the registered tool and is paging-only today."""
+    """The legal-arg set comes from the registered tool; #3366 added `query`.
+
+    Before #3366 the tool was paging-only (``handle_id`` / ``offset`` /
+    ``limit``); the bounded structured-query surface (#3366) added the
+    ``query`` argument, which widens the derived set beyond the shipped paging
+    contract and flips ``_RESULT_QUERY_IS_PAGING_ONLY`` to ``False`` — exactly
+    the automatic relaxation this guard was designed for (issue #3370, "Out of
+    scope"). The SQL/aggregate/jq drift rules go dormant as a result.
+    """
     assert "handle_id" in _LEGAL_RESULT_QUERY_ARGS
-    assert sorted(_LEGAL_RESULT_QUERY_ARGS) == ["handle_id", "limit", "offset"]
-    assert _RESULT_QUERY_IS_PAGING_ONLY is True
+    assert sorted(_LEGAL_RESULT_QUERY_ARGS) == ["handle_id", "limit", "offset", "query"]
+    assert _RESULT_QUERY_IS_PAGING_ONLY is False
 
 
 def test_paging_only_gate_relaxes_when_a_query_arg_ships() -> None:
     """A simulated query-surface widening disables the SQL/aggregate rules."""
     widened = _LEGAL_RESULT_QUERY_ARGS | {"query"}
     assert not (widened <= _SHIPPED_PAGING_CONTRACT_ARGS)
+
+
+def _force_paging_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the paging-only gate ON for the dormant-rule logic fixtures.
+
+    #3366 shipped the ``query`` argument, so live ``_RESULT_QUERY_IS_PAGING_ONLY``
+    is now ``False`` and the SQL/aggregate/jq drift rules are dormant (that is
+    the guard's designed auto-relaxation). The fixtures below still verify the
+    rule *logic* — should the surface ever be removed and the tool revert to
+    paging-only — by forcing the gate back ON.
+    """
+    monkeypatch.setattr(sys.modules[__name__], "_RESULT_QUERY_IS_PAGING_ONLY", True)
 
 
 # ---------------------------------------------------------------------------
@@ -371,7 +392,11 @@ def test_paging_only_gate_relaxes_when_a_query_arg_ships() -> None:
     ],
 )
 def test_phantom_readback_name_is_flagged(name: str) -> None:
-    """Each phantom name (underscore and hyphen spelling) trips Rule A."""
+    """Each phantom name (underscore and hyphen spelling) trips Rule A.
+
+    Rule A (and Rule H) is unconditional — it fires regardless of the
+    paging-only gate — so this needs no gate override.
+    """
     offenses = find_offenses("connectors/x.py", f"drill in with {name} for the rows")
     assert [o.rule for o in offenses] == ["phantom-readback-name"]
 
@@ -390,27 +415,51 @@ def test_phantom_readback_name_is_flagged(name: str) -> None:
         ("sum ... by", "reduced to a result handle; sum memoryMB by org."),
     ],
 )
-def test_sql_guidance_near_a_handle_anchor_is_flagged(label: str, text: str) -> None:
-    """Each SQL/aggregate phrase near a handle anchor trips Rule B."""
+def test_sql_guidance_near_a_handle_anchor_is_flagged(
+    label: str, text: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each SQL/aggregate phrase near a handle anchor trips Rule B (when paging-only)."""
+    _force_paging_only(monkeypatch)
     offenses = find_offenses("connectors/x.py", text)
     assert any(o.rule == f"sql-guidance:{label}" for o in offenses), offenses
 
 
-def test_aggregate_over_the_handle_is_flagged() -> None:
-    """The self-anchored ``aggregate over the handle`` phrase trips Rule B."""
+def test_aggregate_over_the_handle_is_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The self-anchored ``aggregate over the handle`` phrase trips Rule B (when paging-only)."""
+    _force_paging_only(monkeypatch)
     offenses = find_offenses(
         "connectors/x.py", "aggregate over the handle for host/version counts."
     )
     assert [o.rule for o in offenses] == ["aggregate-over-handle"]
 
 
-def test_jq_positional_argument_to_result_query_is_flagged() -> None:
-    """A jq-style positional passed to ``result-query`` trips Rule B."""
+def test_jq_positional_argument_to_result_query_is_flagged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A jq-style positional passed to ``result-query`` trips Rule B (when paging-only)."""
+    _force_paging_only(monkeypatch)
     offenses = find_offenses(
         "docs/cross-repo/x.md",
         "meho operation result-query <handle_id> '.[] | .server.server_ip'",
     )
     assert any(o.rule == "jq-argument-to-result_query" for o in offenses), offenses
+
+
+def test_sql_guidance_is_dormant_now_that_query_surface_shipped() -> None:
+    """Live (post-#3366) the SQL/aggregate/jq rules are dormant, not firing.
+
+    ``result_query`` now has a real query surface, so guidance describing a
+    filter / group / aggregate over the handle is accurate, not drift. The
+    live gate must therefore let those phrases through — only the phantom-name
+    and HandleStore rules stay active.
+    """
+    assert _RESULT_QUERY_IS_PAGING_ONLY is False
+    text = "narrow with result_query (e.g. count by projectId); GROUP BY guestOs"
+    assert find_offenses("connectors/x.py", text) == []
+    # But a phantom read-back name is still caught, gate or no gate.
+    assert find_offenses("connectors/x.py", "use result_aggregate") == [
+        Offense(1, "phantom-readback-name", "use result_aggregate")
+    ]
 
 
 def test_phantom_handlestore_phrase_is_flagged() -> None:

--- a/backend/tests/test_jsonflux_query_contract.py
+++ b/backend/tests/test_jsonflux_query_contract.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Contract-compiler tests for the ``result_query`` query surface (#3366).
+
+The compiler (:mod:`meho_backplane.jsonflux.query.contract`) turns a small
+typed argument grammar into exactly one parameterized, read-only ``SELECT``
+over the single registered handle table. These tests pin the safety
+properties that make the surface stronger than sanitizing a caller SQL
+string: the unsafe forms are simply not expressible.
+
+* No raw-SQL argument exists on the spec at all.
+* Every referenced field is checked against the handle's known columns; an
+  unknown field is rejected (Kubernetes field-selector style).
+* Operators and aggregate functions are fixed allow-lists (a value outside
+  them fails at model construction).
+* The predicate / group / order caps are enforced at construction.
+* Caller values are bound as parameters, never interpolated — so a SQL
+  fragment passed as a value cannot alter the statement structure or smuggle
+  a second statement / a write / DDL.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.jsonflux.query.contract import (
+    RESULT_TABLE,
+    QueryContractError,
+    ResultQuerySpec,
+    compile_query,
+)
+
+_COLUMNS = ["id", "severity", "project", "memoryMB", "host"]
+
+_MAX = 500
+
+
+def _compile(spec: ResultQuerySpec) -> tuple[str, list[object]]:
+    compiled = compile_query(spec, _COLUMNS, max_limit=_MAX)
+    return compiled.sql, compiled.params
+
+
+# ---------------------------------------------------------------------------
+# The statement is always a single read-only SELECT
+# ---------------------------------------------------------------------------
+
+
+def test_no_raw_sql_argument_is_expressible() -> None:
+    """The spec has no ``sql``/``query``/``expr`` field, and forbids extras."""
+    fields = set(ResultQuerySpec.model_fields)
+    assert "sql" not in fields
+    assert not fields & {"query", "expr", "statement", "raw"}
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(sql="SELECT 1")  # type: ignore[call-arg]
+
+
+def test_empty_spec_compiles_to_a_bounded_select_star() -> None:
+    sql, params = _compile(ResultQuerySpec())
+    assert sql == f'SELECT * FROM "{RESULT_TABLE}" LIMIT {_MAX + 1}'
+    assert params == []
+
+
+def test_compiled_sql_is_exactly_one_select_statement() -> None:
+    """Every compiled statement starts with SELECT and has no separator."""
+    specs = [
+        ResultQuerySpec(),
+        ResultQuerySpec(filter=[{"field": "id", "op": "=", "value": 1}]),
+        ResultQuerySpec(group_by=["severity"], aggregate=[{"func": "COUNT"}]),
+        ResultQuerySpec(select=["id", "host"], order_by=[{"field": "id", "direction": "desc"}]),
+    ]
+    for spec in specs:
+        sql, _ = _compile(spec)
+        assert sql.startswith("SELECT ")
+        assert ";" not in sql
+        # No write/DDL/PRAGMA verbs are ever emitted.
+        upper = sql.upper()
+        for forbidden in (" INSERT", " UPDATE", " DELETE", " DROP", " CREATE", "PRAGMA", "ATTACH"):
+            assert forbidden not in upper
+
+
+# ---------------------------------------------------------------------------
+# Values bind as parameters — writes/DDL/multi-statement not smuggle-able
+# ---------------------------------------------------------------------------
+
+
+def test_filter_value_is_bound_not_interpolated() -> None:
+    """A SQL-injection payload in a value lands in params, never in the SQL."""
+    payload = "1; DROP TABLE result; --"
+    sql, params = _compile(ResultQuerySpec(filter=[{"field": "id", "op": "=", "value": payload}]))
+    assert sql == f'SELECT * FROM "{RESULT_TABLE}" WHERE "id" = ? LIMIT {_MAX + 1}'
+    assert params == [payload]
+    assert "DROP" not in sql
+
+
+def test_in_operator_expands_to_one_placeholder_per_value() -> None:
+    sql, params = _compile(
+        ResultQuerySpec(filter=[{"field": "severity", "op": "IN", "value": ["high", "crit"]}])
+    )
+    assert '"severity" IN (?, ?)' in sql
+    assert params == ["high", "crit"]
+
+
+def test_is_null_takes_no_value_and_binds_no_param() -> None:
+    sql, params = _compile(ResultQuerySpec(filter=[{"field": "host", "op": "IS NULL"}]))
+    assert '"host" IS NULL' in sql
+    assert params == []
+
+
+# ---------------------------------------------------------------------------
+# Field-vs-schema validation (unknown field rejected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        ResultQuerySpec(filter=[{"field": "nope", "op": "=", "value": 1}]),
+        ResultQuerySpec(select=["nope"]),
+        ResultQuerySpec(group_by=["nope"], aggregate=[{"func": "COUNT"}]),
+        ResultQuerySpec(aggregate=[{"func": "SUM", "field": "nope"}]),
+        ResultQuerySpec(order_by=[{"field": "nope"}]),
+    ],
+)
+def test_unknown_field_is_rejected(spec: ResultQuerySpec) -> None:
+    """A field not in the handle's known columns fails compilation."""
+    with pytest.raises(QueryContractError):
+        compile_query(spec, _COLUMNS, max_limit=_MAX)
+
+
+def test_injection_shaped_field_name_is_an_unknown_field() -> None:
+    """A field carrying SQL is not a known column → rejected, never emitted."""
+    with pytest.raises(QueryContractError):
+        compile_query(
+            ResultQuerySpec(select=['id"; DROP TABLE result; --']),
+            _COLUMNS,
+            max_limit=_MAX,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operator / aggregate allow-lists (fixed vocabularies)
+# ---------------------------------------------------------------------------
+
+
+def test_operator_outside_allow_list_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(filter=[{"field": "id", "op": "LIKE", "value": "x%"}])
+
+
+def test_aggregate_function_outside_allow_list_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(aggregate=[{"func": "MEDIAN", "field": "memoryMB"}])
+
+
+# ---------------------------------------------------------------------------
+# Caps (predicate ≤ 10, group_by ≤ 4, order_by ≤ 4)
+# ---------------------------------------------------------------------------
+
+
+def test_more_than_ten_predicates_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(filter=[{"field": "id", "op": "=", "value": i} for i in range(11)])
+
+
+def test_more_than_four_group_by_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(group_by=["id", "severity", "project", "host", "memoryMB"])
+
+
+def test_more_than_four_order_by_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(
+            order_by=[
+                {"field": "id"},
+                {"field": "severity"},
+                {"field": "project"},
+                {"field": "host"},
+                {"field": "memoryMB"},
+            ]
+        )
+
+
+def test_extra_top_level_argument_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultQuerySpec(bogus=1)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Aggregate / group projection shaping
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_with_aggregate_projects_keys_then_aggregates() -> None:
+    sql, _ = _compile(
+        ResultQuerySpec(
+            group_by=["project"],
+            aggregate=[{"func": "COUNT"}, {"func": "SUM", "field": "memoryMB"}],
+        )
+    )
+    assert '"project", COUNT(*) AS "count", SUM("memoryMB") AS "sum_memoryMB"' in sql
+    assert 'GROUP BY "project"' in sql
+
+
+def test_select_alongside_aggregate_is_rejected() -> None:
+    with pytest.raises(QueryContractError):
+        compile_query(
+            ResultQuerySpec(select=["id"], aggregate=[{"func": "COUNT"}]),
+            _COLUMNS,
+            max_limit=_MAX,
+        )
+
+
+def test_non_count_aggregate_requires_a_field() -> None:
+    with pytest.raises(QueryContractError):
+        compile_query(
+            ResultQuerySpec(aggregate=[{"func": "SUM"}]),
+            _COLUMNS,
+            max_limit=_MAX,
+        )
+
+
+def test_order_by_non_group_key_in_grouped_query_is_rejected() -> None:
+    with pytest.raises(QueryContractError):
+        compile_query(
+            ResultQuerySpec(
+                group_by=["project"],
+                aggregate=[{"func": "COUNT"}],
+                order_by=[{"field": "id"}],
+            ),
+            _COLUMNS,
+            max_limit=_MAX,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Limit clamping
+# ---------------------------------------------------------------------------
+
+
+def test_limit_clamps_to_max_and_fetches_one_extra() -> None:
+    compiled = compile_query(ResultQuerySpec(limit=100000), _COLUMNS, max_limit=_MAX)
+    assert compiled.effective_limit == _MAX
+    assert compiled.sql.endswith(f"LIMIT {_MAX + 1}")
+
+
+def test_caller_limit_below_max_is_honoured() -> None:
+    compiled = compile_query(ResultQuerySpec(limit=10), _COLUMNS, max_limit=_MAX)
+    assert compiled.effective_limit == 10
+    assert compiled.sql.endswith("LIMIT 11")

--- a/backend/tests/test_mcp_tool_result_query.py
+++ b/backend/tests/test_mcp_tool_result_query.py
@@ -26,7 +26,7 @@ from fastapi.testclient import TestClient
 
 import meho_backplane.operations.result_query as result_query_core
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.connectors.result_handle_store import SpilledWindow
+from meho_backplane.connectors.result_handle_store import SpilledRowSet, SpilledWindow
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
@@ -80,6 +80,18 @@ class _FakeStore:
             stored_rows=len(rows),
             truncated=False,
         )
+
+    async def fetch_rows(
+        self,
+        *,
+        tenant_id: UUID,
+        operator_sub: str,
+        handle_id: UUID,
+    ) -> SpilledRowSet | None:
+        rows = self._rows.get((str(tenant_id), operator_sub, str(handle_id)))
+        if rows is None:
+            return None
+        return SpilledRowSet(rows=rows, total_rows=len(rows), stored_rows=len(rows))
 
 
 @pytest.fixture
@@ -207,7 +219,122 @@ def test_result_query_rejects_extra_argument(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
     fake_store: _FakeStore,
 ) -> None:
-    client, _op = client_with_operator
+    """#3366 relaxed this to reject only *genuinely* unknown args.
+
+    A bogus top-level key is still rejected (``additionalProperties: false``),
+    but the newly-legal ``query`` argument is accepted — proving the schema
+    widened for the real query surface, not for arbitrary keys.
+    """
+    client, op = client_with_operator
     response = _call(client, {"handle_id": str(uuid4()), "bogus": 1})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+    # ``query`` is a legal arg now: seed a handle and confirm it dispatches.
+    handle = uuid4()
+    fake_store.seed(
+        tenant_id=OPERATOR_TENANT_ID, operator_sub=op.sub, handle_id=handle, rows=[{"id": 1}]
+    )
+    ok = _call(client, {"handle_id": str(handle), "query": {"select": ["id"]}})
+    assert "error" not in ok.json(), ok.json()
+
+
+# ---------------------------------------------------------------------------
+# #3366 — query mode (bounded structured query over the handle)
+# ---------------------------------------------------------------------------
+
+
+def test_input_schema_advertises_the_query_argument(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """`tools/list` now exposes the optional `query` arg alongside paging."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    schema = next(t for t in response.json()["result"]["tools"] if t["name"] == "result_query")[
+        "inputSchema"
+    ]
+    assert "query" in schema["properties"]
+    # Paging args stay; the top-level stays closed to unknown args.
+    assert {"handle_id", "offset", "limit", "query"} <= set(schema["properties"])
+    assert schema["additionalProperties"] is False
+
+
+def _seed(fake_store: _FakeStore, op: Operator, handle: UUID) -> None:
+    rows = [
+        {"id": i, "severity": "high" if i % 2 else "low", "project": f"p{i % 3}"} for i in range(30)
+    ]
+    fake_store.seed(tenant_id=OPERATOR_TENANT_ID, operator_sub=op.sub, handle_id=handle, rows=rows)
+
+
+def test_query_mode_filters_server_side(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    fake_store: _FakeStore,
+) -> None:
+    client, op = client_with_operator
+    handle = uuid4()
+    _seed(fake_store, op, handle)
+    response = _call(
+        client,
+        {
+            "handle_id": str(handle),
+            "query": {"filter": [{"field": "severity", "op": "=", "value": "high"}]},
+        },
+    )
+    assert response.status_code == 200
+    payload = _structured(response.json()["result"])
+    assert payload["returned_rows"] == 15
+    assert {r["severity"] for r in payload["rows"]} == {"high"}
+    assert payload["coverage"] == "complete"
+
+
+def test_query_mode_aggregates_server_side(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    fake_store: _FakeStore,
+) -> None:
+    client, op = client_with_operator
+    handle = uuid4()
+    _seed(fake_store, op, handle)
+    response = _call(
+        client,
+        {
+            "handle_id": str(handle),
+            "query": {
+                "group_by": ["project"],
+                "aggregate": [{"func": "COUNT"}],
+                "order_by": [{"field": "project"}],
+            },
+        },
+    )
+    payload = _structured(response.json()["result"])
+    assert {r["project"]: r["count"] for r in payload["rows"]} == {"p0": 10, "p1": 10, "p2": 10}
+
+
+def test_query_mode_unknown_field_is_recoverable_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    fake_store: _FakeStore,
+) -> None:
+    client, op = client_with_operator
+    handle = uuid4()
+    _seed(fake_store, op, handle)
+    response = _call(client, {"handle_id": str(handle), "query": {"select": ["nope"]}})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert body["error"]["data"]["reason"] == "invalid_query"
+
+
+def test_query_mode_bad_operator_is_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    fake_store: _FakeStore,
+) -> None:
+    client, op = client_with_operator
+    handle = uuid4()
+    _seed(fake_store, op, handle)
+    response = _call(
+        client,
+        {
+            "handle_id": str(handle),
+            "query": {"filter": [{"field": "id", "op": "LIKE", "value": 1}]},
+        },
+    )
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -1083,6 +1083,11 @@ async def test_reduce_spills_full_rows_and_flips_drill_in_available() -> None:
     # too, so a consumer that got the handle over REST (never touching MCP)
     # learns how to page it without a discovery dance.
     assert "POST /api/v1/operations/result-query" in drill_in.rationale
+    # #3366: the rationale advertises the bounded structured-query surface —
+    # the agent can return just the matching rows / per-group counts instead
+    # of paging the whole set — naming the structured args, not raw SQL.
+    assert "group_by" in drill_in.rationale
+    assert "query" in drill_in.rationale
 
 
 async def test_recovery_unchanged_when_inline_sample_is_byte_bounded() -> None:

--- a/backend/tests/test_operations_result_query_filter.py
+++ b/backend/tests/test_operations_result_query_filter.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Core tests for the ``result_query`` bounded query surface (#3366).
+
+Drives :func:`meho_backplane.operations.result_query.run_result_query`
+against a fake store, pinning the four behaviours the acceptance criteria
+name: the bounds (row cap + ``truncated`` flag, byte cap, wall-time budget
+via a worker-thread ``conn.interrupt()``), coverage labelling when the spill
+was capped, the isolation/not-found semantics reused from the paging read,
+and end-to-end filter / aggregate correctness through the hardened engine.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from typing import Any
+
+import duckdb
+import pytest
+
+import meho_backplane.operations.result_query as rq
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.result_handle_store import SpilledRowSet
+from meho_backplane.jsonflux.query.contract import QueryContractError, ResultQuerySpec
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000ff")
+
+
+def _operator(sub: str = "op-a", tenant_id: uuid.UUID | None = _TENANT) -> Operator:
+    fields = {
+        "sub": sub,
+        "name": "Test Operator",
+        "email": None,
+        "raw_jwt": "<test-raw-jwt>",
+        "tenant_id": tenant_id,
+        "tenant_role": TenantRole.OPERATOR,
+    }
+    if tenant_id is None:
+        # ``Operator.tenant_id`` is a required UUID; bypass validation to
+        # exercise the core's defensive no-tenant-context branch directly.
+        return Operator.model_construct(**fields)
+    return Operator(**fields)
+
+
+class _FakeStore:
+    """In-memory stand-in returning a fixed row set for one operator."""
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        total_rows: int | None = None,
+        owner_sub: str = "op-a",
+    ) -> None:
+        self._rows = rows
+        self._total = total_rows if total_rows is not None else len(rows)
+        self._owner = owner_sub
+
+    async def fetch_rows(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        handle_id: uuid.UUID,
+    ) -> SpilledRowSet | None:
+        if operator_sub != self._owner:
+            return None
+        return SpilledRowSet(rows=self._rows, total_rows=self._total, stored_rows=len(self._rows))
+
+
+def _stub_settings(*, rows: int = 500, out_bytes: int = 262144, timeout: int = 5) -> Any:
+    return types.SimpleNamespace(
+        result_query_max_output_rows=rows,
+        result_query_max_output_bytes=out_bytes,
+        result_query_timeout_seconds=timeout,
+    )
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, store: _FakeStore, settings: Any) -> None:
+    monkeypatch.setattr(rq, "get_result_handle_store", lambda: store)
+    monkeypatch.setattr(rq, "get_settings", lambda: settings)
+
+
+def _sample_rows(n: int) -> list[dict[str, Any]]:
+    return [
+        {"id": i, "severity": "high" if i % 2 else "low", "project": f"p{i % 3}"} for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filter / aggregate correctness through the hardened engine
+# ---------------------------------------------------------------------------
+
+
+async def test_filter_returns_only_matching_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(20)), _stub_settings())
+    result = await rq.run_result_query(
+        _operator(),
+        uuid.uuid4(),
+        ResultQuerySpec(filter=[{"field": "severity", "op": "=", "value": "high"}]),
+    )
+    assert result["returned_rows"] == 10
+    assert {row["severity"] for row in result["rows"]} == {"high"}
+    assert result["coverage"] == "complete"
+
+
+async def test_group_by_aggregate_returns_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(30)), _stub_settings())
+    result = await rq.run_result_query(
+        _operator(),
+        uuid.uuid4(),
+        ResultQuerySpec(
+            group_by=["project"],
+            aggregate=[{"func": "COUNT"}],
+            order_by=[{"field": "project"}],
+        ),
+    )
+    counts = {row["project"]: row["count"] for row in result["rows"]}
+    assert counts == {"p0": 10, "p1": 10, "p2": 10}
+
+
+# ---------------------------------------------------------------------------
+# Bounds: row cap + truncated flag
+# ---------------------------------------------------------------------------
+
+
+async def test_row_cap_truncates_and_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(60)), _stub_settings(rows=10))
+    result = await rq.run_result_query(_operator(), uuid.uuid4(), ResultQuerySpec())
+    assert result["returned_rows"] == 10
+    assert result["limit"] == 10
+    assert result["truncated"] is True
+
+
+async def test_under_cap_is_not_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(5)), _stub_settings(rows=10))
+    result = await rq.run_result_query(_operator(), uuid.uuid4(), ResultQuerySpec())
+    assert result["returned_rows"] == 5
+    assert result["truncated"] is False
+
+
+async def test_caller_limit_below_cap_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(60)), _stub_settings(rows=500))
+    result = await rq.run_result_query(_operator(), uuid.uuid4(), ResultQuerySpec(limit=3))
+    assert result["returned_rows"] == 3
+    assert result["truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Bounds: serialized-output byte cap (tested on wide rows)
+# ---------------------------------------------------------------------------
+
+
+async def test_output_byte_cap_rejects_wide_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    wide = [{"id": i, "blob": "x" * 5000} for i in range(50)]
+    _install(monkeypatch, _FakeStore(wide), _stub_settings(out_bytes=2048))
+    with pytest.raises(rq.ResultQueryOutputTooLargeError) as exc:
+        await rq.run_result_query(_operator(), uuid.uuid4(), ResultQuerySpec())
+    # The error is actionable: it names the remedy (narrow the result).
+    assert "select" in str(exc.value).lower()
+
+
+async def test_output_byte_cap_lets_narrow_projection_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wide = [{"id": i, "blob": "x" * 5000} for i in range(50)]
+    _install(monkeypatch, _FakeStore(wide), _stub_settings(out_bytes=2048))
+    result = await rq.run_result_query(
+        _operator(), uuid.uuid4(), ResultQuerySpec(select=["id"], limit=20)
+    )
+    assert result["returned_rows"] == 20
+    assert all(set(row) == {"id"} for row in result["rows"])
+
+
+# ---------------------------------------------------------------------------
+# Bounds: wall-time budget via worker-thread conn.interrupt()
+# ---------------------------------------------------------------------------
+
+
+async def test_wall_time_budget_interrupts_a_slow_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query over the budget is aborted via ``conn.interrupt()``.
+
+    The compiler only emits bounded single-table SELECTs, so to exercise the
+    real interrupt path deterministically ``_execute_sync`` is swapped for a
+    genuinely slow cross-join over the registered table — the same connection
+    the core interrupts from the event loop on timeout. The worker's
+    ``execute`` then raises ``InterruptException`` and the core surfaces the
+    recoverable :class:`ResultQueryTimeoutError`.
+    """
+    _install(monkeypatch, _FakeStore(_sample_rows(400)), _stub_settings(timeout=1))
+
+    def _slow(engine: Any, _compiled: Any) -> tuple[list[str], list[Any]]:
+        cur = engine.conn.execute(
+            "SELECT count(*) AS n FROM result a, result b, result c, result d"
+        )
+        return [d[0] for d in cur.description], cur.fetchall()
+
+    monkeypatch.setattr(rq, "_execute_sync", _slow)
+    with pytest.raises(rq.ResultQueryTimeoutError):
+        await rq.run_result_query(_operator(), uuid.uuid4(), ResultQuerySpec())
+
+
+# ---------------------------------------------------------------------------
+# Coverage semantics: capped spill labelled as covering the stored subset
+# ---------------------------------------------------------------------------
+
+
+async def test_partial_coverage_when_spill_was_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _FakeStore(_sample_rows(60), total_rows=500)
+    _install(monkeypatch, store, _stub_settings())
+    result = await rq.run_result_query(
+        _operator(),
+        uuid.uuid4(),
+        ResultQuerySpec(aggregate=[{"func": "COUNT"}]),
+    )
+    assert result["stored_rows"] == 60
+    assert result["total_rows"] == 500
+    assert result["coverage"] == "partial"
+    assert result["coverage_note"] is not None
+    assert "60" in result["coverage_note"] and "500" in result["coverage_note"]
+    # The aggregate is over the stored subset, not the whole inventory.
+    assert result["rows"][0]["count"] == 60
+
+
+async def test_complete_coverage_when_whole_set_stored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(30)), _stub_settings())
+    result = await rq.run_result_query(
+        _operator(), uuid.uuid4(), ResultQuerySpec(aggregate=[{"func": "COUNT"}])
+    )
+    assert result["coverage"] == "complete"
+    assert result["coverage_note"] is None
+
+
+# ---------------------------------------------------------------------------
+# Isolation + error propagation
+# ---------------------------------------------------------------------------
+
+
+async def test_no_tenant_is_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(5)), _stub_settings())
+    with pytest.raises(rq.ResultHandleNotFoundError):
+        await rq.run_result_query(_operator(tenant_id=None), uuid.uuid4(), ResultQuerySpec())
+
+
+async def test_cross_operator_is_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(5), owner_sub="op-a"), _stub_settings())
+    with pytest.raises(rq.ResultHandleNotFoundError):
+        await rq.run_result_query(_operator(sub="op-b"), uuid.uuid4(), ResultQuerySpec())
+
+
+async def test_unknown_field_surfaces_contract_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(monkeypatch, _FakeStore(_sample_rows(5)), _stub_settings())
+    with pytest.raises(QueryContractError):
+        await rq.run_result_query(
+            _operator(), uuid.uuid4(), ResultQuerySpec(select=["does_not_exist"])
+        )
+
+
+# ---------------------------------------------------------------------------
+# The engine the core builds is the hardened one (sanity anchor)
+# ---------------------------------------------------------------------------
+
+
+def test_core_reuses_the_hardened_engine() -> None:
+    """The core registers rows in a locked, single-threaded engine."""
+    engine = rq.QueryEngine()
+    try:
+        with pytest.raises(duckdb.InvalidInputException):
+            engine.conn.execute("SET threads=4")
+    finally:
+        engine.close()

--- a/backend/tests/test_result_handle_store.py
+++ b/backend/tests/test_result_handle_store.py
@@ -29,6 +29,7 @@ import redis.exceptions
 
 from meho_backplane.connectors.result_handle_store import (
     ResultHandleStore,
+    SpilledRowSet,
     SpilledWindow,
 )
 
@@ -297,3 +298,85 @@ def test_key_shape_is_tenant_scoped() -> None:
     assert _key(tenant, handle) == (
         "meho:reshandle:00000000-0000-0000-0000-0000000000aa:00000000-0000-0000-0000-0000000000bb"
     )
+
+
+# ---------------------------------------------------------------------------
+# #3366 — fetch_rows: the full-set read the query surface uses
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_rows_returns_the_full_authorized_set() -> None:
+    """The full-set read returns every stored row + the true total."""
+    fake = _FakeRedis()
+    store = ResultHandleStore(fake)
+    tenant = uuid4()
+    handle = uuid4()
+    rows = _rows(120)
+    await store.spill(
+        tenant_id=tenant,
+        operator_sub="op-a",
+        handle_id=handle,
+        op_id="vault.kv.list",
+        rows=rows,
+        total_rows=120,
+        ttl_seconds=3600,
+        max_rows=10000,
+    )
+    row_set = await store.fetch_rows(tenant_id=tenant, operator_sub="op-a", handle_id=handle)
+    assert isinstance(row_set, SpilledRowSet)
+    assert row_set.total_rows == 120
+    assert row_set.stored_rows == 120
+    assert [r["i"] for r in row_set.rows] == list(range(120))
+
+
+async def test_fetch_rows_reports_capped_spill() -> None:
+    """When the spill was capped, stored_rows < total_rows is preserved."""
+    fake = _FakeRedis()
+    store = ResultHandleStore(fake)
+    tenant = uuid4()
+    handle = uuid4()
+    await store.spill(
+        tenant_id=tenant,
+        operator_sub="op-a",
+        handle_id=handle,
+        op_id="k8s.pods.list",
+        rows=_rows(500),
+        total_rows=500,
+        ttl_seconds=3600,
+        max_rows=100,
+    )
+    row_set = await store.fetch_rows(tenant_id=tenant, operator_sub="op-a", handle_id=handle)
+    assert row_set is not None
+    assert row_set.stored_rows == 100
+    assert row_set.total_rows == 500
+    assert len(row_set.rows) == 100
+
+
+async def test_fetch_rows_cross_operator_is_a_miss() -> None:
+    """A different operator gets a miss, not another operator's rows (#304)."""
+    fake = _FakeRedis()
+    store = ResultHandleStore(fake)
+    tenant = uuid4()
+    handle = uuid4()
+    await store.spill(
+        tenant_id=tenant,
+        operator_sub="op-a",
+        handle_id=handle,
+        op_id="op",
+        rows=_rows(10),
+        total_rows=10,
+        ttl_seconds=3600,
+        max_rows=10000,
+    )
+    assert await store.fetch_rows(tenant_id=tenant, operator_sub="op-b", handle_id=handle) is None
+
+
+async def test_fetch_rows_unknown_handle_is_none() -> None:
+    store = ResultHandleStore(_FakeRedis())
+    assert await store.fetch_rows(tenant_id=uuid4(), operator_sub="op-a", handle_id=uuid4()) is None
+
+
+async def test_fetch_rows_fails_open_on_unreachable_store() -> None:
+    """An unreachable client yields None, never an exception (fail-open)."""
+    store = ResultHandleStore(_BrokenRedis())
+    assert await store.fetch_rows(tenant_id=uuid4(), operator_sub="op-a", handle_id=uuid4()) is None

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -793,3 +793,77 @@ def test_vault_check_runner_role_blank_normalises_to_none(
         assert get_settings().vault_check_runner_role is None
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# #3366 — result_query bounded query-surface knobs
+# ---------------------------------------------------------------------------
+
+
+def test_result_query_bounds_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset → the documented defaults (500 rows / 256 KB / 5 s).
+
+    ``Settings`` is a plain ``BaseModel``, so a field only reads its env var
+    if ``get_settings`` hand-maps it. This pins that each knob's default flows
+    through the constructor when the env var is absent.
+    """
+    _base_env(monkeypatch)
+    for var in (
+        "RESULT_QUERY_MAX_OUTPUT_ROWS",
+        "RESULT_QUERY_MAX_OUTPUT_BYTES",
+        "RESULT_QUERY_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.result_query_max_output_rows == 500
+        assert settings.result_query_max_output_bytes == 262144
+        assert settings.result_query_timeout_seconds == 5
+    finally:
+        get_settings.cache_clear()
+
+
+def test_result_query_bounds_read_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each knob's env var is hand-mapped in ``get_settings`` (not inert).
+
+    A field without a constructor mapping stays at its default forever — the
+    silent-inert trap #3366 called out. This proves all three env vars reach
+    the constructed ``Settings``.
+    """
+    _base_env(monkeypatch)
+    monkeypatch.setenv("RESULT_QUERY_MAX_OUTPUT_ROWS", "250")
+    monkeypatch.setenv("RESULT_QUERY_MAX_OUTPUT_BYTES", "131072")
+    monkeypatch.setenv("RESULT_QUERY_TIMEOUT_SECONDS", "9")
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.result_query_max_output_rows == 250
+        assert settings.result_query_max_output_bytes == 131072
+        assert settings.result_query_timeout_seconds == 9
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "result_query_max_output_rows",
+        "result_query_max_output_bytes",
+        "result_query_timeout_seconds",
+    ],
+)
+def test_result_query_bounds_reject_non_positive(field: str) -> None:
+    """Each knob is ``gt=0`` — a zero/negative value fails construction."""
+    with pytest.raises(ValidationError):
+        Settings(
+            keycloak_issuer_url="https://keycloak.test/realms/meho",
+            keycloak_audience="meho-backplane",
+            vault_addr="https://vault.test",
+            database_url="sqlite+aiosqlite:///:memory:",
+            **{field: 0},
+        )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -21905,6 +21905,35 @@
         "title": "AgentRunSummaryResponse",
         "description": "One row of the agent-run list (``GET /agents/runs``).\n\nA scannable index row: identity, lifecycle state, resolved model\ncoordinates, timestamps, and the ``work_ref`` change-ticket\nreference the list filters on (work_ref I3-T2 #1662). The full\n``output`` blob is omitted \u2014 a caller wanting a run's result polls\n``GET /agents/runs/{handle}``."
       },
+      "Aggregate": {
+        "properties": {
+          "func": {
+            "type": "string",
+            "enum": [
+              "COUNT",
+              "SUM",
+              "MIN",
+              "MAX",
+              "AVG"
+            ],
+            "title": "Func",
+            "description": "Aggregate function (fixed allow-list)."
+          },
+          "field": {
+            "type": "string",
+            "nullable": true,
+            "title": "Field",
+            "description": "Column to aggregate; omit only for COUNT (compiles to COUNT(*))."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "func"
+        ],
+        "title": "Aggregate",
+        "description": "One aggregate output column: ``func(field)`` (``COUNT`` may omit field).\n\n``COUNT`` with no ``field`` compiles to ``COUNT(*)``; every other\nfunction requires a field. The output alias is derived deterministically\n(``count`` / ``sum_<field>`` / ...) and quoted, so callers never inject\nan alias identifier."
+      },
       "ApprovalRequestStatus": {
         "type": "string",
         "enum": [
@@ -27409,6 +27438,43 @@
         "title": "EventSourceUpdate",
         "description": "PATCH body. Every field optional; ``name`` / ``slug`` are absent.\n\n``name`` and ``slug`` are immutable (rename or re-slug = delete +\nre-create) because ``slug`` is a live routing key external senders are\nalready pointed at. Sending ``secret`` rotates the Vault secret in\nplace at the source's existing ``secret_ref`` -- a new KV-v2 version at\nthe same path, so the ingest path reads the new value on its next\nlookup with no downtime (#2880 acceptance criterion 2). Omitting\n``secret`` leaves the stored secret untouched."
       },
+      "FilterPredicate": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Field",
+            "description": "Column to test; must exist on the handle."
+          },
+          "op": {
+            "type": "string",
+            "enum": [
+              "=",
+              "!=",
+              "<",
+              "<=",
+              ">",
+              ">=",
+              "IN",
+              "IS NULL"
+            ],
+            "title": "Op",
+            "description": "Comparison operator (fixed allow-list)."
+          },
+          "value": {
+            "title": "Value",
+            "description": "The comparison value, bound as a parameter. Omit for `IS NULL`; a list for `IN`; a scalar for the ordering/equality operators."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "field",
+          "op"
+        ],
+        "title": "FilterPredicate",
+        "description": "One ``WHERE`` clause term: ``field op value``.\n\n``value`` is omitted for ``IS NULL``, a list for ``IN`` (each element\nbound as its own placeholder), and a scalar otherwise. The value is\nalways bound as a DuckDB prepared-statement parameter \u2014 never\ninterpolated \u2014 so it cannot alter the statement's structure."
+      },
       "FingerprintResult": {
         "properties": {
           "vendor": {
@@ -28962,6 +29028,33 @@
         "title": "OperatorIdentity",
         "description": "Operator identity surface exposed to the CLI and MCP ``meho_status``.\n\nExcludes ``raw_jwt`` deliberately \u2014 the bearer token must never\nappear in a response body, and the :class:`Operator` model carries\nit for downstream Vault forward-auth only.\n\n``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session\nconfirm *which tenant and role it runs as* from inside the session \u2014\nthe check the clean-room program's \"logged in as operator, not\ntenant_admin\" discipline needs, and the identity the ``meho_status``\ntool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)\nalready promises. Both are always present on the validated\n:class:`Operator` (JWT claims), so the surface can never omit them;\nthey serialise as a UUID string / role value under\n``model_dump(mode=\"json\")`` \u2014 the same wire shape the\n``meho://tenant/<id>/info`` resource returns."
       },
+      "OrderBy": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Field",
+            "description": "Column to sort by; must exist on the handle."
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "title": "Direction",
+            "description": "Sort direction.",
+            "default": "asc"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "field"
+        ],
+        "title": "OrderBy",
+        "description": "One ``ORDER BY`` term: a known column plus a direction."
+      },
       "PairAddonRequest": {
         "properties": {
           "name": {
@@ -29897,7 +29990,7 @@
             "type": "integer",
             "minimum": 0.0,
             "title": "Offset",
-            "description": "Zero-based index of the first row to return. Page by advancing this by the previous `limit`.",
+            "description": "Zero-based index of the first row to return (paging mode). Page by advancing this by the previous `limit`.",
             "default": 0
           },
           "limit": {
@@ -29905,8 +29998,13 @@
             "maximum": 500.0,
             "minimum": 1.0,
             "title": "Limit",
-            "description": "Page size. Default 50; max 500. Matches the `result_query` MCP tool's upper bound.",
+            "description": "Page size (paging mode). Default 50; max 500. Matches the `result_query` MCP tool's upper bound.",
             "default": 50
+          },
+          "query": {
+            "$ref": "#/components/schemas/ResultQuerySpec",
+            "nullable": true,
+            "description": "Optional structured query. When present, the handle is queried server-side (filter / select / group_by / aggregate / order_by / limit) as one bounded read-only SELECT and `offset` / `limit` are ignored. Every referenced field must be a column on the handle; there is no raw-SQL argument."
           }
         },
         "additionalProperties": false,
@@ -29915,7 +30013,65 @@
           "handle_id"
         ],
         "title": "ResultQueryBody",
-        "description": "POST body for ``/api/v1/operations/result-query`` (#3179).\n\nThe REST twin of the MCP ``result_query`` tool's ``inputSchema``:\n``handle_id`` is the UUID minted onto a reduced ``/call`` response's\n``result.handle.handle_id`` / ``fetch_more.drill_in.example_call``, and\n``offset`` / ``limit`` window the spilled set. The bounds mirror the MCP\nschema (``offset >= 0``; ``1 <= limit <= MAX_LIMIT``) so the two surfaces\nvalidate identically. ``extra=\"forbid\"`` rejects unknown body fields with\na 422, matching the sibling ``CallOperationBody`` posture.\n\nFiltering / projection is out of scope (issue #3179 non-goal): parity is\nthe same offset/limit window the MCP tool serves, not more."
+        "description": "POST body for ``/api/v1/operations/result-query`` (#3179).\n\nThe REST twin of the MCP ``result_query`` tool's ``inputSchema``:\n``handle_id`` is the UUID minted onto a reduced ``/call`` response's\n``result.handle.handle_id`` / ``fetch_more.drill_in.example_call``, and\n``offset`` / ``limit`` window the spilled set. The bounds mirror the MCP\nschema (``offset >= 0``; ``1 <= limit <= MAX_LIMIT``) so the two surfaces\nvalidate identically. ``extra=\"forbid\"`` rejects unknown body fields with\na 422, matching the sibling ``CallOperationBody`` posture.\n\n``query`` (#3366) is the optional structured query: when present, the\nhandle is queried server-side as one bounded read-only ``SELECT``\n(filter / project / group / aggregate) and ``offset`` / ``limit`` are\nignored. It mirrors the MCP tool's ``query`` argument exactly (the same\n:class:`~meho_backplane.jsonflux.query.contract.ResultQuerySpec`), so the\ntwo surfaces stay in lockstep; there is deliberately no raw-SQL argument\non either."
+      },
+      "ResultQuerySpec": {
+        "properties": {
+          "filter": {
+            "items": {
+              "$ref": "#/components/schemas/FilterPredicate"
+            },
+            "type": "array",
+            "maxItems": 10,
+            "title": "Filter",
+            "description": "Predicates AND-ed into the WHERE clause (max 10)."
+          },
+          "select": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Select",
+            "description": "Projection: columns to return. Omit for all columns. Not allowed together with `aggregate` (the output is then the group keys plus the aggregates)."
+          },
+          "group_by": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "title": "Group By",
+            "description": "Columns to group by (max 4)."
+          },
+          "aggregate": {
+            "items": {
+              "$ref": "#/components/schemas/Aggregate"
+            },
+            "type": "array",
+            "title": "Aggregate",
+            "description": "Aggregate output columns (COUNT/SUM/MIN/MAX/AVG)."
+          },
+          "order_by": {
+            "items": {
+              "$ref": "#/components/schemas/OrderBy"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "title": "Order By",
+            "description": "Sort terms (max 4)."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Limit",
+            "description": "Max output rows. Omitted or above the server ceiling clamps to the ceiling (500); the result flags `truncated` when more rows existed."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ResultQuerySpec",
+        "description": "The structured, validated query arguments for a single handle.\n\nEvery field is optional: an empty spec compiles to ``SELECT * FROM\nresult LIMIT <max>`` \u2014 a full read-back capped at the output ceiling.\nThe list caps (``filter`` \u2264 10, ``group_by`` \u2264 4, ``order_by`` \u2264 4)\nand the operator/aggregate allow-lists are enforced here, at\nconstruction; field-vs-schema validation needs the handle's columns and\nhappens in :func:`compile_query`."
       },
       "RetireChecklistReport": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -36,6 +36,15 @@ const (
 	AgentRunStatusSucceeded        AgentRunStatus = "succeeded"
 )
 
+// Defines values for AggregateFunc.
+const (
+	AggregateFuncAVG   AggregateFunc = "AVG"
+	AggregateFuncCOUNT AggregateFunc = "COUNT"
+	AggregateFuncMAX   AggregateFunc = "MAX"
+	AggregateFuncMIN   AggregateFunc = "MIN"
+	AggregateFuncSUM   AggregateFunc = "SUM"
+)
+
 // Defines values for ApprovalRequestStatus.
 const (
 	ApprovalRequestStatusApproved ApprovalRequestStatus = "approved"
@@ -285,6 +294,18 @@ const (
 	EventSourceStatusPaused EventSourceStatus = "paused"
 )
 
+// Defines values for FilterPredicateOp.
+const (
+	FilterPredicateOpEmpty            FilterPredicateOp = "!="
+	FilterPredicateOpEqual            FilterPredicateOp = "="
+	FilterPredicateOpGreaterThan      FilterPredicateOp = ">"
+	FilterPredicateOpGreaterThanEqual FilterPredicateOp = ">="
+	FilterPredicateOpIN               FilterPredicateOp = "IN"
+	FilterPredicateOpISNULL           FilterPredicateOp = "IS NULL"
+	FilterPredicateOpLessThan         FilterPredicateOp = "<"
+	FilterPredicateOpLessThanEqual    FilterPredicateOp = "<="
+)
+
 // Defines values for GatewayResultBodyOutcome.
 const (
 	GatewayResultBodyOutcomeFailed    GatewayResultBodyOutcome = "failed"
@@ -340,6 +361,12 @@ const (
 	OperationRunStatusPending   OperationRunStatus = "pending"
 	OperationRunStatusRunning   OperationRunStatus = "running"
 	OperationRunStatusSucceeded OperationRunStatus = "succeeded"
+)
+
+// Defines values for OrderByDirection.
+const (
+	OrderByDirectionAsc  OrderByDirection = "asc"
+	OrderByDirectionDesc OrderByDirection = "desc"
 )
 
 // Defines values for PermissionVerdict.
@@ -1175,6 +1202,23 @@ type AgentRunSummaryResponse struct {
 	Turns   int            `json:"turns"`
 	WorkRef *string        `json:"work_ref"`
 }
+
+// Aggregate One aggregate output column: “func(field)“ (“COUNT“ may omit field).
+//
+// “COUNT“ with no “field“ compiles to “COUNT(*)“; every other
+// function requires a field. The output alias is derived deterministically
+// (“count“ / “sum_<field>“ / ...) and quoted, so callers never inject
+// an alias identifier.
+type Aggregate struct {
+	// Field Column to aggregate; omit only for COUNT (compiles to COUNT(*)).
+	Field *string `json:"field"`
+
+	// Func Aggregate function (fixed allow-list).
+	Func AggregateFunc `json:"func"`
+}
+
+// AggregateFunc Aggregate function (fixed allow-list).
+type AggregateFunc string
 
 // ApprovalRequestStatus Closed lifecycle status of an :class:`ApprovalRequest`.
 //
@@ -4682,6 +4726,26 @@ type EventSourceUpdate struct {
 	Status *EventSourceStatus `json:"status,omitempty"`
 }
 
+// FilterPredicate One “WHERE“ clause term: “field op value“.
+//
+// “value“ is omitted for “IS NULL“, a list for “IN“ (each element
+// bound as its own placeholder), and a scalar otherwise. The value is
+// always bound as a DuckDB prepared-statement parameter — never
+// interpolated — so it cannot alter the statement's structure.
+type FilterPredicate struct {
+	// Field Column to test; must exist on the handle.
+	Field string `json:"field"`
+
+	// Op Comparison operator (fixed allow-list).
+	Op FilterPredicateOp `json:"op"`
+
+	// Value The comparison value, bound as a parameter. Omit for `IS NULL`; a list for `IN`; a scalar for the ordering/equality operators.
+	Value interface{} `json:"value,omitempty"`
+}
+
+// FilterPredicateOp Comparison operator (fixed allow-list).
+type FilterPredicateOp string
+
 // FingerprintResult Connector fingerprint per consumer-needs L95.
 type FingerprintResult struct {
 	Build       *string                 `json:"build"`
@@ -5814,6 +5878,18 @@ type OperatorIdentity struct {
 	TenantRole TenantRole `json:"tenant_role"`
 }
 
+// OrderBy One “ORDER BY“ term: a known column plus a direction.
+type OrderBy struct {
+	// Direction Sort direction.
+	Direction *OrderByDirection `json:"direction,omitempty"`
+
+	// Field Column to sort by; must exist on the handle.
+	Field string `json:"field"`
+}
+
+// OrderByDirection Sort direction.
+type OrderByDirection string
+
 // PairAddonRequest Intake for :meth:`AddonPairingService.pair` — the handshake body.
 //
 // “addon_contract_version“ is the contract version the add-on speaks;
@@ -6313,17 +6389,60 @@ type ResultIngestResponse struct {
 // validate identically. “extra="forbid"“ rejects unknown body fields with
 // a 422, matching the sibling “CallOperationBody“ posture.
 //
-// Filtering / projection is out of scope (issue #3179 non-goal): parity is
-// the same offset/limit window the MCP tool serves, not more.
+// “query“ (#3366) is the optional structured query: when present, the
+// handle is queried server-side as one bounded read-only “SELECT“
+// (filter / project / group / aggregate) and “offset“ / “limit“ are
+// ignored. It mirrors the MCP tool's “query“ argument exactly (the same
+// :class:`~meho_backplane.jsonflux.query.contract.ResultQuerySpec`), so the
+// two surfaces stay in lockstep; there is deliberately no raw-SQL argument
+// on either.
 type ResultQueryBody struct {
 	// HandleId The result handle's UUID, taken from a reduced `/call` response's `result.handle.handle_id` or `fetch_more.drill_in.example_call.args.handle_id`.
 	HandleId openapi_types.UUID `json:"handle_id"`
 
-	// Limit Page size. Default 50; max 500. Matches the `result_query` MCP tool's upper bound.
+	// Limit Page size (paging mode). Default 50; max 500. Matches the `result_query` MCP tool's upper bound.
 	Limit *int `json:"limit,omitempty"`
 
-	// Offset Zero-based index of the first row to return. Page by advancing this by the previous `limit`.
+	// Offset Zero-based index of the first row to return (paging mode). Page by advancing this by the previous `limit`.
 	Offset *int `json:"offset,omitempty"`
+
+	// Query The structured, validated query arguments for a single handle.
+	//
+	// Every field is optional: an empty spec compiles to ``SELECT * FROM
+	// result LIMIT <max>`` — a full read-back capped at the output ceiling.
+	// The list caps (``filter`` ≤ 10, ``group_by`` ≤ 4, ``order_by`` ≤ 4)
+	// and the operator/aggregate allow-lists are enforced here, at
+	// construction; field-vs-schema validation needs the handle's columns and
+	// happens in :func:`compile_query`.
+	Query *ResultQuerySpec `json:"query,omitempty"`
+}
+
+// ResultQuerySpec The structured, validated query arguments for a single handle.
+//
+// Every field is optional: an empty spec compiles to “SELECT * FROM
+// result LIMIT <max>“ — a full read-back capped at the output ceiling.
+// The list caps (“filter“ ≤ 10, “group_by“ ≤ 4, “order_by“ ≤ 4)
+// and the operator/aggregate allow-lists are enforced here, at
+// construction; field-vs-schema validation needs the handle's columns and
+// happens in :func:`compile_query`.
+type ResultQuerySpec struct {
+	// Aggregate Aggregate output columns (COUNT/SUM/MIN/MAX/AVG).
+	Aggregate *[]Aggregate `json:"aggregate,omitempty"`
+
+	// Filter Predicates AND-ed into the WHERE clause (max 10).
+	Filter *[]FilterPredicate `json:"filter,omitempty"`
+
+	// GroupBy Columns to group by (max 4).
+	GroupBy *[]string `json:"group_by,omitempty"`
+
+	// Limit Max output rows. Omitted or above the server ceiling clamps to the ceiling (500); the result flags `truncated` when more rows existed.
+	Limit *int `json:"limit"`
+
+	// OrderBy Sort terms (max 4).
+	OrderBy *[]OrderBy `json:"order_by,omitempty"`
+
+	// Select Projection: columns to return. Omit for all columns. Not allowed together with `aggregate` (the output is then the group keys plus the aggregates).
+	Select *[]string `json:"select,omitempty"`
 }
 
 // RetireChecklistReport Top-level shape returned by :func:`compute_retire_checklist`.

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -762,7 +762,7 @@ func TestPostResultQueryPassesTypedBody(t *testing.T) {
 		},
 	}
 	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
-	got, err := postResultQuery(context.Background(), f, handle, 5, 50)
+	got, err := postResultQuery(context.Background(), f, handle, 5, 50, nil)
 	if err != nil {
 		t.Fatalf("postResultQuery: %v", err)
 	}
@@ -795,7 +795,7 @@ func TestPostResultQueryRefreshOn401(t *testing.T) {
 		},
 	}
 	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
-	if _, err := postResultQuery(context.Background(), f, handle, 0, 50); err != nil {
+	if _, err := postResultQuery(context.Background(), f, handle, 0, 50, nil); err != nil {
 		t.Fatalf("postResultQuery after refresh: %v", err)
 	}
 	if f.refreshCount != 1 {
@@ -815,7 +815,7 @@ func TestPostResultQueryNotFoundClassifiesAsApiResponseError(t *testing.T) {
 		},
 	}
 	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
-	_, err := postResultQuery(context.Background(), f, handle, 0, 50)
+	_, err := postResultQuery(context.Background(), f, handle, 0, 50, nil)
 	if err == nil {
 		t.Fatalf("expected non-2xx error; got nil")
 	}
@@ -834,7 +834,7 @@ func TestPostResultQueryTransportErrorPropagates(t *testing.T) {
 	transportErr := errors.New("dial tcp: connection refused")
 	f := &fakeOperationsClient{resultQueryErrors: []error{transportErr}}
 	handle := makeHandleUUID(t, "11111111-1111-1111-1111-111111111111")
-	_, err := postResultQuery(context.Background(), f, handle, 0, 50)
+	_, err := postResultQuery(context.Background(), f, handle, 0, 50, nil)
 	if !errors.Is(err, transportErr) {
 		t.Fatalf("expected transport error to propagate verbatim; got %v", err)
 	}

--- a/cli/internal/cmd/operation/resultquery.go
+++ b/cli/internal/cmd/operation/resultquery.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
@@ -20,11 +21,13 @@ import (
 
 // ResultQueryResult mirrors the backend result-query envelope — the
 // `dict[str, Any]` returned by POST /api/v1/operations/result-query
-// (read_result_window). Hand-written for the same reason as CallResult /
-// GroupSummary: the FastAPI route types its return as `dict[str, Any]`, so
-// the oapi-codegen generator emits `*map[string]interface{}` with no typed
-// model worth using. Rows stay `[]json.RawMessage` so the renderer pretty-
-// prints each row without imposing a per-vendor row shape.
+// (read_result_window / run_result_query). Hand-written for the same reason
+// as CallResult / GroupSummary: the FastAPI route types its return as
+// `dict[str, Any]`, so the oapi-codegen generator emits
+// `*map[string]interface{}` with no typed model worth using. Rows stay
+// `[]json.RawMessage` so the renderer pretty-prints each row without imposing
+// a per-vendor row shape. Coverage / CoverageNote are populated only in query
+// mode (#3366).
 type ResultQueryResult struct {
 	HandleID     string            `json:"handle_id"`
 	Rows         []json.RawMessage `json:"rows"`
@@ -34,27 +37,37 @@ type ResultQueryResult struct {
 	TotalRows    int               `json:"total_rows"`
 	StoredRows   int               `json:"stored_rows"`
 	Truncated    bool              `json:"truncated"`
+	Coverage     string            `json:"coverage,omitempty"`
+	CoverageNote *string           `json:"coverage_note,omitempty"`
 }
 
 // newResultQueryCmd returns the `meho operation result-query` command —
 // the CLI verb the vcf-logs result-handle hint already advertises
-// (cli/internal/cmd/vcf-logs/query.go), made truthful by #3179.
+// (cli/internal/cmd/vcf-logs/query.go), made truthful by #3179 and given a
+// bounded query surface by #3366.
 //
 // CLI shape:
 //
 //	meho operation result-query <handle_id> \
-//	  [--offset N]                             # zero-based first row (default 0)
-//	  [--limit N]                              # page size (default 50, max 500)
+//	  [--offset N]                             # paging: zero-based first row (default 0)
+//	  [--limit N]                              # paging: page size (default 50, max 500)
+//	  [--where "<field> <op> <value>"]         # query: repeatable WHERE predicate
+//	  [--select <field>]                       # query: repeatable projection column
+//	  [--group-by <field>]                     # query: repeatable GROUP BY key
+//	  [--aggregate "<FUNC> [field]"]           # query: repeatable aggregate
+//	  [--order-by "<field> [asc|desc]"]        # query: repeatable sort term
+//	  [--query-limit N]                        # query: max output rows (clamps to 500)
 //	  [--json]                                 # machine-readable output
 //	  [--backplane <url>]                      # override the backplane URL
 //
 // It wraps POST /api/v1/operations/result-query, the REST twin of the MCP
-// `result_query` tool: after `meho operation call` reduces a large list
-// response, the reduced envelope carries a `handle` (`result.handle.
-// handle_id`); this verb pages the FULL set back beyond the inline sample.
+// `result_query` tool. With no query flags it pages the FULL set back beyond
+// the inline sample; with any query flag it runs one bounded, read-only query
+// server-side (filter / project / group / aggregate) and `--offset` /
+// `--limit` are ignored.
 //
 // Exit codes mirror `meho operation groups`:
-//   - 0   window returned cleanly (including the past-the-end empty window)
+//   - 0   window/result returned cleanly (including the past-the-end empty window)
 //   - 2   auth_expired
 //   - 3   unreachable
 //   - 4   unexpected response shape (incl. a 404 handle-not-found miss, which
@@ -63,21 +76,37 @@ func newResultQueryCmd() *cobra.Command {
 	var (
 		offset            int
 		limit             int
+		whereTerms        []string
+		selectCols        []string
+		groupByCols       []string
+		aggregateTerms    []string
+		orderByTerms      []string
+		queryLimit        int
 		jsonOut           bool
 		backplaneOverride string
 	)
 	cmd := &cobra.Command{
 		Use:   "result-query <handle_id>",
-		Short: "Page rows back from a JSONFlux result handle",
+		Short: "Page or query rows back from a JSONFlux result handle",
 		Long: "result-query calls POST /api/v1/operations/result-query — the " +
 			"REST twin of the MCP `result_query` tool. After `meho operation " +
 			"call` reduces a large list response, the reduced envelope carries " +
-			"a `handle` (`result.handle.handle_id`); this verb pages the FULL " +
+			"a `handle` (`result.handle.handle_id`); this verb reads the FULL " +
 			"set back beyond the inline sample.\n\n" +
-			"--offset advances the window (page by adding the previous --limit); " +
-			"--limit sets the page size (default 50, max 500). A window whose " +
-			"offset is past the stored row count returns an empty `rows` list — " +
-			"that's the end of the set, not an error.\n\n" +
+			"Paging mode (default): --offset advances the window (page by adding " +
+			"the previous --limit); --limit sets the page size (default 50, max " +
+			"500). A window whose offset is past the stored row count returns an " +
+			"empty `rows` list — that's the end of the set, not an error.\n\n" +
+			"Query mode: pass any of --where / --select / --group-by / " +
+			"--aggregate / --order-by / --query-limit to run one bounded, " +
+			"read-only query server-side instead of paging. --where takes " +
+			"\"<field> <op> [value]\" (op one of = != < <= > >= IN 'IS NULL'; " +
+			"IN takes a comma-separated value list); --aggregate takes " +
+			"\"<FUNC> [field]\" (FUNC one of COUNT SUM MIN MAX AVG); --order-by " +
+			"takes \"<field> [asc|desc]\". Every referenced field must be a " +
+			"column on the handle; there is no raw-SQL argument. Results carry a " +
+			"`coverage` label — `partial` means the spill was capped so a count " +
+			"covers only the stored subset, not the whole inventory.\n\n" +
 			"A handle that does not exist, has expired (TTL elapsed), or belongs " +
 			"to a different operator is a 404 carrying a structured " +
 			"`reason=handle_not_found` detail: re-run the original operation to " +
@@ -90,15 +119,34 @@ func newResultQueryCmd() *cobra.Command {
 				HandleID:          args[0],
 				Offset:            offset,
 				Limit:             limit,
+				WhereTerms:        whereTerms,
+				SelectCols:        selectCols,
+				GroupByCols:       groupByCols,
+				AggregateTerms:    aggregateTerms,
+				OrderByTerms:      orderByTerms,
+				QueryLimit:        queryLimit,
+				QueryLimitSet:     cmd.Flags().Changed("query-limit"),
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
 		},
 	}
 	cmd.Flags().IntVar(&offset, "offset", 0,
-		"zero-based index of the first row to return (page by advancing this by --limit)")
+		"paging: zero-based index of the first row to return (advance by --limit)")
 	cmd.Flags().IntVar(&limit, "limit", 50,
-		"page size; default 50, max 500 (matches the result_query MCP tool)")
+		"paging: page size; default 50, max 500 (matches the result_query MCP tool)")
+	cmd.Flags().StringArrayVar(&whereTerms, "where", nil,
+		"query: WHERE predicate \"<field> <op> [value]\" (repeatable; op = != < <= > >= IN 'IS NULL')")
+	cmd.Flags().StringArrayVar(&selectCols, "select", nil,
+		"query: projection column to return (repeatable; omit for all columns)")
+	cmd.Flags().StringArrayVar(&groupByCols, "group-by", nil,
+		"query: GROUP BY key column (repeatable, max 4)")
+	cmd.Flags().StringArrayVar(&aggregateTerms, "aggregate", nil,
+		"query: aggregate \"<FUNC> [field]\" (repeatable; FUNC = COUNT SUM MIN MAX AVG)")
+	cmd.Flags().StringArrayVar(&orderByTerms, "order-by", nil,
+		"query: sort term \"<field> [asc|desc]\" (repeatable, max 4)")
+	cmd.Flags().IntVar(&queryLimit, "query-limit", 0,
+		"query: max output rows (clamps to 500); the result flags truncation when more matched")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit the full result-query envelope as JSON instead of the human render")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -110,6 +158,13 @@ type resultQueryOptions struct {
 	HandleID          string
 	Offset            int
 	Limit             int
+	WhereTerms        []string
+	SelectCols        []string
+	GroupByCols       []string
+	AggregateTerms    []string
+	OrderByTerms      []string
+	QueryLimit        int
+	QueryLimitSet     bool
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -124,6 +179,10 @@ func runResultQuery(cmd *cobra.Command, opts resultQueryOptions) error {
 			output.Unexpected(fmt.Sprintf("handle_id is not a valid UUID: %v", err)),
 			opts.JSONOut)
 	}
+	spec, err := buildResultQuerySpec(opts)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
@@ -132,7 +191,7 @@ func runResultQuery(cmd *cobra.Command, opts resultQueryOptions) error {
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	result, err := postResultQuery(cmd.Context(), client, handleID, opts.Offset, opts.Limit)
+	result, err := postResultQuery(cmd.Context(), client, handleID, opts.Offset, opts.Limit, spec)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
@@ -143,22 +202,198 @@ func runResultQuery(cmd *cobra.Command, opts resultQueryOptions) error {
 	return nil
 }
 
+// buildResultQuerySpec assembles the structured query from the query flags,
+// or returns nil when none were passed (paging mode). Field-vs-schema
+// validation happens server-side; this only shapes the request.
+func buildResultQuerySpec(opts resultQueryOptions) (*api.ResultQuerySpec, error) {
+	if len(opts.WhereTerms) == 0 && len(opts.SelectCols) == 0 &&
+		len(opts.GroupByCols) == 0 && len(opts.AggregateTerms) == 0 &&
+		len(opts.OrderByTerms) == 0 && !opts.QueryLimitSet {
+		return nil, nil
+	}
+	spec := &api.ResultQuerySpec{}
+	if len(opts.WhereTerms) > 0 {
+		preds := make([]api.FilterPredicate, 0, len(opts.WhereTerms))
+		for _, raw := range opts.WhereTerms {
+			pred, err := parseWherePredicate(raw)
+			if err != nil {
+				return nil, err
+			}
+			preds = append(preds, pred)
+		}
+		spec.Filter = &preds
+	}
+	if len(opts.SelectCols) > 0 {
+		spec.Select = &opts.SelectCols
+	}
+	if len(opts.GroupByCols) > 0 {
+		spec.GroupBy = &opts.GroupByCols
+	}
+	if len(opts.AggregateTerms) > 0 {
+		aggs := make([]api.Aggregate, 0, len(opts.AggregateTerms))
+		for _, raw := range opts.AggregateTerms {
+			agg, err := parseAggregate(raw)
+			if err != nil {
+				return nil, err
+			}
+			aggs = append(aggs, agg)
+		}
+		spec.Aggregate = &aggs
+	}
+	if len(opts.OrderByTerms) > 0 {
+		terms := make([]api.OrderBy, 0, len(opts.OrderByTerms))
+		for _, raw := range opts.OrderByTerms {
+			term, err := parseOrderBy(raw)
+			if err != nil {
+				return nil, err
+			}
+			terms = append(terms, term)
+		}
+		spec.OrderBy = &terms
+	}
+	if opts.QueryLimitSet {
+		limit := opts.QueryLimit
+		spec.Limit = &limit
+	}
+	return spec, nil
+}
+
+// parseWherePredicate parses "<field> <op> [value]" into a FilterPredicate.
+// The value is JSON-typed where possible (so `id = 5` binds an integer, not
+// the string "5"); IN takes a comma-separated list; IS NULL takes no value.
+func parseWherePredicate(raw string) (api.FilterPredicate, error) {
+	s := strings.TrimSpace(raw)
+	if lower := strings.ToLower(s); strings.HasSuffix(lower, "is null") {
+		field := strings.TrimSpace(s[:len(s)-len("is null")])
+		if field == "" {
+			return api.FilterPredicate{}, fmt.Errorf("--where %q: missing field before IS NULL", raw)
+		}
+		return api.FilterPredicate{Field: field, Op: api.FilterPredicateOpISNULL}, nil
+	}
+	parts := strings.Fields(s)
+	if len(parts) < 3 {
+		return api.FilterPredicate{}, fmt.Errorf(
+			"--where %q: expected \"<field> <op> <value>\" (op one of = != < <= > >= IN 'IS NULL')", raw)
+	}
+	field := parts[0]
+	opToken := parts[1]
+	valueText := strings.TrimSpace(s[strings.Index(s, opToken)+len(opToken):])
+	op, ok := normalizeWhereOp(opToken)
+	if !ok {
+		return api.FilterPredicate{}, fmt.Errorf(
+			"--where %q: unsupported operator %q (use = != < <= > >= IN 'IS NULL')", raw, opToken)
+	}
+	pred := api.FilterPredicate{Field: field, Op: op}
+	if op == api.FilterPredicateOpIN {
+		items := []any{}
+		for _, tok := range strings.Split(valueText, ",") {
+			items = append(items, jsonTypedValue(strings.TrimSpace(tok)))
+		}
+		var v any = items
+		pred.Value = v
+		return pred, nil
+	}
+	pred.Value = jsonTypedValue(valueText)
+	return pred, nil
+}
+
+func normalizeWhereOp(token string) (api.FilterPredicateOp, bool) {
+	switch strings.ToUpper(token) {
+	case "=":
+		return api.FilterPredicateOpEqual, true
+	case "!=":
+		return api.FilterPredicateOpEmpty, true
+	case "<":
+		return api.FilterPredicateOpLessThan, true
+	case "<=":
+		return api.FilterPredicateOpLessThanEqual, true
+	case ">":
+		return api.FilterPredicateOpGreaterThan, true
+	case ">=":
+		return api.FilterPredicateOpGreaterThanEqual, true
+	case "IN":
+		return api.FilterPredicateOpIN, true
+	default:
+		return "", false
+	}
+}
+
+// jsonTypedValue returns the JSON-decoded value of s (number, bool, null)
+// when it parses as a JSON scalar, else the raw string — so numeric and
+// boolean literals bind with their real type while bare words stay strings.
+func jsonTypedValue(s string) any {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err == nil {
+		switch v.(type) {
+		case float64, bool, nil:
+			return v
+		}
+	}
+	return s
+}
+
+func parseAggregate(raw string) (api.Aggregate, error) {
+	parts := strings.Fields(strings.TrimSpace(raw))
+	if len(parts) == 0 {
+		return api.Aggregate{}, fmt.Errorf("--aggregate %q: expected \"<FUNC> [field]\"", raw)
+	}
+	fn := api.AggregateFunc(strings.ToUpper(parts[0]))
+	switch fn {
+	case api.AggregateFuncCOUNT, api.AggregateFuncSUM, api.AggregateFuncMIN,
+		api.AggregateFuncMAX, api.AggregateFuncAVG:
+	default:
+		return api.Aggregate{}, fmt.Errorf(
+			"--aggregate %q: unsupported function %q (use COUNT SUM MIN MAX AVG)", raw, parts[0])
+	}
+	agg := api.Aggregate{Func: fn}
+	if len(parts) > 1 {
+		field := parts[1]
+		agg.Field = &field
+	}
+	return agg, nil
+}
+
+func parseOrderBy(raw string) (api.OrderBy, error) {
+	parts := strings.Fields(strings.TrimSpace(raw))
+	if len(parts) == 0 {
+		return api.OrderBy{}, fmt.Errorf("--order-by %q: expected \"<field> [asc|desc]\"", raw)
+	}
+	term := api.OrderBy{Field: parts[0]}
+	if len(parts) > 1 {
+		switch strings.ToLower(parts[1]) {
+		case "asc":
+			dir := api.OrderByDirectionAsc
+			term.Direction = &dir
+		case "desc":
+			dir := api.OrderByDirectionDesc
+			term.Direction = &dir
+		default:
+			return api.OrderBy{}, fmt.Errorf(
+				"--order-by %q: direction must be asc or desc", raw)
+		}
+	}
+	return term, nil
+}
+
 // postResultQuery issues the typed POST via the generated client, runs the
 // one-shot 401-refresh dance via the AuthedClient's Refresh hook (mirroring
-// postCall), and unmarshals the 200 body into ResultQueryResult. Non-2xx
-// outcomes — including the 404 handle-not-found miss — wrap as
-// *apiResponseError for renderRequestError to classify.
+// postCall), and unmarshals the 200 body into ResultQueryResult. When *spec*
+// is non-nil the request carries the structured query (query mode) and the
+// backend ignores offset/limit. Non-2xx outcomes — including the 404
+// handle-not-found miss — wrap as *apiResponseError for renderRequestError.
 func postResultQuery(
 	ctx context.Context,
 	client operationsAPI,
 	handleID openapi_types.UUID,
 	offset int,
 	limit int,
+	spec *api.ResultQuerySpec,
 ) (*ResultQueryResult, error) {
 	body := api.ResultQueryBody{
 		HandleId: handleID,
 		Offset:   &offset,
 		Limit:    &limit,
+		Query:    spec,
 	}
 	apiParams := &api.PostResultQueryApiV1OperationsResultQueryPostParams{}
 	resp, err := client.PostResultQueryApiV1OperationsResultQueryPostWithResponse(ctx, apiParams, body)
@@ -185,20 +420,28 @@ func postResultQuery(
 }
 
 // printResultQueryResult renders a ResultQueryResult as a human-readable
-// header line plus the pretty-printed rows window. The header states the
-// window position + the full/stored counts so the operator knows how far
-// they've paged and whether the tail was truncated at spill time; --json
-// carries the raw envelope.
+// header line plus the pretty-printed rows. The header states the window
+// position + the full/stored counts; a query-mode result additionally prints
+// its coverage caveat when the spill was capped. --json carries the raw
+// envelope.
 func printResultQueryResult(w io.Writer, r *ResultQueryResult) {
 	end := r.Offset + r.ReturnedRows
 	fmt.Fprintf(w, "%s — rows %d..%d of %d (stored %d), returned %d\n",
 		r.HandleID, r.Offset, end, r.TotalRows, r.StoredRows, r.ReturnedRows)
+	if r.Coverage == "partial" && r.CoverageNote != nil {
+		fmt.Fprintf(w, "  coverage: %s\n", *r.CoverageNote)
+	}
 	if r.Truncated {
-		fmt.Fprintf(w, "  note: spill was capped at %d of %d rows; rows past %d are not retrievable\n",
-			r.StoredRows, r.TotalRows, r.StoredRows)
+		if r.Coverage != "" {
+			fmt.Fprintf(w, "  note: output row cap reached (%d rows); more matched — narrow the query or raise --query-limit\n",
+				r.ReturnedRows)
+		} else {
+			fmt.Fprintf(w, "  note: spill was capped at %d of %d rows; rows past %d are not retrievable\n",
+				r.StoredRows, r.TotalRows, r.StoredRows)
+		}
 	}
 	if r.ReturnedRows == 0 {
-		fmt.Fprintln(w, "  (empty window — offset is at or past the end of the stored set)")
+		fmt.Fprintln(w, "  (empty window — no rows matched, or the offset is past the end of the stored set)")
 		return
 	}
 	for _, row := range r.Rows {

--- a/docs-site/reference/cli.md
+++ b/docs-site/reference/cli.md
@@ -3163,16 +3163,22 @@ meho operation preview <connector_id> <op_id> [flags]
 
 ### `meho operation result-query`
 
-Page rows back from a JSONFlux result handle
+Page or query rows back from a JSONFlux result handle
 
 ```
 meho operation result-query <handle_id> [flags]
 ```
 
+- `--aggregate` — query: aggregate "<FUNC> [field]" (repeatable; FUNC = COUNT SUM MIN MAX AVG)
 - `--backplane` — backplane URL to query (defaults to the URL recorded by the most recent `meho login`)
+- `--group-by` — query: GROUP BY key column (repeatable, max 4)
 - `--json` — emit the full result-query envelope as JSON instead of the human render
-- `--limit` — page size; default 50, max 500 (matches the result_query MCP tool)
-- `--offset` — zero-based index of the first row to return (page by advancing this by --limit)
+- `--limit` — paging: page size; default 50, max 500 (matches the result_query MCP tool)
+- `--offset` — paging: zero-based index of the first row to return (advance by --limit)
+- `--order-by` — query: sort term "<field> [asc|desc]" (repeatable, max 4)
+- `--query-limit` — query: max output rows (clamps to 500); the result flags truncation when more matched
+- `--select` — query: projection column to return (repeatable; omit for all columns)
+- `--where` — query: WHERE predicate "<field> <op> [value]" (repeatable; op = != < <= > >= IN 'IS NULL')
 
 ### `meho operation search`
 

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -198,17 +198,26 @@ connection via `_harden_connection()`:
 ```python
 self.conn.execute("SET enable_external_access=false")
 self.conn.execute("SET allow_community_extensions=false")
+self.conn.execute("SET autoinstall_known_extensions=false")
+self.conn.execute("SET autoload_known_extensions=false")
+self.conn.execute("SET max_memory='256MB'")
+self.conn.execute("SET threads=1")
 self.conn.execute("SET lock_configuration=true")  # must be last
 ```
 
 `enable_external_access=false` denies `ATTACH`, `COPY`, and
 `read_csv`/`read_json`/`read_parquet`; `allow_community_extensions=false`
-blocks third-party extension installs; `lock_configuration=true` freezes
-all further configuration and so must be applied **last** (it would
-otherwise prevent the preceding `SET`s). This is defense-in-depth against
-the latent arbitrary-file-read / SSRF / untrusted-extension surface that
-arbitrary SQL (e.g. a future `result_query` drill-in) would expose. See
-the [DuckDB securing guide](https://duckdb.org/docs/operations_manual/securing_duckdb/overview).
+plus the `autoinstall`/`autoload_known_extensions=false` pair block both
+third-party and built-in extension installs/loads; `max_memory` and
+`threads` bound the engine's resources; `lock_configuration=true` freezes
+all further configuration and so must be applied **last** — every `SET`
+above must precede it, because a post-lock `SET` raises
+`InvalidInputException` on the pinned `duckdb==1.5.5`. This is
+defense-in-depth against the latent arbitrary-file-read / SSRF /
+untrusted-extension surface that arbitrary SQL (e.g. the `result_query`
+query surface, #3366) would expose. See the
+[DuckDB securing guide](https://duckdb.org/docs/current/operations_manual/securing_duckdb/overview.html)
+and the [configuration reference](https://duckdb.org/docs/current/configuration/overview.html).
 
 ## Reducer adapter
 
@@ -447,6 +456,61 @@ MCP-only: a REST consumer that received a handle off `POST /api/v1/
 operations/call` was at a dead end. This is the design first drafted as
 the `HandleStore` in G3.1-T4 (#304, closed-superseded), revived and
 narrowed to the reduce-time spill case.
+
+### Query surface (#3366)
+
+Paging alone forces an agent that needs "the one CVE row" or "counts by
+project" to pull the whole set into context and filter client-side — the
+opposite of what the handle exists for. `result_query` therefore has a
+second mode alongside paging: `run_result_query` reads the **full**
+authorized set back (`ResultHandleStore.fetch_rows`), registers it in a
+fresh hardened `QueryEngine` under the table name `result`, and runs one
+**bounded, compiled `SELECT`** shaped by a structured `query` argument —
+filter predicates (≤10; `=, !=, <, <=, >, >=, IN, IS NULL`), `select`
+projection, `group_by` (≤4), aggregates (`COUNT/SUM/MIN/MAX/AVG`),
+`order_by` (≤4), and `limit`. The MCP `inputSchema` and the REST
+`ResultQueryBody` gain the same optional `query` object in lockstep;
+paging (`handle_id`/`offset`/`limit`) is unchanged and backward-compatible.
+
+**Why a compiled contract, not raw SQL.** The contract compiler
+([`jsonflux/query/contract.py`](../../backend/src/meho_backplane/jsonflux/query/contract.py))
+turns the typed grammar into exactly one parameterized read-only `SELECT`
+over the single registered table. Every referenced field is checked
+against the handle's known columns (unknown field → rejected, Kubernetes
+field-selector style); operators and aggregate functions are fixed
+allow-lists; caller values bind as DuckDB prepared-statement parameters,
+never string-interpolated. The unsafe forms are simply **not
+expressible** — there is no `sql=` argument on any transport. This is a
+stronger property than sanitizing a caller SQL string, verified against
+the locked `duckdb==1.5.5` / `pyarrow==25.0.1`: a `:memory:` database
+cannot be opened `read_only` (raises `CatalogException`); with
+`enable_external_access=false` an in-memory `CREATE TABLE … AS SELECT`
+still succeeds; and `execute("A; B")` silently runs both statements — so
+a raw-SQL contract would force MEHO to build and maintain a SQL parser to
+close holes that compiling from a fixed template avoids by construction
+(the negative anchor is MotherDuck's
+[`mcp-server-motherduck`](https://github.com/motherduckdb/mcp-server-motherduck):
+read-only alone is not sufficient).
+
+**Bounds.** Output rows are capped at `RESULT_QUERY_MAX_OUTPUT_ROWS`
+(default 500) with an explicit `truncated` flag (grouped results capped
+identically); the serialized output is capped at
+`RESULT_QUERY_MAX_OUTPUT_BYTES` (default 256 KB) **after** the row cap
+with an actionable over-budget error; and each compiled `SELECT` runs
+under a `RESULT_QUERY_TIMEOUT_SECONDS` (default 5) wall-time budget —
+DuckDB exposes no native Python query timeout, so the core runs
+`conn.execute()` on a worker thread and calls `conn.interrupt()` on
+expiry (raising `InterruptException`; see the
+[DuckDB Python API](https://duckdb.org/docs/current/clients/python/reference/index.html)).
+The engine's `max_memory` / `threads` ceilings (set in the sandbox above)
+bound it further.
+
+**Coverage.** Because the spill is capped at
+`RESULT_HANDLE_MAX_SPILL_ROWS`, a query may run over a subset. Every
+result carries `coverage`: `complete` when `stored_rows == total_rows`,
+else `partial` plus a `coverage_note` — so a `COUNT` over a capped spill
+is labelled as covering the stored subset only, never presented as a
+whole-inventory total.
 
 ### Sample ordering — head vs tail (G0.19-T1, #1479)
 

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -447,7 +447,7 @@ add-on-family gate.
 | `meho_status` | read_only | — | Return caller identity + backplane dependency status. |
 | `preview_operation` | operator | — | Preview an operation without running it. |
 | `query_topology` | operator | — | Query the topology graph (dependents, blast radius, timeline). |
-| `result_query` | operator | — | Read rows back from a JSONFlux result handle. |
+| `result_query` | operator | — | Read rows back from a JSONFlux result handle: page a window, or run a bounded structured query (filter / project / group / aggregate) server-side. |
 | `search_docs` | operator | `meho-docs` | Search a vendor-document collection for an authoritative fact. |
 | `search_knowledge` | operator | — | Search the tenant knowledge base. |
 | `search_memory` | operator | — | Search the operator's accessible memories. |

--- a/docs/codebase/result-spill.md
+++ b/docs/codebase/result-spill.md
@@ -37,14 +37,62 @@ The handle itself is minted **unconditionally** on every reduce — a
 skipped spill never suppresses the handle, it only flips the drill-in
 branch to `available=false`.
 
+## Read-back modes: paging vs. query (#3366)
+
+`result_query` reads a spilled handle back two ways, on both transports
+(the MCP tool and `POST /api/v1/operations/result-query`), through one
+shared core:
+
+- **Paging** (`handle_id` + `offset` + `limit`) — `read_result_window`
+  returns a row window, unchanged since #3179.
+- **Query** (`handle_id` + a `query` object) — `run_result_query`
+  compiles the structured arguments into **exactly one parameterized,
+  read-only `SELECT`** over the handle's rows and returns just the
+  matching rows or the per-group aggregates. The `query` grammar is
+  filter predicates (≤10; operators `=, !=, <, <=, >, >=, IN, IS NULL`),
+  `select` projection, `group_by` (≤4), aggregates
+  (`COUNT/SUM/MIN/MAX/AVG`), `order_by` (≤4), and `limit`. There is **no
+  raw-SQL argument** on any transport.
+
+The query runs inside the reduce-time `QueryEngine`'s sandbox rebuilt
+per call: the full authorized rows come back from `fetch_rows`, are
+`register`ed under the table name `result`, and the compiled statement
+is the only thing that touches them. Every referenced field is validated
+against the handle's known columns (unknown field → rejected); operators
+and aggregate functions are fixed allow-lists; caller values bind as
+DuckDB prepared-statement parameters, never string-interpolated. See
+[`docs/architecture/jsonflux.md`](../architecture/jsonflux.md#query-surface-3366)
+for why compiling from a fixed template is a stronger safety property
+than sanitizing a caller SQL string (verified on the pinned
+`duckdb==1.5.5`).
+
+### Bounds and coverage
+
+Every query result is bounded: output rows are capped at
+`RESULT_QUERY_MAX_OUTPUT_ROWS` (default 500) with an explicit
+`truncated` flag (grouped results capped identically); the serialized
+output is capped at `RESULT_QUERY_MAX_OUTPUT_BYTES` (default 256 KB)
+**after** the row cap, with an actionable over-budget error; and each
+compiled `SELECT` runs under a `RESULT_QUERY_TIMEOUT_SECONDS` (default 5)
+wall-time budget enforced by running `conn.execute()` on a worker thread
+and calling `conn.interrupt()` on expiry.
+
+Because the spill itself is capped at `RESULT_HANDLE_MAX_SPILL_ROWS`, a
+query may run over a subset of the true collection. The result carries
+`coverage`: `complete` when `stored_rows == total_rows`, else `partial`
+plus a `coverage_note` — so a `COUNT` over a capped spill is labelled as
+covering the stored subset, **never** presented as a whole-inventory
+total.
+
 ## Key types
 
 | Symbol | Where | Role |
 |---|---|---|
 | `JsonFluxReducer._spill` / `_SpillOutcome` | `backend/src/meho_backplane/operations/jsonflux_reducer.py` | Persists the materialized rows; reports `stored_rows` **or** a machine-readable `skip_reason` |
 | `FetchMoreDrillIn.reason` / `DrillInUnavailableReason` | `backend/src/meho_backplane/connectors/schemas.py` | The two-valued no-spill cause on the wire (#1629) |
-| `ResultHandleStore.spill` / `fetch_window` | `backend/src/meho_backplane/connectors/result_handle_store.py` | Fail-open Valkey persistence + operator/tenant-scoped read-back |
-| `read_result_window` / `ResultHandleNotFoundError` | `backend/src/meho_backplane/operations/result_query.py` | Transport-neutral windowed-read core both surfaces wrap (#3179); misses raise the recoverable not-found error |
+| `ResultHandleStore.spill` / `fetch_window` / `fetch_rows` | `backend/src/meho_backplane/connectors/result_handle_store.py` | Fail-open Valkey persistence + operator/tenant-scoped read-back; `fetch_rows` returns the full authorized set for the query surface (#3366) |
+| `read_result_window` / `run_result_query` / `ResultHandleNotFoundError` | `backend/src/meho_backplane/operations/result_query.py` | Transport-neutral windowed-read core (#3179) + bounded query core (#3366) both surfaces wrap; misses raise the recoverable not-found error |
+| `compile_query` / `ResultQuerySpec` / `QueryContractError` | `backend/src/meho_backplane/jsonflux/query/contract.py` | Compiles the validated query grammar to one parameterized read-only `SELECT` (#3366) |
 | `result_query` (MCP) | `backend/src/meho_backplane/mcp/tools/result_query.py` | MCP read surface; misses surface as recoverable `handle_not_found` (`-32602`) |
 | `POST /api/v1/operations/result-query` | `backend/src/meho_backplane/api/v1/operations.py` | REST read surface; misses surface as a `404` with `reason=handle_not_found` (#3179) |
 | `_reduce_or_error` | `backend/src/meho_backplane/operations/dispatcher.py` | Builds `reducer_context` (`tenant_id`, `operator_sub`, `op_id`, hints) from the authenticated `Operator` |
@@ -137,6 +185,12 @@ code-level diagnosis at `v0.13.0` (`f6ee330`):
 - `RESULT_HANDLE_MAX_SPILL_ROWS` (default 10000, validated `> 0`) caps
   the per-key value size; `ttl_seconds` (reducer default 3600) bounds
   lifetime server-side.
+- `RESULT_QUERY_MAX_OUTPUT_ROWS` (500) / `RESULT_QUERY_MAX_OUTPUT_BYTES`
+  (256 KB) / `RESULT_QUERY_TIMEOUT_SECONDS` (5) bound a single query's
+  output rows, serialized size, and wall time (#3366); all validated
+  `> 0`.
+- `duckdb==1.5.5` / `pyarrow==25.0.1` (pinned) — the sandboxed
+  `QueryEngine` the compiled query runs inside.
 
 ## Known issues
 
@@ -149,6 +203,8 @@ code-level diagnosis at `v0.13.0` (`f6ee330`):
 ## References
 
 - #1507 — spill store + `result_query` + drill-in (G0.20-T7).
+- #3366 — bounded validated query surface over the handle (filter /
+  project / group / aggregate, no raw SQL).
 - #1629 — no-spill `reason` surfacing + skip logging + this diagnosis
   (G0.23-T3, RDC cycle-8 signal `k8s-logs-mcp-five-row-sample-cap`).
 - #1479 — tail sample ordering for log-shaped ops (G0.19-T1).


### PR DESCRIPTION
## Summary

- Extends the shipped `result_query` read-back stack with a **bounded, validated server-side query surface** over a single JSONFlux handle — filter / project / group / aggregate — with **no raw-SQL argument** on any transport. Paging (`handle_id`/`offset`/`limit`) is unchanged and backward-compatible; the new query mode is one optional `query` object added to the MCP `inputSchema` and the REST `ResultQueryBody` in lockstep, both dispatching through one shared core.
- **Compile, don't sanitize.** New `jsonflux/query/contract.py` compiles a typed grammar (predicates ≤10; operators `=, !=, <, <=, >, >=, IN, IS NULL`; `select`; `group_by` ≤4; aggregates `COUNT/SUM/MIN/MAX/AVG`; `order_by` ≤4; `limit`) into exactly one parameterized read-only `SELECT`. Every referenced field is validated against the handle's known columns (unknown field → rejected); operators/aggregates are fixed allow-lists; values bind as DuckDB prepared-statement parameters — the unsafe forms are not expressible.
- **Bounded.** Output rows ≤ `result_query_max_output_rows` (500, single-sourced via `MAX_LIMIT`) with an explicit `truncated` flag; serialized-output cap `result_query_max_output_bytes` (256 KB) applied after the row cap with an actionable error; wall-time budget `result_query_timeout_seconds` (5 s) enforced by running `conn.execute()` on a worker thread and calling `conn.interrupt()` on expiry. `max_memory=256MB` + `threads=1` + `autoinstall/autoload_known_extensions=false` added to `_harden_connection` **before** `lock_configuration=true`.
- **Coverage.** When `stored_rows < total_rows` (capped spill) the result is labelled `coverage="partial"` with a `coverage_note` — a `COUNT` over a capped spill is never presented as a whole-inventory total.
- New full-set store read `ResultHandleStore.fetch_rows` (sibling of `fetch_window`, same tenant + `operator_sub` isolation and None-on-miss non-disclosure); three new `gt=0` Settings with hand-wired `get_settings` env mappings (round-trip tested); CLI `--where/--select/--group-by/--aggregate/--order-by/--query-limit` flags with the OpenAPI snapshot + generated client + CLI docs regenerated; reducer drill-in hint + `docs/codebase/{mcp,result-spill}.md` + `docs/architecture/jsonflux.md` updated.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — clean on all touched files (one pre-existing `connectors/net/icmp.py` `MSG_ERRQUEUE` error, macOS-only, unrelated)
- [x] `pytest tests/test_jsonflux_query_contract.py tests/test_operations_result_query_filter.py` — new; rejects writes/DDL, multi-statement, unknown field, disallowed operator/aggregate, cap overflow; bounds + coverage covered
- [x] `pytest tests/test_mcp_tool_result_query.py tests/test_api_v1_operations.py` — dual-edge parity + back-compat; the two negative tests relaxed to reject only genuinely-unknown args and to accept `query`
- [x] `pytest tests/test_operations_jsonflux_reducer.py tests/test_jsonflux_query_engine_sandbox.py` — reducer hint + sandbox green
- [x] `pytest tests/test_mcp_surface_conformance.py tests/test_mcp_surface_filter.py` — no new tool, count unchanged
- [x] `pytest tests/test_connectors_no_phantom_readback_tool.py tests/test_consumer_doc_tool_names.py tests/test_result_handle_store.py tests/test_settings.py tests/test_mcp_output_schema_conformance.py` — green (guard auto-relaxes now that a query arg ships; guard-the-guard fixtures updated)
- [x] Full block above run together: **364 passed**
- [x] `cd cli && go build ./... && go vet ./...` — clean; operation pkg tests pass
- [x] `make snapshot-openapi && make generate && make cli-docs` then `git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go docs-site/reference/cli.md` — clean (idempotent regen)

## Out of scope

- Cross-handle joins; a raw `sql=` argument; a new MCP tool (extends `result_query`, count unchanged).
- Retention/TTL defaults and the spill path — this surface defines its own output/resource bounds.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3366
