### PR TITLE
fix(connectors): enforce a passive-only kubeconfig schema for k8s (F03)

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/__init__.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/__init__.py
@@ -50,6 +50,10 @@ from meho_backplane.connectors.kubernetes.kubeconfig import (
     load_kubernetes_credential,
     parse_kubeconfig_yaml,
 )
+from meho_backplane.connectors.kubernetes.kubeconfig_schema import (
+    UnsupportedKubeconfigError,
+    enforce_passive_kubeconfig,
+)
 from meho_backplane.connectors.kubernetes.ops import KUBERNETES_OPS, KubernetesOp
 from meho_backplane.connectors.kubernetes.wcp import (
     WcpLoginError,
@@ -106,10 +110,12 @@ __all__ = [
     "KubernetesCredential",
     "KubernetesOp",
     "KubernetesTargetLike",
+    "UnsupportedKubeconfigError",
     "WcpLoginError",
     "WcpSsoCredential",
     "WcpToken",
     "build_wcp_api_configuration",
+    "enforce_passive_kubeconfig",
     "load_kubeconfig_from_vault",
     "load_kubernetes_credential",
     "parse_kubeconfig_yaml",

--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
@@ -78,6 +78,9 @@ from meho_backplane.connectors._shared.vault_creds import (
     VaultCredentialsReadError,
     load_vault_secret_data,
 )
+from meho_backplane.connectors.kubernetes.kubeconfig_schema import (
+    enforce_passive_kubeconfig,
+)
 
 __all__ = [
     "DEFAULT_KUBECONFIG_FIELD",
@@ -211,6 +214,16 @@ def parse_kubeconfig_yaml(kubeconfig_text: str) -> dict[str, Any]:
     :exc:`ValueError`, never the underlying :exc:`yaml.YAMLError`
     subclass, so callers don't need to import ``yaml`` just to catch
     parse failures.
+
+    This is a pure parse: it does **not** vet the kubeconfig's contents.
+    The production loaders
+    (:func:`load_kubeconfig_from_vault` / :func:`load_kubernetes_credential`)
+    pass the result through
+    :func:`~meho_backplane.connectors.kubernetes.kubeconfig_schema.enforce_passive_kubeconfig`
+    before it reaches ``kubernetes_asyncio``, so an ``exec`` provider,
+    legacy ``auth-provider`` block or local-file credential reference in
+    a tenant-controlled secret never reaches the library's
+    subprocess/file-read boundary.
     """
     try:
         parsed = yaml.safe_load(kubeconfig_text)
@@ -340,6 +353,13 @@ async def load_kubeconfig_from_vault(
     ValueError
         Raised by :func:`parse_kubeconfig_yaml` when the kubeconfig
         field is not parseable YAML or does not parse to a mapping.
+    meho_backplane.connectors.kubernetes.kubeconfig_schema.UnsupportedKubeconfigError
+        A :exc:`ValueError` subclass raised by
+        :func:`~meho_backplane.connectors.kubernetes.kubeconfig_schema.enforce_passive_kubeconfig`
+        when the parsed kubeconfig carries an ``exec`` provider, a legacy
+        ``auth-provider`` block, a local-file credential/CA reference, or
+        a structurally invalid endpoint/proxy/TLS field — rejected before
+        the dict reaches ``kubernetes_asyncio``.
     meho_backplane.auth.vault.VaultClientError
         Login-phase failure raised by the Vault backend —
         :class:`~meho_backplane.auth.vault.VaultUnreachableError`
@@ -384,7 +404,11 @@ async def load_kubeconfig_from_vault(
         field=field,
     )
 
-    return parse_kubeconfig_yaml(kubeconfig_text)
+    # Enforce the passive-only schema before the dict can reach
+    # ``kubernetes_asyncio``'s loader: reject exec providers, legacy
+    # auth-provider blocks and local-file credential/CA references, and
+    # return a fresh config built from only the validated fields.
+    return enforce_passive_kubeconfig(parse_kubeconfig_yaml(kubeconfig_text))
 
 
 async def load_kubernetes_credential(
@@ -443,7 +467,14 @@ async def load_kubernetes_credential(
             secret_ref=target.secret_ref,
             mode="kubeconfig",
         )
-        return KubeconfigCredential(parse_kubeconfig_yaml(kubeconfig_text))
+        # Enforce the passive-only schema before the dict reaches the
+        # library: exec providers, legacy auth-provider blocks and
+        # local-file credential/CA references are rejected here; a fresh
+        # config is built from only the validated fields. The WCP branch
+        # below never carries a kubeconfig dict, so it is unaffected.
+        return KubeconfigCredential(
+            enforce_passive_kubeconfig(parse_kubeconfig_yaml(kubeconfig_text))
+        )
 
     if WCP_USERNAME_FIELD in secret_data and WCP_PASSWORD_FIELD in secret_data:
         username = _require_str_field(

--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig_schema.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig_schema.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Passive-only kubeconfig schema for the Kubernetes connector.
+
+A kubeconfig the connector loads comes from a per-target credential
+secret (Vault KV-v2 / GCP Secret Manager). Target creation is
+tenant-admin gated, so the secret is *tenant-controlled* — but a
+tenant's right to manage its own credentials must not translate into
+code execution or arbitrary file reads inside the shared backplane
+process. ``kubernetes_asyncio``'s kubeconfig loader honours the full
+client-side kubeconfig feature set, several parts of which reach an
+out-of-band sink when the document is loaded:
+
+* an ``exec`` credential provider spawns a **subprocess** with the
+  configured command/args (``KubeConfigLoader.load_from_exec_plugin``);
+* a legacy ``auth-provider`` block (``gcp`` / ``oidc`` / vendor
+  plugins) performs a **network token fetch/refresh**
+  (``load_gcp_token`` / ``_load_oid_token``);
+* a file-path reference — cluster ``certificate-authority``, user
+  ``client-certificate`` / ``client-key`` / ``tokenFile`` — makes the
+  loader **read that local path** off the backplane's own filesystem
+  (``FileOrData`` falls back to the ``<key>`` file path whenever the
+  inline ``<key>-data`` field is absent).
+
+This module enforces a minimal server-side schema *before* the parsed
+mapping can reach that loader. It rejects the three sink classes above
+with a specific, fail-closed error, explicitly validates the cluster
+endpoint / proxy / TLS options, and returns a **fresh** mapping built
+from only the accepted fields — the untrusted input mapping is never
+handed to the library. Only inline authentication survives: a bearer
+``token``, HTTP-basic ``username``/``password``, and inline
+``client-certificate-data`` / ``client-key-data`` / cluster
+``certificate-authority-data``.
+
+No executable-provider facility is retained: ``exec`` is rejected
+unconditionally, with no parameter or elevation that re-enables it. A
+deployment that genuinely needs exec-plugin credentials must run that
+behind a separate platform-admin-managed, isolated facility (out of
+scope here); this module never spawns a subprocess.
+
+Verified against ``kubernetes_asyncio`` 36.1.0
+(``config.kube_config.KubeConfigLoader`` /
+``config.kube_config.FileOrData``). See
+:doc:`docs/codebase/connectors-kubernetes.md` (Passive-only kubeconfig
+schema) and the Kubernetes upstream guidance that untrusted kubeconfig
+can cause code execution or file exposure
+(https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit
+
+__all__ = [
+    "UnsupportedKubeconfigError",
+    "enforce_passive_kubeconfig",
+]
+
+
+class UnsupportedKubeconfigError(ValueError):
+    """A kubeconfig requested an active / out-of-band credential mechanism.
+
+    Raised when a parsed kubeconfig carries an ``exec`` provider, a
+    legacy ``auth-provider`` block, a local-file credential/CA
+    reference, or a structurally invalid endpoint/proxy/TLS field.
+    Subclasses :exc:`ValueError` so it flows through the loaders'
+    documented ``ValueError`` contract (raised today by
+    :func:`~meho_backplane.connectors.kubernetes.kubeconfig.parse_kubeconfig_yaml`)
+    and the dispatcher's catch-all maps it to a ``connector_error``
+    result. The message names only the offending *section / field* —
+    never a credential value, server endpoint, or certificate — so it
+    is safe to log.
+    """
+
+
+#: Cluster ``cluster`` block: file-path reference that makes the library
+#: read local disk. Rejected even when the inline ``-data`` sibling is
+#: also present (no ambiguity in a passive config). The accepted cluster
+#: fields — ``server`` / ``certificate-authority-data`` /
+#: ``insecure-skip-tls-verify`` / ``tls-server-name`` / ``proxy-url`` —
+#: are each handled and validated explicitly in :func:`_clean_cluster_entry`.
+_REJECTED_CLUSTER_KEYS = frozenset({"certificate-authority"})
+
+#: User ``user`` block: inline authentication fields the connector
+#: accepts, in the order they are copied into the fresh config.
+_INLINE_USER_FIELDS: tuple[str, ...] = (
+    "token",
+    "username",
+    "password",
+    "client-certificate-data",
+    "client-key-data",
+)
+
+#: User ``user`` block: subprocess (``exec``), legacy provider
+#: (``auth-provider``) and local-file credential sinks. Any presence is
+#: a hard rejection.
+_REJECTED_USER_KEYS = frozenset(
+    {
+        "exec",
+        "auth-provider",
+        "tokenFile",
+        "client-certificate",
+        "client-key",
+    }
+)
+
+#: Context ``context`` block: the only fields the loader needs to bind a
+#: context to its cluster/user.
+_CONTEXT_FIELDS: tuple[str, ...] = ("cluster", "user", "namespace")
+
+#: URL schemes an API ``server`` endpoint may use.
+_ALLOWED_SERVER_SCHEMES = frozenset({"http", "https"})
+
+#: URL schemes a cluster ``proxy-url`` may use.
+_ALLOWED_PROXY_SCHEMES = frozenset({"http", "https", "socks5", "socks5h"})
+
+
+def enforce_passive_kubeconfig(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate a parsed kubeconfig and rebuild it as a passive-only config.
+
+    ``config`` is the mapping produced by
+    :func:`~meho_backplane.connectors.kubernetes.kubeconfig.parse_kubeconfig_yaml`.
+    Returns a fresh mapping in the shape
+    ``kubernetes_asyncio.config.new_client_from_config_dict`` /
+    ``load_kube_config_from_dict`` accept, containing only fields that
+    were validated here — the input mapping is never returned or handed
+    to the library.
+
+    Raises
+    ------
+    UnsupportedKubeconfigError
+        Any ``exec`` provider, legacy ``auth-provider`` block, local-file
+        credential/CA reference, or a structurally invalid
+        endpoint/proxy/TLS/context field.
+    """
+    if not isinstance(config, dict):
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig must be a mapping, got {type(config).__name__}"
+        )
+
+    clean: dict[str, Any] = {}
+
+    for key in ("apiVersion", "kind"):
+        if key in config:
+            value = config[key]
+            if not isinstance(value, str):
+                raise UnsupportedKubeconfigError(f"kubeconfig {key!r} must be a string")
+            clean[key] = value
+
+    if "current-context" in config:
+        current = config["current-context"]
+        if not isinstance(current, str):
+            raise UnsupportedKubeconfigError("kubeconfig 'current-context' must be a string")
+        clean["current-context"] = current
+
+    clusters = config.get("clusters")
+    if clusters is not None:
+        clean["clusters"] = [
+            _clean_cluster_entry(entry, index)
+            for index, entry in enumerate(_require_list(clusters, "clusters"))
+        ]
+
+    users = config.get("users")
+    if users is not None:
+        clean["users"] = [
+            _clean_user_entry(entry, index)
+            for index, entry in enumerate(_require_list(users, "users"))
+        ]
+
+    contexts = config.get("contexts")
+    if contexts is not None:
+        clean["contexts"] = [
+            _clean_context_entry(entry, index)
+            for index, entry in enumerate(_require_list(contexts, "contexts"))
+        ]
+
+    return clean
+
+
+def _require_list(value: Any, section: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {section!r} must be a list, got {type(value).__name__}"
+        )
+    return value
+
+
+def _entry_label(entry: dict[str, Any], section: str, index: int) -> str:
+    """A value-free label for error messages: the entry ``name`` or index.
+
+    ``name`` is operator-chosen metadata (never a credential), so it is
+    safe to surface; the fallback index avoids leaking anything when a
+    malformed entry has no usable name.
+    """
+    name = entry.get("name")
+    if isinstance(name, str) and name:
+        return f"{section} entry {name!r}"
+    return f"{section} entry #{index}"
+
+
+def _copy_name(entry: dict[str, Any], out: dict[str, Any], label: str) -> None:
+    name = entry.get("name")
+    if not isinstance(name, str) or not name:
+        raise UnsupportedKubeconfigError(f"kubeconfig {label} is missing a string 'name'")
+    out["name"] = name
+
+
+def _require_str(value: Any, label: str, field: str) -> str:
+    if not isinstance(value, str):
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} field {field!r} must be a string, got {type(value).__name__}"
+        )
+    return value
+
+
+def _clean_cluster_entry(entry: Any, index: int) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig clusters entry #{index} must be a mapping")
+    label = _entry_label(entry, "clusters", index)
+    inner = entry.get("cluster")
+    if not isinstance(inner, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig {label} is missing a 'cluster' mapping")
+
+    rejected = sorted(_REJECTED_CLUSTER_KEYS & inner.keys())
+    if rejected:
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} references a local file via {rejected!r}; "
+            "only inline 'certificate-authority-data' is permitted"
+        )
+
+    clean_inner: dict[str, Any] = {"server": _validate_server(inner.get("server"), label)}
+
+    if "certificate-authority-data" in inner:
+        clean_inner["certificate-authority-data"] = _require_str(
+            inner["certificate-authority-data"], label, "certificate-authority-data"
+        )
+    if "insecure-skip-tls-verify" in inner:
+        flag = inner["insecure-skip-tls-verify"]
+        if not isinstance(flag, bool):
+            raise UnsupportedKubeconfigError(
+                f"kubeconfig {label} 'insecure-skip-tls-verify' must be a boolean"
+            )
+        clean_inner["insecure-skip-tls-verify"] = flag
+    if "tls-server-name" in inner:
+        clean_inner["tls-server-name"] = _require_str(
+            inner["tls-server-name"], label, "tls-server-name"
+        )
+    if "proxy-url" in inner:
+        clean_inner["proxy-url"] = _validate_proxy(inner["proxy-url"], label)
+
+    out: dict[str, Any] = {"cluster": clean_inner}
+    _copy_name(entry, out, label)
+    return out
+
+
+def _clean_user_entry(entry: Any, index: int) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig users entry #{index} must be a mapping")
+    label = _entry_label(entry, "users", index)
+    inner = entry.get("user")
+    if not isinstance(inner, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig {label} is missing a 'user' mapping")
+
+    rejected = sorted(_REJECTED_USER_KEYS & inner.keys())
+    if rejected:
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} uses an unsupported credential mechanism {rejected!r}; "
+            "exec plugins, legacy auth-provider blocks and local credential files are "
+            "rejected — use an inline token, username/password, or client "
+            "certificate/key data"
+        )
+
+    clean_inner: dict[str, Any] = {}
+    for key in _INLINE_USER_FIELDS:
+        if key in inner:
+            clean_inner[key] = _require_str(inner[key], label, key)
+
+    out: dict[str, Any] = {"user": clean_inner}
+    _copy_name(entry, out, label)
+    return out
+
+
+def _clean_context_entry(entry: Any, index: int) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig contexts entry #{index} must be a mapping")
+    label = _entry_label(entry, "contexts", index)
+    inner = entry.get("context")
+    if not isinstance(inner, dict):
+        raise UnsupportedKubeconfigError(f"kubeconfig {label} is missing a 'context' mapping")
+
+    clean_inner: dict[str, Any] = {}
+    for key in _CONTEXT_FIELDS:
+        if key in inner:
+            clean_inner[key] = _require_str(inner[key], label, key)
+
+    out: dict[str, Any] = {"context": clean_inner}
+    _copy_name(entry, out, label)
+    return out
+
+
+def _validate_server(server: Any, label: str) -> str:
+    if not isinstance(server, str) or not server.strip():
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} is missing a non-empty string 'server' endpoint"
+        )
+    parts = urlsplit(server)
+    if parts.scheme not in _ALLOWED_SERVER_SCHEMES or not parts.netloc:
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} 'server' must be an http(s) URL with a host"
+        )
+    return server
+
+
+def _validate_proxy(proxy: Any, label: str) -> str:
+    if not isinstance(proxy, str) or not proxy.strip():
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} 'proxy-url' must be a non-empty string"
+        )
+    parts = urlsplit(proxy)
+    if parts.scheme not in _ALLOWED_PROXY_SCHEMES or not parts.netloc:
+        raise UnsupportedKubeconfigError(
+            f"kubeconfig {label} 'proxy-url' must be an http/https/socks5 URL with a host"
+        )
+    return proxy

--- a/backend/tests/test_connectors_k8s_kubeconfig_schema.py
+++ b/backend/tests/test_connectors_k8s_kubeconfig_schema.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Passive-only kubeconfig schema enforcement (security review F03, #265).
+
+Covers :func:`enforce_passive_kubeconfig` and its wiring into the two
+production credential loaders. The threat model: a tenant-controlled
+kubeconfig secret must not be able to reach ``kubernetes_asyncio``'s
+loader with an ``exec`` provider (subprocess), a legacy ``auth-provider``
+block (network token fetch) or a local-file credential/CA reference
+(disk read) inside the shared backplane process.
+
+The pure-function tests assert the schema rejects those sinks and
+rebuilds a fresh config from only vetted fields; the loader/connector
+tests assert a synthetic exec config never reaches the (mocked) library
+client-build boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.kubernetes import KubernetesConnector
+from meho_backplane.connectors.kubernetes.kubeconfig import (
+    KubeconfigCredential,
+    WcpSsoCredential,
+    load_kubernetes_credential,
+)
+from meho_backplane.connectors.kubernetes.kubeconfig_schema import (
+    UnsupportedKubeconfigError,
+    enforce_passive_kubeconfig,
+)
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+
+def _passive_config() -> dict[str, Any]:
+    """A minimal valid inline-token kubeconfig mapping (as parsed YAML)."""
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "inline-bearer"}}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path — accepted inline auth is preserved; a fresh config is built.
+# (Acceptance criteria 3 + 4.)
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_and_rebuilds_inline_token_config() -> None:
+    config = _passive_config()
+    result = enforce_passive_kubeconfig(config)
+    assert result == {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "clusters": [{"cluster": {"server": "https://k8s.test:6443"}, "name": "c1"}],
+        "users": [{"user": {"token": "inline-bearer"}, "name": "u1"}],
+        "contexts": [{"context": {"cluster": "c1", "user": "u1"}, "name": "default"}],
+    }
+
+
+def test_accepts_inline_client_certificate_and_ca_data() -> None:
+    config = {
+        "apiVersion": "v1",
+        "clusters": [
+            {
+                "name": "c1",
+                "cluster": {
+                    "server": "https://k8s.test:6443",
+                    "certificate-authority-data": "Y2EtcGVt",
+                    "tls-server-name": "k8s.internal",
+                    "insecure-skip-tls-verify": False,
+                },
+            }
+        ],
+        "users": [
+            {
+                "name": "u1",
+                "user": {
+                    "client-certificate-data": "Y2VydC1wZW0=",
+                    "client-key-data": "a2V5LXBlbQ==",
+                },
+            }
+        ],
+    }
+    result = enforce_passive_kubeconfig(config)
+    assert result["clusters"][0]["cluster"] == {
+        "server": "https://k8s.test:6443",
+        "certificate-authority-data": "Y2EtcGVt",
+        "tls-server-name": "k8s.internal",
+        "insecure-skip-tls-verify": False,
+    }
+    assert result["users"][0]["user"] == {
+        "client-certificate-data": "Y2VydC1wZW0=",
+        "client-key-data": "a2V5LXBlbQ==",
+    }
+
+
+def test_accepts_basic_auth_config() -> None:
+    config = _passive_config()
+    config["users"] = [{"name": "u1", "user": {"username": "admin", "password": "s3cr3t"}}]
+    result = enforce_passive_kubeconfig(config)
+    assert result["users"][0]["user"] == {"username": "admin", "password": "s3cr3t"}
+
+
+def test_returns_fresh_mapping_not_the_input() -> None:
+    config = _passive_config()
+    result = enforce_passive_kubeconfig(config)
+    assert result is not config
+    assert result["clusters"] is not config["clusters"]
+    assert result["clusters"][0] is not config["clusters"][0]
+    assert result["clusters"][0]["cluster"] is not config["clusters"][0]["cluster"]
+
+
+def test_drops_unrecognised_keys() -> None:
+    config = _passive_config()
+    config["extensions"] = [{"name": "x", "extension": {"do": "stuff"}}]
+    config["clusters"][0]["cluster"]["disable-compression"] = True
+    config["users"][0]["user"]["as"] = "impersonated"
+    result = enforce_passive_kubeconfig(config)
+    assert "extensions" not in result
+    assert "disable-compression" not in result["clusters"][0]["cluster"]
+    assert "as" not in result["users"][0]["user"]
+
+
+def test_accepts_http_and_https_and_socks5_endpoints() -> None:
+    for server in ("https://k8s.test:6443", "http://127.0.0.1:8080"):
+        config = _passive_config()
+        config["clusters"][0]["cluster"]["server"] = server
+        assert enforce_passive_kubeconfig(config)["clusters"][0]["cluster"]["server"] == server
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["proxy-url"] = "socks5://proxy.test:1080"
+    result = enforce_passive_kubeconfig(config)
+    assert result["clusters"][0]["cluster"]["proxy-url"] == "socks5://proxy.test:1080"
+
+
+# ---------------------------------------------------------------------------
+# Reject active / out-of-band credential mechanisms.
+# (Acceptance criteria 1 + 5.)
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_exec_provider() -> None:
+    config = _passive_config()
+    config["users"][0]["user"] = {
+        "exec": {
+            "apiVersion": "client.authentication.k8s.io/v1",
+            "command": "/bin/evil-plugin",
+            "args": ["--steal"],
+        }
+    }
+    with pytest.raises(UnsupportedKubeconfigError, match="exec"):
+        enforce_passive_kubeconfig(config)
+
+
+@pytest.mark.parametrize("provider_name", ["gcp", "oidc", "azure"])
+def test_rejects_legacy_auth_provider(provider_name: str) -> None:
+    config = _passive_config()
+    config["users"][0]["user"] = {"auth-provider": {"name": provider_name, "config": {}}}
+    with pytest.raises(UnsupportedKubeconfigError, match="auth-provider"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_token_file_reference() -> None:
+    config = _passive_config()
+    config["users"][0]["user"] = {"tokenFile": "/var/run/secrets/token"}
+    with pytest.raises(UnsupportedKubeconfigError, match="tokenFile"):
+        enforce_passive_kubeconfig(config)
+
+
+@pytest.mark.parametrize("file_key", ["client-certificate", "client-key"])
+def test_rejects_user_local_file_reference(file_key: str) -> None:
+    config = _passive_config()
+    config["users"][0]["user"] = {file_key: "/etc/k8s/creds.pem"}
+    with pytest.raises(UnsupportedKubeconfigError, match=file_key):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_certificate_authority_file_reference() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["certificate-authority"] = "/etc/k8s/ca.crt"
+    with pytest.raises(UnsupportedKubeconfigError, match="certificate-authority"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_certificate_authority_file_even_beside_inline_data() -> None:
+    # The library would prefer the inline data and ignore the file, but a
+    # passive config must not carry a local-file reference at all.
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["certificate-authority"] = "/etc/k8s/ca.crt"
+    config["clusters"][0]["cluster"]["certificate-authority-data"] = "Y2EtcGVt"
+    with pytest.raises(UnsupportedKubeconfigError, match="certificate-authority"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_no_parameter_re_enables_exec() -> None:
+    # Acceptance criterion 5: no retained executable-provider facility —
+    # enforcement takes only the config, with no allow/escalate switch.
+    import inspect
+
+    params = list(inspect.signature(enforce_passive_kubeconfig).parameters)
+    assert params == ["config"]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint / proxy / TLS validation. (Acceptance criterion 3.)
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_cluster_without_server() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"] = {"certificate-authority-data": "Y2EtcGVt"}
+    with pytest.raises(UnsupportedKubeconfigError, match="server"):
+        enforce_passive_kubeconfig(config)
+
+
+@pytest.mark.parametrize("server", ["file:///etc/passwd", "ssh://host", "unix:///run/k.sock"])
+def test_rejects_non_http_server_scheme(server: str) -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["server"] = server
+    with pytest.raises(UnsupportedKubeconfigError, match="http"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_server_without_host() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["server"] = "https://"
+    with pytest.raises(UnsupportedKubeconfigError, match="host"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_invalid_proxy_scheme() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["proxy-url"] = "ftp://proxy.test"
+    with pytest.raises(UnsupportedKubeconfigError, match="proxy-url"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_non_bool_insecure_skip_tls_verify() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = "true"
+    with pytest.raises(UnsupportedKubeconfigError, match="insecure-skip-tls-verify"):
+        enforce_passive_kubeconfig(config)
+
+
+def test_rejects_non_string_token() -> None:
+    config = _passive_config()
+    config["users"][0]["user"]["token"] = 12345
+    with pytest.raises(UnsupportedKubeconfigError, match="token"):
+        enforce_passive_kubeconfig(config)
+
+
+# ---------------------------------------------------------------------------
+# Error hygiene — messages never echo a credential / endpoint / cert value.
+# ---------------------------------------------------------------------------
+
+
+def test_rejection_message_omits_secret_values() -> None:
+    config = _passive_config()
+    config["clusters"][0]["cluster"]["server"] = "https://secret-endpoint.internal:6443"
+    config["users"][0]["user"] = {
+        "exec": {"command": "/bin/exfiltrate-SECRET", "args": ["token-CANARY"]},
+    }
+    with pytest.raises(UnsupportedKubeconfigError) as excinfo:
+        enforce_passive_kubeconfig(config)
+    message = str(excinfo.value)
+    assert "exfiltrate-SECRET" not in message
+    assert "token-CANARY" not in message
+
+    bad_server = _passive_config()
+    bad_server["clusters"][0]["cluster"]["server"] = "ftp://secret-endpoint.internal:6443"
+    with pytest.raises(UnsupportedKubeconfigError) as server_exc:
+        enforce_passive_kubeconfig(bad_server)
+    assert "secret-endpoint.internal" not in str(server_exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Loader + connector wiring — the rejected config never reaches the
+# library client-build boundary. (Acceptance criteria 2 + 4.)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="k8s/rke2-meho",
+)
+
+_EXEC_KUBECONFIG_YAML = """apiVersion: v1
+kind: Config
+current-context: default
+clusters:
+- name: c1
+  cluster: {server: 'https://k8s.test:6443'}
+contexts:
+- name: default
+  context: {cluster: c1, user: u1}
+users:
+- name: u1
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      command: /bin/evil-plugin
+      args: ['--steal']
+"""
+
+_INLINE_KUBECONFIG_YAML = """apiVersion: v1
+kind: Config
+current-context: default
+clusters:
+- name: c1
+  cluster: {server: 'https://k8s.test:6443'}
+contexts:
+- name: default
+  context: {cluster: c1, user: u1}
+users:
+- name: u1
+  user: {token: inline-bearer}
+"""
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="op.test.jwt",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def test_default_loader_rejects_exec_kubeconfig(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_fake_client(monkeypatch, secret={"kubeconfig": _EXEC_KUBECONFIG_YAML})
+
+    async def _check() -> None:
+        with pytest.raises(UnsupportedKubeconfigError, match="exec"):
+            await load_kubernetes_credential(_TARGET, _make_operator())
+
+    asyncio.run(_check())
+
+
+def test_default_loader_accepts_inline_token_kubeconfig(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_client(monkeypatch, secret={"kubeconfig": _INLINE_KUBECONFIG_YAML})
+
+    async def _check() -> None:
+        credential = await load_kubernetes_credential(_TARGET, _make_operator())
+        assert isinstance(credential, KubeconfigCredential)
+        assert credential.config["users"][0]["user"] == {"token": "inline-bearer"}
+
+    asyncio.run(_check())
+
+
+def test_exec_config_never_reaches_library_client_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The synthetic exec config raises before ``new_client_from_config_dict``."""
+    install_fake_client(monkeypatch, secret={"kubeconfig": _EXEC_KUBECONFIG_YAML})
+    connector = KubernetesConnector()  # default (non-injected) credential loader
+
+    async def _check() -> None:
+        with patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+        ) as client_factory:
+            with pytest.raises(UnsupportedKubeconfigError):
+                await connector._get_api_client(_TARGET, _make_operator())
+            client_factory.assert_not_awaited()
+
+    asyncio.run(_check())
+
+
+def test_wcp_secret_bypasses_the_kubeconfig_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vSphere Supervisor secret (username/password) is unaffected by F03."""
+    install_fake_client(
+        monkeypatch, secret={"username": "administrator@vsphere.local", "password": "pw"}
+    )
+
+    async def _check() -> None:
+        credential = await load_kubernetes_credential(_TARGET, _make_operator())
+        assert isinstance(credential, WcpSsoCredential)
+        assert credential.username == "administrator@vsphere.local"
+
+    asyncio.run(_check())

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -201,6 +201,68 @@ credential-agnostic and uses whatever SSO pair is staged. Sibling
 issue #2902 (operator-CLI login-token longevity) is a different surface
 (Keycloak OIDC) and shares no implementation with this WCP token dance.
 
+## Passive-only kubeconfig schema (F03, #265)
+
+A static kubeconfig is read from a per-target credential secret (Vault
+KV-v2 / GSM). Target creation is tenant-admin gated, so the kubeconfig is
+**tenant-controlled** — but a tenant's right to manage its own credential
+must not translate into code execution or arbitrary file reads inside the
+shared backplane process. `kubernetes_asyncio`'s kubeconfig loader
+honours the full client-side feature set, three parts of which reach an
+out-of-band sink the moment the document is loaded:
+
+- an **`exec` credential provider** spawns a *subprocess* with the
+  configured command/args (`KubeConfigLoader.load_from_exec_plugin`);
+- a legacy **`auth-provider`** block (`gcp` / `oidc` / vendor plugins)
+  performs a *network token fetch/refresh* (`load_gcp_token` /
+  `_load_oid_token`);
+- a **file-path reference** — cluster `certificate-authority`, user
+  `client-certificate` / `client-key` / `tokenFile` — makes the loader
+  *read that local path* off the backplane's own filesystem (`FileOrData`
+  falls back to the `<key>` file whenever the inline `<key>-data` sibling
+  is absent).
+
+`connectors/kubernetes/kubeconfig_schema.py` (`enforce_passive_kubeconfig`)
+enforces a minimal server-side schema **before** the parsed mapping can
+reach that loader. It:
+
+- **rejects** the three sink classes above with a specific, fail-closed
+  `UnsupportedKubeconfigError` (a `ValueError` subclass, so it flows
+  through the loaders' documented `ValueError` contract and the
+  dispatcher's catch-all → `connector_error`). The message names only the
+  offending section/field — never a credential value, endpoint, or
+  certificate — so it is safe to log (preserves the no-leak canary
+  discipline);
+- **explicitly validates** the cluster `server` endpoint (must be an
+  http(s) URL with a host), `proxy-url` (http/https/socks5 URL with a
+  host), `insecure-skip-tls-verify` (boolean), `tls-server-name`, and the
+  inline `certificate-authority-data`;
+- **rebuilds a fresh mapping** from only the accepted fields — the
+  untrusted input mapping is never returned or handed to the library.
+  Only inline authentication survives: a bearer `token`, HTTP-basic
+  `username`/`password`, and inline `client-certificate-data` /
+  `client-key-data` / cluster `certificate-authority-data`.
+
+Enforcement sits at the trust boundary — the Vault/GSM read — in **both**
+production loaders (`load_kubernetes_credential`, the default, and the
+legacy-injectable `load_kubeconfig_from_vault`), immediately after
+`parse_kubeconfig_yaml`. `parse_kubeconfig_yaml` itself stays a pure
+parse; the injectable `kubeconfig_loader=` / `credential_loader=` test
+seams build dicts directly and are trusted (never a tenant secret).
+
+The **WCP SSO path is unaffected**: a Supervisor secret carries
+`username`/`password`, resolves to a `WcpSsoCredential`, and never
+constructs a kubeconfig dict — so `enforce_passive_kubeconfig` is not on
+that path.
+
+No executable-provider facility is retained: `exec` is rejected
+unconditionally, with no parameter or elevation re-enabling it. A
+deployment that genuinely needs exec-plugin credentials would run that
+behind a separate platform-admin-managed, isolated facility (out of scope
+here). This mirrors the Kubernetes upstream warning that untrusted
+kubeconfig can cause code execution or file exposure
+([kubeconfig guidance](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)).
+
 ## Probe ↔ dispatch convergence on the route operator (G0.16-T4 #1306)
 
 The `Connector.fingerprint(target, operator=None)` ABC signature


### PR DESCRIPTION
## Summary

- Security review **F03** (evoila-bosnia/meho-internal#265): a
  tenant-controlled kubeconfig secret could reach `kubernetes_asyncio`'s
  loader with an `exec` provider (subprocess), a legacy `auth-provider`
  block (network token fetch) or a local-file credential/CA reference
  (disk read) inside the shared backplane process.
- New `connectors/kubernetes/kubeconfig_schema.py`
  (`enforce_passive_kubeconfig`) enforces a minimal server-side schema
  **before** the parsed mapping reaches the library: it rejects those
  three sink classes with a fail-closed `UnsupportedKubeconfigError` (a
  `ValueError` subclass), explicitly validates the cluster
  endpoint / `proxy-url` / TLS options, and rebuilds a **fresh** config
  from only the vetted inline fields — the untrusted mapping is never
  handed to the library.
- Wired into **both** production loaders (`load_kubernetes_credential`,
  `load_kubeconfig_from_vault`) at the Vault/GSM trust boundary, right
  after `parse_kubeconfig_yaml`. Inline token / basic-auth / inline
  client-cert+key and the WCP SSO flow keep working; error messages name
  only the offending section/field, never a credential value or endpoint.

## State on main

Net-new — no part of this was already on `main`. The 2026-09-06
containment PRs (#3423 / #3427) covered the approval-decision / admin
routes and the mcp-remote token, not the Kubernetes kubeconfig path;
`main` had no kubeconfig schema enforcement. All acceptance criteria are
implemented here.

## Acceptance criteria

- [x] Documented passive-only schema rejects exec providers, unsupported
  legacy auth providers and arbitrary local credential/CA file references
  before library processing — `enforce_passive_kubeconfig` +
  `docs/codebase/connectors-kubernetes.md` (Passive-only kubeconfig
  schema).
- [x] Synthetic rejected input never reaches the mocked subprocess /
  local-file boundary —
  `test_exec_config_never_reaches_library_client_build` asserts
  `new_client_from_config_dict` is never awaited when the loaded
  kubeconfig carries an exec provider.
- [x] Endpoint, proxy, context and TLS options explicitly validated and a
  fresh client configuration constructed from accepted fields —
  `_validate_server` / `_validate_proxy` / bool `insecure-skip-tls-verify`
  / `tls-server-name`, and a freshly-built mapping
  (`test_returns_fresh_mapping_not_the_input`).
- [x] Supported inline token/certificate authentication and WCP flows
  continue through the existing dispatch seam —
  `test_default_loader_accepts_inline_token_kubeconfig`,
  `test_wcp_secret_bypasses_the_kubeconfig_schema`, plus the unchanged
  `test_connectors_k8s_auth` / `test_connectors_k8s_credread` /
  `test_connectors_k8s_wcp` suites.
- [x] No retained executable-provider facility — exec is rejected
  unconditionally, no parameter re-enables it
  (`test_no_parameter_re_enables_exec`).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on changed files
- [x] `mypy` (strict) — clean on changed files (the one reported error is
  a pre-existing darwin-only `MSG_ERRQUEUE` false positive in
  `net/icmp.py`, unrelated to this change; CI runs on Linux)
- [x] `pytest tests/test_connectors_k8s_kubeconfig_schema.py` — new suite,
  all criteria
- [x] `pytest tests/test_connectors_k8s_auth.py tests/test_connectors_k8s_credread.py`
  — 71 passed with the new enforcement in the default-loader path
- [x] full backend unit lane (`--ignore=tests/integration`)

## Out of scope

- WCP/Supervisor SSO token exchange (`_wcp_configuration`) — separate
  build path, not kubeconfig-driven, and unaffected.
- Connector-singleton / credential-cache re-architecture (F04,
  evoila-bosnia/meho-internal#266).
- The inline token/certificate happy path, which keeps working.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#265
