### PR TITLE
ci(pr-smoke): export buildx cache to an isolated pr-smoke scope (S17)

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -212,12 +212,19 @@ jobs:
           build-args: |
             GIT_SHA=${{ env.PR_HEAD_SHA }}
             BUILD_DATE=${{ github.event.pull_request.updated_at }}
-          # GHA-backed remote cache. Shared scope with image.yml means the
-          # PR build reuses every layer the main-push cache already has,
-          # dropping cold-build wall-clock to a handful of seconds when
-          # only application code changed.
+          # GHA-backed remote cache. cache-from reads the default
+          # `buildkit` scope, so the PR build still reuses every layer the
+          # main-push (image.yml) cache already has — a warm-cache read that
+          # drops cold-build wall-clock to a handful of seconds when only
+          # application code changed. cache-to exports to an ISOLATED
+          # `pr-smoke` scope, never the default scope image.yml restores
+          # from. This job runs under pull_request_target with GITHUB_REF
+          # pinned to `main`; without the separate export scope an unmerged
+          # PR-head build could write cache that the cosign-signed release
+          # build in image.yml later restores, letting unmerged code enter
+          # the signed artefact by cache reuse.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,scope=pr-smoke,mode=max
           # No provenance / sbom / cosign here: PR images are transient
           # (deleted after teardown OR garbage-collected after the chart
           # is uninstalled; we don't promise immutable retention). The

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -1610,9 +1610,16 @@ parallel on every PR:
 
 `pr-smoke.yml` does **not** duplicate the image build with
 `image.yml` — it pushes a transient PR-tag, while `image.yml` on PRs
-builds without pushing (gate only). The two workflows share the GHA
-buildx cache scope, so the smoke's build typically hits a warm cache
-when application code is the only delta.
+builds without pushing (gate only). The smoke build **reads** the shared
+GHA buildx cache (`cache-from: type=gha`, the default `buildkit` scope),
+so it typically hits a warm cache when application code is the only
+delta — but it **exports** only to an isolated `cache-to:
+type=gha,scope=pr-smoke,mode=max` scope. Because `pr-smoke.yml` runs
+under `pull_request_target` with `GITHUB_REF` pinned to `main`, that
+isolation keeps an unmerged PR-head build from writing the default cache
+scope the cosign-signed `image.yml` release build restores from; the
+release image's trust chain never depends on cache produced by unmerged
+code, while the per-PR build keeps its warm-cache read.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- `pr-smoke.yml` runs under `pull_request_target`, so `GITHUB_REF` resolves to the base ref `main` and its `cache-to: type=gha,mode=max` wrote the **default `buildkit` GHA cache scope** — the same scope the cosign-signed `image.yml` release build restores from. A same-repo, write-access (or compromised-collaborator) PR could export a layer that buildkit later pulls into the signed `ghcr.io/evoila/meho` release image by cache-key reuse, a review-bypass into the signed-artefact path.
- Fix (the issue's preferred mitigation): keep the warm-cache **read** (`cache-from: type=gha` still restores the default scope, so the per-PR build stays fast) but **export** only to an isolated `cache-to: type=gha,scope=pr-smoke,mode=max` that `image.yml` never restores.
- `image.yml`'s cache config and the release signing path are left unchanged (out of scope per the task).
- Corrected the now-false "share the GHA buildx cache scope" rationale — both the inline comment in `pr-smoke.yml` and the `docs/codebase/devops.md` "Per-PR ephemeral cluster smoke" section now document the isolated export scope.

## Already met on `main` (drift note)

- **AC2** (`grep -c 'scope=' .github/workflows/image.yml` → `0`) was already satisfied on current `main`: the F15b/#284 change (`ci(image): scan before publish`) reworked `image.yml`'s publish flow but added no cache `scope=`. This PR touches only `pr-smoke.yml` + docs, so `image.yml` stays at `scope=` count `0`.

## Test plan

- [x] **AC1** `grep -nE 'cache-to: type=gha,mode=max$' .github/workflows/pr-smoke.yml` — empty (line now `cache-to: type=gha,scope=pr-smoke,mode=max`).
- [x] **AC2** `grep -c 'scope=' .github/workflows/image.yml` — `0` (unchanged).
- [x] **AC3** `grep -n 'Shared scope with image.yml' .github/workflows/pr-smoke.yml` — empty (comment rewritten).
- [x] **AC4** `actionlint .github/workflows/pr-smoke.yml .github/workflows/image.yml` — exit `0` (actionlint 1.7.12, repo `.github/actionlint.yaml`).
- [x] **AC5** `grep -n 'scope' docs/codebase/devops.md` hits within the "Per-PR ephemeral cluster smoke" section — documents `type=gha,scope=pr-smoke,mode=max` isolation.

(No ruff/mypy/pytest: workflow-YAML + docs change; `actionlint` is the applicable static gate per the task.)

## Out of scope

- `image.yml` cache config and the release signing path — unchanged.
- Runner-isolation / disposable-environment scope of F06/#268 (this is the file-and-mechanism-specific companion, per the task's coordination note).
- Enabling/gating `vars.RKE2_SMOKE_ENABLED` and consumer-side auth (meho-internal#53).
- Adjacent findings (pre-existing, not touched): `actionlint` on the full `.github/workflows/` tree flags a missing `meho-runners-ci-heavy` label in `.github/actionlint.yaml` (used by `ci.yml`), plus SC2028/SC2001 shellcheck notes in `cli-release.yml`/`runner-smoke.yml`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#305
