### PR TITLE
fix(mcpb): pin transitive qs to 6.16.0 to clear two qs advisories

### DIFF
--- a/clients/claude-desktop-mcpb/package-lock.json
+++ b/clients/claude-desktop-mcpb/package-lock.json
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/clients/claude-desktop-mcpb/package.json
+++ b/clients/claude-desktop-mcpb/package.json
@@ -6,5 +6,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "mcp-remote": "0.1.38"
+  },
+  "overrides": {
+    "qs": "^6.16.0"
   }
 }


### PR DESCRIPTION
## Summary

- Pins the transitive `qs` in the Claude Desktop `.mcpb` bundle from **6.15.3 → 6.16.0**, clearing **GHSA-4mjr-xmp4-gh2g / CVE-2026-82417** (qs DoS via attacker-controlled `isBuffer`) and **GHSA-x5fp-wj9c-mxmx / CVE-2026-82562** (qs array-limit bypass via bracket-key comma parsing). Both are fixed in 6.16.0.
- `qs` is pulled transitively via `express` / `body-parser` under the pinned `mcp-remote@0.1.38`. Both parents cap `qs` at `~6.15.1`, so 6.16.0 is outside their range — an npm **`overrides`** floor (`"qs": "^6.16.0"`) is the correct mechanism rather than bumping `mcp-remote` (deliberately pinned at 0.1.38, the proven onramp per #2666).
- `qs` 6.16.0 is a drop-in: identical dependency set (`side-channel`, `es-define-property`) and engines, same 6.x public API. The regenerated `package-lock.json` changes only the `qs` entry.

## Already met on main / re-confirmed at implementation

- No prior fix for this existed on `origin/main` (b7090ea0); qs was still 6.15.3.
- Advisory IDs and fixed version **re-confirmed live via OSV at implementation** (the issue flagged them as September-2026 IDs unverifiable offline): both advisories affect 6.15.3 and are fixed in 6.16.0; OSV reports 6.16.0 clean.

## Test plan

- [x] **AC1 — override + lock regenerated.** Added `overrides: { "qs": "^6.16.0" }`; `npm install` regenerated the lock. `node_modules/qs` now resolves **6.16.0**; no `6.15.3` remains anywhere in the lock. Lock is idempotent (a second `npm install --package-lock-only` produces no drift) and `npm ci` (strict sync) passes.
- [x] **AC2 — production tree rescanned.** `npm ci --omit=dev` in a clean staging dir, then `npm audit --omit=dev` → **0 advisories** (info/low/moderate/high/critical all 0); no GHSA-4mjr-xmp4-gh2g / GHSA-x5fp-wj9c-mxmx present. Targeted OSV rescan of the installed `qs 6.16.0` → 0 vulns.
- [x] **AC3 — OAuth callback / MCP relay flows.** Launcher in-process contract suite `node --test clients/claude-desktop-mcpb/test/index.test.mjs` → **12/12 pass**. Express+qs OAuth-callback smoke: `express@4.22.2` wires its qs-backed query parser and `qs.parse("code=...&state=...&scope=...")` round-trips correctly under 6.16.0. `build.sh` packs the bundle (manifest schema validates) with **qs 6.16.0 embedded** in `node_modules`.
- [x] Wording guard (`grep -ri "custom connector"`) → clean.

## Call-path reachability (AC4)

Not a demonstrated backplane exploit. `qs` is a transitive dependency of `mcp-remote`'s Express-based **local OAuth-callback HTTP server**, exercised only during interactive OAuth on a Claude Desktop install (parsing the `?code=&state=` redirect query). MEHO's backplane never routes untrusted input through this bundle's `qs`. This is package-hygiene remediation (bringing the vendored tree to a non-affected `qs`), not the closure of a proven reachable vulnerability. Consistent with the issue's Low triage.

## Out of scope

- Auditing non-`qs` transitive dependencies of `mcp-remote` (separate review, per the issue).
- The full backend Python unit lane is **not applicable** — this diff is two files under `clients/claude-desktop-mcpb/` (a Node lockfile + `package.json`), has zero Python/backend surface, and is not in the backend CI path. The authoritative gate is `mcpb-bundle.yml` (path-scoped to `clients/claude-desktop-mcpb/**`): launcher `node --test` + `build.sh` pack — both run and passed locally above.

Closes evoila-bosnia/meho-internal#278
