### PR TITLE
fix(holodeck): require approval for holodeck.k8s.exec

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -1446,7 +1446,10 @@ READ_OPS: tuple[HolodeckOp, ...] = (
             "state without mutating it. The schema pattern enforces "
             "the ``kubectl <read-verb> ...`` shape at the validator "
             "layer; the handler re-checks the verb as a belt-and-braces "
-            "safety gate."
+            "safety gate. Because the command line is operator-supplied, "
+            "this op is approval-gated: a dispatch parks for human "
+            "approval before the command runs, rather than executing "
+            "unattended."
         ),
         parameter_schema={
             "type": "object",
@@ -1539,9 +1542,9 @@ READ_OPS: tuple[HolodeckOp, ...] = (
             "additionalProperties": True,
         },
         group_key="k8s",
-        tags=("read-only", "k8s", "kubectl", "holodeck"),
-        safety_level="safe",
-        requires_approval=False,
+        tags=("k8s", "kubectl", "holodeck", "approval-gated"),
+        safety_level="dangerous",
+        requires_approval=True,
         llm_instructions={
             "when_to_use": (
                 "Call when the operator wants to inspect the K8s "
@@ -1557,7 +1560,10 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                 "<verb> <resource>`` / ``kubectl auth whoami`` for "
                 "authorization inspection. Mutating verbs and "
                 "mutating sub-verbs (``config set-context``, "
-                "``auth reconcile``, etc.) fail closed. " + _SSH_TRANSPORT_NOTE
+                "``auth reconcile``, etc.) fail closed. This op is "
+                "approval-gated: a dispatch parks for human approval "
+                "before the command runs, rather than executing "
+                "unattended. " + _SSH_TRANSPORT_NOTE
             ),
             "parameter_hints": {
                 "command": (

--- a/backend/src/meho_backplane/connectors/holodeck/ops_write.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_write.py
@@ -3,10 +3,13 @@
 
 """Approval-gated remediation write ops for :class:`HolodeckConnector` (G3.18-T2 #2154).
 
-G3.8 (#371) shipped the connector plus 8 read ops; every one is
-``requires_approval=False`` and read-only -- ``holodeck.k8s.exec``
-re-validates its verb against a read-only safelist, so ``kubectl delete``
-cannot pass. The VCF-9.x backup-fill outage (Initiative #2145) needed three
+G3.8 (#371) shipped the connector plus 8 read ops. The reads are
+``requires_approval=False`` and read-only, except ``holodeck.k8s.exec``,
+which forwards an operator-supplied command line and is now
+``requires_approval=True`` (approval-gated); it still re-validates its
+verb against a read-only safelist, so ``kubectl delete`` cannot pass.
+
+The VCF-9.x backup-fill outage (Initiative #2145) needed three
 narrow writes the connector could not express, so recovery fell back to
 local root SSH with no MEHO audit row. This module closes that gap with
 three **tightly bounded** remediation writes:

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -518,11 +518,16 @@ def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
     """Every read op (EXPECTED_OP_IDS) carries safety_level='safe' and no approval.
 
     The G3.18-T2 (#2154) write ops are dangerous / requires_approval=True and
-    are asserted in ``test_connectors_holodeck_write.py``.
+    are asserted in ``test_connectors_holodeck_write.py``. ``holodeck.k8s.exec``
+    is also exempt: it forwards an operator-supplied kubectl command line and is
+    approval-gated (evoila-bosnia/meho-internal#267), asserted in
+    ``test_holodeck_e2e_k8s_exec_parks_for_approval``.
     """
     read_ids = set(EXPECTED_OP_IDS)
     for op in HOLODECK_OPS:
         if op.op_id not in read_ids:
+            continue
+        if op.op_id == "holodeck.k8s.exec":
             continue
         assert op.safety_level == "safe", f"{op.op_id} should be safe"
         assert not op.requires_approval, f"{op.op_id} should not require approval"
@@ -709,15 +714,17 @@ async def test_holodeck_e2e_service_list_dispatches_ok(
 
 
 @pytest.mark.asyncio
-async def test_holodeck_e2e_k8s_exec_safe_verb_dispatches_ok(
+async def test_holodeck_e2e_k8s_exec_parks_for_approval(
     holodeck_e2e: _HolodeckE2EBundle,
     captured_events: list[Any],
 ) -> None:
-    """holodeck.k8s.exec with a read-only verb (`kubectl get pods`)
-    succeeds and returns the fixture stdout. This exercises the full
-    safety path: the schema-layer pattern accepts the shape, the
-    handler-layer `parse_kubectl_command` accepts the verb, and the
-    fake-shell returns the fixture stdout.
+    """holodeck.k8s.exec forwards an operator-supplied kubectl command
+    line, so it is approval-gated (safety_level='dangerous',
+    requires_approval=True) and no longer dispatches unattended. Even a
+    read-only verb now parks: the policy gate returns ``awaiting_approval``
+    with a pending approval-request id, and the call never reaches the
+    fake-shell (no fixture stdout leaks). Containment:
+    evoila-bosnia/meho-internal#267.
     """
     del captured_events
     result = await call_operation(
@@ -729,10 +736,12 @@ async def test_holodeck_e2e_k8s_exec_safe_verb_dispatches_ok(
             "params": {"command": "kubectl get pods -n holodeck"},
         },
     )
-    assert result["status"] == "ok", f"holodeck.k8s.exec failed: {result.get('error')}"
-    out = result["result"].get("stdout", "")
-    assert "holo-dhcp" in out, f"Expected fixture stdout; got {out!r}"
-    assert result["result"].get("exit_status") == 0
+    assert result["status"] == "awaiting_approval", (
+        f"holodeck.k8s.exec should park for approval; got {result!r}"
+    )
+    assert result.get("extras", {}).get("approval_request_id"), result
+    # The command must never have reached the fake-shell.
+    assert "holo-dhcp" not in repr(result)
 
 
 @pytest.mark.asyncio
@@ -1047,6 +1056,24 @@ async def test_holodeck_e2e_all_ops_write_audit_rows(
                 "params": params,
             },
         )
+        if op_id == "holodeck.k8s.exec":
+            # Approval-gated (evoila-bosnia/meho-internal#267): the dispatch
+            # parks instead of executing, writing an APPROVAL audit row
+            # (path='approval.request') rather than a DISPATCH row.
+            assert result["status"] == "awaiting_approval", (
+                f"holodeck.k8s.exec should park; got {result!r}"
+            )
+            async with sessionmaker() as session:
+                db_result = await session.execute(
+                    select(AuditLog).where(
+                        AuditLog.method == "APPROVAL",
+                        AuditLog.path == "approval.request",
+                    )
+                )
+                rows = [r for r in db_result.scalars().all() if r.payload.get("op_id") == op_id]
+            assert rows, f"No APPROVAL audit row found for parked op {op_id!r}"
+            continue
+
         assert result["status"] == "ok", f"Op {op_id} failed: {result.get('error')}"
 
         async with sessionmaker() as session:

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -1441,6 +1441,12 @@ _READ_OP_IDS: frozenset[str] = frozenset(
     }
 )
 
+#: ``holodeck.k8s.exec`` forwards an operator-supplied ``kubectl``
+#: command line, so it is approval-gated (safety_level='dangerous',
+#: requires_approval=True) and is exempt from the read-op safe /
+#: no-approval invariants below. Containment: evoila-bosnia/meho-internal#267.
+_APPROVAL_GATED_READ_OP_IDS: frozenset[str] = frozenset({"holodeck.k8s.exec"})
+
 
 def test_holodeck_ops_has_seventeen_entries() -> None:
     """about + 7 T2 reads + disk.usage + #2847 backups.list + 3 write ops +
@@ -1473,9 +1479,17 @@ def test_holodeck_ops_all_have_holodeck_namespace() -> None:
 
 
 def test_holodeck_read_ops_all_safe() -> None:
-    """Every T2 read op is read-only -- safety_level='safe' is mandatory."""
+    """Every T2 read op is read-only -- safety_level='safe' is mandatory.
+
+    ``holodeck.k8s.exec`` is exempt: it forwards an operator-supplied
+    kubectl command line and is approval-gated (asserted separately in
+    ``test_holodeck_k8s_exec_is_approval_gated``). See
+    evoila-bosnia/meho-internal#267.
+    """
     for op in HOLODECK_OPS:
         if op.op_id not in _READ_OP_IDS:
+            continue
+        if op.op_id in _APPROVAL_GATED_READ_OP_IDS:
             continue
         assert op.safety_level == "safe", (
             f"{op.op_id!r} has safety_level={op.safety_level!r}; every read op must be safe"
@@ -1483,12 +1497,32 @@ def test_holodeck_read_ops_all_safe() -> None:
 
 
 def test_holodeck_read_ops_all_no_approval_required() -> None:
+    # ``holodeck.k8s.exec`` is approval-gated (evoila-bosnia/meho-internal#267);
+    # exempt it here and assert its gate in test_holodeck_k8s_exec_is_approval_gated.
     for op in HOLODECK_OPS:
         if op.op_id not in _READ_OP_IDS:
+            continue
+        if op.op_id in _APPROVAL_GATED_READ_OP_IDS:
             continue
         assert op.requires_approval is False, (
             f"{op.op_id!r} should not require approval -- reads only"
         )
+
+
+def test_holodeck_k8s_exec_is_approval_gated() -> None:
+    """``holodeck.k8s.exec`` forwards an operator-supplied ``kubectl``
+    command line, so it is approval-gated rather than an unattended read
+    op: safety_level='dangerous' + requires_approval=True. This is the
+    positive counterpart to the read-op safe / no-approval invariants,
+    which exempt this op. Containment: evoila-bosnia/meho-internal#267.
+    """
+    op = next(o for o in HOLODECK_OPS if o.op_id == "holodeck.k8s.exec")
+    assert op.safety_level == "dangerous", (
+        f"holodeck.k8s.exec must be dangerous; got {op.safety_level!r}"
+    )
+    assert op.requires_approval is True, (
+        "holodeck.k8s.exec must require approval (operator-supplied command line)"
+    )
 
 
 def test_holodeck_ops_all_parameter_schemas_have_additional_properties_false() -> None:

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -230,8 +230,12 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   `Get-Service | Where-Object { $_.Name -like 'Holo*' } | Select-Object
   Name,Status,DisplayName | ConvertTo-Json -Depth 4`. Same `{rows, total}`
   envelope and the same single-dict / `null` normalisation as `pod.list`.
-- **`holodeck.k8s.exec`** (group `k8s`, **read-only**). Forwards a
-  ``kubectl`` command to the in-appliance K8s cluster. Two complementary
+- **`holodeck.k8s.exec`** (group `k8s`, `safety_level=dangerous`,
+  `requires_approval=True`). Forwards an operator-supplied ``kubectl``
+  command to the in-appliance K8s cluster. Because the command line is
+  operator-supplied, the op is approval-gated: a dispatch parks for
+  human approval rather than running unattended. Its verb safelist still
+  confines it to read-only ``kubectl`` verbs, and two complementary
   allowlist layers reject both mutating verbs and shell-injection shapes
   (`;`, `&&`, `||`, `|`, `$(...)`, backticks, `>`, `<`, newline):
 


### PR DESCRIPTION
## Summary

This tightens gating of `holodeck.k8s.exec`, a read-class op that forwards an operator-supplied `kubectl` command line to the in-appliance Kubernetes cluster over SSH. It previously carried `safety_level="safe"` + `requires_approval=False`, so it dispatched unattended. This change raises `safety_level` to `dangerous` and sets `requires_approval=True`, so the dispatcher's policy gate parks the call for human approval (`awaiting_approval`) instead of auto-executing. The op's read-only verb safelist and shell-metacharacter rejection are unchanged; only the gating posture changes. The descriptor `tags`/`description`/`llm_instructions` and the codebase doc were updated to drop the unattended-read-only framing.

This is the direct posture the sibling `k8s.exec` op (kubernetes connector) already uses (`dangerous` + `requires_approval=True`).

## Decision gate

Branch A (require approval). A consumer search across this repo and the read-only lab and automation checkouts (`holodeck.k8s.exec`, `k8s.exec`, `k8s_exec`) found no Sensor, scheduled, or otherwise unattended consumer of the op: references are the connector implementation, its tests, the operator-interactive CLI verb, and documentation. The lab material explicitly treats the op as operator-driven ("operator-typed-auth only, never agent-driven"). With no unattended consumer, requiring approval is safe.

Approval-gating is honoured for typed connector ops on the shared dispatch path: `operations/_validate.py` routes a `requires_approval` descriptor to `NEEDS_APPROVAL` for every principal kind, and `operations/dispatcher.py` parks it via `_handle_needs_approval` → `result_awaiting_approval`.

## Tests

- Exempted `holodeck.k8s.exec` from the three holodeck read-op safe/no-approval invariants (two in the ops test, one in the e2e test), each with a comment referencing the tracking ref.
- Added a positive descriptor test asserting `dangerous` + `requires_approval=True`.
- Rewrote the e2e "dispatches ok" test into a park test asserting the op now returns `awaiting_approval` with a pending approval-request id and never reaches the connector handler; special-cased the all-ops audit-row test so the parked op is checked for its approval audit row.
- `ruff check` / `ruff format --check` clean; `mypy src/` clean for the changed files.
- Full backend unit lane (per-PR scope: `tests`, excluding `tests/integration` and `tests/migrations`) run locally: 14524 passed, 116 skipped. The only failures are three pre-existing environment-specific tests unrelated to this change and in untouched files (raw-ICMP socket, live DNS bind, and a `helm template` subprocess), which pass on the Linux CI runners.

Ref: evoila-bosnia/meho-internal#267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
