### PR TITLE
fix(approvals): transactional decision transitions + decision-time deadline (F12 / #274)

### DIFF
--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -93,6 +93,7 @@ from meho_backplane.operations.approval_context import (
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    ApprovalRequestExpiredError,
     ParamsMismatchError,
     PreviewBindingMissingError,
     ResultAccessForbiddenError,
@@ -439,6 +440,13 @@ async def _capture_operator_decision(
             status_code=http_status.HTTP_409_CONFLICT,
             detail=f"approval_request_already_{exc.status}",
         ) from exc
+    except ApprovalRequestExpiredError as exc:
+        # F12 / #274: the pending deadline has passed — refuse the approval
+        # at decision time rather than trusting the background expiry sweep.
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="approval_request_expired",
+        ) from exc
     except PreviewBindingMissingError as exc:
         # #3197: a destructive row with no preview-hash binding cannot be
         # approved (fail-closed re-verification of the mandatory binding).
@@ -662,6 +670,13 @@ async def _record_approval_decision(
         raise HTTPException(
             status_code=http_status.HTTP_409_CONFLICT,
             detail=f"approval_request_already_{exc.status}",
+        ) from exc
+    except ApprovalRequestExpiredError as exc:
+        # F12 / #274: the pending deadline has passed — refuse the approval
+        # at decision time rather than trusting the background expiry sweep.
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="approval_request_expired",
         ) from exc
     except ParamsMismatchError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -104,6 +104,7 @@ __all__ = [
     "ApprovalError",
     "ApprovalNotFoundError",
     "ApprovalRequestAlreadyDecidedError",
+    "ApprovalRequestExpiredError",
     "NonHumanApprovalError",
     "ParamsMismatchError",
     "PreviewBindingMissingError",
@@ -164,6 +165,27 @@ class ApprovalRequestAlreadyDecidedError(ApprovalError):
         self.request_id = request_id
         self.status = status
         super().__init__(f"approval_request {request_id} is already in terminal state {status!r}")
+
+
+class ApprovalRequestExpiredError(ApprovalError):
+    """The pending request's deadline has passed; it cannot be approved.
+
+    Raised by :func:`approve_request` when a still-``pending`` row is past
+    its ``expires_at`` deadline at decision time (security F12 / #274). The
+    deadline is re-checked on the approve path rather than trusting the
+    background expiry sweep (:mod:`~meho_backplane.operations.approval_expiry`),
+    whose default cadence is 300s and whose per-tick failures are
+    swallowed to keep the loop alive: an overdue intent must be
+    un-approvable *immediately*, not only after the next successful sweep.
+    The row is left ``pending`` for the sweeper to transition to
+    ``expired`` with its decision audit row — this exception only refuses
+    the approval. The route layer maps it to 409 (conflict), the same
+    class as an already-decided row.
+    """
+
+    def __init__(self, request_id: uuid.UUID) -> None:
+        self.request_id = request_id
+        super().__init__(f"approval_request {request_id} deadline has passed")
 
 
 class ParamsMismatchError(ApprovalError):
@@ -778,7 +800,10 @@ async def reject_request(
     """
     _check_reviewer_role(operator)
 
-    request = await _load_for_tenant(session, request_id, operator.tenant_id)
+    # Row lock (security F12 / #274): a competing approve / reject / expiry
+    # on this row serialises on the lock, so the loser re-reads the
+    # committed terminal state and refuses rather than overwriting it.
+    request = await _load_for_tenant(session, request_id, operator.tenant_id, for_update=True)
 
     if request.status != ApprovalRequestStatus.PENDING.value:
         raise ApprovalRequestAlreadyDecidedError(request_id, request.status)
@@ -828,16 +853,26 @@ async def claim_resume(
     """Win the exactly-one-resumer claim for *request_id* (#2293, G0.30).
 
     A single conditional ``UPDATE approval_request SET resumed_at = :now
-    WHERE id = :request_id AND resumed_at IS NULL`` -- the atomic claim
-    every resumer of an approved op must win before it re-dispatches
-    ``dispatch(..., _approved=True)``: the in-process agent waiter
-    (:mod:`meho_backplane.agent.approval_wait`), the shared
+    WHERE id = :request_id AND resumed_at IS NULL AND status = 'approved'``
+    -- the atomic claim every resumer of an approved op must win before it
+    re-dispatches ``dispatch(..., _approved=True)``: the in-process agent
+    waiter (:mod:`meho_backplane.agent.approval_wait`), the shared
     :func:`resume_dispatch_after_approval` operator path (REST ``/approve``
     + ``/decide``, MCP by-id approve, UI approve), and any future resumer.
     Returns ``True`` when this caller set ``resumed_at`` (one row touched)
     and therefore owns the single execution; ``False`` when another
-    resumer already claimed it (zero rows touched) and this caller must
-    no-op cleanly.
+    resumer already claimed it, or the row is not ``approved`` (zero rows
+    touched) and this caller must no-op cleanly.
+
+    The ``status = 'approved'`` predicate (security F12 / #274) makes the
+    claim require the approved state *in the same statement* as the
+    single-resumer latch, so no execution can follow a losing/rejected/
+    expired transition even under a race: a request that a competing
+    reject or expiry won cannot be claimed for execution. Every resume
+    surface already only reaches here after the decision committed
+    ``approved``, so this tightens the invariant without changing the
+    live control flow -- it fails closed if a resume is ever attempted
+    against a non-approved row.
 
     Why a conditional ``UPDATE`` rather than a Python ``if`` + edit (the
     same reasoning as :func:`~meho_backplane.operations.agent_run.extend_lease`'s
@@ -873,6 +908,7 @@ async def claim_resume(
             update(ApprovalRequest)
             .where(ApprovalRequest.id == request_id)
             .where(ApprovalRequest.resumed_at.is_(None))
+            .where(ApprovalRequest.status == ApprovalRequestStatus.APPROVED.value)
             .values(resumed_at=stamp)
             .execution_options(synchronize_session=False)
         )
@@ -1325,6 +1361,43 @@ def _deadline_passed_clause(cutoff: datetime, default_ttl: timedelta | None) -> 
     )
 
 
+def _as_utc(value: datetime) -> datetime:
+    """Coerce a possibly-naive datetime to timezone-aware UTC.
+
+    Postgres ``timestamptz`` columns round-trip as aware datetimes, but the
+    SQLite unit-test driver returns naive ones; comparing a naive row value
+    against the aware :func:`_now` cutoff raises ``TypeError``. A naive
+    value is assumed to be UTC (the only zone the queue ever stores), the
+    same normalisation the console / checks surfaces apply on read.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _deadline_has_passed(
+    request: ApprovalRequest,
+    cutoff: datetime,
+    default_ttl: timedelta | None,
+) -> bool:
+    """Row-level mirror of :func:`_deadline_passed_clause` (security F12 / #274).
+
+    The decision-time deadline gate the approve path evaluates in Python
+    on the single locked row, using the same coalesce the background sweep
+    applies in SQL so the two agree on when a row is overdue: a concrete
+    ``expires_at`` compares directly; a legacy null-``expires_at`` row
+    (parked before #2322) is treated as if its deadline were
+    ``created_at + default_ttl`` when a *default_ttl* is supplied, and is
+    never overdue otherwise (the historical contract). Keeping this in
+    lock-step with :func:`_deadline_passed_clause` means an overdue request
+    the approve path refuses is exactly one the sweep would expire.
+    """
+    cutoff = _as_utc(cutoff)
+    if request.expires_at is not None:
+        return _as_utc(request.expires_at) <= cutoff
+    if default_ttl is None:
+        return False
+    return _as_utc(request.created_at) <= cutoff - default_ttl
+
+
 async def expire_stale_requests(
     session: AsyncSession,
     *,
@@ -1380,6 +1453,14 @@ async def expire_stale_requests(
         .where(ApprovalRequest.status == ApprovalRequestStatus.PENDING.value)
         .where(_deadline_passed_clause(cutoff, default_ttl))
         .where(ApprovalRequest.tenant_id == operator.tenant_id)
+        # Lock each swept row FOR UPDATE and skip any a concurrent approve /
+        # reject already holds (security F12 / #274): the sweep never blocks
+        # on an in-flight decision, and it never competes with one for the
+        # same row — the decision path wins that row and the sweep expires
+        # only the rows no operator is deciding, so every transition has
+        # exactly one winner. ``SKIP LOCKED`` is a no-op on SQLite; the
+        # guarantee is proven against Postgres in the integration suite.
+        .with_for_update(skip_locked=True)
     )
     result = await session.execute(stmt)
     rows = list(result.scalars().all())
@@ -1530,16 +1611,27 @@ async def _load_pending_for_approval(
     """Load + validate a row for approval, raising on any precondition failure.
 
     Runs the full approve precondition ladder in order so callers learn
-    the most specific reason first: role gate → tenant-scoped load →
-    pending guard → self-approval guard (G11.7-T1 #1401) → params-hash
-    check (only when *params* is supplied) → destructive preview-binding
-    re-verification (#3197). Returns the validated pending row; the caller
-    flips status + writes the decision audit row.
+    the most specific reason first: role gate → tenant-scoped load (under a
+    row lock) → pending guard → deadline guard (security F12 / #274) →
+    self-approval guard (G11.7-T1 #1401) → params-hash check (only when
+    *params* is supplied) → destructive preview-binding re-verification
+    (#3197). Returns the validated pending row; the caller flips status +
+    writes the decision audit row.
+
+    The row is loaded ``FOR UPDATE`` so a competing approve / reject /
+    expiry serialises on the lock and the loser re-reads the committed
+    terminal state (the pending guard then refuses it) rather than
+    overwriting a decision. The deadline guard re-checks ``expires_at`` at
+    decision time — an overdue pending request is refused with
+    :class:`ApprovalRequestExpiredError` even while the background sweep is
+    delayed or failing, so it can never be approved into execution.
     """
     _check_reviewer_role(operator)
-    request = await _load_for_tenant(session, request_id, operator.tenant_id)
+    request = await _load_for_tenant(session, request_id, operator.tenant_id, for_update=True)
     if request.status != ApprovalRequestStatus.PENDING.value:
         raise ApprovalRequestAlreadyDecidedError(request_id, request.status)
+    if _deadline_has_passed(request, _now(), _resolve_default_ttl()):
+        raise ApprovalRequestExpiredError(request_id)
     _check_self_approval(operator, request)
     if params is not None:
         incoming_hash = compute_params_hash(params)
@@ -1570,14 +1662,26 @@ async def _load_for_tenant(
     session: AsyncSession,
     request_id: uuid.UUID,
     tenant_id: uuid.UUID,
+    *,
+    for_update: bool = False,
 ) -> ApprovalRequest:
     """Load an :class:`ApprovalRequest` by id, enforcing tenant isolation.
 
     Returns the row if found and owned by *tenant_id*; raises
     :class:`ApprovalNotFoundError` for missing rows or cross-tenant
     access (the two cases are indistinguishable to callers).
+
+    When *for_update* is set the row is loaded ``SELECT ... FOR UPDATE``
+    (security F12 / #274): the decision paths (approve / reject) take the
+    row lock so a competing approve / reject / expiry serialises on it and
+    the loser re-reads the committed terminal state rather than
+    overwriting it, yielding exactly one winning transition. The read
+    surfaces (``get_request`` / ``read_approval_result`` / ``list_pending``)
+    leave it unset — they must not lock. On SQLite (the unit-suite driver)
+    ``FOR UPDATE`` is a silent no-op; the concurrency guarantee is proven
+    against Postgres in the integration suite.
     """
-    row = await session.get(ApprovalRequest, request_id)
+    row = await session.get(ApprovalRequest, request_id, with_for_update=for_update)
     if row is None or row.tenant_id != tenant_id:
         raise ApprovalNotFoundError(request_id)
     return row

--- a/backend/src/meho_backplane/ui/routes/approvals/routes.py
+++ b/backend/src/meho_backplane/ui/routes/approvals/routes.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line approvals console
+# BFF; #274 adds one exception import + one handler branch, not a split.
 
 """Approvals UI routes: a notifications bell + approve/deny modal over a session BFF.
 
@@ -130,6 +132,7 @@ from meho_backplane.operations.approval_context import (
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    ApprovalRequestExpiredError,
     PreviewBindingMissingError,
     SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
@@ -797,6 +800,13 @@ async def _commit_decision(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"This request was already {exc.status}.",
+        ) from exc
+    except ApprovalRequestExpiredError as exc:
+        # F12 / #274: the request's deadline lapsed — refuse the approval at
+        # decision time rather than waiting for the background expiry sweep.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This request's approval deadline has passed and it can no longer be decided.",
         ) from exc
     except PreviewBindingMissingError as exc:
         # #3197: a destructive row missing its preview-hash binding cannot be

--- a/backend/tests/integration/test_approval_exactly_one_resumer_e2e.py
+++ b/backend/tests/integration/test_approval_exactly_one_resumer_e2e.py
@@ -121,11 +121,21 @@ async def test_claim_resume_concurrent_race_yields_exactly_one_winner(
     """N concurrent claims on one request resolve to exactly one winner (#2293).
 
     The real-row-lock proof the SQLite unit suite cannot give: fire eight
-    ``claim_resume`` calls at once against a single freshly-parked request;
+    ``claim_resume`` calls at once against a single approved request;
     exactly one wins the conditional UPDATE and the rest lose after it
     commits. ``resumed_at`` ends up stamped exactly once.
+
+    The claim requires the row to be ``approved`` in the same statement as
+    the single-resumer latch (security F12 / #274), so the request is
+    committed ``approved`` before the race — a resume can never follow a
+    non-approved transition.
     """
     request = await _commit_run_bound_pending(requester_sub="agent:race")
+
+    reviewer = _make_operator(sub="human:reviewer", kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as session:
+        await approve_request(session, request.id, operator=reviewer, params=None)
+        await session.commit()
     assert await _reload_resumed_at(request.id) is None
 
     outcomes = await asyncio.gather(*(claim_resume(request.id) for _ in range(8)))

--- a/backend/tests/integration/test_approval_transactional_transitions_e2e.py
+++ b/backend/tests/integration/test_approval_transactional_transitions_e2e.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-Postgres concurrency check for transactional approval transitions (F12 / #274).
+
+Security review finding F12 (meho-internal#274). The approval decision paths
+(approve / reject) load the row ``SELECT ... FOR UPDATE`` and the expiry sweep
+uses ``FOR UPDATE SKIP LOCKED``, so a competing approve / reject / expiry on
+one row serialises on the row lock and yields exactly **one** winning
+transition. The claim primitive
+(:func:`~meho_backplane.operations.approval_queue.claim_resume`) additionally
+requires the ``approved`` state in the same conditional UPDATE, so no execution
+can follow a losing / rejected / expired transition.
+
+Correctness under a genuine race depends on the database serialising concurrent
+writers to the same row — a property SQLite (the unit-suite driver) cannot
+exercise the way production Postgres does; ``FOR UPDATE`` / ``SKIP LOCKED`` are
+silent no-ops there. This suite boots a real Postgres and proves the invariant
+under true concurrency, mirroring the sibling exactly-one-resumer suite
+(:mod:`tests.integration.test_approval_exactly_one_resumer_e2e`):
+
+* **approve vs reject** — two concurrent decisions on one in-window pending row
+  yield exactly one committed decision, one decision audit row, and one terminal
+  status; the loser sees the already-decided guard.
+* **no execution for the loser** — after the race, the execution claim succeeds
+  **iff** the winning state is ``approved``.
+* **reject vs expiry** — a concurrent reject and expiry sweep on one overdue row
+  yield exactly one terminal transition (rejected XOR expired) and one decision
+  audit row.
+* **overdue is un-approvable** — the decision-time deadline gate refuses an
+  overdue row on real Postgres even with no sweep, and the reviewer /
+  self-approval / hash checks still fire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus, AuditLog
+from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.operations.approval_queue import (
+    ApprovalRequestAlreadyDecidedError,
+    ApprovalRequestExpiredError,
+    ParamsMismatchError,
+    SelfApprovalForbiddenError,
+    approve_request,
+    claim_resume,
+    create_pending_request,
+    expire_stale_requests,
+    reject_request,
+)
+
+# ``pg_engine`` (imported for its side effect of being a discoverable
+# fixture) points the process sessionmaker at the testcontainer and seeds
+# the two pinned tenant rows this suite scopes to.
+from .conftest import pg_engine  # noqa: F401 — pytest-discovered fixture
+
+pytestmark = pytest.mark.asyncio
+
+#: One of the two tenants ``pg_engine`` seeds on entry.
+_TENANT: uuid.UUID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _docker_socket_present() -> bool:
+    """Docker usable when the unix socket (or ``DOCKER_HOST``) is present."""
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_skip_no_docker = pytest.mark.skipif(
+    not _docker_socket_present(),
+    reason="Docker socket unavailable in this sandbox; runs in CI where Postgres is provisioned.",
+)
+
+
+def _operator(*, sub: str, kind: PrincipalKind = PrincipalKind.USER) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Transition Race Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=kind,
+    )
+
+
+async def _commit_pending(
+    *,
+    requester_sub: str,
+    op_id: str,
+    expires_at: datetime | None = None,
+    params: dict[str, object] | None = None,
+) -> ApprovalRequest:
+    """Insert + commit a pending request in Postgres and return the row."""
+    requester = _operator(sub=requester_sub, kind=PrincipalKind.AGENT)
+    call_params = params if params is not None else {"path": "secret/agent"}
+    async with get_sessionmaker()() as session:
+        request = await create_pending_request(
+            session,
+            operator=requester,
+            connector_id="rectest-1.x",
+            op_id=op_id,
+            target=None,
+            params=call_params,
+            params_hash=compute_params_hash(call_params),
+            expires_at=expires_at,
+        )
+        await session.commit()
+    return request
+
+
+async def _decision_audit_rows(request_id: uuid.UUID) -> list[AuditLog]:
+    async with get_sessionmaker()() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == "approval.decision")))
+            .scalars()
+            .all()
+        )
+    return [r for r in rows if r.payload.get("approval_request_id") == str(request_id)]
+
+
+async def _reload(request_id: uuid.UUID) -> ApprovalRequest:
+    async with get_sessionmaker()() as session:
+        row = await session.get(ApprovalRequest, request_id)
+        assert row is not None
+        return row
+
+
+@_skip_no_docker
+async def test_concurrent_approve_reject_yields_one_winning_decision(
+    pg_engine: None,  # noqa: F811 — fixture
+) -> None:
+    """A concurrent approve + reject on one row commit exactly one decision (F12).
+
+    Both decisions load the row ``FOR UPDATE``, so they serialise: the winner
+    commits its transition + one decision audit row, and the loser blocks on
+    the lock, re-reads the committed terminal state, and hits the already-
+    decided guard. The final row carries exactly one terminal status, and no
+    execution can follow a losing / rejected state — the post-race claim
+    succeeds iff the winner was ``approved``.
+    """
+    request = await _commit_pending(requester_sub="agent:race", op_id="rectest.approve-reject")
+    reviewer_a = _operator(sub="human:approver")
+    reviewer_b = _operator(sub="human:rejecter")
+
+    async def _do_approve() -> str:
+        async with get_sessionmaker()() as session:
+            try:
+                await approve_request(session, request.id, operator=reviewer_a, params=None)
+                await session.commit()
+                return "approved"
+            except ApprovalRequestAlreadyDecidedError:
+                return "lost"
+
+    async def _do_reject() -> str:
+        async with get_sessionmaker()() as session:
+            try:
+                await reject_request(session, request.id, operator=reviewer_b)
+                await session.commit()
+                return "rejected"
+            except ApprovalRequestAlreadyDecidedError:
+                return "lost"
+
+    outcomes = await asyncio.gather(_do_approve(), _do_reject())
+
+    winners = [o for o in outcomes if o != "lost"]
+    assert len(winners) == 1, outcomes
+    assert outcomes.count("lost") == 1, outcomes
+
+    row = await _reload(request.id)
+    assert row.status in {
+        ApprovalRequestStatus.APPROVED.value,
+        ApprovalRequestStatus.REJECTED.value,
+    }
+    assert row.status == (
+        ApprovalRequestStatus.APPROVED.value
+        if winners[0] == "approved"
+        else ApprovalRequestStatus.REJECTED.value
+    )
+
+    # Exactly one decision audit row committed — no conflicting second record.
+    assert len(await _decision_audit_rows(request.id)) == 1
+
+    # No execution follows a losing / rejected state: the claim latches the
+    # row iff it committed ``approved``.
+    claimed = await claim_resume(request.id)
+    assert claimed is (row.status == ApprovalRequestStatus.APPROVED.value)
+
+
+@_skip_no_docker
+async def test_concurrent_reject_expire_yields_one_terminal_transition(
+    pg_engine: None,  # noqa: F811 — fixture
+) -> None:
+    """A concurrent reject + expiry sweep on one overdue row transition it once (F12).
+
+    The reject loads the row ``FOR UPDATE``; the sweep selects ``FOR UPDATE
+    SKIP LOCKED``. Whichever acquires the row first wins its transition and
+    writes the single decision audit row; the other either skips the locked
+    row (sweep) or re-reads the committed terminal state (reject → already
+    decided). The row ends in exactly one terminal state — rejected XOR
+    expired — never both.
+    """
+    past = datetime.now(UTC) - timedelta(hours=1)
+    request = await _commit_pending(
+        requester_sub="agent:race", op_id="rectest.reject-expire", expires_at=past
+    )
+    rejecter = _operator(sub="human:rejecter")
+    sweeper = _operator(sub="system:approval-expiry")
+
+    async def _do_reject() -> str:
+        async with get_sessionmaker()() as session:
+            try:
+                await reject_request(session, request.id, operator=rejecter)
+                await session.commit()
+                return "rejected"
+            except ApprovalRequestAlreadyDecidedError:
+                return "lost"
+
+    async def _do_expire() -> str:
+        async with get_sessionmaker()() as session:
+            expired = await expire_stale_requests(session, operator=sweeper)
+            await session.commit()
+            return "expired" if any(r.id == request.id for r in expired) else "skipped"
+
+    outcomes = await asyncio.gather(_do_reject(), _do_expire())
+
+    row = await _reload(request.id)
+    assert row.status in {
+        ApprovalRequestStatus.REJECTED.value,
+        ApprovalRequestStatus.EXPIRED.value,
+    }
+    # Exactly one decision audit row — one winning transition, one record.
+    assert len(await _decision_audit_rows(request.id)) == 1
+    # The winner's outcome matches the committed status; the loser no-op'd.
+    if row.status == ApprovalRequestStatus.REJECTED.value:
+        assert "rejected" in outcomes
+    else:
+        assert "expired" in outcomes
+    # The row is not executable in either terminal state.
+    assert await claim_resume(request.id) is False
+
+
+@_skip_no_docker
+async def test_overdue_request_unapprovable_and_checks_preserved(
+    pg_engine: None,  # noqa: F811 — fixture
+) -> None:
+    """The deadline gate + reviewer / self-approval / hash checks hold on Postgres (F12).
+
+    An overdue pending row cannot be approved even with no sweep running, and
+    the pre-existing precondition checks (self-approval, params-hash) still
+    fire on the real database.
+    """
+    # Overdue row: refused by the decision-time deadline gate, no sweep needed.
+    overdue = await _commit_pending(
+        requester_sub="agent:overdue",
+        op_id="rectest.overdue",
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    reviewer = _operator(sub="human:approver")
+    async with get_sessionmaker()() as session:
+        with pytest.raises(ApprovalRequestExpiredError):
+            await approve_request(session, overdue.id, operator=reviewer, params=None)
+    assert (await _reload(overdue.id)).status == ApprovalRequestStatus.PENDING.value
+
+    # Self-approval is still refused (requester == approver) on an in-window row.
+    params: dict[str, object] = {"path": "secret/agent"}
+    self_row = await _commit_pending(
+        requester_sub="agent:selfapprove", op_id="rectest.self", params=params
+    )
+    requester_as_reviewer = _operator(sub="agent:selfapprove", kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as session:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(session, self_row.id, operator=requester_as_reviewer, params=None)
+
+    # A params-hash mismatch is still refused on the REST (params-bearing) path.
+    async with get_sessionmaker()() as session:
+        with pytest.raises(ParamsMismatchError):
+            await approve_request(
+                session, self_row.id, operator=reviewer, params={"path": "secret/other"}
+            )

--- a/backend/tests/test_agent_approval_resume.py
+++ b/backend/tests/test_agent_approval_resume.py
@@ -907,6 +907,20 @@ async def test_resume_no_ops_when_operator_surface_already_claimed(
         await s.commit()
     approval_request_id = request.id
 
+    # The operator surface approved the request (matching the ``approved``
+    # decision broadcast below) and then won the claim. The approve flip is
+    # required because ``claim_resume`` now (F12 / #274) only latches an
+    # ``approved`` row; without it the claim would fail closed on a pending
+    # row rather than modelling the winning operator-surface resumer.
+    from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
+
+    async with sessionmaker() as s:
+        row = await s.get(ApprovalRequest, approval_request_id)
+        assert row is not None
+        row.status = ApprovalRequestStatus.APPROVED.value
+        row.decided_at = datetime.now(UTC)
+        await s.commit()
+
     # An operator surface won the claim first (and re-dispatched).
     assert await claim_resume(approval_request_id) is True
 

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -287,6 +287,21 @@ async def test_resume_dispatches_when_no_target_was_pinned(
         )
         await session.commit()
 
+    # The resume path runs only after the decision committed ``approved``.
+    # ``claim_resume`` (F12 / #274) now latches only an approved row, so flip
+    # the committed row to approved before resuming — the same ordering the
+    # real ``/approve`` → resume flow produces.
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
+
+    async with get_sessionmaker()() as session:
+        row = await session.get(ApprovalRequest, request.id)
+        assert row is not None
+        row.status = ApprovalRequestStatus.APPROVED.value
+        row.decided_at = datetime.now(UTC)
+        await session.commit()
+
     seen: dict[str, Any] = {}
 
     async def _dispatch_spy(**kwargs: Any) -> Any:

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -54,6 +54,7 @@ from meho_backplane.operations._validate import compute_params_hash
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    ApprovalRequestExpiredError,
     NonHumanApprovalError,
     ParamsMismatchError,
     SelfApprovalForbiddenError,
@@ -1806,6 +1807,172 @@ async def test_expired_run_bound_request_cannot_be_approved(
 
 
 # ---------------------------------------------------------------------------
+# decision-time deadline gate (security F12 / #274) — approve refuses an
+# overdue pending row WITHOUT waiting for the background expiry sweep.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approve_refuses_overdue_pending_without_sweep(
+    session: AsyncSession,
+) -> None:
+    """An overdue pending row cannot be approved even if the sweep never ran (F12).
+
+    The row is left ``pending`` (the sweep never runs in this test), yet its
+    ``expires_at`` is in the past. ``approve_request`` checks the deadline at
+    decision time and refuses with :class:`ApprovalRequestExpiredError`, so a
+    delayed or failing expiry sweeper can never leave an overdue intent
+    approvable. The row stays ``pending`` for the sweeper to transition
+    later — the approval is refused, not the transition performed.
+    """
+    requester = _make_operator(sub="agent-requester", principal_kind=PrincipalKind.AGENT)
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+    past = datetime.now(UTC) - timedelta(hours=1)
+
+    request = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.overdue",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+        expires_at=past,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as approve_session:
+        with pytest.raises(ApprovalRequestExpiredError):
+            await approve_request(approve_session, request.id, operator=reviewer)
+
+    # No sweep ran — the row is still pending, only the approval was refused.
+    async with get_sessionmaker()() as check:
+        row = await check.get(ApprovalRequest, request.id)
+        assert row is not None
+        assert row.status == ApprovalRequestStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_approve_refuses_overdue_legacy_null_expiry(
+    session: AsyncSession,
+) -> None:
+    """A legacy null-``expires_at`` row past ``created_at + default_ttl`` is refused (F12).
+
+    Pre-#2322 rows carry ``expires_at IS NULL``. The decision-time gate
+    coalesces the deadline against ``created_at + APPROVAL_DEFAULT_TTL`` — the
+    same rule the sweep predicate uses — so such a row aged past the default
+    TTL is refused on the approve path exactly as the sweep would expire it.
+    """
+    requester = _make_operator(sub="agent-requester", principal_kind=PrincipalKind.AGENT)
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+
+    request = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.legacy-null",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+
+    # Reshape the row into the pre-#2322 legacy shape: null deadline, created
+    # further back than the configured default TTL.
+    ttl_seconds = get_settings().approval_default_ttl_seconds
+    async with get_sessionmaker()() as reshape:
+        row = await reshape.get(ApprovalRequest, request.id)
+        assert row is not None
+        row.expires_at = None
+        row.created_at = datetime.now(UTC) - timedelta(seconds=ttl_seconds + 3600)
+        await reshape.commit()
+
+    async with get_sessionmaker()() as approve_session:
+        with pytest.raises(ApprovalRequestExpiredError):
+            await approve_request(approve_session, request.id, operator=reviewer)
+
+
+@pytest.mark.asyncio
+async def test_approve_allows_request_within_deadline(
+    session: AsyncSession,
+) -> None:
+    """A pending row still inside its deadline approves normally (F12 regression).
+
+    The deadline gate must not refuse a row whose ``expires_at`` is in the
+    future — the default-TTL park is approvable throughout its window.
+    """
+    requester = _make_operator(sub="agent-requester", principal_kind=PrincipalKind.AGENT)
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+    params = {"key": "value"}
+
+    request = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.in-window",
+        target=None,
+        params=params,
+        params_hash=compute_params_hash(params),
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as approve_session:
+        decided = await approve_request(
+            approve_session, request.id, operator=reviewer, params=params
+        )
+        await approve_session.commit()
+
+    assert decided.status == ApprovalRequestStatus.APPROVED.value
+
+
+@pytest.mark.asyncio
+async def test_claim_resume_requires_approved_status() -> None:
+    """The execution claim latches only an ``approved`` row (F12 / #274, AC4).
+
+    ``claim_resume`` carries ``status = 'approved'`` in its conditional
+    UPDATE, so a pending, rejected, or expired row can never be claimed for
+    execution — no execution can follow a losing/rejected transition. An
+    approved row is still latched exactly once (the single-resumer invariant
+    is preserved).
+    """
+    from meho_backplane.operations.approval_queue import claim_resume
+
+    operator = _make_operator(sub="agent-claim-status", principal_kind=PrincipalKind.AGENT)
+
+    # Pending: not claimable.
+    pending = await _commit_pending(operator=operator, op_id="vault.kv.claim-pending")
+    assert await claim_resume(pending.id) is False
+    assert await _reload_resumed_at(pending.id) is None
+
+    # Rejected: not claimable.
+    rejected = await _commit_pending(operator=operator, op_id="vault.kv.claim-rejected")
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, rejected.id)
+        assert row is not None
+        row.status = ApprovalRequestStatus.REJECTED.value
+        await s.commit()
+    assert await claim_resume(rejected.id) is False
+
+    # Expired: not claimable.
+    expired = await _commit_pending(operator=operator, op_id="vault.kv.claim-expired")
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, expired.id)
+        assert row is not None
+        row.status = ApprovalRequestStatus.EXPIRED.value
+        await s.commit()
+    assert await claim_resume(expired.id) is False
+
+    # Approved: claimable exactly once.
+    approved = await _commit_pending(
+        operator=operator, op_id="vault.kv.claim-approved", approved=True
+    )
+    assert await claim_resume(approved.id) is True
+    assert await _reload_resumed_at(approved.id) is not None
+    assert await claim_resume(approved.id) is False
+
+
+# ---------------------------------------------------------------------------
 # pause → approve → resume → execute (integration-style)
 # ---------------------------------------------------------------------------
 
@@ -2618,12 +2785,19 @@ async def test_decide_agent_run_request_no_ops_when_claim_already_taken(
     from meho_backplane.api.v1.approvals import DecideRequestBody, decide_approval_request
     from meho_backplane.connectors.registry import clear_registry
     from meho_backplane.operations import reset_dispatcher_caches
-    from meho_backplane.operations.approval_queue import claim_resume
 
     approval_request_id = await _park_agent_run_request(monkeypatch)
 
-    # The in-process waiter won the claim first (and executed the op).
-    assert await claim_resume(approval_request_id) is True
+    # The in-process waiter won the claim first (and executed the op). Stamp
+    # ``resumed_at`` directly rather than via ``claim_resume``: the claim now
+    # (F12 / #274) requires the ``approved`` state that ``/decide`` is about
+    # to apply, so the "already claimed" precondition is modelled straight on
+    # the latch column, exactly the state a prior winner would have left.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, approval_request_id)
+        assert row is not None
+        row.resumed_at = datetime.now(UTC)
+        await s.commit()
 
     reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
     response = await decide_approval_request(
@@ -3096,8 +3270,15 @@ async def _commit_pending(
     connector_id: str = "vault-1.x",
     params: dict[str, Any] | None = None,
     run_id: uuid.UUID | None = None,
+    approved: bool = False,
 ) -> ApprovalRequest:
-    """Insert + commit a pending request so a fresh session can claim it."""
+    """Insert + commit a request so a fresh session can claim/resume it.
+
+    When *approved* is set the row is flipped to ``approved`` after the
+    insert: :func:`claim_resume` now requires the approved state in its
+    conditional UPDATE (security F12 / #274), and a resume only ever
+    happens on an approved row, so the claim/resume tests seed that state.
+    """
     call_params = params if params is not None else {"key": "value"}
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as s:
@@ -3112,6 +3293,14 @@ async def _commit_pending(
             run_id=run_id,
         )
         await s.commit()
+    if approved:
+        async with sessionmaker() as s:
+            row = await s.get(ApprovalRequest, request.id)
+            assert row is not None
+            row.status = ApprovalRequestStatus.APPROVED.value
+            row.decided_at = datetime.now(UTC)
+            await s.commit()
+        request.status = ApprovalRequestStatus.APPROVED.value
     return request
 
 
@@ -3135,7 +3324,7 @@ async def test_claim_resume_wins_once_then_loses() -> None:
     from meho_backplane.operations.approval_queue import claim_resume
 
     operator = _make_operator(sub="agent-claim")
-    request = await _commit_pending(operator=operator)
+    request = await _commit_pending(operator=operator, approved=True)
 
     assert await _reload_resumed_at(request.id) is None
 
@@ -3168,7 +3357,7 @@ async def test_resume_dispatch_after_approval_noops_when_claim_taken(
     )
 
     operator = _make_operator(sub="agent-noop")
-    request = await _commit_pending(operator=operator)
+    request = await _commit_pending(operator=operator, approved=True)
 
     # Simulate the winning resumer (e.g. the in-process waiter) having
     # already taken the claim.
@@ -3208,7 +3397,7 @@ async def test_resume_dispatch_after_approval_wins_free_claim_and_stamps(
     from meho_backplane.operations.approval_queue import resume_dispatch_after_approval
 
     operator = _make_operator(sub="agent-win")
-    request = await _commit_pending(operator=operator)
+    request = await _commit_pending(operator=operator, approved=True)
     assert await _reload_resumed_at(request.id) is None
 
     dispatch_calls = 0

--- a/backend/tests/test_secret_move_approval.py
+++ b/backend/tests/test_secret_move_approval.py
@@ -668,13 +668,19 @@ async def test_decide_run_bound_no_ops_when_waiter_already_claimed(
     ``dispatch_status="already_resumed"`` — ``write_secret`` must not fire a
     second time.
     """
-    from meho_backplane.operations.approval_queue import claim_resume
-
     fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
     request_id = await _park_run_bound_move(requester_sub="agent:requester")
 
-    # The in-process waiter won the claim first (and executed the op).
-    assert await claim_resume(request_id) is True
+    # The in-process waiter won the claim first (and executed the op). Stamp
+    # ``resumed_at`` directly rather than via ``claim_resume``: the claim now
+    # (F12 / #274) requires the ``approved`` state that ``/decide`` is about
+    # to apply, so the "already claimed" precondition is modelled straight on
+    # the latch column, exactly the state a prior winner would have left.
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, request_id)
+        assert row is not None
+        row.resumed_at = datetime.now(UTC)
+        await s.commit()
 
     body = _decide_approved(request_id, decider_sub="operator:decider")
 

--- a/backend/tests/test_ui_approvals.py
+++ b/backend/tests/test_ui_approvals.py
@@ -201,6 +201,14 @@ def _seed_request(
     """Insert one ``approval_request`` row; return its id."""
     rid = request_id or uuid.uuid4()
     effect = proposed_effect or {"op_id": op_id, "connector_id": connector_id}
+    # A live pending request carries a future deadline. The decision-time
+    # deadline gate (F12 / #274) refuses an overdue row on the approve path,
+    # so a decision-flow test must seed a non-expired deadline; ``None`` (the
+    # default) means "live" here. The expired-banner test passes a concrete
+    # past ``expires_at`` to override this.
+    stored_expires_at = (
+        expires_at if expires_at is not None else datetime.now(UTC) + timedelta(days=1)
+    )
 
     async def _do() -> uuid.UUID:
         sessionmaker = get_sessionmaker()
@@ -222,7 +230,7 @@ def _seed_request(
                     decided_at=decided_at,
                     work_ref=work_ref,
                     created_at=datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
-                    expires_at=expires_at,
+                    expires_at=stored_expires_at,
                 ),
             )
         return rid

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -89,6 +89,58 @@ terminal, so it cannot be approved (the pending guard raises
 `ApprovalRequestAlreadyDecidedError`) — an expired run-bound request can
 never be claimed or re-dispatched (#2293).
 
+## Transactional decision transitions + decision-time deadline (F12 / #274)
+
+The TTL sweep above is a *background* safety net; it is not the only
+guard. Two hardening properties make the decision paths correct
+independently of the sweep and under concurrency (security review finding
+F12):
+
+1. **Decision-time deadline gate.** `approve_request` re-checks the
+   deadline on the row it is about to approve (`_load_pending_for_approval`
+   → `_deadline_has_passed`, the Python mirror of the sweep's
+   `_deadline_passed_clause`, same legacy null-expiry coalesce). An overdue
+   pending row is refused with `ApprovalRequestExpiredError` (mapped to HTTP
+   409 `approval_request_expired` on REST and the console) **even if the
+   sweeper is delayed or failing** — the sweep's default cadence is 300s and
+   its per-tick failures are swallowed to keep the loop alive, so trusting it
+   alone would leave an overdue intent approvable for a whole tick. The gate
+   only *refuses* the approval; the row stays `pending` for the sweep to
+   transition to `expired` with its decision audit row. `reject_request`
+   does **not** apply the gate — rejecting an overdue request is harmless
+   (both are non-executing terminal states).
+
+2. **Row-locked transitions — exactly one winner.** `approve_request` and
+   `reject_request` load the row `SELECT ... FOR UPDATE`
+   (`_load_for_tenant(..., for_update=True)`), and the sweep selects
+   `FOR UPDATE SKIP LOCKED`. A competing approve / reject / expiry on one
+   row therefore serialises on the row lock: the winner commits its
+   transition and its single decision audit row in one transaction; the
+   loser blocks on the lock, re-reads the committed terminal state, and hits
+   the pending guard (`ApprovalRequestAlreadyDecidedError`) or, for the
+   sweep, skips the locked row. The result is one winning transition, one
+   consistent decision record, and no conflicting overwrite. The
+   notification publishes only **after** commit (unchanged), so a phantom
+   event cannot outlive a rolled-back decision.
+
+The **execution claim** carries the same discipline: `claim_resume`'s
+conditional `UPDATE ... WHERE resumed_at IS NULL AND status = 'approved'`
+now requires the `approved` state in the same statement as the
+single-resumer latch (previously it checked only `resumed_at IS NULL`). So
+no execution can follow a losing / rejected / expired transition — a
+request another decision won cannot be claimed for dispatch — while the
+exactly-one-resumer latch (#2293) is preserved. Every resume surface already
+reaches the claim only after the decision committed `approved`, so this
+tightens the invariant without changing the live control flow; it fails
+closed if a resume is ever attempted against a non-approved row.
+
+On SQLite (the unit-test driver) `FOR UPDATE` / `SKIP LOCKED` are silent
+no-ops, so the concurrency guarantee is proven against real Postgres in
+`tests/integration/test_approval_transactional_transitions_e2e.py`
+(concurrent approve/reject and reject/expiry races, one-winner + one
+decision-row + no-execution-for-the-loser), alongside the sibling
+exactly-one-resumer suite.
+
 ## Subject + actor attribution on the request row (#1481)
 
 The `approval_request` row carries the RFC 8693 two-claim attribution


### PR DESCRIPTION
## Summary

Security review finding **F12** (meho-internal#274): the approval decision paths did not re-check the deadline at decision time and loaded the row without a lock, so an overdue pending request stayed approvable until a successful background sweep, and competing approve/reject/expire could read `pending` and overwrite each other.

- **Row-locked transitions.** `approve_request` / `reject_request` load the row `SELECT ... FOR UPDATE` (`_load_for_tenant(..., for_update=True)`) and the expiry sweep selects `FOR UPDATE SKIP LOCKED`. A competing approve/reject/expiry on one row serialises on the lock → exactly one winning transition, one decision audit row; the loser re-reads the committed terminal state and hits the already-decided guard (or the sweep skips the locked row).
- **Decision-time deadline gate.** `approve_request` re-checks the deadline on the locked row (`_deadline_has_passed`, the Python mirror of the sweep's `_deadline_passed_clause`, same legacy null-expiry coalesce). An overdue pending row is refused with the new `ApprovalRequestExpiredError` (HTTP 409 on REST + console) **even while the sweeper is delayed or failing**. `reject_request` does not gate the deadline — both terminal states are non-executing.
- **Execution claim requires `approved`.** `claim_resume`'s conditional `UPDATE ... WHERE resumed_at IS NULL AND status = 'approved'` now requires the approved state in the same statement as the single-resumer latch, so no execution can follow a losing/rejected/expired transition; the exactly-one-resumer latch (#2293) is preserved.

`FOR UPDATE` / `SKIP LOCKED` are silent no-ops on the SQLite unit driver, so the concurrency guarantee is proven against real Postgres in `tests/integration/test_approval_transactional_transitions_e2e.py`.

### Already on `main` (not re-implemented)
- **AC3 (commit-then-publish).** The approve/reject REST + UI routes and the expiry sweeper already write the decision audit row inside the decision transaction and publish the broadcast only **after** commit. This PR keeps that ordering; the row lock additionally makes the committed decision record single-winner.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/...` — clean (3 source files)
- [x] `code-quality.py --diff` — 0 blockers (pre-existing function-size warnings on touched files only)
- [x] **AC1** shared transactional transition + deadline: `test_concurrent_approve_reject_yields_one_winning_decision`, `test_concurrent_reject_expire_yields_one_terminal_transition` (PG), unit `test_approve_allows_request_within_deadline`
- [x] **AC2** overdue un-approvable without sweep: `test_approve_refuses_overdue_pending_without_sweep`, `test_approve_refuses_overdue_legacy_null_expiry`, PG `test_overdue_request_unapprovable_and_checks_preserved`
- [x] **AC4** claim requires approved: `test_claim_resume_requires_approved_status` (pending/rejected/expired not claimable; approved claimable exactly once)
- [x] **AC5** PostgreSQL concurrent approve/reject/expire → one winner, no execution for loser, reviewer/self-approval/hash checks preserved: `tests/integration/test_approval_transactional_transitions_e2e.py` — **3 passed** against a real `pgvector/pgvector:pg16` container locally
- [x] Full backend unit lane: green except 3 pre-existing, unrelated sandbox failures (`test_connectors_net_icmp`, `test_connectors_net_dns_lookup`, `test_chart_mcp_resource_uri` — confirmed failing on clean `origin/main`; ICMP raw-socket / DNS resolver / helm-env, nothing approvals-related)

## Out of scope (per issue)
- The 300s expiry-sweep cadence and the #3325 seniority / self-approval policy are unchanged.
- The atomic `claim_resume` single-resumer latch is preserved (only tightened with the `approved`-state predicate).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#274
