### PR TITLE
fix(connectors): pin SSRF-validated address into the socket connect (#275)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/pinned_transport.py
+++ b/backend/src/meho_backplane/connectors/_shared/pinned_transport.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Address-pinning httpx transports that close the SSRF check/use gap.
+
+A destination guard that resolves a hostname, screens the answer, and
+then hands the *hostname* to httpx leaves a check/use gap: httpx
+re-resolves the name at connect time, so a resolver that changes its
+answer between the screen and the connect (DNS rebinding, or a
+split-horizon flip) can steer the socket at a blocked address the guard
+never saw (evoila-bosnia/meho-internal#275, F13).
+
+This module removes the gap by moving the decision to the socket
+boundary. A pinning transport wraps httpcore's connection pool with a
+network backend whose ``connect_tcp`` resolves-and-screens the host in
+one step and then dials **only** a validated address literal from that
+same resolution. Because the address the socket reaches is the address
+that was screened, there is no second, unscreened resolution to exploit.
+
+What is deliberately *not* touched:
+
+* **TLS SNI / certificate verification.** httpcore derives the TLS
+  ``server_hostname`` from the request origin (or the ``sni_hostname``
+  request extension), never from the value ``connect_tcp`` was handed,
+  so rewriting the TCP target to an IP literal leaves the handshake
+  offering the original hostname as SNI and verifying the presented
+  cert's CN/SAN against it. Chain, hostname, and any per-target CA pin
+  keep biting.
+* **The ``Host:`` header**, which httpx builds from the request URL.
+* **Connection reuse.** ``connect_tcp`` runs only when the pool opens a
+  *new* connection; a warm pooled connection (already pinned to a
+  screened address) is reused untouched, and the next new connection
+  re-screens.
+
+The screening itself is supplied by the caller as a
+:data:`PinnedResolver`: the target-dispatch path passes the target SSRF
+guard (:mod:`meho_backplane.targets.ssrf_guard`), the connector
+spec-ingest path passes its own stricter fetch guard. Each resolver
+owns its own policy (allowlist, fail-open vs fail-closed, error type);
+this module only enforces *connect to what you screened*.
+
+**Explicit proxy note.** An httpx client handed an explicit
+``transport=`` sends every request through that one transport and does
+**not** apply the ambient ``HTTP(S)_PROXY`` mounts it would otherwise
+derive from the environment. That is the correct posture here: routing a
+vendor dial through an ambient proxy would place the destination
+decision on the far side of the proxy, defeating address pinning. MEHO
+configures no such proxy; egress restriction, where wanted, is an
+independent network boundary (the guard does not replace it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from collections.abc import Callable, Iterable, Sequence
+
+import httpcore
+import httpx
+
+__all__ = [
+    "PinnedResolver",
+    "build_pinned_async_transport",
+    "build_pinned_sync_transport",
+]
+
+#: A destination screen for the pinning backend. Given the host httpcore
+#: is about to dial, it returns the IP-literal address set the connection
+#: may use — screening already applied, so it **raises** the caller's own
+#: destination-blocked error when the host is (or resolves to) a
+#: forbidden address — or ``None`` to dial the host unchanged
+#: (passthrough: an allowlisted hostname literal the policy trusts
+#: verbatim, or a name the policy fails open on and lets the stock
+#: resolver handle). An empty sequence is treated as passthrough.
+PinnedResolver = Callable[[str], Sequence[str] | None]
+
+
+class _PinnedAsyncBackend(httpcore.AsyncNetworkBackend):
+    """Async network backend that dials only resolver-validated addresses.
+
+    Wraps the pool's original backend (so trio/asyncio detection and
+    every non-TCP concern are preserved) and overrides ``connect_tcp`` to
+    screen the host and pin the connection. The screen is a blocking
+    ``getaddrinfo`` call, so it runs in a worker thread — the dispatch
+    hot path must not stall the event loop for a DNS round-trip (the same
+    reason :func:`assert_public_destination_async` offloads).
+    """
+
+    def __init__(self, resolver: PinnedResolver, inner: httpcore.AsyncNetworkBackend) -> None:
+        self._resolver = resolver
+        self._inner = inner
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        addresses = await asyncio.to_thread(self._resolver, host)
+        if not addresses:
+            # Passthrough: an allowlisted hostname literal or a name the
+            # policy fails open on — dial by name via the stock backend.
+            return await self._inner.connect_tcp(
+                host,
+                port,
+                timeout=timeout,
+                local_address=local_address,
+                socket_options=socket_options,
+            )
+        last_exc: httpcore.ConnectError | httpcore.ConnectTimeout | None = None
+        for address in addresses:
+            try:
+                return await self._inner.connect_tcp(
+                    address,
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            except (httpcore.ConnectError, httpcore.ConnectTimeout) as exc:
+                last_exc = exc
+        # Every screened address failed to connect (IPv6-then-IPv4
+        # fallback exhausted); surface the last transport error.
+        assert last_exc is not None
+        raise last_exc
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        # A UDS path names a local file, not a network destination — no
+        # host to screen; delegate unchanged.
+        return await self._inner.connect_unix_socket(
+            path, timeout=timeout, socket_options=socket_options
+        )
+
+    async def sleep(self, seconds: float) -> None:
+        await self._inner.sleep(seconds)
+
+
+class _PinnedSyncBackend(httpcore.NetworkBackend):
+    """Synchronous counterpart of :class:`_PinnedAsyncBackend`.
+
+    Used by the connector spec-ingest fetch, which runs on a stock
+    synchronous :class:`httpx.Client`. The screen runs inline — there is
+    no event loop to protect on this path.
+    """
+
+    def __init__(self, resolver: PinnedResolver, inner: httpcore.NetworkBackend) -> None:
+        self._resolver = resolver
+        self._inner = inner
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        addresses = self._resolver(host)
+        if not addresses:
+            return self._inner.connect_tcp(
+                host,
+                port,
+                timeout=timeout,
+                local_address=local_address,
+                socket_options=socket_options,
+            )
+        last_exc: httpcore.ConnectError | httpcore.ConnectTimeout | None = None
+        for address in addresses:
+            try:
+                return self._inner.connect_tcp(
+                    address,
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            except (httpcore.ConnectError, httpcore.ConnectTimeout) as exc:
+                last_exc = exc
+        assert last_exc is not None
+        raise last_exc
+
+    def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        return self._inner.connect_unix_socket(path, timeout=timeout, socket_options=socket_options)
+
+    def sleep(self, seconds: float) -> None:
+        self._inner.sleep(seconds)
+
+
+def build_pinned_async_transport(
+    resolver: PinnedResolver,
+    *,
+    verify: ssl.SSLContext | str | bool = True,
+) -> httpx.AsyncHTTPTransport:
+    """Return an :class:`httpx.AsyncHTTPTransport` that pins via *resolver*.
+
+    ``verify`` is forwarded to the transport's TLS context exactly as
+    :class:`httpx.AsyncClient` would forward it (a ``bool``, a CA-bundle
+    path, or a pre-built :class:`ssl.SSLContext` — the CA-pin / insecure
+    contexts the HTTP adapter builds), so certificate-trust behaviour is
+    unchanged; only the TCP target is pinned. The transport's own
+    connection pool is preserved (limits, retries, keepalive) — its
+    network backend is the sole thing swapped.
+    """
+    transport = httpx.AsyncHTTPTransport(verify=verify)
+    pool = transport._pool
+    pool._network_backend = _PinnedAsyncBackend(resolver, pool._network_backend)
+    return transport
+
+
+def build_pinned_sync_transport(
+    resolver: PinnedResolver,
+    *,
+    verify: ssl.SSLContext | str | bool = True,
+) -> httpx.HTTPTransport:
+    """Return an :class:`httpx.HTTPTransport` that pins via *resolver*.
+
+    Synchronous counterpart of :func:`build_pinned_async_transport`, for
+    the spec-ingest fetch's :class:`httpx.Client`.
+    """
+    transport = httpx.HTTPTransport(verify=verify)
+    pool = transport._pool
+    pool._network_backend = _PinnedSyncBackend(resolver, pool._network_backend)
+    return transport

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -46,9 +46,22 @@ natively. The per-target TLS trust has three states, in precedence order:
    can reach a self-signed / internal-CA appliance with no pin. Per-target,
    never global, and loud — see :func:`_insecure_ssl_context` and the WARN
    emitted at client construction.
-3. **Default** (``verify_tls=True``, no pin) — the client is built with
-   **no** ``verify=`` argument, so the global ``SSL_CERT_FILE`` /
-   chart-trust-bundle path (evoila/meho#209) is in effect unchanged.
+3. **Default** (``verify_tls=True``, no pin) — the transport is built with
+   ``verify=True``, so the global ``SSL_CERT_FILE`` / chart-trust-bundle
+   path (evoila/meho#209) is in effect unchanged (httpx's
+   ``create_ssl_context(verify=True, trust_env=True)`` reads it, exactly
+   as an unconfigured client would).
+
+Each resolved TLS context is carried by the per-target pinning
+**transport** (:func:`build_pinned_async_transport`), not passed as a
+client ``verify=`` argument, because the client is handed an explicit
+``transport=`` that enforces destination pinning at the socket
+(evoila-bosnia/meho-internal#275): ``connect_tcp`` re-screens the host
+and dials only a guard-validated address from that same resolution, so a
+resolver change between the guard's screen and the socket connect cannot
+reach a blocked destination. Only the TCP target is rewritten — TLS SNI,
+certificate verification, and the ``Host:`` header still use the
+original hostname.
 
 **Client pool key:** the pool is keyed on
 :func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`
@@ -79,11 +92,13 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponen
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.pinned_transport import build_pinned_async_transport
 from meho_backplane.connectors.base import Connector
 from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.targets.ssrf_guard import (
     TargetDestinationBlockedError,
     assert_public_destination_async,
+    screen_and_resolve,
 )
 
 logger = structlog.get_logger(__name__)
@@ -213,6 +228,27 @@ def _ca_pin_digest(ca_pem: str | None) -> str:
     if not ca_pem:
         return ""
     return hashlib.sha256(ca_pem.encode("utf-8")).hexdigest()[:16]
+
+
+def _pin_target_addresses(host: str) -> list[str] | None:
+    """Connect-time screen for the pinned transport, in ``SsrfBlockedError`` terms.
+
+    Wraps :func:`screen_and_resolve` (the target SSRF guard's
+    address-returning arm) so a block raised from *inside* the transport's
+    ``connect_tcp`` surfaces as :class:`SsrfBlockedError` — an
+    ``httpx.ConnectError`` subclass — exactly like the ``_http_client``
+    pre-check does. httpx's transport exception mapping re-raises an
+    unmapped exception unchanged, so an ``httpx.ConnectError`` subclass
+    reaches the dispatcher's existing ``ConnectError`` arm (flattened into
+    the structured ``connector_error`` shape) while a bare
+    ``TargetDestinationBlockedError`` (a ``ValueError``) would escape
+    unhandled. It is excluded from :func:`_retryable` for the same reason
+    the pre-check's rejection is: the verdict is deterministic policy.
+    """
+    try:
+        return screen_and_resolve(host)
+    except TargetDestinationBlockedError as exc:
+        raise SsrfBlockedError(str(exc)) from exc
 
 
 def _retryable(exc: BaseException) -> bool:
@@ -536,13 +572,14 @@ class HttpConnector(Connector):
         ca_pin = getattr(target, "tls_ca_pin", None)
         async with self._lock:
             if cache_key not in self._clients:
-                # Pass ``verify=`` only when the target pins a CA (secure)
-                # or opts out of verification (insecure). With neither we
-                # omit the kwarg so the client defaults to httpx's
-                # ``verify=True``, keeping the global ``SSL_CERT_FILE`` path
-                # (evoila/meho#209) byte-identical to a connector with no
-                # TLS config at all.
-                verify_kwargs: dict[str, Any] = {}
+                # Resolve the TLS-trust argument for the pinned transport.
+                # ``True`` keeps httpx's default ``verify=True`` + the
+                # global ``SSL_CERT_FILE`` path (evoila/meho#209)
+                # byte-identical to a connector with no TLS config at all;
+                # a CA-pin or the insecure opt-out supersedes it below.
+                # The transport (not the client) carries this context now,
+                # because the client is handed an explicit ``transport=``.
+                verify_arg: ssl.SSLContext | bool = True
                 if ca_pin:
                     # Secure supersession (evoila/meho#1784): trust the
                     # pinned CA while keeping CERT_REQUIRED + hostname
@@ -559,7 +596,7 @@ class HttpConnector(Connector):
                         host=getattr(target, "host", None),
                         ca_pin_digest=_ca_pin_digest(ca_pin),
                     )
-                    verify_kwargs["verify"] = _build_ca_pinned_ssl_context(ca_pin)
+                    verify_arg = _build_ca_pinned_ssl_context(ca_pin)
                 elif not verify_tls:
                     # Per-target, audited last resort (evoila/meho#1774):
                     # the dispatch forwards a Vault-resolved credential over
@@ -572,7 +609,21 @@ class HttpConnector(Connector):
                         target=getattr(target, "name", None),
                         host=getattr(target, "host", None),
                     )
-                    verify_kwargs["verify"] = _insecure_ssl_context()
+                    verify_arg = _insecure_ssl_context()
+                # Pin the connection to a guard-validated address at the
+                # socket boundary (evoila-bosnia/meho-internal#275). The
+                # ``_http_client`` pre-check above screens the stored name
+                # on every acquisition; this transport re-screens inside
+                # ``connect_tcp`` and dials only an address from that same
+                # resolution, so a resolver that changes its answer between
+                # the screen and the connect cannot steer the socket at a
+                # blocked destination the guard never saw. It preserves the
+                # original hostname for TLS SNI + cert verification and the
+                # ``Host:`` header (only the TCP target is rewritten). A
+                # blocked answer surfaces as ``SsrfBlockedError`` via
+                # ``_pin_target_addresses``, reaching the dispatcher's
+                # ``ConnectError`` arm and staying out of the retry policy.
+                transport = build_pinned_async_transport(_pin_target_addresses, verify=verify_arg)
                 self._clients[cache_key] = _SameOriginRedirectClient(
                     base_url=self._base_url(target),
                     timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
@@ -588,7 +639,7 @@ class HttpConnector(Connector):
                     # origin and forward NSX's ``X-XSRF-TOKEN`` and the
                     # login body to an attacker-controlled ``Location``
                     # (open-redirect SSRF, evoila/meho-internal#101 row L11).
-                    **verify_kwargs,
+                    transport=transport,
                 )
             return self._clients[cache_key]
 

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -85,6 +85,7 @@ from openapi_spec_validator.schemas import (
     openapi_v31_schema_validator as _oas31_schema_validator,
 )
 
+from meho_backplane.connectors._shared.pinned_transport import build_pinned_sync_transport
 from meho_backplane.operations._rfc6570 import split_path_operator
 from meho_backplane.operations.ingest.exceptions import (
     InvalidSchemaError,
@@ -658,12 +659,41 @@ def _assert_fetchable_remote_url(url: str) -> None:
     hostname = parsed.hostname
     if not hostname:
         raise InvalidSpecError("spec URI must include a hostname")
+    _screen_fetch_host(hostname)
+
+
+def _screen_fetch_host(hostname: str) -> list[str]:
+    """Resolve *hostname* and return the public addresses it may be fetched at.
+
+    The destination screen shared by :func:`_assert_fetchable_remote_url`
+    (which discards the result — it only needs the raise) and
+    :func:`_pin_fetch_addresses` (the pinning transport's connect-time
+    resolver, which dials one of the returned addresses). Resolving once
+    and connecting to that same answer is what closes the check/use gap:
+    without pinning, httpx re-resolves the name at connect time and a
+    resolver that has since moved the name into private space is followed
+    (evoila-bosnia/meho-internal#275).
+
+    Fails **closed**, unlike the target guard: an unresolvable name is
+    rejected here (the ingest path has no split-horizon fail-open case),
+    and there is no allowlist — the fetch path is public-https-only. Every
+    resolved address must be public; any private / loopback / link-local /
+    ULA / unspecified / multicast / reserved candidate rejects the whole
+    fetch. The message stays path-free (no resolved IP echoed) so the
+    response is not a network-topology oracle.
+
+    Raises:
+        InvalidSpecError: The hostname is unresolvable, resolves to no
+            addresses, resolves to an unrecognised address format, or any
+            resolved address is non-public.
+    """
     try:
         addr_infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
     except socket.gaierror as exc:
         raise InvalidSpecError("spec URI hostname could not be resolved") from exc
     if not addr_infos:
         raise InvalidSpecError("spec URI hostname resolved to no addresses")
+    addresses: list[str] = []
     for _family, _type, _proto, _canonname, sockaddr in addr_infos:
         raw_ip = sockaddr[0]
         try:
@@ -682,6 +712,23 @@ def _assert_fetchable_remote_url(url: str) -> None:
                 "spec URI resolves to a non-public address; remote fetch "
                 f"refused. {_INLINE_SPEC_ONRAMP_REMEDIATION}."
             )
+        addresses.append(str(addr))
+    return addresses
+
+
+def _pin_fetch_addresses(host: str) -> list[str]:
+    """Connect-time destination screen for the spec-fetch pinning transport.
+
+    Passed to :func:`build_pinned_sync_transport` so the fetch client's
+    ``connect_tcp`` screens the host it is about to dial and connects only
+    to a validated address from that same resolution — for the initial
+    fetch and every redirect hop that opens a fresh connection. Delegates
+    to :func:`_screen_fetch_host`, so it raises :class:`InvalidSpecError`
+    on a non-public / unresolvable answer; httpx's transport exception
+    mapping re-raises that unmapped type unchanged, so it surfaces from
+    the fetch exactly like the pre-fetch guard's rejection.
+    """
+    return _screen_fetch_host(host)
 
 
 def _load_spec_bytes(spec_path_or_uri: str, content: str | None = None) -> bytes:
@@ -761,7 +808,16 @@ def _fetch_spec_bytes(spec_path_or_uri: str) -> bytes:
     _assert_fetchable_remote_url(spec_path_or_uri)
 
     current_url = spec_path_or_uri
-    with httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=False) as client:
+    # Pin the fetch to a guard-validated address at the socket boundary
+    # (evoila-bosnia/meho-internal#275): the guard above (and per redirect
+    # hop below) screens the name, but httpx would otherwise re-resolve it
+    # at connect time. The pinning transport re-screens inside
+    # ``connect_tcp`` and dials only an address from that same resolution,
+    # so a resolver that changes its answer between the screen and the
+    # connect cannot steer the fetch at a private address. TLS SNI + cert
+    # verification and the ``Host:`` header keep the original hostname.
+    transport = build_pinned_sync_transport(_pin_fetch_addresses)
+    with httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=False, transport=transport) as client:
         for _ in range(_MAX_REDIRECTS + 1):
             # Stream rather than buffer: ``client.get`` reads the whole
             # body into memory before the size cap below can fire, which

--- a/backend/src/meho_backplane/targets/ssrf_guard.py
+++ b/backend/src/meho_backplane/targets/ssrf_guard.py
@@ -93,6 +93,7 @@ __all__ = [
     "TargetDestinationBlockedError",
     "assert_public_destination",
     "assert_public_destination_async",
+    "screen_and_resolve",
 ]
 
 #: Env var holding the operator-configured destination allowlist:
@@ -245,34 +246,56 @@ def _resolve_addrs(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Addr
     return addrs
 
 
-def assert_public_destination(host: str) -> None:
-    """Reject *host* when it is, or resolves to, a non-public address.
+def _reject_blocked(
+    addrs: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...],
+) -> None:
+    """Raise when any address in *addrs* is blocked and not allowlisted.
 
-    *host* may be an IPv4/IPv6 literal (bracketed IPv6 URL form
-    accepted) or a hostname. IP literals are checked directly. Anything
-    else is first normalized to the host httpx will actually dial via
-    :func:`_dialed_host` (values embedding credentials, a query, or a
-    fragment are refused outright; a path- or port-bearing value is
-    reduced to its dialed host) — so a stored value cannot be screened
-    as one destination and dialed as another. The dialed host is then
-    re-checked as an IP literal (an embedded-port form like
-    ``<ip>:<port>`` normalizes back to a screenable literal), matched
-    against the allowlist's hostname entries (an allowlisted name is
-    trusted verbatim — no resolution round-trip), and otherwise
-    resolved via :func:`_resolve_addrs`, with **every** resolved
-    address screened (any blocked, non-allowlisted candidate rejects,
-    matching the ingest guard's posture).
+    The single screening loop shared by :func:`assert_public_destination`
+    and :func:`screen_and_resolve`, so the assert-only and
+    return-the-addresses entry points can never diverge on which
+    destinations they reject. Any blocked, non-allowlisted candidate
+    rejects the whole set (the ingest guard's all-or-nothing posture).
+    """
+    for addr in addrs:
+        if not _is_blocked(addr):
+            continue
+        if any(addr in network for network in networks):
+            continue
+        raise TargetDestinationBlockedError(
+            "target destination is not a public address; refusing it as a "
+            f"server-side request forgery risk ({_REMEDIATION})"
+        )
 
-    Raises:
-        TargetDestinationBlockedError: The destination is non-public and
-            not exempted by :data:`TARGET_SSRF_ALLOWLIST_ENV`, embeds
-            URL structure the guard refuses, or cannot be parsed as a
-            dialable destination. The message never includes the
-            resolved address (no internal-topology oracle).
+
+def _screen(host: str) -> list[str] | None:
+    """Screen *host* and return the validated addresses it may dial.
+
+    The shared core of both public entry points. *host* may be an
+    IPv4/IPv6 literal (bracketed IPv6 URL form accepted) or a hostname.
+    IP literals are checked directly. Anything else is first normalized
+    to the host httpx will actually dial via :func:`_dialed_host` (values
+    embedding credentials, a query, or a fragment are refused outright; a
+    path- or port-bearing value is reduced to its dialed host) — so a
+    stored value cannot be screened as one destination and dialed as
+    another. The dialed host is then re-checked as an IP literal (an
+    embedded-port form like ``<ip>:<port>`` normalizes back to a
+    screenable literal), matched against the allowlist's hostname entries
+    (an allowlisted name is trusted verbatim — no resolution round-trip),
+    and otherwise resolved via :func:`_resolve_addrs`, with **every**
+    resolved address screened.
+
+    Returns the concrete IP-literal address set a connection may dial, or
+    ``None`` when the destination is dialed by name unchanged: an empty
+    host, an allowlisted hostname literal, or an unresolvable name
+    (fail-open — see the module docstring). Raises
+    :class:`TargetDestinationBlockedError` on a blocked, non-allowlisted
+    address, on refused URL structure, or on an unparseable value.
     """
     candidate = host.strip()
     if not candidate:
-        return
+        return None
     networks, hostnames = _parse_allowlist()
     literal = (
         candidate[1:-1] if candidate.startswith("[") and candidate.endswith("]") else candidate
@@ -285,17 +308,53 @@ def assert_public_destination(host: str) -> None:
             addrs = [ipaddress.ip_address(dialed)]
         except ValueError:
             if dialed.rstrip(".").lower() in hostnames:
-                return
+                return None
             addrs = _resolve_addrs(dialed)
-    for addr in addrs:
-        if not _is_blocked(addr):
-            continue
-        if any(addr in network for network in networks):
-            continue
-        raise TargetDestinationBlockedError(
-            "target destination is not a public address; refusing it as a "
-            f"server-side request forgery risk ({_REMEDIATION})"
-        )
+    _reject_blocked(addrs, networks)
+    return [str(addr) for addr in addrs] if addrs else None
+
+
+def assert_public_destination(host: str) -> None:
+    """Reject *host* when it is, or resolves to, a non-public address.
+
+    The create/update-time and connect-time *pre-check* entry point:
+    screens *host* via :func:`_screen` and discards the resolved
+    addresses. See :func:`_screen` for the normalization and screening
+    rules; :func:`screen_and_resolve` is the connect-time variant that
+    returns the validated address set for the pinning transport.
+
+    Raises:
+        TargetDestinationBlockedError: The destination is non-public and
+            not exempted by :data:`TARGET_SSRF_ALLOWLIST_ENV`, embeds
+            URL structure the guard refuses, or cannot be parsed as a
+            dialable destination. The message never includes the
+            resolved address (no internal-topology oracle).
+    """
+    _screen(host)
+
+
+def screen_and_resolve(host: str) -> list[str] | None:
+    """Screen *host* and return the addresses a connection may pin to.
+
+    The connect-time arm consumed by the pinning transport
+    (:mod:`meho_backplane.connectors._shared.pinned_transport`). It
+    mirrors :func:`assert_public_destination`'s screening exactly — same
+    allowlist, same block predicate, same message — but instead of only
+    asserting, it hands back the concrete IP-literal address set the
+    socket may dial, so the transport connects to a screened address
+    rather than re-resolving the name. Because the address returned here
+    is the address the connection uses, a resolver that changes its
+    answer between the screen and the connect cannot steer the socket at
+    a destination the guard never saw (the check/use gap,
+    evoila-bosnia/meho-internal#275).
+
+    Returns ``None`` for a passthrough destination — an empty host, an
+    allowlisted hostname literal (trusted verbatim), or an unresolvable
+    name (fail-open; the transport's own resolution then fails or
+    succeeds naturally). Raises :class:`TargetDestinationBlockedError`
+    identically to :func:`assert_public_destination`.
+    """
+    return _screen(host)
 
 
 async def assert_public_destination_async(host: str) -> None:

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -55,8 +55,10 @@ from __future__ import annotations
 import datetime as _dt
 import socket as _socket
 import ssl
+import tempfile as _tempfile
 import threading as _threading
 import types
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from unittest.mock import patch
 from uuid import UUID
@@ -70,9 +72,11 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.pinned_transport import _PinnedAsyncBackend
 from meho_backplane.connectors.adapters import HttpConnector
 from meho_backplane.connectors.adapters.http import HttpConnector as _HttpConnectorDirect
 from meho_backplane.connectors.adapters.http import (
+    SsrfBlockedError,
     _build_ca_pinned_ssl_context,
     _ca_pin_digest,
     _effective_scheme,
@@ -86,6 +90,7 @@ from meho_backplane.connectors.schemas import (
     OperationResult,
     ProbeResult,
 )
+from meho_backplane.targets.ssrf_guard import TARGET_SSRF_ALLOWLIST_ENV
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1728,3 +1733,239 @@ def test_same_origin_http_scheme_upgrade_is_cross_origin() -> None:
     http_same = httpx.URL("http://rabbit.example.com:15672/api/whoami/")
     assert _same_origin(http_base, https_same_host) is False
     assert _same_origin(http_base, http_same) is True
+
+
+# ---------------------------------------------------------------------------
+# Socket-boundary address pinning (F13, evoila-bosnia/meho-internal#275)
+#
+# These drive the real transport against loopback servers (respx is not
+# used — it short-circuits above ``connect_tcp``, which is exactly the seam
+# under test). They prove the pin dials only a guard-validated address, that
+# a resolver flip between the screen and the connect cannot reach a blocked
+# address, and that the original hostname is preserved for Host + TLS
+# SNI/CA verification.
+# ---------------------------------------------------------------------------
+
+
+class _PinRecordingHandler(BaseHTTPRequestHandler):
+    # HTTP/1.1 keepalive so a pooled client can reuse one connection across
+    # requests (the reuse test asserts a single accepted TCP connection).
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:
+        self.server.received_hosts.append(self.headers.get("Host"))  # type: ignore[attr-defined]
+        body = b'{"ok": true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:
+        return None
+
+
+class _PinLoopbackServer:
+    """A recording loopback HTTP(S) server on 127.0.0.1:0.
+
+    Counts accepted TCP connections (to prove keepalive reuse) and records
+    the ``Host`` header of every request. When *ssl_context* is given it
+    serves HTTPS by wrapping the listening socket.
+    """
+
+    def __init__(self, ssl_context: ssl.SSLContext | None = None) -> None:
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _PinRecordingHandler)
+        self._httpd.received_hosts = []  # type: ignore[attr-defined]
+        self.connections = 0
+        base_get_request = self._httpd.get_request
+
+        def _counting_get_request() -> Any:
+            self.connections += 1
+            return base_get_request()
+
+        self._httpd.get_request = _counting_get_request  # type: ignore[method-assign]
+        if ssl_context is not None:
+            self._httpd.socket = ssl_context.wrap_socket(self._httpd.socket, server_side=True)
+        self._thread = _threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def port(self) -> int:
+        return int(self._httpd.server_address[1])
+
+    @property
+    def received_hosts(self) -> list[str]:
+        return self._httpd.received_hosts  # type: ignore[attr-defined,no-any-return]
+
+    def stop(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+def _patch_target_resolver(monkeypatch: pytest.MonkeyPatch, *ips: str) -> None:
+    """Point the target guard's DNS seam at a fixed answer (no real DNS)."""
+    import ipaddress
+
+    addrs = [ipaddress.ip_address(ip) for ip in ips]
+    monkeypatch.setattr("meho_backplane.targets.ssrf_guard._resolve_addrs", lambda host: addrs)
+
+
+def _server_tls_context(hostname: str) -> tuple[ssl.SSLContext, str]:
+    """Return a TLS server context presenting a fresh CA-signed leaf for *hostname*.
+
+    Returns ``(server_ssl_context, ca_pem)`` — the CA PEM is what a target
+    pins via ``tls_ca_pin`` so the connector verifies the chain and the
+    hostname while the socket is pinned to loopback.
+    """
+    ca_key, ca_cert = _gen_ca()
+    leaf_key, leaf_cert = _gen_leaf(ca_key, ca_cert, hostname)
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    with _tempfile.NamedTemporaryFile("wb", suffix=".pem", delete=False) as cf:
+        cf.write(leaf_cert.public_bytes(serialization.Encoding.PEM))
+        cf.write(_key_pem(leaf_key))
+        chain_path = cf.name
+    server_ctx.load_cert_chain(chain_path)
+    return server_ctx, _pem(ca_cert)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_pinned_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pooled client is built on the address-pinning transport."""
+    monkeypatch.setenv(TARGET_SSRF_ALLOWLIST_ENV, "127.0.0.0/8")
+    _patch_target_resolver(monkeypatch, "127.0.0.1")
+    conn = _ConcreteHttpConnector()
+    client = await conn._http_client(_make_target(host="appliance.test"))
+    assert isinstance(client._transport._pool._network_backend, _PinnedAsyncBackend)
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pin_blocks_resolver_flip_to_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Screen a public answer, then the resolver flips to loopback: no dial.
+
+    The bounded resolver-change test (acceptance criterion 2). The
+    ``_http_client`` pre-check sees the public answer and pools a client;
+    the transport's ``connect_tcp`` re-screens, sees the loopback answer,
+    and refuses — so the live loopback server receives nothing.
+    """
+    monkeypatch.delenv(TARGET_SSRF_ALLOWLIST_ENV, raising=False)  # guard fully on
+    server = _PinLoopbackServer()
+    try:
+        import ipaddress
+
+        calls = {"n": 0}
+
+        def _flipping_resolver(host: str) -> list[Any]:
+            calls["n"] += 1
+            # 1st call: the pre-check screens a public answer (passes).
+            # 2nd call: the connect-time pin screens the loopback answer.
+            ip = "93.184.216.34" if calls["n"] == 1 else "127.0.0.1"
+            return [ipaddress.ip_address(ip)]
+
+        monkeypatch.setattr("meho_backplane.targets.ssrf_guard._resolve_addrs", _flipping_resolver)
+        conn = _ConcreteHttpConnector()
+        target = _make_target(host="rebind.test", port=server.port, extras={"scheme": "http"})
+        with pytest.raises(SsrfBlockedError):
+            await conn._get_json(target, "/api/items", operator=_make_operator("tok"))
+        assert server.received_hosts == []  # the blocked socket never opened
+        await conn.aclose()
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_pin_dials_validated_address_and_preserves_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowlisted private target connects and keeps the original Host.
+
+    Acceptance criteria 3 + 5: the pin dials the validated loopback
+    address, and the ``Host:`` header still carries the hostname (only the
+    TCP target is rewritten).
+    """
+    monkeypatch.setenv(TARGET_SSRF_ALLOWLIST_ENV, "127.0.0.0/8")
+    _patch_target_resolver(monkeypatch, "127.0.0.1")
+    server = _PinLoopbackServer()
+    try:
+        conn = _ConcreteHttpConnector()
+        target = _make_target(host="appliance.test", port=server.port, extras={"scheme": "http"})
+        result = await conn._get_json(target, "/api/items", operator=_make_operator("tok"))
+        assert result == {"ok": True}
+        assert server.received_hosts == [f"appliance.test:{server.port}"]
+        await conn.aclose()
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_pin_reuses_pooled_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two requests on one client reuse a single pinned connection (keepalive).
+
+    Acceptance criterion 4 (connection reuse): pinning must not defeat the
+    pool — the second request rides the warm connection, so the server sees
+    one TCP connection for two requests.
+    """
+    monkeypatch.setenv(TARGET_SSRF_ALLOWLIST_ENV, "127.0.0.0/8")
+    _patch_target_resolver(monkeypatch, "127.0.0.1")
+    server = _PinLoopbackServer()
+    try:
+        conn = _ConcreteHttpConnector()
+        target = _make_target(host="appliance.test", port=server.port, extras={"scheme": "http"})
+        await conn._get_json(target, "/api/a", operator=_make_operator("tok"))
+        await conn._get_json(target, "/api/b", operator=_make_operator("tok"))
+        assert len(server.received_hosts) == 2
+        assert server.connections == 1
+        await conn.aclose()
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_pin_preserves_tls_sni_and_ca_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Over real TLS: the pin dials loopback while SNI + CA-pin verify the name.
+
+    Acceptance criterion 3 end-to-end. The target pins the server's CA and
+    resolves (via the guard seam) to loopback; the handshake succeeds only
+    because SNI + certificate verification still use the hostname the leaf's
+    SAN was issued for, not the pinned IP.
+    """
+    monkeypatch.setenv(TARGET_SSRF_ALLOWLIST_ENV, "127.0.0.0/8")
+    _patch_target_resolver(monkeypatch, "127.0.0.1")
+    server_ctx, ca_pem = _server_tls_context("appliance.lab.internal")
+    server = _PinLoopbackServer(ssl_context=server_ctx)
+    try:
+        conn = _ConcreteHttpConnector()
+        target = _make_target(host="appliance.lab.internal", port=server.port, tls_ca_pin=ca_pem)
+        result = await conn._get_json(target, "/api/items", operator=_make_operator("tok"))
+        assert result == {"ok": True}
+        assert server.received_hosts == [f"appliance.lab.internal:{server.port}"]
+        await conn.aclose()
+    finally:
+        server.stop()
+
+
+@pytest.mark.asyncio
+async def test_pin_tls_hostname_mismatch_still_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pin does not weaken hostname verification: a wrong-name cert fails.
+
+    The server presents a leaf for ``other.lab.internal`` but the target
+    dials ``appliance.lab.internal``; even though the CA is pinned and the
+    socket reaches loopback, the handshake fails closed on the SAN
+    mismatch — proving the pin left hostname verification intact.
+    """
+    monkeypatch.setenv(TARGET_SSRF_ALLOWLIST_ENV, "127.0.0.0/8")
+    _patch_target_resolver(monkeypatch, "127.0.0.1")
+    server_ctx, ca_pem = _server_tls_context("other.lab.internal")
+    server = _PinLoopbackServer(ssl_context=server_ctx)
+    try:
+        conn = _ConcreteHttpConnector()
+        target = _make_target(host="appliance.lab.internal", port=server.port, tls_ca_pin=ca_pem)
+        with pytest.raises(httpx.ConnectError):
+            await conn._get_json(target, "/api/items", operator=_make_operator("tok"))
+        await conn.aclose()
+    finally:
+        server.stop()

--- a/backend/tests/test_connectors_shared_pinned_transport.py
+++ b/backend/tests/test_connectors_shared_pinned_transport.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the address-pinning httpx transports (F13, meho-internal#275).
+
+The pinning transport closes the SSRF check/use gap: a destination guard
+that screens a hostname and then hands the *name* to httpx leaves httpx
+free to re-resolve at connect time, so a resolver that changes its answer
+between the screen and the connect can steer the socket at a blocked
+address. The transport removes that gap by screening inside
+``connect_tcp`` and dialing only a validated address from that same
+resolution.
+
+Coverage matrix:
+
+* The pinning backend dials the resolver-returned address literal, not
+  the hostname it was handed (async + sync).
+* A resolver returning ``None`` (passthrough — allowlisted literal /
+  fail-open name) dials the original host unchanged.
+* A resolver that raises (a blocked destination) never opens a socket.
+* Multiple screened addresses are tried in order (IPv4/IPv6 fallback):
+  the first reachable one wins; all-unreachable surfaces the last error.
+* ``connect_unix_socket`` and ``sleep`` delegate untouched.
+* The transport builders swap only the pool's network backend and carry
+  the requested TLS ``verify`` context.
+* A client handed the explicit pinned transport dials the target
+  directly — an ambient ``HTTPS_PROXY`` does not interpose (pinning
+  governs the real dial).
+* Following a redirect to a new origin re-screens that origin at the
+  socket, so a blocked redirect target is refused at connect.
+"""
+
+from __future__ import annotations
+
+import ssl
+import threading
+from collections.abc import Iterable, Sequence
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpcore
+import httpx
+import pytest
+
+from meho_backplane.connectors._shared.pinned_transport import (
+    _PinnedAsyncBackend,
+    _PinnedSyncBackend,
+    build_pinned_async_transport,
+    build_pinned_sync_transport,
+)
+
+
+class _RecordingSyncStream(httpcore.NetworkStream):
+    """A no-op sync stream stand-in returned by the fake backend."""
+
+    def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+        return b""
+
+    def write(self, buffer: bytes, timeout: float | None = None) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: str | None = None,
+        timeout: float | None = None,
+    ) -> httpcore.NetworkStream:
+        return self
+
+    def get_extra_info(self, info: str) -> object:
+        return None
+
+
+class _FakeSyncBackend(httpcore.NetworkBackend):
+    """Records the (host, port) each ``connect_tcp`` was asked to dial.
+
+    ``fail_hosts`` names address literals that should raise
+    :class:`httpcore.ConnectError` (to exercise the multi-address fallback
+    loop); everything else "connects" and returns a stream.
+    """
+
+    def __init__(self, fail_hosts: set[str] | None = None) -> None:
+        self.dialed: list[tuple[str, int]] = []
+        self.unix_paths: list[str] = []
+        self._fail_hosts = fail_hosts or set()
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        self.dialed.append((host, port))
+        if host in self._fail_hosts:
+            raise httpcore.ConnectError(f"refused {host}")
+        return _RecordingSyncStream()
+
+    def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        self.unix_paths.append(path)
+        return _RecordingSyncStream()
+
+    def sleep(self, seconds: float) -> None:
+        return None
+
+
+class _RecordingAsyncStream(httpcore.AsyncNetworkStream):
+    async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
+        return b""
+
+    async def write(self, buffer: bytes, timeout: float | None = None) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+    async def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: str | None = None,
+        timeout: float | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        return self
+
+    def get_extra_info(self, info: str) -> object:
+        return None
+
+
+class _FakeAsyncBackend(httpcore.AsyncNetworkBackend):
+    def __init__(self, fail_hosts: set[str] | None = None) -> None:
+        self.dialed: list[tuple[str, int]] = []
+        self.unix_paths: list[str] = []
+        self.slept: list[float] = []
+        self._fail_hosts = fail_hosts or set()
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        self.dialed.append((host, port))
+        if host in self._fail_hosts:
+            raise httpcore.ConnectError(f"refused {host}")
+        return _RecordingAsyncStream()
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.AsyncNetworkStream:
+        self.unix_paths.append(path)
+        return _RecordingAsyncStream()
+
+    async def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+
+
+class _BlockedError(Exception):
+    """A resolver's destination-blocked error stand-in."""
+
+
+# ---------------------------------------------------------------------------
+# Sync backend
+# ---------------------------------------------------------------------------
+
+
+def test_sync_pins_to_resolved_address() -> None:
+    inner = _FakeSyncBackend()
+    backend = _PinnedSyncBackend(lambda host: ["93.184.216.34"], inner)
+    backend.connect_tcp("api.example.com", 443)
+    assert inner.dialed == [("93.184.216.34", 443)]
+
+
+def test_sync_passthrough_when_resolver_returns_none() -> None:
+    inner = _FakeSyncBackend()
+    backend = _PinnedSyncBackend(lambda host: None, inner)
+    backend.connect_tcp("allowlisted.internal", 8443)
+    assert inner.dialed == [("allowlisted.internal", 8443)]
+
+
+def test_sync_blocked_resolver_opens_no_socket() -> None:
+    inner = _FakeSyncBackend()
+
+    def _resolver(host: str) -> Sequence[str] | None:
+        raise _BlockedError("no")
+
+    backend = _PinnedSyncBackend(_resolver, inner)
+    with pytest.raises(_BlockedError):
+        backend.connect_tcp("evil.example.com", 443)
+    assert inner.dialed == []
+
+
+def test_sync_multi_address_fallback_tries_in_order() -> None:
+    # First screened address is unreachable; the pin falls through to the
+    # second (IPv6-then-IPv4 style fallback).
+    inner = _FakeSyncBackend(fail_hosts={"2001:db8::1"})
+    backend = _PinnedSyncBackend(lambda host: ["2001:db8::1", "93.184.216.34"], inner)
+    backend.connect_tcp("dual.example.com", 443)
+    assert inner.dialed == [("2001:db8::1", 443), ("93.184.216.34", 443)]
+
+
+def test_sync_all_addresses_unreachable_raises_last_error() -> None:
+    inner = _FakeSyncBackend(fail_hosts={"10.0.0.1", "10.0.0.2"})
+    backend = _PinnedSyncBackend(lambda host: ["10.0.0.1", "10.0.0.2"], inner)
+    with pytest.raises(httpcore.ConnectError):
+        backend.connect_tcp("h.example.com", 443)
+    assert inner.dialed == [("10.0.0.1", 443), ("10.0.0.2", 443)]
+
+
+def test_sync_unix_socket_and_sleep_delegate() -> None:
+    inner = _FakeSyncBackend()
+    backend = _PinnedSyncBackend(lambda host: ["1.2.3.4"], inner)
+    backend.connect_unix_socket("/tmp/x.sock")
+    backend.sleep(0.0)
+    assert inner.unix_paths == ["/tmp/x.sock"]
+
+
+# ---------------------------------------------------------------------------
+# Async backend
+# ---------------------------------------------------------------------------
+
+
+async def test_async_pins_to_resolved_address() -> None:
+    inner = _FakeAsyncBackend()
+    backend = _PinnedAsyncBackend(lambda host: ["93.184.216.34"], inner)
+    await backend.connect_tcp("api.example.com", 443)
+    assert inner.dialed == [("93.184.216.34", 443)]
+
+
+async def test_async_passthrough_when_resolver_returns_none() -> None:
+    inner = _FakeAsyncBackend()
+    backend = _PinnedAsyncBackend(lambda host: None, inner)
+    await backend.connect_tcp("allowlisted.internal", 8443)
+    assert inner.dialed == [("allowlisted.internal", 8443)]
+
+
+async def test_async_blocked_resolver_opens_no_socket() -> None:
+    inner = _FakeAsyncBackend()
+
+    def _resolver(host: str) -> Sequence[str] | None:
+        raise _BlockedError("no")
+
+    backend = _PinnedAsyncBackend(_resolver, inner)
+    with pytest.raises(_BlockedError):
+        await backend.connect_tcp("evil.example.com", 443)
+    assert inner.dialed == []
+
+
+async def test_async_multi_address_fallback_tries_in_order() -> None:
+    inner = _FakeAsyncBackend(fail_hosts={"2001:db8::1"})
+    backend = _PinnedAsyncBackend(lambda host: ["2001:db8::1", "93.184.216.34"], inner)
+    await backend.connect_tcp("dual.example.com", 443)
+    assert inner.dialed == [("2001:db8::1", 443), ("93.184.216.34", 443)]
+
+
+async def test_async_unix_socket_and_sleep_delegate() -> None:
+    inner = _FakeAsyncBackend()
+    backend = _PinnedAsyncBackend(lambda host: ["1.2.3.4"], inner)
+    await backend.connect_unix_socket("/tmp/x.sock")
+    await backend.sleep(0.5)
+    assert inner.unix_paths == ["/tmp/x.sock"]
+    assert inner.slept == [0.5]
+
+
+# ---------------------------------------------------------------------------
+# Transport builders
+# ---------------------------------------------------------------------------
+
+
+def test_build_sync_transport_swaps_backend_and_keeps_verify() -> None:
+    ctx = ssl.create_default_context()
+    transport = build_pinned_sync_transport(lambda host: None, verify=ctx)
+    assert isinstance(transport._pool._network_backend, _PinnedSyncBackend)
+    assert transport._pool._ssl_context is ctx
+
+
+def test_build_async_transport_swaps_backend_and_keeps_verify() -> None:
+    ctx = ssl.create_default_context()
+    transport = build_pinned_async_transport(lambda host: None, verify=ctx)
+    assert isinstance(transport._pool._network_backend, _PinnedAsyncBackend)
+    assert transport._pool._ssl_context is ctx
+
+
+# ---------------------------------------------------------------------------
+# Integration: real loopback sockets
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.server.received_hosts.append(self.headers.get("Host"))  # type: ignore[attr-defined]
+        location = self.server.redirect_to  # type: ignore[attr-defined]
+        if location is not None:
+            self.send_response(302)
+            self.send_header("Location", location)
+            self.end_headers()
+            return
+        body = b'{"ok": true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:
+        return None
+
+
+class _LoopbackServer:
+    def __init__(self, redirect_to: str | None = None) -> None:
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingHandler)
+        self._httpd.received_hosts = []  # type: ignore[attr-defined]
+        self._httpd.redirect_to = redirect_to  # type: ignore[attr-defined]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def port(self) -> int:
+        return int(self._httpd.server_address[1])
+
+    @property
+    def received_hosts(self) -> list[str]:
+        return self._httpd.received_hosts  # type: ignore[attr-defined,no-any-return]
+
+    def stop(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+@pytest.fixture
+def loopback_server() -> Iterable[_LoopbackServer]:
+    server = _LoopbackServer()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_pinned_client_ignores_ambient_proxy_and_dials_target(
+    loopback_server: _LoopbackServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambient HTTPS_PROXY must not interpose on the pinned transport.
+
+    A client handed an explicit ``transport=`` sends every request through
+    that transport and skips httpx's environment proxy mounts. With a bogus
+    proxy set, the pinned client still reaches the loopback target directly
+    (the pin governs the real dial), and the target sees the original Host.
+    """
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")  # would fail if honoured
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    transport = build_pinned_sync_transport(lambda host: ["127.0.0.1"])
+    with httpx.Client(transport=transport, trust_env=True) as client:
+        resp = client.get(f"http://pinned.test:{loopback_server.port}/x")
+    assert resp.status_code == 200
+    # Host header carries the original hostname, not the pinned IP.
+    assert loopback_server.received_hosts == [f"pinned.test:{loopback_server.port}"]
+
+
+def test_pinned_client_screens_redirect_hop_at_socket() -> None:
+    """A cross-origin redirect re-screens the new origin at connect time.
+
+    The resolver permits ``a.test`` (→ loopback server) but blocks
+    ``b.test``. httpx follows the 302, opens a fresh connection to
+    ``b.test``, and the pin refuses it at ``connect_tcp`` — so the socket
+    to the blocked origin never opens.
+    """
+    server_b = _LoopbackServer()
+    server_a = _LoopbackServer(redirect_to=f"http://b.test:{server_b.port}/next")
+    try:
+
+        def _resolver(host: str) -> Sequence[str] | None:
+            if host == "a.test":
+                return ["127.0.0.1"]
+            raise _BlockedError(f"blocked {host}")
+
+        transport = build_pinned_sync_transport(_resolver)
+        with (
+            httpx.Client(transport=transport, follow_redirects=True) as client,
+            pytest.raises(_BlockedError),
+        ):
+            client.get(f"http://a.test:{server_a.port}/start")
+        # A got the initial request; B was never dialed.
+        assert server_a.received_hosts == [f"a.test:{server_a.port}"]
+        assert server_b.received_hosts == []
+    finally:
+        server_a.stop()
+        server_b.stop()

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -43,6 +43,8 @@ from meho_backplane.operations.ingest.openapi import (
     _INLINE_SPEC_ONRAMP_REMEDIATION,
     _MAX_REDIRECTS,
     _assert_fetchable_remote_url,
+    _pin_fetch_addresses,
+    _screen_fetch_host,
     _server_base_path,
 )
 from meho_backplane.operations.ingest.refs import (
@@ -2356,3 +2358,92 @@ def test_find_unresolvable_local_refs_reports_only_dangling_pointers() -> None:
     # (str.isdigit accepts "²" but int() rejects it).
     assert find_unresolvable_local_refs({"$ref": "#/allOf/²", "allOf": [{}]}) == ["#/allOf/²"]
     assert find_unresolvable_local_refs({"$ref": "#/allOf/0", "allOf": [{}]}) == []
+
+
+# -- Spec-fetch address pinning (F13, evoila-bosnia/meho-internal#275) -------
+
+
+def test_screen_fetch_host_returns_public_addresses() -> None:
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        return_value=[
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("2001:4860:4860::8888", 443)),
+        ],
+    ):
+        assert _screen_fetch_host("cdn.example.test") == [
+            "93.184.216.34",
+            "2001:4860:4860::8888",
+        ]
+
+
+def test_screen_fetch_host_fails_closed_on_unresolvable() -> None:
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            side_effect=socket.gaierror("no such host"),
+        ),
+        pytest.raises(InvalidSpecError, match="could not be resolved"),
+    ):
+        _screen_fetch_host("nowhere.invalid")
+
+
+def test_screen_fetch_host_rejects_private_address() -> None:
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 443))],
+        ),
+        pytest.raises(InvalidSpecError, match="non-public"),
+    ):
+        _screen_fetch_host("public-looking.example.test")
+
+
+def test_pin_fetch_addresses_delegates_to_screen() -> None:
+    # The pinning resolver returns exactly the screened public address set,
+    # and raises identically on a blocked answer.
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))],
+    ):
+        assert _pin_fetch_addresses("cdn.example.test") == ["93.184.216.34"]
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 443))],
+        ),
+        pytest.raises(InvalidSpecError, match="non-public"),
+    ):
+        _pin_fetch_addresses("public-looking.example.test")
+
+
+def test_fetch_pins_and_blocks_resolver_flip_to_loopback() -> None:
+    """A resolver that flips public→loopback between screen and connect is refused.
+
+    The bounded resolver-change test for the ingest path (acceptance
+    criteria 2 + 6). The pre-fetch guard screens the public answer; the
+    pinning transport re-screens inside ``connect_tcp`` and sees the
+    loopback answer, so the fetch is refused before the socket opens — no
+    respx here, so the real transport (and the pin) is exercised.
+    """
+    import socket as _socket
+
+    calls = {"n": 0}
+
+    def _flip(hostname: str, port: object, **kwargs: object) -> list:
+        calls["n"] += 1
+        # 1st call: the pre-fetch guard screens a public answer (passes).
+        # 2nd call: the connect-time pin screens the loopback answer.
+        ip = "93.184.216.34" if calls["n"] == 1 else "127.0.0.1"
+        return [(_socket.AF_INET, _socket.SOCK_STREAM, 0, "", (ip, 443))]
+
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            side_effect=_flip,
+        ),
+        pytest.raises(InvalidSpecError, match="non-public"),
+    ):
+        parse_openapi("https://spec.example.test/openapi.yaml")
+    # Both the pre-fetch screen and the connect-time pin resolved the name.
+    assert calls["n"] >= 2

--- a/backend/tests/test_targets_ssrf_guard.py
+++ b/backend/tests/test_targets_ssrf_guard.py
@@ -63,6 +63,7 @@ from meho_backplane.targets.ssrf_guard import (
     TARGET_SSRF_ALLOWLIST_ENV,
     TargetDestinationBlockedError,
     assert_public_destination,
+    screen_and_resolve,
 )
 
 # 93.184.216.34 (example.com's long-stable A record) — a public, globally
@@ -456,3 +457,91 @@ def test_ssrf_blocked_error_is_connect_error_but_not_retryable() -> None:
     err = SsrfBlockedError("blocked")
     assert isinstance(err, httpx.ConnectError)
     assert _retryable(err) is False
+
+
+# ---------------------------------------------------------------------------
+# screen_and_resolve — the address-returning arm the pinning transport uses
+# ---------------------------------------------------------------------------
+
+
+def test_screen_and_resolve_returns_public_ip_literal(_guard_live: pytest.MonkeyPatch) -> None:
+    assert screen_and_resolve(_PUBLIC_IP) == [_PUBLIC_IP]
+
+
+def test_screen_and_resolve_returns_resolved_addresses(
+    _guard_live: pytest.MonkeyPatch,
+) -> None:
+    _patch_resolver(_guard_live, _PUBLIC_IP, "93.184.216.35")
+    assert screen_and_resolve("public.example.com") == [_PUBLIC_IP, "93.184.216.35"]
+
+
+def test_screen_and_resolve_empty_host_is_passthrough(_guard_live: pytest.MonkeyPatch) -> None:
+    assert screen_and_resolve("   ") is None
+
+
+def test_screen_and_resolve_unresolvable_is_passthrough(_guard_live: pytest.MonkeyPatch) -> None:
+    _patch_resolver(_guard_live)  # resolves to nothing
+    assert screen_and_resolve("nowhere.invalid") is None
+
+
+def test_screen_and_resolve_allowlisted_hostname_is_passthrough(
+    _guard_live: pytest.MonkeyPatch,
+) -> None:
+    # An allowlisted hostname literal is trusted verbatim — no resolution
+    # round-trip, so the pin dials it by name (passthrough).
+    _guard_live.setenv(TARGET_SSRF_ALLOWLIST_ENV, "vcenter.lab.internal")
+    _patch_resolver(_guard_live, "10.0.0.5")  # would be blocked if resolved
+    assert screen_and_resolve("vcenter.lab.internal") is None
+
+
+@pytest.mark.parametrize("host", _NON_PUBLIC_HOSTS)
+def test_screen_and_resolve_rejects_non_public_literal(
+    host: str, _guard_live: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(TargetDestinationBlockedError):
+        screen_and_resolve(host)
+
+
+def test_screen_and_resolve_rejects_hostname_resolving_private(
+    _guard_live: pytest.MonkeyPatch,
+) -> None:
+    _patch_resolver(_guard_live, "10.0.0.7")
+    with pytest.raises(TargetDestinationBlockedError):
+        screen_and_resolve("benign.example.com")
+
+
+def test_screen_and_resolve_cidr_allowlist_returns_the_address(
+    _guard_live: pytest.MonkeyPatch,
+) -> None:
+    # An allowlisted CIDR permits an otherwise-blocked resolved address,
+    # and the pin gets that address to dial.
+    _guard_live.setenv(TARGET_SSRF_ALLOWLIST_ENV, "10.0.0.0/8")
+    _patch_resolver(_guard_live, "10.0.0.9")
+    assert screen_and_resolve("appliance.example.com") == ["10.0.0.9"]
+
+
+@pytest.mark.parametrize(
+    "host",
+    _NON_PUBLIC_HOSTS + _STRUCTURED_NON_PUBLIC_HOSTS + _REFUSED_STRUCTURE_HOSTS,
+)
+def test_screen_and_resolve_matches_assert_public_destination_rejections(
+    host: str, _guard_live: pytest.MonkeyPatch
+) -> None:
+    """The address-returning arm rejects exactly where the assert-only arm does.
+
+    Both entry points share ``_screen``; this pins that they can never
+    diverge on which destinations they refuse (blocked literals, blocked
+    dialed hosts behind URL structure, and refused structure alike).
+    """
+    _patch_resolver(_guard_live, "10.0.0.7")
+    assert_raised = False
+    try:
+        assert_public_destination(host)
+    except TargetDestinationBlockedError:
+        assert_raised = True
+    screen_raised = False
+    try:
+        screen_and_resolve(host)
+    except TargetDestinationBlockedError:
+        screen_raised = True
+    assert assert_raised is screen_raised is True

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1716,11 +1716,25 @@ activity:
    next request. A redirect from a public host to a private IP is rejected
    at the hop — the private-target socket is never opened.
 
-4. **Response size cap.** The response body is streamed and rejected if it
+4. **Socket-boundary address pinning (`_pin_fetch_addresses`,
+   evoila-bosnia/meho-internal#275).** The pre-connect guard (#2) and the
+   per-hop guard (#3) screen the *name*, but httpx would re-resolve it at
+   connect time — a check/use gap a resolver flip (DNS rebinding) could
+   exploit. `_fetch_spec_bytes` runs its fetch over
+   `build_pinned_sync_transport(_pin_fetch_addresses)`, so the socket
+   `connect_tcp` re-screens the host via `_screen_fetch_host` (shared with
+   the pre-fetch guard) and dials **only** a validated address from that
+   same resolution — for the initial fetch and every redirect hop that
+   opens a fresh connection. TLS SNI, certificate verification, and the
+   `Host:` header still use the original hostname. Because the client is
+   handed an explicit `transport=`, ambient `HTTP(S)_PROXY` mounts do not
+   interpose on the pinned dial.
+
+5. **Response size cap.** The response body is streamed and rejected if it
    exceeds 20 MiB (`_MAX_SPEC_BYTES`), preventing a redirect to a large
    internal endpoint from exhausting pod memory.
 
-5. **Oracle-free error messages that name the inline remedy.** Error
+6. **Oracle-free error messages that name the inline remedy.** Error
    messages never echo the operator-supplied URI, the resolved IP /
    hostname, or OS-level error text — the rejection is path-free so it
    is not a network-topology oracle. The scheme + non-public rejections

--- a/docs/codebase/target-ssrf-guard.md
+++ b/docs/codebase/target-ssrf-guard.md
@@ -9,8 +9,19 @@ attached. Without a destination screen, anything able to drive
 RFC 1918 space, `169.254.169.254` (cloud metadata), or the IPv6
 analogues and have the backplane deliver a credential there — classic
 server-side request forgery. The guard rejects non-public destinations
-at **two layers** and is overridable only through an explicit,
+at **three layers** — create/update, a connect-time pre-check, and the
+socket boundary itself — and is overridable only through an explicit,
 operator-configured allowlist env var.
+
+The socket-boundary layer (evoila-bosnia/meho-internal#275) is what
+makes the guard robust against a resolver whose answer changes *between*
+the screen and the connect (DNS rebinding, split-horizon flip). Screening
+a hostname and then handing the *name* to httpx leaves httpx free to
+re-resolve at connect time — a check/use gap. The dispatch transport
+closes it by re-screening inside the socket `connect_tcp` and dialing
+**only** a validated address from that same resolution; only the TCP
+target is rewritten, so TLS SNI, certificate verification, and the
+`Host:` header still use the original hostname.
 
 MEHO is an on-prem product: registering appliances on private space is
 the normal case, not an edge case. The intended deployment posture is
@@ -29,15 +40,38 @@ off-switch.
   - `TargetDestinationBlockedError(ValueError)` — raised on rejection.
     `ValueError` so pydantic validators surface it as a structured 422.
   - `assert_public_destination(host)` / `assert_public_destination_async(host)`
-    — sync (schema-validator) and async (dispatch hot path, via
-    `asyncio.to_thread`) entry points.
+    — sync (schema-validator) and async (dispatch pre-check hot path, via
+    `asyncio.to_thread`) entry points; screen and discard.
+  - `screen_and_resolve(host)` — the connect-time arm the pinning
+    transport consumes: it shares `_screen` with
+    `assert_public_destination` (same allowlist, same block predicate,
+    same message) but **returns** the validated IP-literal address set to
+    dial (or `None` for a passthrough — empty host / allowlisted hostname
+    literal / unresolvable name).
+  - `_screen(host)` — the shared screening core both entry points call,
+    so the assert-only and address-returning arms can never diverge.
   - `_dialed_host(candidate)` — normalizes a non-IP-literal value to
     the host component httpx actually dials for `https://{candidate}`
     (refusing credentials/query/fragment and unparseable values).
   - `_resolve_addrs(host)` — the single DNS seam
     (`socket.getaddrinfo`), monkeypatched by tests.
+- `meho_backplane/connectors/_shared/pinned_transport.py` — the
+  address-pinning httpx transports shared by the target-dispatch and
+  spec-ingest paths:
+  - `build_pinned_async_transport(resolver, verify=...)` /
+    `build_pinned_sync_transport(...)` — build an
+    `httpx.AsyncHTTPTransport` / `httpx.HTTPTransport` and swap its
+    connection pool's network backend for a pinning one, preserving the
+    TLS `verify` context.
+  - `_PinnedAsyncBackend` / `_PinnedSyncBackend` — `httpcore` network
+    backends whose `connect_tcp` calls the `resolver`, dials only a
+    returned address (trying each in order for IPv4/IPv6 fallback), and
+    passes a `None` result through to the stock backend.
 - `meho_backplane/connectors/adapters/http.py` —
-  `SsrfBlockedError(httpx.ConnectError)`, the connect-time rejection.
+  `SsrfBlockedError(httpx.ConnectError)`, the connect-time rejection;
+  `_pin_target_addresses(host)`, the dispatch resolver that wraps
+  `screen_and_resolve` so a socket-boundary block surfaces as
+  `SsrfBlockedError` (not a bare `ValueError`).
 
 ## Control flow
 
@@ -62,16 +96,28 @@ off-switch.
    `is_reserved` / `is_multicast` / `is_unspecified` union (kept
    alongside `is_global` because global-scope multicast reports
    `is_global=True` in both address families).
-2. **Connect** — `HttpConnector._http_client` awaits
+2. **Connect pre-check** — `HttpConnector._http_client` awaits
    `assert_public_destination_async(target.host)` on **every**
    acquisition, before the pool lookup, so a pooled client for a
    hostname whose DNS answer has since moved into private space is
-   refused too (DNS-rebind window). Rejection is re-raised as
-   `SsrfBlockedError`, an `httpx.ConnectError` subclass, so the
-   dispatcher's existing `ConnectError` arm flattens it into the
-   structured `connector_error` shape — no dispatcher changes. It is
-   excluded from the transport retry policy (`_retryable`): the verdict
-   is deterministic.
+   refused too. Rejection is re-raised as `SsrfBlockedError`, an
+   `httpx.ConnectError` subclass, so the dispatcher's existing
+   `ConnectError` arm flattens it into the structured `connector_error`
+   shape — no dispatcher changes. It is excluded from the transport
+   retry policy (`_retryable`): the verdict is deterministic.
+3. **Socket boundary** — the pooled client is built on a pinning
+   transport (`build_pinned_async_transport(_pin_target_addresses, …)`).
+   When httpcore opens a new connection its `connect_tcp` runs
+   `_pin_target_addresses` → `screen_and_resolve`, which resolves the
+   host once, screens that exact answer, and returns the validated
+   addresses; the transport dials one of them directly. The pre-check
+   (step 2) and this socket screen use *different* resolutions, so the
+   pre-check alone left a check/use gap; step 3 removes it because the
+   address the socket reaches is the address that was screened. A block
+   here raises `SsrfBlockedError` from inside the dial (httpx's transport
+   exception mapping re-raises the unmapped subclass unchanged), so it
+   reaches the same `ConnectError` arm. A warm pooled connection is
+   reused untouched; the next new connection re-screens.
 
 Design choices:
 
@@ -102,15 +148,34 @@ Design choices:
   deliberately not allowlisted suite-wide. Guard tests
   (`backend/tests/test_targets_ssrf_guard.py`) clear/re-pin both.
 
+## Ingest spec-fetch pinning
+
+The connector spec-ingest fetch (`operations/ingest/openapi.py`) is a
+second sink of the same check/use class and gets the same treatment. Its
+own guard, `_assert_fetchable_remote_url`, screens the URL host before
+the fetch and re-screens every redirect hop; `_fetch_spec_bytes` now
+runs that fetch over `build_pinned_sync_transport(_pin_fetch_addresses)`,
+so `connect_tcp` re-screens the host it is about to dial and connects
+only to a validated address — for the initial fetch and every redirect
+hop that opens a fresh connection. The shared screen is
+`_screen_fetch_host` (used by both the pre-fetch guard and the pin
+resolver). This path is stricter than the target guard: it fails
+**closed** on an unresolvable name and has no allowlist (public-https
+only). It stays a distinct guard with a distinct error type
+(`InvalidSpecError`); only the pinning *transport* is shared.
+
 ## Known issues
 
-- The ingest spec-fetch guard (`_assert_fetchable_remote_url`) still
-  lacks the `not is_global` posture this guard adopted, so CGNAT
-  `100.64.0.0/10` passes it — separate sink, adjacent follow-up.
-- The guard screens the transport's *intended* destination; it does not
-  pin the subsequent httpx socket connect to the screened address
-  (full DNS pinning would require a custom transport). The per-dispatch
-  re-check narrows the TOCTOU window to a single dispatch.
+- The ingest spec-fetch guard (`_assert_fetchable_remote_url` /
+  `_screen_fetch_host`) still lacks the `not is_global` posture this
+  guard adopted, so CGNAT `100.64.0.0/10` passes it — separate sink,
+  adjacent follow-up.
+- When an explicit proxy is configured the dial target decision moves to
+  the far side of the proxy; the pinning transport is handed to the
+  client as an explicit `transport=`, which bypasses httpx's ambient
+  `HTTP(S)_PROXY` mounts, so the direct dial is pinned. MEHO configures
+  no such proxy; deployment egress policy remains an independent
+  boundary the guard does not replace.
 - Non-HTTP transports (`SshConnector`, the kubeconfig-driven Kubernetes
   connector, GitHub App session client) are separate sinks outside this
   guard.
@@ -135,6 +200,9 @@ private-range example.
 ## References
 
 - Task: evoila-bosnia/meho-internal#153 (parent backlog #101, goal #87)
+- Socket-boundary pinning: evoila-bosnia/meho-internal#275 (F13, the
+  2026-09-06 security review) — bind SSRF destination checks to the
+  actual HTTP connection.
 - OWASP SSRF Prevention Cheat Sheet:
   <https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html>
 - Sibling guard: `backend/src/meho_backplane/operations/ingest/openapi.py`


### PR DESCRIPTION
## Summary

- Closes the SSRF check/use gap (F13, 2026-09-06 security review): both the
  target-dispatch transport (`connectors/adapters/http.py` + `targets/ssrf_guard.py`)
  and the connector spec-ingest fetch (`operations/ingest/openapi.py`) screened a
  hostname and then handed the *name* to httpx, which re-resolved it at connect
  time — so a resolver that changed its answer between the screen and the connect
  (DNS rebinding / split-horizon flip) could steer the socket at a blocked address
  the guard never saw.
- Adds a shared address-pinning transport (`connectors/_shared/pinned_transport.py`)
  whose `httpcore` network backend re-screens the host inside `connect_tcp` and dials
  **only** a validated address from that same resolution. Only the TCP target is
  rewritten: TLS SNI, certificate verification (incl. per-target CA pin), and the
  `Host:` header still use the original hostname.
- Both in-scope sinks now dispatch/fetch over the pinned transport. The existing
  `#153` create/update + connect-time pre-check screens are retained (defense in
  depth), not reimplemented; the same-origin redirect protection is untouched.

## What was already on `main`

The 2026-09-06 containment PRs #3423 (holodeck approval) and #3427 (human-principal
on admin routes) are unrelated sinks — the F13 check/use gap was untouched on `main`.
This PR implements the whole F13 remediation fresh; no acceptance criterion was
already met.

## Design

- `targets/ssrf_guard.py`: factored the screen into a shared `_screen` core; added
  `screen_and_resolve(host)` which returns the validated IP-literal set to pin (or
  `None` for a passthrough — empty host / allowlisted hostname literal / unresolvable
  name). `assert_public_destination` now delegates to `_screen`, byte-identical
  behaviour (proven by a parity test).
- `connectors/_shared/pinned_transport.py`: `build_pinned_{async,sync}_transport(resolver, verify=...)`
  build a stock httpx transport and swap the pool's network backend for a pinning one.
  The backend resolves in a worker thread on the async path, tries each screened
  address in order (IPv4/IPv6 fallback), and passes `None` through to the stock backend.
- `adapters/http.py`: the per-target pooled client is built on the pinned transport;
  `_pin_target_addresses` wraps `screen_and_resolve` so a socket-boundary block surfaces
  as `SsrfBlockedError` (an `httpx.ConnectError`), reaching the dispatcher's existing
  `ConnectError` arm and staying out of the retry policy.
- `operations/ingest/openapi.py`: `_screen_fetch_host` is now shared by the pre-fetch
  guard and the connect-time resolver `_pin_fetch_addresses`; `_fetch_spec_bytes` runs
  over `build_pinned_sync_transport`. Stricter than the target guard: fails closed on
  unresolvable, no allowlist, https-only.
- Handing the client an explicit `transport=` bypasses httpx's ambient `HTTP(S)_PROXY`
  mounts, so the pin governs the real dial (MEHO configures no proxy; egress policy is
  an independent boundary).

## Acceptance criteria

- [x] **Enforce allowed destination addresses at the socket/transport boundary** —
  `_Pinned{Async,Sync}Backend.connect_tcp` dials only resolver-validated addresses
  (`test_connectors_shared_pinned_transport.py`; `test_dispatch_uses_pinned_transport`).
- [x] **A bounded resolver-change test cannot connect to a blocked loopback/private
  address after screening a public answer (synthetic/local only)** —
  `test_pin_blocks_resolver_flip_to_loopback` (dispatch) and
  `test_fetch_pins_and_blocks_resolver_flip_to_loopback` (ingest): screen public,
  connect-time resolver flips to loopback, refused before the socket opens; the live
  loopback server receives nothing.
- [x] **Preserve Host + TLS SNI/hostname/CA verification** —
  `test_pin_dials_validated_address_and_preserves_host` (Host),
  `test_pin_preserves_tls_sni_and_ca_verification` (real TLS: pin dials loopback while
  SNI + CA-pin verify the hostname), `test_pin_tls_hostname_mismatch_still_fails_closed`.
- [x] **IPv4/IPv6, reconnects, reuse, proxy, redirects; same-origin redirect protection
  intact** — multi-address fallback unit tests, `test_pin_reuses_pooled_connection`
  (one TCP connection for two requests), `test_pinned_client_ignores_ambient_proxy_and_dials_target`,
  `test_pinned_client_screens_redirect_hop_at_socket`; existing `_SameOriginRedirectClient`
  tests remain green.
- [x] **Approved public + explicitly authorized private targets remain functional;
  egress is independent** — positive functional tests + full unit lane green; proxy/egress
  note in the docs.
- [x] **Spec-ingest fetch connects through the same pinned-resolver transport for the
  initial fetch and every redirect hop** — `_fetch_spec_bytes` uses
  `build_pinned_sync_transport(_pin_fetch_addresses)`; `_screen_fetch_host` shared with
  the pre-fetch guard; per-hop `_assert_fetchable_remote_url` belt retained.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` (changed files) — clean (one pre-existing macOS-only `socket.MSG_ERRQUEUE`
  false positive in the untouched `connectors/net/icmp.py`; Linux CI resolves it)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing warns only)
- [x] `pytest tests/test_connectors_shared_pinned_transport.py tests/test_targets_ssrf_guard.py tests/test_operations_ingest_openapi.py tests/test_connectors_http_adapter.py` — 314 passed
- [x] Full backend unit lane (`tests/`, excl. `tests/integration`) — see CI

## Docs

- `docs/codebase/target-ssrf-guard.md` — three-layer model, the pinning transport,
  `screen_and_resolve`, and the ingest-fetch pinning; the stale "does not pin the
  socket connect" known-issue is removed.
- `docs/codebase/spec-ingestion.md` — socket-boundary pinning added to the SSRF
  protection list.

## Out of scope

- The `#153` create/update + pre-connect screen — retained, not reimplemented.
- Same-origin redirect handling (`_SameOriginRedirectClient`) — already present.
- Non-HTTP transports beyond the address-pinning treatment where they dial by hostname.
- The ingest guard's missing `not is_global` (CGNAT) posture — pre-existing, tracked
  as an adjacent follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#275
