### PR TITLE
fix(connectors): keep the RKE2 join tokens off the rke2 process argv (S12)

### DIFF
--- a/backend/src/meho_backplane/connectors/rke2/ops_write.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_write.py
@@ -19,12 +19,19 @@ THE audit rule: the dispatcher persists the **raw** handler result on the
 audit row (``dispatcher.py`` ``raw_payload=redaction.raw``); connector-boundary
 redaction never scrubs ``raw_payload``. So the only reliable control is that
 this handler **never returns the token** -- old or new, not the value, not in
-any field. The OLD token is read on-disk server-side inside the sudo script (a
-shell ``$(cat ...)``), so its value never enters Python. The NEW token is
-minted server-side (:func:`secrets.token_hex`), written to **Vault** under the
-operator's identity, and only a **pointer** to the Vault location plus
-non-secret metadata (``rotated`` / ``node`` / ``exit_status``) is returned. The
-op is pinned in
+any field. Neither value ever reaches the world-readable ``/proc/<pid>/cmdline``
+of the ``rke2`` child either (S12, meho-internal#300): the OLD token is read
+on-disk server-side inside the sudo script (a shell ``$(cat ...)``, so its
+value never enters Python) and handed to ``rke2`` through the ``RKE2_TOKEN``
+environment variable -- the upstream ``EnvVar`` backing for ``--token`` -- so
+it lands in owner-readable ``/proc/<pid>/environ`` (``0400``), not argv. The NEW
+token is **minted on the node by ``rke2 token rotate`` itself**: ``--new-token``
+has no ``EnvVar`` backing, so it is omitted (passing a value there would put it
+straight back on argv), and rke2 mints the replacement in-process and persists
+it to the ``0600`` server token file. The handler reads that file back over the
+same governed SSH channel and writes the value to **Vault** under the operator's
+identity; only a **pointer** to the Vault location plus non-secret metadata
+(``rotated`` / ``node`` / ``exit_status``) is returned. The op is pinned in
 :data:`~meho_backplane.broadcast.events._CREDENTIAL_MINT_OPS` and registers a
 non-secret park-time preview builder (``ops_write_preview``). A read-only
 fingerprint gate refuses a non-server / inactive / below-CVE-floor node
@@ -72,7 +79,6 @@ import asyncio
 import base64
 import posixpath
 import re
-import secrets
 import shlex
 from typing import TYPE_CHECKING, Any
 
@@ -149,6 +155,11 @@ RKE2_TOKEN_PATH: str = "/var/lib/rancher/rke2/server/token"
 #: Absolute path to the ``rke2`` binary the installer drops. Absolute so the
 #: sudo script never depends on root's ``PATH``.
 _RKE2_BIN: str = "/var/lib/rancher/rke2/bin/rke2"
+
+#: The stdout marker the rotate script prints the read-back token behind. The
+#: handler parses this one line and writes the value straight to Vault -- the
+#: token never enters a log or the returned dict.
+_ROTATED_TOKEN_MARKER: str = "MEHO_ROTATED_TOKEN"
 
 #: The systemd unit an RKE2 **server** node runs. Its presence in
 #: ``systemctl list-unit-files`` is the role signal; ``is-active`` on it is
@@ -396,13 +407,28 @@ async def _stash_token_in_vault(
     }
 
 
-def _build_rotate_script(new_token: str) -> str:
-    """Build the sudo script: read OLD on-disk as root, run ``rke2 token rotate``.
+def _build_rotate_script() -> str:
+    """Build the sudo script that rotates the server token off the rke2 argv.
 
-    The OLD token is a shell variable (``$(cat ...)``) -- it never enters
-    Python. The NEW token is the only interpolated value (``shlex.quote``'d),
-    streamed on stdin via the safe-sudo primitive, never in argv / history /
-    log.
+    Neither token value reaches the world-readable ``/proc/<pid>/cmdline`` of
+    the ``rke2`` process (S12, meho-internal#300):
+
+    * The OLD token is read on-disk as root (``$(cat ...)`` -- it never enters
+      Python) and handed to the child via the ``RKE2_TOKEN`` environment
+      variable, the upstream ``EnvVar`` backing for ``--token`` (k3s
+      ``pkg/cli/cmds/token.go``). It therefore lands in ``/proc/<pid>/environ``
+      (owner-readable ``0400``), not argv.
+    * ``--new-token`` is omitted. It has **no** ``EnvVar`` backing, so pushing a
+      node-minted value through it would put that value straight back on argv.
+      Omitted, ``rke2 token rotate`` mints the replacement in-process
+      (``util.Random``, k3s ``pkg/server/handlers/token.go``) and persists it to
+      the ``0600`` server token file before it returns.
+
+    The script then reads the rotated token back from that file and prints it on
+    stdout behind :data:`_ROTATED_TOKEN_MARKER` for the handler to stash in
+    Vault; rke2's own chatter is redirected to stderr so stdout carries only
+    that one line. ``set -e`` aborts (nothing emitted) if the rotate exits
+    non-zero or the on-disk token did not actually change.
     """
     return (
         "set -euo pipefail\n"
@@ -410,9 +436,30 @@ def _build_rotate_script(new_token: str) -> str:
         f"TOKENFILE={shlex.quote(RKE2_TOKEN_PATH)}\n"
         'if [ ! -r "$TOKENFILE" ]; then echo "old-token-unreadable" >&2; exit 3; fi\n'
         'OLD=$(cat "$TOKENFILE")\n'
-        f'{shlex.quote(_RKE2_BIN)} token rotate --token "$OLD" '
-        f"--new-token {shlex.quote(new_token)}\n"
+        'export RKE2_TOKEN="$OLD"\n'
+        f"{shlex.quote(_RKE2_BIN)} token rotate 1>&2\n"
+        'NEW=$(cat "$TOKENFILE")\n'
+        'if [ -z "$NEW" ] || [ "$NEW" = "$OLD" ]; then '
+        'echo "new-token-not-observed" >&2; exit 4; fi\n'
+        f"printf '{_ROTATED_TOKEN_MARKER}=%s\\n' \"$NEW\"\n"
     )
+
+
+def _parse_rotated_token(stdout: str) -> str | None:
+    """Return the rotated token from the script's read-back line, else ``None``.
+
+    The rotate script prints exactly one ``MEHO_ROTATED_TOKEN=<value>`` line on
+    stdout (rke2's own output rides stderr). The value is a live cluster
+    credential -- the sole caller writes it straight to Vault and never logs or
+    returns it.
+    """
+    prefix = f"{_ROTATED_TOKEN_MARKER}="
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            value = line[len(prefix) :].strip()
+            if value:
+                return value
+    return None
 
 
 async def rke2_token_rotate(
@@ -426,10 +473,11 @@ async def rke2_token_rotate(
     Runs only on the ``_approved=True`` resume path. Flow: fail closed
     without an operator (no Vault sink) -> resolve the sudo credential ->
     read-only fingerprint gate (server role + active service + safe version)
-    -> mint a new token -> one sudo script that reads the OLD token on-disk
-    and runs ``rke2 token rotate`` -> stash the NEW token in Vault -> return
-    a pointer + non-secret metadata. The token value (old or new) never
-    appears in the returned dict.
+    -> one sudo script that hands the OLD token to ``rke2`` via ``RKE2_TOKEN``
+    and runs ``rke2 token rotate`` (which mints the NEW token node-side, off
+    argv) -> read the new token back over the same governed SSH channel ->
+    stash it in Vault -> return a pointer + non-secret metadata. The token
+    value (old or new) never appears in the returned dict.
     """
     del params  # schema declares no params; the target addresses the node
 
@@ -453,14 +501,15 @@ async def rke2_token_rotate(
     if gate_error is not None:
         return gate_error
 
-    # Mint + rotate. The OLD token is read on-disk as root inside the script;
-    # the NEW token is minted here and only ever leaves as a Vault pointer.
-    new_token = secrets.token_hex(32)
+    # Rotate. The OLD token is read on-disk as root inside the script and handed
+    # to rke2 via the RKE2_TOKEN env; the NEW token is minted node-side by rke2
+    # itself and read back over this same governed channel -- neither value is
+    # interpolated by the backplane or placed on any process argv.
     node = _node_label(target)
     result = await run_remote_bash_with_sudo(
         connector,
         target,
-        _build_rotate_script(new_token),
+        _build_rotate_script(),
         operator=operator,
         sudo_password=sudo_password,
     )
@@ -474,6 +523,19 @@ async def rke2_token_rotate(
             "exit_status": exit_status,
             "node": node,
             "gate": "rotate",
+        }
+
+    new_token = _parse_rotated_token(getattr(result, "stdout", "") or "")
+    if new_token is None:
+        # The rotate exited 0 but the read-back line was absent. The cluster
+        # token did change on-disk, so report honestly -- ``rotated: True`` with
+        # no Vault pointer and no token value (mirrors the Vault-failure shape).
+        return {
+            "rotated": True,
+            "node": node,
+            "exit_status": exit_status,
+            "token_ref": None,
+            "readback_error": "rotated-token-not-read-back",
         }
 
     return await _stash_token_in_vault(
@@ -877,6 +939,7 @@ _TOKEN_ROTATE_RESPONSE_SCHEMA: dict[str, Any] = {
         "error": {"type": "string"},
         "gate": {"type": "string"},
         "vault_error": {"type": "string"},
+        "readback_error": {"type": "string"},
         "version": {"type": ["string", "null"]},
     },
     "required": ["rotated"],
@@ -891,12 +954,13 @@ _RKE2_TOKEN_ROTATE_OP = Rke2Op(
     description=(
         "Runs ``rke2 token rotate`` on an RKE2 server node over SSH to "
         "replace the cluster's server join token. Takes NO parameters "
-        "and NO token value: the new token is minted server-side, the "
-        "OLD token is read on-disk as root inside the rotate script, and "
-        "the new token is written to Vault -- only a pointer to the Vault "
-        "location plus non-secret metadata (rotated / node / exit_status) "
-        "is returned, so no token value ever reaches the result, the "
-        "audit row, or the broadcast feed. A read-only fingerprint gate "
+        "and NO token value: the OLD token is read on-disk as root inside "
+        "the rotate script and handed to rke2 via the RKE2_TOKEN env, the "
+        "new token is minted node-side by rke2 itself and read back over "
+        "the SSH channel, and it is written to Vault -- only a pointer to "
+        "the Vault location plus non-secret metadata (rotated / node / "
+        "exit_status) is returned, so no token value ever reaches the "
+        "result, the audit row, or the broadcast feed. A read-only fingerprint gate "
         "refuses a non-server node, an inactive rke2-server, or a "
         "below-floor / known-bad (v1.27.10+rke2r1) RKE2 version before "
         "any mutation, because a botched rotate wedges every future node "
@@ -922,7 +986,9 @@ _RKE2_TOKEN_ROTATE_OP = Rke2Op(
             "location the new token was stashed at -- the token VALUE is "
             "never returned. On a gate refusal or failure: {rotated: "
             "false, error, gate}. If the rotate succeeded but the Vault "
-            "stash failed: {rotated: true, token_ref: null, vault_error}."
+            "stash failed: {rotated: true, token_ref: null, vault_error}. "
+            "If it succeeded but the rotated token could not be read back: "
+            "{rotated: true, token_ref: null, readback_error}."
         ),
     },
 )

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -1546,15 +1546,24 @@ import contextlib  # noqa: E402 -- grouped with the write-op section it serves
 
 from meho_backplane.auth.operator import Operator, TenantRole  # noqa: E402
 from meho_backplane.connectors.rke2.ops_write import (  # noqa: E402
+    _ROTATED_TOKEN_MARKER,
     WRITE_OPS,
+    _build_rotate_script,
     parse_rke2_release,
     rke2_token_rotate,
     rke2_version_rotate_verdict,
 )
 
-# A minted-token canary. The handler must NEVER surface the minted token in
-# its result envelope (the raw result is persisted on the audit row).
+# A rotated-token canary. The node mints the new token and the handler reads it
+# back over the SSH channel; the handler must NEVER surface that value in its
+# result envelope (the raw result is persisted on the audit row).
 _CANARY_NEW_TOKEN = "K10CANARYnewtokenvalueMUSTNOTLEAK0000deadbeef"  # gitleaks:allow NOSONAR
+
+
+def _rotate_stdout(token: str = _CANARY_NEW_TOKEN) -> str:
+    """The one-line read-back the rotate script prints on stdout."""
+    return f"{_ROTATED_TOKEN_MARKER}={token}\n"
+
 
 _OP_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000024f9")
 _OPERATOR = Operator(
@@ -1660,7 +1669,7 @@ def test_parse_rke2_release_shapes() -> None:
 @pytest.mark.asyncio
 async def test_token_rotate_happy_path_returns_pointer_never_token() -> None:
     connector = Rke2SshConnector()
-    sudo_proc = _proc(stdout="", exit_status=0)
+    sudo_proc = _proc(stdout=_rotate_stdout(), exit_status=0)
     with (
         patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
         patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
@@ -1668,7 +1677,6 @@ async def test_token_rotate_happy_path_returns_pointer_never_token() -> None:
             "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
             new_callable=AsyncMock,
         ) as mock_sudo,
-        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
         _patch_vault_write(version=9) as write_mock,
     ):
         mock_secret.return_value = {"password": _CANARY_PASSWORD}
@@ -1682,15 +1690,17 @@ async def test_token_rotate_happy_path_returns_pointer_never_token() -> None:
     assert ref["backend"] == "vault"
     assert ref["kv_version"] == 9
     assert f"tenants/{_OP_TENANT}/rke2/" in ref["path"]
-    # THE audit rule: the minted token never appears in the returned result.
+    # THE audit rule: the read-back token never appears in the returned result.
     assert _CANARY_NEW_TOKEN not in repr(result)
-    # ...but it WAS written to Vault (the sink) and passed to the sudo script.
+    # ...but it WAS read off stdout and written to Vault (the sink).
     write_mock.assert_called_once()
     assert write_mock.call_args.kwargs["secret"] == {"token": _CANARY_NEW_TOKEN}
+    # The script rotates without ever quoting a token onto the rke2 argv.
     script = mock_sudo.await_args.args[2]
     assert "/var/lib/rancher/rke2/bin/rke2 token rotate" in script
     assert 'OLD=$(cat "$TOKENFILE")' in script  # OLD read server-side, never in Python
-    assert _CANARY_NEW_TOKEN in script  # new token quoted into the script body only
+    assert 'export RKE2_TOKEN="$OLD"' in script  # OLD reaches rke2 via env, not argv
+    assert _CANARY_NEW_TOKEN not in script  # the new token is minted node-side
 
 
 @pytest.mark.asyncio
@@ -1703,17 +1713,74 @@ async def test_token_rotate_vault_write_failure_is_honest_no_token() -> None:
             "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
             new_callable=AsyncMock,
         ) as mock_sudo,
-        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
         _patch_vault_write(raises=True),
     ):
         mock_secret.return_value = {"password": _CANARY_PASSWORD}
         mock_cmd.return_value = _proc(stdout=_preflight_stdout())
-        mock_sudo.return_value = _proc(exit_status=0)
+        mock_sudo.return_value = _proc(stdout=_rotate_stdout(), exit_status=0)
         result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
 
     assert result["rotated"] is True  # the cluster token DID rotate
     assert result["token_ref"] is None
     assert result["vault_error"] == "RuntimeError"
+    assert _CANARY_NEW_TOKEN not in repr(result)
+
+
+def test_token_rotate_keeps_tokens_off_argv() -> None:
+    """AC (S12 / meho-internal#300): neither token reaches the rke2 argv.
+
+    The OLD token rides the ``RKE2_TOKEN`` env (the upstream ``EnvVar`` backing
+    for ``--token``); the NEW token is minted node-side by ``rke2`` itself
+    (``--new-token`` omitted -- it has no env backing, so a value there would
+    land on the world-readable ``/proc/<pid>/cmdline``) and read back from the
+    ``0600`` token file. So the generated script carries no ``--token`` /
+    ``--new-token`` argv flag at all, and the ``$OLD`` marker appears only in an
+    ``export`` (env) context.
+    """
+    script = _build_rotate_script()
+
+    rotate_lines = [ln for ln in script.splitlines() if "token rotate" in ln]
+    assert rotate_lines, "expected an `rke2 token rotate` invocation line"
+    for line in rotate_lines:
+        # No token flag on the rke2 invocation -> nothing to place a token
+        # value or the $OLD marker behind on argv.
+        assert "--token" not in line
+        assert "--new-token" not in line
+
+    # The OLD token reaches rke2 only via the env, never as `--token "$OLD"`.
+    assert 'export RKE2_TOKEN="$OLD"' in script
+    assert '--token "$OLD"' not in script
+    # The builder takes no token argument and never interpolates a new-token
+    # value, so no new-token canary can appear after a `--new-token` flag.
+    assert "--new-token" not in script
+    # The rotated token is read back from the on-disk file, not from argv.
+    assert _ROTATED_TOKEN_MARKER in script
+    assert 'NEW=$(cat "$TOKENFILE")' in script
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_readback_absent_is_honest() -> None:
+    """Exit 0 with no read-back line -> honest partial state, no token, no Vault write."""
+    connector = Rke2SshConnector()
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        patch(
+            "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
+            new_callable=AsyncMock,
+        ) as mock_sudo,
+        _patch_vault_write() as write_mock,
+    ):
+        mock_secret.return_value = {"password": _CANARY_PASSWORD}
+        mock_cmd.return_value = _proc(stdout=_preflight_stdout())
+        # rke2 chatter with no marker line (rke2's own stdout would ride stderr).
+        mock_sudo.return_value = _proc(stdout="Token rotated, restart nodes\n", exit_status=0)
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+
+    assert result["rotated"] is True  # the cluster token DID rotate on the node
+    assert result["token_ref"] is None
+    assert result["readback_error"] == "rotated-token-not-read-back"
+    write_mock.assert_not_called()  # nothing read back -> nothing to stash
     assert _CANARY_NEW_TOKEN not in repr(result)
 
 
@@ -1782,7 +1849,6 @@ async def test_token_rotate_nonzero_exit_no_vault_no_output() -> None:
             "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
             new_callable=AsyncMock,
         ) as mock_sudo,
-        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
         _patch_vault_write() as write_mock,
     ):
         mock_secret.return_value = {"password": _CANARY_PASSWORD}

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -47,6 +47,7 @@ import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.rke2 import Rke2SshConnector
+from meho_backplane.connectors.rke2.ops_write import _ROTATED_TOKEN_MARKER
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import reset_dispatcher_caches
@@ -186,9 +187,13 @@ async def _fake_shell_process_factory(process: Any) -> None:
         # The safe-sudo wire command streams the script + password on stdin;
         # drain it (the real mktemp pipeline would consume it) so the client
         # write side doesn't break, then simulate a successful
-        # `rke2 token rotate` (exit 0, no stdout, never echoing a token).
+        # `rke2 token rotate` that mints the new token node-side and prints it
+        # back behind the read-back marker on stdout (rke2's own chatter would
+        # ride stderr). The handler stashes that value in Vault; the audit-row
+        # assertions below prove it never lands on the row.
         with contextlib.suppress(Exception):
             await process.stdin.read()
+        process.stdout.write(f"{_ROTATED_TOKEN_MARKER}={_MINTED_TOKEN_CANARY}\n")
         process.exit(0)
         return
     else:
@@ -598,8 +603,9 @@ from meho_backplane.db.models import AuditLog  # noqa: E402
 from meho_backplane.operations import dispatch  # noqa: E402
 from meho_backplane.targets.resolver import resolve_target  # noqa: E402
 
-# The minted token the handler generates on the approved path. Patched to a
-# fixed canary so the audit-row assertion can prove it never lands there.
+# The token the node mints and the handler reads back over the governed SSH
+# channel on the approved path. The fake shell emits this fixed canary so the
+# audit-row assertion can prove the read-back value never lands on the row.
 _MINTED_TOKEN_CANARY = "K10E2Ecanaryminted00000000deadbeefMUSTNOTLEAK"  # gitleaks:allow NOSONAR
 
 
@@ -669,10 +675,7 @@ async def test_rke2_token_rotate_approved_audit_row_has_no_token(
     """AC: approved resume rotates + stashes to Vault; the raw audit row has NO token."""
     del captured_events
     op_id = "rke2.token.rotate"
-    with (
-        _fake_vault_write(version=5),
-        patch("secrets.token_hex", return_value=_MINTED_TOKEN_CANARY),
-    ):
+    with _fake_vault_write(version=5):
         result = await _dispatch_rotate(rke2_e2e, approved=True)
 
     assert result["status"] == "ok", result.get("error")

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -58,12 +58,17 @@ T2 (#2429) adds the **first approval-gated write op** (in the
 - `rke2.token.rotate` — rotates the RKE2 server join token cluster-wide via
   `rke2 token rotate` over sudo-SSH. `safety_level="dangerous"`,
   `requires_approval=True`. Takes **no parameters and no token value**: the
-  new token is minted server-side, the OLD token is read on-disk as root
-  inside the rotate script, and the new token is written to Vault — only a
-  **pointer** to the Vault location plus non-secret metadata (`rotated` /
-  `node` / `exit_status`) is returned. A read-only fingerprint gate refuses a
-  non-server node, an inactive `rke2-server`, or a below-floor / known-bad
-  (`v1.27.10+rke2r1`) RKE2 version before any mutation.
+  OLD token is read on-disk as root inside the rotate script and handed to
+  `rke2` via the `RKE2_TOKEN` env (the upstream `EnvVar` backing for
+  `--token`); the new token is minted node-side by `rke2 token rotate` itself
+  (`--new-token` is omitted — it has no `EnvVar` backing, so a value there
+  would land on argv), read back over the SSH channel, and written to Vault —
+  only a **pointer** to the Vault location plus non-secret metadata (`rotated`
+  / `node` / `exit_status`) is returned. Neither token value ever reaches the
+  world-readable `/proc/<pid>/cmdline` of the rke2 process (S12,
+  meho-internal#300). A read-only fingerprint gate refuses a non-server node,
+  an inactive `rke2-server`, or a below-floor / known-bad (`v1.27.10+rke2r1`)
+  RKE2 version before any mutation.
 
 T3 (#2430) adds two more **approval-gated node-write ops**
 (`safety_level="dangerous"` / `requires_approval=true`), both in the shared
@@ -207,10 +212,14 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   - `rke2.token.rotate` (#2429): `rke2_token_rotate` (the async handler, bound
     via the `token_rotate` shim), `rke2_version_rotate_verdict` /
     `parse_rke2_release` (the pure version-gate logic against the per-minor
-    CVE-fix floor + the `v1.27.10+rke2r1` deny). The minted new token is
-    stashed in Vault under
-    `secret/tenants/<tenant_id>/rke2/<node>/server-token`; only a pointer is
-    returned. `_sudo.py` carries the family's own safe-`sudo -S` primitive
+    CVE-fix floor + the `v1.27.10+rke2r1` deny). The OLD token rides the
+    `RKE2_TOKEN` env (its upstream `--token` `EnvVar` backing) and the new
+    token is minted node-side by `rke2` (`--new-token` omitted), read back over
+    the SSH channel via the `_parse_rotated_token` marker line, and stashed in
+    Vault under `secret/tenants/<tenant_id>/rke2/<node>/server-token`; only a
+    pointer is returned, and neither token touches the rke2
+    `/proc/<pid>/cmdline`. `_sudo.py` carries the family's own safe-`sudo -S`
+    primitive
     (`run_remote_bash_with_sudo`) — the #697-hardened wire shape (script bytes
     first, password last on stdin, never in argv / history / log).
     `ops_write_preview.py` registers a non-secret park-time `proposed_effect`
@@ -383,8 +392,10 @@ dispatcher persists the **raw** handler result on the audit row and
 connector-boundary redaction never scrubs `raw_payload`, so the only reliable
 control is that the handler never returns the token — old or new. Both are
 handled off the result surface: the OLD token is read on-disk as root inside
-the sudo script (a shell `$(cat ...)`, never entering Python), and the NEW
-token is minted here, written to Vault, and returned only as a pointer. The
+the sudo script (a shell `$(cat ...)`, never entering Python) and passed to
+`rke2` via the `RKE2_TOKEN` env, and the NEW token is minted node-side by
+`rke2 token rotate` itself, read back over the SSH channel, written to Vault,
+and returned only as a pointer. The
 op is additionally pinned in `broadcast/events._CREDENTIAL_MINT_OPS`
 (defence-in-depth: `.rotate` would otherwise classify `other` and broadcast
 full detail) and its park-time preview carries no token value.


### PR DESCRIPTION
## Summary

- **S12 fix (meho-internal#300):** `rke2.token.rotate` put both the old and the new server join token on the `rke2` child's argv (`token rotate --token "$OLD" --new-token <new>`), leaking them through the world-readable `/proc/<pid>/cmdline` on the server node during the rotate exec. This closes that window for **both** tokens.
- **OLD token → `RKE2_TOKEN` env.** It is read on-disk as root (`$(cat …)`, never entering Python) and exported as `RKE2_TOKEN` — the upstream `EnvVar` backing for `--token` — so it reaches the child only through owner-readable `/proc/<pid>/environ` (`0400`), never argv.
- **NEW token → minted node-side by rke2, read back over the governed channel.** `--new-token` is omitted (it has **no** `EnvVar` backing, so a value there lands straight on argv). rke2 mints the replacement in-process and persists it to the `0600` server token file; the script reads it back and prints it behind a single stdout marker, and the handler stashes it in Vault, returning only the `token_ref` pointer.
- **Docstring corrected.** The false `never in argv` claim is gone; the module/handler/op text now describes the env + read-back mechanism. `docs/codebase/connectors-rke2.md` updated to match.

The token value (old or new) is never interpolated by the backplane and never reaches argv, logs, the audit `raw_payload`, or the returned dict.

### Nothing was already fixed on `main`
Containment PRs #3423/#3427 (v0.33.5) addressed different findings; the vulnerable `--token "$OLD" --new-token …` invocation was still present on `origin/main` at the time of this change. All acceptance criteria are implemented here.

### API research (Hard rule 2 — the design hinges on this)
Verified against k3s master (rke2 vendors k3s's `token` subcommand):
- `--token` **has** `EnvVar` backing `RKE2_TOKEN` (`pkg/cli/cmds/token.go`) → OLD token can go off-argv via env.
- `--new-token` has **no** `EnvVar` backing, and is *"randomly generated if unspecified"* (rke2 docs). When omitted, the server generates it (`util.Random(16)`), writes the new formatted token to `/var/lib/rancher/rke2/server/token` (`filepath.Join(control.DataDir, "token")`) **synchronously before the HTTP 200**, and the CLI then sleeps 1s for etcd propagation (`pkg/server/handlers/token.go`, `pkg/cli/token/token.go`). So reading that `0600` file back after a successful rotate yields the new token — the read-back path used here.

### Deviation from the literal wording of acceptance criterion 1
Criterion 1 suggests minting the new token *in the script* (`openssl rand` / `rke2 token generate`) and consuming it via `--new-token` *from a node-local variable*. Because `--new-token` has no env backing, feeding any node-local `$NEW` through `--new-token "$NEW"` would re-open the exact `/proc/<pid>/cmdline` window this task closes (bash expands the variable onto the rke2 argv). Omitting `--new-token` and letting rke2 mint the token in-process is functionally node-side minting, is strictly more secure (the value never leaves rke2's memory until the `0600` file), and satisfies criterion 2 (no `--token`/`--new-token` argv flag at all) and the stated desired outcome. The backplane never interpolates the value; it is minted node-side, read back over the governed SSH channel, and stored in Vault (`secret_ref`) — matching the intent of the Option-A rewrite.

## Test plan
- [x] `uv run ruff check src/…/rke2/ops_write.py` — clean
- [x] `uv run ruff format --check` (src + both test files) — clean
- [x] `uv run mypy src/…/rke2/ops_write.py` — clean
- [x] `uv run pytest tests/test_connectors_rke2.py -q` — 107 passed
- [x] `uv run pytest tests/test_connectors_rke2_e2e.py -q` — 9 passed (fake shell now emits the read-back marker; audit-row assertions prove the read-back value never lands on the row)
- [x] New unit test `test_token_rotate_keeps_tokens_off_argv` — asserts no `--token`/`--new-token` argv flag; OLD via `export RKE2_TOKEN="$OLD"`; token read back from the on-disk file
- [x] New unit test `test_token_rotate_readback_absent_is_honest` — exit 0 with no marker → `rotated: True`, `token_ref: None`, `readback_error`, no Vault write
- [x] `grep -n 'never in argv' …/ops_write.py` → empty; `grep -n -- '--token "$OLD"' …/ops_write.py` → empty
- [x] Full backend unit lane (`pytest -n auto --dist loadscope`, integration + migrations excluded): 14689 passed; the only failures are pre-existing environmental ones unrelated to rke2 (net-ICMP raw socket, net-DNS nameserver query, a `helm template` chart test, and one xdist-only flake that passes serially)

## Out of scope
- The two other approval-gated rke2 write ops (drain / service restart) — they pass no credential on argv.
- Node `/proc` `hidepid` enforcement and upstream rke2 env/file-flag requests.
- CHANGELOG entry (batched by the orchestrator into a docs-only wave PR).

Closes evoila-bosnia/meho-internal#300
