### PR TITLE
fix(operations): reject undeclared params on ingested ops (S05)

### DIFF
--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -112,9 +112,20 @@ def _split_ingested_params(
     Algorithm: walk ``parameter_schema["properties"]``; for each
     property, read the ``x-meho-param-loc`` extension (default
     ``"query"`` -- the most common OpenAPI shape) and route the
-    matching params dict entry to the corresponding bucket. Params
-    not declared in the schema fall through to the **body** bucket --
-    the OpenAPI convention for free-form request bodies.
+    matching params dict entry to the corresponding bucket. A param
+    absent from ``properties`` has no ``x-meho-param-loc`` to read, so it
+    takes that same ``"query"`` default and routes to the **query**
+    bucket.
+
+    On the dispatch path such undeclared params never reach this splitter:
+    the dispatcher validates an ingested op against a schema with
+    ``additionalProperties: false`` (built in by the ingester since #293,
+    and applied as a backstop by
+    :func:`~meho_backplane.operations._validate.ingested_schema_for_validation`
+    for descriptors ingested before that fix), so an undeclared name is
+    already rejected as ``invalid_params`` upstream. The ``"query"``
+    default therefore only ever fires here for a caller that resolves
+    buckets without that gate (the read-only request preview).
 
     The four buckets are returned even when empty so the caller's
     request-building branch can pass them positionally without

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -49,6 +49,7 @@ _log = structlog.get_logger(__name__)
 __all__ = [
     "InvalidOpSchemaError",
     "compute_params_hash",
+    "ingested_schema_for_validation",
     "policy_gate",
     "validate_params",
 ]
@@ -141,6 +142,41 @@ def validate_params(
         missing_ref = f"#{pointer}" if pointer.startswith("/") else pointer
         raise InvalidOpSchemaError(missing_ref) from exc
     return out
+
+
+def ingested_schema_for_validation(parameter_schema: dict[str, Any]) -> dict[str, Any]:
+    """Return *parameter_schema* strengthened to reject undeclared params.
+
+    Fail-closed dispatch backstop (#293 / security review S05) for
+    ``source_kind='ingested'`` descriptors. The OpenAPI ingester now emits
+    ``additionalProperties: false`` on every built schema
+    (:func:`~meho_backplane.operations.ingest.openapi._build_parameter_schema`),
+    but a descriptor persisted before that fix carries no such clause, so
+    :func:`validate_params` -- JSON Schema 2020-12, which defaults
+    ``additionalProperties`` to ``true`` -- would accept a param the op
+    never declared and let the dispatcher forward it verbatim onto the
+    vendor query string. Applying the clause at the dispatch seam closes
+    that window for already-ingested connectors without a re-ingest, and
+    produces the *same* ``invalid_params`` error shape (``validator ==
+    "additionalProperties"``) a freshly-ingested strict descriptor does.
+
+    A no-op when the schema already declares ``additionalProperties`` (a
+    post-fix descriptor, or one an operator deliberately widened) or is
+    not an object schema with declared ``properties`` (an empty ``{}``
+    descriptor stays permissive, matching :func:`validate_params`). The
+    returned mapping is a shallow copy -- the stored descriptor's JSON
+    column is never mutated, and the nested ``properties`` /
+    ``components`` are shared by reference (``additionalProperties: false``
+    constrains only the top-level instance keys, so nested body/object
+    fields stay unconstrained).
+    """
+    if not isinstance(parameter_schema, dict):
+        return parameter_schema
+    if "properties" not in parameter_schema:
+        return parameter_schema
+    if "additionalProperties" in parameter_schema:
+        return parameter_schema
+    return {**parameter_schema, "additionalProperties": False}
 
 
 def _is_mutating(descriptor: EndpointDescriptor) -> bool:

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -331,6 +331,7 @@ from meho_backplane.operations._request_preview import (
 from meho_backplane.operations._validate import (
     InvalidOpSchemaError,
     compute_params_hash,
+    ingested_schema_for_validation,
     policy_gate,
     validate_params,
 )
@@ -2385,8 +2386,18 @@ async def dispatch(
         return result_unknown_op(op_id, known_op_count, _elapsed_ms(started))
 
     # --- Step 3: parameter_schema validation ------------------------------
+    # #293 (security review S05): for an ingested (generic-connector) op,
+    # validate against a schema that forbids undeclared params. Freshly
+    # ingested descriptors already carry ``additionalProperties: false``
+    # (openapi._build_parameter_schema); this backstop applies the same
+    # clause to descriptors ingested before that fix, so an undeclared
+    # param is rejected as ``invalid_params`` here rather than defaulting
+    # onto the vendor query string in ``_split_ingested_params``.
+    schema_to_validate = descriptor.parameter_schema
+    if descriptor.source_kind == "ingested":
+        schema_to_validate = ingested_schema_for_validation(descriptor.parameter_schema)
     try:
-        validation_errors = validate_params(descriptor.parameter_schema, params)
+        validation_errors = validate_params(schema_to_validate, params)
     except InvalidOpSchemaError as exc:
         # #3095: the stored schema itself is broken (dangling $ref) --
         # the descriptor is at fault, not the caller. Structured error

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -1181,6 +1181,7 @@ def _safety_level_for(method: str) -> SafetyLevel:
     return "safe"
 
 
+# code-quality-allow: function-size - pre-existing spec builder; #293 adds one key
 def _build_parameter_schema(
     *,
     path: str,
@@ -1226,7 +1227,9 @@ def _build_parameter_schema(
     dispatcher uses ``x-meho-param-loc == "body"`` to recover the
     payload regardless of property name. Operations with no params
     at all get the empty-but-valid ``{"type": "object", "properties":
-    {}}``.
+    {}, "additionalProperties": false}``. The ``additionalProperties:
+    false`` clause (#293) makes ``validate_params`` reject any param the
+    op did not declare instead of defaulting it onto the vendor query.
 
     Nested ``$ref`` strings inside the inlined schemas are preserved
     verbatim, and the components they transitively reference are
@@ -1273,7 +1276,13 @@ def _build_parameter_schema(
         if body_property["required"]:
             required.append("body")
 
-    schema: dict[str, object] = {"type": "object", "properties": properties}
+    # #293 (S05): ``additionalProperties: false`` fails closed on any param
+    # the op never declared (else it defaults onto the vendor query string).
+    schema: dict[str, object] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     _attach_component_closure(

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -487,6 +487,85 @@ async def test_dispatch_returns_invalid_params_when_schema_violated(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_ingested_rejects_undeclared_param(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#293 (S05): an undeclared param on an ingested op -> ``invalid_params``.
+
+    Regression for the generic-connector query-injection gap: an ingested
+    descriptor persisted *before* the ingester emitted
+    ``additionalProperties: false`` carries a permissive schema, so a param
+    the op never declared used to pass validation and get forwarded onto
+    the vendor query string. The dispatcher now validates ingested ops
+    against a strict schema, so the additive key is rejected here -- before
+    any connector is resolved or vendor request built. The descriptor is
+    deliberately built WITHOUT ``additionalProperties`` to prove the
+    dispatch-seam backstop, not just the freshly-ingested strict schema.
+    """
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import EndpointDescriptor
+
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product="demo",
+        version="1.0",
+        impl_id="demo-rest",
+        op_id="GET:/api/things",
+        source_kind="ingested",
+        method="GET",
+        path="/api/things",
+        handler_ref=None,
+        summary="List things",
+        description="Pre-#293 ingested op with a permissive schema.",
+        tags=[],
+        # No ``additionalProperties`` clause -- the pre-fix persisted shape.
+        parameter_schema={
+            "type": "object",
+            "properties": {"filter": {"type": "string", "x-meho-param-loc": "query"}},
+        },
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=stub_embedding_service.encode_one.return_value,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+    operator = _make_operator()
+    target = _FakeTarget(product="demo", version="1.0")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="demo-rest-1.0",
+        op_id="GET:/api/things",
+        target=target,
+        # ``filter`` is declared; ``cascade`` is not -- the injected switch.
+        params={"filter": "name=foo", "cascade": "true"},
+    )
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras["error_code"] == "invalid_params"
+    validation = result.extras["validation_errors"]
+    assert isinstance(validation, list)
+    assert any(err["validator"] == "additionalProperties" for err in validation)
+    # No vendor request was built -- the reject is a pre-dispatch fault, so
+    # no broadcast event fires for a would-be call.
+    assert captured_events == []
+
+
+@pytest.mark.asyncio
 async def test_dispatch_returns_invalid_op_schema_for_poisoned_descriptor(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -2292,7 +2292,62 @@ def test_parse_schema_without_nested_refs_gains_no_components_key() -> None:
                 "x-meho-param-loc": "body",
             }
         },
+        # #293: the top-level ingested schema fails closed on undeclared params.
+        "additionalProperties": False,
     }
+
+
+def test_build_parameter_schema_fails_closed_on_undeclared_params() -> None:
+    """AC (#293 / S05): every built ingested schema carries ``additionalProperties: false``.
+
+    JSON Schema 2020-12 defaults ``additionalProperties`` to ``true``, so
+    without the clause a param the op never declared passes
+    ``validate_params`` and the dispatcher forwards it verbatim onto the
+    vendor query string. The ingester now emits the clause on every
+    built ``parameter_schema`` so the generic-connector dispatch surface
+    is confined to its declared params.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
+
+    # Every ingested op's built schema fails closed on additive keys.
+    for proto in rows:
+        assert proto.parameter_schema["additionalProperties"] is False, proto.op_id
+
+    # The clause is load-bearing: a strict validator over the built schema
+    # rejects an undeclared param with an ``additionalProperties`` error,
+    # while a declared param validates clean at the additive-key layer.
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    validator = Draft202012Validator(list_pets.parameter_schema)
+    undeclared = [
+        err
+        for err in validator.iter_errors({"undeclared_switch": "on"})
+        if err.validator == "additionalProperties"
+    ]
+    assert undeclared, "undeclared param must raise an additionalProperties error"
+    declared_only = [
+        err
+        for err in validator.iter_errors({"limit": 5})
+        if err.validator == "additionalProperties"
+    ]
+    assert declared_only == []
+
+
+def test_response_schema_is_not_strict_additional_properties() -> None:
+    """Only the top-level *parameter* schema fails closed -- responses stay open.
+
+    ``additionalProperties: false`` on a response schema would make the
+    JSONFlux reducer choke on any vendor field the spec under-declares;
+    #293 hardens the request contract only, so ``response_schema`` never
+    gains the clause.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
+    page = _by_op_id(rows)["GET:/pets"].response_schema
+    assert page is not None
+    assert "additionalProperties" not in page
 
 
 def test_parse_response_schema_is_deliberately_not_bundled() -> None:

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -458,7 +458,7 @@ Frozen Pydantic v2 model. One per operation. Maps 1:1 to a subset of
 | `summary` | `summary` | Verbatim from spec |
 | `description` | `description` | Verbatim from spec |
 | `tags` | `tags` | Spec tags + optional `spec:<source>` marker |
-| `parameter_schema` | `parameter_schema` | Flattened JSON Schema 2020-12 with `x-meho-param-loc` |
+| `parameter_schema` | `parameter_schema` | Flattened JSON Schema 2020-12 with `x-meho-param-loc`; `additionalProperties: false` (#293) |
 | `response_schema` | `response_schema` | Success-response schema or `None` |
 | `safety_level` | `safety_level` | HTTP-verb heuristic, operator-overridable at review |
 | `requires_approval` | `requires_approval` | Always `False` at parse time |
@@ -1816,6 +1816,21 @@ defect class out:
   refusal (extras carry `missing_ref` + re-ingest remediation) —
   covering rows persisted by pre-#3095 ingests until they are
   re-ingested.
+
+Undeclared params fail closed too (#293 / security review S05).
+`_build_parameter_schema` emits `additionalProperties: false` on every
+built object, so `validate_params` rejects a param the op never declared
+as `invalid_params` rather than letting it default onto the vendor query
+string (`_split_ingested_params` routes an undeclared name to the `query`
+bucket). For descriptors ingested before that clause existed, the
+dispatcher applies the same strictness at the Step-3 validation seam —
+`ingested_schema_for_validation` (`operations/_validate.py`), scoped to
+`source_kind='ingested'` — so the fail-closed posture covers persisted
+rows without a re-ingest and yields the same `additionalProperties`
+error shape a freshly-ingested strict descriptor does. Typed/composite
+ops already carry the clause; `response_schema` deliberately does not
+(the JSONFlux reducer must tolerate vendor fields the spec
+under-declares).
 
 ### Repairing pre-#3095 rows (#3102)
 


### PR DESCRIPTION
## Summary

- Security review S05 (evoila-bosnia/meho-internal#293): the OpenAPI ingester built each ingested op's `parameter_schema` with no `additionalProperties` clause, so JSON Schema 2020-12's permissive default let a param the op never declared pass `validate_params` and get forwarded verbatim onto the vendor query string (`_split_ingested_params` routes an undeclared name to the `query` bucket). A principal already authorized for a generic-connector op could thus append arbitrary, operator-unreviewed query params (fields/expand/filter/force/cascade/dryRun-style switches) onto any vendor request.
- **Primary fix** — `_build_parameter_schema` (`operations/ingest/openapi.py`) now emits `additionalProperties: false` on every built ingested schema, so `validate_params` fails closed on any undeclared param. This confines a generic connector's dispatch surface to exactly its declared parameter set — the posture typed/composite ops already carry.
- **Fail-closed dispatch backstop** — the dispatcher's Step-3 validation now strengthens the schema for `source_kind='ingested'` ops via `ingested_schema_for_validation` (`operations/_validate.py`), so descriptors **already persisted** before this fix (no clause in their stored schema) are also rejected — without a re-ingest, and with the same `additionalProperties` error shape a freshly-ingested strict descriptor produces. The reject happens before the policy gate and before any connector is resolved or vendor request built.
- **Docstring corrected** — `_split_ingested_params`'s docstring claimed undeclared params fall to the **body** bucket; the code routes them to **query**. The docstring now matches the code and notes that the dispatch gate rejects undeclared params upstream (so the query fallback only fires for the read-only request preview).

## Design note

The task's recommended mitigation suggested rejecting undeclared params "in `_split_ingested_params`". That function is a pure 4-tuple splitter shared with the read-only request preview, and acceptance criterion 3 explicitly wants it to keep the query fallback with an honest docstring. Rejecting undeclared params at the dispatcher's Step-3 validation seam instead (a) fires before any vendor request is built — the outcome the finding asks for, (b) reuses `validate_params` so new (strict-schema) and old (persisted) descriptors return an identical `invalid_params` payload, and (c) needs no exception plumbing through the preview-shared resolver. The backstop is scoped to the send path (dispatch); new descriptors are protected uniformly across dispatch/preview/gateway by the schema clause itself.

## Already on main

None of this Task's criteria were met on `origin/main` at branch time: `_build_parameter_schema` had no `additionalProperties` clause and `_split_ingested_params`'s docstring still said "fall through to the **body**". The 2026-09-06 containment PRs (#3423/#3427) addressed a different finding (F05/F06) and did not touch the ingested-param contract.

## Test plan

- [x] `ruff check` — clean (changed files)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (changed source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (9 pre-existing warnings; one `code-quality-allow: function-size` on the already-101-line `_build_parameter_schema`, whose only change is a single schema key)
- [x] **AC1** `_build_parameter_schema` output carries `additionalProperties: false` — `test_build_parameter_schema_fails_closed_on_undeclared_params` (new, `test_operations_ingest_openapi.py`) asserts the clause on every built schema and that a strict validator rejects an undeclared key
- [x] **AC2** ingested op + undeclared param → `invalid_params` — `test_dispatch_ingested_rejects_undeclared_param` (new, `test_operations_dispatcher.py`), built against a **pre-fix** (no-clause) descriptor to prove the dispatch backstop
- [x] **AC3** `grep "fall through to the \*\*body\*\*" _branches.py` → nothing (docstring corrected)
- [x] **AC4** `grep additionalProperties openapi.py` → clause emitted on the built schema
- [x] **AC5** `uv run pytest tests -k "ingest or dispatcher"` → 916 passed, 27 skipped, 0 failed
- [x] Full backend unit lane (`uv run pytest tests`) — green

## Out of scope

- Value-level validation of declared params (types/ranges/enums) beyond additive-key rejection.
- Header/path/body smuggling; `_split_ingested_params` bucket routing is unchanged beyond the unknown-key case.
- Typed and composite ops — they already carry `additionalProperties: false`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#293
