### PR TITLE
fix(checks): re-gate the sensor runner on the descriptor's current safety_level at dispatch

### DIFF
--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -83,14 +83,17 @@ with ``sub=sensor.identity_sub`` (#2503's per-row column, default
 ``"__sensor__"``), ``tenant_id=sensor.tenant_id``,
 ``TenantRole.OPERATOR`` -- the topology-refresh ``_system_operator`` mould with
 the sub sourced from the row. ``principal_kind`` defaults to ``USER``, so
-:func:`~meho_backplane.operations._validate.policy_gate` auto-executes the
-``safe`` op (#2503's registration guard enforces ``safe`` **at Sensor create
-time**; the runner does not re-validate ``safety_level`` at dispatch, matching
-the platform's default-allow-on-``requires_approval`` policy, so an op
-re-registered to a higher safety level *after* a Sensor is created would still
-run here -- a caution/dangerous escalation is a platform-level concern, not
-re-gated in the runner. The agent-credential path is never touched here and
-no agent run may exist on this path).
+:func:`~meho_backplane.operations._validate.policy_gate` would auto-execute the
+op: the non-agent verdict parks only the ``destructive`` and
+``requires_approval`` tiers, never re-consulting ``safety_level`` for a ``USER``
+(that consultation lives behind the SERVICE-only branch). #2503's registration
+guard enforces ``safe`` **at Sensor create time**, but a versioned re-ingest
+could later re-classify a sensored op to ``caution`` / ``dangerous`` while
+keeping ``requires_approval=False``. So :func:`_run_evaluation` **re-asserts the
+safe-tier floor at dispatch** (#303): it re-resolves the current descriptor and
+fails closed to ``unknown`` unless it is still ``safe`` -- no non-safe mutation
+runs here unattended. The agent-credential path is never touched here and no
+agent run may exist on this path.
 
 ``raw_jwt`` is the runner's own **service-principal** token (#2642) when
 ``CHECK_RUNNER_CLIENT_ID`` / ``CHECK_RUNNER_CLIENT_SECRET`` are configured, and
@@ -149,6 +152,7 @@ from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Sensor
 from meho_backplane.metrics import note_loop_tick
+from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.operations.meta_tools import _resolve_target_or_error
 from meho_backplane.scheduler.cron import (
@@ -352,11 +356,51 @@ def _target_resolution_outcome(envelope: dict[str, object]) -> AssertionOutcome:
     )
 
 
-async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
-    """Resolve the sensor's target, dispatch its op, and evaluate. Never raises.
+async def _safe_tier_floor(snap: _SensorSnapshot) -> AssertionOutcome | None:
+    """Re-assert the safe-tier floor at dispatch (#303). ``None`` means proceed.
 
-    The stored ``target`` is resolved through the shared ``call_operation`` seam
-    (:func:`~meho_backplane.operations.meta_tools._resolve_target_or_error`)
+    The create guard
+    (:class:`~meho_backplane.checks.service.SensorRequiresSafeOperationError`)
+    proves ``safety_level == "safe"`` only at registration. The non-agent policy
+    verdict never re-consults ``safety_level`` for the runner's synthetic
+    ``USER`` operator (it parks only the ``destructive`` / ``requires_approval``
+    tiers), so an op re-ingested to ``caution`` / ``dangerous`` after the Sensor
+    was created -- while keeping ``requires_approval=False`` -- would otherwise
+    auto-execute its mutation on every unattended tick. Re-resolve the current
+    descriptor with the same helper the create guard uses
+    (:func:`~meho_backplane.operations._lookup.lookup_descriptor`) and fail
+    closed to ``unknown`` when it is missing or no longer ``safe``; a still-safe
+    op returns ``None`` and dispatches unchanged. ``parse_connector_id`` is
+    forgiving (never raises); a descriptor read that errors rides
+    :func:`_run_evaluation`'s never-raises contract to ``unknown`` as well.
+    """
+    product, version, impl_id = parse_connector_id(snap.connector_id)
+    descriptor = await lookup_descriptor(
+        tenant_id=snap.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=snap.op_id,
+    )
+    if descriptor is None:
+        return _unknown_outcome("op_descriptor_missing")
+    if descriptor.safety_level != "safe":
+        return _unknown_outcome(
+            "op_not_safe_at_dispatch",
+            safety_level=descriptor.safety_level,
+        )
+    return None
+
+
+async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
+    """Re-gate on safety, resolve the target, dispatch the op, and evaluate. Never raises.
+
+    A **dispatch-time safe-tier floor** guards the dispatch (:func:`_safe_tier_floor`,
+    #303): a sensored op re-classified above ``safe`` after create records
+    ``unknown`` here instead of auto-executing unattended.
+
+    The stored ``target`` is then resolved through the shared ``call_operation``
+    seam (:func:`~meho_backplane.operations.meta_tools._resolve_target_or_error`)
     before dispatch -- the dispatcher's connector resolver reads ``product`` /
     ``version`` off a resolved :class:`~meho_backplane.db.models.Target` row, not
     off the raw stored dict, so skipping this step mislabelled every
@@ -369,6 +413,13 @@ async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
     now = datetime.now(UTC)
     try:
         async with asyncio.timeout(_EVAL_TIMEOUT_SECONDS):
+            # Dispatch-time safe-tier floor (#303): refuse to dispatch a
+            # sensored op that is no longer ``safe``. Runs before the operator
+            # is built or the target is resolved, so a re-classified op does
+            # neither -- it just records ``unknown``.
+            floor_outcome = await _safe_tier_floor(snap)
+            if floor_outcome is not None:
+                return floor_outcome
             # Inside the timeout: building the operator may mint a
             # check-runner principal token (#2642), i.e. reach Keycloak. That
             # call carries its own HTTP timeout, but a slow IdP must burn the

--- a/backend/src/meho_backplane/checks/service.py
+++ b/backend/src/meho_backplane/checks/service.py
@@ -132,12 +132,16 @@ class SensorRequiresSafeOperationError(Exception):
     at create; the boundary maps it to 422 ``sensor_requires_safe_operation``
     (the MCP transport surfaces the same code as an invalid-params error).
 
-    This is a **create-time honesty guard, not the security boundary**:
-    the dispatch-time policy gate
-    (:func:`meho_backplane.operations.dispatcher.dispatch`) still runs on
-    every #2505 evaluation, so a descriptor whose ``safety_level`` is later
-    re-ingested harder fails closed at dispatch even for an already-created
-    sensor.
+    This is a **create-time honesty guard**. The dispatch-time policy gate
+    (:func:`meho_backplane.operations.dispatcher.dispatch`) does run on every
+    #2505 evaluation, but for the sensor runner's synthetic ``USER`` operator it
+    fails closed at dispatch only for the ``destructive`` and
+    ``requires_approval`` tiers -- it does not re-consult ``safety_level`` for
+    the ``caution`` / ``dangerous`` tiers on that path. The safe-tier floor for
+    a re-ingested op is re-asserted separately by the runner itself
+    (:func:`meho_backplane.checks.runner._run_evaluation`, #303): a sensored op
+    re-classified above ``safe`` after create records ``unknown`` instead of
+    dispatching.
     """
 
     #: Machine-readable error code surfaced on every transport.

--- a/backend/tests/test_checks_confirmation.py
+++ b/backend/tests/test_checks_confirmation.py
@@ -38,6 +38,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
+from sqlalchemy import select
 
 import meho_backplane.checks.investigate as inv
 from meho_backplane.checks.repository import create_sensor, record_sensor_result
@@ -51,6 +52,7 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     CheckDashboard,
     CheckDashboardSensor,
+    EndpointDescriptor,
     Sensor,
     SensorCadenceKind,
     Tenant,
@@ -99,6 +101,43 @@ async def _seed_tenant(tenant_id: uuid.UUID = _TENANT) -> None:
             await session.commit()
 
 
+async def _seed_safe_descriptor() -> None:
+    """Seed the global safe ``vmware.vm.list`` descriptor the runner re-resolves.
+
+    The runner re-asserts the safe-tier floor at dispatch (#303) by resolving
+    the current descriptor, so a sensor created through the repository (which
+    bypasses the service create guard) needs its op to resolve to a ``safe``
+    descriptor for the dispatch path to run -- as in production, where the
+    create guard guarantees one exists. Idempotent.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        existing = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.product == "vmware",
+                EndpointDescriptor.version == "9.0",
+                EndpointDescriptor.impl_id == "vmware-rest",
+                EndpointDescriptor.op_id == "vmware.vm.list",
+            )
+        )
+        if existing.scalars().first() is not None:
+            return
+        session.add(
+            EndpointDescriptor(
+                product="vmware",
+                version="9.0",
+                impl_id="vmware-rest",
+                op_id="vmware.vm.list",
+                source_kind="ingested",
+                method="GET",
+                path="/vmware.vm.list",
+                parameter_schema={"type": "object", "properties": {}},
+                safety_level="safe",
+            )
+        )
+        await session.commit()
+
+
 async def _create_sensor(
     *,
     retry_times: int,
@@ -106,6 +145,7 @@ async def _create_sensor(
     interval_seconds: int = 300,
 ) -> uuid.UUID:
     await _seed_tenant()
+    await _seed_safe_descriptor()
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         row = await create_sensor(

--- a/backend/tests/test_sensor_runner.py
+++ b/backend/tests/test_sensor_runner.py
@@ -47,6 +47,7 @@ import httpx
 import pytest
 import respx
 import structlog
+from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
@@ -89,6 +90,7 @@ from meho_backplane.db.models import (
 )
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
+from meho_backplane.operations._lookup import parse_connector_id
 from meho_backplane.scheduler.cron import next_fire_after
 from meho_backplane.scheduler.loop import _SCHEDULER_ADVISORY_LOCK_KEY
 from meho_backplane.settings import get_settings
@@ -133,14 +135,18 @@ async def _seed_tenant(tenant_id: uuid.UUID = _TENANT) -> None:
             await session.commit()
 
 
-async def _seed_safe_descriptor() -> None:
-    """Insert the global safe ``vmware.vm.list`` descriptor the create guard reads.
+async def _seed_safe_descriptor(safety_level: str = "safe") -> None:
+    """Insert the global ``vmware.vm.list`` descriptor the create guard reads.
 
     ``SensorAdminService.create`` resolves ``connector_id="vmware-rest-9.0"`` +
     ``op_id="vmware.vm.list"`` to a ``safety_level='safe'`` descriptor before it
     writes the row; the runner-file helpers create rows via the repository
     directly (bypassing the guard), so the descriptor is only needed by the
     tests that exercise the real service create path (#2699).
+
+    *safety_level* defaults to ``"safe"``; a test simulating a versioned
+    re-ingest that raised the tier after create passes ``"caution"`` /
+    ``"dangerous"`` to prove the runner's dispatch-time floor (#303).
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -153,6 +159,46 @@ async def _seed_safe_descriptor() -> None:
                 source_kind="ingested",
                 method="GET",
                 path="/vmware.vm.list",
+                parameter_schema={"type": "object", "properties": {}},
+                safety_level=safety_level,
+            )
+        )
+        await session.commit()
+
+
+async def _ensure_safe_descriptor(connector_id: str, op_id: str) -> None:
+    """Seed a global ``safe`` descriptor for *(connector_id, op_id)* if none exists.
+
+    The runner re-asserts the safe-tier floor at dispatch (#303) by resolving
+    the current descriptor, so a sensor created straight through the repository
+    (which bypasses the service create guard) needs its op to resolve to a
+    ``safe`` descriptor for the dispatch path to run at all -- exactly as in
+    production, where the create guard guarantees one exists. Idempotent: a
+    connector that already registered its descriptor (the net / k8s typed ops,
+    or a test that seeded a non-``safe`` tier first) is left untouched.
+    """
+    product, version, impl_id = parse_connector_id(connector_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        existing = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.product == product,
+                EndpointDescriptor.version == version,
+                EndpointDescriptor.impl_id == impl_id,
+                EndpointDescriptor.op_id == op_id,
+            )
+        )
+        if existing.scalars().first() is not None:
+            return
+        session.add(
+            EndpointDescriptor(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                op_id=op_id,
+                source_kind="ingested",
+                method="GET",
+                path=f"/{op_id}",
                 parameter_schema={"type": "object", "properties": {}},
                 safety_level="safe",
             )
@@ -174,6 +220,7 @@ async def _create_interval_sensor(
     params: dict[str, Any] | None = None,
 ) -> uuid.UUID:
     await _seed_tenant(tenant_id)
+    await _ensure_safe_descriptor(connector_id, op_id)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         row = await create_sensor(
@@ -209,6 +256,7 @@ async def _create_cron_sensor(
     base: datetime,
 ) -> uuid.UUID:
     await _seed_tenant(tenant_id)
+    await _ensure_safe_descriptor("vmware-rest-9.0", "vmware.vm.list")
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         row = await create_sensor(
@@ -735,6 +783,87 @@ async def test_ok_dispatch_routes_payload_into_evaluator_and_persists(
     assert row.last_evidence["observed"] == 3
     assert row.last_evaluated_at is not None
     assert row.state_since is not None
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch-time safe-tier floor (#303)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sensor_dispatch_skips_op_reingested_above_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sensored op re-classified above ``safe`` after create is not dispatched.
+
+    The create guard only proves safety at registration; a versioned re-ingest
+    could re-classify the op to ``caution`` while keeping
+    ``requires_approval=False``, which the non-agent policy verdict would
+    auto-execute for the runner's synthetic ``USER``. The runner's dispatch-time
+    floor (#303) must fail closed: ``dispatch`` is never reached and the
+    persisted outcome is ``unknown``.
+    """
+    dispatched = 0
+
+    async def _counting_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal dispatched
+        dispatched += 1
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _counting_dispatch)
+
+    # Seed the descriptor at ``caution`` *before* the sensor is created, so the
+    # factory's idempotent safe-seed leaves it as-is -- the op the live sensor
+    # references now resolves above the safe floor at dispatch time.
+    await _seed_tenant()
+    await _seed_safe_descriptor(safety_level="caution")
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    assert dispatched == 0, "a caution-tier op must not dispatch on the sensor cadence"
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "unknown"
+    assert row.last_evidence is not None
+    assert row.last_evidence["reason"] == "op_not_safe_at_dispatch"
+    assert row.last_evidence["safety_level"] == "caution"
+
+
+@pytest.mark.asyncio
+async def test_sensor_dispatch_runs_when_op_is_safe_at_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``safe`` op still dispatches and routes its payload to the evaluator.
+
+    Happy-path regression guard paired with
+    :func:`test_sensor_dispatch_skips_op_reingested_above_safe`: the
+    dispatch-time floor must let a genuinely ``safe`` op through unchanged.
+    """
+    dispatched = 0
+
+    async def _counting_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal dispatched
+        dispatched += 1
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _counting_dispatch)
+
+    await _seed_tenant()
+    await _seed_safe_descriptor(safety_level="safe")
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    assert dispatched == 1, "a safe-tier op must dispatch on the sensor cadence"
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.last_value == 3
+    assert row.last_evidence is not None
+    assert row.last_evidence["observed"] == 3
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -90,13 +90,17 @@ healthy or wedged. See `docs/codebase/connectors-net-diagnostics.md`
    `EndpointDescriptor` via `lookup_descriptor` (tenant-scoped, then
    global). No descriptor ⇒ 422 `sensor_operation_not_found`.
 4. **Safe-only guard**: `descriptor.safety_level != "safe"` ⇒ 422
-   `sensor_requires_safe_operation`. This is a create-time-only guard:
-   the dispatch-time policy gate (`operations/dispatcher.dispatch`)
-   still runs on every evaluation, but it does **not** re-validate
-   `safety_level` — a descriptor re-ingested to a less-safe level keeps
-   auto-executing on schedule (`checks/runner.py`, "Dispatch
-   identity"). The platform-level half of that trade-off — the
-   reporting/triage mitigation — is #2702: a connector re-ingest
+   `sensor_requires_safe_operation`. This is the create-time half of a
+   two-point enforcement. The dispatch-time policy gate
+   (`operations/dispatcher.dispatch`) does **not** re-consult
+   `safety_level` for the runner's synthetic `USER` operator (it parks
+   only the `destructive` / `requires_approval` tiers), so the runner
+   itself re-asserts the safe floor at dispatch (#303, `checks/runner.py`
+   `_run_evaluation`, "Dispatch identity"): a descriptor re-ingested
+   above `safe` after create records `unknown`
+   (`reason: op_not_safe_at_dispatch`) instead of auto-executing on
+   schedule. The platform-level reporting/triage mitigation is #2702: a
+   connector re-ingest
    that overwrites a pinned op's `safety_level` surfaces the diff — with
    each affected sensor's id/name/tenant_id, scoped to the ingest's
    tenant for tenant-scoped ingests — on the ingest result's
@@ -269,8 +273,9 @@ Each surface carries the four verbs — `list` / `create` / `delete` plus the
   `docs/codebase/connectors-net-diagnostics.md` § *Refusal is a dispatch
   error, not a reading*.
 - The safe-only guard's descriptor read and the insert are in separate
-  sessions (a TOCTOU window); acceptable because the dispatch-time policy
-  gate is the real boundary.
+  sessions (a TOCTOU window); acceptable because the runner re-asserts the
+  safe-tier floor at dispatch (#303), so a race that lands a non-safe
+  descriptor records `unknown` rather than executing.
 - **The `identity_sub` ownership guard (#2699) is create-time only.** There
   is no update route, so it covers every new row, but any `sensor` row
   persisted *before* the guard landed with a spoofed `identity_sub` keeps


### PR DESCRIPTION
## Summary

- **Re-gate the sensor runner on the descriptor's current `safety_level` at dispatch (S15).** The create guard (`checks/service.py`) proves `safety_level == "safe"` only at registration. The runner dispatches each sensor's stored op on every unattended tick as a synthetic `USER` operator, and the non-agent policy verdict parks only the `destructive` / `requires_approval` tiers — it never re-consults `safety_level` for a `USER`. So an op re-ingested to `caution`/`dangerous` after the sensor was created (keeping `requires_approval=False`) would auto-execute its mutation unattended on the sensor cadence.
- `_run_evaluation` now calls a new `_safe_tier_floor` helper that re-resolves the current descriptor via `lookup_descriptor` (the same helper the create guard uses) before dispatch and records `unknown` — fail closed — when it is missing (`op_descriptor_missing`) or no longer safe (`op_not_safe_at_dispatch`). Safe-tier sensors evaluate unchanged.
- Corrected the over-stated `service.py` docstring: "fails closed at dispatch" is now scoped to the `destructive` / `requires_approval` tiers the policy gate actually parks, and points at the runner's own safe-tier floor for the re-ingest case. `docs/codebase/sensor.md` records the two-point enforcement.

## Already on main

Nothing in this Task was pre-satisfied by the 2026-09-06 containment PRs (#3423 / #3427, v0.33.5). The `destructive`-tier and `requires_approval` fail-closed behaviour on the non-agent path (#3196 / #3198 / #3152) was already present and is unchanged; this Task extends the same discipline to the `caution`/`dangerous` tiers on the unattended sensor `USER` dispatch, which was still open.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (runner.py, service.py, both test files)
- [x] `mypy src/meho_backplane/checks/runner.py src/meho_backplane/checks/service.py` — clean
- [x] `grep -n lookup_descriptor .../checks/runner.py` — resolve call in the evaluation path (`_safe_tier_floor`, invoked before `dispatch(`)
- [x] `grep -n "fails closed at dispatch" .../checks/service.py` — scoped to destructive/`requires_approval`, not a bare all-tier claim
- [x] New `test_sensor_dispatch_skips_op_reingested_above_safe` — registers a `caution` descriptor for the sensor's op, runs one tick, asserts `dispatch` is never called and the persisted outcome is `unknown` (`reason=op_not_safe_at_dispatch`)
- [x] New `test_sensor_dispatch_runs_when_op_is_safe_at_dispatch` — safe-tier happy-path regression guard (dispatch called, payload routed to the evaluator)
- [x] `pytest tests/test_sensor_runner.py tests/test_checks_confirmation.py tests/test_checks_watchdog.py tests/test_operations_subop_policy_gate.py` — all pass
- [x] Full backend unit lane — green (see run notes)
- [x] `code-quality.py --diff` — 0 blockers (`_run_evaluation` back to 76 lines after extracting `_safe_tier_floor`)

## Test-fixture note

The runner now resolves the descriptor at dispatch, so the sensor-runner and confirmation test factories (which create sensors straight through the repository, bypassing the service create guard) seed a matching `safe` descriptor idempotently — faithful to production, where the create guard guarantees one exists. Connectors that already register their own descriptors (net / k8s typed ops) are left untouched.

## Out of scope (per the Task)

- The default-allow policy for interactive human `USER` operators on non-sensor `call_operation` paths.
- The destructive / `requires_approval` verdict tiers and the #3133 announce gate (already fail closed / off by default).
- Re-designing the create-time guard, the `safety_level` taxonomy, or the `_is_mutating` heuristic.
- The check-runner service-principal token / Vault role wiring (#2642 / #2757).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#303
