### PR TITLE
docs(clients): keep the static token out of the mcp-remote command line

### DIFF
--- a/docs-site/clients/mcp-remote-shim.md
+++ b/docs-site/clients/mcp-remote-shim.md
@@ -53,8 +53,17 @@ same:
 
 ```bash
 npx -y mcp-remote@0.1.38 https://meho.example.com/mcp \
-  --header "Authorization:${MEHO_TOKEN}"
+  --header 'Authorization:${MEHO_TOKEN}'
 ```
+
+The single quotes are load-bearing: they stop the shell from expanding
+`${MEHO_TOKEN}`, so the literal `${MEHO_TOKEN}` reaches `mcp-remote`,
+which substitutes the value from its own environment — the token itself
+never lands on the command line, where it would otherwise sit in the
+process table for the whole life of this long-running shim. Because the
+token still lives in the shim's environment as a bearer credential, treat
+this static-token stopgap as unsuitable for shared or multi-user
+workstations.
 
 The backplane is HTTPS, so no `--allow-http` is needed. Set
 `NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem` in the client's


### PR DESCRIPTION
## What changed

`docs-site/clients/mcp-remote-shim.md` told operators to run the shim
with the header value in **double** quotes:

```bash
--header "Authorization:${MEHO_TOKEN}"
```

Under `bash` the double quotes let the shell expand `${MEHO_TOKEN}`
before `npx` execs, so the token becomes part of the long-running shim
process's argv and stays readable in the process table for its whole
lifetime. `mcp-remote` is designed to interpolate `${VAR}` itself, from
its own environment, when the value reaches it unexpanded — so the fix
is to pass the header **single**-quoted:

```bash
--header 'Authorization:${MEHO_TOKEN}'
```

This commit:

- switches the one recipe line to single quotes,
- adds a sentence explaining that the literal `${MEHO_TOKEN}` must reach
  `mcp-remote` unexpanded so the token never lands on the command line, and
- adds a one-line caveat that this static-token stopgap is unsuitable for
  shared or multi-user workstations.

Scope: only the `mcp-remote` interpolation recipe is affected. The other
`--header "Authorization: Bearer $TOKEN"` occurrences in the docs are
`@modelcontextprotocol/inspector --cli` smoke-test commands — short-lived
invocations that rely on shell expansion (the Inspector does not do
`${VAR}` interpolation), so single-quoting them would break them; they are
left unchanged.

## README evidence (pinned version)

Verified against the exact pinned version via `npm view mcp-remote@0.1.38
readme` (no install). The README's **Custom Headers** section documents
the environment-interpolation form:

```jsonc
"args": [
  "mcp-remote",
  "https://remote.mcp.server/sse",
  "--header",
  "Authorization:${AUTH_HEADER}" // note no spaces around ':'
],
"env": {
  "AUTH_HEADER": "Bearer <auth-token>" // spaces OK in env vars
}
```

The same README states the rationale directly: "To keep a credential out
of the process arguments — where any other user on the machine can read
it from the process list — put the headers in a file instead..." — i.e.
`mcp-remote` treats the command line as observable and expects the secret
to arrive by environment interpolation, confirming `${VAR}` support in
0.1.38.

Ref: evoila-bosnia/meho-internal#262

🤖 Generated with [Claude Code](https://claude.com/claude-code)