### PR TITLE
fix(operations): narrow RFC6570 reserved-expansion safe set + reject dot-segments (S04)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
@@ -64,6 +64,7 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vcf_logs.session import VcfLogsTargetLike
+from meho_backplane.operations._rfc6570 import has_dot_segment
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
@@ -88,11 +89,15 @@ _EVENTS_PATH_PREFIX = "/api/v2/events/"
 
 # RFC6570 §3.2.3 reserved-expansion safe-set — the gen-delims + sub-delims
 # that stay literal so vRLI's slash-delimited constraint chain reaches the
-# appliance intact. Mirrors the ingested dispatcher's ``_RFC6570_RESERVED_SAFE``
-# (``meho_backplane.operations._branches``); the shared behaviour is pinned by
-# ``test_event_query_path_keeps_reserved_constraint_slashes_literal`` so the
-# typed path and the ingested ``{+constraints}`` path cannot drift (#2003).
-_CONSTRAINTS_RESERVED_SAFE = ":/?#[]@!$&'()*+,;="
+# appliance intact. ``?`` and ``#`` are excluded (a constraint sub-path never
+# needs them, and leaving them literal would let an agent-supplied constraint
+# open a query string / fragment and address a resource the op's audit gate
+# never authorised, #S04); they encode to ``%3F`` / ``%23`` instead. Mirrors
+# the ingested dispatcher's ``_RFC6570_RESERVED_SAFE``
+# (``meho_backplane.operations._branches``) byte-for-byte; the shared behaviour
+# is pinned by ``test_event_query_path_keeps_reserved_constraint_slashes_literal``
+# so the typed path and the ingested ``{+constraints}`` path cannot drift (#2003).
+_CONSTRAINTS_RESERVED_SAFE = ":/[]@!$&'()*+,;="
 
 # vRLI caps an unbounded events query at the appliance default; the op exposes
 # ``limit`` so the agent can bound the pull explicitly (the adopter's incident
@@ -142,7 +147,21 @@ def build_event_query_path(constraints: str) -> str:
     literal on the wire while spaces / control chars still encode — identical to
     how the ingested dispatcher renders a ``{+constraints}`` template (#2003 /
     #2066).
+
+    A ``..`` path-traversal dot-segment in the chain is rejected with
+    :class:`ValueError` before encoding (#S04): the literal slashes that let a
+    genuine constraint chain through are the same slashes a ``..`` would use to
+    climb out of ``/api/v2/events/`` and address a different appliance
+    resource than the read-only op the audit gate authorised. ``?`` / ``#`` can
+    no longer open a query string / fragment either — they are outside the
+    safe-set and encode.
     """
+    if has_dot_segment(constraints):
+        raise ValueError(
+            "vrli.event.query: 'constraints' may not contain a '..' path-traversal "
+            "segment; compose the chain from field/OP value pairs without "
+            "parent-directory references"
+        )
     return _EVENTS_PATH_PREFIX + quote(constraints, safe=_CONSTRAINTS_RESERVED_SAFE)
 
 

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -47,7 +47,7 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.base import Connector
 from meho_backplane.db.models import EndpointDescriptor
 from meho_backplane.flight_recorder import typed as flight_recorder_typed
-from meho_backplane.operations._rfc6570 import RFC6570_PATH_OPERATORS
+from meho_backplane.operations._rfc6570 import RFC6570_PATH_OPERATORS, has_dot_segment
 
 __all__ = [
     "IngestedRequest",
@@ -91,7 +91,16 @@ _PATH_VAR_RE = re.compile(rf"\{{([{re.escape(RFC6570_PATH_OPERATORS)}]?)([^{{}}]
 # unencoded so they keep their structural meaning in the URL. Genuinely
 # unsafe characters (space, control chars) are still percent-encoded by
 # :func:`urllib.parse.quote` because they are absent from this set.
-_RFC6570_RESERVED_SAFE = ":/?#[]@!$&'()*+,;="
+#
+# ``?`` and ``#`` are deliberately excluded (they are gen-delims RFC6570 would
+# otherwise pass through): a *path*-segment value never needs them, and leaving
+# them literal would let a caller-supplied path param open a query string
+# (``?``) or fragment (``#``) and address a different resource than the op the
+# governance/audit gate authorised. Encoding them (``%3F`` / ``%23``) keeps the
+# value confined to the path. The mirrored typed set
+# ``vcf_logs.typed_ops._CONSTRAINTS_RESERVED_SAFE`` stays byte-for-byte
+# identical (pinned by ``test_event_query_path_keeps_reserved_constraint_slashes_literal``).
+_RFC6570_RESERVED_SAFE = ":/[]@!$&'()*+,;="
 
 
 def _split_ingested_params(
@@ -180,20 +189,34 @@ def _substitute_path(path_template: str, path_params: dict[str, Any]) -> str:
 
     In both forms a genuinely-unsafe character (space, control chars) is
     still percent-encoded -- only the reserved structural chars differ.
+    ``?`` and ``#`` are never in the reserved safe set (see
+    :data:`_RFC6570_RESERVED_SAFE`), so a value can never open a query string
+    or fragment; and before either form encodes the value, a ``..`` traversal
+    dot-segment (:func:`~meho_backplane.operations._rfc6570.has_dot_segment`)
+    is rejected -- so the resolved wire path can never address a resource
+    outside the op's declared template, which is what the governance/audit
+    gate authorised on ``descriptor.op_id`` (#S04).
 
-    Missing path vars raise :class:`KeyError` so the dispatcher's caller
-    surfaces them as ``invalid_params`` rather than producing a request
-    with a literal ``{var}`` in the URL. The lookup is keyed on the bare
-    variable name (operator stripped), so ``{+constraints}`` resolves the
-    param named ``constraints``.
+    Missing path vars raise :class:`KeyError`, and a ``..`` dot-segment value
+    raises :class:`ValueError`, so the dispatcher's caller surfaces both as a
+    caller-side ``invalid_params`` fault rather than producing a request with
+    a literal ``{var}`` -- or a traversed path -- in the URL. The lookup is
+    keyed on the bare variable name (operator stripped), so ``{+constraints}``
+    resolves the param named ``constraints``.
     """
 
     def _replace(match: re.Match[str]) -> str:
         operator, name = match.group(1), match.group(2)
         if name not in path_params:
             raise KeyError(f"path template requires {name!r} but it was not supplied")
+        value = str(path_params[name])
+        if has_dot_segment(value):
+            raise ValueError(
+                f"path parameter {name!r} may not contain a '..' path-traversal "
+                "segment; supply a value without parent-directory references"
+            )
         safe = _RFC6570_RESERVED_SAFE if operator in ("+", "#") else ""
-        return quote(str(path_params[name]), safe=safe)
+        return quote(value, safe=safe)
 
     return _PATH_VAR_RE.sub(_replace, path_template)
 
@@ -256,10 +279,11 @@ async def resolve_ingested_request(
     real request: the path substitution, the ``mount_op_path`` prefix
     application, the requestBody unwrap (#1656) all run identically.
 
-    Raises the same :class:`RuntimeError` (missing method/path) and
-    :class:`KeyError` (unsubstituted path var) the dispatch path raised
-    inline, so both the execute and the preview surface them through the
-    dispatcher's structured-error mapping unchanged.
+    Raises the same :class:`RuntimeError` (missing method/path),
+    :class:`KeyError` (unsubstituted path var) and :class:`ValueError` (a
+    ``..`` path-traversal dot-segment in a path value, #S04) the dispatch
+    path raised inline, so both the execute and the preview surface them
+    through the dispatcher's structured-error mapping unchanged.
     """
     method = (descriptor.method or "").upper()
     path_template = descriptor.path or ""

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -393,11 +393,12 @@ async def _build_ingested_preview(
     # ``dispatch_ingested`` sends through -- no drift.
     #
     # ``resolve_ingested_request`` deliberately *raises* on a path-template
-    # fault (``KeyError`` for an unsubstituted path var, ``RuntimeError`` for
-    # a descriptor missing its method/path) because the execute path relies on
+    # fault (``KeyError`` for an unsubstituted path var, ``ValueError`` for a
+    # ``..`` path-traversal dot-segment value (#S04), ``RuntimeError`` for a
+    # descriptor missing its method/path) because the execute path relies on
     # the dispatcher's structured-error mapping (``dispatcher`` generic
     # ``except``) to convert them. The preview path has no such wrapper, so we
-    # catch those two -- and only those two -- here and map them to the same
+    # catch those three -- and only those -- here and map them to the same
     # structured ``error`` envelope every other preview fault returns, honouring
     # this module's documented never-raises contract (#2066). ``resolve_*``
     # itself is left untouched so the execute-path contract is unchanged.
@@ -409,7 +410,7 @@ async def _build_ingested_preview(
             target=target,
             params=params,
         )
-    except (KeyError, RuntimeError) as exc:
+    except (KeyError, ValueError, RuntimeError) as exc:
         return {
             "status": "error",
             "op_id": op_id,
@@ -418,7 +419,8 @@ async def _build_ingested_preview(
             "error": (
                 f"dispatch_error: the operation's request could not be resolved "
                 f"({exc}). This usually means a required path parameter was not "
-                "supplied or the descriptor is missing its method/path."
+                "supplied, a path value carried a '..' traversal segment, or the "
+                "descriptor is missing its method/path."
             ),
             "extras": {
                 "error_code": "dispatch_error",

--- a/backend/src/meho_backplane/operations/_rfc6570.py
+++ b/backend/src/meho_backplane/operations/_rfc6570.py
@@ -38,8 +38,11 @@ never mistaken for part of the variable name.
 
 from __future__ import annotations
 
+from urllib.parse import unquote
+
 __all__ = [
     "RFC6570_PATH_OPERATORS",
+    "has_dot_segment",
     "split_path_operator",
 ]
 
@@ -80,3 +83,39 @@ def split_path_operator(name: str) -> tuple[str, str]:
     if len(name) >= 2 and name[0] in RFC6570_PATH_OPERATORS:
         return name[0], name[1:]
     return "", name
+
+
+def has_dot_segment(value: str) -> bool:
+    """Return ``True`` if *value* carries a ``..`` parent-directory dot-segment.
+
+    A shared guard for the two RFC6570 reserved-expansion renderers -- the
+    ingested ``_substitute_path`` and the typed vRLI ``build_event_query_path``
+    -- which keep ``/`` literal so structural slashes reach the appliance
+    intact. That literal ``/`` is also the opening for a caller-supplied value
+    to inject extra path segments, so before either renderer percent-encodes
+    the value it rejects a ``..`` traversal segment. Living beside
+    :data:`RFC6570_PATH_OPERATORS` in this stdlib-only leaf keeps both renderers
+    on one definition -- the same anti-drift stance the operator set already
+    takes (#2003 / #2066).
+
+    One layer of percent-decoding is applied before the split so an already
+    percent-encoded ``%2e%2e`` is caught, not only a literal ``..``. The value
+    is then split on ``/`` and each segment tested for an exact ``..`` -- the
+    RFC3986 §3.3 dot-segment. A ``..`` embedded in a larger segment (``a..b``,
+    ``CONTAINS ..``) is data, not a segment, and is left alone; only a
+    standalone ``..`` segment is a traversal, whether it sits at the start
+    (``../x``), interior (``x/../y``), end (``x/..``), or is the whole value
+    (``..``).
+
+    >>> has_dot_segment("text/CONTAINS error/hostname/CONTAINS vcsa")
+    False
+    >>> has_dot_segment("../../etc/passwd")
+    True
+    >>> has_dot_segment("a/../b")
+    True
+    >>> has_dot_segment("%2e%2e/x")
+    True
+    >>> has_dot_segment("a..b")
+    False
+    """
+    return any(segment == ".." for segment in unquote(value).split("/"))

--- a/backend/tests/test_connectors_vcf_logs_typed_event_query.py
+++ b/backend/tests/test_connectors_vcf_logs_typed_event_query.py
@@ -52,6 +52,7 @@ from meho_backplane.connectors.vcf_logs import (
     VcfLogsConnector,
 )
 from meho_backplane.connectors.vcf_logs.typed_ops import (
+    _CONSTRAINTS_RESERVED_SAFE,
     VRLI_EVENT_QUERY_OP,
     build_event_query_path,
     event_query_impl,
@@ -59,6 +60,7 @@ from meho_backplane.connectors.vcf_logs.typed_ops import (
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, Target
 from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._branches import _RFC6570_RESERVED_SAFE
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.meta_tools import call_operation
 from tests.acceptance._vrli_canary_fixtures import (
@@ -137,12 +139,57 @@ def test_build_event_query_path_empty_constraint_is_the_base_events_path() -> No
 
 
 def test_build_event_query_path_keeps_reserved_constraint_slashes_literal() -> None:
-    """A reserved constraint chain keeps ``/`` literal, encodes spaces (#2003)."""
+    """A reserved constraint chain keeps ``/`` literal, encodes spaces (#2003).
+
+    Also pins the #S04 hardening: neither the typed constraint safe-set nor the
+    ingested dispatcher's mirror carries ``?`` / ``#`` (a path value can never
+    open a query string or fragment), and the two sets stay byte-for-byte
+    identical so the typed and ingested reserved-expansion paths cannot drift.
+    """
     path = build_event_query_path(VRLI_RESERVED_CONSTRAINT_VALUE)
     assert path == VRLI_RESERVED_CONSTRAINT_WIRE_PATH
     # Structural slashes survived; only the space was percent-encoded.
     assert "%2F" not in path
     assert "%20" in path
+    # #S04: query / fragment delimiters are out of both safe sets, which stay
+    # identical (drift-pinned).
+    assert "?" not in _CONSTRAINTS_RESERVED_SAFE
+    assert "#" not in _CONSTRAINTS_RESERVED_SAFE
+    assert "?" not in _RFC6570_RESERVED_SAFE
+    assert "#" not in _RFC6570_RESERVED_SAFE
+    assert _CONSTRAINTS_RESERVED_SAFE == _RFC6570_RESERVED_SAFE
+
+
+def test_build_event_query_path_encodes_query_and_fragment_delimiters() -> None:
+    """``?`` / ``#`` in a constraint chain percent-encode, never open a query/fragment (#S04)."""
+    assert build_event_query_path("a?b") == "/api/v2/events/a%3Fb"
+    assert build_event_query_path("a#b") == "/api/v2/events/a%23b"
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        "..",  # bare
+        "../etc/passwd",  # leading
+        "text/CONTAINS x/../secrets",  # interior
+        "text/CONTAINS x/..",  # trailing
+        "%2e%2e/x",  # already percent-encoded
+    ],
+)
+def test_build_event_query_path_rejects_dot_segment(constraints: str) -> None:
+    """A ``..`` dot-segment in the constraint chain is rejected before encoding (#S04).
+
+    The literal slashes that carry a genuine constraint chain are the same
+    slashes a ``..`` would use to climb out of ``/api/v2/events/`` and address
+    another appliance resource than the read-only op the audit gate authorised.
+    """
+    with pytest.raises(ValueError, match="traversal"):
+        build_event_query_path(constraints)
+
+
+def test_build_event_query_path_allows_dots_inside_a_segment() -> None:
+    """A ``..`` embedded in a larger segment is data, not a dot-segment (#S04)."""
+    assert build_event_query_path("text/CONTAINS ..") == "/api/v2/events/text/CONTAINS%20.."
 
 
 @pytest.mark.asyncio
@@ -202,6 +249,19 @@ async def test_event_query_impl_rejects_non_string_constraints() -> None:
 
     with pytest.raises(ValueError, match="constraints"):
         await event_query_impl(conn, _make_operator(), _Target(), {"constraints": ["not", "str"]})
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_rejects_dot_segment_constraints() -> None:
+    """A ``..`` traversal constraint never reaches the connector session (#S04)."""
+    conn = _FakeConnector({"events": []})
+
+    with pytest.raises(ValueError, match="traversal"):
+        await event_query_impl(
+            conn, _make_operator(), _Target(), {"constraints": "../../etc/passwd"}
+        )
+    # No request was issued — the value was rejected before the session call.
+    assert conn.calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_branches_substitute_path.py
+++ b/backend/tests/test_operations_branches_substitute_path.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import pytest
 
-from meho_backplane.operations._branches import _substitute_path
+from meho_backplane.operations._branches import _RFC6570_RESERVED_SAFE, _substitute_path
 
 
 def test_simple_expansion_encodes_reserved_slash() -> None:
@@ -78,3 +78,54 @@ def test_missing_param_still_raises_keyerror() -> None:
         _substitute_path("/v1/{+path}", {})
     with pytest.raises(KeyError):
         _substitute_path("/v1/{cluster}", {})
+
+
+# --- S04: reserved-expansion path-escape hardening -------------------------
+
+
+def test_reserved_safe_set_excludes_query_and_fragment_delimiters() -> None:
+    """``?`` / ``#`` are never in the reserved safe set (#S04).
+
+    Leaving them literal would let a caller-supplied ``{+var}`` value open a
+    query string or fragment and address a resource the op's audit gate never
+    authorised (which keys on ``descriptor.op_id``, not the resolved path).
+    """
+    assert "?" not in _RFC6570_RESERVED_SAFE
+    assert "#" not in _RFC6570_RESERVED_SAFE
+
+
+def test_reserved_expansion_encodes_query_and_fragment_delimiters() -> None:
+    """A ``?`` / ``#`` in a ``{+var}`` value is percent-encoded, not passed through."""
+    assert _substitute_path("/v1/{+p}", {"p": "a?b"}) == "/v1/a%3Fb"
+    assert _substitute_path("/v1/{+p}", {"p": "a#b"}) == "/v1/a%23b"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "..",  # bare
+        "../etc/passwd",  # leading
+        "a/../b",  # interior
+        "a/..",  # trailing
+        "../../etc/passwd",  # multi-level
+        "%2e%2e/x",  # already percent-encoded
+    ],
+)
+def test_dot_segment_value_is_rejected_before_substitution(value: str) -> None:
+    """A ``..`` dot-segment value raises ``ValueError`` before it reaches the wire.
+
+    Rejected in **both** expansion forms — a traversal segment is never a
+    legitimate path value, and reserved expansion keeps ``/`` literal so a
+    ``..`` there would climb out of the op's declared path (#S04). The
+    dispatcher surfaces the raise as a caller-side ``invalid_params`` fault.
+    """
+    with pytest.raises(ValueError, match="traversal"):
+        _substitute_path("/v1/{+p}", {"p": value})
+    with pytest.raises(ValueError, match="traversal"):
+        _substitute_path("/v1/{p}", {"p": value})
+
+
+def test_dot_in_a_larger_segment_is_data_not_a_dot_segment() -> None:
+    """``..`` embedded in a larger segment is data and passes through unchanged."""
+    assert _substitute_path("/v1/{+p}", {"p": "a..b"}) == "/v1/a..b"
+    assert _substitute_path("/v1/{+p}", {"p": "text/CONTAINS .."}) == "/v1/text/CONTAINS%20.."

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -88,7 +88,12 @@ typed and profiled paths is proven in
   lifespan through the typed-op registrar (queued in the package
   `__init__`), so it dispatches with **zero catalog ingest** — no
   `endpoint_descriptor` ingested row. `build_event_query_path` renders the
-  reserved-expansion constraint sub-path with literal slashes (#2003/#2066).
+  reserved-expansion constraint sub-path with literal slashes (#2003/#2066),
+  and rejects a `..` traversal dot-segment (shared
+  `operations/_rfc6570.has_dot_segment`) before encoding — the literal slashes
+  that carry a genuine chain are also what a `..` would use to climb out of
+  `/api/v2/events/`; `?`/`#` are outside the safe set so a constraint can never
+  open a query string or fragment (#S04).
   Mirrors `vmware_rest/typed_ops.py` (`vmware.host.usage`, #2257) and
   `argocd/ops.py`.
 - **Re-exports of the shared module**: `VcfCredentialsLoader`,

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -154,16 +154,25 @@ JSON value at runtime (`_TargetArg` in `operations/meta_tools.py`), so no
 target-failure mode returns a 4xx.
 
 The shared resolver `resolve_ingested_request` deliberately *raises* on a
-path-template fault — `KeyError` for an unsubstituted path var, `RuntimeError`
+path-template fault — `KeyError` for an unsubstituted path var, `ValueError`
+for a path value carrying a `..` traversal dot-segment (#S04), `RuntimeError`
 for a descriptor missing its method/path — because the **execute** path relies
 on the dispatcher's generic `except` to convert them to a structured
 `connector_error`. The preview path has no such wrapper, so
-`_build_ingested_preview` catches exactly those two and maps them to a
-`dispatch_error` envelope (#2066). Before that wrap they escaped uncaught and
-surfaced as MCP `-32603` / HTTP 500 — violating the never-raises contract this
-table documents. `resolve_ingested_request` itself is unchanged (the
+`_build_ingested_preview` catches exactly those three and maps them to a
+`dispatch_error` envelope (#2066 / #S04). Before that wrap they escaped uncaught
+and surfaced as MCP `-32603` / HTTP 500 — violating the never-raises contract
+this table documents. `resolve_ingested_request` itself is unchanged (the
 execute-path contract must keep raising), so the two surfaces stay aligned via
 their respective wrappers, not a shared swallow.
+
+The `ValueError` arm closes an in-path escape: reserved expansion (`{+var}` /
+`{#var}`) keeps `/` literal, so a caller-supplied path value could otherwise
+carry extra segments or a `..` dot-segment and address a different resource
+than the op the governance/audit gate authorised (the gate keys on
+`descriptor.op_id`, never the resolved wire path). `_substitute_path` rejects a
+`..` dot-segment before encoding and the reserved safe set no longer carries
+`?` / `#`, so a value can never open a query string or fragment either.
 
 ## Redaction
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -484,7 +484,13 @@ stripping the operator from the template. `descriptor.path` keeps the operator
 verbatim — the renderer needs it to pick reserved expansion. The operator set
 both stages strip is shared via `operations/_rfc6570.RFC6570_PATH_OPERATORS`,
 so the property key and the lookup key can never drift (the keying-vs-rendering
-mismatch that made these ops undispatchable at v0.19.0). A spec declaring both
+mismatch that made these ops undispatchable at v0.19.0). Reserved expansion
+keeps `/` literal by design, so `_substitute_path` hardens the value before it
+renders (#S04): the reserved safe set excludes `?` / `#` (a path value can
+never open a query string or fragment) and a `..` traversal dot-segment
+(`operations/_rfc6570.has_dot_segment` — the same shared leaf) is rejected with
+`ValueError` before encoding, so the resolved wire path can never leave the op's
+declared template that the audit gate authorised. A spec declaring both
 `path` and `+path` as **path** parameters collapses onto the same bare key and
 raises `InvalidSchemaError` rather than silently dropping one. The collision
 guard is scoped to path-vs-path only: a name shared *across different* `in`


### PR DESCRIPTION
## Summary

- Security S04: narrow the RFC6570 reserved-expansion safe set and reject `..` dot-segments so an agent-supplied path value can never escape the governed op path (open a query string / fragment, or traverse to another resource than the op the audit gate authorised — the gate keys on `descriptor.op_id`, never the resolved wire path).
- Drop `?` and `#` from both mirrored safe sets — `_RFC6570_RESERVED_SAFE` (`operations/_branches.py`, the ingested `{+var}`/`{#var}` resolver) and `_CONSTRAINTS_RESERVED_SAFE` (`connectors/vcf_logs/typed_ops.py`, the vRLI `event.query` constraint chain). They now percent-encode (`%3F` / `%23`); the two sets stay byte-for-byte identical.
- Reject a `..` traversal dot-segment before substitution via a new stdlib-only shared helper `operations/_rfc6570.has_dot_segment` (the same anti-drift leaf that already shares `RFC6570_PATH_OPERATORS`), used by both renderers. It decodes one layer of percent-encoding (so `%2e%2e` is caught too), splits on `/`, and flags only a standalone `..` segment — leading (`../x`), interior (`x/../y`), trailing (`x/..`), or bare (`..`); a `..` embedded in a larger segment (`a..b`, `CONTAINS ..`) is data and passes through. Genuine slash-delimited vRLI constraint chains still reach the appliance with literal slashes intact.
- Extend the request-preview resolver's never-raises wrapper to catch the new `ValueError` (`operations/_request_preview.py`), mapping a traversal value to the same `dispatch_error` envelope it already returns for the resolver's `KeyError` / `RuntimeError` faults.

## Drift check vs origin/main

Re-checked `origin/main` (`a5af5209`) before coding: both safe sets still carried `?`/`#` and neither renderer had any dot-segment guard. **None** of the acceptance criteria were already met on main — this PR implements all of them. (Containment PRs #3423/#3427 addressed other findings and did not touch this resolver.)

## Test plan

- [x] `ruff check` — clean on all changed files
- [x] `ruff format --check` — clean (6 files already formatted)
- [x] `mypy src/meho_backplane/operations/_branches.py connectors/vcf_logs/typed_ops.py _rfc6570.py _request_preview.py` — Success, no issues
- [x] `pytest tests/test_operations_branches_substitute_path.py tests/test_operations_rfc6570.py tests/test_connectors_vcf_logs_typed_event_query.py -q` — 68 passed
- [x] Affected cluster (+ spec-reconcile, request-preview, preview) — 103 passed, 1 skipped
- [x] Full backend unit lane — see CI

### Acceptance criteria

- [x] Neither safe set contains `?`/`#`: `grep -nE 'RESERVED_SAFE = ' backend/src/meho_backplane/operations/_branches.py backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py` → both now `":/[]@!$&'()*+,;="`.
- [x] A value containing `..` (leading/interior/trailing/bare, and percent-encoded `%2e%2e`) is rejected as an `invalid_params`-class fault (`ValueError`) before substitution — new negative tests `test_dot_segment_value_is_rejected_before_substitution` (both expansion forms) and `test_build_event_query_path_rejects_dot_segment` + `test_event_query_impl_rejects_dot_segment_constraints` (no request issued).
- [x] Existing positive cases still pass (simple encodes `/`, reserved keeps `/` literal, spaces encode, empty constraint → base path).
- [x] `ruff check` and `mypy` clean on `_branches.py` and `vcf_logs/typed_ops.py`.
- [x] `test_event_query_path_keeps_reserved_constraint_slashes_literal` still passes and gained assertions that neither safe set contains `?`/`#` and that the two sets are identical.

### Docs

- `docs/codebase/dispatch-request-preview.md`, `spec-ingestion.md`, `connectors-vcf-logs.md` updated to describe the hardened resolver and the new `ValueError` preview arm.

## Out of scope

- The dormant G0.7 ingest pipeline shipping (no `source_kind='ingested'` rows exist today) — this hardens the shared resolver, not ingest.
- SSRF host/rebinding defense (#275/F13).
- Keying the audit row on the resolved wire path (the optional hardening bullet) — file separately if pursued.
- Empty-segment rejection was left out deliberately: an empty segment is not a traversal vector, and a blanket check would risk over-rejecting a legitimate empty path value in the general `_substitute_path`; the desired outcome names only `..` and query/fragment escape, both of which are closed.

Closes evoila-bosnia/meho-internal#292
