### PR TITLE
fix(addons): authorize heartbeat + capability writes by paired service subject (F11)

### DIFF
--- a/backend/src/meho_backplane/api/v1/addon_capability.py
+++ b/backend/src/meho_backplane/api/v1/addon_capability.py
@@ -72,10 +72,14 @@ async def declare_capabilities(
     """Declare an add-on's advertised surfaces (paired service principal only).
 
     The paired add-on authenticates as its own **service** principal and
-    replaces its declaration wholesale. A non-service principal is 403; an
-    unpaired add-on is 404; an unknown capability kind or a malformed /
-    duplicate declaration is 422 (rejected by the request schema before this
-    handler runs). Audited via the audit middleware.
+    replaces its declaration wholesale. A non-service principal is 403. The
+    pairing is resolved by the caller's service-account ``sub`` and must be
+    ``{name}``'s own pairing, so a paired service cannot replace another
+    add-on's advertised surfaces; a caller that owns no pairing named
+    ``{name}`` is 404 (indistinguishable from an absent one). An unknown
+    capability kind or a malformed / duplicate declaration is 422 (rejected by
+    the request schema before this handler runs). Audited via the audit
+    middleware.
     """
     if operator.principal_kind is not PrincipalKind.SERVICE:
         raise HTTPException(
@@ -89,7 +93,9 @@ async def declare_capabilities(
     )
     service = AddonCapabilityService()
     try:
-        return await service.declare(operator.tenant_id, name, payload)
+        return await service.declare(
+            operator.tenant_id, name, payload, service_account_sub=operator.sub
+        )
     except AddonNotPairedError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,

--- a/backend/src/meho_backplane/api/v1/addon_pairing.py
+++ b/backend/src/meho_backplane/api/v1/addon_pairing.py
@@ -219,8 +219,11 @@ async def heartbeat_pairing(
     """Record an add-on liveness heartbeat (paired service principal only).
 
     The paired add-on authenticates as its own service principal and stamps
-    ``last_seen_at``. A non-service principal is 403; an unpaired add-on is
-    404. Audited via the audit middleware.
+    ``last_seen_at``. A non-service principal is 403. The pairing is resolved
+    by the caller's service-account ``sub`` and must be ``{name}``'s own
+    pairing, so a paired service cannot heartbeat another add-on's pairing; a
+    caller that owns no pairing named ``{name}`` is 404 (indistinguishable from
+    an absent one). Audited via the audit middleware.
     """
     if operator.principal_kind is not PrincipalKind.SERVICE:
         raise HTTPException(
@@ -234,7 +237,7 @@ async def heartbeat_pairing(
     )
     service = AddonPairingService()
     try:
-        return await service.heartbeat(operator.tenant_id, name)
+        return await service.heartbeat(operator.tenant_id, name, service_account_sub=operator.sub)
     except AddonNotPairedError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,

--- a/backend/src/meho_backplane/operations/addon_capability.py
+++ b/backend/src/meho_backplane/operations/addon_capability.py
@@ -58,7 +58,7 @@ from meho_backplane.operations.addon_capability_schemas import (
     CapabilityRead,
     DeclareCapabilitiesRequest,
 )
-from meho_backplane.operations.addon_pairing import AddonNotPairedError
+from meho_backplane.operations.addon_pairing import resolve_owned_pairing
 from meho_backplane.operations.addon_pairing_contract import is_contract_compatible
 
 __all__ = ["AddonCapabilityService"]
@@ -86,6 +86,8 @@ class AddonCapabilityService:
         tenant_id: uuid.UUID,
         addon_name: str,
         request: DeclareCapabilitiesRequest,
+        *,
+        service_account_sub: str,
     ) -> CapabilityDeclarationResponse:
         """Persist an add-on's complete surface set (replace-all).
 
@@ -94,23 +96,26 @@ class AddonCapabilityService:
         version — all in one transaction. Returns the persisted declaration
         with its live ``active`` state.
 
+        Object-level authorization runs in-transaction via
+        :func:`~meho_backplane.operations.addon_pairing.resolve_owned_pairing`:
+        the pairing is resolved by the caller's ``service_account_sub``, and
+        *addon_name* must be that pairing's own name, so one paired service can
+        never replace another add-on's advertised surfaces.
+
         Raises
         ------
         AddonNotPairedError
-            When no pairing matches ``(tenant_id, addon_name)``.
+            When the caller owns no pairing named ``addon_name`` in
+            ``tenant_id``.
         """
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
-            pairing = (
-                await session.execute(
-                    select(AddonPairing).where(
-                        AddonPairing.tenant_id == tenant_id,
-                        AddonPairing.name == addon_name,
-                    )
-                )
-            ).scalar_one_or_none()
-            if pairing is None:
-                raise AddonNotPairedError(addon_name)
+            pairing = await resolve_owned_pairing(
+                session,
+                tenant_id=tenant_id,
+                service_account_sub=service_account_sub,
+                requested_name=addon_name,
+            )
 
             await session.execute(
                 delete(AddonCapability).where(AddonCapability.pairing_id == pairing.id)

--- a/backend/src/meho_backplane/operations/addon_pairing.py
+++ b/backend/src/meho_backplane/operations/addon_pairing.py
@@ -59,6 +59,7 @@ from datetime import UTC, datetime
 import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.keycloak_admin import (
     KeycloakAdminClient,
@@ -80,6 +81,7 @@ __all__ = [
     "AddonAlreadyPairedError",
     "AddonNotPairedError",
     "AddonPairingService",
+    "resolve_owned_pairing",
 ]
 
 #: Add-on name alphabet: letters, digits, hyphen, underscore, dot. Mirrors
@@ -121,6 +123,52 @@ class AddonNotPairedError(Exception):
     def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"add-on {name!r} is not paired")
+
+
+async def resolve_owned_pairing(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    service_account_sub: str,
+    requested_name: str,
+) -> AddonPairing:
+    """Resolve the caller's own pairing by subject, requiring name *requested_name*.
+
+    The shared object-level authorization guard for an add-on's **self-service
+    writes** — the liveness heartbeat (#3025) and the capability declaration
+    (#3026). Both are the paired add-on's own action, so the pairing is
+    resolved by the caller's Keycloak service-account ``sub`` (captured at pair
+    time as :attr:`~meho_backplane.db.models.AddonPairing.service_account_sub`),
+    never by the ``{name}`` in the request path. The requested name must be the
+    caller's own pairing name; a mismatch is refused indistinguishably from an
+    absent pairing, so one paired service can neither act on another's pairing
+    nor probe which add-on names exist. This is the write-side counterpart of
+    the step-event subscription bind
+    (:meth:`~meho_backplane.operations.addon_step_events.AddonStepEventService.resolve_pairing_for_sub`).
+
+    The guard takes the caller's *session* so it runs inside the mutation's own
+    transaction: the authorization and the write commit as one unit and a
+    concurrent unpair cannot slip between the check and the mutation.
+
+    Raises
+    ------
+    AddonNotPairedError
+        When *service_account_sub* binds to no pairing in *tenant_id* — a
+        non-add-on service principal, or a pre-#3027 pairing whose
+        ``service_account_sub`` is ``NULL`` (fails closed until it re-pairs) —
+        or binds to a pairing whose name is not *requested_name*.
+    """
+    pairing = (
+        await session.execute(
+            select(AddonPairing).where(
+                AddonPairing.tenant_id == tenant_id,
+                AddonPairing.service_account_sub == service_account_sub,
+            )
+        )
+    ).scalar_one_or_none()
+    if pairing is None or pairing.name != requested_name:
+        raise AddonNotPairedError(requested_name)
+    return pairing
 
 
 class AddonPairingService:
@@ -471,24 +519,27 @@ class AddonPairingService:
         self,
         tenant_id: uuid.UUID,
         name: str,
+        *,
+        service_account_sub: str,
     ) -> PairedAddonRead:
         """Stamp the add-on's liveness ``last_seen_at`` to now.
 
         Called by the paired add-on itself (authenticating as its service
-        principal). Raises :class:`AddonNotPairedError` when no pairing
-        matches ``(tenant_id, name)``.
+        principal). Object-level authorization runs in-transaction via
+        :func:`resolve_owned_pairing`: the pairing is resolved by the caller's
+        ``service_account_sub``, and *name* must be that pairing's own name, so
+        one paired service can never heartbeat another add-on's pairing. Raises
+        :class:`AddonNotPairedError` when the caller owns no pairing named
+        *name*.
         """
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
-            result = await session.execute(
-                select(AddonPairing).where(
-                    AddonPairing.tenant_id == tenant_id,
-                    AddonPairing.name == name,
-                )
+            row = await resolve_owned_pairing(
+                session,
+                tenant_id=tenant_id,
+                service_account_sub=service_account_sub,
+                requested_name=name,
             )
-            row = result.scalar_one_or_none()
-            if row is None:
-                raise AddonNotPairedError(name)
             row.last_seen_at = datetime.now(UTC)
             row.updated_at = datetime.now(UTC)
             await session.flush()

--- a/backend/tests/addon_reference_double.py
+++ b/backend/tests/addon_reference_double.py
@@ -203,6 +203,7 @@ class ReferenceAddon:
             self.tenant_id,
             self.name,
             DeclareCapabilitiesRequest(capabilities=capabilities),
+            service_account_sub=self.service_account_sub,
         )
 
     async def produce_step_event(

--- a/backend/tests/test_addon_capability_service.py
+++ b/backend/tests/test_addon_capability_service.py
@@ -83,12 +83,26 @@ def _fk_enforced(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     get_settings.cache_clear()
 
 
-def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
+def _sub_for(name: str) -> str:
+    """The service-account sub a pairing named *name* captures at pair time.
+
+    Distinct per add-on: the object-level write guard resolves a pairing by
+    the caller's sub, so a shared sub across two pairings in one tenant would
+    make that resolution ambiguous. ``declare`` is authorized against this
+    value, so a caller passes ``_sub_for(name)`` to act on its own pairing.
+    """
+    return f"svc-{name}"
+
+
+def _mock_kc_ok(
+    internal_id: str = _KC_INTERNAL_ID,
+    service_account_sub: str = "svc-account-uuid",
+) -> MagicMock:
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=internal_id)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.delete_client = AsyncMock(return_value=None)
-    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
+    mock_client.get_service_account_user_id = AsyncMock(return_value=service_account_sub)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
     return MagicMock(return_value=mock_client)
@@ -110,7 +124,10 @@ async def _pair(name: str = "automation") -> None:
         addon_contract_version=BACKPLANE_CONTRACT_VERSION,
         addon_min_backplane_version=BACKPLANE_CONTRACT_VERSION,
     )
-    with patch(_PATCH_TARGET, _mock_kc_ok(f"{_KC_INTERNAL_ID[:-2]}{len(name):02d}")):
+    with patch(
+        _PATCH_TARGET,
+        _mock_kc_ok(f"{_KC_INTERNAL_ID[:-2]}{len(name):02d}", _sub_for(name)),
+    ):
         await AddonPairingService().pair(_TENANT, "op-admin", request)
 
 
@@ -155,6 +172,7 @@ async def test_declare_persists_and_stamps_contract_version() -> None:
             (CapabilityKind.META_TOOL_FAMILY, "inventory"),
             (CapabilityKind.EVENT_KIND, "run.step.completed"),
         ),
+        service_account_sub=_sub_for("automation"),
     )
     assert result.addon == "automation"
     assert result.active is True
@@ -181,10 +199,14 @@ async def test_redeclare_is_replace_all() -> None:
             (CapabilityKind.META_TOOL_FAMILY, "inventory"),
             (CapabilityKind.CLI_VERB_FAMILY, "vm"),
         ),
+        service_account_sub=_sub_for("automation"),
     )
     # A smaller re-declaration drops "vm" — no dead surface left behind.
     result = await service.declare(
-        _TENANT, "automation", _decl((CapabilityKind.META_TOOL_FAMILY, "inventory"))
+        _TENANT,
+        "automation",
+        _decl((CapabilityKind.META_TOOL_FAMILY, "inventory")),
+        service_account_sub=_sub_for("automation"),
     )
     assert [(c.kind, c.name) for c in result.capabilities] == [
         (CapabilityKind.META_TOOL_FAMILY, "inventory")
@@ -197,7 +219,10 @@ async def test_declare_on_unpaired_addon_raises() -> None:
     await _seed_tenant()
     with pytest.raises(AddonNotPairedError):
         await AddonCapabilityService().declare(
-            _TENANT, "ghost", _decl((CapabilityKind.CONSOLE_PANEL, "pairing"))
+            _TENANT,
+            "ghost",
+            _decl((CapabilityKind.CONSOLE_PANEL, "pairing")),
+            service_account_sub=_sub_for("ghost"),
         )
 
 
@@ -220,9 +245,13 @@ async def test_active_capabilities_filters_by_health_and_kind() -> None:
             (CapabilityKind.META_TOOL_FAMILY, "inventory"),
             (CapabilityKind.EVENT_KIND, "run.step.completed"),
         ),
+        service_account_sub=_sub_for("automation"),
     )
     await service.declare(
-        _TENANT, "ssp", _decl((CapabilityKind.EVENT_KIND, "portal.request.raised"))
+        _TENANT,
+        "ssp",
+        _decl((CapabilityKind.EVENT_KIND, "portal.request.raised")),
+        service_account_sub=_sub_for("ssp"),
     )
 
     everything = await service.active_capabilities(_TENANT)
@@ -245,7 +274,10 @@ async def test_activation_flips_when_pairing_goes_contract_incompatible() -> Non
     await _pair("automation")
     service = AddonCapabilityService()
     await service.declare(
-        _TENANT, "automation", _decl((CapabilityKind.META_TOOL_FAMILY, "inventory"))
+        _TENANT,
+        "automation",
+        _decl((CapabilityKind.META_TOOL_FAMILY, "inventory")),
+        service_account_sub=_sub_for("automation"),
     )
     assert (await service.list_declared(_TENANT, "automation")).active is True
     assert len(await service.active_capabilities(_TENANT)) == 1
@@ -280,6 +312,7 @@ async def test_unpair_cascade_deletes_capabilities(_fk_enforced: None) -> None:
             (CapabilityKind.META_TOOL_FAMILY, "inventory"),
             (CapabilityKind.CLI_VERB_FAMILY, "vm"),
         ),
+        service_account_sub=_sub_for("automation"),
     )
     assert await _capability_row_count("automation") == 2
 

--- a/backend/tests/test_addon_pairing_service.py
+++ b/backend/tests/test_addon_pairing_service.py
@@ -200,7 +200,9 @@ async def test_heartbeat_stamps_last_seen() -> None:
     service = AddonPairingService()
     with patch(_PATCH_TARGET, _mock_kc_ok()):
         await service.pair(_TENANT, "op-admin", _request())
-        entry = await service.heartbeat(_TENANT, "automation")
+        entry = await service.heartbeat(
+            _TENANT, "automation", service_account_sub="svc-account-uuid"
+        )
     assert entry.last_seen_at is not None
     rows = await _fetch(_TENANT)
     assert rows[0].last_seen_at is not None
@@ -210,7 +212,7 @@ async def test_heartbeat_stamps_last_seen() -> None:
 async def test_heartbeat_unpaired_raises() -> None:
     await _seed_tenant()
     with pytest.raises(AddonNotPairedError):
-        await AddonPairingService().heartbeat(_TENANT, "ghost")
+        await AddonPairingService().heartbeat(_TENANT, "ghost", service_account_sub="nobody")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_v1_addon_capability.py
+++ b/backend/tests/test_api_v1_addon_capability.py
@@ -97,15 +97,18 @@ def _token(
     )
 
 
-def _service_token(key: Any) -> str:
+def _service_token(key: Any, *, sub: str = "addon-svc") -> str:
     """A paired add-on's ``principal_kind=service`` / ``read_only`` token."""
-    return _token(key, sub="addon-svc", role=TenantRole.READ_ONLY, principal_kind="service")
+    return _token(key, sub=sub, role=TenantRole.READ_ONLY, principal_kind="service")
 
 
-def _mock_kc_ok() -> MagicMock:
+def _mock_kc_ok(*, sub: str = "addon-svc", internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     mock_client = AsyncMock()
-    mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
-    mock_client.get_service_account_user_id = AsyncMock(return_value="svc-account-uuid")
+    mock_client.create_client = AsyncMock(return_value=internal_id)
+    # The declare route now authorizes by the caller's service-account sub, so
+    # the pairing must capture the same sub the declaring service token carries
+    # (``addon-svc``) — otherwise a legitimate self-declaration would 404.
+    mock_client.get_service_account_user_id = AsyncMock(return_value=sub)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.delete_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -304,3 +307,67 @@ async def test_show_activation_flips_with_pairing_health(client: TestClient) -> 
     body = unhealthy.json()
     assert body["active"] is False
     assert len(body["capabilities"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_declare_cannot_target_another_pairing(client: TestClient) -> None:
+    """Object-level authz: a paired service declares only its OWN surfaces.
+
+    Two paired add-ons share a tenant. Service A (bound to ``automation``)
+    cannot replace ``other``'s advertised surfaces; an unrelated service
+    subject is denied; A's own declaration still succeeds and B's surfaces are
+    left untouched.
+    """
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-decl-authz")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        with patch(_PATCH_TARGET, _mock_kc_ok(sub="addon-svc")):
+            client.post(
+                "/api/v1/addons/pairings",
+                json={
+                    "name": "automation",
+                    "addon_contract_version": BACKPLANE_CONTRACT_VERSION,
+                    "addon_min_backplane_version": BACKPLANE_CONTRACT_VERSION,
+                },
+                headers=admin,
+            )
+        with patch(
+            _PATCH_TARGET,
+            _mock_kc_ok(sub="other-svc", internal_id="cc000000-0000-0000-0000-0000000cafe1"),
+        ):
+            client.post(
+                "/api/v1/addons/pairings",
+                json={
+                    "name": "other",
+                    "addon_contract_version": BACKPLANE_CONTRACT_VERSION,
+                    "addon_min_backplane_version": BACKPLANE_CONTRACT_VERSION,
+                },
+                headers=admin,
+            )
+
+        a = {"Authorization": f"Bearer {_service_token(key, sub='addon-svc')}"}
+        stranger = {"Authorization": f"Bearer {_service_token(key, sub='stranger-svc')}"}
+
+        # A cannot replace B's advertised surfaces — 404, indistinguishable
+        # from an absent pairing (never reveal another add-on's existence).
+        impersonate = client.put(
+            "/api/v1/addons/pairings/other/capabilities", json=_decl_body(), headers=a
+        )
+        assert impersonate.status_code == 404, impersonate.text
+        assert impersonate.json()["detail"] == "addon_not_paired"
+
+        # An unrelated service subject is denied on A's own surface.
+        outsider = client.put(_CAPS_URL, json=_decl_body(), headers=stranger)
+        assert outsider.status_code == 404, outsider.text
+
+        # A's own declaration still succeeds.
+        own = client.put(_CAPS_URL, json=_decl_body(), headers=a)
+        assert own.status_code == 200, own.text
+        assert own.json()["addon"] == "automation"
+
+        # B's surfaces were never touched by A's impersonation attempt.
+        b_view = client.get("/api/v1/addons/pairings/other/capabilities", headers=admin)
+        assert b_view.status_code == 200, b_view.text
+        assert b_view.json()["capabilities"] == []

--- a/backend/tests/test_api_v1_addon_pairing.py
+++ b/backend/tests/test_api_v1_addon_pairing.py
@@ -95,19 +95,20 @@ def _token(
     )
 
 
-def _service_token(key: Any) -> str:
+def _service_token(key: Any, *, sub: str = "addon-svc") -> str:
     """A paired add-on's ``principal_kind=service`` / ``read_only`` token."""
-    return _token(key, sub="addon-svc", role=TenantRole.READ_ONLY, principal_kind="service")
+    return _token(key, sub=sub, role=TenantRole.READ_ONLY, principal_kind="service")
 
 
-def _mock_kc_ok() -> MagicMock:
+def _mock_kc_ok(*, sub: str = "addon-svc", internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
     mock_client = AsyncMock()
-    mock_client.create_client = AsyncMock(return_value=_KC_INTERNAL_ID)
+    mock_client.create_client = AsyncMock(return_value=internal_id)
     mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
-    # The service token below authenticates with sub="addon-svc"; the pair
-    # flow captures the same value as service_account_sub so the paired
-    # add-on's subscription binds to its own pairing (#3027).
-    mock_client.get_service_account_user_id = AsyncMock(return_value="addon-svc")
+    # The service token authenticates with sub="addon-svc"; the pair flow
+    # captures the same value as service_account_sub so the paired add-on's
+    # heartbeat / capability writes bind to its own pairing (#3025/#3026) and
+    # its step-event subscription binds to its own log (#3027).
+    mock_client.get_service_account_user_id = AsyncMock(return_value=sub)
     mock_client.delete_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
@@ -256,6 +257,54 @@ async def test_heartbeat_unpaired_is_404(client: TestClient) -> None:
         mock_discovery_and_jwks(r, public_jwks(key))
         resp = client.post("/api/v1/addons/pairings/ghost/heartbeat", headers=headers)
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_cannot_target_another_pairing(client: TestClient) -> None:
+    """Object-level authz: a paired service heartbeats only its OWN pairing.
+
+    Two paired add-ons share a tenant. Service A (bound to ``automation``)
+    cannot stamp ``other``'s liveness; an unrelated service subject is denied;
+    A's own heartbeat still succeeds.
+    """
+    await _seed_tenant()
+    key = make_rsa_keypair("kid-hb-authz")
+    admin = {"Authorization": f"Bearer {_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        with patch(_PATCH_TARGET, _mock_kc_ok(sub="addon-svc")):
+            client.post("/api/v1/addons/pairings", json=_pair_body(), headers=admin)
+        with patch(
+            _PATCH_TARGET,
+            _mock_kc_ok(sub="other-svc", internal_id="cc000000-0000-0000-0000-0000000beef1"),
+        ):
+            client.post(
+                "/api/v1/addons/pairings",
+                json={
+                    "name": "other",
+                    "addon_contract_version": BACKPLANE_CONTRACT_VERSION,
+                    "addon_min_backplane_version": BACKPLANE_CONTRACT_VERSION,
+                },
+                headers=admin,
+            )
+
+        a = {"Authorization": f"Bearer {_service_token(key, sub='addon-svc')}"}
+        stranger = {"Authorization": f"Bearer {_service_token(key, sub='stranger-svc')}"}
+
+        # A cannot stamp B's liveness — 404, indistinguishable from an absent
+        # pairing (never reveal another add-on's existence).
+        impersonate = client.post("/api/v1/addons/pairings/other/heartbeat", headers=a)
+        assert impersonate.status_code == 404, impersonate.text
+        assert impersonate.json()["detail"] == "addon_not_paired"
+
+        # An unrelated service subject is denied on A's own pairing.
+        outsider = client.post("/api/v1/addons/pairings/automation/heartbeat", headers=stranger)
+        assert outsider.status_code == 404, outsider.text
+
+        # A's own heartbeat still succeeds.
+        own = client.post("/api/v1/addons/pairings/automation/heartbeat", headers=a)
+        assert own.status_code == 200, own.text
+        assert own.json()["last_seen_at"] is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_automation_activation.py
+++ b/backend/tests/test_mcp_automation_activation.py
@@ -116,7 +116,9 @@ async def _declare_meta_tool_family(addon: str = _AUTOMATION_FAMILY) -> None:
             CapabilityDeclaration(kind=CapabilityKind.META_TOOL_FAMILY, name=_AUTOMATION_FAMILY),
         ],
     )
-    await AddonCapabilityService().declare(OPERATOR_TENANT_ID, addon, request)
+    await AddonCapabilityService().declare(
+        OPERATOR_TENANT_ID, addon, request, service_account_sub="svc-account-uuid"
+    )
 
 
 async def _drive_contract_incompatible(name: str = _AUTOMATION_FAMILY) -> None:

--- a/backend/tests/test_mcp_output_schema_conformance.py
+++ b/backend/tests/test_mcp_output_schema_conformance.py
@@ -678,6 +678,7 @@ async def test_meho_automation_list_conforms(
                 CapabilityDeclaration(kind=CapabilityKind.META_TOOL_FAMILY, name="automation"),
             ],
         ),
+        service_account_sub="svc-account-uuid",
     )
     payload = _assert_conforms("meho_automation_list", _call(client, "meho_automation_list", {}))
     assert [p["addon"] for p in payload["providers"]] == ["automation"]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10262,7 +10262,7 @@
           "addon-pairing"
         ],
         "summary": "Heartbeat Pairing",
-        "description": "Record an add-on liveness heartbeat (paired service principal only).\n\nThe paired add-on authenticates as its own service principal and stamps\n``last_seen_at``. A non-service principal is 403; an unpaired add-on is\n404. Audited via the audit middleware.",
+        "description": "Record an add-on liveness heartbeat (paired service principal only).\n\nThe paired add-on authenticates as its own service principal and stamps\n``last_seen_at``. A non-service principal is 403. The pairing is resolved\nby the caller's service-account ``sub`` and must be ``{name}``'s own\npairing, so a paired service cannot heartbeat another add-on's pairing; a\ncaller that owns no pairing named ``{name}`` is 404 (indistinguishable from\nan absent one). Audited via the audit middleware.",
         "operationId": "heartbeat_pairing_api_v1_addons_pairings__name__heartbeat_post",
         "parameters": [
           {
@@ -10391,7 +10391,7 @@
           "addon-pairing"
         ],
         "summary": "Declare Capabilities",
-        "description": "Declare an add-on's advertised surfaces (paired service principal only).\n\nThe paired add-on authenticates as its own **service** principal and\nreplaces its declaration wholesale. A non-service principal is 403; an\nunpaired add-on is 404; an unknown capability kind or a malformed /\nduplicate declaration is 422 (rejected by the request schema before this\nhandler runs). Audited via the audit middleware.",
+        "description": "Declare an add-on's advertised surfaces (paired service principal only).\n\nThe paired add-on authenticates as its own **service** principal and\nreplaces its declaration wholesale. A non-service principal is 403. The\npairing is resolved by the caller's service-account ``sub`` and must be\n``{name}``'s own pairing, so a paired service cannot replace another\nadd-on's advertised surfaces; a caller that owns no pairing named\n``{name}`` is 404 (indistinguishable from an absent one). An unknown\ncapability kind or a malformed / duplicate declaration is 422 (rejected by\nthe request schema before this handler runs). Audited via the audit\nmiddleware.",
         "operationId": "declare_capabilities_api_v1_addons_pairings__name__capabilities_put",
         "parameters": [
           {

--- a/docs/codebase/addon-pairing.md
+++ b/docs/codebase/addon-pairing.md
@@ -107,8 +107,13 @@ Routes (both under the `addon-pairing` tag):
 
 - `PUT /api/v1/addons/pairings/{name}/capabilities` — the paired add-on
   (authenticating as its **service** principal; a human principal is 403)
-  declares its complete surface set. 404 when unpaired; 422 on an unknown kind
-  or a duplicate declaration. Audited (`op_id=addon.capabilities.declare`).
+  declares its complete surface set. The pairing is resolved by the caller's
+  service-account `sub` (the shared `resolve_owned_pairing` guard), and `{name}`
+  must be that pairing's own name, so a paired service cannot replace another
+  add-on's surfaces; a caller owning no pairing named `{name}` is 404. 422 on an
+  unknown kind or a duplicate declaration. Audited
+  (`op_id=addon.capabilities.declare`). See **Object-level write authorization**
+  below.
 - `GET /api/v1/addons/pairings/{name}/capabilities` — an operator reads the
   declared surfaces + live activation state. 404 when absent / cross-tenant.
 
@@ -207,11 +212,41 @@ can still mint tokens), then hard-delete the row. Audited
 
 **Heartbeat** (`POST /api/v1/addons/pairings/{name}/heartbeat`): the paired
 add-on, authenticating as its own **service** principal (a human principal is
-403), stamps `last_seen_at`.
+403), stamps `last_seen_at`. The pairing is resolved by the caller's
+service-account `sub` (the shared `resolve_owned_pairing` guard) and `{name}`
+must be that pairing's own name, so one paired service cannot heartbeat
+another's pairing; a caller owning no pairing named `{name}` is 404
+(indistinguishable from an absent one). See **Object-level write authorization**
+below.
 
 **Health**: `build_health_response` calls `_pairing_health(tenant_id)`, which
 lists active pairings and maps each to a `PairingHealth`
 (`contract_compatible` recomputed live). Empty list when nothing is paired.
+
+## Object-level write authorization
+
+An add-on's **self-service writes** — the liveness heartbeat (#3025) and the
+capability declaration (#3026) — are the paired add-on's own action, so both
+authorize by the caller's identity, not by the `{name}` in the request path. A
+single shared guard, `operations/addon_pairing.resolve_owned_pairing`, resolves
+the pairing by `(tenant_id, service_account_sub)` — the Keycloak service-account
+`sub` captured at pair time — and requires the requested name to be that
+pairing's own name. `AddonPairingService.heartbeat` and
+`AddonCapabilityService.declare` both call it as the first statement inside
+their write transaction, so authorization and the mutation commit as one unit
+and a concurrent unpair cannot slip between the check and the write.
+
+The failure mode is deliberately non-revealing: a caller whose `sub` binds to no
+pairing (a non-add-on service principal, or a pre-#3027 pairing whose
+`service_account_sub` is `NULL` — which fails closed until it re-pairs) and a
+caller whose `sub` binds to a *different* pairing both raise `AddonNotPairedError`
+→ 404 `addon_not_paired`, indistinguishable from an absent add-on, so a paired
+service can neither act on another's pairing nor probe which names exist. This
+is the write-side counterpart of the step-event subscription bind
+(`resolve_pairing_for_sub`; see `addon-step-events.md`). Cross-tenant isolation
+is unchanged — the guard filters by the JWT-derived `tenant_id` — and the
+operator/admin pairing-management routes (`pair` / `unpair` / `list` / `show`)
+keep their separate role gates.
 
 ## Dependencies
 
@@ -229,15 +264,14 @@ lists active pairings and maps each to a `PairingHealth`
   Pairing management is REST + console; pairing health already flows to
   `meho status` via `/api/v1/health` and the `meho_status` MCP tool. Adding
   the Go verbs is a separate change (OpenAPI snapshot + oapi-codegen regen).
-- **Heartbeat principal binding** is coarse: it requires a `service`
-  principal in the pairing's tenant, matched by add-on name. A finer binding
-  (verifying the caller's client id against the pairing's
-  `keycloak_client_id`) is a hardening follow-up for the initiative's
-  security-review DoD item. Task #3027 added
-  `AddonPairing.service_account_sub` (the add-on's token `sub`, captured at
-  pair time), which enables exactly this check — heartbeat could verify
-  `operator.sub == service_account_sub` — though it is not yet wired here.
-  See `addon-step-events.md` for the step-event push contract that uses it.
+- **Heartbeat / capability-declare object-level binding is wired.** Both
+  self-service writes resolve the pairing by the caller's
+  `service_account_sub` and match the requested name via the shared
+  `resolve_owned_pairing` guard (see **Object-level write authorization**), so
+  a same-tenant service token can no longer heartbeat or re-declare another
+  paired add-on. A pre-#3027 pairing whose `service_account_sub` is `NULL`
+  fails closed (cannot self-serve until it re-pairs), matching the step-event
+  subscription's stance.
 - **Console is read-only**: pair / unpair are REST-only. Console write
   actions (a pair/unpair button behind CSRF) are a follow-up.
 - **Paired-surface activation (#3029) is the first real consumer of the


### PR DESCRIPTION
## Summary
- **Object-level authorization for add-on self-service writes (F11).** The
  liveness heartbeat and the capability declaration authorized only on
  `principal_kind == SERVICE`, then resolved the target pairing by the URL path
  `{name}`. Any valid **same-tenant** service token could heartbeat or replace
  the advertised surfaces of *another* paired add-on by naming it in the path.
- **One shared service-layer guard.** New `resolve_owned_pairing` (in
  `operations/addon_pairing.py`) resolves the pairing by
  `(tenant_id, service_account_sub)` — the Keycloak service-account `sub`
  captured at pair time — and requires `{name}` to be the caller's own pairing.
  Both `AddonPairingService.heartbeat` and `AddonCapabilityService.declare` call
  it as the first statement inside their write transaction, so authorization and
  the mutation commit atomically. This mirrors the step-event subscription bind
  (`resolve_pairing_for_sub`) the events endpoint already uses.
- **Non-revealing denial.** A caller whose `sub` binds to no pairing, or to a
  differently-named pairing, gets `404 addon_not_paired` — indistinguishable
  from an absent add-on, so a paired service can neither act on another's
  pairing nor probe which names exist.
- Regenerated `cli/api/openapi.json` for the two updated operation descriptions
  (`make snapshot-openapi`); `make generate` / `make cli-docs` produced no
  change to the Go client or the CLI reference.

## Acceptance criteria
- [x] **Use one shared mutation guard resolving pairing by tenant and
  service-account subject, then match the requested add-on name.** —
  `resolve_owned_pairing`, called by both `heartbeat` and `declare`.
- [x] **Paired service A cannot update B's heartbeat or replace B's
  capabilities within the same tenant.** — `test_heartbeat_cannot_target_another_pairing`
  and `test_declare_cannot_target_another_pairing` (both assert 404 and that B's
  surfaces are untouched).
- [x] **An unrelated service subject is denied, while A's own
  heartbeat/capability calls succeed.** — same two tests: a `stranger-svc`
  subject → 404; A's own call → 200.
- [x] **Existing cross-tenant boundaries and separately authorized
  operator/admin pairing-management rights remain intact.** — the guard filters
  by the JWT-derived `tenant_id` (unchanged); `pair` / `unpair` / `list` /
  `show` keep their role gates (existing `test_pair_requires_tenant_admin`, show
  operator-gating, etc. stay green).

None of these criteria were already met on `origin/main`: the security
containment PRs (#3423 / #3427) did not touch these files, and both writes still
resolved by path name on the base this branch was cut from.

## Test plan
- [x] `ruff check` — clean (changed modules)
- [x] `ruff format --check` — clean
- [x] `mypy src` (strict) — clean for changed files (the sole reported error,
  `connectors/net/icmp.py:205 MSG_ERRQUEUE`, is a pre-existing macOS-only
  platform artifact — `socket.MSG_ERRQUEUE` is Linux-only — in a file this PR
  does not touch)
- [x] `code-quality.py --diff` — 0 blockers (4 warnings: pre-existing
  `pair`/`unpair`/file-size in `addon_pairing.py`, plus `declare` at 63 lines
  inflated by the required docstring)
- [x] `pytest tests/test_addon_pairing_service.py tests/test_addon_capability_service.py tests/test_api_v1_addon_pairing.py tests/test_api_v1_addon_capability.py` — 39 passed
- [x] `pytest tests/test_mcp_automation_activation.py tests/test_addon_reference_double.py tests/test_addon_orchestration_linkage.py tests/test_addon_step_events.py` — 31 passed
- [x] `pytest tests/test_mcp_output_schema_conformance.py` — 23 passed
- [x] Full backend unit lane (`pytest tests`, excl. `integration`/`migrations`, `MEHO_SKIP_SPEC_INGEST_TESTS=1`, `-n 4 --dist loadscope`)
- [x] `make snapshot-openapi && make generate && make cli-docs` — only `cli/api/openapi.json` changed (drift gate satisfied)

## Out of scope
- Operator/admin pairing-management endpoints (separately authorized; read-only
  carve-out preserved).
- Cross-tenant isolation, which already held via `tenant_id` scoping.

## Notes for reviewers
- The `test_api_v1_addon_capability.py` KC mock previously returned
  `service_account_sub="svc-account-uuid"` while its service token carried
  `sub="addon-svc"` — an internal inconsistency that only passed because the old
  route ignored the sub. Aligned to `"addon-svc"` so a legitimate
  self-declaration binds. `test_addon_capability_service.py` now gives each
  pairing a distinct `_sub_for(name)` sub so per-name resolution is unambiguous.
- Pre-#3027 pairings whose `service_account_sub` is `NULL` now fail closed on
  these self-service writes (cannot heartbeat/declare until they re-pair),
  matching the step-event subscription's existing stance. Documented in
  `docs/codebase/addon-pairing.md`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#273
