### PR TITLE
fix(connectors): key k8s client caches by tenant+target identity (F04)

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -66,7 +66,11 @@ from kubernetes_asyncio import client, config
 from kubernetes_asyncio.stream.ws_client import WsApiClient
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.system_operator import (
+    is_system_operator,
+    synthesise_system_operator,
+)
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.kubernetes.kubeconfig import (
     CredentialLoader,
@@ -347,14 +351,15 @@ class KubernetesConnector(Connector):
             self._credential_loader = _adapt_kubeconfig_loader(kubeconfig_loader)
         else:
             self._credential_loader = load_kubernetes_credential
-        self._api_clients: dict[str, client.ApiClient] = {}
+        self._api_clients: dict[tuple[str, str], client.ApiClient] = {}
         # Parallel cache of websocket-transport clients, keyed the same
-        # way as ``_api_clients`` (``secret_ref``). Only ``k8s.exec``
+        # way as ``_api_clients`` (the tenant-unique ``(tenant_id, id)``
+        # tuple from :func:`target_cache_key`). Only ``k8s.exec``
         # populates it -- pod exec is an HTTP Upgrade to the
         # ``v4.channel.k8s.io`` sub-protocol, which the ordinary
         # ``ApiClient`` cannot speak. Built lazily from the same
         # operator-identity kubeconfig and closed in :meth:`aclose`.
-        self._ws_api_clients: dict[str, WsApiClient] = {}
+        self._ws_api_clients: dict[tuple[str, str], WsApiClient] = {}
         self._lock = asyncio.Lock()
 
     async def fingerprint(
@@ -1733,22 +1738,30 @@ class KubernetesConnector(Connector):
             self._ws_api_clients.clear()
 
     @staticmethod
-    def _cache_key(target: KubernetesTargetLike) -> str:
-        """Globally unique cache key for *target*.
+    def _cache_key(target: KubernetesTargetLike) -> tuple[str, str]:
+        """Tenant-unique ``(tenant_id, id)`` cache key for *target*.
 
-        Keyed on ``secret_ref`` (the Vault path the kubeconfig lives
-        at) rather than ``target.name``. Once G0.3 (#224) lands its
-        ``Target`` model, target names are unique only within a tenant
-        — two tenants legitimately holding a target both named
-        ``"rke2-meho"`` would otherwise share an :class:`ApiClient`
-        built from whichever kubeconfig loaded first, and the second
-        tenant's ops would silently execute against the first
-        tenant's cluster. The Vault path is the operator's chosen
-        opaque identifier for the kubeconfig and is globally unique
-        by the consumer's ``targets.yaml`` convention. Swap to
-        ``target.id`` when G0.3 finalises a row-PK shape.
+        Delegates to the shared
+        :func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`
+        so both client caches derive the identical key and no
+        two-cache-keying-skew can creep in. ``id`` is the targets-table
+        primary key and ``(tenant_id, name)`` is its only uniqueness
+        constraint, so ``(tenant_id, id)`` uniquely identifies one target
+        row across all tenants.
+
+        This replaces the former ``secret_ref``-only key (security F04,
+        evoila/meho#266): keying on the Vault path alone collapsed two
+        targets in different tenants that happen to share a ``secret_ref``
+        onto one entry, so the second tenant was served the first
+        tenant's authenticated client without ever passing its own
+        credential-store authorization. ``(tenant_id, id)`` is the row's
+        stable identity and subsumes the credential reference (the
+        ``secret_ref`` column is a property of that row); an operator
+        repointing the secret, rotating the credential, or the target
+        being revoked is handled by :meth:`invalidate_credentials`, not by
+        folding a mutable column into the key.
         """
-        return target.secret_ref
+        return target_cache_key(target)
 
     async def _get_api_client(
         self,
@@ -1774,22 +1787,30 @@ class KubernetesConnector(Connector):
         injected path.
 
         Cache-hit fast path: when the :class:`ApiClient` is already
-        cached for this target's :meth:`_cache_key`, the operator
-        argument is ignored (the credential has already been resolved
-        under a prior operator's identity). This is the v0.2 design
-        choice: credentials are tied to ``target.secret_ref`` (the shared
-        service account) rather than the acting operator, so the client
-        is shareable across operators. For a WCP target the cached
+        cached for this target's :meth:`_cache_key`, a *real* operator
+        reuses it — the credential is tied to the target's shared service
+        account rather than the acting operator, so the client is
+        shareable across real operators. For a WCP target the cached
         client's short-lived Supervisor token refreshes transparently via
         the :class:`Configuration`'s ``refresh_api_key_hook`` — the client
         object stays cached, only its bearer rotates. A future
         per-operator auth model (impersonation) would re-key the cache on
-        operator identity; until then ``secret_ref`` is sufficient.
+        operator identity.
+
+        The fast path is **closed to the synthesised system operator**
+        (:func:`~meho_backplane.connectors._shared.system_operator.is_system_operator`),
+        as every peer connector's cache is (#1008): a system/operator-less
+        caller — reachable through the operator-less ``k8s.ls`` forwarder —
+        always falls through to the fail-closed credential loader and can
+        never be served a warm client a real operator primed but it could
+        not resolve itself. In production the loader then fails closed at
+        the operator-context Vault read (the placeholder JWT is rejected),
+        so the cache write below is never reached for the system operator.
         """
         key = self._cache_key(target)
         async with self._lock:
             cached = self._api_clients.get(key)
-            if cached is not None:
+            if cached is not None and not is_system_operator(operator):
                 return cached
             credential = await self._credential_loader(target, operator)
             if isinstance(credential, WcpSsoCredential):
@@ -1842,8 +1863,10 @@ class KubernetesConnector(Connector):
         """Resolve (and cache) the websocket-transport client for *target*.
 
         Mirrors :meth:`_get_api_client` exactly -- same lock, same
-        :meth:`_cache_key` (``secret_ref``), same operator-identity
-        credential load -- but builds a
+        tenant-unique :meth:`_cache_key`, same operator-identity
+        credential load, same system-operator fast-path closure
+        (:func:`~meho_backplane.connectors._shared.system_operator.is_system_operator`,
+        #1008) -- but builds a
         :class:`~kubernetes_asyncio.stream.WsApiClient` instead of an
         ordinary :class:`~kubernetes_asyncio.client.ApiClient`. The ws
         client is the only transport that can speak the
@@ -1871,7 +1894,7 @@ class KubernetesConnector(Connector):
         key = self._cache_key(target)
         async with self._lock:
             cached = self._ws_api_clients.get(key)
-            if cached is not None:
+            if cached is not None and not is_system_operator(operator):
                 return cached
             credential = await self._credential_loader(target, operator)
             if isinstance(credential, WcpSsoCredential):
@@ -1890,3 +1913,42 @@ class KubernetesConnector(Connector):
                 host=target.host,
             )
             return ws_client
+
+    async def invalidate_credentials(self, target: KubernetesTargetLike) -> None:
+        """Evict both cached clients for *target* so the next call re-reads Vault.
+
+        Duck-typed credential-eviction hook (#2396): the dispatcher's
+        establish-auth-failure arm probes for ``invalidate_credentials``
+        via ``getattr`` and calls it so an operator's out-of-band
+        credential restage converges on the next dispatch without a
+        backplane restart. It is also the seam that satisfies the F04
+        (evoila/meho#266) requirement that credential rotation, target
+        mutation and revocation invalidate both cache types: dropping the
+        cached :class:`ApiClient` (REST) *and* :class:`WsApiClient`
+        (exec/websocket) for the target's tenant-unique
+        :meth:`_cache_key` forces the next :meth:`_get_api_client` /
+        :meth:`_get_ws_api_client` to re-read the (possibly rotated or
+        re-pointed) credential and rebuild.
+
+        The evicted clients are closed so their aiohttp/httpx connector
+        pools are not leaked, under the same lock the build path holds so
+        the pop is serialised against an in-flight build. A WCP target's
+        normal mid-session token expiry does **not** route here — that is
+        handled in place by the cached :class:`Configuration`'s
+        refresh hook (out of scope for this eviction); only a genuine
+        rotation / mutation / revocation drops the whole client.
+        """
+        key = self._cache_key(target)
+        async with self._lock:
+            api_client = self._api_clients.pop(key, None)
+            if api_client is not None:
+                await api_client.close()
+            ws_client = self._ws_api_clients.pop(key, None)
+            if ws_client is not None:
+                await ws_client.close()
+            if api_client is not None or ws_client is not None:
+                _log.info(
+                    "kubernetes_client_cache_invalidated",
+                    target=target.name,
+                    host=target.host,
+                )

--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
@@ -130,8 +130,18 @@ class KubernetesTargetLike(Protocol):
     path the operator-context Vault read resolves to a kubeconfig YAML
     string under the ``kubeconfig`` field (consumer's ``targets.yaml``
     convention, locked in decision #8).
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the REST and websocket/exec client caches use, so two same-named
+    targets — or two same-``secret_ref`` targets — in different tenants
+    never share a cached client (evoila/meho#1642, security F04). The
+    concrete ``Target`` model (G0.3 #224 — closed) carries both fields as
+    UUIDs, so it satisfies this Protocol unchanged.
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -198,6 +198,10 @@ class _K3sTarget:
 
     def __post_init__(self) -> None:
         self.id: UUID = uuid4()
+        # Tenant-unique cache key component (#1642, security F04). Aligns
+        # with the seeded Target ORM row's tenant so the connector's
+        # client cache and the resolver agree on the target identity.
+        self.tenant_id: UUID = _OPERATOR_TENANT_ID
         self.preferred_impl_id: str | None = None
 
         class _FP:

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -28,10 +28,11 @@ from __future__ import annotations
 import contextlib
 import os
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -68,6 +69,9 @@ class _K3sTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 # ---------------------------------------------------------------------------
@@ -234,17 +238,24 @@ async def test_probe_against_unreachable_host_returns_not_ok(
 async def test_api_client_cached_across_calls_against_live_k3s(
     k3s_connector: tuple[KubernetesConnector, _K3sTarget],
 ) -> None:
-    """Second fingerprint against the same target reuses the cached client."""
+    """Second fingerprint against the same target reuses the cached client.
+
+    Fingerprints under a **real** operator: the client cache is closed to
+    the synthesised system operator (`operator=None`), so an operator-less
+    fingerprint deliberately rebuilds each call (security F04 / R02, #266).
+    A real operator is served the warm client on the second call.
+    """
     connector, target = k3s_connector
+    operator = _make_k3d_operator()
     # Derive the cache key from the SUT itself so the test tracks the
-    # connector's keying contract (currently ``target.secret_ref``;
-    # see ``KubernetesConnector._cache_key``). Indexing by
+    # connector's keying contract (the tenant-unique ``(tenant_id, id)``
+    # tuple; see ``KubernetesConnector._cache_key``). Indexing by
     # ``target.name`` instead raised ``KeyError`` whenever the k3s
     # testcontainer actually provisioned.
     cache_key = connector._cache_key(target)
-    await connector.fingerprint(target)
+    await connector.fingerprint(target, operator)
     cached_client_id_after_first = id(connector._api_clients[cache_key])
-    await connector.fingerprint(target)
+    await connector.fingerprint(target, operator)
     cached_client_id_after_second = id(connector._api_clients[cache_key])
     assert cached_client_id_after_first == cached_client_id_after_second
 

--- a/backend/tests/integration/test_connectors_k8s_live_vault.py
+++ b/backend/tests/integration/test_connectors_k8s_live_vault.py
@@ -138,6 +138,8 @@ class _LiveK3dTarget:
 
     def __post_init__(self) -> None:
         self.id: UUID = uuid4()
+        # Tenant-unique cache key component (#1642, security F04).
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
         self.preferred_impl_id: str | None = None
         self.fingerprint = type("_FP", (), {"version": "1.32.0"})()
 

--- a/backend/tests/test_connectors_k8s_auth.py
+++ b/backend/tests/test_connectors_k8s_auth.py
@@ -34,9 +34,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -44,6 +45,11 @@ import pytest
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import Connector
 from meho_backplane.connectors._shared import credential_backend as cb
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.system_operator import (
+    SYSTEM_OPERATOR_SUB,
+    synthesise_system_operator,
+)
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.kubernetes import (
     KubernetesConnector,
@@ -96,6 +102,11 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04). Distinct
+    # ``id`` per instance so two stub targets never collapse onto one
+    # cache entry; ``tenant_id`` defaults to the nil UUID.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -706,16 +717,32 @@ async def test_api_clients_per_target_are_distinct() -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_client_cache_key_is_secret_ref_not_name() -> None:
-    """Two tenants holding same-named targets get distinct ApiClients.
+async def test_api_client_same_secret_ref_different_tenants_get_distinct_clients() -> None:
+    """Same ``secret_ref`` in DIFFERENT tenants never share a cached ApiClient.
 
-    Locks in the forward-compat fix for G0.3 tenant-scoped target name
-    uniqueness — keying on ``target.name`` alone would silently
-    cross-pollinate ApiClients across tenants. ``secret_ref`` is the
-    operator's chosen globally-unique Vault path.
+    Regression guard for security F04 (evoila/meho#266): the REST client
+    cache used to key on ``target.secret_ref`` alone, so two targets in
+    different tenants that happen to share a Vault path collapsed onto one
+    entry — tenant B was served tenant A's authenticated client without
+    ever passing B's credential-store authorization. The cache keys on the
+    tenant-unique ``(tenant_id, id)`` tuple instead.
     """
-    tenant_a = _StubTarget(name="rke2-meho", host="t-a.test", port=6443, secret_ref="tenant-a/k8s")
-    tenant_b = _StubTarget(name="rke2-meho", host="t-b.test", port=6443, secret_ref="tenant-b/k8s")
+    tenant_a = _StubTarget(
+        name="rke2-meho",
+        host="t-a.test",
+        port=6443,
+        secret_ref="k8s/shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_b = _StubTarget(
+        name="rke2-meho",
+        host="t-b.test",
+        port=6443,
+        secret_ref="k8s/shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
 
     async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
         del operator
@@ -731,12 +758,234 @@ async def test_api_client_cache_key_is_secret_ref_not_name() -> None:
         c_a = await connector._get_api_client(tenant_a, op)
         c_b = await connector._get_api_client(tenant_b, op)
 
+    # Each tenant triggered its own build -- no cross-tenant cache hit.
     assert c_a is not c_b
     assert factory.call_count == 2
     assert set(connector._api_clients.keys()) == {
-        tenant_a.secret_ref,
-        tenant_b.secret_ref,
+        target_cache_key(tenant_a),
+        target_cache_key(tenant_b),
     }
+
+
+def _ws_build_patches(built: list[MagicMock]) -> tuple[Any, Any]:
+    """Patch the WsApiClient build path so ``_get_ws_api_client`` needs no real config.
+
+    Mirrors :mod:`tests.test_connectors_k8s_exec`: the connector does a
+    local ``from kubernetes_asyncio.config import load_kube_config_from_dict``
+    inside :meth:`_get_ws_api_client`, so patching the module attribute is
+    picked up on each call. ``WsApiClient`` is patched on the connector
+    module (where it was imported) and records each built client.
+    """
+
+    def _make(**_kwargs: Any) -> MagicMock:
+        client_mock = MagicMock(close=AsyncMock())
+        built.append(client_mock)
+        return client_mock
+
+    return (
+        patch("kubernetes_asyncio.config.load_kube_config_from_dict", new=AsyncMock()),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.WsApiClient",
+            side_effect=_make,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ws_client_same_secret_ref_different_tenants_get_distinct_clients() -> None:
+    """Same ``secret_ref`` in DIFFERENT tenants never share a cached WsApiClient.
+
+    The exec/websocket cache is the second F04 fast-path (evoila/meho#266)
+    and must key on the same tenant-unique ``(tenant_id, id)`` tuple as the
+    REST cache — the exec forwarder is exactly the operator-less path an
+    attacker would ride.
+    """
+    tenant_a = _StubTarget(
+        name="rke2-meho",
+        host="t-a.test",
+        port=6443,
+        secret_ref="k8s/shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_b = _StubTarget(
+        name="rke2-meho",
+        host="t-b.test",
+        port=6443,
+        secret_ref="k8s/shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+    connector = _make_connector_with_stub_kubeconfig()
+    op = _make_operator()
+    built: list[MagicMock] = []
+    load_patch, ws_patch = _ws_build_patches(built)
+    with load_patch, ws_patch:
+        c_a = await connector._get_ws_api_client(tenant_a, op)
+        c_b = await connector._get_ws_api_client(tenant_b, op)
+
+    assert c_a is not c_b
+    assert len(built) == 2
+    assert set(connector._ws_api_clients.keys()) == {
+        target_cache_key(tenant_a),
+        target_cache_key(tenant_b),
+    }
+
+
+@pytest.mark.asyncio
+async def test_rest_warm_cache_not_served_to_system_operator() -> None:
+    """A warm REST client primed by a real operator is NOT served to the system operator.
+
+    The system/operator-less caller (:func:`synthesise_system_operator`,
+    reachable through the operator-less ``k8s.ls`` forwarder) must fall
+    through to the fail-closed loader — it can never borrow a warm client a
+    real operator resolved (#1008). Keyed off ``SYSTEM_OPERATOR_SUB``.
+    """
+    call_log: list[str] = []
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del target
+        call_log.append(operator.sub)
+        return _stub_kubeconfig_dict()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+    with patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        side_effect=lambda _d: MagicMock(close=AsyncMock()),
+    ):
+        await connector._get_api_client(_TARGET_A, _make_operator())
+        await connector._get_api_client(_TARGET_A, synthesise_system_operator())
+
+    assert call_log == ["op-test", SYSTEM_OPERATOR_SUB]
+
+
+@pytest.mark.asyncio
+async def test_ws_warm_cache_not_served_to_system_operator() -> None:
+    """A warm exec/websocket client is NOT served to the system operator either."""
+    call_log: list[str] = []
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del target
+        call_log.append(operator.sub)
+        return _stub_kubeconfig_dict()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+    built: list[MagicMock] = []
+    load_patch, ws_patch = _ws_build_patches(built)
+    with load_patch, ws_patch:
+        await connector._get_ws_api_client(_TARGET_A, _make_operator())
+        await connector._get_ws_api_client(_TARGET_A, synthesise_system_operator())
+
+    assert call_log == ["op-test", SYSTEM_OPERATOR_SUB]
+
+
+@pytest.mark.asyncio
+async def test_rest_system_operator_fails_closed_against_warm_cache() -> None:
+    """With a warm cache, a system-operator load runs the loader and fails closed.
+
+    Proves the bypass is closed end to end: even though a real operator
+    primed the cache, the system caller hits the loader, which fails closed
+    per its contract (a system-initiated read cannot resolve per-target
+    credentials).
+    """
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del target
+        if operator.sub == SYSTEM_OPERATOR_SUB:
+            raise VaultCredentialsReadError(
+                "system-initiated calls cannot read per-target vendor credentials"
+            )
+        return _stub_kubeconfig_dict()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+    with patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        side_effect=lambda _d: MagicMock(close=AsyncMock()),
+    ):
+        await connector._get_api_client(_TARGET_A, _make_operator())  # warm the cache
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await connector._get_api_client(_TARGET_A, synthesise_system_operator())
+
+
+@pytest.mark.asyncio
+async def test_real_operator_reuse_unchanged_after_system_operator_call() -> None:
+    """Real-operator REST reuse is unaffected by the system-operator cache bypass.
+
+    The system operator falls through to the loader, which fails closed
+    (as it does in production — the placeholder JWT is rejected at the
+    operator-context Vault read), so it never clobbers the warm entry a
+    real operator primed. A second real-operator call still reuses the
+    same cached client (loader run once for the real operator).
+    """
+    real_calls = 0
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        nonlocal real_calls
+        del target
+        if operator.sub == SYSTEM_OPERATOR_SUB:
+            raise VaultCredentialsReadError(
+                "system-initiated calls cannot read per-target vendor credentials"
+            )
+        real_calls += 1
+        return _stub_kubeconfig_dict()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+    with patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        side_effect=lambda _d: MagicMock(close=AsyncMock()),
+    ):
+        c1 = await connector._get_api_client(_TARGET_A, _make_operator())  # cold real load
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await connector._get_api_client(_TARGET_A, synthesise_system_operator())  # bypass
+        c3 = await connector._get_api_client(_TARGET_A, _make_operator())  # warm real reuse
+
+    assert real_calls == 1
+    assert c1 is c3
+
+
+@pytest.mark.asyncio
+async def test_invalidate_credentials_drops_and_closes_both_caches() -> None:
+    """Rotation / mutation / revocation evicts and closes both cached client types.
+
+    Satisfies the F04 (evoila/meho#266) requirement that credential
+    rotation, target mutation and revocation invalidate both cache types:
+    :meth:`invalidate_credentials` pops the REST and exec/websocket clients
+    for the target's tenant-unique key and closes them, so the next call
+    re-reads the (possibly rotated) credential and rebuilds.
+    """
+    connector = _make_connector_with_stub_kubeconfig()
+    op = _make_operator()
+    rest_client = MagicMock(close=AsyncMock())
+    built_ws: list[MagicMock] = []
+    load_patch, ws_patch = _ws_build_patches(built_ws)
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=rest_client,
+        ),
+        load_patch,
+        ws_patch,
+    ):
+        await connector._get_api_client(_TARGET_A, op)
+        await connector._get_ws_api_client(_TARGET_A, op)
+
+        key = connector._cache_key(_TARGET_A)
+        assert key in connector._api_clients
+        assert key in connector._ws_api_clients
+
+        await connector.invalidate_credentials(_TARGET_A)
+
+    rest_client.close.assert_awaited_once()
+    built_ws[0].close.assert_awaited_once()
+    assert connector._api_clients == {}
+    assert connector._ws_api_clients == {}
+
+    # Idempotent: invalidating an already-clean target is a no-op.
+    await connector.invalidate_credentials(_TARGET_A)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -40,10 +40,11 @@ rationale.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.models import (
@@ -129,6 +130,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_credread.py
+++ b/backend/tests/test_connectors_k8s_credread.py
@@ -221,6 +221,8 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": "1.32.0"})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642, security F04).
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
         self.name = "k8s-credread"
         self.host = "k8s-credread.test.invalid"
         self.port = 6443

--- a/backend/tests/test_connectors_k8s_dispatcher_shim.py
+++ b/backend/tests/test_connectors_k8s_dispatcher_shim.py
@@ -40,9 +40,10 @@ invoke -> result-wrap pipeline is asserted in one test.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -129,6 +130,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_exec.py
+++ b/backend/tests/test_connectors_k8s_exec.py
@@ -18,8 +18,8 @@ Coverage matrix (per #1404 acceptance criteria):
   ``exit_code``.
 * Timeout: a socket that never closes is torn down at the deadline; the
   handler returns partial output + ``timed_out=true`` + ``exit_code=None``.
-* ``self._ws_api_clients`` is cached per ``secret_ref`` and closed on
-  ``aclose`` (no leaked sockets).
+* ``self._ws_api_clients`` is cached per target (the tenant-unique
+  ``(tenant_id, id)`` key) and closed on ``aclose`` (no leaked sockets).
 * 1 MiB cap: a stream over the cap is truncated from the front and
   ``truncated_byte_count`` is recorded.
 * ``stdin`` / ``tty`` are pinned ``False`` on the wire (no interactive
@@ -33,9 +33,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.stream.ws_client import (
@@ -68,6 +69,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(
@@ -488,7 +492,7 @@ async def test_exec_single_oversized_frame_is_bounded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ws_client_cached_per_secret_ref_and_closed_on_aclose() -> None:
+async def test_ws_client_cached_per_target_and_closed_on_aclose() -> None:
     connector = _make_connector()
     operator = _make_operator()
 
@@ -515,8 +519,8 @@ async def test_ws_client_cached_per_secret_ref_and_closed_on_aclose() -> None:
         c1 = await connector._get_ws_api_client(_TARGET, operator)
         c2 = await connector._get_ws_api_client(_TARGET, operator)
 
-    assert c1 is c2, "second call must hit the per-secret_ref cache"
-    assert len(built) == 1, "only one WsApiClient built for one secret_ref"
+    assert c1 is c2, "second call must hit the per-target cache"
+    assert len(built) == 1, "only one WsApiClient built for one target"
     assert connector._cache_key(_TARGET) in connector._ws_api_clients
 
     await connector.aclose()

--- a/backend/tests/test_connectors_k8s_kubeconfig_schema.py
+++ b/backend/tests/test_connectors_k8s_kubeconfig_schema.py
@@ -21,9 +21,10 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -301,6 +302,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_logs.py
+++ b/backend/tests/test_connectors_k8s_logs.py
@@ -35,9 +35,10 @@ Coverage matrix (per #325 acceptance criteria):
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -65,6 +66,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -37,10 +37,11 @@ from __future__ import annotations
 
 import random
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.models import (
@@ -148,6 +149,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_storage_cr.py
+++ b/backend/tests/test_connectors_k8s_storage_cr.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.models import (
@@ -89,6 +90,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_topology.py
+++ b/backend/tests/test_connectors_k8s_topology.py
@@ -37,10 +37,11 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.models import (
@@ -149,6 +150,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_wcp.py
+++ b/backend/tests/test_connectors_k8s_wcp.py
@@ -25,9 +25,10 @@ import base64
 import json
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -86,6 +87,9 @@ class _StubTarget:
     secret_ref: str
     verify_tls: bool = True
     tls_ca_pin: str | None = None
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _WCP_TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_workload.py
+++ b/backend/tests/test_connectors_k8s_workload.py
@@ -32,10 +32,11 @@ runs in every CI lane regardless of Docker availability.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.models import (
@@ -138,6 +139,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_k8s_write.py
+++ b/backend/tests/test_connectors_k8s_write.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 from kubernetes_asyncio.client.exceptions import ApiException
@@ -92,6 +93,9 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: str
+    # Tenant-unique cache key components (#1642, security F04).
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/docs/codebase/kubernetes-connector.md
+++ b/docs/codebase/kubernetes-connector.md
@@ -27,10 +27,27 @@ copy this pattern in G3.x).
   -- the connector class. Inherits from `Connector` (the ABC in
   `meho_backplane.connectors.base`). Class-level attrs `product` /
   `version` / `impl_id` advertise the registry-v2 key. Caches one
-  `kubernetes_asyncio.client.ApiClient` per target keyed on
-  `target.secret_ref` (the Vault path holding the kubeconfig); the
-  cache key is intentionally the secret_ref, not `target.name`, so two
-  tenants holding same-named targets get distinct ApiClients.
+  `kubernetes_asyncio.client.ApiClient` (REST) and, lazily, one
+  `WsApiClient` (exec/websocket) per target, both keyed on the
+  tenant-unique `(tenant_id, id)` tuple from the shared
+  `target_cache_key` helper (`connectors/_shared/cache_key.py`). Keying
+  on the target-row primary key — not `target.name` and not
+  `target.secret_ref` — is a cross-tenant isolation requirement
+  (security F04, #266): two targets in different tenants that share a
+  name *or* a Vault `secret_ref` must never collapse onto one cached
+  client, or the second tenant is served the first tenant's
+  authenticated client without passing its own credential-store
+  authorization. Both cache fast-paths also apply the
+  `is_system_operator` guard (#1008): a system/operator-less caller
+  (reachable through the operator-less `k8s.ls` forwarder) always falls
+  through to the fail-closed credential loader and is never served a
+  warm client a real operator primed. `invalidate_credentials(target)`
+  is the duck-typed eviction hook (#2396) the dispatcher's
+  establish-auth-failure arm calls and the seam that lets credential
+  rotation / target mutation / revocation drop *both* cached client
+  types for the target; a WCP Supervisor's normal mid-session token
+  expiry is still handled in place by the cached `Configuration`'s
+  refresh hook, not by eviction.
 
 * `KubernetesOp` (`backend/src/meho_backplane/connectors/kubernetes/ops.py`)
   -- frozen dataclass describing one op's metadata. Each field mirrors
@@ -53,9 +70,10 @@ copy this pattern in G3.x).
   against this same tuple.
 
 * `KubernetesTargetLike` (`backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py`)
-  -- Protocol the connector reads against. Only four attributes:
-  `name`, `host`, `port`, `secret_ref`. The G0.3 `Target` model
-  satisfies it structurally once G0.3 lands.
+  -- Protocol the connector reads against: `name`, `host`, `port`,
+  `secret_ref`, plus `id` / `tenant_id` (the `(tenant_id, id)` cache
+  key components, #266). The G0.3 `Target` model carries all of them as
+  UUIDs, so it satisfies the Protocol structurally.
 
 * `ops_logs.py` (the `k8s.logs` handler)
   -- contains the module-level `k8s_logs(connector, target, params)`
@@ -120,8 +138,8 @@ copy this pattern in G3.x).
 2. `KubernetesConnector.logs(target, params)` delegates to
    `ops_logs.k8s_logs(connector, target, params)`.
 3. `k8s_logs` resolves the `ApiClient` for the target via
-   `connector._get_api_client(target)` (cached on secret_ref) and
-   builds a `client.CoreV1Api(api_client)`.
+   `connector._get_api_client(target)` (cached on the tenant-unique
+   `(tenant_id, id)` key) and builds a `client.CoreV1Api(api_client)`.
 4. `resolve_pod_and_container()` lists pods in the namespace, picks
    the exact match if present, falls back to prefix match. Multi-
    container pods without `container` raise


### PR DESCRIPTION
## Summary

- Re-keys both Kubernetes connector client caches (REST `ApiClient` and exec/websocket `WsApiClient`) from `target.secret_ref` alone to the tenant-unique `(tenant_id, id)` tuple via the shared `target_cache_key` helper — closing security **F04** (evoila/meho#266): two targets in different tenants that share a Vault `secret_ref` no longer collapse onto one cached, already-authenticated client.
- Applies the `is_system_operator` fast-path guard on **both** caches, matching every peer connector (#1008): a system/operator-less caller — the exact path reachable through the operator-less `k8s.ls` forwarder (finding R02) — always falls through to the fail-closed credential loader and is never served a warm client a real operator primed.
- Adds an `invalidate_credentials(target)` hook (the duck-typed #2396 eviction seam) that drops **and closes** both cached client types for a target, so credential rotation / target mutation / revocation force a fresh authenticated rebuild. WCP mid-session token refresh-in-place is untouched.
- `KubernetesTargetLike` gains `id` / `tenant_id` (the concrete `Target` model already carries them as UUIDs); no REST route/schema or migration changed.

This mirrors the merged #92 precedent (VCF/Harbor/NSX/SDDC re-keying) and the shared `connectors/_shared/cache_key.py` mandate that every connector cache derive the identical key. The `secret_ref` column is a property of the target row, so `(tenant_id, id)` subsumes the credential-reference identity dimension; a rotated/re-pointed secret or a revoked target is handled by `invalidate_credentials`, not by folding a mutable column into the key. The application Vault registration guard (#99, `api/v1/targets.py`) is **not touched** — this is the defense-in-depth cache-layer mitigation that holds even where that guard is a no-op (non-Vault / disabled-prefix config).

**Already on `main`:** none of this task was done at base `068f0b8` — `_cache_key` still returned `target.secret_ref`. The 2026-09-06 containment PRs (#3423/#3427) did not touch the k8s client caches.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (`src/…/kubernetes/`, `tests/`)
- [x] `mypy src/…/kubernetes/` — no issues (20 files)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (8 pre-existing size warnings)
- [x] `pytest tests/test_connectors_k8s_auth.py` — 46 passed
- [x] Full k8s unit subset — 438 passed (after re-keying every k8s test target stub with `id`/`tenant_id`)
- [x] Full backend unit lane — see CI

### Acceptance criteria

- [x] **REST and WS/exec caches include tenant, target ID, credential reference/config** — both keyed by `target_cache_key(target)` = `(tenant_id, id)`; row PK subsumes the credential reference. (`test_api_client_same_secret_ref_different_tenants_get_distinct_clients`, `test_ws_client_same_secret_ref_different_tenants_get_distinct_clients`)
- [x] **Tenant-B same-reference target cannot receive A's client** — the two same-`secret_ref`/different-tenant regression tests (REST + WS).
- [x] **Denied access stays denied after warming; auth not skippable by cache hit** — `test_rest_system_operator_fails_closed_against_warm_cache`, `test_rest_warm_cache_not_served_to_system_operator`, `test_ws_warm_cache_not_served_to_system_operator`.
- [x] **Both fast-paths apply `is_system_operator`** — source (both `_get_api_client` / `_get_ws_api_client`); `test_real_operator_reuse_unchanged_after_system_operator_call`.
- [x] **Rotation / mutation / revocation invalidate both cache types** — `invalidate_credentials`; `test_invalidate_credentials_drops_and_closes_both_caches`.
- [x] **Applicable non-Vault/disabled-prefix config tested; existing Vault ACL/path guards not weakened** — synthetic tests warm the cache directly with non-Vault-shaped refs/arbitrary tenants (the config where the #99 registration guard is a no-op); no Vault ACL/path guard touched.

## Out of scope

- Non-Kubernetes connector caches (done in #92).
- Re-architecting the process-global connector singleton into a per-tenant instance pool (re-keying is the minimal fix); WCP token-refresh-in-place is preserved.
- Adjacent finding (recorded, not fixed): `_get_api_client` is now 63 lines (warn > 60) purely from the expanded security-posture docstring; body logic is unchanged and small.

Closes evoila-bosnia/meho-internal#266
