### PR TITLE
docs(changelog): [Unreleased] entries for twelve merged security-review Tasks (#262 wave 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,54 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — RFC6570 reserved-expansion no longer opens a query/fragment or path-traversal escape (evoila-bosnia/meho-internal#292 / #3434)
+
+- The `{+var}` / `{#var}` reserved-expansion safe set now drops `?` and `#` (they percent-encode to `%3F` / `%23`) and a `..` dot-segment — leading, interior, trailing, bare, or percent-encoded (`%2e%2e`) — is rejected before path substitution, so an agent-supplied path value can no longer open a query string / fragment or traverse to a different resource than the op the audit gate authorised (the gate keys on `op_id`, never the resolved wire path). Both mirrored renderers are hardened — the ingested `{+var}`/`{#var}` resolver and the vRLI `event.query` constraint chain — which keep genuine slash-delimited constraints literal.
+
+### Security — checks-investigator briefing fences target-returned sensor evidence (evoila-bosnia/meho-internal#302 / #3433)
+
+- Each correlated Sensor's target-returned `last_value` / `last_evidence` / offender sample is now collected into an `## Observed sensor evidence (target-returned)` section wrapped once in the same `wrap_untrusted_text` envelope the event-matcher path uses, so a monitored target that plants instruction text in a returned field can no longer steer the auto-fired, diagnose-only investigator (e.g. force `re_escalate=false` to suppress a genuine red). The deterministic server facts — the transition snapshot, the per-Sensor name / state / op lines, and the output contract — stay outside the fence.
+
+### Security — CLI interactive secret prompts suppress terminal echo (evoila-bosnia/meho-internal#308 / #3438)
+
+- `meho admin keycloak bootstrap-clients` and `meho event-source add/update --secret-stdin` now read an interactively-typed secret with terminal echo off (a `golang.org/x/term` no-echo read) when the input is a TTY, so a secret entered at the fallback prompt no longer lands in scrollback or a session recording (CWE-549). Piped `--secret-stdin`, the env-var paths, and every non-TTY input take the existing buffered read unchanged.
+
+### Security — audit_log append-only enforced at the datastore (evoila-bosnia/meho-internal#306 / #3435)
+
+- Migration `0100` installs a Postgres `BEFORE UPDATE OR DELETE ... FOR EACH ROW` trigger on `audit_log` that raises, so a direct `UPDATE` / `DELETE` fails under every role — including a superuser — and the append-only, tamper-evident audit trail (CLAUDE.md postulate 7 / v0.1-spec §6) is now enforced at the datastore, not only by code convention. `INSERT` / `SELECT` and the synchronous audit write path are untouched; the SQLite dev/test lane is a clean no-op.
+
+### Security — scheduler agent-credential Vault path namespaced per (tenant, principal) (evoila-bosnia/meho-internal#298 / #3436)
+
+- The scheduler's agent client-credentials Vault key was derived from a single lossy-sanitised `{client_id}` with no tenant component, so name variants (`agent:a-b` / `a_b` / `a.b`) and the same name across tenants collapsed to one key and a second `register` silently overwrote the first principal's secret (credential confusion + availability). The key now threads the owning `tenant_id` and encodes the identity ref as a reversible, injective hex segment, so distinct principals can never collide; the default keeps a single dynamic path segment (`secret/data/agents/{tenant_id}_{client_id}/credentials`) so the deployed Vault ACL glob still matches without a policy re-scope. **Operator upgrade note:** agent secrets written under the old key resolve to a different path after upgrade and must be re-registered — the read fails closed until they are.
+
+### Security — SSRF-validated address pinned into the socket connect for dispatch and spec ingest (evoila-bosnia/meho-internal#275 / #3437)
+
+- Both the target-dispatch transport and the connector spec-ingest fetch screened a hostname and then handed the *name* to httpx, which re-resolved it at connect time — so a resolver that flipped its answer between the screen and the connect (DNS rebinding / split-horizon) could steer the socket at a blocked address the guard never saw. A shared address-pinning transport now re-screens the host inside `connect_tcp` and dials **only** a validated address from that same resolution; TLS SNI, certificate / per-target CA-pin verification, and the `Host:` header still use the original hostname. The existing create/update and connect-time pre-check screens are retained as defense in depth.
+
+### Security — approval decisions are transactional with a decision-time deadline gate (evoila-bosnia/meho-internal#274 / #3441)
+
+- `approve_request` / `reject_request` now load the approval row `SELECT ... FOR UPDATE` (the expiry sweep uses `FOR UPDATE SKIP LOCKED`), so a competing approve / reject / expire on one row serialises to exactly one winning transition and one decision audit row. `approve_request` re-checks the deadline on the locked row and refuses an overdue pending request with the new `ApprovalRequestExpiredError` (HTTP 409) **even while the background sweeper is delayed or failing**, and `claim_resume`'s single-resumer latch now additionally requires `status = 'approved'` in the same statement, so no execution can follow a losing / rejected / expired transition.
+
+### Security — broadcast subchart ships its own ingress NetworkPolicy and default-on Valkey auth (evoila-bosnia/meho-internal#276 / #3439)
+
+- The broadcast subchart now renders its own ingress NetworkPolicy that selects the Valkey Pod and admits `tcp/6379` only from the backplane Pods (the umbrella policy selected the backplane, not the store, so the store stayed reachable cluster-wide even at `networkPolicy.enabled=true`), and turns on Valkey `requirepass` auth by default via a chart-managed Secret (or `broadcast.auth.existingSecret`) that both the store and the backplane client read through `secretKeyRef` — keeping the password out of the ConfigMap, the process command line, and `BROADCAST_REDIS_URL`. The kind CI harness deliberately disables both the NetworkPolicy and the auth for its chaos test. (This is the `evoila/meho` chart half of #276; the `values-rdc.yaml` flip and the live CNI verification stay on the Task.)
+
+### Security — Desktop .mcpb bundle pins transitive qs to 6.16.0 (evoila-bosnia/meho-internal#278 / #3444)
+
+- The Claude Desktop `.mcpb` bundle now floors its transitive `qs` dependency (pulled via `express` / `body-parser` under the pinned `mcp-remote@0.1.38`) at `^6.16.0` through an npm `overrides` entry, clearing GHSA-4mjr-xmp4-gh2g / CVE-2026-82417 (qs DoS via attacker-controlled `isBuffer`) and GHSA-x5fp-wj9c-mxmx / CVE-2026-82562 (qs array-limit bypass via bracket-key comma parsing), both fixed in 6.16.0. This is package-hygiene remediation — `qs` here parses only the interactive OAuth-callback query on a Desktop install, never backplane input — so `mcp-remote` stays pinned at the proven 0.1.38.
+
+### Security — passive-only kubeconfig schema rejects exec / auth-provider / file refs before load (evoila-bosnia/meho-internal#265 / #3443)
+
+- A tenant-controlled kubeconfig secret could reach `kubernetes_asyncio`'s loader with an `exec` provider (subprocess), a legacy `auth-provider` block (network token fetch), or a local-file credential / CA reference (disk read) inside the shared backplane process. A new passive-only schema (`enforce_passive_kubeconfig`) now runs at the Vault / GSM trust boundary right after parse: it rejects those three sink classes with a fail-closed `UnsupportedKubeconfigError`, validates the cluster endpoint / `proxy-url` / TLS options, and rebuilds a fresh config from only the vetted inline fields, so the untrusted mapping never reaches the library. Inline token / basic-auth / inline client-cert+key and the WCP SSO flow keep working.
+
+### Security — tenant preamble bands neutralise embedded block delimiters at interpolation (evoila-bosnia/meho-internal#301 / #3442)
+
+- The MCP session preamble wraps tenant-admin free text (convention `title` / `body`, doc-collection `vendor` / `when_to_use` / `description`) in fixed positional delimiters as an OWASP-LLM01 isolation control but interpolated the field values verbatim, so a `tenant_admin` who embedded a band terminator planted a second terminator inside the block and promoted the text after it out of the lower-trust guidelines band. Each band module now neutralises any `BLOCK_START` / `BLOCK_END` substring in the interpolated free text before the positional wrapper runs, so every assembled band carries exactly one delimiter pair; applied at interpolation time, so rows already stored render safely with no migration.
+
+### Security — sensor runner re-gates on the descriptor's current safety_level at dispatch (evoila-bosnia/meho-internal#303 / #3440)
+
+- The sensor create guard proved `safety_level == "safe"` only at registration, while the runner dispatched the stored op on every unattended tick as a synthetic `USER` whose policy verdict never re-consulted `safety_level` — so an op re-ingested to `caution` / `dangerous` (still `requires_approval=False`) after a sensor was created would auto-execute its mutation unattended on the sensor cadence. `_run_evaluation` now re-resolves the current descriptor before dispatch and fails closed — recording `unknown` with `op_descriptor_missing` or `op_not_safe_at_dispatch` — when the op is missing or no longer safe; safe-tier sensors evaluate unchanged.
+
 ## [0.33.5] - 2026-09-06
 
 ### Security — enforce the human-only governance rule on the REST approval-decision and grant/principal-admin routes, not just MCP (evoila-bosnia/meho-internal#289 / #3427)


### PR DESCRIPTION
Adds one operator-readable `Security` bullet under `## [Unreleased]` for each of the twelve security-review Tasks (Initiative evoila-bosnia/meho-internal#262, wave 1) whose implementation PRs merged to `main` on 2026-09-07 with their CHANGELOG hunks stripped per the repo rule (code PRs strip CHANGELOG; one docs-only entries PR follows). Each bullet is drawn from the merged PR's body and diff — no invented behaviour — and every one carries the migration/upgrade note its Task flagged (notably the scheduler agent-secret re-registration note for #298).

Anchors covered (planning issue / PR):

- evoila-bosnia/meho-internal#292 / #3434
- evoila-bosnia/meho-internal#302 / #3433
- evoila-bosnia/meho-internal#308 / #3438
- evoila-bosnia/meho-internal#306 / #3435
- evoila-bosnia/meho-internal#298 / #3436
- evoila-bosnia/meho-internal#275 / #3437
- evoila-bosnia/meho-internal#274 / #3441
- evoila-bosnia/meho-internal#276 / #3439
- evoila-bosnia/meho-internal#278 / #3444
- evoila-bosnia/meho-internal#265 / #3443
- evoila-bosnia/meho-internal#301 / #3442
- evoila-bosnia/meho-internal#303 / #3440

Touches CHANGELOG.md only.
