### PR TITLE
fix(ui-auth): bind the OAuth login callback to the initiating browser (F10)

### DIFF
--- a/backend/src/meho_backplane/ui/auth/flow.py
+++ b/backend/src/meho_backplane/ui/auth/flow.py
@@ -73,6 +73,23 @@ Security discipline (#865 is auth)
   callback consumes it (single-use semantics). A second callback
   with the same ``state`` finds no verifier and is rejected.
 
+* ``browser_binding`` is the login-CSRF defence (F10, #272). ``state``
+  and a server-side verifier map do NOT by themselves tie the flow to
+  the browser that started it: an attacker can start their own login,
+  capture the resulting callback URL (which carries ``state``), and
+  induce a victim to follow it -- completing the flow in the victim's
+  browser and logging the victim into the attacker's account. To close
+  that, :func:`build_authorization_request` mints a second random
+  per-flow secret, stores it in the :class:`PendingFlow`, and returns it
+  so the route sets it as a short-lived ``HttpOnly`` cookie on the
+  initiating browser. :func:`exchange_code_for_tokens` requires the
+  callback to replay that cookie value and rejects the flow when it is
+  missing or does not match -- before the token exchange or any session
+  creation. The binding value is deliberately independent of ``state``
+  because ``state`` is on the URL the attacker controls; the binding
+  lives only in the browser cookie (RFC 9700 §2.1: bind the flow to the
+  initiating user-agent).
+
 References
 ----------
 
@@ -91,6 +108,7 @@ References
 from __future__ import annotations
 
 import asyncio
+import hmac
 import time
 from dataclasses import dataclass
 from typing import Any, Final
@@ -366,13 +384,16 @@ async def build_authorization_request(
     *,
     redirect_uri: str,
     return_to: str,
-) -> tuple[str, str]:
+) -> tuple[str, str, str]:
     """Mint a PKCE-protected authorization URL and register the verifier.
 
-    Returns ``(authorization_url, state)``. The route handler 302s the
-    browser at *authorization_url* and stores nothing client-side --
-    the verifier (and the originally-requested *return_to* URL) live
-    in :class:`PKCEVerifierStore`, keyed on the returned *state*.
+    Returns ``(authorization_url, state, browser_binding)``. The route
+    handler 302s the browser at *authorization_url*, sets
+    *browser_binding* as a short-lived ``HttpOnly`` cookie on the
+    initiating browser (the login-CSRF defence, F10 #272), and stores
+    nothing else client-side -- the verifier, the *browser_binding*, and
+    the originally-requested *return_to* URL all live in
+    :class:`PKCEVerifierStore`, keyed on the returned *state*.
 
     Parameters
     ----------
@@ -399,6 +420,12 @@ async def build_authorization_request(
     # compliant URL-safe random string. Length 48 yields ~64 chars of
     # base64 -- comfortably above the spec's 43-128 char floor.
     code_verifier = generate_token(48)
+    # Browser-binding secret (F10, #272): an independent random token
+    # the route hands to the initiating browser via cookie. Kept
+    # separate from ``state`` because ``state`` rides the callback URL
+    # an attacker can replay; the binding value must live only in the
+    # browser to tie the flow to the user-agent that started it.
+    browser_binding = generate_token(48)
     resource = _resource_indicator(settings)
     async with _build_oauth_client(settings, redirect_uri=redirect_uri) as client:
         url, state = client.create_authorization_url(
@@ -406,8 +433,13 @@ async def build_authorization_request(
             code_verifier=code_verifier,
             resource=resource,
         )
-    await get_verifier_store().put(state, code_verifier=code_verifier, return_to=return_to)
-    return url, state
+    await get_verifier_store().put(
+        state,
+        code_verifier=code_verifier,
+        return_to=return_to,
+        browser_binding=browser_binding,
+    )
+    return url, state, browser_binding
 
 
 async def _post_to_token_endpoint(
@@ -480,11 +512,39 @@ def _project_token_response(token: dict[str, Any], return_to: str) -> TokenExcha
     )
 
 
+def _verify_browser_binding(pending: PendingFlow, browser_binding: str | None) -> None:
+    """Reject the flow when the callback's browser cookie does not match.
+
+    The login-CSRF defence (F10, #272). *browser_binding* is the value
+    the initiating browser replayed from its short-lived cookie; a
+    genuine completion carries the same secret
+    :func:`build_authorization_request` stashed in *pending*. A missing
+    cookie (an attacker-induced callback in a browser that never started
+    the flow) or a mismatched one fails closed here -- **before** the
+    token-endpoint POST and any session creation. The comparison is
+    constant-time (:func:`hmac.compare_digest`) so a timing side channel
+    cannot recover the stored value.
+
+    The ``isascii`` guard keeps a hostile cookie carrying non-ASCII
+    bytes from raising ``TypeError`` inside ``compare_digest`` (which
+    refuses non-ASCII ``str`` operands) -- such a value can never equal
+    the stored token (an ASCII :func:`generate_token` output), so it is
+    treated as a mismatch and fails closed rather than 500ing.
+    """
+    if (
+        browser_binding is None
+        or not browser_binding.isascii()
+        or not hmac.compare_digest(browser_binding, pending.browser_binding)
+    ):
+        raise OAuthFlowError("browser_binding_mismatch")
+
+
 async def exchange_code_for_tokens(
     *,
     redirect_uri: str,
     authorization_response: str,
     state: str | None,
+    browser_binding: str | None,
 ) -> TokenExchangeResult:
     """Exchange the callback's ``code`` + stored ``code_verifier`` for tokens.
 
@@ -503,6 +563,12 @@ async def exchange_code_for_tokens(
         cross-checks the response's ``state`` against this value and
         raises :class:`MismatchingStateError` on mismatch -- the
         belt-and-braces CSRF guard.
+    browser_binding
+        The value the initiating browser replayed from its short-lived
+        login-binding cookie (F10, #272). ``None`` when the callback
+        carried no such cookie. Cross-checked against the secret stashed
+        at login; a missing or mismatched value fails the flow closed
+        before the token exchange, defeating login CSRF.
 
     Returns
     -------
@@ -515,7 +581,8 @@ async def exchange_code_for_tokens(
     OAuthFlowConfigurationError
         Client knobs are unset.
     OAuthFlowError
-        ``state`` is unknown / expired / the response is malformed.
+        ``state`` is unknown / expired, the browser binding is missing
+        or mismatched, or the response is malformed.
     httpx.HTTPError
         Network failure on the token-endpoint POST.
     """
@@ -529,6 +596,9 @@ async def exchange_code_for_tokens(
     pending = await get_verifier_store().pop(state)
     if pending is None:
         raise OAuthFlowError("unknown_or_expired_state")
+    # Reject a callback the initiating browser did not start BEFORE the
+    # token POST / session creation (login-CSRF defence, F10 #272).
+    _verify_browser_binding(pending, browser_binding)
     token = await _post_to_token_endpoint(
         settings,
         endpoints,

--- a/backend/src/meho_backplane/ui/auth/routes.py
+++ b/backend/src/meho_backplane/ui/auth/routes.py
@@ -87,6 +87,7 @@ References
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from datetime import timedelta
 from typing import Annotated, Final
@@ -105,6 +106,7 @@ from meho_backplane.auth.jwt import verify_jwt_for_audience
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.settings import Settings, get_settings
 from meho_backplane.ui.auth.flow import (
+    AUTHORIZATION_FLOW_TTL_SECONDS,
     MISSING_CLIENT_SECRET_DETAIL,
     OAuthFlowConfigurationError,
     OAuthFlowError,
@@ -120,12 +122,16 @@ from meho_backplane.ui.auth.session_store import (
 
 __all__ = [
     "AUTHORIZATION_STATE_EXPIRED_DETAIL",
+    "LOGIN_BINDING_COOKIE_PREFIX",
     "LOGIN_PATH",
     "SESSION_COOKIE_NAME",
     "SESSION_TTL_MARGIN_SECONDS",
     "build_router",
+    "clear_login_binding_cookie",
     "clear_session_cookie",
     "compute_redirect_uri",
+    "login_binding_cookie_name",
+    "set_login_binding_cookie",
     "set_session_cookie",
 ]
 
@@ -170,6 +176,84 @@ _DEFAULT_RETURN_TO: Final[str] = "/ui/"
 #: ``_exchange_or_translate`` log discipline), so the body still does
 #: not telegraph what an attacker probed.
 AUTHORIZATION_STATE_EXPIRED_DETAIL: Final[str] = "authorization_state_expired"
+
+#: Name prefix of the short-lived login-binding cookie (F10, #272). The
+#: full cookie name embeds a hash of the flow's ``state`` (see
+#: :func:`login_binding_cookie_name`) so two concurrent logins from one
+#: browser get distinct cookies and never overwrite each other's
+#: binding -- a single fixed name would break legitimate concurrent
+#: login attempts. ``state`` is public (it travels on the callback URL),
+#: so hashing it into the name discloses nothing; the cookie *value* is
+#: the per-flow secret.
+LOGIN_BINDING_COOKIE_PREFIX: Final[str] = "meho_ob_"
+
+#: Path the login-binding cookie is scoped to. Narrower than the session
+#: cookie's ``/`` because the binding is written at ``/ui/auth/login``
+#: and read only at ``/ui/auth/callback`` -- both under ``/ui/auth`` --
+#: so there is no reason to expose it on ``/api/*`` requests.
+_LOGIN_BINDING_COOKIE_PATH: Final[str] = "/ui/auth"
+
+
+def login_binding_cookie_name(state: str) -> str:
+    """Per-flow name of the login-binding cookie, derived from *state*.
+
+    Hashing ``state`` into a bounded, cookie-name-safe hex suffix keeps
+    concurrent logins in one browser from clobbering each other's
+    binding cookie: each flow carries a distinct ``state`` and therefore
+    a distinct cookie name. The callback recomputes the same name from
+    the ``state`` on the callback URL, so no server-side lookup is
+    needed to find the right cookie.
+    """
+    digest = hashlib.sha256(state.encode("utf-8")).hexdigest()[:32]
+    return f"{LOGIN_BINDING_COOKIE_PREFIX}{digest}"
+
+
+def set_login_binding_cookie(response: RedirectResponse, state: str, browser_binding: str) -> None:
+    """Attach the short-lived login-binding cookie to *response* (F10, #272).
+
+    Sets the per-flow secret :func:`~meho_backplane.ui.auth.flow.
+    build_authorization_request` minted, so the callback can prove the
+    completing browser is the one that started the flow.
+
+    ``SameSite=Lax`` -- deliberately weaker than the session cookie's
+    ``Strict`` -- because the callback arrives as a top-level GET
+    navigation the IdP initiates from its own origin; for a separately
+    hosted Keycloak that is a cross-site navigation, and ``Strict``
+    would drop the cookie there and break every login. ``Lax`` is sent
+    on exactly that top-level navigation and withheld from every other
+    cross-site context (image loads, fetches, form POSTs), which is the
+    callback-compatible policy RFC 9700 calls for. ``HttpOnly`` +
+    ``Secure`` match the session cookie's hardening (no JS read, TLS
+    only). ``Max-Age`` mirrors the server-side flow TTL so an abandoned
+    login's cookie self-expires rather than lingering.
+    """
+    response.set_cookie(
+        key=login_binding_cookie_name(state),
+        value=browser_binding,
+        max_age=AUTHORIZATION_FLOW_TTL_SECONDS,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path=_LOGIN_BINDING_COOKIE_PATH,
+    )
+
+
+def clear_login_binding_cookie(response: Response, state: str) -> None:
+    """Erase the login-binding cookie once its flow completes (F10, #272).
+
+    Called on the callback success path so the single-use binding is
+    consumed and cleared. The attributes match
+    :func:`set_login_binding_cookie` (same name, path, ``Secure`` /
+    ``HttpOnly`` / ``SameSite``) so user agents that check attribute
+    parity on overwrite reliably expire it.
+    """
+    response.delete_cookie(
+        key=login_binding_cookie_name(state),
+        path=_LOGIN_BINDING_COOKIE_PATH,
+        secure=True,
+        httponly=True,
+        samesite="lax",
+    )
 
 
 def compute_redirect_uri() -> str:
@@ -313,7 +397,7 @@ async def _handle_login(
     log = structlog.get_logger(__name__)
     return_to = _safe_return_to(return_to)
     try:
-        url, state = await build_authorization_request(
+        url, state, browser_binding = await build_authorization_request(
             redirect_uri=compute_redirect_uri(),
             return_to=return_to,
         )
@@ -334,7 +418,11 @@ async def _handle_login(
             detail="upstream_auth_provider_unreachable",
         ) from exc
     log.info("ui_auth_login_redirect", state=state, return_to=return_to)
-    return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+    response = RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+    # Hand the initiating browser its login-binding cookie so the
+    # callback can prove this same browser completes the flow (F10 #272).
+    set_login_binding_cookie(response, state, browser_binding)
+    return response
 
 
 def _raise_idp_error(idp_error: str, idp_error_description: str | None) -> None:
@@ -355,14 +443,21 @@ async def _exchange_or_translate(
     *,
     state: str | None,
     authorization_response: str,
+    browser_binding: str | None,
 ) -> TokenExchangeResult:
     """Run the token exchange and map every error class to an HTTPException.
 
-    Encapsulates the chain of authlib / verifier-store / network
-    failures the callback can hit so the calling handler stays under
-    the 100-line code-quality cap. The token-side log discipline
+    Encapsulates the chain of authlib / verifier-store / browser-binding
+    / network failures the callback can hit so the calling handler stays
+    under the 100-line code-quality cap. The token-side log discipline
     (don't surface specific failure causes in the response body, only
     in structlog) lives here.
+
+    *browser_binding* is the value the callback replayed from the
+    login-binding cookie (F10, #272); a missing / mismatched value is
+    raised as an :class:`OAuthFlowError` inside
+    :func:`exchange_code_for_tokens` and collapses into the same
+    recoverable 400 as an expired ``state`` below.
     """
     log = structlog.get_logger(__name__)
     try:
@@ -370,6 +465,7 @@ async def _exchange_or_translate(
             redirect_uri=compute_redirect_uri(),
             authorization_response=authorization_response,
             state=state,
+            browser_binding=browser_binding,
         )
     except OAuthFlowConfigurationError:
         log.warning("ui_auth_oauth_not_configured", route="callback")
@@ -465,12 +561,20 @@ async def _handle_callback(
     del code
     if error:
         _raise_idp_error(error, error_description)
+    # The login-binding cookie the initiating browser holds for this
+    # ``state`` (F10, #272). Absent when the browser hitting this
+    # callback did not start the flow -- an attacker-induced callback in
+    # a victim's browser -- in which case the binding check inside
+    # ``exchange_code_for_tokens`` fails the flow closed before any
+    # token exchange or session creation.
+    browser_binding = request.cookies.get(login_binding_cookie_name(state)) if state else None
     # ``str(request.url)`` carries the full callback URL with query
     # string -- authlib's :meth:`fetch_token` parses ``code`` and
     # ``state`` out of it.
     tokens = await _exchange_or_translate(
         state=state,
         authorization_response=str(request.url),
+        browser_binding=browser_binding,
     )
     session_id, operator_sub, tenant_id = await _persist_session_from_tokens(tokens)
     log.info(
@@ -485,6 +589,11 @@ async def _handle_callback(
         status_code=status.HTTP_302_FOUND,
     )
     set_session_cookie(response, session_id)
+    # Single-use: the binding is consumed, so clear its cookie now that
+    # the flow has completed (F10, #272). ``state`` is non-None on any
+    # path that reaches here (a None state raises inside the exchange).
+    if state:
+        clear_login_binding_cookie(response, state)
     return response
 
 

--- a/backend/src/meho_backplane/ui/auth/verifier_store.py
+++ b/backend/src/meho_backplane/ui/auth/verifier_store.py
@@ -70,10 +70,22 @@ class PendingFlow:
     callback should redirect to on success. ``created_at`` is the
     monotonic-clock value at registration so the reaper can drop
     abandoned entries without depending on wall-clock skew.
+
+    ``browser_binding`` is the login-CSRF defence (F10, #272): a random
+    per-flow secret handed to the initiating browser in a short-lived
+    ``HttpOnly`` cookie at login time. The callback replays it from the
+    cookie and :func:`exchange_code_for_tokens` rejects the flow when it
+    is absent or mismatched -- so an attacker who starts their own login
+    and induces a victim to follow the unconsumed callback URL cannot
+    complete it in the victim's browser (the victim never holds the
+    matching cookie). It is a distinct random value from ``state``
+    precisely because ``state`` travels on the callback URL the attacker
+    controls; the binding value lives only in the browser cookie.
     """
 
     code_verifier: str
     return_to: str
+    browser_binding: str
     created_at: float
 
 
@@ -96,11 +108,20 @@ class PKCEVerifierStore:
         self._flows: dict[str, PendingFlow] = {}
         self._lock = asyncio.Lock()
 
-    async def put(self, state: str, *, code_verifier: str, return_to: str) -> None:
+    async def put(
+        self,
+        state: str,
+        *,
+        code_verifier: str,
+        return_to: str,
+        browser_binding: str,
+    ) -> None:
         """Register a fresh flow.
 
         Runs a bounded expired-entry sweep before the insert so the
-        map never grows beyond the live-flow set.
+        map never grows beyond the live-flow set. ``browser_binding`` is
+        the per-flow secret the callback cross-checks against the
+        initiating browser's cookie (F10, #272).
         """
         now = time.monotonic()
         async with self._lock:
@@ -116,6 +137,7 @@ class PKCEVerifierStore:
             self._flows[state] = PendingFlow(
                 code_verifier=code_verifier,
                 return_to=return_to,
+                browser_binding=browser_binding,
                 created_at=now,
             )
 

--- a/backend/tests/test_ui_auth_flow.py
+++ b/backend/tests/test_ui_auth_flow.py
@@ -69,7 +69,11 @@ from meho_backplane.ui.auth.middleware import require_ui_session
 from meho_backplane.ui.auth.revalidation import (
     reset_read_revalidation_cache_for_testing,
 )
-from meho_backplane.ui.auth.routes import AUTHORIZATION_STATE_EXPIRED_DETAIL
+from meho_backplane.ui.auth.routes import (
+    AUTHORIZATION_STATE_EXPIRED_DETAIL,
+    LOGIN_BINDING_COOKIE_PREFIX,
+    login_binding_cookie_name,
+)
 from meho_backplane.ui.auth.session_store import (
     create_session,
     load_session,
@@ -192,6 +196,23 @@ def _build_app(*, include_dummy_ui_route: bool = True) -> FastAPI:
     return app
 
 
+def _https_client(app: FastAPI | None = None) -> TestClient:
+    """A ``TestClient`` over HTTPS so ``Secure`` cookies survive the round-trip.
+
+    The BFF cookies -- the ``meho_session`` cookie and the F10 (#272)
+    login-binding cookie -- are ``Secure``, and the default
+    ``http://testserver`` transport silently drops ``Secure`` cookies (a
+    production deploy is HTTPS-only). Any login->callback flow that must
+    replay the login-binding cookie the login response set uses this
+    client instead of a plain ``TestClient``.
+    """
+    return TestClient(
+        app if app is not None else _build_app(),
+        base_url="https://testserver",
+        follow_redirects=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # /ui/auth/login -- builds the PKCE authorization URL (AC 1)
 # ---------------------------------------------------------------------------
@@ -230,17 +251,29 @@ def test_login_persists_verifier_in_server_side_store_not_cookie() -> None:
     """The PKCE verifier MUST NOT live in the client cookie.
 
     Defends decision #11's "tokens stay server-side" contract: a
-    verifier in a cookie would defeat the property PKCE protects.
+    verifier in a cookie would defeat the property PKCE protects. Login
+    does set the F10 (#272) login-binding cookie, but that carries a
+    *separate* opaque per-flow secret -- never the ``code_verifier`` --
+    so the PKCE property is intact.
     """
     with respx.mock(assert_all_called=False) as mock_router:
         _mock_oidc_metadata(mock_router)
         client = TestClient(_build_app(), follow_redirects=False)
         response = client.get("/ui/auth/login")
-    # No cookies set on the login redirect -- the verifier is in
-    # the server-side store, not on the client.
-    assert response.cookies == {}
     # The store has exactly one pending flow now.
-    assert get_verifier_store().size() == 1
+    store = get_verifier_store()
+    assert store.size() == 1
+    pending = next(iter(store._flows.values()))
+    # The only cookie the login redirect sets is the login-binding
+    # cookie, and it does NOT carry the session cookie or the PKCE
+    # verifier -- both stay server-side.
+    raw_set_cookie = response.headers["set-cookie"]
+    assert LOGIN_BINDING_COOKIE_PREFIX in raw_set_cookie
+    assert SESSION_COOKIE_NAME not in response.cookies
+    assert pending.code_verifier not in raw_set_cookie
+    # The binding cookie's value is the per-flow secret stored server
+    # side -- it is what the callback cross-checks, not the verifier.
+    assert pending.browser_binding in raw_set_cookie
 
 
 def test_login_503s_when_client_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -357,7 +390,7 @@ def test_callback_creates_session_and_sets_cookie() -> None:
                 },
             ),
         )
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = _https_client()
         # Step 1: login mints a state + verifier.
         login_response = client.get("/ui/auth/login?return_to=/ui/dashboard")
         login_location = login_response.headers["location"]
@@ -549,7 +582,7 @@ def test_callback_502s_when_token_endpoint_unreachable() -> None:
     with respx.mock(assert_all_called=False) as mock_router:
         _mock_oidc_metadata(mock_router)
         mock_router.post(_TOKEN_ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = _https_client()
         login_response = client.get("/ui/auth/login")
         state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
         response = client.get(
@@ -575,13 +608,221 @@ def test_callback_rejects_replayed_state_after_first_consumption() -> None:
                 },
             ),
         )
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = _https_client()
         login_response = client.get("/ui/auth/login")
         state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
         first = client.get(f"/ui/auth/callback?code=code-1&state={state}")
         second = client.get(f"/ui/auth/callback?code=code-2&state={state}")
     assert first.status_code == 302
     assert second.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /ui/auth login-CSRF browser binding (F10, #272)
+# ---------------------------------------------------------------------------
+
+
+def _token_json(access_token: str) -> dict[str, Any]:
+    """Minimal Keycloak token-endpoint body for the binding tests."""
+    return {
+        "access_token": access_token,
+        "refresh_token": "rt",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+    }
+
+
+def test_login_sets_browser_binding_cookie_with_lax_httponly_secure() -> None:
+    """F10 (#272): login sets a short-lived HttpOnly/Secure/SameSite=Lax cookie.
+
+    ``SameSite=Lax`` (not ``Strict``) is the callback-compatible policy:
+    the callback is a top-level GET the IdP initiates, cross-site for a
+    separately hosted Keycloak, and ``Strict`` would drop the cookie.
+    The cookie is scoped to ``/ui/auth`` and its value is the per-flow
+    secret the store holds.
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    state = parse_qs(urlparse(response.headers["location"]).query)["state"][0]
+    name = login_binding_cookie_name(state)
+    binding_header = next(
+        h for h in response.headers.get_list("set-cookie") if h.startswith(f"{name}=")
+    )
+    lowered = binding_header.lower()
+    assert "httponly" in lowered
+    assert "secure" in lowered
+    assert "samesite=lax" in lowered
+    assert "path=/ui/auth" in lowered
+    assert f"max-age={AUTHORIZATION_FLOW_TTL_SECONDS}" in lowered
+    # The cookie value is the per-flow secret the store stashed -- not
+    # the PKCE verifier, and distinct from the OAuth ``state``.
+    pending = next(iter(get_verifier_store()._flows.values()))
+    assert response.cookies[name] == pending.browser_binding
+    assert pending.browser_binding != state
+
+
+def test_callback_from_second_browser_without_binding_cookie_is_rejected() -> None:
+    """F10 (#272): the headline attack -- A's unconsumed callback in B fails.
+
+    Browser A starts login; browser B (a fresh client that never started
+    the flow, so it holds none of A's cookies) follows A's callback URL.
+    No session is created and the token endpoint is never reached -- the
+    binding is checked before token exchange.
+    """
+    access_token, jwks = _mint_access_token()
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        token_route = mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(200, json=_token_json(access_token)),
+        )
+        browser_a = TestClient(_build_app(), follow_redirects=False)
+        login = browser_a.get("/ui/auth/login")
+        state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+        # Browser B: separate cookie jar -> no binding cookie for `state`.
+        browser_b = TestClient(_build_app(), follow_redirects=False)
+        response = browser_b.get(
+            f"/ui/auth/callback?code=attacker-code&state={state}",
+            headers=_JSON_ACCEPT,
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == AUTHORIZATION_STATE_EXPIRED_DETAIL
+    # Rejected before the token exchange -- no session, no token POST.
+    assert not token_route.called
+    assert SESSION_COOKIE_NAME not in response.cookies
+
+
+def test_callback_same_browser_succeeds_and_clears_binding_cookie() -> None:
+    """F10 (#272): the initiating browser completes login; the cookie is cleared.
+
+    Same-browser success is the legitimate path -- it must still work --
+    and the single-use binding cookie is expired on the success response.
+    """
+    access_token, jwks = _mint_access_token()
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(200, json=_token_json(access_token)),
+        )
+        client = _https_client()
+        login = client.get("/ui/auth/login?return_to=/ui/dashboard")
+        state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+        callback = client.get(f"/ui/auth/callback?code=test-code&state={state}")
+    assert callback.status_code == 302
+    assert callback.headers["location"] == "/ui/dashboard"
+    assert SESSION_COOKIE_NAME in callback.cookies
+    # The binding cookie is expired (Max-Age=0) on the success response.
+    name = login_binding_cookie_name(state)
+    binding_header = next(
+        h for h in callback.headers.get_list("set-cookie") if h.startswith(f"{name}=")
+    )
+    assert "max-age=0" in binding_header.lower()
+
+
+def test_concurrent_logins_bind_independently_and_both_complete() -> None:
+    """F10 (#272): concurrent logins in one browser must not break binding.
+
+    Two logins from one browser get distinct per-``state`` cookie names,
+    so the second does not clobber the first's binding, and both
+    callbacks complete.
+    """
+    access_token, jwks = _mint_access_token()
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(200, json=_token_json(access_token)),
+        )
+        client = _https_client()
+        login1 = client.get("/ui/auth/login?return_to=/ui/one")
+        state1 = parse_qs(urlparse(login1.headers["location"]).query)["state"][0]
+        login2 = client.get("/ui/auth/login?return_to=/ui/two")
+        state2 = parse_qs(urlparse(login2.headers["location"]).query)["state"][0]
+        # Distinct per-flow cookie names -- login2 did not overwrite the
+        # login1 binding cookie.
+        assert login_binding_cookie_name(state1) != login_binding_cookie_name(state2)
+        cb1 = client.get(f"/ui/auth/callback?code=c1&state={state1}")
+        cb2 = client.get(f"/ui/auth/callback?code=c2&state={state2}")
+    assert cb1.status_code == 302
+    assert cb1.headers["location"] == "/ui/one"
+    assert cb2.status_code == 302
+    assert cb2.headers["location"] == "/ui/two"
+
+
+def test_exchange_code_rejects_missing_browser_binding() -> None:
+    """F10 (#272): the flow primitive fails closed when no binding is presented."""
+    from meho_backplane.ui.auth.flow import OAuthFlowError
+
+    async def _go() -> None:
+        with respx.mock(assert_all_called=False) as mock_router:
+            _mock_oidc_metadata(mock_router)
+            _url, state, _binding = await build_authorization_request(
+                redirect_uri=_REDIRECT_URI,
+                return_to="/ui/",
+            )
+            with pytest.raises(OAuthFlowError):
+                await exchange_code_for_tokens(
+                    redirect_uri=_REDIRECT_URI,
+                    authorization_response=f"{_REDIRECT_URI}?code=c&state={state}",
+                    state=state,
+                    browser_binding=None,
+                )
+
+    asyncio.run(_go())
+
+
+def test_exchange_code_rejects_mismatched_browser_binding() -> None:
+    """F10 (#272): a binding value that is not the stored secret fails closed.
+
+    No token-endpoint mock is registered, so a regression that let the
+    exchange proceed past the mismatch would raise a respx "not mocked"
+    error rather than silently pass.
+    """
+    from meho_backplane.ui.auth.flow import OAuthFlowError
+
+    async def _go() -> None:
+        with respx.mock(assert_all_called=False) as mock_router:
+            _mock_oidc_metadata(mock_router)
+            _url, state, binding = await build_authorization_request(
+                redirect_uri=_REDIRECT_URI,
+                return_to="/ui/",
+            )
+            with pytest.raises(OAuthFlowError):
+                await exchange_code_for_tokens(
+                    redirect_uri=_REDIRECT_URI,
+                    authorization_response=f"{_REDIRECT_URI}?code=c&state={state}",
+                    state=state,
+                    browser_binding=f"{binding}-tampered",
+                )
+
+    asyncio.run(_go())
+
+
+def test_exchange_code_rejects_non_ascii_browser_binding() -> None:
+    """F10 (#272): a hostile non-ASCII binding fails closed, not 500.
+
+    ``hmac.compare_digest`` refuses non-ASCII ``str`` operands; the
+    guard must map that to the recoverable ``OAuthFlowError`` rather
+    than let a ``TypeError`` escape as a 500.
+    """
+    from meho_backplane.ui.auth.flow import OAuthFlowError
+
+    async def _go() -> None:
+        with respx.mock(assert_all_called=False) as mock_router:
+            _mock_oidc_metadata(mock_router)
+            _url, state, _binding = await build_authorization_request(
+                redirect_uri=_REDIRECT_URI,
+                return_to="/ui/",
+            )
+            with pytest.raises(OAuthFlowError):
+                await exchange_code_for_tokens(
+                    redirect_uri=_REDIRECT_URI,
+                    authorization_response=f"{_REDIRECT_URI}?code=c&state={state}",
+                    state=state,
+                    browser_binding="bindïng-with-nön-ascii",
+                )
+
+    asyncio.run(_go())
 
 
 # ---------------------------------------------------------------------------
@@ -1035,7 +1276,7 @@ def test_pkce_verifier_store_pop_is_single_use() -> None:
 
     async def _go() -> None:
         store = PKCEVerifierStore()
-        await store.put("state-1", code_verifier="v", return_to="/ui/")
+        await store.put("state-1", code_verifier="v", return_to="/ui/", browser_binding="b1")
         first = await store.pop("state-1")
         second = await store.pop("state-1")
         assert first is not None
@@ -1053,7 +1294,7 @@ def test_pkce_verifier_store_expires_past_ttl(
     async def _go() -> None:
         store = PKCEVerifierStore()
         # First put -- normal.
-        await store.put("state-stale", code_verifier="v1", return_to="/ui/")
+        await store.put("state-stale", code_verifier="v1", return_to="/ui/", browser_binding="bs")
         assert store.size() == 1
         # Fast-forward monotonic time past the TTL by patching the
         # store's internal time reference.
@@ -1066,7 +1307,7 @@ def test_pkce_verifier_store_expires_past_ttl(
             lambda: original() + AUTHORIZATION_FLOW_TTL_SECONDS + 1,
         )
         # A fresh put triggers the reap and drops the stale entry.
-        await store.put("state-fresh", code_verifier="v2", return_to="/ui/")
+        await store.put("state-fresh", code_verifier="v2", return_to="/ui/", browser_binding="bf")
         assert store.size() == 1
         assert await store.pop("state-stale") is None
         fresh = await store.pop("state-fresh")
@@ -1086,7 +1327,7 @@ def test_build_authorization_request_carries_state_and_resource() -> None:
     async def _go() -> None:
         with respx.mock(assert_all_called=False) as mock_router:
             _mock_oidc_metadata(mock_router)
-            url, state = await build_authorization_request(
+            url, state, _binding = await build_authorization_request(
                 redirect_uri=_REDIRECT_URI,
                 return_to="/ui/dashboard",
             )
@@ -1110,6 +1351,7 @@ def test_exchange_code_rejects_unknown_state() -> None:
                     redirect_uri=_REDIRECT_URI,
                     authorization_response=(f"{_REDIRECT_URI}?code=c&state=forged"),
                     state="forged",
+                    browser_binding=None,
                 )
 
     asyncio.run(_go())
@@ -1136,7 +1378,7 @@ def test_full_login_round_trip_lets_authenticated_page_through() -> None:
                 },
             ),
         )
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = _https_client()
         # 1. Unauthenticated -> redirect to login.
         deep_link = client.get("/ui/sentinel")
         assert deep_link.status_code == 302

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -424,7 +424,7 @@ def test_callback_creates_session_and_redirects_to_dashboard() -> None:
                 },
             ),
         )
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = TestClient(_build_app(), base_url="https://testserver", follow_redirects=False)
         login_response = client.get("/ui/auth/login")  # default return_to=/ui/
         state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
         callback = client.get(
@@ -804,7 +804,7 @@ def test_full_flow_unauth_login_callback_then_dashboard() -> None:
                 },
             ),
         )
-        client = TestClient(_build_app(), follow_redirects=False)
+        client = TestClient(_build_app(), base_url="https://testserver", follow_redirects=False)
         _trust_test_cookies(client)
         # Step 1: hit /ui/ unauthenticated -> 302 to login.
         first = client.get("/ui/")

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -83,8 +83,8 @@ Sanctioned exceptions:
 | `meho_backplane.ui.security_headers` | Pure-ASGI `UIFramingHeadersMiddleware` (clickjacking-defence hardening, #101 row L12). Stamps every `/ui/*` response with `Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY` (the two OWASP-recommended anti-framing headers; both are sent for defence-in-depth + legacy-browser support). Registered **outermost** in `main.py` (last `add_middleware`) so the headers land even on `UISessionMiddleware`'s 302-to-login -- a framed login page is itself a clickjacking surface. `/ui/`-scoped by construction: out-of-prefix `/api/*` / `/mcp` JSON responses pass through unstamped. The CSP is `frame-ancestors`-only -- deliberately NOT a full content-security policy (broadening to `script-src`/`style-src` would risk breaking the HTMX + Alpine + inline-script render). Uses `MutableHeaders(scope=message).setdefault(...)` on `http.response.start` (Starlette's own header-stamping recipe) so a route that ever sets its own `frame-ancestors` CSP keeps its value. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware; G0.25 (#1694) wires the rotation primitive into the request path (`refresh` + `errors` modules). |
 | `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `load_session_for_update` (side-effect-free `SELECT ... FOR UPDATE` variant for the refresh path, G0.25 #1694), `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. `rotate_refresh` optionally extends `expires_at` by a refreshed token's lifetime (`new_lifetime=`), monotonic and clamped to `created_at + ui_session_absolute_lifetime_seconds`, and accepts a caller-supplied clock (`now=`, default wall clock) so a caller that pre-checks `expires_at` (the inline refresh path) shares one reading with the internal replay gate -- two independent clock reads would leave a microsecond gap where the gate's "expired" branch self-deadlocks on the caller's own row lock. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. `list_active_sessions(operator_sub, tenant_id)` returns the caller's own live sessions (own `operator_sub` + `tenant_id`, `revoked_at IS NULL`, `expires_at > now()`, ordered `last_seen_at DESC`) as token-free `ActiveSessionRow` projections (the Fernet ciphertext columns are never read for a metadata listing) and `revoke_other_sessions(operator_sub, tenant_id, keep_session_id)` soft-deletes every own active session except the current one -- both back the Account surface (G10.11-T1 #1892) and take their `(operator_sub, tenant_id)` from the validated session context, never a form field. |
-| `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter) and registers the per-flow verifier in a server-side `PKCEVerifierStore`. `exchange_code_for_tokens` pops the verifier and exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
-| `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Callback verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks. Sets `meho_session` cookie with `HttpOnly; Secure; SameSite=Strict; Path=/`. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
+| `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter), mints a second per-flow `browser_binding` secret (login-CSRF defence, F10 #272), and registers the verifier + binding + `return_to` in a server-side `PKCEVerifierStore`; it returns `(url, state, browser_binding)`. `exchange_code_for_tokens` pops the pending flow, **rejects it (`browser_binding_mismatch`) when the callback's replayed binding is missing or does not match — before the token exchange** (constant-time `hmac.compare_digest`), then exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
+| `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Login sets the short-lived `browser_binding` cookie (`login_binding_cookie_name(state)` = `meho_ob_<sha256(state)[:32]>`; `HttpOnly; Secure; SameSite=Lax; Path=/ui/auth; Max-Age=<flow TTL>`) — `Lax`, not `Strict`, so it survives the cross-site top-level callback navigation from a separately hosted Keycloak; the per-`state` name lets concurrent logins from one browser bind independently. Callback reads that cookie, passes it to `exchange_code_for_tokens` for the binding check, verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks, sets `meho_session` (`HttpOnly; Secure; SameSite=Strict; Path=/`), and clears the single-use binding cookie on success. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
 | `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`, plus `tenant_slug` + `tenant_name` populated from a same-transaction `tenant` PK lookup added by G0.15-T9 #1217) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. `require_ui_admin` (the write-route RBAC gate) loads + verifies the stored access token through `meho_backplane.ui.auth.refresh`, so expired tokens silently refresh instead of 401ing (G0.25 #1694). After every successful row load the middleware also runs the drift-gated read-path revalidation (`meho_backplane.ui.auth.revalidation.revalidate_read_session`): past `ui_session_read_revalidation_seconds` (default 300; `0` = every request) without a validation, the stored token is re-presented to the JWKS-cached JWT chain -- an in-memory check on a cache hit, escalating to one reactive refresh only once the token is past `exp` -- and a terminal failure collapses to the same redirect-to-login as a missing session. This bounds IdP revocation / role-demotion lag on read renders to ~(access-token TTL + threshold) instead of the 12 h absolute session lifetime; the anchor is a process-local last-validated map (not `last_seen_at`, which active sessions bump every request, so a gap-based gate would never fire for exactly the sessions that matter). |
 | `meho_backplane.ui.auth.refresh` | Inline token-refresh lifecycle (G0.25 #1694). `load_fresh_session` (proactive: refresh when the row is within 60 s of `expires_at`), `verify_access_token_with_refresh` (reactive: refresh once on the JWT chain's `token_expired`, re-verify), both funnelling into `refresh_session_tokens` -- the `SELECT ... FOR UPDATE`-serialised chokepoint that POSTs the RFC 6749 § 6 refresh grant (single attempt, 5 s timeout) and rotates the row via `rotate_refresh` (RFC 9700 § 4.14). Concurrent refreshes: first wins; the loser observes the rotated pair under the lock and skips its network call. Failures log `ui_auth_token_refresh_failed` (reason: `invalid_grant` / `network_error` / `timeout` / `malformed_response`) and raise `401 session_expired`; successes log `ui_auth_token_refresh_succeeded` (session_id, old/new expires_at, time_cost_ms). No token material in logs. The refresh performs zero `Set-Cookie` operations -- `meho_session` and `meho_csrf` stay byte-identical, so in-flight pages and their CSRF tokens survive a rotation (no #1706-class cookie desync). The seam serves **token-presenting** dependencies: `require_ui_admin`, the session middleware's drift-gated read-path revalidation (`meho_backplane.ui.auth.revalidation`), plus (G10.x #121) every per-route operator lift that re-verifies the stored access token to surface `tenant_role` / `sub` — `agents.operator`, `connectors.operator` (and the topology write gates that reuse its `lift_operator_from_session`), `memory.operator`, and the `kb` / `runbooks` / `operations` / `audit` / `keycloak` / `vault` route resolvers. Each calls `load_fresh_session` then `verify_access_token_with_refresh` (mirroring the `approvals` / `corpus` / `retrieval` precedent) rather than bare `load_session` + `verify_jwt_for_audience`, so no token-consuming `/ui/*` route 401s on an expired-but-refreshable token. The soft-fail role probes (`runbooks` / `audit` `_resolve_role`, the `agents` / `connectors` `resolve_role_probe`) keep their `try/except` → "no privileges" floor: a terminal `session_expired` from an unavailable refresh is absorbed there, never a 5xx. The dashboard-feed fix (#1696) needed no caller here — it re-pointed the tray at the existing session-gated `/ui/broadcast/stream` bridge, which reads Valkey directly under `require_ui_session` and never presents the access token. |
 | `meho_backplane.ui.auth.errors` | App-level `HTTPException` handler registered in `main.py` for the whole app (G0.25 #1694). Intercepts two recoverable shapes, both only for HTML navigations (`Accept: text/html`): (1) `401 session_expired` on `/ui/*` (G0.25 #1694) -> `302 /ui/auth/login?return_to=<path>` + `meho_session` cookie clear; (2) `400 authorization_state_expired` on `/ui/auth/callback` (G0.29 #2089, Leg 1) -> `303 /ui/auth/login` (no cookie touched -- pre-session; no `return_to` -- it died with the expired verifier). Non-HTML callers on either shape keep the structured JSON body (the `session_expired` case also clears the dead cookie). Every other HTTPException -- including the callback's genuine IdP `authorization_failed` and its token-endpoint `502` -- delegates byte-for-byte to FastAPI's stock `http_exception_handler`, so `/api/*` 401 codes and the non-recoverable callback errors are untouched. |
@@ -206,23 +206,30 @@ Round-trip shape:
    `UISessionMiddleware` finds no usable session and 302s to
    `/ui/auth/login?return_to=<original-path>`.
 2. **`/ui/auth/login`.** `build_authorization_request` generates a
-   per-flow PKCE `code_verifier`, asks authlib to build the
-   authorization URL (carries `code_challenge`,
+   per-flow PKCE `code_verifier` **and an independent per-flow
+   `browser_binding` secret** (login-CSRF defence, F10 #272), asks
+   authlib to build the authorization URL (carries `code_challenge`,
    `code_challenge_method=S256`, and the RFC 8707 `resource` parameter
    set to `<backplane_url>/api`), and registers the verifier +
-   `return_to` in the `PKCEVerifierStore` keyed on `state`. The
-   verifier never leaves the server.
+   `browser_binding` + `return_to` in the `PKCEVerifierStore` keyed on
+   `state`. The verifier and binding secret never leave the server
+   except that the binding is *also* set as a short-lived `HttpOnly;
+   Secure; SameSite=Lax` cookie on the initiating browser, scoped to
+   `/ui/auth`, under a per-`state` name.
 3. **Keycloak authenticates the operator.** Browser arrives at
    `/ui/auth/callback?code=...&state=...`.
 4. **`/ui/auth/callback`.** `exchange_code_for_tokens` pops the
-   verifier from the store (single-use), POSTs
-   `code+code_verifier+client_secret` to Keycloak's token endpoint,
-   and returns the access + refresh tokens. The callback then
-   validates the access token through the chassis JWT chain
-   (`verify_jwt_for_audience`) so the BFF inherits issuer / audience
-   / sub / tenant_id / tenant_role defences; on success it calls
-   `create_session` to write the encrypted row and sets the
-   `meho_session` cookie.
+   pending flow from the store (single-use), then **rejects it before
+   any token exchange when the browser did not replay the matching
+   `browser_binding` cookie** (constant-time compare) — this is what
+   defeats login CSRF, below. On a good binding it POSTs
+   `code+code_verifier+client_secret` to Keycloak's token endpoint and
+   returns the access + refresh tokens. The callback then validates the
+   access token through the chassis JWT chain (`verify_jwt_for_audience`)
+   so the BFF inherits issuer / audience / sub / tenant_id / tenant_role
+   defences; on success it calls `create_session` to write the encrypted
+   row, sets the `meho_session` cookie, and clears the now-consumed
+   binding cookie.
 5. **302 to the original `return_to`.** Operator lands on the page
    they were originally bounced from.
 
@@ -248,6 +255,7 @@ Per-flow state custody:
 | --- | --- | --- |
 | `code_verifier` | Server-side `PKCEVerifierStore` keyed on `state` | One authorization round-trip (≤10 min) |
 | `state` (CSRF) | On the IdP's authorization URL + echoed in callback | Same one round-trip |
+| `browser_binding` (login-CSRF) | Server-side `PKCEVerifierStore` **and** a per-`state` browser cookie (`meho_ob_<hash>`, `HttpOnly` + `Secure` + `SameSite=Lax` + `Path=/ui/auth`) | Same one round-trip; cookie `Max-Age` = flow TTL; cleared on callback success |
 | `meho_session` cookie | Browser, `HttpOnly` + `Secure` + `SameSite=Strict` | Session lifetime (seeded at login from access-token expiry minus 60s margin; extended by the sliding window #869 and by every successful token refresh #1694, both capped at `created_at + ui_session_absolute_lifetime_seconds`) |
 | Access + refresh tokens | `web_session` row, Fernet-encrypted | Rotated in place on every silent refresh (#1694); the row -- and therefore the cookie value -- survives rotation unchanged |
 
@@ -255,6 +263,40 @@ The `code_verifier` deliberately does NOT live in a cookie -- a
 verifier alongside the code on the redirect URI would defeat the
 property PKCE protects (an attacker capturing one captures both).
 Server-side custody is the whole point.
+
+Login-CSRF browser binding (F10, #272): `state` + PKCE + the
+server-side verifier map do not, by themselves, tie the flow to the
+browser that started it. An attacker can authenticate their **own**
+account, capture the resulting `code`+`state` callback URL, and induce
+a victim to follow it; because the verifier map is keyed only on
+`state` (which travels on that URL), the victim's browser would
+complete the flow and receive a session for the **attacker's**
+identity (login CSRF / session confusion -- the victim then works in
+the wrong account). The fix binds each flow to its initiating
+user-agent: login mints a second random `browser_binding` secret,
+stores it in the pending flow, and hands it to the browser as the
+short-lived cookie above; the callback must replay it, and
+`exchange_code_for_tokens` rejects a missing or mismatched value
+(constant-time `hmac.compare_digest`) **before the token exchange and
+before any session is created**. The victim never holds the attacker's
+binding cookie, so the induced callback fails closed. A binding
+mismatch surfaces as the same recoverable `400
+authorization_state_expired` as an expired `state` (it never
+telegraphs the specific cause), so an HTML navigation still gets the
+one-click login restart. The binding value is independent of `state`
+(which is public on the URL) and is **not** the PKCE `code_verifier`,
+so PKCE's server-only custody is intact. The cookie is `SameSite=Lax`,
+not `Strict` like the session cookie, because the callback is a
+top-level GET the IdP initiates -- cross-site for a separately hosted
+Keycloak, where `Strict` would drop the cookie and break every login;
+`Lax` is sent on exactly that top-level navigation and withheld from
+every other cross-site context. Because the cookie name embeds a hash
+of `state`, two concurrent logins from one browser bind independently
+(neither clobbers the other's cookie), and each is single-use --
+cleared on its own callback's success. This is distinct from the
+post-session BFF read-revalidation of #149: that hardens an
+**existing** session; this closes login CSRF **before** a session
+exists.
 
 Mid-session token refresh (G0.25 #1694): Keycloak's access token
 (~5 min TTL) routinely dies long before the session row does --


### PR DESCRIPTION
## Summary

- **Closes the login-CSRF / session-confusion gap (F10) in the backplane BFF.** `state` + PKCE + the server-side verifier map (keyed only on `state`, which travels on the callback URL) did **not** tie the flow to the browser that started it: an attacker could authenticate their own account, capture the resulting `code`+`state` callback URL, and induce a victim to follow it — completing the flow in the victim's browser and logging the victim into the **attacker's** account (RFC 9700 §4.x login CSRF).
- **Binds each flow to its initiating user-agent.** `build_authorization_request` now mints a second, independent per-flow secret (`browser_binding`), stashes it in the `PendingFlow`, and returns it; `/ui/auth/login` sets it as a short-lived **`HttpOnly; Secure; SameSite=Lax; Path=/ui/auth; Max-Age=<flow TTL>`** cookie on the initiating browser. The callback replays the cookie and `exchange_code_for_tokens` rejects a missing or mismatched value (constant-time `hmac.compare_digest`) **before the token-endpoint POST and before any session is created**. The binding is single-use — its cookie is cleared on callback success.
- **`SameSite=Lax`, not `Strict`** (unlike the session cookie): the callback is a top-level GET the IdP initiates, which is cross-site for a separately hosted Keycloak, where `Strict` would drop the cookie and break every login. `Lax` is sent on exactly that top-level navigation and withheld from every other cross-site context — the callback-compatible policy RFC 9700 calls for.
- **Concurrent logins bind independently.** The cookie name embeds `sha256(state)[:32]` (`meho_ob_<hash>`), so two concurrent logins from one browser get distinct cookies and neither clobbers the other's binding. `state` is public (it's on the URL), so hashing it into the name discloses nothing; the cookie *value* is the per-flow secret.
- A binding mismatch surfaces as the same recoverable `400 authorization_state_expired` as an expired `state` (it never telegraphs the specific cause), so an HTML navigation still gets the one-click login restart via the existing app-level error handler.

## Acceptance criteria

- [x] **Both applications bind state/PKCE to a short-lived pre-login browser cookie with secure, HttpOnly, callback-compatible SameSite.** Backplane half delivered here (`HttpOnly; Secure; SameSite=Lax; Path=/ui/auth`). **Automation half is a separate repo — see "Cross-repo scope" below.**
- [x] **Missing/mismatched browser binding rejected before token completion/session creation; consumed once and cleared.** `_verify_browser_binding` runs after the single-use `pop(state)` and before `_post_to_token_endpoint`; the binding cookie is cleared on the callback success response.
- [x] **Two-browser test:** `test_callback_from_second_browser_without_binding_cookie_is_rejected` — browser B (no binding cookie) following A's callback gets a 400, no token POST, no session cookie. `test_callback_same_browser_succeeds_and_clears_binding_cookie` — same-browser login succeeds and the cookie is expired (`Max-Age=0`).
- [x] **Replay and expired-state fail; access-token verification + redirect-target validation stay enforced.** `state` remains single-use (`pop`); `test_callback_rejects_replayed_state_after_first_consumption` still green; `verify_jwt_for_audience` and `_safe_return_to` are untouched.
- [x] **Supported deployments/proxy paths + concurrent legitimate logins without weakening binding.** `test_concurrent_logins_bind_independently_and_both_complete`; the `Secure` cookie works behind a TLS-terminating proxy, and the per-`state` cookie name is the concurrency guarantee.

## Test plan

- [x] `ruff check` — clean (5 files)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/auth/` — Success, no issues (9 source files)
- [x] `pytest tests/test_ui_auth_flow.py tests/test_ui_chassis_smoke.py` — 69 passed, 1 skipped (pre-existing empty-param route test); the 7 new F10 binding tests all pass
- [x] Full backend UI test surface (`tests/test_ui_*.py`) green
- [x] Blast-radius: every caller of the three changed signatures (`build_authorization_request`, `exchange_code_for_tokens`, `PKCEVerifierStore.put`) is inside the auth package + its tests; no external caller. No REST route parameter/schema changed (the binding cookie is read from `request.cookies`), so the OpenAPI/CLI snapshot is unchanged.

## Cross-repo scope

This PR delivers the **backplane** (`evoila/meho`) half of #272. The task's AC #1 also covers `meho_automation` (source refs `A/backend/src/meho_automation/ui/auth/{flow,routes}.py`), which lives in the **`evoila-bosnia/meho-automation`** repo and cannot be changed from this PR. The automation half needs a sibling PR applying the same pattern there. Flagging for the orchestrator to track/file; the `Closes` line below auto-closes the tracking issue on merge of this backplane PR.

## Out of scope

- Post-session BFF read-session revalidation (closed #149) — this task is login CSRF *before* a session exists.
- `docs/codebase/ui.md` updated to document the browser-binding leg; no CHANGELOG entry (orchestrator batches those).
- Adjacent finding: `flow.py` (591→661) and `routes.py` (591→700) cross the informal 600-line file-size guideline after these additions; both were already near the line and the repo ships no file-size gate. Splitting these security-sensitive modules is out of scope for this fix.

<!-- auto-implement-issue: fresh, iteration 1 -->

Part of evoila-bosnia/meho-internal#272 (evoila/meho backplane half; the meho_automation ui/auth sibling lands with the held automation roll — orchestrator keeps #272 open)
