### PR TITLE
fix(security): authenticate SSH, SMTP and Keycloak-admin peers before sending credentials (F08 / #270)

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -45,9 +45,31 @@ concurrent requests to distinct targets proceed in parallel; only requests
 to the *same* target serialize during the SSH handshake. SSH key exchange
 is expensive — pooling matters more here than for HTTP.
 
-**Host key checking.** ``known_hosts=None`` disables host-key verification
-for v0.2; pinning is deferred to v0.2.next once a Vault-managed key store
-is in place.
+**Host key checking (fail-closed).** The Vault secret at ``secret_ref`` is
+the key store the v0.2 deferral was waiting on, so host-key verification
+is now enforced by default. Two optional fields on the resolved secret
+drive it:
+
+* ``known_hosts`` — one or more OpenSSH ``known_hosts``-format lines
+  pinning the target's host key(s) (``<host-pattern> <keytype>
+  <base64>``). When present it is parsed via
+  ``asyncssh.import_known_hosts`` and passed to ``asyncssh.connect``;
+  an unexpected or unknown host key then raises
+  :exc:`asyncssh.HostKeyNotVerifiable` during key exchange, **before**
+  any password or private key is offered to the peer.
+* ``known_hosts_insecure`` — a truthy escape hatch that restores the
+  old ``known_hosts=None`` (no verification) behaviour for a single
+  target, logging a loud ``ssh_host_key_check_disabled`` warning on
+  every connect. Mirrors the ``meho admin keycloak
+  --insecure-skip-tls-verify`` opt-in and the target-level
+  ``verify_tls=false`` posture: opt-in, per-target, never the default.
+
+A secret carrying neither field fails closed:
+:exc:`SshHostKeyUnpinnedError` is raised before the connection opens,
+so an unpinned target can never disclose a password to an impostor
+host by default. The host-key material is threaded through
+``_auth_config``'s return dict alongside the auth kwargs (subclasses
+that override ``_auth_config`` MUST include a ``known_hosts`` entry).
 
 **Timeouts.** ``_run_command`` wraps ``conn.run()`` in
 ``asyncio.wait_for``; expiry raises :exc:`asyncio.TimeoutError`.
@@ -80,6 +102,70 @@ logger = structlog.get_logger()
 type Target = Any
 
 _POOL_TTL_S: float = 300.0  # 5-minute idle eviction window
+
+
+class SshHostKeyUnpinnedError(ValueError):
+    """A target's Vault secret configures no host-key trust and no opt-out.
+
+    Raised (fail-closed) by :func:`_known_hosts_from_secret` before a
+    connection is opened when the resolved secret carries neither a
+    ``known_hosts`` pin nor a truthy ``known_hosts_insecure`` escape
+    hatch. Without a pin, host-key verification cannot be performed, and
+    connecting anyway would let an impostor host collect a password (or
+    supply forged command output on a key-only session) — the F08
+    finding this guard closes. Subclasses :exc:`ValueError` so the
+    G0.6 dispatcher shim maps it to a ``connector_error`` result, the
+    same class the missing-credentials guard in :meth:`SshConnector._auth_config`
+    already uses.
+    """
+
+    def __init__(self, target_name: str) -> None:
+        super().__init__(
+            f"target '{target_name}': host-key verification is unconfigured. "
+            "Add a `known_hosts` pin (OpenSSH known_hosts lines for the target's "
+            "host key) to the target's Vault secret, or set "
+            "`known_hosts_insecure: true` to opt out of verification for this "
+            "target (logged loudly on every connect)."
+        )
+
+
+def _secret_flag_is_true(value: object) -> bool:
+    """Interpret a Vault secret field as a boolean opt-in flag.
+
+    A KV-v2 field can round-trip as a native ``bool`` (JSON write) or as
+    a string (``vault kv put k=true``), so both shapes are honoured;
+    everything else is falsey.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _known_hosts_from_secret(
+    target_name: str, secret: dict[str, Any]
+) -> asyncssh.SSHKnownHosts | None:
+    """Resolve the ``asyncssh.connect(known_hosts=...)`` value for a secret.
+
+    Returns a parsed :class:`asyncssh.SSHKnownHosts` when the secret pins
+    ``known_hosts`` (enforced: an unexpected key raises
+    :exc:`asyncssh.HostKeyNotVerifiable` before auth), or ``None`` when
+    the secret sets a truthy ``known_hosts_insecure`` escape hatch
+    (verification disabled, warned). A secret with neither fails closed
+    via :exc:`SshHostKeyUnpinnedError`. A pin always wins over the
+    escape hatch when both are set — the secure reading of contradictory
+    config.
+    """
+    pin_raw = secret.get("known_hosts")
+    if pin_raw:
+        pin = strip_credential_value(pin_raw)
+        if pin:
+            return asyncssh.import_known_hosts(pin)
+    if _secret_flag_is_true(secret.get("known_hosts_insecure")):
+        logger.warning("ssh_host_key_check_disabled", target=target_name)
+        return None
+    raise SshHostKeyUnpinnedError(target_name)
 
 
 def _ssh_output(result: Any) -> str | None:
@@ -196,23 +282,34 @@ class SshConnector(Connector):
     async def _auth_config(
         self, target: Target, operator: Operator | None = None
     ) -> dict[str, Any]:
-        """Resolve ``target.secret_ref`` from Vault and derive auth kwargs.
+        """Resolve ``target.secret_ref`` from Vault and derive connect kwargs.
 
-        Returns ``{username, client_keys=[key]}`` for key auth, or
-        ``{username, password}`` for password auth. Raises :exc:`ValueError`
-        when the resolved secret carries neither ``ssh_private_key`` nor
-        ``password``; Vault resolution failures propagate per
-        :meth:`_resolve_secret`'s two-phase error contract.
+        Returns ``{username, known_hosts, client_keys=[key]}`` for key
+        auth, or ``{username, known_hosts, password}`` for password auth.
+        ``known_hosts`` is the fail-closed host-key trust value resolved
+        by :func:`_known_hosts_from_secret` (a parsed
+        :class:`asyncssh.SSHKnownHosts` pin, or ``None`` for the audited
+        per-target opt-out); it is threaded here so :meth:`_connect`
+        never has to re-read the secret. Raises :exc:`ValueError` when
+        the resolved secret carries neither ``ssh_private_key`` nor
+        ``password``, and :exc:`SshHostKeyUnpinnedError` when it pins no
+        host key and sets no opt-out; Vault resolution failures propagate
+        per :meth:`_resolve_secret`'s two-phase error contract.
         """
         secret = await self._resolve_secret(target, operator)
         username: str = strip_credential_value(secret.get("username", "root"))
+        known_hosts = _known_hosts_from_secret(target.name, secret)
         private_key_raw = secret.get("ssh_private_key")
         if private_key_raw:
             key = asyncssh.import_private_key(strip_credential_value(private_key_raw))
-            return {"username": username, "client_keys": [key]}
+            return {"username": username, "known_hosts": known_hosts, "client_keys": [key]}
         password_raw = secret.get("password")
         if password_raw:
-            return {"username": username, "password": strip_credential_value(password_raw)}
+            return {
+                "username": username,
+                "known_hosts": known_hosts,
+                "password": strip_credential_value(password_raw),
+            }
         raise ValueError(
             f"target '{target.name}': the Vault secret at secret_ref must include "
             "ssh_private_key or password"
@@ -259,13 +356,20 @@ class SshConnector(Connector):
                 del self._connections[cache_key]
 
             auth_kwargs = await self._auth_config(target, operator)
+            # ``known_hosts`` is fail-closed: the base ``_auth_config`` (and
+            # every subclass override) resolves it via
+            # ``_known_hosts_from_secret``. A missing key here means a
+            # subclass override forgot to thread it — refuse rather than
+            # silently disable verification.
+            if "known_hosts" not in auth_kwargs:
+                raise SshHostKeyUnpinnedError(getattr(target, "name", "?"))
             conn = await asyncssh.connect(
                 target.host,
                 port=target.port or 22,
                 username=auth_kwargs["username"],
                 client_keys=auth_kwargs.get("client_keys"),
                 password=auth_kwargs.get("password"),
-                known_hosts=None,
+                known_hosts=auth_kwargs["known_hosts"],
             )
             self._connections[cache_key] = (conn, time.monotonic())
             logger.info("ssh_connected", target=target.name, host=target.host)

--- a/backend/src/meho_backplane/connectors/mail/transport.py
+++ b/backend/src/meho_backplane/connectors/mail/transport.py
@@ -23,7 +23,19 @@ byte, so the ``mail_smtp_starttls`` flag is moot there). Any other
 port opens plaintext via :class:`smtplib.SMTP` and, when
 ``mail_smtp_starttls`` is set (default), upgrades with ``starttls()``
 followed by a fresh ``ehlo()`` — the RFC 3207 requirement to rediscover
-extensions on the encrypted channel. ``login()`` runs only when a
+extensions on the encrypted channel.
+
+TLS trust (F08 #270): **both** paths are handed an explicit validating
+context (:func:`_build_tls_context` → :func:`ssl.create_default_context`,
+``check_hostname=True`` + ``CERT_REQUIRED``) rather than the
+``ssl._create_stdlib_context()`` smtplib falls back to when ``context``
+is ``None`` — that fallback leaves ``CERT_NONE`` and hostname checking
+off, so mail contents and credentials would flow to an unverified peer.
+``mail_smtp_ca_bundle`` optionally pins an internal relay's CA (the
+bundle replaces the public roots); there is no verification-disable
+knob. A wrong-name / untrusted-chain / expired certificate raises
+:class:`ssl.SSLError`, refused as ``reason="smtp_tls_error"`` before any
+AUTH or message data reaches the peer. ``login()`` runs only when a
 username is configured (an internal relay commonly needs none) **and
 only on an encrypted channel**: ``smtplib.login()`` imposes no TLS
 precondition of its own, so AUTH LOGIN/PLAIN would put base64-wrapped —
@@ -52,12 +64,17 @@ Reason codes are stable:
 * ``smtp_auth_error`` — :class:`smtplib.SMTPAuthenticationError`.
 * ``smtp_recipients_refused`` — the server rejected every recipient
   (:class:`smtplib.SMTPRecipientsRefused`).
+* ``smtp_tls_error`` — TLS certificate verification / handshake failure
+  on either the implicit-TLS or STARTTLS path
+  (:class:`ssl.SSLError`): wrong name, untrusted chain, expired cert.
 * ``smtp_error`` — any other :class:`smtplib.SMTPException`.
 
-The ``except`` ordering below is load-bearing: ``SMTPException``
-subclasses :class:`OSError` (since Python 3.4), so the specific SMTP
-arms and the generic ``SMTPException`` arm must precede the ``OSError``
-arm or a refused login would misreport as a connect error.
+The ``except`` ordering below is load-bearing: both
+:class:`smtplib.SMTPException` and :class:`ssl.SSLError` subclass
+:class:`OSError` (since Python 3.4), so every specific SMTP arm, the
+generic ``SMTPException`` arm, and the ``SSLError`` arm must precede the
+``OSError`` arm or a refused login / a certificate rejection would
+misreport as a connect error.
 
 Logging discipline: structlog events carry host/port/reason only —
 never the password, never the message body. The recipient list and
@@ -69,6 +86,7 @@ from __future__ import annotations
 
 import asyncio
 import smtplib
+import ssl
 from dataclasses import dataclass
 from email.message import EmailMessage
 from typing import Final
@@ -111,12 +129,33 @@ class MailSendResult:
     reason: str | None = None
 
 
+def _build_tls_context(ca_bundle: str) -> ssl.SSLContext:
+    """Build the validating TLS context both SMTP paths hand to the socket.
+
+    :func:`ssl.create_default_context` returns a context with
+    ``check_hostname=True`` and ``verify_mode=CERT_REQUIRED`` — the
+    opposite of the ``ssl._create_stdlib_context()`` smtplib falls back
+    to when ``context`` is left ``None`` (that one disables both, the F08
+    finding). A non-empty *ca_bundle* pins an internal relay's CA: passing
+    ``cafile`` makes ``create_default_context`` load *only* that bundle
+    (it skips ``load_default_certs``), so the trust anchor is the internal
+    CA rather than the public roots — the SMTP analogue of the
+    target-level ``tls_ca_pin``. Hostname verification stays on in both
+    cases, so ``server_hostname`` (the configured ``mail_smtp_host``,
+    which smtplib passes to ``wrap_socket``) must match the certificate.
+    """
+    if ca_bundle:
+        return ssl.create_default_context(cafile=ca_bundle)
+    return ssl.create_default_context()
+
+
 def _send_sync(
     msg: EmailMessage,
     *,
     host: str,
     port: int,
     starttls: bool,
+    ca_bundle: str,
     username: str,
     password: str,
     from_addr: str,
@@ -129,6 +168,13 @@ def _send_sync(
     ``QUIT`` and closes the connection on every exit path
     (:class:`smtplib.SMTP` is a context manager).
 
+    Both TLS paths are handed the same validating context from
+    :func:`_build_tls_context` — the implicit-TLS ``SMTP_SSL``
+    constructor (port 465) and the ``STARTTLS`` upgrade — so a
+    wrong-name, untrusted-chain or expired MTA certificate raises
+    :class:`ssl.SSLError` and the send is refused *before* any AUTH or
+    message data reaches the peer.
+
     ``encrypted`` tracks whether the channel is confidential — true from
     construction under implicit TLS, true again once ``starttls()``
     returns. It gates ``login()`` at the call site rather than being
@@ -136,8 +182,11 @@ def _send_sync(
     how TLS is established cannot leave the credential guard behind.
     """
     try:
+        context = _build_tls_context(ca_bundle)
         if port == _IMPLICIT_TLS_PORT:
-            client: smtplib.SMTP = smtplib.SMTP_SSL(host, port, timeout=_SMTP_TIMEOUT_SECONDS)
+            client: smtplib.SMTP = smtplib.SMTP_SSL(
+                host, port, timeout=_SMTP_TIMEOUT_SECONDS, context=context
+            )
             encrypted = True
         else:
             client = smtplib.SMTP(host, port, timeout=_SMTP_TIMEOUT_SECONDS)
@@ -145,7 +194,7 @@ def _send_sync(
         with client:
             client.ehlo()
             if starttls and port != _IMPLICIT_TLS_PORT:
-                client.starttls()
+                client.starttls(context=context)
                 # RFC 3207: the pre-TLS EHLO response is void; rediscover
                 # the server's extensions on the encrypted channel.
                 client.ehlo()
@@ -165,6 +214,12 @@ def _send_sync(
         return "smtp_connect_error"
     except smtplib.SMTPException:
         return "smtp_error"
+    except ssl.SSLError:
+        # Certificate verification / handshake failure on either TLS path
+        # (wrong name, untrusted chain, expired cert). ``ssl.SSLError``
+        # subclasses ``OSError``, so this arm MUST precede the ``OSError``
+        # arm below or a trust failure would misreport as a connect error.
+        return "smtp_tls_error"
     except OSError:
         # Raw socket-level connect failure (refused, DNS, timeout) —
         # smtplib raises these un-wrapped from the constructor's connect.
@@ -229,6 +284,7 @@ async def send_email(*, to: list[str], subject: str, body: str) -> MailSendResul
         host=settings.mail_smtp_host,
         port=settings.mail_smtp_port,
         starttls=settings.mail_smtp_starttls,
+        ca_bundle=settings.mail_smtp_ca_bundle,
         username=settings.mail_smtp_username,
         password=settings.mail_smtp_password,
         from_addr=settings.mail_from,

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -62,7 +62,10 @@ from meho_backplane.connectors._shared.vault_creds import (
     CredentialsReadError,
     strip_credential_value,
 )
-from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.adapters.ssh import (
+    SshConnector,
+    _known_hosts_from_secret,
+)
 from meho_backplane.connectors.pfsense.ops import PFSENSE_OPS
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
@@ -285,10 +288,15 @@ class PfSenseConnector(SshConnector):
         """
         secret = await self._resolve_secret(target, operator)
         username = strip_credential_value(secret.get("username", "admin"))
+        # Host-key trust is resolved by the shared SSH-adapter helper so the
+        # fail-closed pin / opt-out contract is identical to the base
+        # connector — the key-only *auth* policy is the only pfSense-specific
+        # narrowing here.
+        known_hosts = _known_hosts_from_secret(getattr(target, "name", str(target)), secret)
         private_key_raw = secret.get("ssh_private_key")
         if private_key_raw:
             key = asyncssh.import_private_key(strip_credential_value(private_key_raw))
-            return {"username": username, "client_keys": [key]}
+            return {"username": username, "known_hosts": known_hosts, "client_keys": [key]}
         raise ValueError(
             f"target '{getattr(target, 'name', target)!r}': pfSense connector requires "
             f"ssh_private_key in the target's Vault secret — password auth is not "

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1637,6 +1637,16 @@ class Settings(BaseModel):
     mail_smtp_host: str = Field(default="")
     mail_smtp_port: int = Field(default=587, gt=0, le=65535)
     mail_smtp_starttls: bool = True
+    # F08 (#270) — both TLS paths (implicit ``SMTP_SSL`` and ``STARTTLS``)
+    # verify the MTA's certificate against a validating
+    # ``ssl.create_default_context`` with hostname checking on. Empty (the
+    # default) trusts the system CA bundle; set to a PEM CA-bundle path to
+    # pin an internal relay's CA instead (the file's CAs *replace* the
+    # system trust, matching the target-level ``tls_ca_pin`` posture). There
+    # is deliberately no blanket "skip verification" knob — an internal
+    # relay with a private CA is trusted by pointing this at its CA, never
+    # by disabling verification.
+    mail_smtp_ca_bundle: str = Field(default="")
     mail_smtp_username: str = Field(default="")
     mail_smtp_password: str = Field(default="", repr=False)
     mail_from: str = Field(default="")
@@ -2353,6 +2363,7 @@ def get_settings() -> Settings:
         mail_smtp_starttls=parse_bool_env(
             os.environ.get("MAIL_SMTP_STARTTLS", "true"),
         ),
+        mail_smtp_ca_bundle=os.environ.get("MAIL_SMTP_CA_BUNDLE", "").strip(),
         mail_smtp_username=os.environ.get("MAIL_SMTP_USERNAME", "").strip(),
         mail_smtp_password=os.environ.get("MAIL_SMTP_PASSWORD", "").strip(),
         mail_from=os.environ.get("MAIL_FROM", "").strip(),

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -111,10 +111,20 @@ def _container_vault_secrets() -> Iterator[None]:
 
     The container lane exercises the real SSH pool but has no Vault; the
     stub returns the same ``{username, password}`` the pre-#2155 embedded
-    ``secret_ref`` dict carried.
+    ``secret_ref`` dict carried. ``known_hosts_insecure`` opts this
+    ephemeral testcontainer out of host-key verification (#270): the
+    container's host key is regenerated on every image build, so there is
+    nothing stable to pin — the opt-out is the correct choice here, and
+    the base adapter now fails closed without it.
     """
     with stub_ssh_vault_secrets(
-        {_CONTAINER_SECRET_PATH: {"username": "root", "password": _CONTAINER_PASSWORD}}
+        {
+            _CONTAINER_SECRET_PATH: {
+                "username": "root",
+                "password": _CONTAINER_PASSWORD,
+                "known_hosts_insecure": True,
+            }
+        }
     ):
         yield
 

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -362,7 +362,15 @@ class _SeededBind9Connector(Bind9Connector):  # type: ignore[misc]
         self._test_creds = creds
 
     async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
-        return {"username": self._test_creds.username, "password": self._test_creds.password}
+        # ``known_hosts=None`` opts this ephemeral testcontainer out of
+        # host-key verification (#270): the container's host key is freshly
+        # generated per run, so there is nothing stable to pin here. Threaded
+        # explicitly because ``_connect`` now requires the key.
+        return {
+            "username": self._test_creds.username,
+            "password": self._test_creds.password,
+            "known_hosts": None,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -56,6 +56,7 @@ import pytest
 import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
 from meho_backplane.connectors import all_connectors_v2
 from meho_backplane.connectors._shared.pwsh import PwshRunError
+from meho_backplane.connectors.adapters.ssh import SshHostKeyUnpinnedError
 from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
 from meho_backplane.connectors.holodeck.connector import parse_photon_version
 from meho_backplane.connectors.registry import clear_registry
@@ -127,9 +128,18 @@ _FAKE_KEY_FOOTER = "-----END " + "OPENSSH PRIVATE KEY" + "-----"
 _CANARY_PRIVATE_KEY = f"{_FAKE_KEY_HEADER}\nFAKE-CANARY-KEY-BODY\n{_FAKE_KEY_FOOTER}\n"
 
 
-def _target_with_secret(name: str, secret: dict[str, Any]) -> _StubTarget:
+def _target_with_secret(
+    name: str, secret: dict[str, Any], *, pin_host_key: bool = True
+) -> _StubTarget:
     secret_path = f"meho/testing/holodeck/{name}"
-    _VAULT_SECRETS[secret_path] = secret
+    merged = dict(secret)
+    # HolodeckConnector inherits the base fail-closed host-key contract
+    # (#270); these credential-focused tests opt the throwaway targets out
+    # of verification so the credential branch is what is exercised. Pass
+    # ``pin_host_key=False`` to leave a secret unpinned (fail-closed case).
+    if pin_host_key and "known_hosts" not in merged and "known_hosts_insecure" not in merged:
+        merged["known_hosts_insecure"] = True
+    _VAULT_SECRETS[secret_path] = merged
     return _StubTarget(
         name=name,
         host=f"{name}.test.invalid",
@@ -257,7 +267,7 @@ async def test_auth_config_password_default() -> None:
     """Password-only secret -> ``{username, password}``; no key path taken."""
     connector = HolodeckConnector()
     auth = await connector._auth_config(_password_target())
-    assert auth == {"username": "root", "password": _CANARY_PASSWORD}
+    assert auth == {"username": "root", "known_hosts": None, "password": _CANARY_PASSWORD}
     assert "client_keys" not in auth
 
 
@@ -278,7 +288,7 @@ async def test_auth_config_key_preferred_when_present() -> None:
     # ``strip_credential_value`` trims the surrounding whitespace before
     # the key reaches asyncssh (#1474); internal newlines are preserved.
     imp.assert_called_once_with(_CANARY_PRIVATE_KEY.strip())
-    assert auth == {"username": "root", "client_keys": [stub_key]}
+    assert auth == {"username": "root", "known_hosts": None, "client_keys": [stub_key]}
     assert "password" not in auth
 
 
@@ -286,6 +296,18 @@ async def test_auth_config_raises_when_neither_credential_is_set() -> None:
     connector = HolodeckConnector()
     with pytest.raises(ValueError, match="ssh_private_key or password"):
         await connector._auth_config(_no_cred_target())
+
+
+async def test_auth_config_fails_closed_when_host_key_unconfigured() -> None:
+    """An unpinned secret (no pin, no opt-out) refuses before connecting (#270)."""
+    connector = HolodeckConnector()
+    target = _target_with_secret(
+        "holorouter-unpinned",
+        {"username": "root", "password": _CANARY_PASSWORD},
+        pin_host_key=False,
+    )
+    with pytest.raises(SshHostKeyUnpinnedError):
+        await connector._auth_config(target)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_mail.py
+++ b/backend/tests/test_connectors_mail.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import re
 import smtplib
 import socket
+import ssl
 from collections.abc import AsyncIterator, Iterator
 from email.message import EmailMessage
 from pathlib import Path
@@ -134,10 +135,24 @@ class _RecordingSMTP:
 
     instances: ClassVar[list[_RecordingSMTP]]
 
-    def __init__(self, host: str, port: int, timeout: float | None = None) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        *,
+        context: object | None = None,
+    ) -> None:
         self.host = host
         self.port = port
         self.timeout = timeout
+        # The implicit-TLS (SMTP_SSL) constructor receives the validating
+        # context; the plaintext SMTP constructor gets None and the context
+        # arrives later on ``starttls``. Both are captured so tests can
+        # assert the transport hands a verifying context to every TLS path
+        # (#270).
+        self.init_context = context
+        self.starttls_context: object | None = None
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
         self.sent_messages: list[EmailMessage] = []
         type(self).instances.append(self)
@@ -152,6 +167,7 @@ class _RecordingSMTP:
         self.calls.append(("ehlo", ()))
 
     def starttls(self, *, context: object | None = None) -> None:
+        self.starttls_context = context
         self.calls.append(("starttls", ()))
 
     def login(self, user: str, password: str) -> None:
@@ -173,6 +189,66 @@ class _ExplodingSMTP:
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         raise AssertionError("smtplib.SMTP must not be constructed when the send is refused")
+
+
+def _self_signed_ca_pem() -> str:
+    """Build a throwaway self-signed CA certificate as PEM text.
+
+    Used only to prove ``_build_tls_context`` loads a pinned bundle as a
+    trust anchor; the key is discarded — nothing is signed with it.
+    """
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.serialization import Encoding
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "meho-mail-test-ca")])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(hours=1))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(Encoding.PEM).decode()
+
+
+def _assert_validating_context(ctx: object) -> None:
+    """Assert *ctx* is an SSL context that verifies the peer (#270).
+
+    The whole point of the fix is that neither TLS path is handed
+    ``None`` (which makes smtplib fall back to the unverified
+    ``ssl._create_stdlib_context``). A verifying context has hostname
+    checking on and ``CERT_REQUIRED``.
+    """
+    assert isinstance(ctx, ssl.SSLContext), f"expected an ssl.SSLContext, got {ctx!r}"
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+class _TLSFailingSMTPSSL:
+    """``SMTP_SSL`` stand-in whose constructor raises a cert-verify error."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise ssl.SSLCertVerificationError("certificate verify failed: self-signed")
+
+
+class _STARTTLSFailingSMTP(_RecordingSMTP):
+    """Plaintext ``SMTP`` stand-in whose ``starttls`` raises a cert-verify error."""
+
+    instances: ClassVar[list[_RecordingSMTP]] = []
+
+    def starttls(self, *, context: object | None = None) -> None:
+        raise ssl.SSLCertVerificationError("certificate verify failed: unknown CA")
 
 
 @pytest.fixture
@@ -375,6 +451,9 @@ async def test_starttls_and_login_run_in_sequence_when_configured(
     (client,) = recording_smtp.instances
     assert (client.host, client.port) == ("smtp.internal", 587)
     assert client.timeout == mail_transport._SMTP_TIMEOUT_SECONDS
+    # STARTTLS receives an explicit validating context (#270): hostname
+    # checking on, CERT_REQUIRED — not the unverified stdlib fallback.
+    _assert_validating_context(client.starttls_context)
     assert [name for name, _ in client.calls] == [
         "ehlo",
         "starttls",
@@ -423,7 +502,76 @@ async def test_port_465_uses_implicit_tls_without_starttls(
     assert result == MailSendResult(sent=True, reason=None)
     (client,) = recording_smtp.instances
     assert client.port == 465
+    # Implicit TLS: the validating context is handed to the SMTP_SSL
+    # constructor, so the handshake verifies the cert before any data (#270).
+    _assert_validating_context(client.init_context)
     assert [name for name, _ in client.calls] == ["ehlo", "send_message", "quit"]
+
+
+async def test_implicit_tls_cert_verification_failure_refuses_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 465 handshake against an untrusted cert refuses with smtp_tls_error.
+
+    The failure is raised by ``SMTP_SSL``'s constructor — before any AUTH
+    or message data — and maps to the dedicated TLS reason code rather
+    than a misleading connect error (#270).
+    """
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _ExplodingSMTP)
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP_SSL", _TLSFailingSMTPSSL)
+    _configure_mail_env(monkeypatch, MAIL_SMTP_PORT="465")
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_tls_error")
+
+
+async def test_starttls_cert_verification_failure_refuses_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A STARTTLS upgrade against an untrusted cert refuses with smtp_tls_error.
+
+    The upgrade raises before ``login`` / ``send_message``, so no
+    credential or message reaches the unverified peer.
+    """
+    _STARTTLSFailingSMTP.instances = []
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _STARTTLSFailingSMTP)
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP_SSL", _ExplodingSMTP)
+    _configure_mail_env(
+        monkeypatch,
+        MAIL_SMTP_USERNAME="meho-mailer",
+        MAIL_SMTP_PASSWORD="s3cret",
+    )
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_tls_error")
+    (client,) = _STARTTLSFailingSMTP.instances
+    call_names = [name for name, _ in client.calls]
+    assert "login" not in call_names
+    assert "send_message" not in call_names
+    assert not client.sent_messages
+
+
+def test_build_tls_context_defaults_to_system_trust() -> None:
+    """No CA bundle ⇒ a verifying context over the system trust store."""
+    ctx = mail_transport._build_tls_context("")
+    _assert_validating_context(ctx)
+
+
+def test_build_tls_context_pins_ca_bundle(tmp_path: Path) -> None:
+    """A CA-bundle path ⇒ a verifying context that loads that bundle (#270)."""
+    ca_pem = _self_signed_ca_pem()
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text(ca_pem)
+
+    ctx = mail_transport._build_tls_context(str(bundle))
+
+    _assert_validating_context(ctx)
+    # The pinned CA is loaded as a trust anchor (it replaces the system
+    # roots, matching the target-level tls_ca_pin posture).
+    subjects = [dict(ca["subject"][0]) for ca in ctx.get_ca_certs()]
+    assert any(s.get("commonName") == "meho-mail-test-ca" for s in subjects)
 
 
 async def test_plaintext_channel_refuses_auth_instead_of_logging_in(

--- a/backend/tests/test_connectors_pfsense_auth.py
+++ b/backend/tests/test_connectors_pfsense_auth.py
@@ -51,6 +51,7 @@ import pytest
 
 import meho_backplane.connectors.pfsense  # noqa: F401 -- import for registry side-effects
 from meho_backplane.connectors import all_connectors_v2
+from meho_backplane.connectors.adapters.ssh import SshHostKeyUnpinnedError
 from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
 from meho_backplane.connectors.pfsense.connector import parse_pfsense_version
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
@@ -113,10 +114,22 @@ def _vault_secrets() -> Iterator[None]:
 
 
 def _target_with_secret(
-    name: str, secret: dict[str, Any], *, host: str | None = None, port: int | None = 22
+    name: str,
+    secret: dict[str, Any],
+    *,
+    host: str | None = None,
+    port: int | None = 22,
+    pin_host_key: bool = True,
 ) -> _StubTarget:
     secret_path = f"meho/testing/pfsense/{name}"
-    _VAULT_SECRETS[secret_path] = secret
+    merged = dict(secret)
+    # PfSenseConnector._auth_config inherits the base fail-closed host-key
+    # contract (#270); these auth-focused tests opt the throwaway targets
+    # out of verification so the key-only *credential* policy is what is
+    # exercised. Pass ``pin_host_key=False`` for the unpinned case.
+    if pin_host_key and "known_hosts" not in merged and "known_hosts_insecure" not in merged:
+        merged["known_hosts_insecure"] = True
+    _VAULT_SECRETS[secret_path] = merged
     return _StubTarget(
         name=name,
         host=host if host is not None else "pfsense.test.invalid",
@@ -263,6 +276,20 @@ async def test_auth_config_defaults_username_to_admin() -> None:
     connector = PfSenseConnector()
     auth = await connector._auth_config(target)
     assert auth["username"] == "admin"
+
+
+async def test_auth_config_fails_closed_when_host_key_unconfigured() -> None:
+    """An unpinned secret refuses before auth even with a valid key (#270)."""
+    private_key = asyncssh.generate_private_key("ssh-ed25519")
+    pem = private_key.export_private_key().decode()
+    target = _target_with_secret(
+        "pfsense-unpinned",
+        {"username": "admin", "ssh_private_key": pem},
+        pin_host_key=False,
+    )
+    connector = PfSenseConnector()
+    with pytest.raises(SshHostKeyUnpinnedError):
+        await connector._auth_config(target)
 
 
 # ---------------------------------------------------------------------------
@@ -627,7 +654,7 @@ async def test_per_target_connection_isolation() -> None:
         patch.object(
             connector,
             "_auth_config",
-            AsyncMock(return_value={"username": "admin", "client_keys": []}),
+            AsyncMock(return_value={"username": "admin", "known_hosts": None, "client_keys": []}),
         ),
     ):
         got_a = await connector._connect(target_a)

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -51,7 +51,12 @@ import pytest
 from meho_backplane.connectors._shared.system_operator import SYSTEM_OPERATOR_SUB
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters import SshConnector
-from meho_backplane.connectors.adapters.ssh import _POOL_TTL_S
+from meho_backplane.connectors.adapters.ssh import (
+    _POOL_TTL_S,
+    SshHostKeyUnpinnedError,
+    _known_hosts_from_secret,
+    _secret_flag_is_true,
+)
 from meho_backplane.connectors.adapters.ssh import SshConnector as _SshConnectorDirect
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
@@ -68,6 +73,30 @@ _SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
 _CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
 _CLIENT_PUB = _CLIENT_KEY.convert_to_public()
 _PASSWORD = "test-secret"  # NOSONAR — in-process asyncssh test server only, no real system
+
+# Host-key pin material (#270). The in-process server presents
+# ``_SERVER_KEY``; ``_SERVER_PUB_OPENSSH`` is that public key in the
+# OpenSSH one-line format a ``known_hosts`` entry uses. ``_WRONG_PUB_OPENSSH``
+# is an unrelated key used to prove a mismatched pin fails closed before
+# any credential is offered.
+_SERVER_PUB_OPENSSH = _SERVER_KEY.convert_to_public().export_public_key("openssh").decode().strip()
+_WRONG_PUB_OPENSSH = (
+    asyncssh.generate_private_key("ssh-ed25519")
+    .convert_to_public()
+    .export_public_key("openssh")
+    .decode()
+    .strip()
+)
+
+# Sentinel marking "pin the real server key" (the secure default a
+# target builder applies) apart from an explicit ``known_hosts=None``
+# (omit the pin entirely — the unpinned, fail-closed case).
+_PIN_SERVER_KEY = object()
+
+
+def _known_hosts_line(host: str, pub_openssh: str = _SERVER_PUB_OPENSSH) -> str:
+    """Build one OpenSSH ``known_hosts`` line: ``<host> <keytype> <base64>``."""
+    return f"{host} {pub_openssh}"
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +172,23 @@ def vault_secrets() -> Iterator[dict[str, dict[str, Any]]]:
         yield registry
 
 
+def _host_key_fields(host: str, known_hosts: Any, known_hosts_insecure: bool) -> dict[str, Any]:
+    """Assemble the host-key trust fields a target's secret carries (#270).
+
+    ``known_hosts=_PIN_SERVER_KEY`` (the default) pins the real server
+    key so the secure path is exercised; a string pins that verbatim;
+    ``None`` omits the pin entirely. ``known_hosts_insecure`` sets the
+    audited opt-out flag instead.
+    """
+    if known_hosts_insecure:
+        return {"known_hosts_insecure": True}
+    if known_hosts is _PIN_SERVER_KEY:
+        return {"known_hosts": _known_hosts_line(host)}
+    if known_hosts is None:
+        return {}
+    return {"known_hosts": known_hosts}
+
+
 def _password_target(
     name: str = "srv-01",
     *,
@@ -151,6 +197,8 @@ def _password_target(
     username: str = "test",
     target_id: str | None = None,
     tenant_id: str = "00000000-0000-0000-0000-000000000000",
+    known_hosts: Any = _PIN_SERVER_KEY,
+    known_hosts_insecure: bool = False,
 ) -> Any:
     # Carries ``id`` and ``tenant_id`` because the connection pool keys on
     # ``target_cache_key`` (``(tenant_id, id)``); a double missing either
@@ -158,7 +206,11 @@ def _password_target(
     # a distinct ``id`` from ``name`` so distinct-name targets in the same
     # tenant land on distinct pool keys by default.
     secret_path = f"meho/testing/ssh/{tenant_id}/{name}"
-    _VAULT_SECRETS[secret_path] = {"username": username, "password": _PASSWORD}
+    _VAULT_SECRETS[secret_path] = {
+        "username": username,
+        "password": _PASSWORD,
+        **_host_key_fields(host, known_hosts, known_hosts_insecure),
+    }
     return types.SimpleNamespace(
         name=name,
         host=host,
@@ -177,10 +229,16 @@ def _key_target(
     username: str = "test",
     target_id: str | None = None,
     tenant_id: str = "00000000-0000-0000-0000-000000000000",
+    known_hosts: Any = _PIN_SERVER_KEY,
+    known_hosts_insecure: bool = False,
 ) -> Any:
     private_key_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
     secret_path = f"meho/testing/ssh/{tenant_id}/{name}"
-    _VAULT_SECRETS[secret_path] = {"username": username, "ssh_private_key": private_key_pem}
+    _VAULT_SECRETS[secret_path] = {
+        "username": username,
+        "ssh_private_key": private_key_pem,
+        **_host_key_fields(host, known_hosts, known_hosts_insecure),
+    }
     return types.SimpleNamespace(
         name=name,
         host=host,
@@ -491,9 +549,20 @@ async def test_aclose_skips_already_closed_connections(
 
 
 def _target_with_secret(name: str, secret: dict[str, Any]) -> Any:
-    """Register *secret* at a per-name Vault path and return a matching target."""
+    """Register *secret* at a per-name Vault path and return a matching target.
+
+    These are *credential*-focused ``_auth_config`` unit tests, so a
+    host-key opt-out is injected by default (unless the secret already
+    carries host-key fields) — host-key enforcement itself is covered by
+    the dedicated pin / mismatch / opt-out tests above. Without this,
+    every credential assertion would trip the fail-closed host-key guard
+    first (#270).
+    """
     secret_path = f"meho/testing/ssh/cfg/{name}"
-    _VAULT_SECRETS[secret_path] = secret
+    merged = dict(secret)
+    if "known_hosts" not in merged and "known_hosts_insecure" not in merged:
+        merged["known_hosts_insecure"] = True
+    _VAULT_SECRETS[secret_path] = merged
     return types.SimpleNamespace(name=name, host="h", port=22, secret_ref=secret_path)
 
 
@@ -512,6 +581,10 @@ async def test_auth_config_key_auth_returns_client_keys(
     assert "client_keys" in cfg
     assert len(cfg["client_keys"]) == 1
     assert "password" not in cfg
+    # _auth_config always threads the resolved host-key trust value (#270);
+    # here the opt-out injected by the helper resolves to None.
+    assert "known_hosts" in cfg
+    assert cfg["known_hosts"] is None
 
 
 @pytest.mark.asyncio
@@ -681,3 +754,164 @@ async def test_idle_ttl_evicts_stale_connection(
     assert ssh_second is not ssh_first
     assert not ssh_second.is_closed()
     await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Host-key verification (#270, F08) — fail-closed pin / mismatch / opt-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pinned_host_key_connects_and_runs_command(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """A secret pinning the server's real host key connects (secure path)."""
+    conn = _ConcreteSshConnector()
+    # Default builder pins the real server key; make it explicit here.
+    target = _password_target(
+        name="pinned-ok",
+        host=ssh_server.host,
+        port=ssh_server.port,
+        known_hosts=_known_hosts_line(ssh_server.host),
+    )
+
+    result = await conn._run_command(target, "echo ok")
+
+    assert result.exit_status == 0
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wrong_host_key_pin_fails_before_auth(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """A pin for the wrong host key aborts at key exchange, before credentials.
+
+    ``asyncssh`` raises :exc:`asyncssh.HostKeyNotVerifiable` during the
+    handshake when the presented key does not match the pin, so no
+    password / private key is ever offered to the impostor — the F08
+    fail-closed contract.
+    """
+    conn = _ConcreteSshConnector()
+    target = _password_target(
+        name="wrong-pin",
+        host=ssh_server.host,
+        port=ssh_server.port,
+        known_hosts=_known_hosts_line(ssh_server.host, _WRONG_PUB_OPENSSH),
+    )
+
+    with pytest.raises(asyncssh.HostKeyNotVerifiable):
+        await conn._connect(target)
+
+    assert conn._connections == {}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unpinned_secret_fails_closed(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """A secret with neither a pin nor the opt-out raises before connecting."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(
+        name="unpinned",
+        host=ssh_server.host,
+        port=ssh_server.port,
+        known_hosts=None,
+    )
+
+    with pytest.raises(SshHostKeyUnpinnedError):
+        await conn._connect(target)
+
+    assert conn._connections == {}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_insecure_opt_out_connects_and_warns(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """``known_hosts_insecure`` restores no-verification behaviour, warned."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(
+        name="opt-out",
+        host=ssh_server.host,
+        port=ssh_server.port,
+        known_hosts_insecure=True,
+    )
+
+    with patch("meho_backplane.connectors.adapters.ssh.logger") as mock_logger:
+        result = await conn._run_command(target, "echo ok")
+
+    assert result.exit_status == 0
+    warned = [
+        c
+        for c in mock_logger.warning.call_args_list
+        if c.args[:1] == ("ssh_host_key_check_disabled",)
+    ]
+    assert warned, "opt-out path must log ssh_host_key_check_disabled"
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_auth_config_missing_known_hosts(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """A subclass _auth_config that omits ``known_hosts`` fails closed at _connect."""
+
+    class _NoHostKeyConnector(_ConcreteSshConnector):
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
+            return {"username": "test", "password": _PASSWORD}
+
+    conn = _NoHostKeyConnector()
+    target = _password_target(name="no-hk", host=ssh_server.host, port=ssh_server.port)
+
+    with pytest.raises(SshHostKeyUnpinnedError):
+        await conn._connect(target)
+    await conn.aclose()
+
+
+def test_known_hosts_from_secret_pin_takes_precedence_over_opt_out() -> None:
+    """When both a pin and the opt-out are set, the pin (secure) wins."""
+    secret = {
+        "known_hosts": _known_hosts_line("10.0.0.1"),
+        "known_hosts_insecure": True,
+    }
+    resolved = _known_hosts_from_secret("t", secret)
+    assert isinstance(resolved, asyncssh.SSHKnownHosts)
+
+
+def test_known_hosts_from_secret_opt_out_returns_none() -> None:
+    assert _known_hosts_from_secret("t", {"known_hosts_insecure": "true"}) is None
+
+
+def test_known_hosts_from_secret_unpinned_raises() -> None:
+    with pytest.raises(SshHostKeyUnpinnedError):
+        _known_hosts_from_secret("t", {"username": "u"})
+
+
+def test_known_hosts_from_secret_blank_pin_is_not_a_pin() -> None:
+    """A whitespace-only ``known_hosts`` is treated as absent (fail closed)."""
+    with pytest.raises(SshHostKeyUnpinnedError):
+        _known_hosts_from_secret("t", {"known_hosts": "   "})
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("", False),
+        (None, False),
+        (1, False),
+    ],
+)
+def test_secret_flag_is_true(value: Any, expected: bool) -> None:
+    assert _secret_flag_is_true(value) is expected

--- a/cli/internal/cmd/admin/keycloak/keycloak.go
+++ b/cli/internal/cmd/admin/keycloak/keycloak.go
@@ -100,6 +100,7 @@ func newBootstrapClientsCmd() *cobra.Command {
 		skipUserProvisioning  bool
 		mcpRedirectURIs       []string
 		mcpWebOrigins         []string
+		keycloakCABundle      string
 		insecureSkipTLS       bool
 		dryRun                bool
 		cliOfflineSessionIdle int
@@ -187,12 +188,41 @@ func newBootstrapClientsCmd() *cobra.Command {
 				Err:                          cmd.ErrOrStderr(),
 			}
 
+			// TLS trust selection (F08 / #270). The package-level
+			// Bootstrap uses defaultHTTPClient() (system trust store)
+			// unless we stash a custom client via the package-internal
+			// httpClientOverride indirection. The two overrides are
+			// mutually exclusive: a CA-bundle pin keeps verification on
+			// (preferred), a blanket skip turns it off (escape hatch).
+			if keycloakCABundle != "" && insecureSkipTLS {
+				return errors.New(
+					"--keycloak-ca-bundle and --insecure-skip-tls-verify are " +
+						"mutually exclusive: pin the realm CA (verified TLS) or " +
+						"skip verification entirely, not both")
+			}
+			if keycloakCABundle != "" {
+				// Verified TLS against the pinned realm CA — the
+				// admin-password grant and every Bearer-token request
+				// run over a checked certificate chain + hostname.
+				client, cerr := newCABundleClient(keycloakCABundle)
+				if cerr != nil {
+					return cerr
+				}
+				httpClientOverride = client
+				defer func() { httpClientOverride = nil }()
+			}
 			if insecureSkipTLS {
-				// The package-level Bootstrap uses defaultHTTPClient();
-				// when the operator workstation has no system trust
-				// for the realm's CA we need to flip the TLS skip on
-				// a custom client. Build it here and stash it via a
-				// package-internal indirection (httpClientOverride).
+				// Escape hatch: verification off. Loud, opt-in, and never
+				// the default — the master-realm admin password and the
+				// minted admin token cross an unverified connection, so
+				// an active intermediary could capture both.
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"WARNING: --insecure-skip-tls-verify disables TLS "+
+						"certificate AND hostname verification for every "+
+						"Keycloak request. The master-realm admin password and "+
+						"the minted admin token will be sent over an unverified "+
+						"connection. Prefer --keycloak-ca-bundle=<realm-ca.pem> "+
+						"to pin the realm CA with verification left on.")
 				httpClientOverride = newInsecureClient()
 				defer func() { httpClientOverride = nil }()
 			}
@@ -238,8 +268,14 @@ func newBootstrapClientsCmd() *cobra.Command {
 		"redirect URI(s) for the MCP browser-flow client (default: loopback localhost + 127.0.0.1, any port/path)")
 	cmd.Flags().StringSliceVar(&mcpWebOrigins, "mcp-web-origin", nil,
 		"CORS web origin(s) for the MCP browser-flow client (default: `+` — allow the redirect-URI origins)")
+	cmd.Flags().StringVar(&keycloakCABundle, "keycloak-ca-bundle", "",
+		"path to a PEM CA bundle to verify the Keycloak server certificate against "+
+			"(keeps chain + hostname verification ON while trusting an internal realm CA). "+
+			"Preferred over --insecure-skip-tls-verify; the two are mutually exclusive")
 	cmd.Flags().BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false,
-		"skip TLS verification when calling Keycloak (one-time bootstrap convenience; do not use in CI against untrusted Keycloaks)")
+		"escape hatch: skip TLS certificate AND hostname verification for every "+
+			"Keycloak request (sends the admin password + token over an unverified "+
+			"connection; prints a loud warning). Prefer --keycloak-ca-bundle")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"print what would be provisioned without making any API calls")
 	cmd.Flags().IntVar(&cliOfflineSessionIdle, "cli-offline-access", 0,
@@ -292,6 +328,25 @@ func newInsecureClient() *http.Client {
 	transport.TLSClientConfig = newSkipVerifyTLSConfig()
 	c.Transport = transport
 	return c
+}
+
+// newCABundleClient builds an http.Client that verifies the Keycloak
+// server certificate against the PEM CA bundle at caBundlePath, with
+// certificate-chain and hostname verification left ON. Used by the
+// --keycloak-ca-bundle flag — the verified-TLS alternative to
+// --insecure-skip-tls-verify for a realm fronted by an internal CA.
+// Returns an error when the bundle can't be read or holds no PEM
+// certificates.
+func newCABundleClient(caBundlePath string) (*http.Client, error) {
+	tlsConfig, err := newCABundleTLSConfig(caBundlePath)
+	if err != nil {
+		return nil, err
+	}
+	c := defaultHTTPClient()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	c.Transport = transport
+	return c, nil
 }
 
 // readPassword prompts on stderr and reads one line from in, returning

--- a/cli/internal/cmd/admin/keycloak/tls.go
+++ b/cli/internal/cmd/admin/keycloak/tls.go
@@ -3,13 +3,23 @@
 
 package keycloak
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
 
 // newSkipVerifyTLSConfig returns a *tls.Config with InsecureSkipVerify
 // set, isolated to its own file so the bootstrap and command code
 // don't carry the import noise. Only called from the
 // --insecure-skip-tls-verify code path; the production default is the
 // system trust store via http.DefaultTransport's TLSClientConfig=nil.
+//
+// Prefer --keycloak-ca-bundle (newCABundleTLSConfig) over this flag: a
+// CA-bundle pin keeps certificate *and* hostname verification on while
+// still trusting an internal realm CA. This blanket skip disables both
+// and is the last-resort escape hatch, warned loudly at the call site.
 //
 // We accept the gosec G402 lint hit at the call site (the only one in
 // the package); the install-time use case — operator workstation
@@ -19,4 +29,30 @@ import "crypto/tls"
 //nolint:gosec // intentional opt-in to InsecureSkipVerify via flag
 func newSkipVerifyTLSConfig() *tls.Config {
 	return &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+}
+
+// newCABundleTLSConfig returns a *tls.Config that trusts the CA(s) in
+// the PEM file at caBundlePath while keeping full certificate-chain and
+// hostname verification on (InsecureSkipVerify stays false). This is the
+// secure supersession of --insecure-skip-tls-verify for the common
+// install-time case: the operator's workstation has no system trust for
+// the realm's private CA, but does have that CA's certificate on disk.
+// The admin-password grant and every subsequent Bearer-token request
+// then run over verified TLS. Mirrors the target-level `tls_ca_pin`
+// (the backplane's per-target CA pin): the bundle replaces the system
+// roots for this client rather than adding to them.
+func newCABundleTLSConfig(caBundlePath string) (*tls.Config, error) {
+	pem, err := os.ReadFile(caBundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("read CA bundle %q: %w", caBundlePath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf(
+			"CA bundle %q contained no PEM certificates", caBundlePath)
+	}
+	return &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}, nil
 }

--- a/cli/internal/cmd/admin/keycloak/tls_test.go
+++ b/cli/internal/cmd/admin/keycloak/tls_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeSelfSignedCA writes a minimal self-signed CA certificate to a
+// temp PEM file and returns its path. Enough for AppendCertsFromPEM to
+// accept it as a trust anchor — the F08 CA-bundle-pin path.
+func writeSelfSignedCA(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "meho-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write CA pem: %v", err)
+	}
+	return path
+}
+
+func TestNewCABundleTLSConfig_TrustsBundleWithVerificationOn(t *testing.T) {
+	path := writeSelfSignedCA(t)
+
+	cfg, err := newCABundleTLSConfig(path)
+	if err != nil {
+		t.Fatalf("newCABundleTLSConfig: %v", err)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Error("CA-bundle TLS config must keep InsecureSkipVerify false")
+	}
+	if cfg.RootCAs == nil {
+		t.Error("CA-bundle TLS config must set a RootCAs pool")
+	}
+	if cfg.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %d, want >= TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestNewCABundleTLSConfig_RejectsNonPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	if err := os.WriteFile(path, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	if _, err := newCABundleTLSConfig(path); err == nil {
+		t.Fatal("expected an error for a file with no PEM certificates")
+	}
+}
+
+func TestNewCABundleTLSConfig_MissingFileErrors(t *testing.T) {
+	if _, err := newCABundleTLSConfig(filepath.Join(t.TempDir(), "absent.pem")); err == nil {
+		t.Fatal("expected an error for a missing CA bundle file")
+	}
+}
+
+// TestBootstrapClientsCmd_CABundleAndInsecureAreMutuallyExclusive drives
+// the cobra RunE far enough to reach the TLS-trust selection and asserts
+// the two flags are refused together (before any network call).
+func TestBootstrapClientsCmd_CABundleAndInsecureAreMutuallyExclusive(t *testing.T) {
+	t.Setenv("KEYCLOAK_ADMIN_PASSWORD", "pw") //nolint:gosec // test-only literal
+	cmd := newBootstrapClientsCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--keycloak-base-url", "https://kc.example.com",
+		"--realm", "evba",
+		"--admin-username", "admin",
+		"--skip-user-provisioning",
+		"--keycloak-ca-bundle", writeSelfSignedCA(t),
+		"--insecure-skip-tls-verify",
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected mutually-exclusive error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want it to mention mutual exclusion", err.Error())
+	}
+}
+
+// TestBootstrapClientsCmd_InsecureFlagWarnsLoudly asserts the escape
+// hatch prints a loud stderr warning (F08 AC: the flag stays opt-in and
+// warned). Runs under --dry-run so no Keycloak call is made.
+func TestBootstrapClientsCmd_InsecureFlagWarnsLoudly(t *testing.T) {
+	t.Setenv("KEYCLOAK_ADMIN_PASSWORD", "pw") //nolint:gosec // test-only literal
+	cmd := newBootstrapClientsCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--keycloak-base-url", "https://kc.example.com",
+		"--realm", "evba",
+		"--admin-username", "admin",
+		"--mcp-resource-uri", "https://meho.example.com/mcp",
+		"--skip-user-provisioning",
+		"--insecure-skip-tls-verify",
+		"--dry-run",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry-run with --insecure-skip-tls-verify: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "WARNING: --insecure-skip-tls-verify") {
+		t.Errorf("stderr missing loud warning; got:\n%s", errOut.String())
+	}
+}
+
+// TestBootstrapClientsCmd_CABundleReadErrorSurfaces asserts the
+// --keycloak-ca-bundle path is wired into RunE: an unreadable bundle
+// fails the command rather than silently falling back to system trust.
+func TestBootstrapClientsCmd_CABundleReadErrorSurfaces(t *testing.T) {
+	t.Setenv("KEYCLOAK_ADMIN_PASSWORD", "pw") //nolint:gosec // test-only literal
+	cmd := newBootstrapClientsCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--keycloak-base-url", "https://kc.example.com",
+		"--realm", "evba",
+		"--admin-username", "admin",
+		"--mcp-resource-uri", "https://meho.example.com/mcp",
+		"--skip-user-provisioning",
+		"--keycloak-ca-bundle", filepath.Join(t.TempDir(), "absent.pem"),
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected a CA-bundle read error, got nil")
+	}
+	if !strings.Contains(err.Error(), "read CA bundle") {
+		t.Errorf("error = %q, want it to mention the CA bundle read failure", err.Error())
+	}
+}

--- a/docs-site/reference/cli.md
+++ b/docs-site/reference/cli.md
@@ -50,8 +50,9 @@ meho admin keycloak bootstrap-clients [flags]
 - `--cli-client-id` — public client_id for the device-code flow (matches chart's `config.keycloakCliClientId`)
 - `--cli-offline-access` — opt the device-code CLI client into the long-lived offline-token path: assign `offline_access` as an optional client scope and bound its per-client offline-session idle timeout to the given number of seconds. Off by default. A bare `--cli-offline-access` uses 172800 seconds (48h); to pass a custom value use the equals form, e.g. `--cli-offline-access=86400`. Pairs with `meho login --offline`. Security: this enables a long-lived refresh token on the operator's disk — keep the bound tight and prefer the OS keyring for storage
 - `--dry-run` — print what would be provisioned without making any API calls
-- `--insecure-skip-tls-verify` — skip TLS verification when calling Keycloak (one-time bootstrap convenience; do not use in CI against untrusted Keycloaks)
+- `--insecure-skip-tls-verify` — escape hatch: skip TLS certificate AND hostname verification for every Keycloak request (sends the admin password + token over an unverified connection; prints a loud warning). Prefer --keycloak-ca-bundle
 - `--keycloak-base-url` — Keycloak base URL, e.g. https://keycloak.example.com
+- `--keycloak-ca-bundle` — path to a PEM CA bundle to verify the Keycloak server certificate against (keeps chain + hostname verification ON while trusting an internal realm CA). Preferred over --insecure-skip-tls-verify; the two are mutually exclusive
 - `--mcp-client-id` — public client_id for the MCP browser-flow client
 - `--mcp-redirect-uri` — redirect URI(s) for the MCP browser-flow client (default: loopback localhost + <ip>, any port/path)
 - `--mcp-resource-uri` — audience the `meho-mcp-audience` mapper emits, e.g. https://meho.example.com/mcp (no trailing slash)

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -2079,6 +2079,14 @@ output, or process supervisor logs. The pattern mirrors the
 reference shell script's mode-600 tempfile dance, adapted for Go's
 stdin reader.
 
+Prefer a **scoped provisioning identity** over the master-realm
+`admin` user where the deployment supports it: a service account
+granted only the `realm-management` client roles this verb needs
+(`manage-clients`, `manage-users`, `query-groups`) has a far smaller
+blast radius than the master-admin credential if it is ever exposed.
+The verb accepts any admin-capable identity via `--admin-username`;
+the master realm is only the default, not a requirement.
+
 ### HTTP client
 
 Stdlib `net/http` + `encoding/json` — no Keycloak Go SDK in
@@ -2088,11 +2096,20 @@ protocol-mappers + client-scopes + users + groups, all under
 a bad supply-chain tradeoff. The same discipline as the rest of the
 CLI: every transitive import has to justify its place in `go.sum`.
 
-The `--insecure-skip-tls-verify` flag flips `tls.Config.InsecureSkipVerify`
-on a custom transport for the one-time bootstrap case where the
-operator workstation has not yet trusted the realm's internal CA.
-The flag is opt-in and explicit; the default uses the system trust
-store via `http.DefaultTransport`.
+**TLS trust (F08 / #270).** The default uses the system trust store via
+`http.DefaultTransport`. For a realm fronted by an internal CA, prefer
+`--keycloak-ca-bundle <realm-ca.pem>`: it loads that bundle into the
+client's `tls.Config.RootCAs` (`newCABundleTLSConfig`) with certificate-
+chain **and** hostname verification left on, so the master-realm
+admin-password grant and every subsequent Bearer-token request run over
+verified TLS. `--insecure-skip-tls-verify` remains as a last-resort
+escape hatch that flips `tls.Config.InsecureSkipVerify` (turning both
+checks off) — it now prints a loud stderr warning naming the exposed
+admin password + token, and is **mutually exclusive** with
+`--keycloak-ca-bundle` (passing both is refused at the validation
+boundary). The blanket-skip flag sends the admin credentials over an
+unverified connection, so a CA-bundle pin is the correct choice whenever
+the CA cert is available.
 
 ### Tests
 

--- a/docs/codebase/connectors-linux.md
+++ b/docs/codebase/connectors-linux.md
@@ -70,7 +70,11 @@ policy), not a rewrite.
 lock), the per-command timeout, the one-flight-recorder-span-per-command
 seam, and `aclose()`. It overrides only `fingerprint` / `probe` /
 `execute` and adds `about` plus the per-op bound-method handler shims. It
-does **not** override `_auth_config` and does **not** touch `known_hosts`.
+does **not** override `_auth_config`; it therefore inherits the base
+adapter's fail-closed host-key contract (#270) unchanged — a target
+whose Vault secret carries no `known_hosts` pin and no
+`known_hosts_insecure` opt-out is refused before the SSH connection
+opens (see `connectors-shared-vault-creds.md § SSH host-key trust`).
 
 **Credentials are per target — and that is exactly right here.** Because
 the Linux host *is* the target (a 1:1 target↔host mapping), "one
@@ -339,8 +343,11 @@ resolves at run time instead.
 - **`connectors-vmware-rest-guest-ops.md`** still names tier (b) as
   deferred; that pointer is updated to reference this built connector as
   part of the initiative wrap-up (T3), not T1.
-- **Host-key pinning** is inherited from the base as deferred to v0.2.next
-  (`known_hosts=None`); this connector sets no host-key policy of its own.
+- **Host-key verification** is inherited from the base adapter, which is
+  now fail-closed (#270): a Linux target's Vault secret must carry a
+  `known_hosts` pin (or the audited `known_hosts_insecure` opt-out) or
+  dispatch is refused before connecting. This connector sets no host-key
+  policy of its own beyond that inherited default.
 - **`file.read` is confined to read roots but not file-content-denylisted**
   — a root-SSH operator can already read those trees over raw SSH; the
   governed path adds audit, and confinement to config/log/state roots is

--- a/docs/codebase/connectors-mail.md
+++ b/docs/codebase/connectors-mail.md
@@ -71,6 +71,19 @@ too, not just agent-initiated sends.
 other port opens plaintext and upgrades via `starttls()` + re-`ehlo()`
 when `MAIL_SMTP_STARTTLS` is set (default true).
 
+**TLS trust (F08 / #270):** both TLS paths are handed an explicit
+validating context (`ssl.create_default_context` — `check_hostname=True`,
+`CERT_REQUIRED`), never smtplib's `context=None` fallback (which uses
+`ssl._create_stdlib_context` with verification and hostname checking
+**off**, so mail and credentials would flow to an unverified peer).
+`MAIL_SMTP_CA_BUNDLE` optionally pins an internal relay's CA (a PEM path;
+the bundle **replaces** the public roots, matching the target-level
+`tls_ca_pin` posture). There is no verification-disable knob — trust an
+internal relay by pointing `MAIL_SMTP_CA_BUNDLE` at its CA, never by
+turning verification off. A wrong-name / untrusted-chain / expired
+certificate is refused as `reason="smtp_tls_error"` before any AUTH or
+message data reaches the peer.
+
 **Credentials never ride a cleartext socket.** `_send_sync` carries an
 `encrypted` flag — true from construction under implicit TLS, true
 again once `starttls()` returns — and `login()` is gated on it.
@@ -96,6 +109,7 @@ unconfigured, or delivery-failed send is the **product**, not an error
 | `smtp_auth_requires_tls` | a username is configured but the channel is still cleartext |
 | `smtp_auth_error` | `SMTPAuthenticationError` |
 | `smtp_recipients_refused` | `SMTPRecipientsRefused` (server rejected every recipient) |
+| `smtp_tls_error` | `ssl.SSLError` on either TLS path (wrong name / untrusted chain / expired cert) |
 | `smtp_error` | any other `SMTPException` |
 
 The `except` ordering in `transport._send_sync` is load-bearing:
@@ -112,6 +126,7 @@ all in `Settings` (`settings.py`, env-mapped in `get_settings`):
 | `MAIL_SMTP_HOST` | `""` | MTA host; empty ⇒ transport unconfigured |
 | `MAIL_SMTP_PORT` | `587` | 465 ⇒ implicit TLS (`SMTP_SSL`) |
 | `MAIL_SMTP_STARTTLS` | `true` | upgrade via STARTTLS on non-465 ports; off + a username ⇒ `smtp_auth_requires_tls` |
+| `MAIL_SMTP_CA_BUNDLE` | `""` | PEM CA-bundle path pinning an internal relay's CA (replaces the system roots); empty ⇒ system trust. No disable-verification knob |
 | `MAIL_SMTP_USERNAME` | `""` | `login()` runs only when set, and only on an encrypted channel |
 | `MAIL_SMTP_PASSWORD` | `""` | `repr=False`; never logged |
 | `MAIL_FROM` | `""` | From header + envelope sender; empty ⇒ unconfigured |

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -434,6 +434,43 @@ decode / impersonation / WIF-selection / STS-exchange / error /
 no-secret-in-logs behaviour with a canned payload and a mocked STS endpoint
 — no live GCP (`tests/test_connectors_gsm_creds.py`).
 
+## SSH host-key trust (F08 / #270)
+
+The SSH adapter (`connectors/adapters/ssh.py`) reads its host-key trust
+material from the **same** KV-v2 secret this seam resolves, so host-key
+provisioning is a Vault-secret concern documented here. Two optional
+fields sit alongside `username` / `password` / `ssh_private_key`:
+
+- **`known_hosts`** — one or more OpenSSH `known_hosts`-format lines
+  (`<host-pattern> <keytype> <base64>`) pinning the target's host
+  key(s). When present, `asyncssh.import_known_hosts` parses it and the
+  connection verifies the presented key during key exchange; a
+  mismatch or unknown host raises `asyncssh.HostKeyNotVerifiable`
+  **before** any password / private key is offered.
+- **`known_hosts_insecure`** — a truthy flag (`true` / `1` / `yes` /
+  `on`, or a JSON boolean) that restores the pre-#270 no-verification
+  behaviour for that one target, logging `ssh_host_key_check_disabled`
+  on every connect. It is the audited, opt-in escape hatch (the SSH
+  analogue of the target-level `verify_tls=false` and the
+  `meho admin keycloak --insecure-skip-tls-verify` flag), never the
+  default.
+
+A secret carrying **neither** field fails closed: `_auth_config` raises
+`SshHostKeyUnpinnedError` before the connection opens. A pin always
+wins over the opt-out when both are present.
+
+**Provisioning.** Capture the target's public host key once from a
+trusted vantage (`ssh-keyscan -t ed25519 <host>`, reviewed against the
+host's `/etc/ssh/ssh_host_*_key.pub` out of band) and store the line
+under `known_hosts` in the target's Vault secret. Prefer a single
+modern key type (ed25519) per host.
+
+**Rotation.** When a host's key legitimately changes (reinstall, key
+rotation), update the `known_hosts` field in Vault; the next pool miss
+picks up the new pin. Because the pin lives in the secret, host-key
+rotation follows the same reviewed Vault-write path as credential
+rotation — no code change, no redeploy.
+
 ## Dependencies
 
 - **`hvac`** (2.4.0 resolved) — `client.secrets.kv.v2.read_secret_version`


### PR DESCRIPTION
## Summary

Security finding **F08** (#270): three independent source paths sent
credentials to an unauthenticated peer. This PR closes the three that
live in `evoila/meho`.

- **SSH host-key verification (fail-closed).** `connectors/adapters/ssh.py`
  hard-coded `known_hosts=None`. Host-key trust now comes from the
  target's Vault secret (the key store the v0.2 deferral named): a
  `known_hosts` pin is enforced by `asyncssh` during key exchange —
  **before** any password/key is offered — a truthy `known_hosts_insecure`
  is an audited, warned per-target opt-out, and a secret with neither
  **fails closed** (`SshHostKeyUnpinnedError`). Threaded through
  `_auth_config`; the pfSense override is updated in lockstep. Every
  SSH connector (bind9, pfSense, holodeck, rke2, linux, …) inherits this.
- **SMTP validating TLS.** `connectors/mail/transport.py` built `SMTP_SSL`
  and `starttls()` with `context=None`, which smtplib fills with an
  unverified stdlib context (`CERT_NONE`, hostname check off). Both paths
  now pass an explicit `ssl.create_default_context` (CERT_REQUIRED +
  hostname). New `MAIL_SMTP_CA_BUNDLE` pins an internal relay's CA
  (replaces the system roots, mirroring `tls_ca_pin`). A trust failure is
  refused as `smtp_tls_error` before AUTH or message data. No
  verification-disable knob.
- **`meho admin keycloak` CA-bundle pin.** The Go CLI routed the
  master-realm admin password and the minted admin token through a
  blanket `InsecureSkipVerify`. Adds `--keycloak-ca-bundle` (loads the
  realm CA into `tls.Config.RootCAs`, chain + hostname verification left
  on); `--insecure-skip-tls-verify` stays as a **loud, warned,
  mutually-exclusive** escape hatch.

## Already on `main`

Containment PRs #3423 / #3427 (v0.33.5) addressed other findings; none of
them touched these three source paths, so all of F08's `evoila/meho`
acceptance criteria remained open and are implemented here.

## Acceptance criteria

- [x] **SSH uses managed pins; unexpected host key fails before auth** —
  `test_wrong_host_key_pin_fails_before_auth` (raises
  `asyncssh.HostKeyNotVerifiable` from `_connect`, pool stays empty);
  `test_unpinned_secret_fails_closed`.
- [x] **SMTP_SSL + STARTTLS use a validating context, hostname + CA trust,
  no delivery to a wrong/untrusted peer** —
  `test_port_465_uses_implicit_tls_without_starttls` /
  `test_starttls_and_login_run_in_sequence_when_configured` assert a
  `CERT_REQUIRED` + `check_hostname` context on each path;
  `test_*_cert_verification_failure_refuses_send` return `smtp_tls_error`
  with no `login`/`send_message`.
- [ ] **Keycloak bootstrap/admin shell scripts remove `curl -k`** — AC3
  targets `keycloak-bootstrap-*.sh` in **`claude-rdc-hetzner-dc`** (repo
  D), not `evoila/meho`; **out of scope for this PR** (needs a separate
  PR in that repo).
- [x] **`meho admin keycloak` offers a CA-bundle pin instead of blanket
  `InsecureSkipVerify`; escape hatch stays opt-in + warned** —
  `TestNewCABundleTLSConfig_*`,
  `TestBootstrapClientsCmd_CABundleAndInsecureAreMutuallyExclusive`,
  `TestBootstrapClientsCmd_InsecureFlagWarnsLoudly`,
  `TestBootstrapClientsCmd_CABundleReadErrorSurfaces`.
- [x] **Trusted peers pass; wrong-name / untrusted-chain / wrong-key fail
  closed** — the bounded local tests above.
- [x] **Document trust provisioning/rotation + prefer scoped identities** —
  `connectors-shared-vault-creds.md § SSH host-key trust`,
  `connectors-mail.md`, `codebase/cli.md` (CA bundle + scoped provisioning
  identity), `connectors-linux.md`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (changed files)
- [x] `mypy src/` — clean on changed files (pre-existing darwin-only
  `socket.MSG_ERRQUEUE` error in untouched `net/icmp.py`; CI runs on Linux)
- [x] `pytest` — ssh adapter, mail, holodeck/pfsense auth, settings,
  checks notify/broadcast, + full backend unit lane
- [x] `code-quality.py --diff` — 0 blockers (3 pre-existing size warnings
  on files touched, recorded below)
- [x] Go: `go build ./...`, `go vet`, `go test -race -cover ./internal/cmd/admin/keycloak/...`
- [x] `make cli-docs` regenerated `docs-site/reference/cli.md`
  (new flag); `openapi.json` / `client.gen.go` unchanged (no REST change)

## Out of scope

- The `keycloak-bootstrap-*.sh` scripts + their `curl -k` (AC3) —
  `claude-rdc-hetzner-dc` repo, separate PR.
- Re-designing the Keycloak bootstrap identity model beyond the CA-bundle
  pin + a documented scoped-identity preference (per the issue's Out of
  scope).
- No credential rotation is performed — the final AC ties rotation to
  deployment/exposure evidence, and no compromise was established.
- Code-quality warnings (pre-existing debt on touched files, not
  introduced here): `ssh.py` 446 lines, `mail/transport.py` `_send_sync`
  76 / `send_email` 78 lines.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#270
