### PR TITLE
test(connectors): widen phantom-readback guard to docs/** + docs-site/** (#3386)

### DIFF
--- a/backend/tests/test_connectors_no_phantom_readback_tool.py
+++ b/backend/tests/test_connectors_no_phantom_readback_tool.py
@@ -195,20 +195,28 @@ _SQL_PHRASE_RES: tuple[tuple[str, re.Pattern[str]], ...] = (
 #: Files walked, as ``(root, glob)`` pairs, all relative to the repo root.
 _SCAN_ROOTS: tuple[tuple[Path, str], ...] = (
     (_REPO_ROOT / "backend" / "src" / "meho_backplane" / "connectors", "*.py"),
-    (_REPO_ROOT / "docs" / "codebase", "*.md"),
-    (_REPO_ROOT / "docs" / "cross-repo", "*.md"),
+    (_REPO_ROOT / "docs", "**/*.md"),
+    (_REPO_ROOT / "docs-site", "**/*.md"),
     (_REPO_ROOT / "cli" / "internal" / "cmd", "*.go"),
 )
+
+#: Historical registers that name the phantom tools deliberately -- excluded
+#: from the recursive ``docs`` walk. ``docs/decisions/locked-decisions.md`` and
+#: ``docs/architecture/mcp.md`` list the meta-tool surface (including the three
+#: phantom read-back names) as a design record, not as agent-facing guidance.
+_EXCLUDED_DOCS_PREFIXES: tuple[str, ...] = ("docs/decisions/", "docs/architecture/")
 
 #: Per-site negative-mention allow-list: ``(path suffix, line substring)``.
 #: An offending line is legal when its path ends with the suffix AND the
 #: line contains the substring -- both scoped tightly to the one sentence
 #: that documents a phantom's *absence*. Re-confirmed against the tree on
 #: 2026-09-05: ``docs/codebase/mcp.md`` L410-413 ("a nonexistent
-#: ``search_connectors`` / ``result_aggregate``"). ``docs-site`` is not a
-#: scan root here, so ``first-operations.md`` needs no entry.
+#: ``search_connectors`` / ``result_aggregate``") and, now that ``docs-site``
+#: is a scan root, ``docs-site/guides/first-operations.md`` L218 (the line
+#: disavowing the three phantom read-back tool names).
 _NEGATIVE_MENTION_ALLOWLIST: tuple[tuple[str, str], ...] = (
     ("docs/codebase/mcp.md", "reciprocal, not divergent"),
+    ("docs-site/guides/first-operations.md", "or `result_describe` tool"),
 )
 
 
@@ -299,6 +307,8 @@ def _scan_tree() -> list[str]:
     for root, glob in _SCAN_ROOTS:
         for path in sorted(root.rglob(glob)):
             rel = str(path.relative_to(_REPO_ROOT))
+            if rel.startswith(_EXCLUDED_DOCS_PREFIXES):
+                continue
             for offense in find_offenses(rel, path.read_text(encoding="utf-8")):
                 hits.append(f"{rel}:{offense.lineno} [{offense.rule}] {offense.text}")
     return hits
@@ -312,8 +322,9 @@ def _scan_tree() -> list[str]:
 def test_no_agent_facing_string_points_at_a_phantom_readback_surface() -> None:
     """No scanned file points the agent at a phantom read-back surface.
 
-    Fails when a connector descriptor, a ``docs/codebase`` / ``docs/cross-repo``
-    page, or a CLI ``Long`` help string reintroduces a phantom read-back
+    Fails when a connector descriptor, any ``docs/`` or ``docs-site/`` page
+    (bar the historical registers in ``docs/decisions`` / ``docs/architecture``),
+    or a CLI ``Long`` help string reintroduces a phantom read-back
     name, a phantom HandleStore reference, or SQL/aggregate/jq guidance
     against the paging-only ``result_query``.
     """


### PR DESCRIPTION
## Summary
- The phantom read-back guard (`backend/tests/test_connectors_no_phantom_readback_tool.py`) runs in the required `Python (ruff + mypy + pytest)` lane but walked only `docs/codebase` + `docs/cross-repo`, so `docs-site/**` and other `docs/` subtrees (`docs/cli`, `docs/runbooks`, …) had no required-lane coverage. A hyphen-spelled `result-aggregate` could re-enter via `docs-site` — the only guard touching that tree (`scripts/ci/check_consumer_tool_names.py`) is underscore-only and advisory (no `merge_group`).
- Widens `_SCAN_ROOTS` to recursive `docs` + `docs-site` markdown walks; keeps the connectors `*.py` and `cli/internal/cmd` `*.go` roots unchanged.
- Adds `_EXCLUDED_DOCS_PREFIXES = ("docs/decisions/", "docs/architecture/")` (historical registers that list the phantom tool names on purpose) and skips them in `_scan_tree`.
- Adds one per-site allow-list entry for `docs-site/guides/first-operations.md` (phrase `` or `result_describe` tool ``, the disavowal line), mirroring the existing `docs/codebase/mcp.md` entry. Updates the stale allow-list comment and the test docstring. Tests-only; the SQL/aggregate rules stay dormant (no change to `_PHANTOM_NAME_RE`, no raw-SQL rule added).

## Sibling-task interaction (#3388 / PR #3402)
- PR #3402 (docs freshness, #3388) edits `docs-site/guides/first-operations.md`. Confirmed via `gh pr diff 3402`: the disavowal line `` no `result_aggregate`, `result_export`, or `result_describe` tool — `` is a **context (unchanged) line** in that PR and keeps the literal phrase `` or `result_describe` tool `` on the same line as the three phantom names. This PR's per-line allow-list substring therefore still matches after #3402 lands. The two PRs touch disjoint files (this = the test; #3402 = docs/backend), so no merge conflict.

## Test plan
- [x] `ruff check` — clean on the test file
- [x] `ruff format --check` — already formatted
- [x] `pytest tests/test_connectors_no_phantom_readback_tool.py tests/test_consumer_doc_tool_names.py -q` — 43 passed
- [x] Dormancy pin `test_sql_guidance_is_dormant_now_that_query_surface_shipped` — passes unchanged
- [x] `docs/decisions/locked-decisions.md:106`, `docs/architecture/mcp.md:7` (excluded), `docs/codebase/mcp.md:412`, `docs-site/guides/first-operations.md:218` (allow-listed) all non-offending — guard green on clean tree
- [x] Injection proof: `result-aggregate` (hyphen) in a `docs-site/**` page **and** `result_aggregate` (underscore) in a `docs/cli/*.md` page both make the guard fail; removing both makes it pass again
- [x] `code-quality.py --diff` — exit 0
- [x] Acceptance grep `docs.*\*\*/\*.md\|docs-site` shows the recursive roots
- Guard wall time after widening: full test file (26 tests) ~1.4s; the scan test itself sub-second

## Out of scope
- No CHANGELOG entry (tests-only, #3374 precedent).
- `scripts/ci/check_consumer_tool_names.py` and its advisory workflow untouched; no always-on raw-SQL rule added (SQL/aggregate dormancy is by design, #3366).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3386
