### PR TITLE
ci(image): scan before publish; promote only the approved digest (F15b / #284)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,12 +5,13 @@
 #
 # Locked tag scheme (Goal #11 — artefact-distribution principle):
 #   PR (branch -> main)   : build only, do NOT push (verifies Dockerfile + deps).
-#   push to main          : push :<git-sha> (immutable) + :main (moving target).
-#   push tag v*           : push :v<x.y.z> (alongside :<sha> + :main from main push).
+#   push to main          : publish :<git-sha> (immutable) + :main (moving target).
+#   push tag v*           : publish :v<x.y.z> (alongside :<sha> + :main from main push).
 #
 # Goal #11 explicitly forbids :latest as a deploy target — operators MUST pin
-# to :<git-sha> (immutable) or :v<x.y.z> (semver, immutable). metadata-action
-# is configured to never emit a "latest" tag for that reason.
+# to :<git-sha> (immutable), :v<x.y.z> (semver, immutable), or the manifest
+# digest. metadata-action is configured to never emit a "latest" tag for that
+# reason.
 #
 # Multi-arch (linux/amd64 + linux/arm64) is mandatory per Initiative #31 DoD;
 # the Dockerfile is digest-pinned and multi-arch ready (PR #163 / Task #32).
@@ -26,6 +27,20 @@
 # (or via the GHCR UI). The workflow can't do this safely from CI — visibility
 # is org-scoped and changing it from a workflow would require a PAT with
 # org admin scope. README.md documents the one-time step.
+#
+# Scan-before-publish gate (#284 / F15b — supply-chain promotion ordering):
+#   The build pushes the manifest list to GHCR BY DIGEST ONLY (push-by-digest,
+#   no tag), so on a push event nothing yet advertises the freshly-built bytes
+#   as a release. The trivy vulnerability scan then runs against that
+#   quarantine digest as a GATE (exit-code 1 on a fixable CRITICAL/HIGH). Only
+#   when the scan passes does the promote step apply the release aliases
+#   (:sha-<sha>, :main, :v<x.y.z>) to the EXACT approved digest, and only then
+#   do cosign sign + SBOM + cosign attest run. A failing scan therefore leaves
+#   an untagged, unsigned, unattested manifest that no release alias points at
+#   (registry retention GC reclaims it) — it can never leave an artifact
+#   advertised as an approved release. Every step downstream of the trivy gate
+#   carries the implicit success() guard, so a red scan skips promote/sign/
+#   attest while the SARIF-upload steps still publish the CVE list.
 #
 # Cosign keyless signing (Task #34, ADR 0006):
 #   - id-token: write (granted in the permissions block) lets the runner mint
@@ -46,18 +61,18 @@
 #
 # Supply-chain attestations (Task #35):
 #   - provenance + sbom on build-push-action emit small inline OCI annotations
-#     into the manifest; the richer syft SBOM attestation + trivy scan run as
-#     additional steps on this same job, after the sign step below.
-#   - anchore/sbom-action invokes syft against the pushed manifest-list digest
-#     and writes SPDX JSON; cosign then packages the SBOM as a Sigstore
+#     into the manifest at build time; the richer syft SBOM attestation runs
+#     as an additional step on this same job, after the scan gate + sign below.
+#   - anchore/sbom-action invokes syft against the approved manifest-list
+#     digest and writes SPDX JSON; cosign then packages the SBOM as a Sigstore
 #     attestation signed under the same keyless identity as the image. The
 #     attestation is content-addressed (bound to the digest, not a tag) so
 #     verification works for every tag alias.
-#   - aquasecurity/trivy-action scans the same digest for CVEs and emits SARIF.
-#     It runs post-push on main/tags with `exit-code: '1'`, so a CRITICAL/HIGH
-#     fixed CVE fails the run as a red-main alarm against silent CVE
-#     accumulation on a stale base image (it is not a PR merge gate — the step
-#     is skipped on pull_request). SARIF results land both on the GitHub
+#   - aquasecurity/trivy-action scans the quarantine digest for CVEs and emits
+#     SARIF. It runs BEFORE publish/sign/attest on main/tags with
+#     `exit-code: '1'`, so a fixable CRITICAL/HIGH CVE fails the run and gates
+#     promotion (it is not a PR merge gate — the step is skipped on
+#     pull_request, which never pushes). SARIF results land both on the GitHub
 #     Security tab (Code scanning alerts) and as a 30-day workflow artefact —
 #     and, because the two upload steps are guarded on the scan step's outcome
 #     (not the default success() gate), they publish even when the scan FAILS,
@@ -137,6 +152,11 @@ jobs:
           #   type=raw,value=main           -> :main         (main push only)
           #   type=semver,pattern={{raw}}   -> :v<x.y.z>     (v* tag push only)
           # NO type=raw,value=latest — Goal #11 forbids :latest as deploy target.
+          #
+          # These tags are NOT fed to the build step: the build pushes by
+          # digest only (quarantine). The promote step applies them to the
+          # approved digest AFTER the trivy gate via `imagetools create`, so
+          # a release alias never advertises an unscanned digest (#284).
           tags: |
             type=sha,format=long
             type=raw,value=main,enable={{is_default_branch}}
@@ -147,7 +167,7 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Build (and conditionally push) image
+      - name: Build image to quarantine digest (no release tag)
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
@@ -156,10 +176,17 @@ jobs:
           # covering amd64 + arm64. Dockerfile is digest-pinned so the base
           # image resolves per-arch automatically.
           platforms: linux/amd64,linux/arm64
-          # PRs build only (verifies Dockerfile + dep resolution).
-          # Main pushes and v* tag pushes go live.
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          # Quarantine push (#284 / F15b). On push events, publish the
+          # manifest list to GHCR BY DIGEST ONLY — `push-by-digest=true`
+          # writes the blobs and the index but creates NO tag, so nothing yet
+          # advertises these bytes as a release. `steps.build.outputs.digest`
+          # is the manifest-list digest the scan + promote + sign + attest
+          # steps below all reference. On PRs `push=false` keeps the old
+          # build-only verification (no registry write). Replaces the former
+          # `push:` + `tags:` inputs: those pushed the release aliases at build
+          # time, before the scan, which is exactly the ordering this task
+          # removes.
+          outputs: type=image,name=ghcr.io/evoila/meho,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           # Build-identity stamps surfaced via GET /version (#631). The
           # Dockerfile already declares `ARG GIT_SHA` / `ARG BUILD_DATE`
@@ -179,15 +206,133 @@ jobs:
           cache-to: type=gha,mode=max
           # Inline OCI provenance + SBOM annotations on the manifest. These
           # are buildkit-native, cheap, and complement (do not replace) the
-          # cosign attestations landing in Task #35.
+          # cosign attestations landing in Task #35. push-by-digest carries
+          # them into the pushed index, so the promote step's manifest-level
+          # carbon-copy preserves them under every release alias.
           provenance: true
           sbom: true
 
-      - name: Echo pushed digest
-        # Surfaces the immutable manifest-list digest in workflow logs.
-        # The cosign sign step below signs by exactly this digest.
+      - name: Echo and guard the quarantine digest
+        # Surfaces the immutable manifest-list digest in workflow logs and
+        # fails loud if the build produced no digest on a push event. The
+        # scan / promote / sign / attest steps all key off this exact digest;
+        # an empty value would silently no-op the gate (e.g. if a future
+        # buildx change stopped emitting the digest for push-by-digest), so
+        # catching it here keeps the pipeline fail-closed rather than shipping
+        # an unscanned, unsigned image.
         if: github.event_name != 'pull_request'
-        run: echo "Pushed digest=${{ steps.build.outputs.digest }}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build produced no manifest digest — cannot scan/promote/sign. Aborting." >&2
+            exit 1
+          fi
+          echo "Quarantine digest=${DIGEST}"
+
+      - name: Vulnerability scan (trivy — gates promotion on fixable CRITICAL/HIGH)
+        id: trivy
+        # trivy scans the quarantine digest (OS packages + language deps,
+        # including the uv-installed Python wheels in /app/.venv) BEFORE any
+        # release alias, signature or attestation exists. Emits SARIF for
+        # upload to the GitHub Security tab.
+        #
+        #   - `severity: CRITICAL,HIGH` restricts the scan to the levels that
+        #     actually matter. `limit-severities-for-sarif: true` makes the
+        #     SARIF honour that filter — without it the trivy-action emits
+        #     ALL severities into SARIF regardless of `severity` (its
+        #     documented default), which is why the Security tab previously
+        #     showed LOW/MEDIUM alerts the `severity` input was meant to drop.
+        #   - `exit-code: '1'` makes the step FAIL when a fixable CRITICAL/HIGH
+        #     CVE is present. This is the PROMOTION GATE (#284 / F15b): the
+        #     promote / sign / attest steps below all carry the implicit
+        #     success() guard, so a red scan skips them and the scanned digest
+        #     is never tagged as a release, signed, or attested. It is NOT a
+        #     PR merge gate — the `if:` below skips it on pull_request, which
+        #     never pushes an image to scan. A red run means "the base image
+        #     drifted; bump the digest (Dependabot docker PR) and re-run", and
+        #     the failed build ships nothing.
+        #   - `ignore-unfixed: true` drops CVEs with no upstream fix
+        #     available, which would otherwise dominate the SARIF without
+        #     any operator action to take.
+        if: github.event_name != 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ghcr.io/evoila/meho@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload trivy SARIF to GitHub Security tab
+        # SARIF upload surfaces findings under repo -> Security -> Code
+        # scanning alerts. Requires `security-events: write` at the job or
+        # workflow level — granted in the top-level permissions block.
+        #
+        # Publish on a FAILED scan too — a red scan is exactly when the CVE
+        # list must reach the Security tab — but stay skipped when the scan
+        # step was SKIPPED (the pull_request path, where it never ran). A bare
+        # `if:` is implicitly success()-gated, so the previous condition
+        # dropped this upload on every red scan; the explicit `!cancelled()`
+        # opts out of that default and the outcome check restores the PR skip.
+        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
+        with:
+          sarif_file: trivy-results.sarif
+          # Category disambiguates this run when other SARIF sources (e.g.
+          # CodeQL itself) upload to the same repo; without it the upload
+          # would overwrite siblings.
+          category: trivy-image-scan
+
+      - name: Upload trivy SARIF as workflow artefact
+        # Mirrors the SARIF upload as a downloadable artefact (30-day
+        # retention) so operators can pull it via `gh run download` without
+        # needing Security-tab access. Same fail-visible guard as the
+        # Security-tab upload above: publishes on a red scan, skips on the
+        # pull_request path where the scan step never ran.
+        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: trivy-results
+          path: trivy-results.sarif
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Promote approved digest to release tags
+        # The trivy gate above passed (a failed scan makes success() false and
+        # skips this step), so the scanned digest is approved. Apply the
+        # release aliases computed by docker/metadata-action
+        # (:sha-<sha>, :main, :v<x.y.z> — event-appropriate) to the EXACT
+        # approved digest with a manifest-level carbon-copy: `imagetools
+        # create` from a single index source re-references the existing bytes
+        # (no rebuild, no blob re-push, same digest), and preserves the
+        # multi-arch children and the inline provenance/SBOM attestations. The
+        # release aliases and the signature/attestation below therefore all
+        # bind the same bytes trivy scanned (#284 / F15b).
+        #
+        # DOCKER_METADATA_OUTPUT_JSON is exported to the job env by the meta
+        # step; reading the tags from it (rather than interpolating a
+        # `${{ }}` value into the shell) keeps the run block free of
+        # expression-injected content.
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          readarray -t tags < <(jq -r '.tags[]' <<< "${DOCKER_METADATA_OUTPUT_JSON}")
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "::error::metadata-action produced no tags to promote." >&2
+            exit 1
+          fi
+          args=()
+          for t in "${tags[@]}"; do args+=(--tag "$t"); done
+          echo "Promoting ghcr.io/evoila/meho@${DIGEST} -> ${tags[*]}"
+          docker buildx imagetools create "${args[@]}" "ghcr.io/evoila/meho@${DIGEST}"
 
       - name: Ensure envsubst (gettext-base) — cosign-installer dep
         # See chart.yml for context. Same PR-skip gate as the cosign step
@@ -225,10 +370,12 @@ jobs:
         # --yes is the non-interactive confirmation (CI has no TTY); it replaces
         # the deprecated COSIGN_EXPERIMENTAL=1 of the cosign-1.x era.
         #
-        # We sign the manifest-list digest, not any tag. For multi-arch builds
-        # docker/build-push-action's `digest` output IS the manifest-list digest,
-        # so this one invocation covers every per-arch child manifest and every
-        # tag alias pointing at this digest (`:sha-<long>`, `:main`, `:v<x.y.z>`).
+        # We sign the manifest-list digest, not any tag — the same approved
+        # digest trivy scanned and the promote step tagged. For multi-arch
+        # builds docker/build-push-action's `digest` output IS the manifest-
+        # list digest, so this one invocation covers every per-arch child
+        # manifest and every tag alias pointing at this digest (`:sha-<long>`,
+        # `:main`, `:v<x.y.z>`).
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -279,70 +426,3 @@ jobs:
             --predicate sbom.spdx.json \
             --type spdxjson \
             "ghcr.io/evoila/meho@${DIGEST}"
-
-      - name: Vulnerability scan (trivy — fails on fixable CRITICAL/HIGH)
-        id: trivy
-        # trivy scans the pushed image (OS packages + language deps,
-        # including the uv-installed Python wheels in /app/.venv). Emits
-        # SARIF for upload to the GitHub Security tab.
-        #
-        #   - `severity: CRITICAL,HIGH` restricts the scan to the levels that
-        #     actually matter. `limit-severities-for-sarif: true` makes the
-        #     SARIF honour that filter — without it the trivy-action emits
-        #     ALL severities into SARIF regardless of `severity` (its
-        #     documented default), which is why the Security tab previously
-        #     showed LOW/MEDIUM alerts the `severity` input was meant to drop.
-        #   - `exit-code: '1'` makes the step FAIL when a CRITICAL/HIGH fixed
-        #     CVE is present. This scan runs POST-PUSH on main/tags against the
-        #     already-pushed digest — it is a red-main alarm against silent
-        #     CVE accumulation on a stale base image, NOT a PR merge gate (the
-        #     `if:` below skips it on pull_request). A red run means "the base
-        #     image drifted; bump the digest (Dependabot docker PR) and
-        #     re-push", not "this merge is blocked".
-        #   - `ignore-unfixed: true` drops CVEs with no upstream fix
-        #     available, which would otherwise dominate the SARIF without
-        #     any operator action to take.
-        if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          image-ref: ghcr.io/evoila/meho@${{ steps.build.outputs.digest }}
-          format: sarif
-          output: trivy-results.sarif
-          severity: CRITICAL,HIGH
-          limit-severities-for-sarif: true
-          ignore-unfixed: true
-          exit-code: '1'
-
-      - name: Upload trivy SARIF to GitHub Security tab
-        # SARIF upload surfaces findings under repo -> Security -> Code
-        # scanning alerts. Requires `security-events: write` at the job or
-        # workflow level — granted in the top-level permissions block.
-        #
-        # Publish on a FAILED scan too — a red scan is exactly when the CVE
-        # list must reach the Security tab — but stay skipped when the scan
-        # step was SKIPPED (the pull_request path, where it never ran). A bare
-        # `if:` is implicitly success()-gated, so the previous condition
-        # dropped this upload on every red scan; the explicit `!cancelled()`
-        # opts out of that default and the outcome check restores the PR skip.
-        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
-        with:
-          sarif_file: trivy-results.sarif
-          # Category disambiguates this run when other SARIF sources (e.g.
-          # CodeQL itself) upload to the same repo; without it the upload
-          # would overwrite siblings.
-          category: trivy-image-scan
-
-      - name: Upload trivy SARIF as workflow artefact
-        # Mirrors the SARIF upload as a downloadable artefact (30-day
-        # retention) so operators can pull it via `gh run download` without
-        # needing Security-tab access. Same fail-visible guard as the
-        # Security-tab upload above: publishes on a red scan, skips on the
-        # pull_request path where the scan step never ran.
-        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: trivy-results
-          path: trivy-results.sarif
-          retention-days: 30
-          if-no-files-found: error

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -46,6 +46,32 @@ jobs:
     name: TruffleHog Secret Scan
     runs-on: meho-runners-ci
     timeout-minutes: 10
+    env:
+      # Scanner container image, pinned by digest (#284 / F15b). The
+      # trufflesecurity/trufflehog action shells out to
+      # `docker run "${IMAGE}:${VERSION}"`, defaulting VERSION to the mutable
+      # `:latest` tag — a supply-chain gap: the required secret-scan gate would
+      # run whatever `:latest` resolves to at pull time, on the self-hosted
+      # meho-runners-ci pool. Keeping the tag+digest in TRUFFLEHOG_VERSION makes
+      # `${IMAGE}:${VERSION}` resolve to
+      # `ghcr.io/trufflesecurity/trufflehog:3.97.1@sha256:<digest>` — a
+      # digest-pinned reference (the `:3.97.1` tag is informational; docker
+      # resolves the `@sha256:` digest). Both the warm-cache step and the scan
+      # action below read these two vars, so they provably reference the SAME
+      # image and `docker run`'s default `--pull missing` finds the warmed
+      # image locally by digest.
+      #
+      # Refresh: the action `uses:` SHA below is bumped weekly by Dependabot
+      # (github-actions ecosystem). Dependabot does not resolve a digest held
+      # in a `with:`/`env:` value (dependabot-core#2057), so bump
+      # TRUFFLEHOG_VERSION in the SAME PR that bumps the action pin — keeping
+      # the scanner image and the action version in lockstep. Resolve the new
+      # digest with:
+      #   docker buildx imagetools inspect \
+      #     ghcr.io/trufflesecurity/trufflehog:<new-version> \
+      #     --format '{{ .Manifest.Digest }}'
+      TRUFFLEHOG_IMAGE: ghcr.io/trufflesecurity/trufflehog
+      TRUFFLEHOG_VERSION: 3.97.1@sha256:deb2af10659a488a14d262a323addcde099d99827a1cf1dc4e93c17915c39f08
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -53,29 +79,30 @@ jobs:
           fetch-depth: 0
 
       - name: Warm the TruffleHog image cache
-        # The trufflesecurity/trufflehog action runs the scan by shelling
-        # out to `docker run ghcr.io/trufflesecurity/trufflehog:latest`
-        # (its action.yml, pinned at the SHA on the scan step below, ends in
-        # `docker run ... "${IMAGE}:${VERSION}"` with those two defaults).
-        # `docker run`'s default `--pull missing` policy means that when the
-        # image is ALREADY in the local daemon no registry round-trip
-        # happens — so pre-pulling it here, with bounded exponential
-        # backoff, turns a transient ghcr.io TLS-handshake timeout under
-        # concurrent CI load (#3310 — the same shared-runner-egress class as
-        # the codeload 429s the action-archive cache already addressed) into
-        # a short delay instead of an exit-125 failure that ejects the PR
-        # from the merge queue on this required check.
+        # The trufflesecurity/trufflehog action runs the scan by shelling out
+        # to `docker run ... "${IMAGE}:${VERSION}"` (its action.yml, pinned at
+        # the SHA on the scan step below). We feed it the digest-pinned
+        # reference from the job `env:` block above (#284 / F15b) instead of
+        # the mutable `:latest` default. `docker run`'s default `--pull
+        # missing` policy means that when the image is ALREADY in the local
+        # daemon no registry round-trip happens — so pre-pulling it here, with
+        # bounded exponential backoff, turns a transient ghcr.io TLS-handshake
+        # timeout under concurrent CI load (#3310 — the same shared-runner-
+        # egress class as the codeload 429s the action-archive cache already
+        # addressed) into a short delay instead of an exit-125 failure that
+        # ejects the PR from the merge queue on this required check.
         #
         # This does NOT weaken the gate: the scan step below is unchanged
         # and still runs `--results=verified,unknown --fail` against the
         # same base..head range on every push, PR and merge_group ref
         # (#3308). This step only isolates the flaky part (the network pull)
         # from the deterministic part (the scan) and retries the pull. The
-        # `image:tag` here must match the action's `${IMAGE}:${VERSION}`
-        # defaults exactly, or the subsequent `docker run` misses the warm
-        # image and pulls again.
+        # `IMAGE` here is `${TRUFFLEHOG_IMAGE}:${TRUFFLEHOG_VERSION}` — exactly
+        # the `${IMAGE}:${VERSION}` the action's `docker run` builds from the
+        # same two vars — so the warm image matches by digest and the
+        # subsequent `docker run` does not pull again.
         env:
-          IMAGE: ghcr.io/trufflesecurity/trufflehog:latest
+          IMAGE: ${{ env.TRUFFLEHOG_IMAGE }}:${{ env.TRUFFLEHOG_VERSION }}
         shell: bash
         run: |
           set -euo pipefail
@@ -104,6 +131,14 @@ jobs:
       - name: TruffleHog Scan
         uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b  # v3.97.1
         with:
+          # Pin the scanner container image by digest (#284 / F15b). The action
+          # runs `docker run "${image}:${version}"`; supplying the digest in
+          # `version` makes that reference resolve to the immutable
+          # `ghcr.io/trufflesecurity/trufflehog:3.97.1@sha256:<digest>` from the
+          # job `env:` block — never the mutable `:latest` the action defaults
+          # to. Same reference the warm-cache step pre-pulled.
+          image: ${{ env.TRUFFLEHOG_IMAGE }}
+          version: ${{ env.TRUFFLEHOG_VERSION }}
           # Pin the scan range on merge_group refs. The action derives its
           # BASE/HEAD from the event payload, but its dispatch only handles
           # push / pull_request / workflow_dispatch / schedule — there is NO

--- a/backend/README.md
+++ b/backend/README.md
@@ -286,9 +286,13 @@ resources continue to use `app.kubernetes.io/name=meho`.
 
 ## Vulnerability scan
 
-Every pushed image is scanned by [trivy](https://github.com/aquasecurity/trivy)
-for known CVEs in OS packages and language dependencies. Findings are
-surfaced two ways:
+Every built image is scanned by [trivy](https://github.com/aquasecurity/trivy)
+for known CVEs in OS packages and language dependencies **before it is
+published as a release**. On a push event the build pushes the manifest list
+to GHCR by digest only (a quarantine push with no tag); trivy scans that
+digest; only a clean scan lets the promote step apply the release aliases
+(`:sha-<sha>`, `:main`, `:v<x.y.z>`) and lets cosign sign + attest the digest.
+Findings are surfaced two ways:
 
 1. **GitHub Security tab.** The workflow uploads the SARIF report to repo →
    *Security* → *Code scanning alerts* (filter category `trivy-image-scan`).
@@ -302,15 +306,18 @@ surfaced two ways:
    jq '.runs[0].results | length' trivy-results.sarif
    ```
 
-**The scan gates main/tag builds.** `exit-code: '1'` fails the run on any
-fixable CRITICAL/HIGH CVE — a red-main alarm against silent CVE accumulation
-on a stale base image (`ignore-unfixed: true` drops CVEs with no upstream
-fix). It runs post-push on main and tags only; the step is skipped on
-pull_request, so it is not a PR merge gate. Because the two SARIF uploads are
-guarded on the scan step's outcome rather than the default `success()` gate,
-a failing scan still publishes its findings to the Security tab and the
-30-day artefact — so a red run's CVE list is one click away. Treat a red run
-as "bump the base-image digest and re-push", not "this merge is blocked".
+**The scan gates promotion of main/tag builds.** `exit-code: '1'` fails the
+run on any fixable CRITICAL/HIGH CVE (`ignore-unfixed: true` drops CVEs with
+no upstream fix). Because the promote / sign / attest steps carry the implicit
+`success()` guard, a failing scan skips all three: the scanned digest is never
+tagged with a release alias, never signed, and never attested — a failed gate
+cannot leave an artifact advertised as an approved release (#284 / F15b). The
+scan is skipped on `pull_request` (which never pushes an image), so it is not
+a PR merge gate. Because the two SARIF uploads are guarded on the scan step's
+outcome rather than the default `success()` gate, a failing scan still
+publishes its findings to the Security tab and the 30-day artefact — so a red
+run's CVE list is one click away. Treat a red run as "bump the base-image
+digest and re-run"; the build ships nothing until the scan is clean.
 
 ## What this skeleton intentionally omits
 

--- a/backend/tests/test_chart_image_digest_pin.py
+++ b/backend/tests/test_chart_image_digest_pin.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Chart-render assertions for the optional image-digest pin (#284 / F15b).
+
+The image pipeline promotes a release by applying tags to the exact
+manifest **digest** it scanned + cosign-signed. To let a deploy pin that
+immutable, content-addressed digest instead of the mutable
+``repository:tag`` reference, the chart grew an optional
+``image.digest`` value: when it is set, the backplane Deployment **and**
+the pre-install migration Job both render ``repository@digest``; when it
+is empty (the default) both fall back to the schema-required
+``repository:tag``. A ``sha256:<64 hex>`` schema pattern rejects a
+malformed pin at ``helm template`` time rather than letting it reach a
+Pod-create rejection.
+
+These tests pin that contract at the unit layer. Two failure modes they
+guard against, both silent:
+
+* A future template edit dropping the ``{{- if .Values.image.digest }}``
+  branch would reopen F15b — the deploy would resolve a mutable tag even
+  when handed the scanned+signed digest — while the CI chart gate
+  (``.github/workflows/chart.yml``), which renders only the tag path,
+  stays green.
+* Loosening the ``digest`` schema pattern would let a malformed pin
+  through to Pod create.
+
+The authoritative chart gate is ``.github/workflows/chart.yml`` (lint +
+``helm template`` + ``kubeconform``); this test mirrors the digest
+assertions at the ``pytest`` layer and skips cleanly where ``helm`` is
+absent (the backend unit-test sandbox does not ship it — the workflow
+gate covers that environment).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+# backend/tests/<this> → parents[2] == repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "charts" / "meho"
+
+# The chart's default image repository (deploy/charts/meho/values.yaml).
+_REPO = "ghcr.io/evoila/meho"
+# A well-formed manifest digest (sha256 of the empty string — 64 hex chars).
+_VALID_DIGEST = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# Minimal chassis-required overrides that satisfy values.schema.json.
+# `image.tag` is always set (schema-required) so the digest tests also
+# prove the digest *wins* over a present tag.
+_BASE_OVERRIDES = [
+    "--set",
+    "image.tag=test",
+    "--set",
+    "ingress.host=meho.test",
+    "--set",
+    "ingress.tls.secretName=meho-tls",
+    "--set",
+    "postgres.credentialsSecret=meho-postgres",
+    "--set",
+    "vault.address=https://vault.test",
+    "--set",
+    "keycloak.issuer=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakIssuerUrl=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakAudience=meho-backplane",
+    "--set",
+    "config.vaultAddr=https://vault.test",
+    "--set",
+    "networkPolicy.postgresCIDR=10.0.1.0/24",
+    "--set",
+    "networkPolicy.vaultCIDR=10.0.2.0/24",
+    "--set",
+    "networkPolicy.keycloakCIDR=10.0.3.0/24",
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed in this sandbox; chart.yml workflow gate covers CI",
+)
+
+
+def _helm_template(template: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    """Run ``helm template --show-only <template>`` without raising."""
+    return subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(_CHART_DIR),
+            *_BASE_OVERRIDES,
+            *extra,
+            "--show-only",
+            template,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _render_image(template: str, *extra: str) -> str:
+    """Return the sole container image of the rendered ``template``."""
+    result = _helm_template(template, *extra)
+    assert result.returncode == 0, result.stderr
+    manifest = cast("dict[str, Any]", yaml.safe_load(result.stdout))
+    containers = manifest["spec"]["template"]["spec"]["containers"]
+    assert len(containers) == 1, f"expected one container, got {len(containers)}"
+    return cast("str", containers[0]["image"])
+
+
+def test_deployment_pins_by_digest_when_set() -> None:
+    """With ``image.digest`` set the Deployment renders ``repository@digest``.
+
+    The digest wins even though ``image.tag`` is also set (base overrides),
+    proving the precedence the F15b deploy pin depends on.
+    """
+    image = _render_image(
+        "templates/deployment.yaml",
+        "--set-string",
+        f"image.digest={_VALID_DIGEST}",
+    )
+    assert image == f"{_REPO}@{_VALID_DIGEST}"
+
+
+def test_migration_job_pins_by_digest_when_set() -> None:
+    """The migration Job must pin the same content-addressed digest (#284).
+
+    A tag on the Job could resolve to different bytes than the Deployment;
+    the digest pin keeps the migration runner and the backplane on the
+    exact same scanned+signed image.
+    """
+    image = _render_image(
+        "templates/migration-job.yaml",
+        "--set-string",
+        f"image.digest={_VALID_DIGEST}",
+    )
+    assert image == f"{_REPO}@{_VALID_DIGEST}"
+
+
+def test_deployment_falls_back_to_tag_without_digest() -> None:
+    """With no digest (the default) the Deployment renders ``repository:tag``."""
+    image = _render_image("templates/deployment.yaml")
+    assert image == f"{_REPO}:test"
+
+
+def test_migration_job_falls_back_to_tag_without_digest() -> None:
+    """With no digest (the default) the migration Job renders ``repository:tag``."""
+    image = _render_image("templates/migration-job.yaml")
+    assert image == f"{_REPO}:test"
+
+
+def test_malformed_digest_is_schema_rejected() -> None:
+    """A digest that is not ``sha256:<64 hex>`` fails values-schema validation.
+
+    The pin must fail loud at ``helm template`` time rather than producing
+    an image reference Kubernetes rejects at Pod create.
+    """
+    result = _helm_template(
+        "templates/deployment.yaml",
+        "--set-string",
+        "image.digest=not-a-valid-digest",
+    )
+    assert result.returncode != 0
+    stderr = result.stderr.lower()
+    assert "digest" in stderr
+    assert "schema" in stderr or "pattern" in stderr

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -58,7 +58,19 @@ spec:
           # fallback: the values schema rejects empty `image.tag` so every
           # install pins the tag explicitly. Goal #11's deploy discipline
           # forbids any moving reference (including a chart-appVersion shadow).
+          #
+          # When `image.digest` is set (#284 / F15b), pin by the immutable
+          # manifest digest (`repository@sha256:...`) — the exact,
+          # content-addressed, scanned+signed digest the image pipeline
+          # promoted, and the reference a `cosign verify` / admission gate
+          # checks the signature against. `tag` stays the human-readable label
+          # of that release; the digest takes precedence in the rendered
+          # reference. With no digest set, fall back to the schema-required tag.
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/charts/meho/templates/migration-job.yaml
+++ b/deploy/charts/meho/templates/migration-job.yaml
@@ -101,8 +101,15 @@ spec:
           # wheel and shares the chassis's Alembic config / SQLAlchemy
           # version. A separate migration image would drift; using the
           # same image guarantees the migrations applied are exactly the
-          # ones the rolling-out Deployment expects.
+          # ones the rolling-out Deployment expects. That includes the
+          # digest pin (#284): when `image.digest` is set the Job runs the
+          # same content-addressed digest the Deployment does, not a tag
+          # that could resolve to different bytes.
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # The runner takes no CLI flags by design — its contract is
           # `alembic upgrade head` against the env-supplied DATABASE_URL.

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -28,6 +28,11 @@
           "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$",
           "description": "Image tag. Empty fails the schema — Goal #11 deploy discipline requires every install to pin an immutable tag. The pattern matches the OCI tag grammar (`[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}`) so a forgotten `<REPLACE: ...>` placeholder from an example values file fails at install instead of producing an image reference Kubernetes rejects at Pod create."
         },
+        "digest": {
+          "type": "string",
+          "pattern": "^(sha256:[0-9a-f]{64})?$",
+          "description": "Optional image manifest digest (`sha256:<64 hex>`). When set, the Deployment pins the image by digest (`repository@digest`) instead of `repository:tag` — the exact, content-addressed, scanned + cosign-signed digest the image pipeline promoted (#284 / F15b), and the reference a `cosign verify` / admission gate checks the signature against. `tag` stays required as the human-readable release label; the digest wins in the rendered image reference. Empty string (the default) deploys by `tag`. The pattern rejects any non-`sha256:` value so a malformed pin fails at install rather than producing an image reference Kubernetes rejects at Pod create."
+        },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"]

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -26,6 +26,15 @@ image:
   # typically passes `--set image.tag=sha-<git-sha>`; Goal #11's deploy
   # discipline forbids the `:latest` tag entirely.
   tag: ""
+  # -- Image manifest digest (`sha256:<64 hex>`), optional. When set, the
+  # Deployment pins the image by digest (`repository@digest`) instead of
+  # `repository:tag` — the exact, content-addressed, scanned + cosign-signed
+  # digest the image pipeline promoted (#284 / F15b). This is the strongest
+  # deploy pin: unlike a tag, a digest can never be re-pointed, and it is the
+  # reference a `cosign verify` / admission gate checks the signature against.
+  # `tag` stays required as the human-readable release label; the digest wins
+  # in the rendered reference. Empty = deploy by `tag` (unchanged default).
+  digest: ""
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -128,6 +128,38 @@ deploy discipline forbids moving references (including a chart-`appVersion`
 shadow), and the chart enforces that contract at the schema layer rather
 than relying on consumers to remember to `--set image.tag`.
 
+**Digest pinning (`image.digest`, #284 / F15b).** An optional
+`image.digest` (`sha256:<64 hex>`, schema-validated) makes the Deployment —
+and the migration Job, which the chart keeps byte-identical to the
+Deployment — render `repository@digest` instead of `repository:tag`. This
+pins the exact, content-addressed digest the image pipeline
+(`.github/workflows/image.yml`) scanned, promoted and cosign-signed: unlike
+a tag, a digest can never be re-pointed, and it is the reference a
+`cosign verify` gate checks the signature against. `tag` stays required as
+the human-readable release label; the digest wins in the rendered reference,
+and an empty digest (the default) keeps the tag path unchanged. The
+`image.yml` quarantine → scan → promote ordering guarantees any digest an
+operator can pin from a release alias was scanned before it was advertised.
+
+**Verifying provenance before deploy.** The install path SHOULD gate on a
+`cosign verify` of the pinned digest against the trusted keyless identity
+before `helm upgrade`, e.g.
+
+```bash
+cosign verify "ghcr.io/evoila/meho@${DIGEST}" \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+(full recipes, including `cosign verify-attestation` for the SBOM, live in
+[`backend/README.md`](../../backend/README.md)). As of #284 **no live
+admission policy enforces this** — the cluster has no Sigstore
+policy-controller / Kyverno image-verification rule, and the lab installer
+(`rdc-hetzner-dc/manifests/meho/install.sh`, a separate repo) runs
+`helm upgrade` without a `cosign verify` step. Adding that gate to the
+install path is the cross-repo follow-up; this chart supplies the digest pin
+it verifies against.
+
 `image.repository` accepts the lowercase OCI grammar including an optional
 `:<port>` segment after the host, so private registries like
 `registry.example.com:5000/team/meho` are valid. The pattern enforces the
@@ -525,6 +557,7 @@ them).
 | Path | Type | Notes |
 | --- | --- | --- |
 | `image.tag` | string | Immutable tag (`sha-<git-sha>` or `v<x.y.z>`); never `:latest`. |
+| `image.digest` | string | Optional `sha256:<64 hex>` digest pin (#284). When set, the Deployment + migration Job render `repository@digest` instead of `repository:tag`; empty (default) uses `image.tag`. |
 | `ingress.host` | string (`hostname`) | External hostname the chart publishes. Required only when `ingress.enabled: true` (default); skipped when ingress is disabled. |
 | `ingress.tls.secretName` | string | TLS Secret (cert-manager-managed or pre-provisioned). Required only when both `ingress.enabled` and `ingress.tls.enabled` are true. |
 | `postgres.credentialsSecret` | string | Kubernetes Secret holding `DATABASE_URL` at key `url`. |
@@ -933,6 +966,19 @@ these workflows:
   queue, preserving PR/push behaviour. When adding any range-deriving
   action to a required-check workflow, check its `merge_group` handling —
   the trigger alone is not enough.
+- **The TruffleHog scanner container image is digest-pinned (#284 /
+  F15b).** The action shells out to `docker run "${IMAGE}:${VERSION}"`,
+  defaulting `VERSION` to the mutable `:latest` tag — so the required
+  secret-scan gate would otherwise run whatever `:latest` resolves to at
+  pull time on the self-hosted `meho-runners-ci` pool. `secret-scan.yml`
+  now sets a job-level `TRUFFLEHOG_VERSION: <ver>@sha256:<digest>` and
+  feeds it to both the warm-cache pre-pull and the action's `version`
+  input, so both reference the same digest-pinned image. The action's
+  `uses:` SHA is bumped weekly by Dependabot (github-actions ecosystem);
+  Dependabot cannot resolve a digest held in a `with:`/`env:` value, so
+  the pinned scanner digest is bumped in lockstep in the same PR (the job
+  `env:` comment carries the `imagetools inspect` command that resolves
+  the new digest).
 
 `chart.yml` additionally guards its `publish` and `verify-anonymous-pull`
 jobs to `github.event_name == 'push'` (was `!= 'pull_request'`), so a


### PR DESCRIPTION
## Summary

Fixes the supply-chain promotion-ordering finding **F15b** (#284): the image
pipeline pushed, signed and attested the release aliases (`:sha-*`, `:main`,
`:v*`) **before** the trivy scan ran, so a failing scan left a signed,
attested artifact already advertised as a release. Deploys pinned by mutable
tag and nothing on the install path verified provenance. This PR reworks the
image pipeline into a **quarantine → scan → promote** flow, adds
digest-pinned deploys, pins the secret-scan scanner image by digest, and
documents the pre-deploy verification story.

- **`image.yml`** builds and pushes the manifest list to GHCR **by digest
  only** (`push-by-digest`, no tag). trivy scans that quarantine digest as a
  **promotion gate**; only a clean scan lets the new promote step apply the
  release aliases to the *exact approved digest* (`imagetools create`
  carbon-copy — no rebuild, preserves the multi-arch children + inline
  provenance/SBOM) and lets `cosign sign` + SBOM + `cosign attest` run. Every
  step past the gate carries the implicit `success()` guard, so a red scan
  ships nothing; a fail-loud guard aborts if the build emits no digest.
- **Chart** gains an optional `image.digest` (`sha256:…`, schema- and
  fail-loud-validated) that pins the Deployment **and the migration Job** by
  `repository@digest`; `tag` stays the human-readable release label.
- **`secret-scan.yml`** pins the TruffleHog scanner container image by digest
  in both the warm-cache pre-pull and the action's `image`/`version` inputs
  (was the mutable `:latest`), DRY via a job-level `env`.

## Acceptance criteria

- [x] **AC1 — quarantine + scan before publish/sign/attest.** Build uses
  `push-by-digest` (no tag); `trivy` (`exit-code:'1'`) runs before promote,
  which is `success()`-gated, as are sign/attest. A failed gate leaves an
  untagged, unsigned, unattested manifest — never an approved-release alias.
- [x] **AC2 — release aliases point only at promoted, scanned digests.** Tags
  are applied solely by the promote step (after the gate) to the scanned
  digest; sign/attest bind the same digest.
- [x] **AC3 — deploy by exact approved digest** (in-repo enabler). `image.digest`
  renders `repository@digest` on the Deployment + migration Job; the
  provenance-verify recipe (issuer/workflow/ref) is documented. *Executing*
  the verify sits on the install path (see AC4).
- [x] **AC4 — verify before deploy + record live state.** Recorded: **no live
  admission policy** enforces signature/provenance today (no Sigstore
  policy-controller / Kyverno rule), and the lab installer
  `rdc-hetzner-dc/manifests/meho/install.sh` (a **separate repo**) runs
  `helm upgrade` with no `cosign verify`. In-repo: the digest pin + the
  documented `cosign verify` / `verify-attestation` recipe are the enablers
  the install-path gate verifies against. Adding the `cosign verify` step to
  the installer is the **cross-repo follow-up** (lab repo), out of this code
  target (`evoila/meho`).
- [x] **AC5 — existing locking/signing/SBOM preserved.** `cosign sign` + syft
  SBOM + `cosign attest` are unchanged (moved after the gate); the chart
  cosign-signing pipeline and the Dockerfile base-image digest pins are
  untouched.
- [x] **AC6 — pin the secret-scan scanner image by digest.** Warm-cache and
  the action `image`/`version` inputs both reference
  `ghcr.io/trufflesecurity/trufflehog:3.97.1@sha256:deb2af…` via one
  job-level `env`; never `:latest`. Dependabot bumps the action `uses:` SHA
  weekly; the paired digest is bumped in lockstep in the same PR (Dependabot
  cannot resolve a digest in a `with:`/`env:` value — the `env` comment
  carries the `imagetools inspect` resolver command).

## Test plan

- [x] `actionlint .github/workflows/image.yml .github/workflows/secret-scan.yml` — clean (incl. shellcheck on the promote/guard run blocks).
- [x] `helm lint` — clean on tag and digest paths.
- [x] `helm template` — Deployment **and** migration Job render `…:test` on the tag path and `…@sha256:deb2af…` on the digest path (both image refs pinned consistently).
- [x] `kubeconform -strict -kubernetes-version 1.28.0` — 13/13 valid on both renders.
- [x] Negative: `--set image.digest=notadigest` fails the schema pattern; bare template still fails-loud on empty `image.tag` (unchanged contract).
- [x] `values.schema.json` parses as valid JSON.
- No Python / frontend / Go changed, so the backend unit lane is unaffected.

## Notes

- Nothing in F15b was already on `main` (the recent containment PRs #3423 / #3427 covered a different finding); this is the full F15b implementation.
- Deliberately **not** shipping a speculative admission-policy chart template: no admission controller is installed on the target cluster, so a default-off `ClusterImagePolicy`/Kyverno rule would be optionality-for-later. The digest pin + documented verify recipe + the recorded cross-repo installer follow-up are the honest in-repo deliverable.

## Out of scope

- Automation build reproducibility (F15a #277); least-privilege migration-job credentials (F14a #276); the VPN/management-plane lockdown program (#234/#248/#249/#250); selected CI input pinning / Go vuln checks (closed #155).
- Adding the `cosign verify` gate to the lab installer (`rdc-hetzner-dc`) — cross-repo follow-up.

---

## Follow-up (auto-implement-issue, iteration 1, 2026-09-07)

Addressed the reviewer's single blocker (**B1**) from the iteration-1 review:

- **B1** `29c96d70` — Added `backend/tests/test_chart_image_digest_pin.py`, a
  helm-render regression test for the new `image.digest` contract (AC3),
  modelled on the established `test_chart_*.py` harness (skip-if-helm-absent,
  `--show-only` per template). It pins: with `image.digest` set, **both** the
  Deployment and the pre-install migration Job render `repository@digest` (and
  the digest wins over a present `tag`); with no digest (default) both fall back
  to `repository:tag`; a malformed digest is rejected by the
  `values.schema.json` `sha256:<64 hex>` pattern at `helm template` time.
  This closes the gap the reviewer flagged — the CI chart gate renders only the
  tag path, so a future drop of the `{{- if .Values.image.digest }}` branch
  would silently reopen F15b. `5 passed` locally (helm v4.2.3).

Adjacent improvement **deferred** (recorded, not a defect):

- The reviewer's optional suggestion to add a `deploy/charts/meho/ci/*-values.yaml`
  digest fixture is not shipped. The chart gate (`.github/workflows/chart.yml`)
  does **not** auto-discover `ci/` value files — it renders via explicit `--set`
  overrides with no chart-testing `ct`, so a fixture alone would not be exercised;
  it would also need a new digest-path `helm template`/lint step in the workflow.
  The pytest-layer regression test is B1's specified required change and closes the
  finding surgically; the workflow-layer duplication is left as an adjacent follow-up.

Corrects the earlier Test-plan note "the backend unit lane is unaffected": this
iteration adds one backend test file (the render harness above). The full backend
unit lane was re-run locally at `29c96d70`; the new test passes, and the only
failures are pre-existing environment flakes reproduced on pristine `main`
(sandbox DNS/ICMP connector probes; a helm-version quirk in
`test_chart_mcp_resource_uri`) — none touched by this change.

<!-- auto-implement-issue: continue, iteration 1 -->

<!-- auto-implement-issue: fresh, iteration 1 -->

Part of evoila-bosnia/meho-internal#284 (evoila/meho arms: quarantine → scan → promote-by-digest, verify recipe; the lab-installer `cosign verify` gate is the recorded cross-repo follow-up — orchestrator keeps #284 open)
