### PR TITLE
docs(changelog): roll [Unreleased] into v0.33.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.33.3] - 2026-09-05
+
 ### Added — net.tls_inspect returns the presented certificate PEM, closing the probe → `tls_ca_pin` loop (#3375)
 
 - `net.tls_inspect` now emits a `pem` field on every presented chain entry
@@ -109,6 +111,19 @@ connector-related release-notes line.
   stays inline (a certificate is a few KB; no JSONFlux handle-threshold change);
   `san` (DNS + IP) is unchanged. Typed-op response-schema addition only — no
   CLI OpenAPI-snapshot change.
+
+### Fixed — result_query guidance corrected to the shipped paging contract (#3369 / #3372)
+
+- Connector `llm_instructions` (ingested into `endpoint_descriptor` and read by
+  the agent at call time), CLI command help, cross-repo onboarding guides, and
+  internal docs described an aspirational result-handle query surface —
+  `result_aggregate` / `result_describe`, and `SELECT` / `WHERE` / `GROUP BY`
+  arguments to `result_query` — that was never registered, sending agents at
+  tools they could never call. All 36 drift sites now describe only the shipped
+  contract — `result_query(handle_id, offset, limit)` paging — and pre-announce
+  no future query surface; the reducer's spill-backend note is corrected
+  (Valkey, not MinIO/S3). Guidance and documentation only — no operation
+  behaviour or CLI OpenAPI-snapshot change.
 
 ## [0.33.2] - 2026-09-05
 

--- a/docs-site/reference/whats-new.md
+++ b/docs-site/reference/whats-new.md
@@ -9,6 +9,22 @@ for each breaking one.
 MEHO is under active development. Each release below links to its full
 notes.
 
+## [v0.33.3](https://github.com/evoila/meho/releases/tag/v0.33.3) — 2026-09-05
+
+- **Probe a target's certificate, then pin it — in one step.** `net.tls_inspect`
+  now returns each presented certificate as PEM (on the leaf and every chain
+  entry), not just facts about it. You can probe an endpoint and feed the right
+  trust anchor straight into a target's `tls_ca_pin` — the leaf for a
+  self-signed appliance, or an issuer/root for a CA-signed one — which is what
+  you need to register a target reachable only through a NAT alias, where
+  ordinary hostname verification can never match. The PEM is public handshake
+  material, never a private key.
+- **The assistant no longer points at result-handle features that don't exist.**
+  The guidance the agent reads, the CLI help, and the onboarding guides had
+  described a result-handle query surface — aggregation, filtering, describe —
+  that was never built. That text now matches what actually ships: paging a
+  result handle by offset and limit, and nothing it cannot do.
+
 ## [v0.33.2](https://github.com/evoila/meho/releases/tag/v0.33.2) — 2026-09-05
 
 - **Standalone ESXi host operations now actually reach the host.** The


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
<!-- Copyright (c) 2026 evoila Group -->

## Description

Release-cutting PR for **v0.33.3** (patch). Rolls the `[Unreleased]` CHANGELOG
section into `## [0.33.3] - 2026-09-05`, leaves a fresh empty `[Unreleased]`
above it, and adds a matching `v0.33.3` section to the docs-site What's new
page. No version-file bumps — the git tag is the sole version source
(`backend/pyproject.toml` stays `0.1.0-dev`; `Chart.yaml` version/appVersion are
calver-bumped by `chart.yml` at publish; the CLI bakes `{{.Tag}}` via GoReleaser).

**Tag is HELD.** Do not tag on merge — the orchestrator tags the merge commit by
SHA once its main CI run is green, per `docs/RELEASING.md` §4.

### Rolled entries (`[0.33.3]`)

- **Added** — `net.tls_inspect` now returns the presented certificate PEM on the
  leaf and every chain entry, closing the governed probe → `tls_ca_pin` loop for
  target registration (#3375). Bullet already present in `[Unreleased]`; shipped
  by PR #3376. Typed-op response-schema addition only — no CLI OpenAPI-snapshot
  change.
- **Fixed** — `result_query` guidance corrected to the shipped paging contract
  (#3369 / #3372). **Backfilled in this PR:** the fix merged after v0.33.2
  without a CHANGELOG bullet, and it is agent-facing (corrects connector
  `llm_instructions` ingested into `endpoint_descriptor`, CLI help, and
  cross-repo onboarding guides that pointed agents at an unshipped
  `result_aggregate` / `result_describe` / SELECT-WHERE query surface). Guidance
  and documentation only — no operation behaviour or CLI OpenAPI-snapshot change.

### Completeness audit

`git log v0.33.2..cb39a93c --oneline` = three merged PRs since the v0.33.2 tag:

- **#3376** (`net.tls_inspect` PEM, PR-half of planning #3375) — covered by the
  Added bullet.
- **#3372** (result_query guidance fix, closes #3369) — **backfilled** here.
- **#3374** (`test(connectors)`: widen phantom read-back guard) — **test-only**,
  single test file, no operator-facing artefact/behaviour/docs change →
  bullet-exempt.

**Also on main since v0.33.2 (no notes):** #3374 test-only. **#3366 not on
main** at cut time.

### Upgrade notes

None required — no fix in this release carries a DB migration, a chart field, a
default-on guard, or a CLI OpenAPI-snapshot change, so no `deploying.md`
upgrade-notes row was appended and §6b's rollback drill does not apply.

### Gates

- Release-body path-freshness gate (`scripts/release/check_release_body_paths.py`
  against `cli/api/openapi.json`) → exit 0 (`0 cited path(s), all resolve`).
- Docs build `uv run --project backend --no-sync mkdocs build --strict` → exit 0,
  clean (only the vendor Material MkDocs-2.0 banner on stderr).
- Lab-identifier scan on added lines → none.

### Compare links

This CHANGELOG uses **bare** version headings — no `[x.y.z]:` compare-link
reference definitions exist anywhere in the file (v0.33.2 / v0.33.1 / v0.33.0 are
all bare) — so none were added, to keep format parity. The docs-site What's new
heading links to the release tag, matching precedent.

## Related issue

Rolls #3375 / #3376 and backfills #3369 / #3372.

## Type of change

- [x] Documentation

## Checklist

- [x] Conventional Commits format on every commit
- [x] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable (N/A — CHANGELOG + docs only)
- [x] Documentation updated where applicable
- [ ] CI green (awaiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
