### PR TITLE
fix(connectors): enforce tenant scope in the secret.move Vault broker (S08)

### DIFF
--- a/backend/src/meho_backplane/connectors/secret/vault_endpoint.py
+++ b/backend/src/meho_backplane/connectors/secret/vault_endpoint.py
@@ -38,6 +38,21 @@ The adapter's structlog events carry only the ``path`` and the ``field``
 *name* — never the field's value, and never the bytes carried by the
 :class:`SecretMaterial`. The value lives only inside the
 :class:`SecretMaterial` between the source read and the sink write.
+
+Tenant scope
+============
+
+This adapter is a **second** KV-v2 read/write path (alongside the
+``vault.kv.*`` handlers in :mod:`meho_backplane.connectors.vault.ops`), so
+both methods run the same default-on defense-in-depth guard,
+:func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`,
+**before** the Vault login. A ``secret.move`` whose source or sink ref
+falls outside the operator's ``secret/tenants/{tenant_id}/`` subtree is
+denied with :class:`~meho_backplane.connectors.vault.tenant_scope.VaultTenantScopeError`
+at the app layer before any Vault round-trip — the broker and the KV-v2
+handlers agree on the tenant subtree (S08, #296). The guard backstops the
+per-tenant ``meho-mcp`` Vault ACL policy; it never grants access the
+policy denies.
 """
 
 from __future__ import annotations
@@ -56,6 +71,7 @@ from meho_backplane.connectors.secret.endpoints import (
     SecretMaterial,
     register_secret_endpoint,
 )
+from meho_backplane.connectors.vault.tenant_scope import enforce_tenant_scope
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -122,6 +138,14 @@ class VaultKvSecretEndpoint:
         hashed and forwarded, so source and sink agree byte-for-byte.
         """
         _log.debug("secret_broker.vault.read", path=self._path, field=self._field)
+        # Defense-in-depth tenant-scope check (#1643 / S08 #296): deny a path
+        # outside the operator's tenant namespace BEFORE the Vault login, so
+        # this second KV-v2 read path enforces the same per-tenant subtree as
+        # the ``vault.kv.*`` handlers. No-op unless
+        # ``vault_kv_tenant_scope_prefix`` is configured; behind the Vault
+        # ``meho-mcp`` ACL policy, never a replacement for it. ``read_only``
+        # so the platform-path allow-list applies on the read side.
+        enforce_tenant_scope(operator, mount=self._mount, path=self._path, read_only=True)
         async with _auth_vault.vault_client_for_operator(operator) as client:
             payload = await asyncio.to_thread(
                 client.secrets.kv.v2.read_secret_version,
@@ -149,6 +173,11 @@ class VaultKvSecretEndpoint:
         guard is a policy-task concern (#1579), not the mechanism.
         """
         _log.debug("secret_broker.vault.write", path=self._path, field=self._field)
+        # Defense-in-depth tenant-scope check (#1643 / S08 #296): deny a write
+        # outside the operator's tenant namespace BEFORE the Vault login.
+        # ``read_only=False`` — a write to the shared platform path under a
+        # non-owning operator stays tenant-scoped (#1725 M1).
+        enforce_tenant_scope(operator, mount=self._mount, path=self._path, read_only=False)
         body: dict[str, str] = {self._field: material.value.decode("utf-8")}
         async with _auth_vault.vault_client_for_operator(operator) as client:
             await asyncio.to_thread(

--- a/backend/tests/test_connectors_secret_broker.py
+++ b/backend/tests/test_connectors_secret_broker.py
@@ -58,6 +58,7 @@ from meho_backplane.connectors.secret.ops import (
     secret_move,
 )
 from meho_backplane.connectors.secret.vault_endpoint import VaultKvSecretEndpoint
+from meho_backplane.connectors.vault.tenant_scope import VaultTenantScopeError
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, EndpointDescriptor
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
@@ -68,6 +69,11 @@ from ._vault_fakes import install_fake_client
 
 _SECRET_VALUE = "hunter2"
 _SECRET_SHA256 = hashlib.sha256(_SECRET_VALUE.encode()).hexdigest()
+
+#: The Nil-UUID system tenant, exempt from the tenant-scope guard. A
+#: module-level singleton (not an inline ``UUID(int=0)`` default) so the
+#: default arg of ``_make_operator`` doesn't trip ruff B008.
+_SYSTEM_TENANT_ID = UUID(int=0)
 
 
 # ---------------------------------------------------------------------------
@@ -111,14 +117,19 @@ async def _registered_secret_broker_op(
     yield
 
 
-def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
-    """A request-scoped operator carrying the JWT the vault adapter forwards."""
+def _make_operator(jwt: str = "fake.jwt.value", *, tenant_id: UUID = _SYSTEM_TENANT_ID) -> Operator:
+    """A request-scoped operator carrying the JWT the vault adapter forwards.
+
+    ``tenant_id`` defaults to the Nil-UUID system tenant (exempt from the
+    tenant-scope guard) so the pre-existing end-to-end tests keep passing
+    unchanged; the S08 guard tests pass a real tenant to exercise it.
+    """
     return Operator(
         sub="test-operator",
         name=None,
         email=None,
         raw_jwt=jwt,
-        tenant_id=UUID(int=0),
+        tenant_id=tenant_id,
         tenant_role=TenantRole.OPERATOR,
     )
 
@@ -487,3 +498,117 @@ async def test_secret_move_invalid_params_returns_dispatcher_error(
 
     assert result.status == "error"
     assert result.extras.get("error_code") == "invalid_params"
+
+
+# ---------------------------------------------------------------------------
+# Tenant-scope guard (S08 #296) — the vault-kv adapter is a second KV-v2
+# read/write path, so it enforces the same default-on per-tenant subtree as
+# the ``vault.kv.*`` handlers, before any Vault round-trip.
+# ---------------------------------------------------------------------------
+
+_TENANT_A = UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _enable_tenant_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the shipped default-on per-tenant prefix so the guard enforces.
+
+    The broker suite's autouse ``_settings_env`` does not touch
+    ``VAULT_KV_TENANT_SCOPE_PREFIX``; a dev/CI shell that emptied it (the
+    #282 lab-config opt-out) would silently disable the guard, so set it
+    explicitly to the shipped default and clear the settings cache.
+    """
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "secret/tenants/{tenant_id}/")
+    get_settings.cache_clear()
+
+
+async def test_secret_move_denies_cross_tenant_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cross-tenant SOURCE ref is denied before any Vault round-trip.
+
+    Operator in tenant A moves ``from`` a path under tenant B's subtree.
+    ``read_secret``'s ``enforce_tenant_scope`` raises
+    ``VaultTenantScopeError`` before ``vault_client_for_operator`` is
+    entered, so the fake hvac client records neither a read nor a write.
+    """
+    _enable_tenant_scope(monkeypatch)
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+    operator = _make_operator(tenant_id=_TENANT_A)
+
+    with pytest.raises(VaultTenantScopeError):
+        await secret_move(
+            operator,
+            None,
+            {
+                "from": f"vault:tenants/{_TENANT_B}/db#password",
+                "to": f"vault:tenants/{_TENANT_A}/replica#password",
+            },
+        )
+
+    # No Vault round-trip on either side — the guard fired before login.
+    assert fake.secrets.kv.v2.read_calls == []
+    assert fake.secrets.kv.v2.put_calls == []
+
+
+async def test_secret_move_denies_cross_tenant_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cross-tenant SINK ref is denied by the write-side guard.
+
+    The in-namespace source read runs, but ``write_secret``'s
+    ``enforce_tenant_scope(read_only=False)`` raises before the sink write,
+    so no ``create_or_update_secret`` reaches the foreign-tenant path.
+    """
+    _enable_tenant_scope(monkeypatch)
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+    operator = _make_operator(tenant_id=_TENANT_A)
+
+    with pytest.raises(VaultTenantScopeError):
+        await secret_move(
+            operator,
+            None,
+            {
+                "from": f"vault:tenants/{_TENANT_A}/db#password",
+                "to": f"vault:tenants/{_TENANT_B}/replica#password",
+            },
+        )
+
+    assert fake.secrets.kv.v2.put_calls == []
+
+
+async def test_secret_move_in_namespace_ref_round_trips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-namespace move passes the guard and round-trips server-side.
+
+    Both refs live under the operator's ``secret/tenants/<A>/`` subtree, so
+    the guard is a no-op and the value is read from the source and written
+    to the sink through the existing ``install_fake_client`` seam.
+    """
+    _enable_tenant_scope(monkeypatch)
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+    operator = _make_operator(tenant_id=_TENANT_A)
+
+    result = await secret_move(
+        operator,
+        None,
+        {
+            "from": f"vault:tenants/{_TENANT_A}/db#password",
+            "to": f"vault:tenants/{_TENANT_A}/replica#password",
+        },
+    )
+
+    assert result == {
+        "status": "moved",
+        "value_sha256": _SECRET_SHA256,
+        "length": len(_SECRET_VALUE.encode()),
+    }
+    assert fake.secrets.kv.v2.put_calls == [
+        {
+            "path": f"tenants/{_TENANT_A}/replica",
+            "secret": {"password": _SECRET_VALUE},
+            "cas": None,
+            "mount_point": "secret",
+        }
+    ]

--- a/backend/tests/test_secret_broker_keycloak_sink.py
+++ b/backend/tests/test_secret_broker_keycloak_sink.py
@@ -250,7 +250,10 @@ async def test_vault_to_keycloak_move_writes_credential_server_side(
     install_fake_client(monkeypatch, secret={"password": _SENTINEL})
 
     params = {
-        "from": "vault:secret/db/prod#password",
+        # Source lives in the operator's own tenant subtree so it passes the
+        # default-on vault-kv tenant-scope guard the broker now runs on its
+        # read path (S08 #296); the sink is a Keycloak-admin path, unguarded.
+        "from": f"vault:tenants/{_OPERATOR_TENANT_ID}/db/prod#password",
         "to": f"keycloak:{_TARGET_NAME}/{_REALM}/{_USERNAME}#password",
         "reason": "provision keycloak operator credential",
     }

--- a/docs/codebase/connectors-secret-broker.md
+++ b/docs/codebase/connectors-secret-broker.md
@@ -68,7 +68,13 @@ boundary redaction:
   field). Reads via `read_secret_version` + the KV-v2 `data.data`
   double-unwrap + `strip_credential_value`; writes via
   `create_or_update_secret` (a single-field body, `cas=None`). Both
-  through `vault_client_for_operator`.
+  through `vault_client_for_operator`. Because this is a **second** KV-v2
+  read/write path alongside the `vault.kv.*` handlers, both methods call
+  the default-on `enforce_tenant_scope` guard
+  ([`vault/tenant_scope.py`](connectors-vault-tenant-scope.md), `read_only=True`
+  on read, `read_only=False` on write) **before** the Vault login, so a
+  cross-tenant `secret.move` is denied at the app layer before any Vault
+  round-trip (S08, #296).
 - **`KeycloakCredentialSecretEndpoint`**
   (`connectors/keycloak/secret_endpoint.py`) — the second adapter (#1578),
   registered under kind `"keycloak"`. **Sink-only**: keycloak credentials
@@ -179,6 +185,11 @@ the posture and relies on the existing gate). The policy refinement
 - The vault adapter forwards the `ref` to hvac's `path=` and defaults the
   mount to `"secret"`; a non-default mount is a richer-ref-grammar
   follow-up, not wired here.
+- **Tenant scope (S08, #296):** the vault-kv adapter enforces the same
+  default-on per-tenant subtree as the `vault.kv.*` handlers via
+  `enforce_tenant_scope` before each Vault call. The keycloak sink is a
+  Keycloak-admin path (not KV-v2) and is out of that guard's scope — it
+  already resolves its target through the tenant-scoped `resolve_target`.
 - The `reason` param is recorded for the approver/audit trail but is not
   read by the handler; it is surfaced to the approver in the ref-only
   `proposed_effect` summary (#1579).

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -39,7 +39,16 @@ called by **every** KV-v2 handler (`read`, `list`, `versions`, `put`,
 **before** the `vault_client_for_operator(...)` login. `read_only` is
 `True` for the read/list/versions handlers and `False` for
 put/patch/delete; it gates the platform-path exemption (below) to
-read-only verbs. On a violation it raises
+read-only verbs.
+
+The secret broker's vault-kv adapter
+([`connectors/secret/vault_endpoint.py`](../../backend/src/meho_backplane/connectors/secret/vault_endpoint.py),
+the `secret.move` source+sink) is a **second** KV-v2 read/write path, so
+it calls the same guard — `read_only=True` in `read_secret`, `read_only=False`
+in `write_secret`, each before its own `vault_client_for_operator(...)`
+login — so a cross-tenant `secret.move` is denied at the app layer before
+any Vault round-trip, exactly as a cross-tenant `vault.kv.*` call is (S08,
+[#296](https://github.com/evoila/meho/issues/296)). On a violation it raises
 `VaultTenantScopeError`; the dispatcher's `connector_error` branch wraps
 it into a structured `OperationResult` with
 `extras["exception_class"] == "VaultTenantScopeError"` — distinct from the


### PR DESCRIPTION
## Summary

- **S08 (security review #262):** the secret broker's vault-kv adapter
  (`VaultKvSecretEndpoint`) is a **second** KV-v2 read/write path
  alongside the `vault.kv.*` handlers, but it skipped the default-on
  `enforce_tenant_scope` guard those handlers run. A `secret.move` whose
  source/sink ref pointed at `secret/tenants/<other>/...` could reach a
  foreign tenant's subtree if the `meho-mcp` Vault ACL policy were
  mis-provisioned too broadly — the exact failure mode this app-layer
  guard backstops.
- Mirror `vault/ops.py`: call `enforce_tenant_scope(operator,
  mount=self._mount, path=self._path, read_only=...)` in `read_secret`
  (`read_only=True`) and `write_secret` (`read_only=False`), **before**
  the Vault login, so the broker and the `vault.kv.*` handlers enforce
  the same per-tenant subtree and raise `VaultTenantScopeError` before
  any Vault round-trip.
- Docs updated: `connectors-vault-tenant-scope.md` (the guard now has a
  second call site) and `connectors-secret-broker.md` (the adapter's
  tenant-scope posture + why keycloak is out of scope).

## Already on `main` vs. remaining

Branched from `origin/main` @ `b7090ea0`. The security-containment PRs
(#3423 / #3427) that landed 2026-09-06 addressed a **different** concern
(F05 secret-value containment); none added the tenant-scope guard to the
broker path. So **all** of this task's acceptance criteria were still
open on `main` and are implemented here — nothing was pre-met.

Out of scope per the issue (unchanged): the keycloak sink adapter (not a
KV-v2 path), the primary `meho-mcp` Vault ACL policy, the empty-prefix
lab-config gap (#282 / F14b), and check-and-set / ref-grammar changes.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/secret/vault_endpoint.py` — clean
- [x] `ruff format --check` (both changed files) — clean
- [x] `mypy src/meho_backplane/connectors/secret/vault_endpoint.py` — `Success: no issues found`
- [x] `pytest tests/test_connectors_secret_broker.py tests/test_connectors_vault_tenant_scope.py tests/test_secret_move_approval.py -q` — 73 passed
- [x] Full backend unit lane (`pytest tests --ignore=tests/integration --ignore=tests/migrations`) — green
- [x] AC1: `grep -n enforce_tenant_scope …/vault_endpoint.py` shows the `read_only=True` call in `read_secret` and the `read_only=False` call in `write_secret`, each before the hvac call
- [x] AC2: `test_secret_move_denies_cross_tenant_ref` — a cross-tenant source ref raises `VaultTenantScopeError`; the fake hvac client records neither read nor write
- [x] AC3: `test_secret_move_in_namespace_ref_round_trips` — an in-namespace move passes the guard and round-trips through the `install_fake_client` seam
- [x] Added `test_secret_move_denies_cross_tenant_sink` — the write-side guard (`read_only=False`) denies a cross-tenant sink before the write

## Out of scope

- Keycloak sink adapter (not KV-v2), the `meho-mcp` ACL policy, the
  empty-prefix lab-config gap (#282), and CAS/ref-grammar changes.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#296
