### PR TITLE
fix(auth): require a human principal on the approval-decision and grant/principal admin routes

### DIFF
--- a/backend/src/meho_backplane/api/v1/agent_grants.py
+++ b/backend/src/meho_backplane/api/v1/agent_grants.py
@@ -70,13 +70,21 @@ from meho_backplane.agents.grant_schemas import (
 )
 from meho_backplane.agents.grants import AgentGrantService, GrantValidationError
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import require_human_principal, require_role
 
 __all__ = ["router"]
 
 router = APIRouter(prefix="/api/v1/agents/grants", tags=["agent-grants"])
 
 _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: Human-only governance gate (meho-internal#289). Attached to grant
+#: **create** and **elevate** so a non-human ``principal_kind`` (agent /
+#: service / runner) cannot mint or widen a grant over REST, even holding
+#: the ``tenant_admin`` role an agent principal is minted with — the REST
+#: half of :mod:`meho_backplane.mcp.human_only`'s policy. Read / show /
+#: revoke keep the plain ``tenant_admin`` gate.
+_require_human = Depends(require_human_principal)
 
 _GRANT_OP_IDS: Final[dict[str, str]] = {
     "list": "agent.grant.list",
@@ -139,7 +147,12 @@ async def show_grant(
     return entry
 
 
-@router.post("", response_model=AgentGrantRead, status_code=http_status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=AgentGrantRead,
+    status_code=http_status.HTTP_201_CREATED,
+    dependencies=[_require_human],
+)
 async def create_grant(
     payload: AgentGrantCreate,
     operator: Operator = _require_admin,
@@ -171,6 +184,7 @@ async def create_grant(
     "/elevate",
     response_model=AgentGrantRead,
     status_code=http_status.HTTP_201_CREATED,
+    dependencies=[_require_human],
 )
 async def elevate_grant(
     payload: AgentElevationCreate,

--- a/backend/src/meho_backplane/api/v1/agent_principals.py
+++ b/backend/src/meho_backplane/api/v1/agent_principals.py
@@ -66,7 +66,7 @@ from meho_backplane.auth.keycloak_admin import (
     KeycloakAdminNotConfiguredError,
 )
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import require_human_principal, require_role
 from meho_backplane.scheduler.vault_credentials import (
     SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
     SchedulerVaultBrokerError,
@@ -78,6 +78,14 @@ router = APIRouter(prefix="/api/v1/agent-principals", tags=["agent-principals"])
 
 _require_operator = Depends(require_role(TenantRole.OPERATOR))
 _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: Human-only governance gate (meho-internal#289). Attached to **register**
+#: so a non-human ``principal_kind`` (agent / service / runner) cannot mint
+#: another agent principal over REST, even holding the ``tenant_admin`` role
+#: an agent principal is minted with — the REST half of
+#: :mod:`meho_backplane.mcp.human_only`'s policy. List / show / revoke keep
+#: their existing role gate.
+_require_human = Depends(require_human_principal)
 
 _OP_IDS: Final[dict[str, str]] = {
     "list": "agent_principal.list",
@@ -174,6 +182,7 @@ async def show_agent_principal(
     "",
     response_model=AgentPrincipalRead,
     status_code=http_status.HTTP_201_CREATED,
+    dependencies=[_require_human],
 )
 async def register_agent_principal(
     body: AgentPrincipalCreate,

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -82,7 +82,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.auth.rbac import require_approvals_access
+from meho_backplane.auth.rbac import require_approvals_access, require_human_principal
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
 from meho_backplane.middleware import verify_jwt_and_bind
@@ -123,6 +123,15 @@ router = APIRouter(prefix="/api/v1/approvals", tags=["approvals"])
 #: not park the op still cannot read its result. See
 #: :func:`~meho_backplane.auth.rbac.require_approvals_access`.
 _require_approvals_access = Depends(require_approvals_access)
+
+#: Human-only governance gate (meho-internal#289). Rejects a non-human
+#: ``principal_kind`` (agent / service / runner) before the endpoint runs —
+#: the REST half of :mod:`meho_backplane.mcp.human_only`'s policy, so the
+#: approval **decision** verbs (approve / reject / decide) are human-only on
+#: every transport. Attached only to the decision routes; the read routes
+#: (list / show / result) keep ``require_approvals_access`` alone so a
+#: service principal's approval bridge can still list the queue.
+_require_human = Depends(require_human_principal)
 
 
 # ---------------------------------------------------------------------------
@@ -672,6 +681,7 @@ async def _record_approval_decision(
 @router.post(
     "/{request_id}/approve",
     response_model=ApproveResponseBody,
+    dependencies=[_require_human],
 )
 async def approve_approval_request(
     request_id: Annotated[uuid.UUID, Path()],
@@ -757,6 +767,7 @@ async def approve_approval_request(
 @router.post(
     "/{request_id}/reject",
     response_model=RejectResponseBody,
+    dependencies=[_require_human],
 )
 async def reject_approval_request(
     request_id: Annotated[uuid.UUID, Path()],
@@ -884,6 +895,7 @@ class DecideResponseBody(BaseModel):
 @router.post(
     "/{request_id}/decide",
     response_model=DecideResponseBody,
+    dependencies=[_require_human],
 )
 async def decide_approval_request(
     request_id: Annotated[uuid.UUID, Path()],

--- a/backend/src/meho_backplane/auth/operator.py
+++ b/backend/src/meho_backplane/auth/operator.py
@@ -121,7 +121,13 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-__all__ = ["Operator", "PrincipalKind", "TenantRole"]
+__all__ = [
+    "MACHINE_PRINCIPAL_KINDS",
+    "Operator",
+    "PrincipalKind",
+    "TenantRole",
+    "is_human_principal",
+]
 
 
 class TenantRole(StrEnum):
@@ -226,3 +232,33 @@ class Operator(BaseModel):
     approver: bool = False
     runner_id: UUID | None = None
     check_runner_dispatch: bool = False
+
+
+#: Machine (non-human) principal kinds. A human operator authenticates as
+#: :attr:`PrincipalKind.USER` (the graceful-fallback default for a token
+#: carrying no ``principal_kind`` claim); every other kind is a machine
+#: credential — an agent client, a non-MEHO service account, or a satellite
+#: runner. The human-only governance verbs (approval decisions, agent-grant
+#: create / elevate, agent-principal register) refuse these kinds on **every**
+#: transport (meho-internal#289): approval is a human decision (v0.1-spec §7).
+MACHINE_PRINCIPAL_KINDS: frozenset[PrincipalKind] = frozenset(
+    {PrincipalKind.AGENT, PrincipalKind.SERVICE, PrincipalKind.RUNNER}
+)
+
+
+def is_human_principal(operator: Operator) -> bool:
+    """Return ``True`` when *operator* is a human (interactive) principal.
+
+    A human principal authenticates as :attr:`PrincipalKind.USER`. Every
+    kind in :data:`MACHINE_PRINCIPAL_KINDS` (agent / service / runner) is a
+    machine credential and returns ``False``.
+
+    Single source of truth for the human-vs-machine split. It is consulted
+    by the transport-independent REST guard
+    (:func:`~meho_backplane.auth.rbac.ensure_human_principal`) and the
+    approval service-layer backstop
+    (:func:`~meho_backplane.operations.approval_queue._check_reviewer_role`)
+    so the two layers enforce one policy — the peer of the MCP transport's
+    :mod:`meho_backplane.mcp.human_only` block.
+    """
+    return operator.principal_kind not in MACHINE_PRINCIPAL_KINDS

--- a/backend/src/meho_backplane/auth/rbac.py
+++ b/backend/src/meho_backplane/auth/rbac.py
@@ -45,10 +45,17 @@ from uuid import UUID
 import structlog
 from fastapi import Depends, HTTPException, status
 
-from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.operator import Operator, TenantRole, is_human_principal
 from meho_backplane.middleware import verify_jwt_and_bind
 
-__all__ = ["authorize_tenant_scope", "require_approvals_access", "require_role"]
+__all__ = [
+    "HUMAN_ONLY_REST_REMEDIATION",
+    "authorize_tenant_scope",
+    "ensure_human_principal",
+    "require_approvals_access",
+    "require_human_principal",
+    "require_role",
+]
 
 #: Linear role ordering. Index = rank; ``read_only`` is rank 0,
 #: ``tenant_admin`` is rank 2. The dependency compares the actual
@@ -254,3 +261,73 @@ def authorize_tenant_scope(operator: Operator, requested: UUID | None) -> UUID:
         status_code=status.HTTP_403_FORBIDDEN,
         detail="cross_tenant_requires_platform_admin",
     )
+
+
+#: Remediation returned when a machine principal reaches a human-only
+#: governance verb over REST. Names the human path (operator console /
+#: ``meho`` CLI) the way the MCP transport's
+#: :data:`~meho_backplane.mcp.human_only.HUMAN_ONLY_MCP_TOOLS` messages do,
+#: so REST and MCP speak one policy (meho-internal#289). Carried on the 403
+#: ``detail`` behind the machine-readable ``human_principal_required:``
+#: prefix, mirroring the ``self_approval_forbidden: <hint>`` shape the
+#: approvals routes already return.
+HUMAN_ONLY_REST_REMEDIATION: Final[str] = (
+    "this is a human-only governance decision (v0.1-spec §7): a machine "
+    "principal (agent / service / runner) has no path to it on any transport. "
+    "Perform it as a human operator via the approvals queue in the operator "
+    "console, or the meho CLI human path (e.g. `meho approvals approve "
+    "<request-id>`, `meho agent grant elevate ...`, `meho agent-principal "
+    "register ...`)."
+)
+
+
+def ensure_human_principal(operator: Operator) -> None:
+    """Refuse a machine principal on a human-only governance verb (#289).
+
+    Transport-independent guard for the verbs that are a **human**
+    decision (v0.1-spec §7): the approval decisions (approve / reject /
+    decide), agent-grant create / elevate, and agent-principal register. A
+    machine principal — ``principal_kind`` in
+    :data:`~meho_backplane.auth.operator.MACHINE_PRINCIPAL_KINDS` (agent /
+    service / runner) — is refused with HTTP 403 and a remediation naming
+    the console / CLI human path, mirroring the MCP transport's human-only
+    block (:mod:`meho_backplane.mcp.human_only`). The two layers are one
+    policy: an agent principal is minted ``tenant_admin`` with the REST
+    audience, so this closes the transport that the MCP block alone could
+    not.
+
+    Independent of — and evaluated **before** — the role / ``approver``
+    floor, so a machine token holding ``tenant_admin`` (or the ``approver``
+    capability) is refused here regardless. The approver capability model
+    (#3243) and the seniority self-approval rules are preserved unchanged
+    for **human** principals: this gate only removes machine kinds; every
+    human decision path downstream is untouched.
+    """
+    if is_human_principal(operator):
+        return
+    structlog.get_logger(__name__).warning(
+        "non_human_principal_denied",
+        operator_sub=operator.sub,
+        principal_kind=operator.principal_kind.value,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"human_principal_required: {HUMAN_ONLY_REST_REMEDIATION}",
+    )
+
+
+def require_human_principal(
+    operator: Operator = Depends(verify_jwt_and_bind),
+) -> Operator:
+    """FastAPI dependency form of :func:`ensure_human_principal` (#289).
+
+    Attach to a human-only governance route as a route-decorator
+    ``dependencies=[...]`` entry (or a parameter default) to reject a
+    machine ``principal_kind`` before the endpoint runs, independent of the
+    route's existing role / approver gate. Returns the validated
+    :class:`~meho_backplane.auth.operator.Operator` so it also composes as a
+    parameter dependency. ``verify_jwt_and_bind`` is request-cached, so
+    pairing this with the route's role dependency verifies the JWT once.
+    """
+    ensure_human_principal(operator)
+    return operator

--- a/backend/src/meho_backplane/mcp/human_only.py
+++ b/backend/src/meho_backplane/mcp/human_only.py
@@ -39,6 +39,19 @@ This module is the single source of truth for two consumers:
 * The guard test ``tests/test_mcp_human_only_surface.py`` asserts none
   of these names is registered and that no tool module wires a handler
   to an approval-decision or grant-elevation endpoint.
+
+This is the **MCP-transport** half of one transport-independent policy:
+approval is a human decision (v0.1-spec §7). The **REST-transport** half
+lives in :func:`meho_backplane.auth.rbac.ensure_human_principal` /
+:func:`~meho_backplane.auth.rbac.require_human_principal`, which reject a
+machine ``principal_kind`` (agent / service / runner) on the approval
+decision routes and on grant create / elevate + agent-principal register —
+closing the seam that an agent principal, minted ``tenant_admin`` with the
+REST audience, would otherwise reach over REST (meho-internal#289). Both
+halves consult the same
+:func:`meho_backplane.auth.operator.is_human_principal` split, so removing
+a verb from the agent surface here and refusing the machine kind there are
+one decision, not two.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -104,6 +104,7 @@ __all__ = [
     "ApprovalError",
     "ApprovalNotFoundError",
     "ApprovalRequestAlreadyDecidedError",
+    "NonHumanApprovalError",
     "ParamsMismatchError",
     "PreviewBindingMissingError",
     "ResultAccessForbiddenError",
@@ -249,6 +250,42 @@ class UnauthorizedApprovalError(ApprovalError):
         super().__init__(
             f"operator {operator_sub!r} with role {role!r} may not approve/reject "
             "an approval request (requires at least 'operator')"
+        )
+
+
+class NonHumanApprovalError(UnauthorizedApprovalError):
+    """A machine (non-human) principal tried to decide an approval request.
+
+    Approving / rejecting / deciding a parked op is a **human** decision
+    (v0.1-spec §7, meho-internal#289). Raised by :func:`_check_reviewer_role`
+    when ``operator.principal_kind`` is a machine kind (agent / service /
+    runner), independent of tenant role or the ``approver`` capability — an
+    agent principal is minted ``tenant_admin``, so a role/approver check
+    alone would admit it.
+
+    Subclasses :class:`UnauthorizedApprovalError` so the existing
+    ``except UnauthorizedApprovalError`` handlers in the REST and console
+    routes still map it to HTTP 403. This service-layer refusal is the
+    transport-independent backstop behind the REST human-principal
+    dependency (:func:`~meho_backplane.auth.rbac.require_human_principal`):
+    a caller reaching the service directly (agent runtime, tests) sees the
+    same human-only policy.
+    """
+
+    def __init__(self, *, operator_sub: str, principal_kind: str) -> None:
+        self.operator_sub = operator_sub
+        self.principal_kind = principal_kind
+        # ``role`` is populated for base-class compatibility (nothing reads
+        # it apart from the message); the refusal is kind-based, not role-
+        # based, so mirror the kind into it rather than a tenant role.
+        self.role = principal_kind
+        # Skip ``UnauthorizedApprovalError.__init__`` (its message talks about
+        # roles); build the kind-aware message off the shared base instead.
+        ApprovalError.__init__(
+            self,
+            f"principal {operator_sub!r} of kind {principal_kind!r} may not "
+            "decide an approval request — approval is a human decision "
+            "(v0.1-spec §7)",
         )
 
 
@@ -1402,7 +1439,19 @@ def _check_reviewer_role(operator: Operator) -> None:
     same decoupled-from-dispatch access model, and keeps ``read_only``
     (no flag) failing closed exactly as before.
     """
-    from meho_backplane.auth.operator import TenantRole
+    from meho_backplane.auth.operator import TenantRole, is_human_principal
+
+    # Human-only governance (v0.1-spec §7, meho-internal#289): a machine
+    # principal (agent / service / runner) can never decide an approval,
+    # regardless of tenant role or the ``approver`` capability. Checked
+    # first so a machine token minted ``tenant_admin`` is refused here too.
+    # This mirrors the REST require_human_principal dependency as the
+    # transport-independent backstop for direct service callers.
+    if not is_human_principal(operator):
+        raise NonHumanApprovalError(
+            operator_sub=operator.sub,
+            principal_kind=operator.principal_kind.value,
+        )
 
     if operator.tenant_role == TenantRole.READ_ONLY and not operator.approver:
         raise UnauthorizedApprovalError(

--- a/backend/tests/test_api_v1_agent_grants.py
+++ b/backend/tests/test_api_v1_agent_grants.py
@@ -189,3 +189,88 @@ def test_operator_role_is_rejected_with_insufficient_role(
         response = client.request(method, path, headers=headers, json=body)
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "insufficient_role"}
+
+
+# ---------------------------------------------------------------------------
+# meho-internal#289 — grant create / elevate are human-only on every
+# transport. An agent principal is minted ``tenant_admin``, so it clears the
+# role gate; the human-principal guard must still refuse it so a machine
+# cannot mint or widen its own (or a sibling's) grant over REST.
+# ---------------------------------------------------------------------------
+
+# RUNNER is refused earlier on the wire (401 missing_runner_id, and the
+# runner path-cage in middleware) so it never reaches this guard over REST;
+# the RUNNER kind is covered at the service layer in test_approval_queue.py.
+_MACHINE_KINDS: tuple[str, ...] = ("agent", "service")
+
+# Only the write verbs that mint / widen a grant carry the human-kind gate.
+_HUMAN_ONLY_GRANT_ENDPOINTS: tuple[tuple[str, dict[str, Any]], ...] = (
+    (
+        "/api/v1/agents/grants",
+        {
+            "principal_sub": "agent:deploy-bot",
+            "op_pattern": "vm.list",
+            "verdict": "auto-execute",
+        },
+    ),
+    (
+        "/api/v1/agents/grants/elevate",
+        {
+            "principal_sub": "agent:deploy-bot",
+            "op_pattern": "vm.power_off",
+            "verdict": "needs-approval",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    ),
+)
+
+
+def _machine_admin_token(key: Any, *, kind: str, sub: str = "machine-admin") -> str:
+    """Mint a machine principal at ``tenant_admin`` — how agents are minted (#289)."""
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        tenant_id=str(_TENANT_A),
+        principal_kind=kind,
+    )
+
+
+@pytest.mark.parametrize("kind", _MACHINE_KINDS)
+@pytest.mark.parametrize("path, body", _HUMAN_ONLY_GRANT_ENDPOINTS)
+def test_machine_principal_denied_on_grant_create_and_elevate(
+    client: TestClient,
+    path: str,
+    body: dict[str, Any],
+    kind: str,
+) -> None:
+    """A machine ``tenant_admin`` token → 403 ``human_principal_required`` (#289)."""
+    key = make_rsa_keypair(f"kid-machine-{kind}")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_machine_admin_token(key, kind=kind)}"}
+        response = client.post(path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"].startswith("human_principal_required"), response.text
+
+
+@pytest.mark.parametrize("path, body", _HUMAN_ONLY_GRANT_ENDPOINTS)
+def test_human_admin_passes_kind_gate_on_grant_create_and_elevate(
+    client: TestClient,
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """A human ``tenant_admin`` clears both the role and the human-kind gate (#289).
+
+    Both auth dependencies fire before request-body validation (the role
+    gate already does, per this module's negative matrix), so a human
+    ``tenant_admin`` sending a deliberately empty body reaches Pydantic
+    validation — HTTP 422, never the human-only gate's 403. That the
+    endpoint validates the body at all proves the auth gates were cleared.
+    """
+    key = make_rsa_keypair("kid-human-admin")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.TENANT_ADMIN)}"}
+        response = client.post(path, headers=headers, json={})
+    assert response.status_code == 422, response.text

--- a/backend/tests/test_api_v1_agent_principals.py
+++ b/backend/tests/test_api_v1_agent_principals.py
@@ -947,3 +947,63 @@ async def test_register_skips_vault_when_token_unset(
     assert resp.status_code == 201, resp.text
     rows = await _fetch_principals(_TENANT_A)
     assert [row.name for row in rows] == ["no-token-bot"]
+
+
+# ---------------------------------------------------------------------------
+# meho-internal#289 — agent-principal register is human-only on every
+# transport. An agent principal is minted ``tenant_admin``, so it clears the
+# role gate; the human-principal guard must still refuse it so a machine
+# cannot mint another agent principal over REST. (The human positive path
+# is the ``tenant_admin`` round-trip test above.)
+# ---------------------------------------------------------------------------
+
+# RUNNER is refused earlier on the wire (401 missing_runner_id, and the
+# runner path-cage in middleware) so it never reaches this guard over REST;
+# the RUNNER kind is covered at the service layer in test_approval_queue.py.
+_MACHINE_KINDS: tuple[str, ...] = ("agent", "service")
+
+
+def _machine_admin_token(key: Any, *, kind: str, sub: str = "machine-admin") -> str:
+    """Mint a machine principal at ``tenant_admin`` — how agents are minted (#289)."""
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        tenant_id=str(_TENANT_A),
+        principal_kind=kind,
+    )
+
+
+@pytest.mark.parametrize("kind", _MACHINE_KINDS)
+def test_machine_principal_denied_on_register(client: TestClient, kind: str) -> None:
+    """A machine ``tenant_admin`` token → 403 ``human_principal_required`` (#289).
+
+    The human-principal dependency fires before the Keycloak / DB work, so
+    no Keycloak mock is needed: an agent/service/runner minted
+    ``tenant_admin`` is refused at the gate.
+    """
+    key = make_rsa_keypair(f"kid-machine-{kind}")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_machine_admin_token(key, kind=kind)}"}
+        response = client.post(
+            "/api/v1/agent-principals", json={"name": "sneaky-bot"}, headers=headers
+        )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"].startswith("human_principal_required"), response.text
+
+
+def test_human_admin_passes_kind_gate_on_register(client: TestClient) -> None:
+    """A human ``tenant_admin`` clears both the role and the human-kind gate (#289).
+
+    Both auth dependencies fire before request-body validation, so a human
+    ``tenant_admin`` sending an empty body reaches Pydantic validation —
+    HTTP 422, never the human-only gate's 403. The full happy path (201)
+    is covered by :func:`test_full_lifecycle_round_trip`.
+    """
+    key = make_rsa_keypair("kid-human-admin")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        response = client.post("/api/v1/agent-principals", json={}, headers=headers)
+    assert response.status_code == 422, response.text

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -642,3 +642,128 @@ def test_show_returns_reviewer_context(client: TestClient) -> None:
     assert rc["subject"] == "web-01 (vm-1042)"
     # Secret hygiene: the secret param never rides the view anywhere.
     assert "hunter2" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# meho-internal#289 — the approval DECISION verbs are human-only on every
+# transport. An agent principal is minted ``tenant_admin`` with the REST
+# audience, so it clears ``require_approvals_access``; the human-only guard
+# must still refuse it (approve / reject / decide), while a human operator
+# passes and the read routes stay open to a service principal (the
+# meho-automation approval bridge lists the queue with a service token).
+# ---------------------------------------------------------------------------
+
+# RUNNER is refused earlier on the wire (401 missing_runner_id, and the
+# runner path-cage in middleware) so it never reaches this guard over REST;
+# the RUNNER kind is covered at the service layer in test_approval_queue.py.
+_MACHINE_KINDS: tuple[str, ...] = ("agent", "service")
+
+_DECISION_ENDPOINTS: tuple[tuple[str, str, dict[str, Any]], ...] = (
+    ("POST", f"/api/v1/approvals/{_APPROVAL_ID_APPROVE}/approve", {"params": {}}),
+    ("POST", f"/api/v1/approvals/{_APPROVAL_ID_REJECT}/reject", {"reason": ""}),
+    ("POST", f"/api/v1/approvals/{_APPROVAL_ID_DECIDE}/decide", {"decision": "approved"}),
+)
+
+
+def _machine_admin_token(key: Any, *, kind: str, sub: str = "machine-admin") -> str:
+    """Mint a machine principal at ``tenant_admin`` — how agents are minted (#289)."""
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        tenant_id=str(_TENANT_A),
+        principal_kind=kind,
+    )
+
+
+@pytest.mark.parametrize("kind", _MACHINE_KINDS)
+@pytest.mark.parametrize("method, path, body", _DECISION_ENDPOINTS)
+def test_machine_principal_denied_on_decision_routes(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any],
+    kind: str,
+) -> None:
+    """A machine ``tenant_admin`` token → 403 ``human_principal_required``.
+
+    The realistic exploit token: an agent/service/runner minted
+    ``tenant_admin`` (so it clears ``require_approvals_access``). The
+    transport-independent human-principal guard refuses it on every
+    decision verb, with a remediation naming the human path.
+    """
+    key = make_rsa_keypair(f"kid-machine-{kind}")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_machine_admin_token(key, kind=kind)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"].startswith("human_principal_required"), response.text
+
+
+@pytest.mark.parametrize("method, path, body", _DECISION_ENDPOINTS)
+def test_human_admin_passes_kind_gate_on_decision_routes(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """A human ``tenant_admin`` clears the kind gate — reaches the 404 path.
+
+    Proves the guard admits humans: a machine token 403s at the gate, a
+    human token gets past it to the deeper not-found handler (the request
+    id does not exist), so the response is 404, not the gate's 403.
+    """
+    key = make_rsa_keypair("kid-human-admin")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.TENANT_ADMIN)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "approval_request_not_found"}
+
+
+@pytest.mark.parametrize("method, path, body", _DECISION_ENDPOINTS)
+def test_human_approver_passes_kind_gate_on_decision_routes(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """A human ``read_only`` + ``approver`` also clears the kind gate (#3243 preserved).
+
+    The approver capability model is unchanged for **human** principals:
+    a dedicated human approver reaches the deeper not-found handler (404),
+    never the human-only gate's 403.
+    """
+    key = make_rsa_keypair("kid-human-approver")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_approve_only_token(key)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "approval_request_not_found"}
+
+
+@pytest.mark.asyncio
+async def test_service_principal_can_still_list_approvals() -> None:
+    """The read plane stays open to a service token (meho-automation bridge, #289).
+
+    ``list`` is gated by ``require_approvals_access`` alone (no human-kind
+    gate), so a service principal at ``tenant_admin`` still reads the queue —
+    the approval-bridge use case the ticket calls out. 200 + the empty
+    tenant queue.
+    """
+    key = make_rsa_keypair("kid-service-list")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="https://testserver",
+        ) as ac:
+            response = await ac.get(
+                "/api/v1/approvals",
+                headers={"Authorization": f"Bearer {_machine_admin_token(key, kind='service')}"},
+            )
+    assert response.status_code == 200, response.text
+    assert response.json() == []

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -54,9 +54,11 @@ from meho_backplane.operations._validate import compute_params_hash
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    NonHumanApprovalError,
     ParamsMismatchError,
     SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
+    _check_reviewer_role,
     approve_request,
     create_pending_request,
     expire_stale_requests,
@@ -155,13 +157,16 @@ def _make_operator(
     sub: str = "reviewer-sub",
     role: TenantRole = TenantRole.OPERATOR,
     tenant_id: uuid.UUID = _TENANT_ID,
-    principal_kind: PrincipalKind = PrincipalKind.AGENT,
+    principal_kind: PrincipalKind = PrincipalKind.USER,
     approver: bool = False,
 ) -> Operator:
-    # Defaults to an AGENT principal: the approval queue only fires for
-    # agent principals (the G11.2-T3 gate hard-denies requires_approval
-    # for human/service principals). Service-level tests that call the
-    # approval API directly are unaffected by the kind. ``approver`` carries
+    # Defaults to a USER (human) principal: deciding a parked op — approve /
+    # reject / decide / expire — is a human-only action on every transport
+    # (v0.1-spec §7, meho-internal#289), so ``_check_reviewer_role`` now
+    # refuses a machine ``principal_kind`` (agent / service / runner). These
+    # service-level tests exercise the reviewer path, so the default reviewer
+    # must be human; a test modelling an agent *parker* passes
+    # ``principal_kind=PrincipalKind.AGENT`` explicitly. ``approver`` carries
     # the orthogonal approve-only capability (#3243) so a ``read_only``
     # reviewer can still decide.
     return Operator(
@@ -998,6 +1003,41 @@ async def test_read_only_operator_cannot_reject(session: AsyncSession) -> None:
     async with get_sessionmaker()() as s2:
         with pytest.raises(UnauthorizedApprovalError):
             await reject_request(s2, pending.id, operator=read_only_op)
+
+
+# ---------------------------------------------------------------------------
+# Human-only decision gate — machine principals cannot decide (#289)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", [PrincipalKind.AGENT, PrincipalKind.SERVICE, PrincipalKind.RUNNER])
+def test_check_reviewer_role_rejects_non_human_principal(kind: PrincipalKind) -> None:
+    """A machine principal is refused by the service-layer reviewer gate (#289).
+
+    Deciding a parked op is a human action (v0.1-spec §7). A machine
+    principal — even one minted ``tenant_admin`` — is refused with
+    :class:`NonHumanApprovalError` (a :class:`UnauthorizedApprovalError`
+    subclass, so the routes still map it to 403). This is the transport-
+    independent backstop behind the REST ``require_human_principal``
+    dependency; the check keys on ``principal_kind``, not role or the
+    ``approver`` capability.
+    """
+    machine = _make_operator(sub="machine-admin", role=TenantRole.TENANT_ADMIN, principal_kind=kind)
+    with pytest.raises(NonHumanApprovalError) as excinfo:
+        _check_reviewer_role(machine)
+    assert excinfo.value.principal_kind == kind.value
+    assert isinstance(excinfo.value, UnauthorizedApprovalError)
+
+
+def test_check_reviewer_role_admits_human_operator() -> None:
+    """A human operator (and a human read_only + approver) still passes (#289).
+
+    The kind gate removes only machine principals; every human decision
+    path is untouched — the ``operator`` role and the orthogonal
+    ``approver`` capability (#3243) both clear the gate.
+    """
+    _check_reviewer_role(_make_operator(role=TenantRole.OPERATOR))
+    _check_reviewer_role(_make_operator(role=TenantRole.READ_ONLY, approver=True))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Make the human-only governance verbs enforce their policy independent of
transport. The approval decision routes — `POST /api/v1/approvals/{id}/approve`,
`/reject`, `/decide` — and the grant `create` / `elevate` and agent-principal
`register` routes now reject a non-human `principal_kind` (agent / service /
runner), returning `403` with a remediation naming the operator console / CLI
human path.

## Why

The decision was previously enforced on only one transport; this moves it into
a single shared guard consulted by every transport, so the same policy holds
regardless of how a request arrives. Approval is a human decision (v0.1-spec §7).

## How

- Single kind-policy datum: `auth.operator.is_human_principal` /
  `MACHINE_PRINCIPAL_KINDS`.
- REST: `auth.rbac.ensure_human_principal` + the `require_human_principal`
  dependency, attached to the five routes above.
- Service layer: `approval_queue._check_reviewer_role` refuses non-human kinds
  via the new `NonHumanApprovalError` (a `UnauthorizedApprovalError` subclass,
  so routes still map it to 403) — a backstop behind the REST dependency.
- `mcp/human_only.py` documents the two layers as one policy.
- Read / list / show on the approvals plane are unchanged, so a service
  principal (the approval bridge) still lists the queue. The approver
  capability model (#3243) and the seniority self-approval rules are preserved
  for human principals.

## Tests

- Machine-kind tokens get `403` on all five routes; a human `tenant_admin` /
  `approver` still passes.
- `_check_reviewer_role` rejects agent / service / runner and admits humans.
- Added to `tests/test_api_v1_approvals.py`, `tests/test_api_v1_agent_grants.py`,
  `tests/test_api_v1_agent_principals.py`, `tests/test_approval_queue.py`.
- `ruff check` / `ruff format --check` clean; no OpenAPI snapshot drift.

Ref: evoila-bosnia/meho-internal#289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
