### PR TITLE
fix(scheduler): namespace agent-credential Vault path per (tenant, principal)

### DIFF
--- a/backend/src/meho_backplane/auth/agent_principals.py
+++ b/backend/src/meho_backplane/auth/agent_principals.py
@@ -363,7 +363,7 @@ class AgentPrincipalService:
           same posture as a Phase-2 DB failure.
         """
         try:
-            await write_agent_secret(client_id, client_secret)
+            await write_agent_secret(client_id, client_secret, tenant_id=tenant_id)
         except SchedulerVaultNotConfiguredError:
             self._log.warning(
                 "agent_principal_register_vault_skip",

--- a/backend/src/meho_backplane/auth/runner_principals.py
+++ b/backend/src/meho_backplane/auth/runner_principals.py
@@ -392,7 +392,7 @@ class RunnerPrincipalService:
           same posture as a Phase-2 DB failure).
         """
         try:
-            await write_agent_secret(client_id, client_secret)
+            await write_agent_secret(client_id, client_secret, tenant_id=tenant_id)
         except SchedulerVaultNotConfiguredError:
             self._log.warning(
                 "runner_principal_register_vault_skip",

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -1024,7 +1024,7 @@ async def _investigate_group(
         name, identity_ref = definition
 
         try:
-            client_id, secret = await resolve_agent_credentials(identity_ref)
+            client_id, secret = await resolve_agent_credentials(identity_ref, tenant_id=tenant_id)
         except AgentCredentialsUnresolvedError as exc:
             _log().warning(
                 "checks_investigation_credentials_unresolved",

--- a/backend/src/meho_backplane/scheduler/credentials.py
+++ b/backend/src/meho_backplane/scheduler/credentials.py
@@ -36,38 +36,45 @@ When **neither** source yields a secret, the resolver raises
 loop logs ``scheduler_credentials_unresolved`` and leaves the trigger
 ``active`` for the next tick).
 
-Identity-ref -> client-id derivation
-------------------------------------
+Per-principal, per-tenant key derivation (security S10, #298)
+-------------------------------------------------------------
 
-``AgentDefinition.identity_ref`` is the Keycloak client-id reference
-set at definition-create time, in the form ``agent:<name>`` (see
-:mod:`~meho_backplane.agents.service` -- the create path normalises
-the reference). The client-id portion is what the
-``client_credentials`` grant authenticates as, so the env-var key the
-scheduler derives is rooted at the bare ``identity_ref`` (sanitised
-for env-var conventions).
+Both the Vault path and the env-var name are derived from **two** inputs
+— the agent's ``identity_ref`` *and* the owning ``tenant_id`` — so that
+two distinct principals can never resolve to the same storage key:
 
-The pattern's ``{client_id}`` placeholder is substituted with the
-sanitised identity_ref:
+* ``AgentDefinition.identity_ref`` is the Keycloak client-id reference
+  set at definition-create time, in the form ``agent:<name>`` /
+  ``runner:<name>``. Its ``{client_id}`` segment is derived by
+  :func:`agent_client_id_from_identity_ref`, a **reversible, injective**
+  hex encoding of the UTF-8 bytes — *not* a lossy sanitiser. The old
+  ``[^A-Za-z0-9_]`` -> ``_`` collapse mapped ``agent:a-b``, ``agent:a_b``
+  and ``agent:a.b`` onto one key (``AGENT_A_B``); the hex encoding keeps
+  them distinct (``6167656e743a612d62`` etc.), and because hex is a
+  byte-level encoding it survives the trailing ``upper()`` without
+  re-colliding case variants (``agent:a-b`` vs ``agent:A-B``).
+* ``{tenant_id}`` is the owning tenant's UUID rendered as ``.hex``. The
+  scheduler / event-matcher / checks-investigator read under the
+  **trigger's** tenant, which is the tenant the principal was registered
+  under, so read and write derive the same key. A principal registered
+  in a different tenant resolves to a different key — the tenant-isolation
+  invariant this filing exists to enforce.
 
-* Non-alphanumeric characters (``:``, ``/``, ``-``, ``.``, ...) collapse
-  to ``_`` so an ``identity_ref`` like ``agent:incident-triage`` is
-  reachable as ``AGENT_INCIDENT_TRIAGE`` (the only env-var-legal form
-  of that string).
-* The whole substituted name is upper-cased.
-* Default pattern ``MEHO_AGENT_SECRET_{client_id}`` therefore yields
-  ``MEHO_AGENT_SECRET_AGENT_INCIDENT_TRIAGE``.
+The env-var name applies a final ``upper()`` across the whole substituted
+pattern; the hex ``{client_id}`` and hex ``{tenant_id}`` are both
+``upper()``-stable, so the uppercase env name and the (mixed-case) Vault
+path address the same logical principal.
 
 :func:`agent_client_id_from_identity_ref` is deterministic + pure (no
-side effects, no I/O) so the env-var-name derivation can be unit-tested
-without fixtures. :func:`resolve_agent_credentials` performs a Vault read
-(I/O) before falling back to :func:`os.environ`.
+side effects, no I/O) so the key derivation can be unit-tested without
+fixtures. :func:`resolve_agent_credentials` performs a Vault read (I/O)
+before falling back to :func:`os.environ`.
 """
 
 from __future__ import annotations
 
 import os
-import re
+import uuid
 
 import structlog
 
@@ -79,70 +86,93 @@ __all__ = [
     "AgentCredentialsUnresolvedError",
     "agent_client_id_from_identity_ref",
     "resolve_agent_credentials",
+    "tenant_key_segment",
 ]
-
-#: Pattern matching any character that is not legal in an env-var name.
-#: POSIX env names are ``[A-Z_][A-Z0-9_]*``; the sanitisation here uses
-#: the same alphabet plus a lowercase tolerance (the post-substitution
-#: ``upper()`` lifts it). Anchored as a class so :func:`re.sub` walks
-#: the string once with no backtracking.
-_ENV_NAME_FORBIDDEN: re.Pattern[str] = re.compile(r"[^A-Za-z0-9_]")
 
 
 class AgentCredentialsUnresolvedError(RuntimeError):
     """The scheduler could not source credentials for a scheduled fire.
 
-    Raised when the env-var (or future Vault path) the pattern resolves
-    to is not present / empty. The scheduler loop catches this, logs +
-    audits the skip, and leaves the trigger ``active`` so an operator
-    who wires the secret unblocks the schedule on the next tick.
+    Raised when neither the Vault path nor the env-var fallback the
+    pattern resolves to yields a secret. The scheduler loop catches this,
+    logs + audits the skip, and leaves the trigger ``active`` so an
+    operator who wires the secret unblocks the schedule on the next tick.
     """
 
 
 def agent_client_id_from_identity_ref(identity_ref: str) -> str:
-    """Return the env-var-safe client-id derived from *identity_ref*.
+    """Return the storage-key ``{client_id}`` segment for *identity_ref*.
 
-    Sanitises by replacing every non-``[A-Za-z0-9_]`` character with
-    ``_``. Preserves case for the caller's later
-    upper-/lower-casing; the secret-key pattern in
-    :attr:`Settings.scheduler_agent_secret_env_pattern` applies the
-    final ``upper()`` after the substitution.
+    A **reversible, injective** hex encoding of the ``identity_ref``'s
+    UTF-8 bytes (``bytes.fromhex(result).decode("utf-8")`` recovers the
+    original). Two distinct identity refs always produce two distinct
+    segments — the property the per-principal Vault path and env-var name
+    depend on (security S10, #298).
 
-    Pure / deterministic. Callers should not rely on the result being
-    reversible -- ``agent:x:y`` and ``agent_x_y`` map to the same
-    sanitised form on purpose (env-vars are a flat namespace).
+    This replaces the pre-#298 lossy sanitiser that collapsed every
+    non-``[A-Za-z0-9_]`` character to ``_``: that mapped ``agent:a-b``,
+    ``agent:a_b`` and ``agent:a.b`` onto the same key, so a second
+    registration silently clobbered the first's stored secret. Hex is a
+    byte-level encoding, so it also survives the callers' trailing
+    ``upper()`` without re-colliding case variants (``agent:a-b`` vs
+    ``agent:A-B``) — every byte difference is preserved as a distinct
+    hex digit pair, and ``upper()`` only lifts ``a``-``f`` to ``A``-``F``
+    uniformly.
+
+    Pure / deterministic — no I/O, no settings read.
     """
-    return _ENV_NAME_FORBIDDEN.sub("_", identity_ref)
+    return identity_ref.encode("utf-8").hex()
 
 
-def _env_var_name_for(identity_ref: str) -> str:
-    """Return the env-var name the secret pattern resolves to for *identity_ref*.
+def tenant_key_segment(tenant_id: uuid.UUID) -> str:
+    """Return the storage-key ``{tenant_id}`` segment for *tenant_id*.
 
-    Substitutes the sanitised + upper-cased identity_ref into
+    The UUID's 32-hex-digit ``.hex`` form: env-var-legal (no hyphens) and
+    Vault-path-legal, and — being fixed-width with no ``_`` — unambiguous
+    when concatenated with the ``{client_id}`` segment under a ``_``
+    separator. Pure / deterministic.
+    """
+    return tenant_id.hex
+
+
+def _env_var_name_for(identity_ref: str, tenant_id: uuid.UUID) -> str:
+    """Return the env-var name the secret pattern resolves to.
+
+    Substitutes the per-tenant ``{tenant_id}`` segment and the reversible
+    ``{client_id}`` segment into
     :attr:`Settings.scheduler_agent_secret_env_pattern`, then upper-cases
     the whole result. Operators who set a non-upper-cased pattern (e.g.
-    ``meho_agent_secret_{client_id}``) otherwise resolve to a mixed-case
-    env-var name that Linux's case-sensitive lookup would miss — the
-    precondition gate would skip every fire with a
+    ``meho_agent_secret_{tenant_id}_{client_id}``) otherwise resolve to a
+    mixed-case env-var name that Linux's case-sensitive lookup would miss
+    — the precondition gate would then skip every fire with a
     ``credentials_unresolved`` warning pointing at the secret rather than
     the case-mismatch. The contract is "the whole substituted name is
-    upper-cased"; this makes the code match it.
+    upper-cased"; this makes the code match it. Both hex segments are
+    ``upper()``-stable, so the uppercase env name still names a distinct
+    key per principal.
     """
     settings = get_settings()
-    sanitised = agent_client_id_from_identity_ref(identity_ref).upper()
-    return settings.scheduler_agent_secret_env_pattern.format(client_id=sanitised).upper()
+    client_seg = agent_client_id_from_identity_ref(identity_ref)
+    return settings.scheduler_agent_secret_env_pattern.format(
+        tenant_id=tenant_key_segment(tenant_id),
+        client_id=client_seg,
+    ).upper()
 
 
-def _secret_from_env(identity_ref: str) -> str:
+def _secret_from_env(identity_ref: str, tenant_id: uuid.UUID) -> str:
     """Return the agent secret from the env var, or ``""`` when unset/empty."""
-    return os.environ.get(_env_var_name_for(identity_ref), "").strip()
+    return os.environ.get(_env_var_name_for(identity_ref, tenant_id), "").strip()
 
 
-async def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
+async def resolve_agent_credentials(identity_ref: str, *, tenant_id: uuid.UUID) -> tuple[str, str]:
     """Resolve ``(client_id, client_secret)`` for a scheduled-fire agent.
 
-    *identity_ref* is :attr:`AgentDefinition.identity_ref` (the
-    Keycloak client-id reference set at definition-create time).
+    *identity_ref* is :attr:`AgentDefinition.identity_ref` (the Keycloak
+    client-id reference set at definition-create time). *tenant_id* is the
+    owning tenant of the firing trigger / dashboard — the same tenant the
+    principal was registered under, so the read derives the key the write
+    used. A principal registered in a different tenant resolves to a
+    different key and does not leak across the tenant boundary (S10 #298).
 
     **Vault-first** (G0.19-T2 #1478): the secret is read from Vault under
     the scheduler's static service token, falling back to the env-var
@@ -163,7 +193,7 @@ async def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
             active for the next tick.
     """
     # Local import avoids a module-load cycle (vault_credentials imports
-    # this module's sanitiser for its Vault-path derivation).
+    # this module's key-segment helpers for its Vault-path derivation).
     from meho_backplane.scheduler.vault_credentials import (
         SchedulerVaultBrokerError,
         SchedulerVaultNotConfiguredError,
@@ -172,7 +202,7 @@ async def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
 
     # 1. Vault-first.
     try:
-        vault_secret = await read_agent_secret(identity_ref)
+        vault_secret = await read_agent_secret(identity_ref, tenant_id=tenant_id)
     except SchedulerVaultNotConfiguredError:
         # No scheduler Vault identity wired — fall through to the env-var
         # path silently (the documented fallback configuration).
@@ -192,15 +222,16 @@ async def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
         return identity_ref, vault_secret
 
     # 2. Env-var fallback / break-glass.
-    env_secret = _secret_from_env(identity_ref)
+    env_secret = _secret_from_env(identity_ref, tenant_id)
     if env_secret:
         return identity_ref, env_secret
 
-    env_name = _env_var_name_for(identity_ref)
+    env_name = _env_var_name_for(identity_ref, tenant_id)
     raise AgentCredentialsUnresolvedError(
-        f"no client_credentials secret resolved for identity_ref={identity_ref!r}; "
-        f"neither the Vault path (scheduler_agent_vault_path_pattern, read under "
-        f"VAULT_SCHEDULER_TOKEN) nor the fallback env var {env_name!r} yielded a "
-        "secret. Register the agent over the API (persists the secret to Vault) or "
-        "wire the agent's Keycloak client secret into the backplane pod env and retry."
+        f"no client_credentials secret resolved for identity_ref={identity_ref!r} "
+        f"(tenant={tenant_id}); neither the Vault path "
+        f"(scheduler_agent_vault_path_pattern, read under VAULT_SCHEDULER_TOKEN) "
+        f"nor the fallback env var {env_name!r} yielded a secret. Register the "
+        "agent over the API (persists the secret to Vault) or wire the agent's "
+        "Keycloak client secret into the backplane pod env and retry."
     )

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -561,6 +561,7 @@ async def _prepare_invocation(
     try:
         agent_client_id, agent_client_secret = await resolve_agent_credentials(
             definition.identity_ref,
+            tenant_id=row.tenant_id,
         )
     except AgentCredentialsUnresolvedError as exc:
         _log.warning(

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -34,8 +34,15 @@ Path convention
 ===============
 
 :attr:`Settings.scheduler_agent_vault_path_pattern` is the **raw Vault
-HTTP API path** (default ``secret/data/agents/{client_id}/credentials``)
-— it embeds the mount (``secret``) and the KV-v2 ``data/`` infix. hvac's
+HTTP API path** (default
+``secret/data/agents/{tenant_id}_{client_id}/credentials``) — it embeds
+the mount (``secret``) and the KV-v2 ``data/`` infix. The ``{tenant_id}``
+and ``{client_id}`` segments are derived per-tenant, per-principal
+(security S10, #298): see
+:func:`~meho_backplane.scheduler.credentials.agent_client_id_from_identity_ref`.
+The default joins them under one ``_`` (a single dynamic path segment) so
+the deployed ``secret/data/agents/*/credentials`` ACL keeps matching
+without a policy re-scope. hvac's
 ``secrets.kv.v2`` helpers want the **logical** path relative to the
 mount (they insert ``data/`` themselves — verified against hvac 2.4.0).
 :func:`split_kv_v2_api_path` reconciles the two so the shipped default
@@ -98,6 +105,7 @@ so a Vault-Agent sidecar (or an operator) that re-mints the token into
 from __future__ import annotations
 
 import asyncio
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -234,25 +242,36 @@ def split_kv_v2_api_path(api_path: str) -> tuple[str, str]:
     return mount, logical
 
 
-def vault_path_for_client_id(client_id: str, *, settings: Settings | None = None) -> str:
-    """Render the configured Vault path pattern for *client_id*.
+def vault_path_for_client_id(
+    client_id: str, *, tenant_id: uuid.UUID, settings: Settings | None = None
+) -> str:
+    """Render the configured Vault path pattern for *client_id* in *tenant_id*.
 
-    Substitutes the sanitised-and-upper-cased ``{client_id}`` token into
-    :attr:`Settings.scheduler_agent_vault_path_pattern`. The sanitisation
-    mirrors the env-var derivation in
+    Substitutes the per-tenant ``{tenant_id}`` segment and the reversible,
+    upper-cased ``{client_id}`` segment into
+    :attr:`Settings.scheduler_agent_vault_path_pattern`. The ``{client_id}``
+    derivation mirrors the env-var derivation in
     :func:`~meho_backplane.scheduler.credentials.agent_client_id_from_identity_ref`
-    so the Vault key and the env-var key are derived from one identity in
-    a consistent shape (``agent:reporter`` → ``AGENT_REPORTER``).
+    so the Vault key and the env-var key are derived from one identity in a
+    consistent shape, and both are threaded with the owning tenant so two
+    distinct principals — name-variants within a tenant, or the same name
+    across tenants — can never resolve to the same Vault key (S10, #298).
     """
     # Local import avoids a module-load cycle: credentials imports this
     # module's read path, so importing credentials at top level here would
     # be circular.
-    from meho_backplane.scheduler.credentials import agent_client_id_from_identity_ref
+    from meho_backplane.scheduler.credentials import (
+        agent_client_id_from_identity_ref,
+        tenant_key_segment,
+    )
 
     if settings is None:
         settings = get_settings()
-    sanitised = agent_client_id_from_identity_ref(client_id).upper()
-    return settings.scheduler_agent_vault_path_pattern.format(client_id=sanitised)
+    client_seg = agent_client_id_from_identity_ref(client_id).upper()
+    return settings.scheduler_agent_vault_path_pattern.format(
+        tenant_id=tenant_key_segment(tenant_id),
+        client_id=client_seg,
+    )
 
 
 def _current_scheduler_token(settings: Settings) -> str:
@@ -503,13 +522,14 @@ async def _execute_with_self_heal[T](
         ) from exc
 
 
-async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
+async def write_agent_secret(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
     """Persist *client_secret* for *identity_ref* to Vault; return the path.
 
     Called from the agent-principal register path after the Keycloak
     client is created and its secret fetched. Writes
-    ``{SECRET_FIELD: client_secret}`` as a KV-v2 secret at the configured
-    path under the scheduler service token.
+    ``{SECRET_FIELD: client_secret}`` as a KV-v2 secret at the
+    per-tenant, per-principal path (S10, #298) derived from *identity_ref*
+    and the owning *tenant_id* under the scheduler service token.
 
     Returns the rendered Vault API path (for logging / audit), never the
     secret value.
@@ -532,7 +552,7 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         other status is evidence about the token, so each keeps ``False``.
     """
     settings = get_settings()
-    api_path = vault_path_for_client_id(identity_ref, settings=settings)
+    api_path = vault_path_for_client_id(identity_ref, tenant_id=tenant_id, settings=settings)
     mount, logical = split_kv_v2_api_path(api_path)
 
     def _write(client: hvac.Client) -> None:
@@ -555,13 +575,17 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
     _log.info(
         "scheduler_agent_secret_written",
         identity_ref=identity_ref,
+        tenant_id=str(tenant_id),
         vault_path=api_path,
     )
     return api_path
 
 
-async def read_agent_secret(identity_ref: str) -> str | None:
+async def read_agent_secret(identity_ref: str, *, tenant_id: uuid.UUID) -> str | None:
     """Read the agent ``client_secret`` for *identity_ref* from Vault.
+
+    Reads the per-tenant, per-principal path (S10, #298) derived from
+    *identity_ref* and the resolving *tenant_id*.
 
     Returns the secret string, or ``None`` when the secret does not exist
     (Vault 404 / missing path) so the caller can fall back to the env-var
@@ -582,7 +606,7 @@ async def read_agent_secret(identity_ref: str) -> str | None:
         re-mint fails, *or* the retry against the re-minted token also fails.
     """
     settings = get_settings()
-    api_path = vault_path_for_client_id(identity_ref, settings=settings)
+    api_path = vault_path_for_client_id(identity_ref, tenant_id=tenant_id, settings=settings)
     mount, logical = split_kv_v2_api_path(api_path)
 
     def _read(client: hvac.Client) -> object:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1643,10 +1643,14 @@ class Settings(BaseModel):
     # ``scheduler_agent_vault_path_pattern`` under the scheduler's static
     # service token (:attr:`vault_scheduler_token`), and falls back to an
     # environment variable derived from this pattern only when the Vault
-    # read yields nothing. ``{client_id}`` is substituted at fire time and
-    # the result is uppercased + non-alphanumeric chars replaced with
-    # underscores so an ``identity_ref`` like ``agent:reporter`` resolves
-    # to ``MEHO_AGENT_SECRET_AGENT_REPORTER``.
+    # read yields nothing. ``{tenant_id}`` and ``{client_id}`` are
+    # substituted at fire time from the owning tenant and the agent's
+    # ``identity_ref`` (a reversible hex encoding, S10 #298), then the
+    # whole name is uppercased — so ``agent:reporter`` in tenant
+    # ``t`` resolves to ``MEHO_AGENT_SECRET_<t.hex>_<hex(agent:reporter)>``
+    # (uppercased). Both placeholders are required so two distinct
+    # principals — name-variants within a tenant, or the same name across
+    # tenants — never resolve to the same env var.
     #
     # The env-var path is the documented **fallback / break-glass**: an
     # operator can wire an agent secret into the backplane pod's env (Helm
@@ -1657,20 +1661,28 @@ class Settings(BaseModel):
     # Keycloak secret to Vault at ``scheduler_agent_vault_path_pattern``
     # (see :meth:`AgentPrincipalService.register`) and the scheduler reads
     # it straight back.
-    scheduler_agent_secret_env_pattern: str = Field(default="MEHO_AGENT_SECRET_{client_id}")
+    scheduler_agent_secret_env_pattern: str = Field(
+        default="MEHO_AGENT_SECRET_{tenant_id}_{client_id}"
+    )
     # The Vault KV-v2 *API* path (mount + ``data/`` infix + logical path)
     # where agent ``client_credentials`` secrets live. Registration writes
     # here; the scheduler reads here -- both via ``vault_path_for_client_id``,
-    # so the two cannot diverge. ``{client_id}`` is substituted with the
-    # **sanitised, UPPER-CASED** identity_ref (non-alphanumeric chars to
-    # ``_``, then ``upper()``), e.g. ``agent:ops-writer`` ->
-    # ``secret/data/agents/AGENT_OPS_WRITER/credentials`` -- not the raw
-    # ``agent:ops-writer`` key. The default addresses the ``secret/``
-    # KV-v2 mount; the leading ``secret/data/`` is the raw API path Vault's
-    # HTTP surface uses, which the read/write helpers split into hvac's
-    # ``(mount_point, logical_path)`` form.
+    # so the two cannot diverge. ``{tenant_id}`` is substituted with the
+    # owning tenant's ``.hex`` and ``{client_id}`` with a **reversible,
+    # UPPER-CASED hex** encoding of the identity_ref (S10 #298), e.g.
+    # ``agent:ops-writer`` in tenant ``t`` ->
+    # ``secret/data/agents/<t.hex>_<hex(agent:ops-writer)>/credentials``.
+    # Threading both means two distinct principals — name-variants within a
+    # tenant, or the same name across tenants — never collide on one key.
+    # The default joins them under one ``_`` (a single dynamic path
+    # segment) so the deployed ``secret/data/agents/*/credentials`` ACL
+    # keeps matching without a policy re-scope
+    # (``docs/cross-repo/vault-provisioning.md``). The default addresses the
+    # ``secret/`` KV-v2 mount; the leading ``secret/data/`` is the raw API
+    # path Vault's HTTP surface uses, which the read/write helpers split
+    # into hvac's ``(mount_point, logical_path)`` form.
     scheduler_agent_vault_path_pattern: str = Field(
-        default="secret/data/agents/{client_id}/credentials"
+        default="secret/data/agents/{tenant_id}_{client_id}/credentials"
     )
     # G11.3-T3 #824 — event-outbox drain loop cadence. 10 s default
     # mirrors the consumer doc's accepted-latency target (the
@@ -1749,7 +1761,7 @@ class Settings(BaseModel):
         (``VAULT_KV_TENANT_SCOPE_PREFIX=""`` opts a mid-migration deploy
         out of the guard) and is accepted verbatim. Same fail-closed-at-
         startup discipline as
-        :meth:`_scheduler_secret_pattern_must_substitute_client_id`.
+        :meth:`_scheduler_secret_pattern_must_substitute_placeholders`.
         """
         if not value.strip():
             # Explicit-disable sentinel — guard is a no-op; nothing to render.
@@ -1820,20 +1832,24 @@ class Settings(BaseModel):
 
     @field_validator("scheduler_agent_secret_env_pattern")
     @classmethod
-    def _scheduler_secret_pattern_must_substitute_client_id(cls, value: str) -> str:
-        """Reject env-var patterns that don't substitute ``{client_id}``.
+    def _scheduler_secret_pattern_must_substitute_placeholders(cls, value: str) -> str:
+        """Reject env-var patterns missing ``{tenant_id}`` or ``{client_id}``.
 
-        Pulled up to :class:`Settings` construction so three otherwise-
+        Pulled up to :class:`Settings` construction so these otherwise-
         silent failure shapes surface at pod startup rather than at
         first scheduled fire:
 
         * **Pattern lacks ``{client_id}``** (typo / copy-paste error):
           ``str.format`` returns the literal pattern, every agent
           resolves to the same env-var key, all scheduled runs share
-          one secret. Cross-tenant principal-credential bleed.
-        * **Pattern uses positional ``{0}`` instead of named
-          ``{client_id}``**: ``str.format(client_id=...)`` raises
-          :class:`KeyError` on first fire. The precondition gate logs
+          one secret.
+        * **Pattern lacks ``{tenant_id}``** (S10 #298): two principals
+          with name-variants that hex-encode distinctly still stay
+          per-tenant only if the tenant is in the key; without it the
+          env fallback loses the per-tenant isolation the Vault path has.
+        * **Pattern uses positional ``{0}`` instead of a named
+          placeholder**: ``str.format(...)`` raises :class:`KeyError` on
+          first fire. The precondition gate logs
           ``scheduler_credentials_unresolved`` and skips forever.
         * **Pattern has unbalanced braces**: ``str.format`` raises
           :class:`ValueError` on first fire. Same skip-forever path.
@@ -1844,17 +1860,48 @@ class Settings(BaseModel):
         should fail the import chain immediately with an actionable
         message, not days later under load.
         """
-        if "{client_id}" not in value:
-            raise ValueError(
-                f"SCHEDULER_AGENT_SECRET_ENV_PATTERN must include "
-                f"'{{client_id}}' so each agent resolves to its own env var; "
-                f"got: {value!r}"
-            )
+        for placeholder in ("{tenant_id}", "{client_id}"):
+            if placeholder not in value:
+                raise ValueError(
+                    f"SCHEDULER_AGENT_SECRET_ENV_PATTERN must include "
+                    f"'{placeholder}' so each agent resolves to its own "
+                    f"per-tenant env var; got: {value!r}"
+                )
         try:
-            value.format(client_id="TEST_CLIENT_ID")
+            value.format(tenant_id="TEST_TENANT_ID", client_id="TEST_CLIENT_ID")
         except (IndexError, KeyError, ValueError) as exc:
             raise ValueError(
                 f"SCHEDULER_AGENT_SECRET_ENV_PATTERN must be a valid "
+                f"str.format pattern; got: {value!r}"
+            ) from exc
+        return value
+
+    @field_validator("scheduler_agent_vault_path_pattern")
+    @classmethod
+    def _scheduler_vault_path_pattern_must_substitute_placeholders(cls, value: str) -> str:
+        """Reject Vault path patterns missing ``{tenant_id}`` or ``{client_id}``.
+
+        The write (registration) and the read (scheduler / event matcher /
+        checks investigator) both render this pattern via
+        :func:`~meho_backplane.scheduler.vault_credentials.vault_path_for_client_id`.
+        A pattern that drops either placeholder collapses two distinct
+        principals onto one Vault key — the exact silent-clobber this
+        filing (S10 #298) closes — so, like
+        :meth:`_scheduler_secret_pattern_must_substitute_placeholders`,
+        the fault surfaces at pod startup rather than at first fire.
+        """
+        for placeholder in ("{tenant_id}", "{client_id}"):
+            if placeholder not in value:
+                raise ValueError(
+                    f"SCHEDULER_AGENT_VAULT_PATH_PATTERN must include "
+                    f"'{placeholder}' so each agent resolves to its own "
+                    f"per-tenant Vault key; got: {value!r}"
+                )
+        try:
+            value.format(tenant_id="TEST_TENANT_ID", client_id="TEST_CLIENT_ID")
+        except (IndexError, KeyError, ValueError) as exc:
+            raise ValueError(
+                f"SCHEDULER_AGENT_VAULT_PATH_PATTERN must be a valid "
                 f"str.format pattern; got: {value!r}"
             ) from exc
         return value
@@ -1870,7 +1917,7 @@ class Settings(BaseModel):
         deploy that thinks it's kill-switched but isn't is the worst-
         case outcome). Same fail-closed-at-startup discipline as
         :meth:`_broadcast_url_must_use_supported_scheme` and
-        :meth:`_scheduler_secret_pattern_must_substitute_client_id`:
+        :meth:`_scheduler_secret_pattern_must_substitute_placeholders`:
         misconfigured env vars surface at import time with an
         actionable message that names the offending entry.
 
@@ -2300,11 +2347,11 @@ def get_settings() -> Settings:
         mail_recipient_allowlist=os.environ.get("MAIL_RECIPIENT_ALLOWLIST", ""),
         scheduler_agent_secret_env_pattern=os.environ.get(
             "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
-            "MEHO_AGENT_SECRET_{client_id}",
+            "MEHO_AGENT_SECRET_{tenant_id}_{client_id}",
         ),
         scheduler_agent_vault_path_pattern=os.environ.get(
             "SCHEDULER_AGENT_VAULT_PATH_PATTERN",
-            "secret/data/agents/{client_id}/credentials",
+            "secret/data/agents/{tenant_id}_{client_id}/credentials",
         ),
         event_drain_tick_interval_seconds=int(
             os.environ.get("EVENT_DRAIN_TICK_INTERVAL_SECONDS", "10"),

--- a/backend/tests/integration/test_event_matcher_pg.py
+++ b/backend/tests/integration/test_event_matcher_pg.py
@@ -28,6 +28,7 @@ import pytest
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.events.drain import run_one_drain_tick
 from tests.test_event_matcher import (
+    _ENV_REPORTER,
     _TENANT_A,
     _all_runs,
     _create_event_trigger,
@@ -49,7 +50,7 @@ def _agent_fire_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     ``agent:reporter`` definition, exactly as :mod:`tests.test_event_matcher`
     does at the unit level.
     """
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     monkeypatch.setattr(
         "meho_backplane.agent.invocation.get_client_credentials_token",
         AsyncMock(return_value="agent-token"),

--- a/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
+++ b/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
@@ -80,6 +81,17 @@ _DEV_ROOT_TOKEN: str = "meho-dev-root-1478"
 
 _IDENTITY_REF: str = "agent:reporter"
 _AGENT_SECRET: str = "dev-only-client-secret-1478"
+#: Owning tenant threaded through the derivation (S10, #298).
+_TENANT: uuid.UUID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+#: Path shape the default pattern renders for ``_IDENTITY_REF`` in
+#: ``_TENANT`` — recomputed independently of the SUT.
+_CLIENT_SEG: str = _IDENTITY_REF.encode("utf-8").hex().upper()
+_API_PATH: str = f"secret/data/agents/{_TENANT.hex}_{_CLIENT_SEG}/credentials"
+_LOGICAL_PATH: str = f"agents/{_TENANT.hex}_{_CLIENT_SEG}/credentials"
+#: The per-tenant env-var name (must stay ABSENT in the Vault-sourced tests).
+_ENV_REPORTER: str = (
+    f"MEHO_AGENT_SECRET_{_TENANT.hex}_{_IDENTITY_REF.encode('utf-8').hex()}"
+).upper()
 
 
 @pytest.fixture(scope="module")
@@ -132,7 +144,7 @@ def _scheduler_vault_env(vault_dev_addr: str, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("VAULT_SCHEDULER_TOKEN", _DEV_ROOT_TOKEN)
     # Belt-and-suspenders: ensure no env-var secret is present so a pass
     # cannot come from the fallback path.
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -140,16 +152,16 @@ def _scheduler_vault_env(vault_dev_addr: str, monkeypatch: pytest.MonkeyPatch) -
 
 async def test_write_then_read_round_trip(_scheduler_vault_env: None) -> None:
     """write_agent_secret -> read_agent_secret round-trips against live Vault."""
-    api_path = await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
-    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+    api_path = await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET, tenant_id=_TENANT)
+    assert api_path == _API_PATH
 
-    read_back = await read_agent_secret(_IDENTITY_REF)
+    read_back = await read_agent_secret(_IDENTITY_REF, tenant_id=_TENANT)
     assert read_back == _AGENT_SECRET
 
 
 async def test_read_missing_returns_none(_scheduler_vault_env: None) -> None:
     """A never-written agent path reads back as ``None`` (env fallback signal)."""
-    assert await read_agent_secret("agent:never-written") is None
+    assert await read_agent_secret("agent:never-written", tenant_id=_TENANT) is None
 
 
 async def test_resolve_is_vault_sourced_with_no_env_var(
@@ -161,14 +173,14 @@ async def test_resolve_is_vault_sourced_with_no_env_var(
     persisted to Vault at registration) is schedulable without an operator
     wiring ``MEHO_AGENT_SECRET_*`` into the pod env.
     """
-    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
+    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET, tenant_id=_TENANT)
 
-    client_id, secret = await resolve_agent_credentials(_IDENTITY_REF)
+    client_id, secret = await resolve_agent_credentials(_IDENTITY_REF, tenant_id=_TENANT)
 
     assert client_id == _IDENTITY_REF
     assert secret == _AGENT_SECRET
     # Prove the env var really was absent (no accidental fallback).
-    assert os.environ.get("MEHO_AGENT_SECRET_AGENT_REPORTER") is None
+    assert os.environ.get(_ENV_REPORTER) is None
 
 
 async def test_resolve_raises_when_neither_vault_nor_env(
@@ -176,7 +188,7 @@ async def test_resolve_raises_when_neither_vault_nor_env(
 ) -> None:
     """Secret in neither Vault nor env -> AgentCredentialsUnresolvedError."""
     with pytest.raises(AgentCredentialsUnresolvedError):
-        await resolve_agent_credentials("agent:no-secret-anywhere")
+        await resolve_agent_credentials("agent:no-secret-anywhere", tenant_id=_TENANT)
 
 
 async def test_seeded_payload_field_shape(vault_dev_addr: str, _scheduler_vault_env: None) -> None:
@@ -185,11 +197,11 @@ async def test_seeded_payload_field_shape(vault_dev_addr: str, _scheduler_vault_
     A direct root-client read confirms the write shape independently of the
     broker's own read path (defends against a write/read key drift).
     """
-    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
+    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET, tenant_id=_TENANT)
     root = hvac.Client(url=vault_dev_addr, token=_DEV_ROOT_TOKEN)
     payload = await asyncio.to_thread(
         root.secrets.kv.v2.read_secret_version,
-        path="agents/AGENT_REPORTER/credentials",
+        path=_LOGICAL_PATH,
         mount_point="secret",
         raise_on_deleted_version=False,
     )

--- a/backend/tests/test_api_v1_agent_principals.py
+++ b/backend/tests/test_api_v1_agent_principals.py
@@ -161,7 +161,7 @@ def _stub_vault_write(monkeypatch: pytest.MonkeyPatch) -> None:
     integration suite (live Vault + Keycloak).
     """
 
-    async def _noop_write(identity_ref: str, client_secret: str) -> str:
+    async def _noop_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         return f"secret/data/agents/{identity_ref}/credentials"
 
     monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _noop_write)
@@ -769,7 +769,7 @@ async def test_register_persists_captured_secret_to_vault(
 
     captured: dict[str, str] = {}
 
-    async def _capture_write(identity_ref: str, client_secret: str) -> str:
+    async def _capture_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         captured["identity_ref"] = identity_ref
         captured["secret"] = client_secret
         return f"secret/data/agents/{identity_ref}/credentials"
@@ -799,6 +799,67 @@ async def test_register_persists_captured_secret_to_vault(
 
 
 @pytest.mark.asyncio
+async def test_register_variant_names_write_distinct_vault_paths(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """S10 #298: two names that collapsed to one key under the old sanitiser
+    (``a-b`` and ``a_b`` -> ``AGENT_A_B``) now write two distinct Vault
+    paths, so the first principal's secret is never overwritten.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-variant-collision")
+
+    # Distinct Keycloak internal ids + secrets per registration so a clobber
+    # would be observable as a lost secret, not merely a lost key.
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(
+        side_effect=[
+            "cc000000-0000-0000-0000-0000000000a1",
+            "cc000000-0000-0000-0000-0000000000a2",
+        ]
+    )
+    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
+    mock_client.get_client_secret = AsyncMock(side_effect=["secret-a-b", "secret-a_b"])
+    mock_client.disable_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=mock_client)
+
+    from meho_backplane.scheduler.vault_credentials import vault_path_for_client_id
+
+    written: dict[str, str] = {}
+
+    async def _capture_by_path(
+        identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID
+    ) -> str:
+        path = vault_path_for_client_id(identity_ref, tenant_id=tenant_id)
+        written[path] = client_secret
+        return path
+
+    monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _capture_by_path)
+
+    with (
+        patch(
+            "meho_backplane.auth.agent_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        for name in ("a-b", "a_b"):
+            resp = client.post(
+                "/api/v1/agent-principals",
+                json={"name": name},
+                headers={"Authorization": f"Bearer {_token(key)}"},
+            )
+            assert resp.status_code == 201, resp.text
+
+    # Two registrations -> two distinct Vault keys, both secrets retained.
+    assert len(written) == 2, written
+    assert set(written.values()) == {"secret-a-b", "secret-a_b"}
+
+
+@pytest.mark.asyncio
 async def test_register_rolls_back_client_on_vault_write_failure(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -821,7 +882,7 @@ async def test_register_rolls_back_client_on_vault_write_failure(
 
     from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
 
-    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+    async def _failing_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         raise SchedulerVaultBrokerError("vault unreachable")
 
     monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _failing_write)
@@ -876,7 +937,7 @@ async def test_register_vault_write_failure_detail_splits_on_token_validity(
         SchedulerVaultBrokerError,
     )
 
-    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+    async def _failing_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         raise SchedulerVaultBrokerError("vault denied", token_invalid=token_invalid)
 
     monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _failing_write)

--- a/backend/tests/test_api_v1_runner_principals.py
+++ b/backend/tests/test_api_v1_runner_principals.py
@@ -104,7 +104,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
 def _stub_vault_write(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub the scheduler Vault write the register path performs (no live Vault)."""
 
-    async def _noop_write(identity_ref: str, client_secret: str) -> str:
+    async def _noop_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         return f"secret/data/runners/{identity_ref}/credentials"
 
     monkeypatch.setattr("meho_backplane.auth.runner_principals.write_agent_secret", _noop_write)
@@ -698,7 +698,7 @@ async def test_register_vault_write_failure_detail_splits_on_token_validity(
         SchedulerVaultBrokerError,
     )
 
-    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+    async def _failing_write(identity_ref: str, client_secret: str, *, tenant_id: uuid.UUID) -> str:
         raise SchedulerVaultBrokerError("vault denied", token_invalid=token_invalid)
 
     monkeypatch.setattr("meho_backplane.auth.runner_principals.write_agent_secret", _failing_write)

--- a/backend/tests/test_checks_investigate.py
+++ b/backend/tests/test_checks_investigate.py
@@ -407,7 +407,7 @@ def _dash(
 
 
 def _patch_creds(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _fake(identity_ref: str) -> tuple[str, str]:
+    async def _fake(identity_ref: str, *, tenant_id: UUID) -> tuple[str, str]:
         return identity_ref, "secret"
 
     monkeypatch.setattr(inv, "resolve_agent_credentials", _fake)
@@ -958,7 +958,7 @@ async def test_credentials_unresolved_is_contained(monkeypatch: pytest.MonkeyPat
     await _seed_definition()
     stub = _install_stub()
 
-    async def _raise(identity_ref: str) -> tuple[str, str]:
+    async def _raise(identity_ref: str, *, tenant_id: UUID) -> tuple[str, str]:
         raise AgentCredentialsUnresolvedError("no secret")
 
     monkeypatch.setattr(inv, "resolve_agent_credentials", _raise)

--- a/backend/tests/test_event_matcher.py
+++ b/backend/tests/test_event_matcher.py
@@ -71,6 +71,9 @@ from meho_backplane.settings import get_settings
 from meho_backplane.untrusted_text import BLOCK_END, BLOCK_START
 
 _TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+#: Per-tenant, per-principal env-var name for ``agent:reporter`` in
+#: ``_TENANT_A`` (S10, #298).
+_ENV_REPORTER = (f"MEHO_AGENT_SECRET_{_TENANT_A.hex}_{b'agent:reporter'.hex()}").upper()
 # A sentinel "upstream" agent definition id the seeded events carry. It is
 # distinct from the seeded ``reporter`` agent's id, so a subscription that
 # targets this upstream (the realistic shape) never re-matches the *fired*
@@ -87,7 +90,7 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     # identity_ref ``agent:reporter`` -> ``AGENT_REPORTER`` env var.
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/backend/tests/test_events_ingest_e2e.py
+++ b/backend/tests/test_events_ingest_e2e.py
@@ -50,13 +50,16 @@ from ._event_source_helpers import (
 )
 
 _TENANT = uuid.UUID("33333333-3333-3333-3333-333333333333")
+#: Per-tenant, per-principal env-var name for ``agent:reactor`` in
+#: ``_TENANT`` (S10, #298).
+_ENV_REACTOR = (f"MEHO_AGENT_SECRET_{_TENANT.hex}_{b'agent:reactor'.hex()}").upper()
 _SECRET_VALUE = "e2e-hmac-key"
 
 
 @pytest.fixture(autouse=True)
 def _agent_secret_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     # identity_ref ``agent:reactor`` -> ``AGENT_REACTOR`` client-credentials env.
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REACTOR", "test-secret")
+    monkeypatch.setenv(_ENV_REACTOR, "test-secret")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -108,6 +108,10 @@ from meho_backplane.scheduler.repository import (
 from meho_backplane.settings import get_settings
 
 _TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+#: Per-tenant, per-principal env-var name the scheduler now derives
+#: for ``agent:reporter`` in ``_TENANT_A`` (S10, #298 — hex client seg,
+#: tenant.hex, whole name uppercased).
+_ENV_REPORTER = (f"MEHO_AGENT_SECRET_{_TENANT_A.hex}_{b'agent:reporter'.hex()}").upper()
 
 
 @pytest.fixture(autouse=True)
@@ -126,7 +130,7 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     # Default seed identity_ref is ``agent:reporter`` -- sanitised by
     # ``agent_client_id_from_identity_ref`` to ``AGENT_REPORTER``.
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -861,7 +865,7 @@ async def test_one_off_with_unresolved_credentials_stays_active_and_fires_on_sec
     the row untouched; the next tick re-runs the gate and fires once
     the operator wires the env var.
     """
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     agent_id = await _seed_tenant_and_agent()
     trigger = await _create_one_off(
         agent_definition_id=agent_id,
@@ -879,7 +883,7 @@ async def test_one_off_with_unresolved_credentials_stays_active_and_fires_on_sec
     )
 
     # Wire the secret -- the next tick fires the long-overdue run.
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     fires_after = await run_one_tick(invoker=_make_invoker())
     assert fires_after == 1
     finalised = await _get_trigger(trigger.id)
@@ -1007,7 +1011,7 @@ async def test_cron_with_unresolved_credentials_stays_active_and_does_not_advanc
     overdue value; once the operator wires the secret, the next tick
     fires the missed instant and advances to the next cron match.
     """
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     agent_id = await _seed_tenant_and_agent()
     base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
     trigger = await _create_cron(agent_definition_id=agent_id, base=base)
@@ -1026,7 +1030,7 @@ async def test_cron_with_unresolved_credentials_stays_active_and_does_not_advanc
     # the advance.
     assert _aware(held.next_fire_at) == stuck_instant
 
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     fires_after = await run_one_tick(invoker=_make_invoker())
     assert fires_after == 1
     fired = await _get_trigger(trigger.id)
@@ -1614,7 +1618,7 @@ async def test_unresolved_credentials_skip_records_skip_state_on_row(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A credentials-unresolved skip projects reason + count onto the row (#2327)."""
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     agent_id = await _seed_tenant_and_agent()
     base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
     trigger = await _create_cron(agent_definition_id=agent_id, base=base)
@@ -1639,7 +1643,7 @@ async def test_missing_definition_skip_records_reason(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A deleted-definition skip stamps ``definition_missing`` on the row (#2327)."""
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     agent_id = await _seed_tenant_and_agent()
     trigger = await _create_cron(
         agent_definition_id=agent_id,
@@ -1677,7 +1681,7 @@ async def test_consecutive_skips_park_the_trigger(
     """
     from meho_backplane.scheduler.loop import _PARK_AFTER_CONSECUTIVE_SKIPS
 
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     agent_id = await _seed_tenant_and_agent()
     base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
     trigger = await _create_cron(agent_definition_id=agent_id, base=base)
@@ -1708,7 +1712,7 @@ async def test_successful_fire_clears_skip_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A successful fire resets the consecutive-skip streak to a clean row (#2327)."""
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_ENV_REPORTER, raising=False)
     agent_id = await _seed_tenant_and_agent()
     base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
     trigger = await _create_cron(agent_definition_id=agent_id, base=base)
@@ -1721,7 +1725,7 @@ async def test_successful_fire_clears_skip_state(
     assert skipped.last_skip_reason == "credentials_unresolved"
 
     # Wire the secret; the next tick fires and clears the skip state.
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setenv(_ENV_REPORTER, "test-secret")
     assert await run_one_tick(invoker=_make_invoker()) == 1
     fired = await _get_trigger(trigger.id)
     assert fired.skip_count == 0

--- a/backend/tests/test_scheduler_credentials.py
+++ b/backend/tests/test_scheduler_credentials.py
@@ -14,8 +14,9 @@ yields nothing.
 Coverage matrix
 ---------------
 
-* **Sanitiser** -- ``agent:reporter`` -> ``AGENT_REPORTER`` (default
-  upper-case + non-alnum -> ``_``); edge cases.
+* **Client-id encoder** -- ``agent:reporter`` -> reversible hex; distinct
+  identity refs (incl. separator / case variants) -> distinct segments
+  (S10, #298).
 * **Vault-first happy path** -- when Vault returns a secret, it wins over
   the env var.
 * **Env-var fallback** -- Vault not configured / secret absent -> the env
@@ -32,6 +33,7 @@ by the integration suite.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import pytest
@@ -43,6 +45,27 @@ from meho_backplane.scheduler.credentials import (
     resolve_agent_credentials,
 )
 from meho_backplane.settings import get_settings
+
+#: A fixed tenant threaded through resolution below (S10, #298 — the
+#: derivation is now per-(tenant, principal)).
+_TENANT = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def _env_var(
+    identity_ref: str,
+    *,
+    tenant_id: uuid.UUID = _TENANT,
+    pattern: str = "MEHO_AGENT_SECRET_{tenant_id}_{client_id}",
+) -> str:
+    """Compute the fallback env-var name for *identity_ref* in *tenant_id*.
+
+    Recomputed here from the encoder so the tests set / assert the exact
+    per-tenant name the resolver derives without hard-coding hex blobs.
+    """
+    return pattern.format(
+        tenant_id=tenant_id.hex,
+        client_id=agent_client_id_from_identity_ref(identity_ref),
+    ).upper()
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +87,7 @@ def _patch_vault_read(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
     the import resolves to.
     """
 
-    async def _fake(identity_ref: str) -> str | None:
+    async def _fake(identity_ref: str, *, tenant_id: uuid.UUID) -> str | None:
         if isinstance(result, BaseException):
             raise result
         return result
@@ -73,20 +96,29 @@ def _patch_vault_read(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
 
 
 @pytest.mark.parametrize(
-    ("identity_ref", "expected"),
+    "identity_ref",
     [
-        ("agent:reporter", "agent_reporter"),
-        ("agent:incident-triage", "agent_incident_triage"),
-        ("agent:billing.summary", "agent_billing_summary"),
-        ("agent:multi:colon:ref", "agent_multi_colon_ref"),
-        ("AGENT_X", "AGENT_X"),
-        ("agent_x", "agent_x"),
-        (":foo:", "_foo_"),
+        "agent:reporter",
+        "agent:incident-triage",
+        "agent:billing.summary",
+        "agent:multi:colon:ref",
+        "AGENT_X",
+        "agent_x",
+        ":foo:",
     ],
 )
-def test_sanitiser_collapses_non_env_chars(identity_ref: str, expected: str) -> None:
-    """Non-``[A-Za-z0-9_]`` chars in *identity_ref* collapse to ``_``."""
-    assert agent_client_id_from_identity_ref(identity_ref) == expected
+def test_client_id_encoder_is_reversible(identity_ref: str) -> None:
+    """The client-id segment is a reversible hex encoding of *identity_ref*."""
+    encoded = agent_client_id_from_identity_ref(identity_ref)
+    assert bytes.fromhex(encoded).decode("utf-8") == identity_ref
+
+
+def test_client_id_encoder_distinguishes_separator_and_case_variants() -> None:
+    """S10 #298: variants that collapsed to ``AGENT_A_B`` under the old
+    sanitiser now encode distinctly — even after the callers' ``upper()``."""
+    variants = ["agent:a-b", "agent:a_b", "agent:a.b", "agent:A-B"]
+    encoded = {agent_client_id_from_identity_ref(v).upper() for v in variants}
+    assert len(encoded) == len(variants)
 
 
 async def test_vault_first_secret_wins_over_env(
@@ -94,9 +126,9 @@ async def test_vault_first_secret_wins_over_env(
 ) -> None:
     """When Vault returns a secret, it is used even if the env var is set."""
     _patch_vault_read(monkeypatch, "vault-secret")
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+    monkeypatch.setenv(_env_var("agent:reporter"), "env-secret")
 
-    client_id, secret = await resolve_agent_credentials("agent:reporter")
+    client_id, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert client_id == "agent:reporter"
     assert secret == "vault-secret"
@@ -107,9 +139,9 @@ async def test_env_fallback_when_vault_returns_none(
 ) -> None:
     """Vault secret absent (``None``) -> the env-var fallback resolves."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+    monkeypatch.setenv(_env_var("agent:reporter"), "env-secret")
 
-    client_id, secret = await resolve_agent_credentials("agent:reporter")
+    client_id, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert client_id == "agent:reporter"
     assert secret == "env-secret"
@@ -125,10 +157,10 @@ async def test_env_fallback_when_vault_not_configured(
     the token is unset; the resolver swallows it and falls back.
     """
     monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+    monkeypatch.setenv(_env_var("agent:reporter"), "env-secret")
     get_settings.cache_clear()
 
-    _, secret = await resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert secret == "env-secret"
 
@@ -145,9 +177,9 @@ async def test_vault_broker_error_falls_back_to_env(
         monkeypatch,
         vault_credentials.SchedulerVaultBrokerError("vault unreachable"),
     )
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+    monkeypatch.setenv(_env_var("agent:reporter"), "env-secret")
 
-    _, secret = await resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert secret == "env-secret"
 
@@ -158,11 +190,11 @@ async def test_resolve_uses_sanitised_uppercased_env_name(
     """Env-var name is sanitised then upper-cased (fallback path)."""
     _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv(
-        "MEHO_AGENT_SECRET_AGENT_INCIDENT_TRIAGE",
+        _env_var("agent:incident-triage"),
         "triage-secret",
     )
 
-    _, secret = await resolve_agent_credentials("agent:incident-triage")
+    _, secret = await resolve_agent_credentials("agent:incident-triage", tenant_id=_TENANT)
 
     assert secret == "triage-secret"
 
@@ -170,10 +202,10 @@ async def test_resolve_uses_sanitised_uppercased_env_name(
 async def test_resolve_missing_both_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     """Neither Vault nor env -> :class:`AgentCredentialsUnresolvedError`."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    monkeypatch.delenv(_env_var("agent:reporter"), raising=False)
 
     with pytest.raises(AgentCredentialsUnresolvedError, match=r"agent:reporter"):
-        await resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
 
 async def test_resolve_empty_env_with_no_vault_raises(
@@ -181,10 +213,10 @@ async def test_resolve_empty_env_with_no_vault_raises(
 ) -> None:
     """An empty env-var value is treated as unset (Helm template defence)."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "")
+    monkeypatch.setenv(_env_var("agent:reporter"), "")
 
     with pytest.raises(AgentCredentialsUnresolvedError):
-        await resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
 
 async def test_resolve_whitespace_only_env_raises(
@@ -192,23 +224,21 @@ async def test_resolve_whitespace_only_env_raises(
 ) -> None:
     """Whitespace-only env-var value is treated as unset."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "   \n\t  ")
+    monkeypatch.setenv(_env_var("agent:reporter"), "   \n\t  ")
 
     with pytest.raises(AgentCredentialsUnresolvedError):
-        await resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
 
 async def test_custom_env_pattern_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-default ``SCHEDULER_AGENT_SECRET_ENV_PATTERN`` reroutes the lookup."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.setenv(
-        "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
-        "OPS_AGENT_{client_id}_PASSPHRASE",
-    )
-    monkeypatch.setenv("OPS_AGENT_AGENT_REPORTER_PASSPHRASE", "rotating-key")
+    pattern = "OPS_AGENT_{tenant_id}_{client_id}_PASSPHRASE"
+    monkeypatch.setenv("SCHEDULER_AGENT_SECRET_ENV_PATTERN", pattern)
+    monkeypatch.setenv(_env_var("agent:reporter", pattern=pattern), "rotating-key")
     get_settings.cache_clear()
 
-    _, secret = await resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert secret == "rotating-key"
 
@@ -220,12 +250,12 @@ async def test_resolve_uppercases_full_env_var_name_even_with_lowercase_pattern(
     _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv(
         "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
-        "meho_agent_secret_{client_id}",
+        "meho_agent_secret_{tenant_id}_{client_id}",
     )
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "the-secret")
+    monkeypatch.setenv(_env_var("agent:reporter"), "the-secret")
     get_settings.cache_clear()
 
-    _, secret = await resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter", tenant_id=_TENANT)
 
     assert secret == "the-secret"
 
@@ -233,10 +263,12 @@ async def test_resolve_uppercases_full_env_var_name_even_with_lowercase_pattern(
 @pytest.mark.parametrize(
     "bad_pattern",
     [
-        "MEHO_AGENT_SECRET_PROD",  # no {client_id} placeholder
-        "MEHO_AGENT_SECRET_{0}",  # positional, no client_id key
-        "MEHO_AGENT_SECRET_{client_id",  # unbalanced opening brace
-        "MEHO_AGENT_SECRET_client_id}",  # unbalanced closing brace
+        "MEHO_AGENT_SECRET_PROD",  # no placeholders at all
+        "MEHO_AGENT_SECRET_{tenant_id}",  # missing {client_id} (S10 #298)
+        "MEHO_AGENT_SECRET_{client_id}",  # missing {tenant_id} (S10 #298)
+        "MEHO_AGENT_SECRET_{0}_{client_id}",  # positional, no tenant_id key
+        "MEHO_AGENT_SECRET_{tenant_id}_{client_id",  # unbalanced opening brace
+        "MEHO_AGENT_SECRET_{tenant_id}_client_id}",  # unbalanced closing brace
     ],
 )
 def test_settings_rejects_malformed_scheduler_secret_pattern(
@@ -255,15 +287,13 @@ def test_settings_accepts_valid_scheduler_secret_pattern(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sanity: a valid pattern passes the validator without error."""
-    monkeypatch.setenv(
-        "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
-        "CORP_AGENT_{client_id}_SECRET",
-    )
+    pattern = "CORP_AGENT_{tenant_id}_{client_id}_SECRET"
+    monkeypatch.setenv("SCHEDULER_AGENT_SECRET_ENV_PATTERN", pattern)
     get_settings.cache_clear()
 
     settings = get_settings()
 
-    assert settings.scheduler_agent_secret_env_pattern == "CORP_AGENT_{client_id}_SECRET"
+    assert settings.scheduler_agent_secret_env_pattern == pattern
 
 
 async def test_error_message_names_expected_env_var(
@@ -271,10 +301,10 @@ async def test_error_message_names_expected_env_var(
 ) -> None:
     """The error names the env var operators need to set (fallback path)."""
     _patch_vault_read(monkeypatch, None)
-    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_BILLING_SUMMARY", raising=False)
+    monkeypatch.delenv(_env_var("agent:billing.summary"), raising=False)
 
     with pytest.raises(AgentCredentialsUnresolvedError) as excinfo:
-        await resolve_agent_credentials("agent:billing.summary")
+        await resolve_agent_credentials("agent:billing.summary", tenant_id=_TENANT)
 
     msg = str(excinfo.value)
-    assert "MEHO_AGENT_SECRET_AGENT_BILLING_SUMMARY" in msg
+    assert _env_var("agent:billing.summary") in msg

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -24,6 +24,7 @@ Vault. The live round-trip is covered by the integration suite.
 from __future__ import annotations
 
 import asyncio
+import uuid
 from collections.abc import Callable
 from typing import Any
 
@@ -34,6 +35,16 @@ from structlog.testing import capture_logs
 
 import meho_backplane.scheduler.vault_credentials as vc
 from meho_backplane.settings import get_settings
+
+#: A fixed tenant threaded through every read/write below (S10, #298 —
+#: the derivation is now per-(tenant, principal)).
+_TENANT = uuid.UUID("11111111-2222-3333-4444-555555555555")
+#: The path shape the default pattern renders for ``agent:reporter`` in
+#: ``_TENANT`` — recomputed here independently of the SUT so it pins the
+#: {tenant_id}_{client_id} contract rather than echoing it.
+_REPORTER_CLIENT_SEG = b"agent:reporter".hex().upper()
+_REPORTER_API_PATH = f"secret/data/agents/{_TENANT.hex}_{_REPORTER_CLIENT_SEG}/credentials"
+_REPORTER_LOGICAL = f"agents/{_TENANT.hex}_{_REPORTER_CLIENT_SEG}/credentials"
 
 
 def _async_return(value: Any) -> Callable[..., Any]:
@@ -180,9 +191,27 @@ def test_split_kv_v2_api_path_rejects_empty_logical(bad: str) -> None:
         vc.split_kv_v2_api_path(bad)
 
 
-def test_vault_path_for_client_id_sanitises_and_uppercases() -> None:
-    path = vc.vault_path_for_client_id("agent:reporter")
-    assert path == "secret/data/agents/AGENT_REPORTER/credentials"
+def test_vault_path_for_client_id_encodes_tenant_and_client() -> None:
+    path = vc.vault_path_for_client_id("agent:reporter", tenant_id=_TENANT)
+    assert path == _REPORTER_API_PATH
+
+
+def test_vault_path_distinct_for_separator_and_case_variants() -> None:
+    """S10 #298: name-variants that collapsed under the old sanitiser
+    (all -> ``AGENT_A_B``) now derive four *distinct* Vault paths."""
+    variants = ["agent:a-b", "agent:a_b", "agent:a.b", "agent:A-B"]
+    paths = {vc.vault_path_for_client_id(v, tenant_id=_TENANT) for v in variants}
+    assert len(paths) == len(variants)
+
+
+def test_vault_path_distinct_for_same_name_across_tenants() -> None:
+    """S10 #298: the same identity_ref in two tenants derives two distinct
+    Vault paths — the credential is scoped to its owning tenant."""
+    tenant_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    tenant_b = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    path_a = vc.vault_path_for_client_id("agent:reporter", tenant_id=tenant_a)
+    path_b = vc.vault_path_for_client_id("agent:reporter", tenant_id=tenant_b)
+    assert path_a != path_b
 
 
 # --- not configured ---------------------------------------------------
@@ -192,27 +221,27 @@ async def test_write_not_configured_raises(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
     get_settings.cache_clear()
     with pytest.raises(vc.SchedulerVaultNotConfiguredError):
-        await vc.write_agent_secret("agent:reporter", "s3cr3t")
+        await vc.write_agent_secret("agent:reporter", "s3cr3t", tenant_id=_TENANT)
 
 
 async def test_read_not_configured_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
     get_settings.cache_clear()
     with pytest.raises(vc.SchedulerVaultNotConfiguredError):
-        await vc.read_agent_secret("agent:reporter")
+        await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT)
 
 
 # --- write ------------------------------------------------------------
 
 
 async def test_write_persists_secret_at_derived_path(fake_kv: _FakeKvV2) -> None:
-    api_path = await vc.write_agent_secret("agent:reporter", "gen-secret")
+    api_path = await vc.write_agent_secret("agent:reporter", "gen-secret", tenant_id=_TENANT)
 
-    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+    assert api_path == _REPORTER_API_PATH
     assert len(fake_kv.writes) == 1
     write = fake_kv.writes[0]
     assert write["mount_point"] == "secret"
-    assert write["path"] == "agents/AGENT_REPORTER/credentials"
+    assert write["path"] == _REPORTER_LOGICAL
     assert write["secret"] == {vc.SECRET_FIELD: "gen-secret"}
 
 
@@ -222,7 +251,7 @@ async def test_write_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> Non
 
     fake_kv.create_or_update_secret = _boom  # type: ignore[assignment]
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
     # An unreachable Vault is already an unambiguous diagnosis; the
     # write path must not spend a lookup-self on it (#2652).
     assert excinfo.value.token_invalid is False
@@ -244,7 +273,7 @@ async def test_write_non_connection_transport_error_maps_to_broker_error(
 
     fake_kv.create_or_update_secret = _boom  # type: ignore[method-assign]
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
     assert excinfo.value.token_invalid is False
     assert fake_kv.token_api.lookup_calls == 0
 
@@ -267,7 +296,7 @@ async def test_write_denied_with_dead_token_sets_token_invalid(fake_kv: _FakeKvV
     fake_kv.token_api.lookup_raises = hvac.exceptions.Forbidden("permission denied")
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is True
     assert fake_kv.token_api.lookup_calls == 1
@@ -283,7 +312,7 @@ async def test_write_denied_with_live_token_keeps_policy_disposition(
     fake_kv.token_api.lookup_result = {"data": {"ttl": 2764800, "expire_time": None}}
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is False
     assert fake_kv.token_api.lookup_calls == 1
@@ -297,7 +326,7 @@ async def test_write_denied_with_unreachable_lookup_stays_conservative(
     fake_kv.token_api.lookup_raises = requests.exceptions.ConnectionError("down")
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is False
 
@@ -334,7 +363,7 @@ async def test_only_a_403_lookup_proves_the_token_is_dead(
     fake_kv.token_api.lookup_raises = lookup_error
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is expected_token_invalid
     assert fake_kv.token_api.lookup_calls == 1
@@ -362,7 +391,7 @@ async def test_non_403_write_rejection_skips_the_probe(
     fake_kv.create_or_update_secret = _boom  # type: ignore[assignment]
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is False
     assert fake_kv.token_api.lookup_calls == 0
@@ -400,10 +429,10 @@ async def test_read_returns_secret(fake_kv: _FakeKvV2) -> None:
     fake_kv.read_result = {
         "data": {"data": {vc.SECRET_FIELD: "gen-secret"}, "metadata": {"version": 1}}
     }
-    secret = await vc.read_agent_secret("agent:reporter")
+    secret = await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT)
     assert secret == "gen-secret"
     assert fake_kv.last_read == {
-        "path": "agents/AGENT_REPORTER/credentials",
+        "path": _REPORTER_LOGICAL,
         "mount_point": "secret",
     }
 
@@ -411,30 +440,30 @@ async def test_read_returns_secret(fake_kv: _FakeKvV2) -> None:
 async def test_read_missing_path_returns_none(fake_kv: _FakeKvV2) -> None:
     """A KV-v2 read of a non-existent path (InvalidPath) returns ``None``."""
     fake_kv.read_raises = hvac.exceptions.InvalidPath("404")
-    assert await vc.read_agent_secret("agent:reporter") is None
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) is None
 
 
 async def test_read_missing_field_returns_none(fake_kv: _FakeKvV2) -> None:
     """A payload without the secret field is treated as 'not in Vault'."""
     fake_kv.read_result = {"data": {"data": {"other": "x"}, "metadata": {}}}
-    assert await vc.read_agent_secret("agent:reporter") is None
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) is None
 
 
 async def test_read_malformed_payload_returns_none(fake_kv: _FakeKvV2) -> None:
     fake_kv.read_result = {"data": {}}
-    assert await vc.read_agent_secret("agent:reporter") is None
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) is None
 
 
 async def test_read_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> None:
     fake_kv.read_raises = requests.exceptions.Timeout("slow")
     with pytest.raises(vc.SchedulerVaultBrokerError):
-        await vc.read_agent_secret("agent:reporter")
+        await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT)
 
 
 async def test_read_vault_error_maps_to_broker_error(fake_kv: _FakeKvV2) -> None:
     fake_kv.read_raises = hvac.exceptions.Forbidden("denied")
     with pytest.raises(vc.SchedulerVaultBrokerError):
-        await vc.read_agent_secret("agent:reporter")
+        await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT)
 
 
 # --- renew-on-use (#2328) --------------------------------------------
@@ -442,12 +471,12 @@ async def test_read_vault_error_maps_to_broker_error(fake_kv: _FakeKvV2) -> None
 
 async def test_read_renews_token_on_success(fake_kv: _FakeKvV2) -> None:
     fake_kv.read_result = {"data": {"data": {vc.SECRET_FIELD: "s"}, "metadata": {}}}
-    assert await vc.read_agent_secret("agent:reporter") == "s"
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) == "s"
     assert fake_kv.token_api.renew_calls == 1
 
 
 async def test_write_renews_token_on_success(fake_kv: _FakeKvV2) -> None:
-    await vc.write_agent_secret("agent:reporter", "s")
+    await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
     assert fake_kv.token_api.renew_calls == 1
 
 
@@ -455,14 +484,14 @@ async def test_renew_failure_does_not_break_read(fake_kv: _FakeKvV2) -> None:
     """A failed best-effort renew is swallowed — the read still returns."""
     fake_kv.read_result = {"data": {"data": {vc.SECRET_FIELD: "s"}, "metadata": {}}}
     fake_kv.token_api.renew_raises = hvac.exceptions.Forbidden("not renewable")
-    assert await vc.read_agent_secret("agent:reporter") == "s"
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) == "s"
     assert fake_kv.token_api.renew_calls == 1
 
 
 async def test_missing_path_read_does_not_renew(fake_kv: _FakeKvV2) -> None:
     """InvalidPath (secret absent) returns before the renew step."""
     fake_kv.read_raises = hvac.exceptions.InvalidPath("404")
-    assert await vc.read_agent_secret("agent:reporter") is None
+    assert await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT) is None
     assert fake_kv.token_api.renew_calls == 0
 
 
@@ -586,9 +615,9 @@ async def test_write_dead_token_self_heals_and_retries(
     monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
     monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
 
-    api_path = await vc.write_agent_secret("agent:reporter", "s3cr3t")
+    api_path = await vc.write_agent_secret("agent:reporter", "s3cr3t", tenant_id=_TENANT)
 
-    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+    assert api_path == _REPORTER_API_PATH
     assert len(jwt_calls) == 1  # a jwt_login occurred
     assert jwt_calls[0]["role"] == "meho-mcp"  # vault_oidc_role fallback (#2757)
     assert jwt_calls[0]["jwt"] == "runner-jwt"
@@ -625,7 +654,7 @@ async def test_read_dead_token_self_heals_and_retries(
     monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
     monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
 
-    secret = await vc.read_agent_secret("agent:reporter")
+    secret = await vc.read_agent_secret("agent:reporter", tenant_id=_TENANT)
 
     assert secret == "gen-secret"  # the retry against the re-minted client won
     assert len(jwt_calls) == 1
@@ -644,7 +673,7 @@ async def test_dead_token_remint_unavailable_falls_back_loud(fake_kv: _FakeKvV2)
     fake_kv.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is True
     assert fake_kv.writes == []
@@ -669,7 +698,7 @@ async def test_selfheal_retry_failure_fails_loud(
     monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is True
     assert kv.writes == []
@@ -689,7 +718,7 @@ async def test_remint_login_denied_falls_back_loud(
     monkeypatch.setattr(vc, "_to_thread_jwt_login", _login_denied)
 
     with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
-        await vc.write_agent_secret("agent:reporter", "s")
+        await vc.write_agent_secret("agent:reporter", "s", tenant_id=_TENANT)
 
     assert excinfo.value.token_invalid is True
     assert fake_kv_any_token.writes == []

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -111,7 +111,8 @@ DBOS rebase swaps only the loop module.
                                                  |
                                                  v
                               +------------------------------------------+
-                              | resolve_agent_credentials(identity_ref)  |
+                              | resolve_agent_credentials(identity_ref,  |
+                              |     tenant_id=row.tenant_id)             |
                               |   -> (client_id, client_secret)          |
                               | AgentInvoker.run_scheduled(name, inputs, |
                               |     agent_client_id=..,                  |
@@ -130,34 +131,42 @@ pod env var only when Vault yields nothing (#1478). The lookup chain:
    `AgentDefinition.identity_ref` (e.g. `agent:reporter`). The
    `identity_ref` verbatim is the `client_id` passed to `run_scheduled`
    (Keycloak's namespace tolerates the `:` separator).
-2. `resolve_agent_credentials(identity_ref)` (in
+2. `resolve_agent_credentials(identity_ref, tenant_id=...)` (in
    [scheduler/credentials.py](../../backend/src/meho_backplane/scheduler/credentials.py))
-   sanitises the ref (non-alphanumeric chars to `_`, upper-case) and
-   resolves the secret:
+   derives the storage key from **two** inputs — the ref and the owning
+   `tenant_id` (the trigger's tenant) — and resolves the secret. The
+   `{client_id}` segment is a **reversible hex encoding** of the ref's
+   UTF-8 bytes (`agent_client_id_from_identity_ref`), not a lossy
+   sanitiser: two distinct principals — name-variants within a tenant
+   (`agent:a-b` vs `agent:a_b`), or the same name across tenants — never
+   collapse onto one key (security S10, #298):
    - **Vault (first).**
      [`read_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)
      reads the secret from `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
-     (default `secret/data/agents/{client_id}/credentials`) under
-     `VAULT_SCHEDULER_TOKEN`. The `{client_id}` token is **not** the raw
-     `identity_ref` — `vault_path_for_client_id` substitutes the
-     **sanitised, UPPER-CASED** form (non-alphanumeric chars to `_`,
-     then `.upper()`), the same shape the env-var key uses below. For
-     `agent:ops-writer` the resolved path is
-     `secret/data/agents/AGENT_OPS_WRITER/credentials` (not a raw
-     `agent:ops-writer` key). Both the read here and the write below call
-     this one helper, so the two paths cannot diverge — an operator
-     hand-provisioning the Vault secret or policy must target the
-     sanitised path. The raw KV-v2 API path is split into hvac's
+     (default `secret/data/agents/{tenant_id}_{client_id}/credentials`)
+     under `VAULT_SCHEDULER_TOKEN`. `vault_path_for_client_id`
+     substitutes `{tenant_id}` with the tenant's `.hex` and `{client_id}`
+     with the UPPER-CASED hex of the ref — so `agent:ops-writer` in
+     tenant `t` resolves to
+     `secret/data/agents/<t.hex>_<hex(agent:ops-writer)>/credentials`.
+     The default joins the two under one `_` (a single dynamic path
+     segment) so the deployed `secret/data/agents/*/credentials` ACL
+     keeps matching without a policy re-scope. Both the read here and the
+     write below call this one helper with the same tenant, so the two
+     paths cannot diverge. The raw KV-v2 API path is split into hvac's
      `(mount_point, logical_path)` form by `split_kv_v2_api_path`.
      This is the path registration writes to (see below), so an agent
      registered + defined purely over the API is schedulable with **no
      pod env var and no redeploy**. A missing path / unset token / read
-     error falls through to the env var.
+     error falls through to the env var. Because the read tenant is the
+     trigger's tenant, a principal registered in a *different* tenant
+     resolves to a different key and does not resolve here — the
+     tenant-isolation invariant.
    - **Env var (fallback / break-glass).** When Vault yields nothing,
      the secret is read from the env var derived from
      `SCHEDULER_AGENT_SECRET_ENV_PATTERN` (default
-     `MEHO_AGENT_SECRET_{client_id}`). For `agent:reporter` the
-     resolved env var is `MEHO_AGENT_SECRET_AGENT_REPORTER`. Operators
+     `MEHO_AGENT_SECRET_{tenant_id}_{client_id}`), threaded with the same
+     tenant + reversible client segment and upper-cased whole. Operators
      wire it the same way `ANTHROPIC_API_KEY` is wired when Vault is
      unavailable.
 3. When **neither** source yields a secret,
@@ -175,13 +184,15 @@ The write side: registering an agent principal
 captures the Keycloak-generated client secret (`get_client_secret`) and
 persists it to Vault at `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
 ([`write_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)),
-under the same scheduler service token. The write resolves the path
-through the **same** `vault_path_for_client_id` helper as the read, so it
-lands on the sanitised, UPPER-CASED path (`agent:ops-writer` →
-`secret/data/agents/AGENT_OPS_WRITER/credentials`) — write and read can
-never target different keys. A Vault-write failure rolls back the
-just-created Keycloak client so registration never produces an
-unschedulable agent.
+under the same scheduler service token, passing the **principal's**
+`tenant_id`. The write resolves the path through the **same**
+`vault_path_for_client_id` helper (and tenant) as the read, so it lands
+on the per-tenant, per-principal key
+(`secret/data/agents/<tenant.hex>_<hex(agent:ops-writer)>/credentials`)
+— write and read can never target different keys, and a name-variant or
+cross-tenant registration can no longer clobber another principal's
+secret (S10, #298). A Vault-write failure rolls back the just-created
+Keycloak client so registration never produces an unschedulable agent.
 
 `VAULT_SCHEDULER_TOKEN` is a static token bound to a narrow read/write
 policy on the agent-credentials path — the lowest-friction


### PR DESCRIPTION
## Summary

- **Security S10 (meho-internal#298).** The scheduler agent client-credentials Vault key was derived from a single, lossy-sanitised `{client_id}` with **no tenant component**: every `[^A-Za-z0-9_]` collapsed to `_`, so `agent:a-b`, `agent:a_b`, `agent:a.b` (and case variants) all mapped to `AGENT_A_B`, and the same name across tenants mapped to one key. A second `register` then silently overwrote the first principal's stored secret via an unconditional KV-v2 write — availability + credential-confusion.
- **Fix:** thread the owning `tenant_id` through the whole derivation, and make the `{client_id}` segment a **reversible, injective hex encoding** of the identity ref (a byte-level encoding, so distinct separator/case variants stay distinct even after the env-name `upper()`). Two distinct principals — name-variants within a tenant, or the same name across tenants — can no longer collide on one key.
- Both patterns gain a `{tenant_id}` placeholder guarded by fail-closed `Settings` validators. The **default keeps a single dynamic path segment** (`secret/data/agents/{tenant_id}_{client_id}/credentials`) so the deployed `secret/data/agents/*/credentials` ACL keeps matching **without a policy re-scope** (that re-scope is out of scope / cross-repo per the Task).
- Read tenant is the trigger/dashboard tenant; `validate_identity_ref` is tenant-scoped (`AgentPrincipal.tenant_id == tenant_id`), so read-tenant always equals the principal's registration tenant for every legitimate flow — the change is backward-compatible for real configs and closes the cross-tenant/variant clobber.

### Already on `main`
Nothing of this Task was already implemented on `main` — the pre-#298 derivation (`credentials.py` lossy sanitiser, single-`{client_id}` patterns, tenant-less `vault_path_for_client_id`) was intact at `origin/main` (`e35f15c1`). The 2026-09-06 containment PRs (#3423/#3427) touched other findings.

## What changed
- `scheduler/credentials.py` — `agent_client_id_from_identity_ref` is now a reversible hex encoder; new `tenant_key_segment`; `resolve_agent_credentials(identity_ref, *, tenant_id)` threads tenant into the Vault read and the env-var fallback.
- `scheduler/vault_credentials.py` — `vault_path_for_client_id` / `write_agent_secret` / `read_agent_secret` take `tenant_id`.
- `auth/agent_principals.py`, `auth/runner_principals.py` — register passes the principal's `tenant_id` on the write.
- `scheduler/loop.py`, `checks/investigate.py` — read passes the trigger/dashboard `tenant_id` (the event matcher inherits it via the shared `_prepare_invocation`).
- `settings.py` — both default patterns gain `{tenant_id}`; two fail-closed validators require `{tenant_id}` + `{client_id}`.
- `docs/codebase/scheduler.md` — credential-resolution section updated to the per-(tenant, principal) key shape.

## Test plan
- [x] `ruff check src/meho_backplane/scheduler/ src/meho_backplane/auth/` — clean
- [x] `mypy src/meho_backplane/scheduler/vault_credentials.py src/meho_backplane/scheduler/credentials.py` — clean
- [x] `ruff format --check` (all changed files) — clean
- [x] `pytest tests/test_scheduler_vault_credentials.py tests/test_scheduler_credentials.py tests/test_api_v1_agent_principals.py tests/test_api_v1_runner_principals.py -q` — 144 passed
- [x] Full backend unit lane (`pytest tests/ --ignore=tests/integration`) — green
- [x] `code-quality.py --diff` — 0 blockers

### Acceptance criteria
- [x] `test_vault_path_distinct_for_separator_and_case_variants` (new, `test_scheduler_vault_credentials.py`) — `agent:a-b`/`a_b`/`a.b`/`A-B` → 4 distinct paths.
- [x] `test_vault_path_distinct_for_same_name_across_tenants` (new, same file) — same name, two tenants → 2 distinct paths.
- [x] New register test `test_register_variant_names_write_distinct_vault_paths` (`test_api_v1_agent_principals.py`) — a second registration whose name collided under the old sanitiser writes a distinct path; the first principal's secret is not overwritten.
- [x] The four-file `pytest` set passes.
- [x] `ruff check` + `mypy` on the scheduler/auth surface pass.

## Out of scope
- The `meho-scheduler` Vault ACL policy (`docs/cross-repo/vault-provisioning.md`) — the single-segment default keeps the existing `secret/data/agents/*/credentials` glob valid, so no re-scope is required or made here.
- The connector KV tenant-scope config gap (meho-internal#282 / F14b) and the K8s-client-cache keying (meho-internal#266 / F04).
- The owner-stamp-alongside-secret defense-in-depth floor from the Task's recommendation: redundant here — the per-(tenant, principal) hex key makes a collision structurally impossible, so it was not added (simplicity-first).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#298
