### PR TITLE
fix(audit): enforce audit_log append-only at the datastore (S18)

### DIFF
--- a/backend/alembic/versions/0023_create_approval_request.py
+++ b/backend/alembic/versions/0023_create_approval_request.py
@@ -225,7 +225,7 @@ def upgrade() -> None:
             "proposed_effect",
             proposed_effect_type,
             nullable=False,
-            server_default=sa.text("'{}'") if is_postgres else sa.text("'{}'"),
+            server_default=sa.text("'{}'"),
         ),
         # Lifecycle columns.
         sa.Column(

--- a/backend/alembic/versions/0100_audit_log_append_only_trigger.py
+++ b/backend/alembic/versions/0100_audit_log_append_only_trigger.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Enforce ``audit_log`` append-only at the datastore (security S18).
+
+Revision ID: 0100
+Revises: 0099
+Create Date: 2026-09-07
+
+CLAUDE.md postulate 7 (v0.1-spec section 6) makes the audit trail
+synchronous, append-only and tamper-evident -- the load-bearing property
+of the whole governance model. Until this migration that property was a
+**code convention only**: the write path is INSERT-only and no code path
+issues an ``UPDATE`` / ``DELETE`` against ``audit_log``, but nothing at the
+datastore stopped one. Anyone with write access to the Postgres instance
+(the app DB role, a DB operator, or in-process code execution) could
+silently rewrite or erase the audit row of the operation just performed --
+the free cover-up a compromise would otherwise inherit.
+
+Security review 2026-09-06 finding S18 (Task meho-internal#306 under
+Initiative #262). Defence-in-depth: an invariant the application depends on
+belongs at the datastore that owns the data, not scattered as convention.
+
+What this migration adds (PostgreSQL only)
+------------------------------------------
+
+* ``audit_log_reject_mutation()`` -- a ``plpgsql`` trigger function that
+  ``RAISE``s on any row it fires for. ``TG_OP`` names the rejected
+  operation in the error message.
+* ``audit_log_append_only`` -- a ``BEFORE UPDATE OR DELETE ... FOR EACH
+  ROW`` trigger that calls the function. ``INSERT`` and ``SELECT`` are
+  untouched, so the synchronous audit write path keeps working; a direct
+  ``UPDATE`` or ``DELETE`` fails at the datastore under **every** role,
+  including the app role and a DB superuser (a row-level trigger fires
+  regardless of privilege).
+
+Dialect guard
+-------------
+
+The enforcement is a production-datastore guarantee, so the DDL runs only
+on ``postgresql``. The SQLite dev/test lane (aiosqlite) cannot execute
+plpgsql trigger DDL, and the unit lanes assert the app-level convention
+rather than the datastore trigger; ``upgrade()`` / ``downgrade()`` are a
+clean no-op there. This keeps the SQLite ``alembic upgrade head`` smokes in
+``tests/test_db_models.py`` green.
+
+Out of scope (tracked separately under #262)
+--------------------------------------------
+
+* Retention / archival ``DELETE`` of aged rows. No retention job exists
+  today (a codebase grep finds only ``select(AuditLog)`` reads). When one
+  lands it drops whole **partitions** -- ``DROP TABLE`` on a partition and
+  ``TRUNCATE`` both bypass row-level triggers -- or runs under a dedicated
+  retention role, so this row-level trigger does not need a bypass hatch.
+* Cryptographic tamper-evidence (hash-chaining / signed rows) is a stronger
+  model than immutability and is not this change.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the trigger then the function (reverse of create
+order), Postgres only. Additive on PostgreSQL (a new trigger + function, no
+ALTER of an existing object); a no-op on SQLite.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0100"
+down_revision: str | None = "0099"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Install the append-only trigger + function on PostgreSQL."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION audit_log_reject_mutation()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            RAISE EXCEPTION
+                'audit_log is append-only: % is not permitted '
+                '(governance invariant, v0.1-spec section 6)', TG_OP;
+        END;
+        $$;
+        """
+    )
+    op.execute("DROP TRIGGER IF EXISTS audit_log_append_only ON audit_log")
+    op.execute(
+        """
+        CREATE TRIGGER audit_log_append_only
+        BEFORE UPDATE OR DELETE ON audit_log
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_log_reject_mutation();
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the trigger then the function (PostgreSQL only)."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.execute("DROP TRIGGER IF EXISTS audit_log_append_only ON audit_log")
+    op.execute("DROP FUNCTION IF EXISTS audit_log_reject_mutation()")

--- a/backend/tests/migrations/test_migration_rollback.py
+++ b/backend/tests/migrations/test_migration_rollback.py
@@ -72,6 +72,7 @@ import respx
 from alembic import command
 from fastapi.testclient import TestClient
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from meho_backplane.auth import vault as vault_module
@@ -807,3 +808,143 @@ def test_docker_skip_reason_explains_ci_path() -> None:
     """
     assert "CI" in _SKIP_REASON
     assert "Docker" in _SKIP_REASON
+
+
+# ---------------------------------------------------------------------------
+# Security S18 #306 — audit_log append-only trigger enforcement
+# ---------------------------------------------------------------------------
+
+
+async def _exercise_audit_log_append_only(async_url: str) -> dict[str, Any]:
+    """INSERT one audit row, then probe UPDATE / DELETE / SELECT.
+
+    Returns a structured result so the synchronous test body can assert
+    on each outcome by name. Each mutating statement runs in its own
+    transaction so a rejected ``UPDATE`` / ``DELETE`` (rolled back on the
+    trigger's ``RAISE``) does not poison the ``INSERT`` verification.
+
+    The trigger installed by migration ``0100`` fires ``BEFORE UPDATE OR
+    DELETE ... FOR EACH ROW`` and raises, so both mutations must surface a
+    :class:`sqlalchemy.exc.DBAPIError` (asyncpg ``RaiseError``, SQLSTATE
+    ``P0001``) while the ``INSERT`` and the read-back succeed.
+    """
+    engine = create_async_engine(async_url)
+    results: dict[str, Any] = {}
+    try:
+        # INSERT — the append path must still work. Only the four NOT NULL
+        # columns without a server default are supplied; id / occurred_at /
+        # payload take their PostgreSQL-side defaults.
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO audit_log (operator_sub, method, path, status_code) "
+                    "VALUES ('op-s18-trigger', 'GET', '/api/v1/health', 200)"
+                )
+            )
+
+        # UPDATE — must be rejected by the trigger.
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text("UPDATE audit_log SET status_code = 500"))
+            results["update_raised"] = False
+            results["update_error"] = ""
+        except DBAPIError as exc:
+            results["update_raised"] = True
+            results["update_error"] = str(exc.orig)
+
+        # DELETE — must be rejected by the trigger.
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text("DELETE FROM audit_log"))
+            results["delete_raised"] = False
+            results["delete_error"] = ""
+        except DBAPIError as exc:
+            results["delete_raised"] = True
+            results["delete_error"] = str(exc.orig)
+
+        # SELECT — the row survived both blocked mutations, unchanged.
+        async with engine.connect() as conn:
+            count = (await conn.execute(text("SELECT COUNT(*) FROM audit_log"))).scalar_one()
+            status = (
+                await conn.execute(
+                    text("SELECT status_code FROM audit_log ORDER BY occurred_at DESC LIMIT 1")
+                )
+            ).scalar_one()
+        results["row_count"] = count
+        results["status_code"] = status
+    finally:
+        await engine.dispose()
+    return results
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestAuditLogAppendOnlyTrigger:
+    """Migration ``0100`` makes ``audit_log`` UPDATE / DELETE fail at the datastore.
+
+    CLAUDE.md postulate 7 (v0.1-spec section 6) asserts the audit trail is
+    append-only and tamper-evident. Before #306 that was a code convention;
+    ``0100`` enforces it with a ``BEFORE UPDATE OR DELETE`` trigger so the
+    property survives a compromise of the app DB role. This class is the
+    Postgres-container proof of that enforcement; it mirrors the
+    testcontainers + ``alembic upgrade`` discipline of
+    :class:`TestForwardCompatRollback` and skips when Docker is absent (the
+    convention-level coverage runs everywhere; the trigger is Postgres-only).
+    """
+
+    def test_audit_log_update_delete_raises(
+        self,
+        env_overrides: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """After ``upgrade head``, raw UPDATE / DELETE raise; INSERT / SELECT succeed.
+
+        Synchronous for the same reason every ``alembic upgrade head``
+        driving test in this suite is: ``alembic.command.upgrade`` invokes
+        :func:`asyncio.run` internally via the env.py async cookbook, so a
+        :func:`pytest.mark.asyncio` decoration would crash on re-entry. The
+        raw-SQL probe is wrapped in its own ``asyncio.run`` boundary.
+        """
+        from testcontainers.postgres import PostgresContainer
+
+        image = os.environ.get("MEHO_TEST_PGVECTOR_IMAGE", "pgvector/pgvector:pg16")
+        with PostgresContainer(image) as pg:
+            sync_url = pg.get_connection_url()
+            async_url = _async_url_from(sync_url)
+
+            monkeypatch.setenv("DATABASE_URL", async_url)
+            get_settings.cache_clear()
+            reset_engine_for_testing()
+
+            cfg = alembic_config()
+            cfg.set_main_option("sqlalchemy.url", async_url)
+            command.upgrade(cfg, "head")
+
+            state = asyncio.run(_exercise_audit_log_append_only(async_url))
+
+            assert state["update_raised"], (
+                "UPDATE audit_log must be rejected by the append-only trigger; "
+                "it succeeded, so the tamper-evidence invariant is not enforced"
+            )
+            assert "append-only" in state["update_error"], (
+                "the trigger's RAISE message must explain the append-only rule; "
+                f"got {state['update_error']!r}"
+            )
+            assert state["delete_raised"], (
+                "DELETE FROM audit_log must be rejected by the append-only trigger; "
+                "it succeeded, so an attacker could erase the trail"
+            )
+            assert "append-only" in state["delete_error"], (
+                "the trigger's RAISE message must explain the append-only rule; "
+                f"got {state['delete_error']!r}"
+            )
+            assert state["row_count"] == 1, (
+                "the INSERT must succeed and the blocked UPDATE/DELETE must leave "
+                f"the single row intact; saw {state['row_count']} rows"
+            )
+            assert state["status_code"] == 200, (
+                "the blocked UPDATE must not have taken effect; "
+                f"status_code is {state['status_code']}, expected the inserted 200"
+            )
+
+            asyncio.run(dispose_engine())
+            reset_engine_for_testing()

--- a/docs/codebase/migrations.md
+++ b/docs/codebase/migrations.md
@@ -148,6 +148,35 @@ Migrations that INSERT, UPDATE, or DELETE rows. Rules:
    delete: the skipped row stays in its pre-migration state, and destructive
    cleanup remains operator-driven.
 
+### Constraint enforcement via triggers (Postgres-only)
+
+Some invariants belong at the datastore, not in application code — the load-bearing
+example is `audit_log` being **append-only** (CLAUDE.md postulate 7 / v0.1-spec
+section 6). Migration `0100` installs a `BEFORE UPDATE OR DELETE ... FOR EACH ROW`
+trigger that `RAISE`s, so a direct `UPDATE` / `DELETE` fails at the datastore under
+every role — including the app DB role and a superuser — while `INSERT` / `SELECT`
+stay untouched. Rules for this kind of migration:
+
+1. **Postgres-only, dialect-guarded.** plpgsql trigger DDL is not portable to the
+   SQLite dev/test lane. Guard the body with an early return so `upgrade()` and
+   `downgrade()` are a clean no-op off PostgreSQL:
+
+   ```python
+   bind = op.get_bind()
+   if bind.dialect.name != "postgresql":
+       return
+   ```
+
+   The unit lanes assert the app-level convention (no code path mutates the row);
+   the trigger is the production-datastore backstop, exercised by the
+   testcontainers slice in `tests/migrations/test_migration_rollback.py`.
+2. **Additive and forward-compatible.** `CREATE TRIGGER` / `CREATE OR REPLACE
+   FUNCTION` are not on the compat guard's banned list, and they keep the rollback
+   contract: an older image against the newer schema only ever `INSERT`s the row it
+   already knew how to write, so the trigger never fires on the hot path.
+3. **Reversible.** `downgrade()` drops the trigger then the function (reverse of
+   create order), also Postgres-guarded.
+
 ## Additive-only constraint
 
 Migrations in `upgrade()` must be additive: `create_table`, `add_column`,


### PR DESCRIPTION
## Summary

- Enforce `audit_log` append-only **at the datastore**, not by code convention (security review 2026-09-06 finding S18). CLAUDE.md postulate 7 / v0.1-spec §6 makes the audit trail append-only and tamper-evident, but until now nothing at the datastore stopped a direct `UPDATE`/`DELETE` — anyone with write access to Postgres (the app DB role, a DB operator, or in-process code execution) could silently rewrite or erase the audit row of the operation just performed.
- Migration `0100` installs a `BEFORE UPDATE OR DELETE ... FOR EACH ROW` trigger (`audit_log_append_only` + function `audit_log_reject_mutation()`) that `RAISE`s. `INSERT`/`SELECT` are untouched, so the synchronous audit write path keeps working; a direct `UPDATE`/`DELETE` fails under **every** role, including a superuser (a row-level trigger fires regardless of privilege).
- Dialect-guarded: the plpgsql DDL runs only on `postgresql`. The SQLite dev/test lane is a clean no-op, so the always-on unit lanes stay green (they assert the app-level convention; the trigger is the production-datastore backstop).
- Documented the new "constraint enforcement via triggers (Postgres-only)" migration pattern in `docs/codebase/migrations.md`.

## Already on `main` (not re-done here)

- The app-level convention already held on `main` (write path is INSERT-only; the only other `AuditLog(...)` is the topology-delete append; a codebase grep finds only `select(AuditLog)` reads — reconfirmed against `src/`). This task adds the **datastore** enforcement that was missing; no prior containment PR touched `audit_log` immutability.

## Design notes

- **Trigger over REVOKE.** The AC accepts a trigger *and/or* an `INSERT`+`SELECT`-only app role. The trigger is self-contained (no external role provisioning / ops runbook dependency) and enforces under every role including the owner, which is exactly what the container test asserts. The role split is left to the retention-role work called out as out-of-scope.
- **Retention stays out of scope.** No retention/reaper path deletes `audit_log` today (the flight-recorder reaper deletes `DispatchTrace`/`DispatchTraceSpan`, not `audit_log`). When retention lands it drops whole **partitions** — `DROP TABLE` on a partition and `TRUNCATE` both bypass row-level triggers — or runs under a dedicated role, so this row-level trigger needs no bypass hatch now.
- **Blast radius.** No `src/` change. The only test paths that remove `audit_log` rows are on SQLite (`test_topology_history_hook`, where the trigger is a no-op) or use `TRUNCATE` (integration/acceptance conftests — `TRUNCATE` does not fire a row-level `DELETE` trigger). Verified there is no `UPDATE`/`DELETE`/`delete(AuditLog)` on `audit_log` in `src/`.

## Out-of-scope cleanup carried to satisfy AC5

- `alembic/versions/0023`: collapsed `sa.text("'{}'") if is_postgres else sa.text("'{}'")` (both branches identical → RUF034) to `sa.text("'{}'")`. Byte-identical DDL. This pre-existing lint error was the **only** thing failing AC5's directory-scoped `uv run ruff check alembic/versions` (CI lints `src/`+`tests/`, never `alembic/`, so it had never surfaced). One-line, zero-risk, same subsystem.

## Test plan

- [x] AC1 — `grep -rniE "trigger|revoke" backend/alembic/versions | grep -i audit_log` returns the new revision `0100_audit_log_append_only_trigger.py`.
- [x] AC2 — new Postgres-container test `TestAuditLogAppendOnlyTrigger::test_audit_log_update_delete_raises` (in `tests/migrations/test_migration_rollback.py`, reusing that file's Docker-socket skip). **Ran green against real Postgres** (Docker present in the dev box): raw `UPDATE`/`DELETE` both raise with the append-only message; raw `INSERT`/`SELECT` succeed and the row survives unchanged. Skips where Docker is absent; runs in CI.
- [x] AC3 — `uv run alembic upgrade head && uv run alembic downgrade -1 && uv run alembic upgrade head` completes (ends at `0100 (head)`).
- [x] AC4 — `uv run pytest tests/test_db_models.py tests/migrations -q --ignore=tests/migrations/test_migration_rollback.py` → 434 passed.
- [x] AC5 — `uv run ruff check alembic/versions` clean; `uv run mypy src/meho_backplane/db/models.py` → success.
- [x] `ruff check` + `ruff format --check` on `src/ tests/` (CI scope) — clean; migration-compat guard passes.

## Out of scope

- Cryptographic tamper-evidence (hash-chaining / signed rows) — a stronger model than immutability; separate.
- `audit_log` retention / `raw_payload` data-minimization (companion sibling under #262).
- Connector code-exec / SSRF findings (F03/F05/F13) — tracked separately under #262.
- Other trails (`broadcast_event`, topology history) — this task is `audit_log` only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#306
