### PR TITLE
feat(charts): broadcast subchart ingress NetworkPolicy + Valkey auth (#276)

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -833,6 +833,19 @@ jobs:
           # fakes) so the guard resolves MCP_RESOURCE_URI to
           # https://meho-test.test/mcp and the install renders — the
           # guard behaviour itself is asserted by the render-time tests.
+          #
+          # #276: the broadcast subchart now ships (default-on) an ingress
+          # NetworkPolicy admitting tcp/6379 only from backplane-labelled
+          # Pods, plus Valkey `requirepass` auth. The G6.1-T9 chaos harness
+          # below drives the store from bare `valkey` Pods that carry
+          # neither the backplane pod-labels nor the password, so on a
+          # NetworkPolicy-enforcing CNI (kindnet enforces it) those probes
+          # hang on connect / are rejected by AUTH. Disable both guards for
+          # this minimal glue-and-recovery smoke — exactly as the umbrella
+          # `networkPolicy.enabled=false` above already does. The hardening
+          # itself is render-tested by
+          # backend/tests/test_chart_broadcast_hardening.py and the chart
+          # `validate` job (helm template + kubeconform), not here.
           helm install meho-test ./deploy/charts/meho \
             --namespace meho-test \
             --wait-for-jobs \
@@ -840,6 +853,8 @@ jobs:
             --set image.tag=test \
             --set ingress.enabled=false \
             --set networkPolicy.enabled=false \
+            --set broadcast.networkPolicy.enabled=false \
+            --set broadcast.auth.enabled=false \
             --set postgres.credentialsSecret=meho-postgres \
             --set postgres.host=pgvector \
             --set vault.address=https://vault.test \

--- a/backend/src/meho_backplane/broadcast/client.py
+++ b/backend/src/meho_backplane/broadcast/client.py
@@ -146,6 +146,9 @@ def get_broadcast_client() -> redis.Redis:
         settings = get_settings()
         _CLIENT = redis.from_url(
             settings.broadcast_redis_url,
+            # requirepass for the chart's auth-enabled Valkey store; ``None``
+            # (the unset default) leaves the connection unauthenticated.
+            password=settings.broadcast_redis_password,
             decode_responses=True,
             socket_timeout=_BROADCAST_FAST_TIMEOUT_SECONDS,
             socket_connect_timeout=_BROADCAST_CONNECT_TIMEOUT_SECONDS,
@@ -184,6 +187,8 @@ def get_broadcast_blocking_client() -> redis.Redis:
         settings = get_settings()
         _BLOCKING_CLIENT = redis.from_url(
             settings.broadcast_redis_url,
+            # Same requirepass as the fast client; ``None`` → no auth.
+            password=settings.broadcast_redis_password,
             decode_responses=True,
             socket_timeout=BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS,
             socket_connect_timeout=_BROADCAST_CONNECT_TIMEOUT_SECONDS,

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1194,6 +1194,14 @@ class Settings(BaseModel):
         default="redis://localhost:6379",
         min_length=1,
     )
+    #: Optional ``requirepass`` for the broadcast Valkey store. The Helm
+    #: chart enables Valkey auth by default and injects this via
+    #: ``BROADCAST_REDIS_PASSWORD`` (secretKeyRef), keeping the password out
+    #: of the plaintext ``BROADCAST_REDIS_URL``. ``None`` (unset) means the
+    #: client connects without auth — the pre-auth default and the local-dev
+    #: ``redis://localhost:6379`` path. Applied as the ``password`` kwarg on
+    #: :func:`redis.asyncio.from_url` in :mod:`meho_backplane.broadcast.client`.
+    broadcast_redis_password: str | None = Field(default=None)
     broadcast_retention_hours: int = Field(default=24, gt=0)
     broadcast_announce_rate_per_minute: int = Field(default=10, ge=0)
     #: Default per-source fixed-window cap for the inbound event-ingest
@@ -2042,6 +2050,10 @@ def get_settings() -> Settings:
             "BROADCAST_REDIS_URL",
             "redis://localhost:6379",
         ),
+        # ``or None`` collapses an empty-string env to no-auth, so an
+        # accidentally-blank BROADCAST_REDIS_PASSWORD does not send a
+        # zero-length password on the AUTH command.
+        broadcast_redis_password=os.environ.get("BROADCAST_REDIS_PASSWORD") or None,
         broadcast_retention_hours=int(
             os.environ.get("BROADCAST_RETENTION_HOURS", "24"),
         ),

--- a/backend/tests/test_broadcast_client.py
+++ b/backend/tests/test_broadcast_client.py
@@ -185,6 +185,46 @@ class TestClientLifecycle:
         assert kwargs.get("host") == "broadcast.test"
         assert kwargs.get("port") == 6379
 
+    def test_no_password_when_env_unset(self, _broadcast_env: None) -> None:
+        """Unset ``BROADCAST_REDIS_PASSWORD`` → no auth (pre-auth default)."""
+        kwargs = get_broadcast_client().connection_pool.connection_kwargs
+        assert kwargs.get("password") is None
+
+    def test_password_applied_from_settings(
+        self,
+        _broadcast_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``BROADCAST_REDIS_PASSWORD`` flows to the Valkey AUTH kwarg (F14a).
+
+        The Helm chart enables Valkey ``requirepass`` by default and injects
+        the password via ``BROADCAST_REDIS_PASSWORD`` (secretKeyRef) rather
+        than embedding it in the plaintext ``BROADCAST_REDIS_URL``. Both the
+        fast and blocking clients must authenticate with it.
+        """
+        monkeypatch.setenv("BROADCAST_REDIS_PASSWORD", "s3cr3t-req")
+        get_settings.cache_clear()
+        reset_broadcast_client_for_testing()
+        reset_broadcast_blocking_client_for_testing()
+
+        fast = get_broadcast_client().connection_pool.connection_kwargs
+        blocking = get_broadcast_blocking_client().connection_pool.connection_kwargs
+        assert fast.get("password") == "s3cr3t-req"
+        assert blocking.get("password") == "s3cr3t-req"
+
+    def test_blank_password_env_collapses_to_no_auth(
+        self,
+        _broadcast_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An accidentally-empty password env sends no AUTH, not a blank one."""
+        monkeypatch.setenv("BROADCAST_REDIS_PASSWORD", "")
+        get_settings.cache_clear()
+        reset_broadcast_client_for_testing()
+
+        kwargs = get_broadcast_client().connection_pool.connection_kwargs
+        assert kwargs.get("password") is None
+
     async def test_dispose_calls_aclose_and_clears_cache(self, _broadcast_env: None) -> None:
         client = get_broadcast_client()
         with patch.object(client, "aclose", new=AsyncMock()) as aclose:

--- a/backend/tests/test_chart_broadcast_hardening.py
+++ b/backend/tests/test_chart_broadcast_hardening.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Chart-render assertions for the F14a workload-isolation hardening (#276).
+
+Two surfaces are pinned here:
+
+* The **umbrella chart** ships a default-deny NetworkPolicy selecting the
+  backplane Pods, and the backplane Deployment asserts an unprivileged
+  ServiceAccount (``automountServiceAccountToken: false``) plus a
+  ``runAsNonRoot`` securityContext. These already shipped; the tests guard
+  them against regression (acceptance criterion 5).
+
+* The **broadcast subchart** now renders its **own** ingress NetworkPolicy
+  selecting the broadcast Pod (admitting tcp/6379 only from the backplane
+  Pods) and a chart-managed ``requirepass`` Secret consumed through
+  ``secretKeyRef`` by both the store and the backplane client. ``protected-
+  mode`` stays on while auth is enabled (acceptance criterion 6).
+
+The authoritative chart gate is ``.github/workflows/chart.yml`` (lint +
+``helm template`` + ``kubeconform``). This test mirrors the assertions at
+the unit layer so the regression is catchable from ``pytest``; it skips
+cleanly where ``helm`` is absent (the backend unit-test sandbox does not
+ship it — the workflow gate covers that environment).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+# backend/tests/<this> → parents[2] == repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "charts" / "meho"
+
+# Minimal chassis-required overrides that satisfy values.schema.json.
+_BASE_OVERRIDES = [
+    "--set",
+    "image.tag=test",
+    "--set",
+    "ingress.host=meho.test",
+    "--set",
+    "ingress.tls.secretName=meho-tls",
+    "--set",
+    "postgres.credentialsSecret=meho-postgres",
+    "--set",
+    "vault.address=https://vault.test",
+    "--set",
+    "keycloak.issuer=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakIssuerUrl=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakAudience=meho-backplane",
+    "--set",
+    "config.vaultAddr=https://vault.test",
+    "--set",
+    "networkPolicy.postgresCIDR=10.0.1.0/24",
+    "--set",
+    "networkPolicy.vaultCIDR=10.0.2.0/24",
+    "--set",
+    "networkPolicy.keycloakCIDR=10.0.3.0/24",
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed in this sandbox; chart.yml workflow gate covers CI",
+)
+
+
+def _render_one(template: str, *extra: str) -> dict[str, Any]:
+    """Return the parsed single manifest for ``--show-only <template>``."""
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(_CHART_DIR),
+            *_BASE_OVERRIDES,
+            *extra,
+            "--show-only",
+            template,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return cast("dict[str, Any]", yaml.safe_load(result.stdout))
+
+
+def _render_all(*extra: str) -> str:
+    """Return the raw multi-document render of the whole chart."""
+    result = subprocess.run(
+        ["helm", "template", "test", str(_CHART_DIR), *_BASE_OVERRIDES, *extra],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Umbrella chart — NetworkPolicy / securityContext / ServiceAccount (AC 5)
+# ---------------------------------------------------------------------------
+
+
+def test_backplane_networkpolicy_is_default_deny_with_explicit_selectors() -> None:
+    """The backplane NetworkPolicy selects the backplane Pods and bounds egress."""
+    np = _render_one("templates/networkpolicy.yaml")
+    assert np["kind"] == "NetworkPolicy"
+    assert np["spec"]["podSelector"]["matchLabels"]["app.kubernetes.io/name"] == "meho"
+    assert set(np["spec"]["policyTypes"]) == {"Ingress", "Egress"}
+    # Egress is CIDR-bounded to the operator-supplied Postgres/Vault/Keycloak
+    # blocks, not a blanket allow.
+    egress_cidrs = {
+        peer["ipBlock"]["cidr"]
+        for rule in np["spec"]["egress"]
+        for peer in rule.get("to", [])
+        if "ipBlock" in peer
+    }
+    assert {"10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"} <= egress_cidrs
+
+
+def test_backplane_deployment_runs_unprivileged_with_no_token_mount() -> None:
+    """securityContext + ServiceAccount keys asserted by the chart, not the image."""
+    dep = _render_one("templates/deployment.yaml")
+    pod_spec = dep["spec"]["template"]["spec"]
+    assert pod_spec["serviceAccountName"] == "test-meho"
+    assert pod_spec["automountServiceAccountToken"] is False
+    assert pod_spec["securityContext"]["runAsNonRoot"] is True
+
+
+def test_service_account_disables_token_automount() -> None:
+    sa = _render_one("templates/serviceaccount.yaml")
+    assert sa["kind"] == "ServiceAccount"
+    assert sa["automountServiceAccountToken"] is False
+
+
+# ---------------------------------------------------------------------------
+# Broadcast subchart — own ingress NetworkPolicy (AC 6)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_networkpolicy_selects_the_store_pod() -> None:
+    """The subchart ships its OWN policy selecting the broadcast Pod.
+
+    A Pod is ingress-isolated only when some policy selects it; the parent
+    policy selects the backplane, so without this the store stays reachable
+    cluster-wide even at ``networkPolicy.enabled=true``.
+    """
+    np = _render_one("charts/broadcast/templates/networkpolicy.yaml")
+    assert np["kind"] == "NetworkPolicy"
+    assert np["spec"]["podSelector"]["matchLabels"]["app.kubernetes.io/name"] == "broadcast"
+    assert np["spec"]["policyTypes"] == ["Ingress"]
+
+
+def test_broadcast_networkpolicy_admits_only_the_backplane_on_6379() -> None:
+    np = _render_one("charts/broadcast/templates/networkpolicy.yaml")
+    ingress = np["spec"]["ingress"]
+    assert len(ingress) == 1
+    ports = ingress[0]["ports"]
+    assert ports == [{"port": 6379, "protocol": "TCP"}]
+    from_labels = ingress[0]["from"][0]["podSelector"]["matchLabels"]
+    assert from_labels["app.kubernetes.io/name"] == "meho"
+    assert from_labels["app.kubernetes.io/instance"] == "test"
+
+
+def test_broadcast_networkpolicy_admits_extra_consumers() -> None:
+    """``extraAllowedSelectors`` adds explicitly-listed consumer peers."""
+    np = _render_one(
+        "charts/broadcast/templates/networkpolicy.yaml",
+        "--set",
+        "broadcast.networkPolicy.extraAllowedSelectors[0].app\\.kubernetes\\.io/name=satellite-runner",
+    )
+    peers = [p["podSelector"]["matchLabels"] for p in np["spec"]["ingress"][0]["from"]]
+    assert {"app.kubernetes.io/name": "satellite-runner"} in peers
+
+
+# ---------------------------------------------------------------------------
+# Broadcast subchart — Valkey auth Secret + wiring (AC 6)
+# ---------------------------------------------------------------------------
+
+
+def test_broadcast_auth_secret_carries_requirepass_key() -> None:
+    secret = _render_one("charts/broadcast/templates/secret.yaml")
+    assert secret["kind"] == "Secret"
+    assert secret["metadata"]["name"] == "test-broadcast-auth"
+    assert "requirepass" in secret["data"]
+    assert secret["data"]["requirepass"]  # non-empty base64 payload
+
+
+def test_broadcast_store_reads_requirepass_via_secret_key_ref() -> None:
+    dep = _render_one("charts/broadcast/templates/deployment.yaml")
+    container = dep["spec"]["template"]["spec"]["containers"][0]
+    env = {e["name"]: e for e in container["env"]}
+    ref = env["VALKEY_REQUIREPASS"]["valueFrom"]["secretKeyRef"]
+    assert ref == {"name": "test-broadcast-auth", "key": "requirepass"}
+    # The password is layered in at start-up, never written to the ConfigMap
+    # or the command line.
+    assert "$VALKEY_REQUIREPASS" in "\n".join(container["command"])
+
+
+def test_broadcast_configmap_keeps_protected_mode_on_with_auth() -> None:
+    cm = _render_one("charts/broadcast/templates/configmap.yaml")
+    conf = cm["data"]["valkey.conf"]
+    assert "protected-mode yes" in conf
+    # requirepass is Secret-sourced, never in the ConfigMap.
+    assert "requirepass" not in conf
+
+
+def test_backplane_client_reads_broadcast_password_via_secret_key_ref() -> None:
+    dep = _render_one("templates/deployment.yaml")
+    container = dep["spec"]["template"]["spec"]["containers"][0]
+    env = {e["name"]: e for e in container["env"]}
+    # The URL stays password-free; the password rides its own secretKeyRef.
+    assert "@" not in env["BROADCAST_REDIS_URL"]["value"]
+    ref = env["BROADCAST_REDIS_PASSWORD"]["valueFrom"]["secretKeyRef"]
+    assert ref == {"name": "test-broadcast-auth", "key": "requirepass"}
+
+
+# ---------------------------------------------------------------------------
+# Broadcast subchart — auth toggles (AC 6 edge behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_auth_disabled_falls_back_to_configmap_and_no_secret() -> None:
+    """Disabling auth keeps the store working (protected-mode off, no Secret)."""
+    rendered = _render_all("--set", "broadcast.auth.enabled=false")
+    assert "test-broadcast-auth" not in rendered
+    assert "BROADCAST_REDIS_PASSWORD" not in rendered
+    cm = _render_one(
+        "charts/broadcast/templates/configmap.yaml",
+        "--set",
+        "broadcast.auth.enabled=false",
+    )
+    assert "protected-mode no" in cm["data"]["valkey.conf"]
+
+
+def test_existing_secret_is_referenced_and_no_secret_rendered() -> None:
+    """An operator-supplied Secret is referenced by both sides; none rendered."""
+    extra = ("--set", "broadcast.auth.existingSecret=my-valkey-secret")
+    store = _render_one("charts/broadcast/templates/deployment.yaml", *extra)
+    store_env = {e["name"]: e for e in store["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert (
+        store_env["VALKEY_REQUIREPASS"]["valueFrom"]["secretKeyRef"]["name"] == "my-valkey-secret"
+    )
+    client = _render_one("templates/deployment.yaml", *extra)
+    client_env = {e["name"]: e for e in client["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert (
+        client_env["BROADCAST_REDIS_PASSWORD"]["valueFrom"]["secretKeyRef"]["name"]
+        == "my-valkey-secret"
+    )
+    # The chart renders no Secret of its own when existingSecret is set — the
+    # chart-managed name never appears anywhere in the render.
+    rendered = _render_all(*extra)
+    assert "test-broadcast-auth" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Migration Job — least-privilege credentials (AC 4, relocated from F15 #277)
+# ---------------------------------------------------------------------------
+
+
+def test_migration_job_carries_only_the_database_credential() -> None:
+    """The migrate Job gets ONLY ``DATABASE_URL`` — never the broadcast, agent,
+    Keycloak, UI-console, or check-runner secrets the backplane Deployment wires.
+
+    A ``pre-install,pre-upgrade`` hook running Alembic needs the database URL
+    and nothing else; carrying the broadcast ``requirepass`` or any LLM/OAuth
+    credential would widen the Job's blast radius past what it requires. The
+    broadcast auth wiring (#276) is added to the backplane Deployment only —
+    this guards that it did not leak into the migration hook.
+    """
+    job = _render_one("templates/migration-job.yaml")
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    env_names = {e["name"] for e in container.get("env", [])}
+    assert env_names == {"DATABASE_URL"}
+    # No ServiceAccount token is mounted either — the runner needs no API access.
+    assert job["spec"]["template"]["spec"]["automountServiceAccountToken"] is False

--- a/deploy/charts/meho/charts/broadcast/templates/configmap.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/configmap.yaml
@@ -7,15 +7,22 @@ metadata:
 data:
   # Minimal Valkey config for the v0.1 ephemeral-streams workload.
   #
-  # * `bind 0.0.0.0` — listen on the Pod IP only; access is gated by the
-  #   parent chart's NetworkPolicy (the broadcast podSelector + port-6379
-  #   egress rule). Cluster network is the only path into the pod.
-  # * `protected-mode no` — Valkey's protected-mode is a defense for
-  #   exposed-without-auth listeners running on a loopback. NetworkPolicy
-  #   gates ingress here, so disabling protected-mode is what allows the
-  #   bound port to accept connections from the backplane pod.
-  # * No `requirepass` — v0.1 single-tenant; auth is reserved for v0.2+ when
-  #   the broadcast feature actually carries cross-tenant streams.
+  # * `bind 0.0.0.0` — listen on the Pod IP. Reachability is gated at two
+  #   layers: the broadcast subchart's own ingress NetworkPolicy
+  #   (`templates/networkpolicy.yaml`, admits tcp/6379 only from the
+  #   backplane Pods) AND `requirepass` authentication (below). Neither the
+  #   ConfigMap nor this comment is the access gate — the NetworkPolicy and
+  #   the Secret-sourced password are.
+  # * `protected-mode` — Valkey refuses connections from non-loopback
+  #   addresses when protected-mode is on AND no password is set. With
+  #   `auth.enabled` (the default) a `requirepass` is layered in at start-up
+  #   (see the Deployment), so protected-mode is kept **on** as defense in
+  #   depth. When an operator disables auth, protected-mode is turned off so
+  #   the bound port still accepts the backplane's (NetworkPolicy-gated)
+  #   connections.
+  # * `requirepass` is NOT written here — it is sourced from a Kubernetes
+  #   Secret via `secretKeyRef` and appended to a runtime config file at Pod
+  #   start-up, so the password never lands in this ConfigMap.
   # * No `save` lines / `appendonly no` — streams are ephemeral by design;
   #   persistence is explicitly out of scope for v0.1.
   # * `maxmemory-policy allkeys-lru` — caps memory growth without dropping
@@ -24,7 +31,7 @@ data:
   #   readOnlyRootFilesystem: true holds.
   valkey.conf: |
     bind 0.0.0.0
-    protected-mode no
+    protected-mode {{ if .Values.auth.enabled }}yes{{ else }}no{{ end }}
     port 6379
     dir /data
     save ""

--- a/deploy/charts/meho/charts/broadcast/templates/deployment.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/deployment.yaml
@@ -37,11 +37,44 @@ spec:
         - name: broadcast
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.auth.enabled }}
+          # With auth on, the Secret-sourced password must reach Valkey
+          # without landing in the ConfigMap OR on the process command line
+          # (a `--requirepass "$VAR"` arg would be visible in `ps` /
+          # /proc/<pid>/cmdline). So the entrypoint copies the ConfigMap
+          # config into the writable emptyDir at `dir /data` and appends
+          # `requirepass <password>` from the env var (sourced via
+          # secretKeyRef below), then execs Valkey against that runtime
+          # file. readOnlyRootFilesystem stays true — only the /data
+          # emptyDir is written.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              cat /etc/valkey/valkey.conf > /data/valkey-runtime.conf
+              printf '\nrequirepass %s\n' "$VALKEY_REQUIREPASS" >> /data/valkey-runtime.conf
+              exec valkey-server /data/valkey-runtime.conf
+          {{- else }}
           # Valkey loads the operator-supplied config from /etc/valkey/valkey.conf
           # mounted from the ConfigMap. The image's entrypoint takes the path as
           # the first positional argument; no `redis-server` shim is needed.
           args:
             - /etc/valkey/valkey.conf
+          {{- end }}
+          {{- if .Values.auth.enabled }}
+          env:
+            # Valkey `requirepass` password, sourced from the chart-managed
+            # (or operator-supplied `existingSecret`) Secret. Consumed by the
+            # start-up command above; the same Secret + key is referenced by
+            # the backplane client (umbrella chart Deployment) so both sides
+            # authenticate with one value.
+            - name: VALKEY_REQUIREPASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingSecret | default (printf "%s-auth" (include "broadcast.fullname" .)) }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+          {{- end }}
           ports:
             - name: redis
               containerPort: 6379

--- a/deploy/charts/meho/charts/broadcast/templates/networkpolicy.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "broadcast.fullname" . }}
+  labels:
+    {{- include "broadcast.labels" . | nindent 4 }}
+spec:
+  # Select the broadcast Pod itself. In Kubernetes a Pod is ingress-isolated
+  # only when *some* NetworkPolicy selects it; the parent chart's policy
+  # selects the backplane Pods, not this store, so without this policy the
+  # Valkey port stays reachable from every Pod in the cluster even at
+  # `networkPolicy.enabled=true`. This is the subchart's own ingress guard
+  # so the store's isolation does not depend on the umbrella chart.
+  podSelector:
+    matchLabels:
+      {{- include "broadcast.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Admit tcp/<service.port> (default 6379) only from the backplane Pods.
+    # The backplane carries `app.kubernetes.io/name: meho` (the umbrella
+    # chart's `meho.selectorLabels`) — `networkPolicy.backplanePodLabels`
+    # holds those labels so the selectors line up. `.Release.Name` scopes
+    # the instance so co-tenant MEHO installs in one namespace stay
+    # partitioned.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.backplanePodLabels | nindent 14 }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- range .Values.networkPolicy.extraAllowedSelectors }}
+        # Explicitly-listed additional in-cluster consumers (label maps).
+        # Default empty — only the backplane reaches the store.
+        - podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+{{- end }}

--- a/deploy/charts/meho/charts/broadcast/templates/secret.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/secret.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) -}}
+{{- /*
+Chart-managed Valkey `requirepass` Secret. Rendered only when auth is on
+and the operator has not supplied their own `existingSecret`. Both the
+store (this subchart's Deployment) and the backplane client (the umbrella
+chart's Deployment) reference this Secret by name + key via `secretKeyRef`,
+so the password value itself never lands in a ConfigMap, an env `value:`,
+or the rendered manifest history.
+
+Password precedence:
+  1. `auth.password` when the operator sets one explicitly.
+  2. the value already stored in this Secret on a prior release — looked up
+     so a `helm upgrade` does NOT rotate the password out from under the
+     running store and client (the classic randAlphaNum-on-every-upgrade
+     footgun).
+  3. a freshly generated 32-char alphanumeric password on first install.
+
+`lookup` returns an empty map during `helm template` / `--dry-run` (no
+cluster round-trip), so a bare render always takes branch 3 and the key is
+always present for the render-test assertions.
+*/}}
+{{- $secretName := printf "%s-auth" (include "broadcast.fullname" .) -}}
+{{- $key := .Values.auth.existingSecretPasswordKey -}}
+{{- $password := .Values.auth.password -}}
+{{- if not $password -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $existing $existing.data (index $existing.data $key) -}}
+{{- $password = index $existing.data $key | b64dec -}}
+{{- else -}}
+{{- $password = randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "broadcast.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $key }}: {{ $password | b64enc | quote }}
+{{- end }}

--- a/deploy/charts/meho/charts/broadcast/values.yaml
+++ b/deploy/charts/meho/charts/broadcast/values.yaml
@@ -71,6 +71,43 @@ service:
   # -- Service port (Redis-protocol default 6379).
   port: 6379
 
+# -- Valkey `requirepass` authentication. Default on: the chart renders a
+# Secret holding a password (or reuses `existingSecret`), the store starts
+# with `requirepass`, and the backplane client authenticates with the same
+# Secret value. `protected-mode` is kept on as defense in depth while auth
+# is enabled. Disable only when an external, separately-secured store is
+# used.
+auth:
+  enabled: true
+  # -- Reference an operator-supplied Secret instead of a chart-managed one.
+  # When set, the chart renders no Secret and both the store and the client
+  # read the password from this Secret at `existingSecretPasswordKey`.
+  existingSecret: ""
+  # -- Key holding the requirepass value (in the chart-managed Secret, or in
+  # `existingSecret` when supplied).
+  existingSecretPasswordKey: requirepass
+  # -- Explicit password. When empty and no `existingSecret` is set the
+  # chart generates a 32-char alphanumeric password on first install and
+  # preserves it across upgrades via a lookup of the existing Secret.
+  password: ""
+
+# -- The broadcast subchart's own ingress NetworkPolicy. Selects the
+# broadcast Pod and admits tcp/<service.port> only from the backplane Pods
+# (and any `extraAllowedSelectors`). Independent of the umbrella chart's
+# NetworkPolicy so the store's isolation does not depend on the parent — a
+# Pod is ingress-isolated only when some policy selects it, and the parent
+# policy selects the backplane, not this store.
+networkPolicy:
+  enabled: true
+  # -- Pod-selector labels identifying the backplane Pods admitted to the
+  # store. Defaults to the umbrella chart's `meho.selectorLabels` name; the
+  # `.Release.Name` instance label is appended automatically.
+  backplanePodLabels:
+    app.kubernetes.io/name: meho
+  # -- Extra pod selectors (label maps) admitted to the store, for
+  # explicitly-listed in-cluster consumers. Default empty.
+  extraAllowedSelectors: []
+
 # -- Pod-level annotations.
 podAnnotations: {}
 

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -93,6 +93,18 @@ spec:
             # (locked driver) parses the `redis://` scheme unchanged.
             - name: BROADCAST_REDIS_URL
               value: "redis://{{ .Release.Name }}-broadcast:{{ .Values.broadcast.service.port }}/0"
+            {{- if .Values.broadcast.auth.enabled }}
+            # BROADCAST_REDIS_PASSWORD carries the Valkey `requirepass` the
+            # broadcast subchart enforces (charts/broadcast). Sourced from the
+            # same Secret + key the store reads, so the URL above stays
+            # password-free (no secret in a plaintext env `value:`) and the
+            # client authenticates via `Settings.broadcast_redis_password`.
+            - name: BROADCAST_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.broadcast.auth.existingSecret | default (printf "%s-broadcast-auth" .Release.Name) }}
+                  key: {{ .Values.broadcast.auth.existingSecretPasswordKey }}
+            {{- end }}
             {{- end }}
             # Other operator-supplied secrets (Keycloak client secret, Vault
             # role bindings) come via ESO-synced Kubernetes Secrets; G2.6

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -791,6 +791,34 @@
             "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
           }
         },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string", "minLength": 1 },
+            "password": { "type": "string" }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "backplanePodLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "extraAllowedSelectors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              }
+            }
+          }
+        },
         "podAnnotations": {
           "type": "object",
           "additionalProperties": { "type": "string" }

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -972,6 +972,21 @@ broadcast:
   service:
     type: ClusterIP
     port: 6379
+  # -- Valkey requirepass authentication (subchart `auth` block). Default on:
+  # the subchart renders a Secret and the backplane client authenticates with
+  # the same value via secretKeyRef. See charts/broadcast/values.yaml.
+  auth:
+    enabled: true
+    existingSecret: ""
+    existingSecretPasswordKey: requirepass
+    password: ""
+  # -- Broadcast subchart's own ingress NetworkPolicy (subchart
+  # `networkPolicy` block). Admits tcp/6379 only from the backplane Pods.
+  networkPolicy:
+    enabled: true
+    backplanePodLabels:
+      app.kubernetes.io/name: meho
+    extraAllowedSelectors: []
 
 # Pre-install / pre-upgrade migration Job (Helm hook).
 #

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -34,7 +34,9 @@ resources that make up a running backplane:
 - Migration Job — `pre-install,pre-upgrade` Helm hook running
   `python -m meho_backplane.db.migrate` before the Deployment rolls forward.
 - Broadcast subchart — in-tree Valkey 9.x Deployment + Service + ConfigMap
-  per ADR 0005.
+  per ADR 0005, plus its **own** ingress NetworkPolicy and a chart-managed
+  `requirepass` Secret (#276) so the store is ingress-isolated and
+  authenticated regardless of the umbrella policy.
 
 ## Log shipping (stdout → collector)
 
@@ -82,9 +84,11 @@ deploy/charts/meho/
         ├── values.yaml
         └── templates/
             ├── _helpers.tpl
-            ├── deployment.yaml   # single-replica Recreate; readonly rootfs + emptyDir /data
-            ├── service.yaml      # ClusterIP :6379 (port name "redis")
-            └── configmap.yaml    # minimal valkey.conf (no auth, no persistence)
+            ├── deployment.yaml    # single-replica Recreate; readonly rootfs + emptyDir /data
+            ├── service.yaml       # ClusterIP :6379 (port name "redis")
+            ├── configmap.yaml     # minimal valkey.conf (requirepass Secret-sourced, no persistence)
+            ├── secret.yaml        # chart-managed requirepass Secret (#276)
+            └── networkpolicy.yaml # own ingress policy: 6379 from backplane only (#276)
 ```
 
 ## Chart contract
@@ -212,6 +216,15 @@ egress rules to:
   is disabled
 - DNS — `udp/53` to the `k8s-app: kube-dns` selector (matches CoreDNS)
 
+The broadcast clause above is an **egress** allowance on the backplane
+side. A Pod is ingress-isolated only when *some* NetworkPolicy selects it,
+and this policy selects the backplane Pods — not the broadcast store. The
+broadcast subchart therefore ships its **own** ingress NetworkPolicy
+(`charts/broadcast/templates/networkpolicy.yaml`, #276) selecting the
+broadcast Pod and admitting `tcp/6379` only from the backplane Pods (and
+any `broadcast.networkPolicy.extraAllowedSelectors`), so the store's
+isolation does not depend on the umbrella policy alone.
+
 Ingress is permitted only from the namespace whose
 `kubernetes.io/metadata.name` label matches
 `networkPolicy.ingressControllerNamespace` (default `ingress-nginx`,
@@ -335,7 +348,8 @@ implementation of that decision.
 | Slug | `broadcast` (not `redis`) | The protocol contract matters more than the brand |
 | Workload | `Deployment` (not `StatefulSet`), single replica | Streams are ephemeral in v0.1; HA via Sentinel/Cluster is v0.2+ |
 | Persistence | None (no PVC, `save ""`, `appendonly no`) | Restart-loss of stream history is acceptable in v0.1 |
-| Auth | None (no `requirepass`) | v0.1 single-tenant; gated at the network layer by the umbrella chart's NetworkPolicy |
+| Auth | `requirepass` (default on), Secret-sourced via `secretKeyRef` (#276) | Defense in depth alongside the ingress policy; `protected-mode` stays on |
+| Network isolation | Own ingress NetworkPolicy — `tcp/6379` from backplane Pods only (#276) | The parent policy selects the backplane, not the store; the store needs its own selector to be isolated |
 | Update strategy | `Recreate` | Single-replica + port-bind constraint makes RollingUpdate worse |
 | Probes | TCP `connect` on 6379 | Minimal — avoids coupling to `redis-cli` / `valkey-cli` binary naming variance |
 | Service | ClusterIP `<release>-broadcast:6379` (port name `redis`) | In-cluster only; backplane consumes via the operator-facing `BROADCAST_REDIS_URL` env |
@@ -373,6 +387,21 @@ dialing localhost while the healthy Service is never contacted. ADR 0005
 locked `redis-py` as the driver — it parses `redis://` schemes against a
 Valkey endpoint unchanged (wire-protocol compatibility carries from
 Redis 7.2.4).
+
+**Valkey auth (#276).** `broadcast.auth.enabled: true` (the default)
+renders a chart-managed Secret (`<release>-broadcast-auth`, key
+`requirepass`) — the password is `broadcast.auth.password` when set, an
+operator's `broadcast.auth.existingSecret` when supplied, or a generated
+32-char value preserved across upgrades via a `lookup` of the existing
+Secret. The store reads it into a runtime config file at Pod start-up (kept
+out of the ConfigMap and off the process command line); the backplane reads
+the *same* Secret into `BROADCAST_REDIS_PASSWORD`, and
+`Settings.broadcast_redis_password` is applied as the `password` kwarg on
+both `redis.asyncio.from_url` clients (`broadcast/client.py`). The
+`BROADCAST_REDIS_URL` above stays password-free so no secret rides a
+plaintext env `value:`. Setting `broadcast.auth.enabled: false` drops the
+Secret, the client password, and flips `protected-mode` off so the
+NetworkPolicy-gated port still accepts connections.
 
 **Operator-supplied secrets.** The Job + the backplane both consume
 `DATABASE_URL` from a Kubernetes Secret named by
@@ -1562,8 +1591,9 @@ when application code is the only delta.
 - HPA / PDB / topologySpreadConstraints — deferred to v0.2. v0.1 is
   single-replica per Goal #11 scope. (ServiceMonitor + PrometheusRule
   shipped in #2885 — see "Metrics scrape wiring" under Chart contract.)
-- Broadcast subchart HA (Sentinel/Cluster), persistence, auth —
-  deferred to v0.2 per ADR 0005.
+- Broadcast subchart HA (Sentinel/Cluster) and persistence — deferred
+  to v0.2 per ADR 0005. (Valkey `requirepass` auth + the subchart's own
+  ingress NetworkPolicy shipped in #276 — see "Broadcast subchart" above.)
 - `broadcast.externalEndpoint` opt-out for operators with a managed
   Redis/Valkey already running — deferred to v0.2 (the
   `broadcast.enabled: false` knob lands in v0.1 as the disable path).


### PR DESCRIPTION
## Summary

- **Broadcast subchart now ships its own ingress NetworkPolicy.** The store selects the broadcast Pod and admits `tcp/6379` only from the backplane Pods (plus any `broadcast.networkPolicy.extraAllowedSelectors`). Before this, isolation depended on the umbrella policy — which selects the *backplane*, not the store — so the Valkey Pod stayed reachable cluster-wide even at `networkPolicy.enabled=true` (a Pod is ingress-isolated only when some policy selects it).
- **Valkey `requirepass` auth, default on**, via a chart-managed Secret (or `broadcast.auth.existingSecret`). Both the store and the backplane client read the same Secret through `secretKeyRef`; the store layers `requirepass` into a runtime config file at start-up so it never lands in the ConfigMap or on the process command line, and the backplane applies it as the `password` kwarg on `redis.asyncio.from_url` (new `broadcast_redis_password` setting) so `BROADCAST_REDIS_URL` stays password-free. `protected-mode` is kept on as defense in depth; the misleading ConfigMap comment is corrected.
- **Render tests** pin the broadcast NetworkPolicy selectors, the auth Secret + secretKeyRef wiring on both sides, the auth-off / existingSecret branches, and guard the umbrella chart's NetworkPolicy / securityContext / ServiceAccount keys and the migration Job's least-privilege credentials.

## Already met on `origin/main` (no change needed)

- **AC 1 (meho chart default-deny NetworkPolicy)** — `templates/networkpolicy.yaml` already renders default-deny with explicit ingress selectors + CIDR/port-bounded egress; `networkPolicy.enabled` already defaults `true`. This PR adds a render-test guard.
- **AC 2's meho-chart half** — the backplane Deployment already asserts `serviceAccountName`, `automountServiceAccountToken: false`, pod/container `securityContext` (`runAsNonRoot`, drop `ALL`, seccomp `RuntimeDefault`), and bounded resources; `serviceaccount.yaml` sets `automountServiceAccountToken: false`.
- **AC 4 (migration Job least-privilege)** — the migrate hook already carries only `DATABASE_URL` and mounts no ServiceAccount token. This PR adds a guard test that the broadcast auth wiring did not leak into the hook.

## Scope: this PR is the `evoila/meho` half of #276

`#276` spans two code repos. This PR covers the **meho chart** (incl. the broadcast subchart). The remaining acceptance criteria target other repos / a live window and are **not** in this PR:

- **Automation chart hardening** (AC 2 body, AC 5 "`/ui`-only automation ingress") lives in `evoila-bosnia/meho-automation` (`deploy/charts/meho-automation/`) — a separate repo, separate PR.
- **`values-rdc.yaml` flip** (`networkPolicy.enabled: false` → on) lives in `evoila-bosnia/claude-rdc-hetzner-dc` — separate repo. The chart default is already `true`.
- **AC 3 live disposable-workload CNI validation** requires the agreed cluster window and is the orchestrator's/operator's step (out of band for an implement PR).

## Test plan

- [x] `helm template` full render (auth on) — 13 docs, valid; broadcast NetworkPolicy + auth Secret + both `secretKeyRef`s present
- [x] `helm template` auth-off render — 12 docs, no Secret, no `BROADCAST_REDIS_PASSWORD`, `protected-mode no`
- [x] `helm template` `existingSecret` render — no chart-managed Secret, both sides reference the supplied Secret
- [x] `helm template` `broadcast.networkPolicy.enabled=false` — broadcast NetworkPolicy omitted (parent only)
- [x] `pytest tests/test_chart_broadcast_hardening.py tests/test_broadcast_client.py` — 49 passed (render + client, incl. AC4/5/6 assertions)
- [x] `pytest tests/test_settings.py` — 76 passed
- [x] `ruff check` / `ruff format --check` / `mypy` — clean on changed backend files
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] full backend unit lane (`pytest tests/ --ignore=tests/integration`) — green
- [x] Verified `redis.asyncio.from_url(url, password=...)` sets AUTH (redis-py 8.1.0) with a password-free URL

## Out of scope

- Tenant Vault path/ACL scoping (F14b) and forwarded-header / target-CIDR / self-approval (F14c).
- Broadcast HA (Sentinel/Cluster) and persistence — still v0.2 per ADR 0005.

<!-- auto-implement-issue: fresh, iteration 1 -->

Part of evoila-bosnia/meho-internal#276 (evoila/meho chart half; the values-rdc.yaml flip + live NetworkPolicy verification stay on the Task in the lab repo — orchestrator keeps #276 open)
