### PR TITLE
fix(plugin): vendor mcp-remote behind a committed lockfile in the Claude Code plugin shim

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -4,11 +4,14 @@
 # Claude Code plugin — PR behavioral + conformance tests.
 #
 # Three suites pin the plugin's behavioural contracts, each stubbing the
-# binary it drives (`npx` / `meho`) on a controlled PATH:
-#   1. The stdio shim wrapper (bin/meho-mcp-remote) `exec`s
-#      `npx -y mcp-remote@… <url> --static-oauth-…` — its argv is the
-#      contract, in particular the OAuth scope metadata the MEHO_MCP_SCOPES
-#      elevation seam makes operator-configurable (stubbed-argv suite).
+# binary it drives (`npm` / `meho`) on a controlled PATH:
+#   1. The stdio shim wrapper (bin/meho-mcp-remote) vendors mcp-remote from
+#      its committed package-lock.json with `npm ci --omit=dev` (no floating
+#      `npx -y`), then runs the lock-installed local entry with
+#      `<url> --static-oauth-…` — the install path and that argv (in
+#      particular the OAuth scope metadata the MEHO_MCP_SCOPES elevation seam
+#      makes operator-configurable) are the contract. `npm`/`npx` are stubbed,
+#      so the suite exercises this with no registry access (behavioural suite).
 #   2. A static guard that every plugin-scoped hooks.json matcher names a
 #      tool actually registered under backend/src/meho_backplane/mcp/tools/
 #      (the meho_ prefix asymmetry silently disarmed the announce hook

--- a/clients/claude-code-plugin/.gitignore
+++ b/clients/claude-code-plugin/.gitignore
@@ -1,0 +1,5 @@
+# Vendored dependency tree. Populated by `npm ci --omit=dev` — into the
+# operator's plugin cache by bin/meho-mcp-remote on first launch, or here by
+# a developer testing locally. Only the pinned package.json + package-lock.json
+# are committed; node_modules is rebuilt from the lock, never committed.
+/node_modules/

--- a/clients/claude-code-plugin/README.md
+++ b/clients/claude-code-plugin/README.md
@@ -106,8 +106,13 @@ the scope is therefore safe: the session behaves exactly as the default.
 ### Prerequisites
 
 - A machine on the internal network / VPN that can reach the backplane.
-- Node.js with `npx` available (the shim runs the smoke-tested
-  `npx -y mcp-remote@0.1.38`).
+- Node.js with `npm` available (the shim vendors the smoke-tested
+  `mcp-remote@0.1.38` from the committed `package-lock.json` with
+  `npm ci --omit=dev` on first launch, then runs the lock-installed local
+  entry — no floating `npx -y` transitive install). The integrity-checked
+  tree is cached under `${XDG_CACHE_HOME:-~/.cache}/meho/mcp-remote`
+  (override with `MEHO_PLUGIN_CACHE`) and re-vendored only when the committed
+  lockfile changes.
 - `mcp-remote` performs the OAuth 2.1 + PKCE handshake against the realm. The
   shim passes `--static-oauth-client-info '{"client_id": "meho-mcp"}'` (overridable
   via `MEHO_MCP_CLIENT_ID`) so it presents the pre-registered public client

--- a/clients/claude-code-plugin/bin/meho-mcp-remote
+++ b/clients/claude-code-plugin/bin/meho-mcp-remote
@@ -70,6 +70,85 @@ if [ -z "${scopes//[[:space:]]/}" ]; then
   scopes="mcp:read mcp:execute"
 fi
 
-exec npx -y mcp-remote@0.1.38 "$url" \
+# Vendor mcp-remote from the committed lockfile instead of resolving it fresh
+# from npm semver ranges at each launch. This shim performs the OAuth 2.1 +
+# PKCE handshake and holds the operator's live backplane session, so its
+# dependency tree must be integrity-pinned, not floated: `npx -y` would
+# resolve mcp-remote's *transitive* graph against upstream semver ranges with
+# no committed integrity check. `npm ci` instead installs the exact tree
+# pinned in package-lock.json — a transitive version cannot change without a
+# reviewed lockfile update (evoila-bosnia/meho-internal#309; mirrors the
+# desktop .mcpb bundle's npm-ci vendoring).
+if ! command -v npm >/dev/null 2>&1; then
+  {
+    echo "meho plugin: 'npm' was not found on PATH. It is required to vendor"
+    echo "  the pinned mcp-remote tree from the committed lockfile. Install"
+    echo "  Node.js (which ships npm) and retry."
+  } >&2
+  exit 1
+fi
+
+# This script lives in <plugin_root>/bin, so its parent is the plugin root
+# where package.json + package-lock.json are committed — resolved from the
+# script's own location, independent of the caller's cwd or install layout.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="$(cd "$script_dir/.." && pwd)"
+
+# Vendor into a per-operator cache OUTSIDE the (possibly read-only) plugin
+# dir, so the install works regardless of where the plugin is installed and
+# survives plugin reinstalls. MEHO_PLUGIN_CACHE overrides the location.
+cache_dir="${MEHO_PLUGIN_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/meho/mcp-remote}"
+mkdir -p "$cache_dir"
+
+# (Re)vendor only when the committed lock differs from the cached copy or the
+# tree is absent — a byte-identical lock skips the install, so steady-state
+# launches pay no npm cost. `npm ci` is intentionally strict: it fails rather
+# than silently reconciling a drifted lock.
+if ! cmp -s "$plugin_root/package-lock.json" "$cache_dir/package-lock.json" \
+   || [ ! -d "$cache_dir/node_modules/mcp-remote" ]; then
+  cp "$plugin_root/package.json" "$plugin_root/package-lock.json" "$cache_dir/"
+  # --omit=dev keeps only the runtime tree; --no-audit/--no-fund suppress
+  # network chatter. npm's own output is sent to stderr so the MCP stdio
+  # channel (stdout) stays clean for the JSON-RPC stream mcp-remote drives.
+  if ! ( cd "$cache_dir" && npm ci --omit=dev --no-audit --no-fund 1>&2 ); then
+    {
+      echo "meho plugin: failed to vendor mcp-remote from the committed"
+      echo "  lockfile ($plugin_root/package-lock.json) into $cache_dir."
+      echo "  Check network access to the npm registry and retry."
+    } >&2
+    # Drop the marker so the next launch re-attempts a clean install.
+    rm -f "$cache_dir/package-lock.json"
+    exit 1
+  fi
+fi
+
+# Resolve the vendored mcp-remote CLI entry from the cache's node_modules by
+# reading the package's own bin mapping, so a future pinned version that
+# relocates its entry script keeps working without editing this shim.
+if ! entry="$(cd "$cache_dir" && node -e '
+const { createRequire } = require("node:module");
+const path = require("node:path");
+const req = createRequire(path.join(process.cwd(), "noop.js"));
+const pkgPath = req.resolve("mcp-remote/package.json");
+const pkg = require(pkgPath);
+const bin = typeof pkg.bin === "string" ? pkg.bin : pkg.bin["mcp-remote"];
+process.stdout.write(path.join(path.dirname(pkgPath), bin));
+')"; then
+  entry=""
+fi
+if [ -z "$entry" ] || [ ! -f "$entry" ]; then
+  {
+    echo "meho plugin: could not resolve the vendored mcp-remote entry in"
+    echo "  $cache_dir/node_modules — the lockfile install may be incomplete."
+    echo "  Remove $cache_dir and retry to force a clean re-vendor."
+  } >&2
+  exit 1
+fi
+
+# Hand mcp-remote the same argv the previous `npx` invocation did: the URL
+# plus the static-OAuth client id and scope metadata. mcp-remote reads
+# process.argv.slice(2), so `node <entry> <url> --flags...` preserves the
+# exact contract. mcp-remote owns this process's stdio from here.
+exec node "$entry" "$url" \
   --static-oauth-client-info "{\"client_id\": \"$client_id\"}" \
   --static-oauth-client-metadata "{\"scope\": \"$scopes\"}"

--- a/clients/claude-code-plugin/package-lock.json
+++ b/clients/claude-code-plugin/package-lock.json
@@ -1,0 +1,1008 @@
+{
+  "name": "meho-claude-code-plugin",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meho-claude-code-plugin",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mcp-remote": "0.1.38"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-remote": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/mcp-remote/-/mcp-remote-0.1.38.tgz",
+      "integrity": "sha512-w+JU4U3CfG29TawXR4JLNQ9d1Un5nT8AGI65f/juCaqUdF/V6fS7wE4o7xNPbB8X58o46hRXEJgYglQMAKQs4w==",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.21.2",
+        "open": "^10.1.0",
+        "strict-url-sanitise": "^0.0.1",
+        "undici": "^7.12.0"
+      },
+      "bin": {
+        "mcp-remote": "dist/proxy.js",
+        "mcp-remote-client": "dist/client.js"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-url-sanitise": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/strict-url-sanitise/-/strict-url-sanitise-0.0.1.tgz",
+      "integrity": "sha512-nuFtF539K8jZg3FjaWH/L8eocCR6gegz5RDOsaWxfdbF5Jqr2VXWxZayjTwUzsWJDC91k2EbnJXp6FuWW+Z4hg==",
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/clients/claude-code-plugin/package.json
+++ b/clients/claude-code-plugin/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "meho-claude-code-plugin",
+  "version": "0.0.0",
+  "description": "Vendored runtime dependency for the MEHO Claude Code plugin's stdio shim (bin/meho-mcp-remote). Not published; the shim runs `npm ci --omit=dev` from the committed lock to vendor an integrity-checked mcp-remote tree on first launch.",
+  "private": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "mcp-remote": "0.1.38"
+  },
+  "overrides": {
+    "qs": "^6.16.0"
+  }
+}

--- a/clients/claude-code-plugin/test/meho-mcp-remote.test.mjs
+++ b/clients/claude-code-plugin/test/meho-mcp-remote.test.mjs
@@ -1,19 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 evoila Group
 //
-// Stubbed-argv suite for bin/meho-mcp-remote — the Claude Code plugin's
-// stdio shim wrapper. The wrapper ends in `exec npx -y mcp-remote@… "$url"
-// --static-oauth-client-info … --static-oauth-client-metadata …`, so the
-// contract worth pinning is the exact argv (and, in particular, the scope
-// metadata) it hands to npx.
+// Behavioural suite for bin/meho-mcp-remote — the Claude Code plugin's
+// stdio shim wrapper. The wrapper no longer floats mcp-remote's transitive
+// tree via `npx -y`; it vendors the exact tree from the committed
+// package-lock.json with `npm ci --omit=dev` into a per-operator cache, then
+// runs the lock-installed local mcp-remote entry in place (#309). Two
+// contracts are pinned here:
+//   1. The install path — the shim runs `npm ci` from the committed lock and
+//      never falls back to `npx -y`; a warm cache is not re-installed.
+//   2. The child argv — the URL and the static-OAuth scope metadata handed to
+//      the vendored entry are exactly what the previous npx invocation passed.
 //
-// npx is stubbed: a fake `npx` on a controlled PATH prints each argument on
-// its own line, then exits 0. The wrapper `exec`s it, so the stub replaces
-// the process and its stdout is the wrapper's stdout — letting the suite
-// assert the child contract without a live backplane or a real mcp-remote.
+// No network / no real npm: `npm` and `npx` are stubbed on a controlled PATH.
+// The `npm` stub fabricates a minimal mcp-remote tree (package.json `bin` +
+// an entry that echoes its argv one-per-line) so the shim can resolve and
+// `exec` a real local entry — the same resolution the real vendored tree
+// uses — without touching the registry. The `npx` stub fails loudly, so any
+// regression back to `npx -y` turns the suite red.
 
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,74 +35,171 @@ import { after, test } from "node:test";
 import assert from "node:assert/strict";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const WRAPPER = join(HERE, "..", "bin", "meho-mcp-remote");
+const PLUGIN_ROOT = join(HERE, "..");
+const WRAPPER = join(PLUGIN_ROOT, "bin", "meho-mcp-remote");
 const URL = "https://meho.internal.example/mcp";
 const DEFAULT_SCOPE = "mcp:read mcp:execute";
 
-// A temp bin dir holding a stub `npx` that echoes its argv, one arg per
-// line. /usr/bin:/bin keeps `env`/`bash` resolvable under the controlled
-// PATH (the wrapper is `#!/usr/bin/env bash`).
-const STUB_BIN = mkdtempSync(join(tmpdir(), "meho-plugin-test-"));
+// Real `node` must stay resolvable under the controlled PATH: the shim shells
+// out to `node` to resolve the vendored entry, then `exec node <entry> …`.
+const NODE_DIR = dirname(process.execPath);
+
+// A temp bin dir holding stub `npm` and `npx`. The npm stub fabricates a
+// mcp-remote tree on `npm ci` and appends its argv+cwd to $NPM_LOG. The npx
+// stub records any invocation to $NPX_LOG and exits non-zero — the shim must
+// never reach it.
+const STUB_BIN = mkdtempSync(join(tmpdir(), "meho-plugin-stub-"));
+writeFileSync(
+  join(STUB_BIN, "npm"),
+  [
+    "#!/usr/bin/env bash",
+    'printf "%s (cwd=%s)\\n" "$*" "$PWD" >> "$NPM_LOG"',
+    'if [ "$1" = "ci" ]; then',
+    "  mkdir -p node_modules/mcp-remote/dist",
+    "  cat > node_modules/mcp-remote/package.json <<'PKG'",
+    '{ "name": "mcp-remote", "version": "0.1.38", "bin": { "mcp-remote": "dist/proxy.js" } }',
+    "PKG",
+    "  cat > node_modules/mcp-remote/dist/proxy.js <<'PROXY'",
+    "#!/usr/bin/env node",
+    "for (const a of process.argv.slice(2)) console.log(a);",
+    "PROXY",
+    "  chmod +x node_modules/mcp-remote/dist/proxy.js",
+    "fi",
+    "exit 0",
+    "",
+  ].join("\n"),
+);
+chmodSync(join(STUB_BIN, "npm"), 0o755);
 writeFileSync(
   join(STUB_BIN, "npx"),
-  '#!/usr/bin/env bash\nfor a in "$@"; do printf "%s\\n" "$a"; done\n',
+  [
+    "#!/usr/bin/env bash",
+    'printf "npx %s\\n" "$*" >> "$NPX_LOG"',
+    'echo "meho-plugin-test: npx must not be invoked by the shim" >&2',
+    "exit 1",
+    "",
+  ].join("\n"),
 );
 chmodSync(join(STUB_BIN, "npx"), 0o755);
-const PATH_WITH_STUB = `${STUB_BIN}:/usr/bin:/bin`;
+const PATH_WITH_STUB = `${STUB_BIN}:${NODE_DIR}:/usr/bin:/bin`;
 
-after(() => rmSync(STUB_BIN, { recursive: true, force: true }));
+const TMP_DIRS = [STUB_BIN];
+after(() => {
+  for (const d of TMP_DIRS) rmSync(d, { recursive: true, force: true });
+});
 
-// Run the wrapper with the stub npx on PATH and no operator config file
-// (MEHO_PLUGIN_CONFIG points at a path that does not exist, so the
-// wrapper's optional `. "$config_file"` sourcing is skipped).
-function runWrapper(extraEnv = {}) {
-  return spawnSync(WRAPPER, [], {
+function freshCache() {
+  const dir = mkdtempSync(join(tmpdir(), "meho-plugin-cache-"));
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+// Run the wrapper with the stubs on PATH, a private vendor cache, and no
+// operator config file (MEHO_PLUGIN_CONFIG points at a nonexistent path, so
+// the wrapper's optional `. "$config_file"` sourcing is skipped). Each run
+// gets its own npm/npx log files.
+function runWrapper({ cache = freshCache(), extraEnv = {} } = {}) {
+  const npmLog = join(cache, "npm-invocations.log");
+  const npxLog = join(cache, "npx-invocations.log");
+  const res = spawnSync(WRAPPER, [], {
     encoding: "utf8",
     env: {
       PATH: PATH_WITH_STUB,
       MEHO_MCP_URL: URL,
-      MEHO_PLUGIN_CONFIG: join(STUB_BIN, "does-not-exist.env"),
+      MEHO_PLUGIN_CACHE: cache,
+      MEHO_PLUGIN_CONFIG: join(cache, "does-not-exist.env"),
+      NPM_LOG: npmLog,
+      NPX_LOG: npxLog,
       ...extraEnv,
     },
   });
+  return { res, cache, npmLog, npxLog };
 }
 
-// Parse the stub's line-per-arg output into the metadata JSON that follows
-// the --static-oauth-client-metadata flag.
+// Parse the fabricated entry's line-per-arg stdout. The vendored entry is
+// exec'd as `node <entry> <url> --static-oauth-client-info {…}
+// --static-oauth-client-metadata {…}`, so it echoes argv.slice(2): the URL
+// followed by the two static-OAuth flag/value pairs.
+function argvFrom(stdout) {
+  return stdout.split("\n").filter((l) => l.length > 0);
+}
 function scopeMetadataFrom(stdout) {
-  const args = stdout.split("\n").filter((l) => l.length > 0);
+  const args = argvFrom(stdout);
   const i = args.indexOf("--static-oauth-client-metadata");
   assert.notEqual(i, -1, `metadata flag absent in argv: ${stdout}`);
   return JSON.parse(args[i + 1]);
 }
 
-test("default: scope metadata is the working surface, url passed through", () => {
-  const res = runWrapper();
+test("vendors from the committed lock and runs the local entry, not npx", () => {
+  const { res, npmLog, npxLog } = runWrapper();
   assert.equal(res.status, 0, `wrapper exited non-zero: ${res.stderr}`);
-  const args = res.stdout.split("\n").filter((l) => l.length > 0);
-  // npx invocation shape: -y mcp-remote@<v> <url> --static-oauth-client-info
-  // {…} --static-oauth-client-metadata {…}
-  assert.equal(args[0], "-y");
-  assert.match(args[1], /^mcp-remote@/);
-  assert.equal(args[2], URL);
+  const args = argvFrom(res.stdout);
+  // New shape: the local entry receives the URL first (no `-y mcp-remote@…`
+  // npx preamble), then the static-OAuth flags.
+  assert.equal(args[0], URL);
+  assert.equal(args[1], "--static-oauth-client-info");
   assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
+  // npm ci ran from the committed lock; npx was never reached.
+  assert.match(readFileSync(npmLog, "utf8"), /^ci --omit=dev/m);
+  assert.equal(existsSync(npxLog), false, "npx stub must not have run");
+});
+
+test("client id + url are handed to the vendored entry verbatim", () => {
+  const { res } = runWrapper();
+  const args = argvFrom(res.stdout);
+  const i = args.indexOf("--static-oauth-client-info");
+  assert.notEqual(i, -1, `client-info flag absent: ${res.stdout}`);
+  assert.deepEqual(JSON.parse(args[i + 1]), { client_id: "meho-mcp" });
+});
+
+test("a warm cache is not re-installed on the next launch", () => {
+  const cache = freshCache();
+  const first = runWrapper({ cache });
+  assert.equal(first.res.status, 0, first.res.stderr);
+  const second = runWrapper({ cache });
+  assert.equal(second.res.status, 0, second.res.stderr);
+  // Both launches share one npm log (keyed on the cache dir). Only the first
+  // should have triggered `npm ci`; the second sees the matching lock + tree.
+  const ciRuns = readFileSync(first.npmLog, "utf8")
+    .split("\n")
+    .filter((l) => l.startsWith("ci "));
+  assert.equal(ciRuns.length, 1, `expected exactly one npm ci, got:\n${ciRuns.join("\n")}`);
 });
 
 test("override: MEHO_MCP_SCOPES sets the requested scope verbatim", () => {
   const elevated = "mcp:read mcp:execute mcp:admin";
-  const res = runWrapper({ MEHO_MCP_SCOPES: elevated });
+  const { res } = runWrapper({ extraEnv: { MEHO_MCP_SCOPES: elevated } });
   assert.equal(res.status, 0, res.stderr);
   assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: elevated });
 });
 
 test("empty MEHO_MCP_SCOPES falls back to the default surface", () => {
-  const res = runWrapper({ MEHO_MCP_SCOPES: "" });
+  const { res } = runWrapper({ extraEnv: { MEHO_MCP_SCOPES: "" } });
   assert.equal(res.status, 0, res.stderr);
   assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
 });
 
 test("whitespace-only MEHO_MCP_SCOPES falls back to the default surface", () => {
-  const res = runWrapper({ MEHO_MCP_SCOPES: "   " });
+  const { res } = runWrapper({ extraEnv: { MEHO_MCP_SCOPES: "   " } });
   assert.equal(res.status, 0, res.stderr);
   assert.deepEqual(scopeMetadataFrom(res.stdout), { scope: DEFAULT_SCOPE });
+});
+
+// The committed lock is the security artifact: it must pin mcp-remote to the
+// smoke-tested build and integrity-lock the transitive tree — including the
+// hardened `qs` the desktop bundle already pins (#3444) — so a floating
+// transitive version cannot slip in without a reviewed lockfile change.
+test("committed package-lock pins mcp-remote + integrity-locks the tree", () => {
+  assert.ok(
+    existsSync(join(PLUGIN_ROOT, "package.json")),
+    "package.json must be committed",
+  );
+  const lock = JSON.parse(
+    readFileSync(join(PLUGIN_ROOT, "package-lock.json"), "utf8"),
+  );
+  assert.equal(lock.packages[""].dependencies["mcp-remote"], "0.1.38");
+  assert.equal(lock.packages["node_modules/mcp-remote"].version, "0.1.38");
+  assert.equal(lock.packages["node_modules/qs"].version, "6.16.0");
+  const integrities = Object.values(lock.packages).filter((p) => p.integrity);
+  assert.ok(integrities.length >= 1, "transitive tree must carry integrity hashes");
 });


### PR DESCRIPTION
## Summary

- The Claude Code plugin's stdio shim ended in `exec npx -y mcp-remote@0.1.38 …`, which floats mcp-remote's **transitive** dependency graph against upstream semver ranges with no committed integrity check — in the same process that runs the OAuth 2.1 + PKCE handshake and holds the operator's live backplane session (S21 / meho-internal#309).
- This mirrors the desktop `.mcpb` bundle's already-hardened pattern: a committed `package.json` + `package-lock.json` pinning `mcp-remote@0.1.38` and its full transitive tree with `integrity` hashes. The shim now runs `npm ci --omit=dev` from the committed lock into a per-operator cache on first launch, then execs the lock-installed local entry with the identical url + static-OAuth argv.
- The lock includes the `qs` `^6.16.0` override the desktop lock pins after #3444, so the plugin does not reintroduce the two `qs` advisories that fix already cleared. `npm ci` is skipped when the cached lock already matches, so steady-state launches pay no npm cost, and the tree is re-vendored only on a reviewed lockfile change.
- `bin/meho-mcp-remote` is the only behavioural change; the vendored tree lands in a cache under `${XDG_CACHE_HOME:-~/.cache}/meho/mcp-remote` (override `MEHO_PLUGIN_CACHE`), never in the (possibly read-only) plugin dir.

Nothing on `origin/main` had pre-fixed any of this — the shim was still on `npx -y` at HEAD (`068f0b81`, which is the #3444 desktop-qs fix); all acceptance criteria were open and are implemented here.

## Test plan

- [x] `node --test clients/claude-code-plugin/test/*.test.mjs` — 14 passed, 0 failed (the CI command from `plugin-test.yml:61`). New assertions: the shim installs from the committed lock, never falls back to `npx` (a loud-failing `npx` stub stays untouched), a warm cache is not re-installed, and the vendored entry receives the exact url + scope/client-id argv (default / elevated / empty / whitespace scope). A lock-guard test pins `mcp-remote 0.1.38` + `qs 6.16.0` + integrity.
- [x] **AC1** `test -f …/package.json && test -f …/package-lock.json` — exit 0.
- [x] **AC2** `grep -c 'npx -y mcp-remote' …/bin/meho-mcp-remote` → `0`; `grep -rl 'npm ci' …/claude-code-plugin/` → non-empty (`bin/meho-mcp-remote`, README, test, .gitignore, package.json).
- [x] **AC3** `grep -n '"mcp-remote"' …/package-lock.json` shows `0.1.38`; `grep -c '"integrity"' …/package-lock.json` → `81` (≥ 1).
- [x] **AC4** `test/meho-mcp-remote.test.mjs` asserts the shim invokes the lock-installed local entry (not `npx -y`) and preserves the scope/url argv contract.
- [x] **AC5** `node --test …/test/*.test.mjs` passes.
- [x] Real end-to-end smoke (network-available dev box): the rewritten shim ran `npm ci` (81 packages) into a temp cache, resolved the local entry, and exec'd real `mcp-remote@0.1.38`, which loaded the static-OAuth client info/metadata and attempted the connection — confirming the full vendor → resolve → exec path and the preserved argv.
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (no Python touched).

Backend `ruff`/`mypy`/`pytest` lane is N/A: this change is Node + bash only (no Python, no REST route/schema, no migration), so no CLI OpenAPI snapshot regen applies. `plugin-test.yml`'s `node --test` is the gate for this path and runs with no registry access (npm/npx stubbed).

## Out of scope

- The desktop `.mcpb` bundle (already lock-vendored via `npm ci --omit=dev`) — meho-internal#278 / #3444 own its `qs` bump.
- Server/backplane image supply chain — meho-internal#277 / F15a.
- Any change to the OAuth scope model, the pre-registered `meho-mcp` client, or the plugin's bash hooks and skills.
- `docs/cross-repo/mcp-client-setup.md`'s `npx -y` line documents the **desktop** bundle prerequisite, not the plugin — left untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#309
