### PR TITLE
fix(cli): suppress terminal echo on interactive secret prompts

### DIFF
--- a/cli/internal/cmd/admin/keycloak/bootstrap_test.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap_test.go
@@ -1056,3 +1056,23 @@ func TestBootstrap_MCPClientHasOfflineAccessOptionalScope(t *testing.T) {
 			putsAfterFirst, putsAfterSecond)
 	}
 }
+
+// TestReadPassword_NonTTYFallbackReadsPipedSecret asserts that when the
+// reader is not an *os.File on a TTY (a piped secret, as every unit test
+// and shell here-string supplies), readPassword still takes the plain
+// buffered line read and returns the secret unchanged — the TTY branch's
+// term.ReadPassword only engages for a real terminal.
+func TestReadPassword_NonTTYFallbackReadsPipedSecret(t *testing.T) {
+	const want = "s3cr3t-from-pipe"
+	var errOut bytes.Buffer
+	got, err := readPassword(strings.NewReader(want+"\n"), &errOut, "Password: ")
+	if err != nil {
+		t.Fatalf("readPassword returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("readPassword = %q, want %q", got, want)
+	}
+	if errOut.String() != "Password: " {
+		t.Fatalf("prompt written to errOut = %q, want %q", errOut.String(), "Password: ")
+	}
+}

--- a/cli/internal/cmd/admin/keycloak/client.go
+++ b/cli/internal/cmd/admin/keycloak/client.go
@@ -59,8 +59,9 @@ func (e *errKeycloakAPI) Error() string {
 // with grant_type=password against the built-in admin-cli client, just
 // like the reference shell script. Returns the bearer access_token
 // string. The username + password are passed via form fields; the
-// caller is responsible for not echoing them — meho admin uses
-// ReadPassword + an env-var fallback that never enters argv.
+// caller is responsible for not echoing them — meho admin reads them
+// with echo suppressed on a TTY (term.ReadPassword) plus an env-var
+// fallback that never enters argv.
 func mintAdminToken(
 	ctx context.Context,
 	httpClient *http.Client,

--- a/cli/internal/cmd/admin/keycloak/keycloak.go
+++ b/cli/internal/cmd/admin/keycloak/keycloak.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // defaultCLIOfflineSessionIdleSeconds is the offline-session idle
@@ -293,19 +294,32 @@ func newInsecureClient() *http.Client {
 	return c
 }
 
-// readPassword prompts on stderr and reads one line from in,
-// returning the trimmed string. Falls back to the env var
-// MEHO_ADMIN_BOOTSTRAP_NONINTERACTIVE for unit tests (when stdin is
-// not a TTY we still want to support a piped password without
-// hanging the cobra Run).
+// readPassword prompts on stderr and reads one line from in, returning
+// the trimmed string. When in is a terminal it reads with echo
+// suppressed via golang.org/x/term, so a secret typed at the prompt
+// never lands in the terminal, scrollback, or a session recording;
+// piped / non-TTY input (unit tests, a here-string) falls back to a
+// plain buffered line read so the cobra Run never hangs.
 func readPassword(in io.Reader, errOut io.Writer, prompt string) (string, error) {
 	if _, err := fmt.Fprint(errOut, prompt); err != nil {
 		return "", err
 	}
-	reader := bufio.NewReader(in)
-	line, err := reader.ReadString('\n')
-	if err != nil && !errors.Is(err, io.EOF) {
-		return "", err
+	var line string
+	if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		b, err := term.ReadPassword(int(f.Fd()))
+		// ReadPassword consumes the trailing Enter without echoing
+		// it, so emit the newline the operator expects to see.
+		fmt.Fprintln(errOut)
+		if err != nil {
+			return "", err
+		}
+		line = string(b)
+	} else {
+		raw, err := bufio.NewReader(in).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return "", err
+		}
+		line = raw
 	}
 	line = strings.TrimRight(line, "\r\n")
 	if line == "" {

--- a/cli/internal/cmd/event-source/eventsource.go
+++ b/cli/internal/cmd/event-source/eventsource.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/output"
@@ -112,9 +113,25 @@ func resolveSecret(cmd *cobra.Command, useStdin bool) (string, bool, error) {
 	if _, err := fmt.Fprint(cmd.ErrOrStderr(), "Enter event-source secret: "); err != nil {
 		return "", false, err
 	}
-	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
-	if err != nil && !errors.Is(err, io.EOF) {
-		return "", false, err
+	in := cmd.InOrStdin()
+	var line string
+	// On an interactive terminal, suppress echo so the typed secret
+	// never lands in the terminal, scrollback, or a session recording.
+	// A piped --secret-stdin (and unit tests) take the plain line read.
+	if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		b, err := term.ReadPassword(int(f.Fd()))
+		// ReadPassword consumes the trailing Enter without echoing it.
+		fmt.Fprintln(cmd.ErrOrStderr())
+		if err != nil {
+			return "", false, err
+		}
+		line = string(b)
+	} else {
+		raw, err := bufio.NewReader(in).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return "", false, err
+		}
+		line = raw
 	}
 	line = strings.TrimRight(line, "\r\n")
 	if line == "" {

--- a/cli/internal/cmd/event-source/eventsource_test.go
+++ b/cli/internal/cmd/event-source/eventsource_test.go
@@ -224,3 +224,30 @@ func TestDescribe404SurfacesError(t *testing.T) {
 		t.Errorf("stderr should surface a not-found message; got:\n%s", stderr)
 	}
 }
+
+// TestResolveSecret_NonTTYFallback asserts that when stdin is a piped
+// reader (not an *os.File on a TTY, as --secret-stdin from a pipe and
+// every unit test supplies), resolveSecret still takes the plain
+// buffered line read and returns the secret unchanged — the TTY branch's
+// term.ReadPassword only engages for a real terminal.
+func TestResolveSecret_NonTTYFallback(t *testing.T) {
+	// Neutralise any ambient env var so the stdin path is exercised.
+	t.Setenv(SecretEnvVar, "")
+
+	const want = "hmac-secret-from-pipe"
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(want + "\n"))
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+
+	got, hasSecret, err := resolveSecret(cmd, true)
+	if err != nil {
+		t.Fatalf("resolveSecret returned error: %v", err)
+	}
+	if !hasSecret {
+		t.Fatal("resolveSecret hasSecret = false, want true")
+	}
+	if got != want {
+		t.Fatalf("resolveSecret = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `meho admin keycloak bootstrap-clients` and `meho event-source add/update --secret-stdin` read a secret at an interactive fallback prompt via a plain buffered line read with terminal echo left **on**, so a typed secret could land in scrollback / a session recording (CWE-549). This hardens both prompts.
- `readPassword` (`cli/internal/cmd/admin/keycloak/keycloak.go`) and `resolveSecret` (`cli/internal/cmd/event-source/eventsource.go`) now read via `golang.org/x/term`'s `ReadPassword` — echo suppressed — **only** when the reader is an `*os.File` on a TTY (`term.IsTerminal`); piped `--secret-stdin` / non-TTY input (and every unit test) falls through to the existing buffered line read unchanged.
- The env-var paths (`KEYCLOAK_ADMIN_PASSWORD` / `KEYCLOAK_ADMIN_USER_PASSWORD`, `MEHO_EVENT_SOURCE_SECRET`) and the piped stdin path are untouched — no behaviour change there.
- `client.go`'s `mintAdminToken` doc comment (which already claimed the admin path uses a no-echo read) is now truthful.

## Already met on `main`

None of this task's acceptance criteria were already satisfied on `main` (current `a5af5209`, post-v0.33.5). The containment PRs #3423 / #3427 did not touch `readPassword` / `resolveSecret`; both still had the plain echo-on buffered read. This PR implements all five criteria.

## Test plan

- [x] `grep -n term.ReadPassword …` — one hit each (the call) in `keycloak.go` and `eventsource.go`
- [x] `grep -n term.IsTerminal …` — the TTY guard present in each, so a non-`*os.File` / piped reader takes the fallback
- [x] New `TestReadPassword_NonTTYFallbackReadsPipedSecret` (`bootstrap_test.go`) and `TestResolveSecret_NonTTYFallback` (`eventsource_test.go`) — assert a piped `strings.Reader` returns the secret unchanged
- [x] `cd cli && go test -race ./internal/cmd/admin/keycloak/... ./internal/cmd/event-source/...` — ok (both packages), plus full `go test -race ./...` green
- [x] `cd cli && golangci-lint run` (v2.12.2) — 0 issues; `gofmt -l …` — clean
- [x] `cd cli && go build ./...` — clean

## Out of scope

- Env-var and piped `--secret-stdin` paths (already no-echo) — unchanged.
- `confirmPrompt` (`eventsource.go`) — a `y/N` confirmation, not a secret.
- Secret transmission / storage / minting — unchanged.
- Any Python backend prompt — this task touches `cli/` only. Docs verified: `docs/codebase/cli.md` makes no echo-behaviour claim, so it stays accurate as-is.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#308
