### PR TITLE
fix(connectors): cap the dispatch-transport response body (S09 / #297)

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -83,6 +83,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
 import ssl
 from typing import Any
 
@@ -124,6 +125,30 @@ class SsrfBlockedError(httpx.ConnectError):
     dispatcher plumbing. Explicitly excluded from :func:`_retryable`:
     the rejection is deterministic policy, not a transient network
     failure, so retrying would only re-run the DNS lookup.
+    """
+
+
+class ResponseTooLargeError(Exception):
+    """Dispatch refused: a vendor response body exceeded the byte cap.
+
+    Raised by :func:`_read_capped_json_response` when a vendor response —
+    declared via ``Content-Length`` or measured while streaming — exceeds
+    :data:`_MAX_RESPONSE_BYTES`, *before* the body (or its parsed object
+    graph) is materialised. The shared generic-connector transport
+    otherwise buffers every vendor response fully into memory, so a single
+    oversized body — from a compromised/malicious appliance, a MITM on a
+    ``verify_tls=false`` channel, or a pathologically large legitimate
+    listing — could exhaust the single-replica pod's heap and OOM-kill it
+    (evoila-bosnia/meho-internal#297).
+
+    A plain :class:`Exception` (not an :class:`httpx.HTTPError`): it is a
+    policy rejection, not a transport fault, so it flattens through the
+    dispatcher's generic ``except Exception`` arm into the structured
+    ``connector_error`` shape carrying this message. Being outside the
+    ``httpx.ConnectError`` / ``httpx.HTTPStatusError`` families, it is
+    automatically excluded from :func:`_retryable` (a deterministic
+    over-cap verdict never resolves on replay), with no explicit exclusion
+    needed.
     """
 
 
@@ -304,6 +329,133 @@ def json_payload_or_empty(resp: httpx.Response) -> dict[str, Any]:
     if resp.status_code == httpx.codes.NO_CONTENT or not resp.content:
         return {}
     return resp.json()  # type: ignore[no-any-return]
+
+
+#: Default ceiling on a single vendor response body the shared dispatch
+#: transport will buffer, in bytes (100 MiB). Large enough for any realistic
+#: JSON listing — full vCenter inventory / event pulls are single-digit to
+#: low-tens of MiB, and set-shaped results are reduced to a handle *after*
+#: parse (JSONFlux, dispatcher step 8) — while bounding a multi-GB transfer
+#: from a compromised/malicious appliance, a ``verify_tls=false`` MITM, or a
+#: pathological legitimate listing that would otherwise OOM the
+#: single-replica pod (evoila-bosnia/meho-internal#297). Mirrors the
+#: streamed byte-cap idiom the spec-fetch (``openapi._MAX_SPEC_BYTES``) and
+#: event-ingest (``events_ingest._read_capped_body``) paths already enforce;
+#: this closes the same gap on the outbound-dispatch path.
+_DEFAULT_MAX_RESPONSE_BYTES = 100 * 1024 * 1024
+
+
+def _resolve_max_response_bytes() -> int:
+    """Resolve the response-body cap, honouring an operator env override.
+
+    ``MEHO_CONNECTOR_MAX_RESPONSE_BYTES`` (a positive integer byte count)
+    tunes the cap per deployment — a tighter-memory pod can lower it. An
+    unset, non-integer, or non-positive value falls back to
+    :data:`_DEFAULT_MAX_RESPONSE_BYTES` so a typo never silently disables
+    the guard.
+    """
+    raw = os.environ.get("MEHO_CONNECTOR_MAX_RESPONSE_BYTES")
+    if raw is None:
+        return _DEFAULT_MAX_RESPONSE_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_RESPONSE_BYTES
+    return value if value > 0 else _DEFAULT_MAX_RESPONSE_BYTES
+
+
+#: Resolved once at import; the streaming guard reads the module global by
+#: name at call time, so a test (or a reload after an env change) can rebind
+#: it to a small value without allocating a real over-cap body.
+_MAX_RESPONSE_BYTES = _resolve_max_response_bytes()
+
+
+def _reject_oversize_content_length(resp: httpx.Response) -> None:
+    """Fast-reject a response whose declared ``Content-Length`` exceeds the cap.
+
+    Fires before a single body byte is read, so an honest oversized
+    response costs nothing to refuse. A missing header falls through to the
+    streaming running-total guard (the real backstop against an absent,
+    understated, or content-encoded length); a malformed header is likewise
+    left to that guard rather than trusted.
+    """
+    declared = resp.headers.get("content-length")
+    if declared is None:
+        return
+    try:
+        length = int(declared)
+    except ValueError:
+        return
+    if length > _MAX_RESPONSE_BYTES:
+        raise ResponseTooLargeError(
+            f"vendor response Content-Length {length} exceeds the "
+            f"{_MAX_RESPONSE_BYTES}-byte response-body cap"
+        )
+
+
+async def _read_capped_json_response(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    extensions: dict[str, Any] | None = None,
+    timeout: Any = httpx.USE_CLIENT_DEFAULT,
+) -> httpx.Response:
+    """Issue the request with a streamed, byte-capped read of the response.
+
+    Shared success-path front for :meth:`HttpConnector._request_json` and
+    :meth:`HttpConnector._post_json`. The default non-streaming
+    ``client.request(...)`` buffers the whole vendor body into memory before
+    the caller can inspect its size; this streams instead
+    (:meth:`httpx.AsyncClient.stream` -> the pooled
+    :class:`_SameOriginRedirectClient`'s ``send`` override, so the
+    same-origin redirect and destination-pinning transport behaviour is
+    unchanged) and enforces a two-part cap: a ``Content-Length`` fast-reject
+    up front, then a running byte total across
+    :meth:`~httpx.Response.aiter_bytes` chunks that aborts the moment the
+    body would exceed :data:`_MAX_RESPONSE_BYTES`. At most the cap (plus one
+    trailing chunk) is ever held in memory, and an over-cap body raises
+    :exc:`ResponseTooLargeError` before :func:`json_payload_or_empty` can
+    parse it.
+
+    An under-cap body is joined and re-materialised into a fully-read
+    :class:`httpx.Response` carrying the original status, headers, request,
+    and extensions, so every downstream step — the flight-recorder span,
+    ``raise_for_status``, and ``json_payload_or_empty`` — sees a response
+    byte-identical to the non-streamed path.
+    """
+    async with client.stream(
+        method,
+        path,
+        params=params,
+        json=json,
+        data=data,
+        headers=headers,
+        extensions=extensions,
+        timeout=timeout,
+    ) as resp:
+        _reject_oversize_content_length(resp)
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes():
+            total += len(chunk)
+            if total > _MAX_RESPONSE_BYTES:
+                raise ResponseTooLargeError(
+                    f"vendor response body exceeded the "
+                    f"{_MAX_RESPONSE_BYTES}-byte response-body cap"
+                )
+            chunks.append(chunk)
+        return httpx.Response(
+            status_code=resp.status_code,
+            headers=resp.headers,
+            content=b"".join(chunks),
+            request=resp.request,
+            extensions=resp.extensions,
+        )
 
 
 # Hard cap on the same-origin redirect chain followed by
@@ -766,7 +918,8 @@ class HttpConnector(Connector):
         # span is recorded before ``raise_for_status`` so a vendor 4xx/5xx is
         # captured too.
         _fr_start = flight_recorder_capture.span_start()
-        resp = await client.request(
+        resp = await _read_capped_json_response(
+            client,
             method,
             path,
             params=params,
@@ -873,7 +1026,8 @@ class HttpConnector(Connector):
         # its matching content-type; a hard-excluded (login / token / DELETE)
         # op has its body dropped by the redaction engine's family rules.
         _fr_start = flight_recorder_capture.span_start()
-        resp = await client.request(
+        resp = await _read_capped_json_response(
+            client,
             verb,
             path,
             params=params,

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -74,12 +74,16 @@ from cryptography.x509.oid import NameOID
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors._shared.pinned_transport import _PinnedAsyncBackend
 from meho_backplane.connectors.adapters import HttpConnector
+from meho_backplane.connectors.adapters import http as http_adapter
 from meho_backplane.connectors.adapters.http import HttpConnector as _HttpConnectorDirect
 from meho_backplane.connectors.adapters.http import (
+    ResponseTooLargeError,
     SsrfBlockedError,
     _build_ca_pinned_ssl_context,
     _ca_pin_digest,
     _effective_scheme,
+    _resolve_max_response_bytes,
+    _retryable,
     _same_origin,
     _SameOriginRedirectClient,
 )
@@ -609,6 +613,207 @@ async def test_request_json_204_no_content_returns_empty_payload() -> None:
         )
 
     assert result == {}
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Response-body byte cap — reject oversize before buffer+parse
+# (evoila-bosnia/meho-internal#297)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_max_response_bytes_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cap honours a positive env override and fails safe on garbage."""
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "4096")
+    assert _resolve_max_response_bytes() == 4096
+
+    # Non-integer and non-positive values fall back to the default, so a
+    # typo never silently disables the guard.
+    default = http_adapter._DEFAULT_MAX_RESPONSE_BYTES
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "not-a-number")
+    assert _resolve_max_response_bytes() == default
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "0")
+    assert _resolve_max_response_bytes() == default
+    monkeypatch.delenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", raising=False)
+    assert _resolve_max_response_bytes() == default
+
+
+def test_oversize_error_is_connector_error_shaped_and_not_retryable() -> None:
+    """The cap error flattens to ``connector_error`` and is never retried.
+
+    It is a plain :class:`Exception` — outside the ``httpx.ConnectError`` /
+    ``httpx.HTTPStatusError`` families the dispatcher special-cases — so it
+    falls through to the generic ``except Exception`` arm that builds the
+    structured ``connector_error`` envelope. Being outside those families
+    also keeps it out of :func:`_retryable`, so a deterministic over-cap
+    verdict does not burn the idempotent-path tenacity budget.
+    """
+    err = ResponseTooLargeError("too big")
+    assert not isinstance(err, (httpx.ConnectError, httpx.HTTPStatusError))
+    assert _retryable(err) is False
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_oversize_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GET body over the cap is rejected before it is ever ``resp.json()``-parsed.
+
+    The body is deliberately **invalid** JSON: if the transport buffered and
+    parsed it (the pre-#297 behaviour), the call would surface a
+    :exc:`json.JSONDecodeError`, not :exc:`ResponseTooLargeError`. Asserting
+    the cap error is raised proves the body was refused before the parse.
+    Here the over-cap size is declared via ``Content-Length``, so the
+    fast-reject arm fires.
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize_invalid_json = b"{ not valid json " + b"x" * 4096
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.get("/api/inventory").respond(
+            200,
+            content=oversize_invalid_json,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError) as exc_info:
+            await conn._request_json(
+                target, "GET", "/api/inventory", operator=_make_operator("tok")
+            )
+
+    assert "cap" in str(exc_info.value)
+    assert "Content-Length" in str(exc_info.value)
+    assert route.called
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_oversize_response_without_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversize body with no ``Content-Length`` is caught by the streamed total.
+
+    An absent (or understated / content-encoded) length header cannot smuggle
+    an oversize body past the guard: the running byte total across
+    ``aiter_bytes`` chunks aborts once the cap is exceeded, before the whole
+    body is buffered.
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize = b'{"items": "' + b"y" * 4096 + b'"}'
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        # A ``ByteStream`` response has no ``Content-Length`` header, so the
+        # fast-reject arm is skipped and the streaming running-total guard is
+        # the one exercised here.
+        mock.get("/api/events").respond(
+            200,
+            stream=httpx.ByteStream(oversize),
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError) as exc_info:
+            await conn._request_json(target, "GET", "/api/events", operator=_make_operator("tok"))
+
+    assert "Content-Length" not in str(exc_info.value)
+    assert "cap" in str(exc_info.value)
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_oversize_response_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The idempotent path does not retry an over-cap rejection — exactly one call.
+
+    The cap verdict is deterministic, so — like the 4xx and SSRF-block arms —
+    it must not consume the tenacity retry budget (which would re-transfer the
+    oversize body three more times).
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.get("/api/inventory").respond(
+            200,
+            content=b"x" * 4096,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError):
+            await conn._request_json(
+                target, "GET", "/api/inventory", operator=_make_operator("tok")
+            )
+
+    assert route.call_count == 1
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_under_cap_returns_parsed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An under-cap JSON response parses to its payload unchanged (regression guard)."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.get("/api/items").respond(200, json={"items": [1, 2, 3]})
+        result = await conn._request_json(
+            target, "GET", "/api/items", operator=_make_operator("tok")
+        )
+
+    assert result == {"items": [1, 2, 3]}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_rejects_oversize_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-idempotent path enforces the same cap as ``_request_json``."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize_invalid_json = b"{ not valid json " + b"z" * 4096
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.post("/api/sessions").respond(
+            200,
+            content=oversize_invalid_json,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError):
+            await conn._post_json(
+                target,
+                "/api/sessions",
+                operator=_make_operator("tok"),
+                json={"provider": "Local"},
+            )
+
+    assert route.called
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_under_cap_returns_parsed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An under-cap non-idempotent response parses unchanged (regression guard)."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.post("/api/widget").respond(200, json={"value": "vm-42"})
+        result = await conn._post_json(
+            target, "/api/widget", operator=_make_operator("tok"), json={"n": 1}
+        )
+
+    assert result == {"value": "vm-42"}
     await conn.aclose()
 
 


### PR DESCRIPTION
## Summary
- The shared generic-connector transport buffered every vendor response fully into memory before checking its size: both `_request_json` and `_post_json` called `client.request(...)` in default non-streaming mode, so httpx read the whole body and `json_payload_or_empty` then expanded it again into a Python object graph. The pooled client carried only an `httpx.Timeout` — no size guard — so one oversized body could OOM-kill the single-replica pod (S09, evoila-bosnia/meho-internal#297).
- Add a configurable response-body byte cap on the outbound-dispatch path, mirroring the streamed idiom the spec-fetch (`openapi._MAX_SPEC_BYTES`) and event-ingest (`events_ingest._read_capped_body`) paths already enforce. New `_read_capped_json_response` streams via `client.stream(...)` (through the same `_SameOriginRedirectClient.send` override, so same-origin-redirect + destination-pinning behaviour is unchanged), does a `Content-Length` fast-reject, then a running byte total across `aiter_bytes()` that aborts before the body is materialised.
- Over-cap bodies raise `ResponseTooLargeError` — a plain `Exception` that flattens through the dispatcher's generic arm into a structured `connector_error` and, being outside the `httpx.ConnectError` / `httpx.HTTPStatusError` families, stays out of the idempotent-path retry budget (deterministic verdict, never retried).
- Under-cap responses are re-materialised into a fully-read `httpx.Response` (same status/headers/request/extensions), so the flight-recorder span, `raise_for_status`, and `json_payload_or_empty` are **byte-identical** to the previous non-streamed path. Default cap 100 MiB, tunable via `MEHO_CONNECTOR_MAX_RESPONSE_BYTES`. Scoped to the two dispatch seams; the deliberate streaming binary paths (`library_download.py`, `net/http_probe.py`) are untouched.

## Already met on main (drift check)
- The sibling SSRF destination-binding hardening (#275 / F13) on this same file — `SsrfBlockedError`, `build_pinned_async_transport`, the connect-time re-screen — had already landed. This PR builds on that: `_read_capped_json_response` streams **through** the pinned transport unchanged, so the two hardenings compose (one bounds *where* a connection may go, this bounds *how much* it may buffer). No other acceptance criterion of #297 was already present — the outbound-dispatch byte cap was still absent.

## Test plan
- [x] `ruff check src/meho_backplane/connectors/adapters/http.py tests/test_connectors_http_adapter.py` — clean (whole-tree `ruff check` + `ruff format --check` also clean)
- [x] `mypy src/meho_backplane/connectors/adapters/http.py` — clean
- [x] `pytest tests/test_connectors_http_adapter.py tests/test_operations_dispatcher.py -q` — 146 passed
- [x] AC grep — `grep -nE "_MAX_RESPONSE_BYTES|content-length|iter_bytes|client.stream" …/http.py` shows the module-level cap constant, the `Content-Length` reject, and the streamed running-total guard
- [x] New `test_request_json_rejects_oversize_response` returns an over-cap **invalid-JSON** body via respx and asserts `ResponseTooLargeError` — proving the body is refused before `resp.json()` would have raised `JSONDecodeError`
- [x] New tests cover the no-`Content-Length` streaming-guard path, the not-retried invariant, `_post_json` oversize, and under-cap regression guards on both seams (parsed payload unchanged), plus `MEHO_CONNECTOR_MAX_RESPONSE_BYTES` env parsing
- [x] `code-quality.py --diff` — exit 0
- [x] Full backend unit lane run (`tests/` minus `integration/`+`migrations/`, `-n auto`): the only failures were in unrelated modules and are environmental/concurrency (approvals-BFF tests pass in isolation; `net` ICMP/DNS raw-socket tests; `test_chart_mcp_resource_uri` fails because the local box has **Helm v4** and the chart renders under Helm 3). My diff touches zero chart/net/approvals files.

## Docs
- No dedicated `docs/codebase/` artifact exists for the shared HTTP-adapter transport internals (its sibling SSRF hardening #275 added none either); the change is documented in-code via docstrings on the cap constant, `ResponseTooLargeError`, `_reject_oversize_content_length`, and `_read_capped_json_response`, matching the `_MAX_SPEC_BYTES` precedent. Docs verified — nothing invalidated.

## Out of scope
- SSRF destination-binding (#275 / F13); spec-ingest / inbound-MCP / event-ingest caps (already present); per-tenant response-quota / rate-limit design; chart-side memory tuning (this fix is app-layer and holds regardless of the pod limit).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#297
