### PR TITLE
ci: isolate untrusted PR jobs from internal runners (F06)

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -74,7 +74,15 @@ jobs:
     # This carries the narrowing that used to live in `on.pull_request.
     # paths`. See the comment on that trigger above for why the filter
     # cannot stay there for a *required* check.
-    runs-on: meho-runners-ci
+    #
+    # Untrusted-PR runner isolation (F06, meho-internal#268). All three
+    # jobs here run PR-controlled build metadata — `pip install -e
+    # ./backend` executes the project's build backend, and the diff
+    # step runs against checked-out PR content — so a fork PR is routed
+    # to a disposable GitHub-hosted runner while trusted refs (same-repo
+    # PR, push, merge_group) stay on the internal pool. See
+    # docs/codebase/devops.md "Untrusted pull-request isolation".
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 5
     outputs:
       manifests: ${{ steps.detect.outputs.manifests }}
@@ -113,7 +121,9 @@ jobs:
     name: Python License Check
     needs: changes
     if: needs.changes.outputs.manifests == 'true'
-    runs-on: meho-runners-ci
+    # Fork PRs to a disposable runner; trusted refs to the internal
+    # pool — see the `changes` job above (F06, meho-internal#268).
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -242,7 +252,9 @@ jobs:
     name: NPM License Check
     needs: changes
     if: needs.changes.outputs.manifests == 'true'
-    runs-on: meho-runners-ci
+    # Fork PRs to a disposable runner; trusted refs to the internal
+    # pool — see the `changes` job above (F06, meho-internal#268).
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/migration-compat.yml
+++ b/.github/workflows/migration-compat.yml
@@ -38,7 +38,15 @@ concurrency:
 jobs:
   check:
     name: Backward-compat migration guard
-    runs-on: meho-runners-ci
+    # Untrusted-PR runner isolation (F06, meho-internal#268). This job
+    # checks out and executes PR-controlled code
+    # (scripts/ci/check_migration_compat.py); on a fork PR that code is
+    # untrusted. It needs no internal route, deployment credential or
+    # build cache, so a fork PR is routed to a disposable GitHub-hosted
+    # runner instead of the internal `meho-runners-ci` pool; same-repo
+    # PRs (trusted) stay on the internal pool. See
+    # docs/codebase/devops.md "Untrusted pull-request isolation".
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -212,12 +212,19 @@ jobs:
           build-args: |
             GIT_SHA=${{ env.PR_HEAD_SHA }}
             BUILD_DATE=${{ github.event.pull_request.updated_at }}
-          # GHA-backed remote cache. Shared scope with image.yml means the
-          # PR build reuses every layer the main-push cache already has,
-          # dropping cold-build wall-clock to a handful of seconds when
-          # only application code changed.
+          # GHA-backed remote cache. cache-from reads the default
+          # `buildkit` scope, so the PR build still reuses every layer the
+          # main-push (image.yml) cache already has — a warm-cache read that
+          # drops cold-build wall-clock to a handful of seconds when only
+          # application code changed. cache-to exports to an ISOLATED
+          # `pr-smoke` scope, never the default scope image.yml restores
+          # from. This job runs under pull_request_target with GITHUB_REF
+          # pinned to `main`; without the separate export scope an unmerged
+          # PR-head build could write cache that the cosign-signed release
+          # build in image.yml later restores, letting unmerged code enter
+          # the signed artefact by cache reuse.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,scope=pr-smoke,mode=max
           # No provenance / sbom / cosign here: PR images are transient
           # (deleted after teardown OR garbage-collected after the chart
           # is uninstalled; we don't promise immutable retention). The

--- a/.github/workflows/readme-version-check.yml
+++ b/.github/workflows/readme-version-check.yml
@@ -59,7 +59,13 @@ permissions:
 jobs:
   readme-version:
     name: README Version Check
-    runs-on: meho-runners-ci
+    # Untrusted-PR runner isolation (F06, meho-internal#268). The check
+    # runs an inline shell against checked-out PR content; on a fork PR
+    # both the workflow body and the content are untrusted, and the job
+    # needs nothing internal (git history + tags only), so fork PRs are
+    # routed to a disposable GitHub-hosted runner while trusted refs
+    # stay on the internal pool. See docs/codebase/devops.md.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -44,7 +44,14 @@ concurrency:
 jobs:
   trufflehog:
     name: TruffleHog Secret Scan
-    runs-on: meho-runners-ci
+    # Untrusted-PR runner isolation (F06, meho-internal#268). Route fork
+    # PRs to a disposable GitHub-hosted runner — TruffleHog shells out
+    # to `docker run` against checked-out PR content and needs only
+    # public ghcr.io egress. Trusted refs (same-repo PR, push, and the
+    # merge_group required-gate with its tuned warm-cache retry —
+    # #3307/#3310) stay on the internal pool unchanged. See
+    # docs/codebase/devops.md.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
     timeout-minutes: 10
     env:
       # Scanner container image, pinned by digest (#284 / F15b). The

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -54,6 +54,15 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
+    # Fork-PR guard (F06, meho-internal#268): never execute PR-controlled
+    # code from a fork on the internal `meho-runners-ci` pool. Unlike the
+    # other PR workflows, this job runs inside a container pulled from
+    # the internal Harbor proxy (harbor.evba.lab, see below), which a
+    # disposable GitHub-hosted runner cannot reach — so untrusted fork
+    # PRs are skipped here rather than relocated. The required `Semgrep
+    # SAST` context still runs for real on the trusted merge_group
+    # (queue-admission) and push refs. Same stance as ci.yml.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners-ci
     timeout-minutes: 15
     # Pulled through the in-cluster Harbor proxy cache

--- a/backend/tests/test_ci_fork_runner_isolation.py
+++ b/backend/tests/test_ci_fork_runner_isolation.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Untrusted-PR runner-isolation invariant across every workflow (F06).
+
+The `meho-runners-ci` / `-ci-heavy` self-hosted pool is internal
+infrastructure. A workflow that runs on that pool in response to a
+**fork** pull request executes attacker-controlled code (the fork's
+checked-out content, and for a fork `pull_request` event the fork's own
+copy of the workflow body) on internal infrastructure — the class of
+self-hosted-runner risk GitHub documents in its secure-use reference.
+
+The finding (meho-internal#268) was that the fix for this had only been
+applied to the principal CI file: `migration-compat.yml`,
+`dependency-license-check.yml`, `readme-version-check.yml`,
+`secret-scan.yml` and `security-scan.yml` scheduled the internal pool on
+`pull_request` with no fork guard. This test pins the invariant across
+**every** workflow so a future addition cannot silently reopen it — the
+exact "audit every workflow, not just the principal CI file" mandate of
+the finding.
+
+Invariant: no job reachable by a fork `pull_request` /
+`pull_request_target` may run on the internal pool unless it is either
+skipped on fork PRs (a fork guard `if:`) or routes fork PRs to a
+disposable GitHub-hosted runner. The check is deliberately a structural
+heuristic on the established idioms in `docs/codebase/devops.md`
+("Untrusted pull-request isolation"); it catches the gross regression
+(an unconditional internal-pool job that a fork PR can schedule), which
+is precisely the F06 bug.
+
+The authoritative enforcement is GitHub settings (fork-PR approval
+policy + runner-group access), which a PR cannot edit and this test
+cannot read; this test guards the in-repo arm.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+# backend/tests/<this> → parents[2] == repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+# Any label naming the internal self-hosted pool (meho-runners-ci,
+# meho-runners-ci-heavy, and the legacy meho-runners form).
+_INTERNAL_POOL_MARKER = "meho-runners"
+# The fork guard the publish workflows use: on a pull_request the job
+# runs only when the head repo IS this repo (fork excluded).
+_FORK_GUARD = "head.repo.full_name == github.repository"
+# The disposable-runner routing expression: a fork pull_request resolves
+# runs-on to a GitHub-hosted label instead of the internal pool.
+_ROUTE_COND = "head.repo.full_name != github.repository"
+_HOSTED_TARGET = "ubuntu-latest"
+# A job gated to push only is not reachable by a pull_request at all.
+_PUSH_ONLY = "github.event_name == 'push'"
+
+
+def _load_workflow(path: Path) -> dict[Any, Any]:
+    with path.open() as fh:
+        return cast("dict[Any, Any]", yaml.safe_load(fh))
+
+
+def _triggers(wf: dict[Any, Any]) -> Any:
+    # PyYAML parses the bare `on:` key as the boolean True (YAML 1.1
+    # treats on/off/yes/no as booleans), so the trigger block lands under
+    # the True key, not the string "on".
+    return wf.get("on", wf.get(True))
+
+
+def _trigger_names(triggers: Any) -> set[str]:
+    if isinstance(triggers, dict):
+        return {str(k) for k in triggers}
+    if isinstance(triggers, list):
+        return {str(k) for k in triggers}
+    if triggers is None:
+        return set()
+    return {str(triggers)}
+
+
+def _is_fork_reachable_workflow(wf: dict[Any, Any]) -> bool:
+    names = _trigger_names(_triggers(wf))
+    return "pull_request" in names or "pull_request_target" in names
+
+
+def _runs_on_str(job: dict[str, Any]) -> str:
+    runs_on = job.get("runs-on")
+    if runs_on is None:
+        return ""
+    if isinstance(runs_on, list):
+        return " ".join(str(x) for x in runs_on)
+    return str(runs_on)
+
+
+def _job_is_safe(job: dict[str, Any]) -> bool:
+    runs_on = _runs_on_str(job)
+    job_if = str(job.get("if", ""))
+
+    # Reusable-workflow job (no runs-on, delegates to `uses:`): the runner
+    # is defined in the called workflow, out of scope here.
+    if not runs_on and "uses" in job:
+        return True
+
+    # Not on the internal pool at all -> disposable / GitHub-hosted.
+    if _INTERNAL_POOL_MARKER not in runs_on:
+        return True
+
+    # References the internal pool. Safe only if one of:
+    #   1. it routes fork PRs to a GitHub-hosted runner, or
+    #   2. a fork guard skips the job on fork PRs, or
+    #   3. the job runs on push events only (never a pull_request).
+    if _ROUTE_COND in runs_on and _HOSTED_TARGET in runs_on:
+        return True
+    if _FORK_GUARD in job_if:
+        return True
+    return _PUSH_ONLY in job_if
+
+
+def _workflow_files() -> list[Path]:
+    files = sorted(_WORKFLOWS_DIR.glob("*.yml")) + sorted(_WORKFLOWS_DIR.glob("*.yaml"))
+    return files
+
+
+def test_workflows_directory_present() -> None:
+    assert _WORKFLOWS_DIR.is_dir(), f"missing {_WORKFLOWS_DIR}"
+    assert _workflow_files(), "no workflow files found"
+
+
+@pytest.mark.parametrize("path", _workflow_files(), ids=lambda p: p.name)
+def test_no_fork_reachable_job_schedules_internal_pool(path: Path) -> None:
+    wf = _load_workflow(path)
+    if not _is_fork_reachable_workflow(wf):
+        pytest.skip(f"{path.name} has no pull_request trigger")
+
+    jobs = wf.get("jobs", {})
+    offenders = [
+        name for name, job in jobs.items() if isinstance(job, dict) and not _job_is_safe(job)
+    ]
+    assert not offenders, (
+        f"{path.name}: job(s) {offenders} can be scheduled on the internal "
+        f"'{_INTERNAL_POOL_MARKER}*' pool by a fork pull_request without a "
+        "fork guard or a disposable-runner route. See docs/codebase/devops.md "
+        "'Untrusted pull-request isolation' (F06)."
+    )
+
+
+def test_migration_compat_routes_fork_off_internal_pool() -> None:
+    # AC3: a fork PR touching only scripts/ci/check_migration_compat.py
+    # cannot schedule an internal runner.
+    wf = _load_workflow(_WORKFLOWS_DIR / "migration-compat.yml")
+    check = wf["jobs"]["check"]
+    runs_on = _runs_on_str(check)
+    assert _ROUTE_COND in runs_on and _HOSTED_TARGET in runs_on, (
+        "migration-compat.yml 'check' job must route fork PRs to a "
+        f"disposable runner; runs-on is {runs_on!r}"
+    )
+
+
+def test_security_scan_skips_fork_prs() -> None:
+    # security-scan runs inside an internal Harbor-proxied container that a
+    # GitHub-hosted runner cannot reach, so it must skip fork PRs (the
+    # required context still runs on merge_group + push).
+    wf = _load_workflow(_WORKFLOWS_DIR / "security-scan.yml")
+    semgrep = wf["jobs"]["semgrep"]
+    assert _FORK_GUARD in str(semgrep.get("if", "")), (
+        "security-scan.yml 'semgrep' job must carry the fork guard"
+    )

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -1610,9 +1610,16 @@ parallel on every PR:
 
 `pr-smoke.yml` does **not** duplicate the image build with
 `image.yml` — it pushes a transient PR-tag, while `image.yml` on PRs
-builds without pushing (gate only). The two workflows share the GHA
-buildx cache scope, so the smoke's build typically hits a warm cache
-when application code is the only delta.
+builds without pushing (gate only). The smoke build **reads** the shared
+GHA buildx cache (`cache-from: type=gha`, the default `buildkit` scope),
+so it typically hits a warm cache when application code is the only
+delta — but it **exports** only to an isolated `cache-to:
+type=gha,scope=pr-smoke,mode=max` scope. Because `pr-smoke.yml` runs
+under `pull_request_target` with `GITHUB_REF` pinned to `main`, that
+isolation keeps an unmerged PR-head build from writing the default cache
+scope the cosign-signed `image.yml` release build restores from; the
+release image's trust chain never depends on cache produced by unmerged
+code, while the per-PR build keeps its warm-cache read.
 
 ## Dependencies
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -1321,6 +1321,11 @@ arbitrary code from a forked PR (`go test`, `pytest`, `helm template`
 with custom values) is never allowed to execute on it. The OR
 short-circuits on `push` events so main-branch CI is unaffected.
 
+This guard is `ci.yml`'s arm of the repo-wide untrusted-PR isolation
+model — the full inventory, the disposable-runner routing pattern, and
+the GitHub-settings enforcement live under "Untrusted pull-request
+isolation" below.
+
 ### Local reproduction
 
 Every gate the workflow runs can be reproduced locally with the same
@@ -1379,6 +1384,108 @@ of CI. Two actions are unique to `ci.yml`:
   v1 configs; pinning the binary to `v1.64.8` keeps the existing
   config valid. A future migration to the v2 schema flips both the
   action major and the binary version together.
+
+## Untrusted pull-request isolation
+
+Self-hosted runners are internal infrastructure. Any workflow that runs
+on the `meho-runners-ci` pool in response to a **fork** pull request runs
+attacker-controlled code (the fork's checked-out content, and for a fork
+`pull_request` event the fork's own copy of the workflow body) on that
+pool. GitHub documents this as the primary self-hosted-runner risk; see
+the [secure-use reference](https://docs.github.com/en/actions/reference/security/secure-use).
+`ci.yml`, `image.yml`, `chart.yml`, `pr-smoke.yml`, `plugin-test.yml`,
+`eval-gate.yml`, `mcpb-bundle.yml` and `consumer-tool-name-check.yml`
+already carried the fork guard; the audit below (F06, meho-internal#268)
+closed the workflows that did not.
+
+### Inventory — every PR-triggered job
+
+Jobs that run in response to `pull_request` / `pull_request_target` and
+their isolation posture:
+
+| Workflow | Runs untrusted PR code? | Isolation mechanism |
+| --- | --- | --- |
+| `ci.yml` | yes (build/test/lint) | fork guard on every job (skip on fork PR) |
+| `image.yml` | yes (Docker build) | fork guard (skip on fork PR) |
+| `chart.yml` | yes (helm template) | fork guard on the internal-pool PR job; publish/verify jobs are `push`-only |
+| `pr-smoke.yml` | yes (`pull_request_target`) | fork guard + `environment: rke2-ci` + PR-head-SHA checkout + isolated `pr-smoke` cache scope |
+| `migration-compat.yml` | yes (runs `check_migration_compat.py`) | **route**: fork PR → disposable GitHub-hosted runner |
+| `dependency-license-check.yml` | yes (`pip install -e ./backend` runs the build backend) | **route**: fork PR → disposable GitHub-hosted runner (all 3 jobs) |
+| `readme-version-check.yml` | yes (inline shell over PR content) | **route**: fork PR → disposable GitHub-hosted runner |
+| `secret-scan.yml` | yes (`docker run` TruffleHog over PR content) | **route**: fork PR → disposable GitHub-hosted runner |
+| `security-scan.yml` | yes (Semgrep over PR content) | **fork guard** (skip on fork PR — the job runs inside the internal Harbor-proxied container, which a GitHub-hosted runner cannot reach; the required context still runs on `merge_group` + `push`) |
+| `docs-site.yml`, `quality-gate.yml` | n/a | already on GitHub-hosted `ubuntu-latest` / `workflow_run` (trusted) |
+
+### Two in-repo isolation patterns
+
+- **Fork guard (skip).** The job-level `if:` the publish workflows use:
+
+  ```yaml
+  if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+  ```
+
+  A fork PR (`head.repo.full_name != github.repository`) skips the job;
+  a skipped required job reports **Success**, so branch protection is
+  satisfied while nothing executes on the internal pool. Used where the
+  job genuinely needs an internal resource — `security-scan.yml` runs in
+  a `harbor.evba.lab`-proxied container, so relocating it to a disposable
+  runner is impossible; the real scan runs on the trusted `merge_group`
+  (queue admission) and `push` refs instead.
+
+- **Route to a disposable runner.** Where the job needs no internal
+  route, deployment credential or trusted build cache — only a language
+  toolchain and public-registry egress — the fork PR runs on an
+  ephemeral GitHub-hosted runner rather than being skipped, so the check
+  still gives external contributors real feedback:
+
+  ```yaml
+  runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'meho-runners-ci' }}
+  ```
+
+  Trusted refs (same-repo PR, `push`, `merge_group`) stay on the internal
+  pool unchanged — this deliberately leaves the tuned `merge_group`
+  required-gate paths (e.g. `secret-scan.yml`'s ghcr warm-cache retry,
+  #3307/#3310) untouched and only relocates the untrusted fork-PR path.
+
+### Enforcement outside PR-editable YAML
+
+For a fork `pull_request`, GitHub runs the workflow body **from the PR
+head** — so the in-YAML arms above hold only while the fork does not also
+rewrite the workflow. They cover the exact exploit in the F06 finding (a
+fork PR touching *only* a checker script inherits `main`'s workflow and
+so routes off the internal pool), but the durable enforcement lives in
+GitHub settings, which a PR cannot edit. Effective settings recorded
+2026-09-07 (`gh api repos/evoila/meho/...`):
+
+- **Fork-PR approval policy** = `all_external_contributors`
+  (`actions/permissions/fork-pr-contributor-approval`) — every external
+  fork PR needs a maintainer's "Approve and run" before any workflow
+  runs. This is the primary containment (flipped 2026-09-06); keep it.
+- **Default workflow token** = `read`, `can_approve_pull_request_reviews`
+  = false (`actions/permissions/workflow`) — least privilege by default;
+  jobs opt into `packages: write` / `id-token: write` explicitly.
+- **Runner-group access** is an org-level setting (not readable from the
+  repo API) and must restrict which repositories/workflows may schedule
+  the `meho-runners-ci*` groups — the belt-and-suspenders against a fork
+  that rewrites `runs-on` back to the internal pool.
+- **`pull_request_target` environment approval**: `pr-smoke.yml`
+  references `environment: rke2-ci`, but that environment does not yet
+  exist (`copilot` and `github-pages` are the only ones). Before
+  `vars.RKE2_SMOKE_ENABLED` is flipped on, `rke2-ci` must be created with
+  required reviewers so the secret-bearing same-repo `pull_request_target`
+  run gates on a human.
+
+### Signing, deployment and cache separation
+
+Untrusted PR jobs carry no signing or deployment identity: cosign
+signing lives in `image.yml` (fork-guarded) and the `chart.yml` publish
+job (`push`-only), and `pr-smoke.yml` exports its buildx cache to an
+isolated `pr-smoke` scope so an unmerged PR-head build can never seed the
+default cache the cosign-signed `image.yml` release build restores from
+(#3475). The CI cluster is recorded as separate from the automation
+cluster; verifying the firewall/routing that a compromised CI runner
+could traverse is an infra check, tracked outside this repo.
+
 
 ## Per-PR ephemeral cluster smoke (`.github/workflows/pr-smoke.yml`)
 


### PR DESCRIPTION
## Summary

- Untrusted **fork** pull requests could schedule the internal
  `meho-runners-ci` pool and run PR-controlled code on it.
  `migration-compat.yml`, `dependency-license-check.yml`,
  `readme-version-check.yml`, `secret-scan.yml` and `security-scan.yml`
  ran on `pull_request` against the internal pool with **no fork guard**
  — the F06 finding.
- Audit **every** PR-triggered workflow (not just the principal CI file)
  and close the gap with two idioms: **route** untrusted fork PRs to a
  disposable GitHub-hosted runner where the job needs no internal
  resource; **fork-guard** (skip) where it does.
- Add a regression test that pins the invariant across all workflows, and
  document the model + the GitHub-settings enforcement in
  `docs/codebase/devops.md`.

Base is `main` with `origin/fix/305-pr-smoke-cache-scope` (PR #3475)
merged in, so this branch already carries the `pr-smoke` cache-scope
isolation hunk and cannot conflict with it.

## Already on `main` (not re-done here)

- The fork guard (`head.repo.full_name == github.repository`) already
  covered `ci.yml`, `image.yml`, `chart.yml`, `pr-smoke.yml`,
  `plugin-test.yml`, `eval-gate.yml`, `mcpb-bundle.yml`,
  `consumer-tool-name-check.yml`.
- `pr-smoke.yml`'s isolated `cache-to: scope=pr-smoke` (PR #3475, merged
  into this branch) already separates the per-PR build cache from the
  cosign-signed `image.yml` release cache (part of AC5).
- The **fork-PR approval policy is already `all_external_contributors`**
  (containment flip, 2026-09-06). Verified, not re-flipped — this is the
  primary settings-side containment.
- Default workflow token is already `read` (least privilege).

## What this PR changes

| Workflow | Before | After |
| --- | --- | --- |
| `migration-compat.yml` | `meho-runners-ci`, no guard | route fork PRs → `ubuntu-latest` |
| `dependency-license-check.yml` (3 jobs) | `meho-runners-ci`, no guard | route fork PRs → `ubuntu-latest` |
| `readme-version-check.yml` | `meho-runners-ci`, no guard | route fork PRs → `ubuntu-latest` |
| `secret-scan.yml` | `meho-runners-ci`, no guard | route fork PRs → `ubuntu-latest` (trusted refs, incl. the tuned merge_group gate, unchanged) |
| `security-scan.yml` | `meho-runners-ci`, no guard | fork guard (skip fork PRs — the job runs in an internal Harbor-proxied container; the required context still runs on merge_group + push) |

The route expression keeps every trusted ref (same-repo PR, `push`,
`merge_group`) on the internal pool exactly as before; only the untrusted
fork-PR path moves.

## Acceptance criteria

- [x] **AC1 — inventory every PR-triggered job.** Full inventory table in
  `docs/codebase/devops.md` → "Untrusted pull-request isolation" and in
  the table above. Five gaps found beyond the two named in the finding.
- [x] **AC2 — untrusted PR code runs only in disposable isolated
  environments.** Routed fork-PR jobs run on `ubuntu-latest` (ephemeral,
  read-only token, no repo secrets, no internal route, no trusted cache);
  `security-scan` skips on fork PRs.
- [x] **AC3 — a fork PR touching only `scripts/ci/check_migration_compat.py`
  cannot schedule an internal runner.** `migration-compat.yml` routes
  fork PRs to `ubuntu-latest`; a fork PR that touches only the checker
  inherits `main`'s (unmodified) workflow, whose conditional resolves
  `runs-on` to `ubuntu-latest` for forks. Pinned by
  `test_migration_compat_routes_fork_off_internal_pool`.
- [~] **AC4 — runner-group/workflow restrictions + sensitive same-repo PR
  environment approvals enforced outside PR-editable YAML; record the
  effective settings.** Effective settings recorded (below + in docs).
  The in-repo arms landed; the runner-group restriction and the
  `rke2-ci` environment approval are **GitHub settings** → see the Apply
  checklist.
- [~] **AC5 — signing/deployment identities and caches separated from
  untrusted builds; verify intended routing.** Documented: signing lives
  in fork-guarded `image.yml` + push-only `chart.yml`; `pr-smoke` cache
  is isolated (#3475); untrusted jobs carry no signing/deploy identity.
  The CI→automation routing check is an infra task → see the checklist.

`[~]` = in-repo arm complete; the residual is a GitHub/infra setting a PR
cannot make (per orchestrator constraint 3).

## Effective settings recorded 2026-09-07

- `actions/permissions/fork-pr-contributor-approval` →
  `{"approval_policy":"all_external_contributors"}`
- `actions/permissions/workflow` →
  `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`
- `actions/permissions` →
  `{"enabled":true,"allowed_actions":"all","sha_pinning_required":false}`
- repo → `{"private":false,"visibility":"public","allow_forking":true}`
- environments present: `copilot`, `github-pages` — **`rke2-ci` does not
  exist yet** (referenced by `pr-smoke.yml`, gated off by
  `vars.RKE2_SMOKE_ENABLED`).

## Apply checklist for Damir (GitHub settings / infra — not PR-editable)

```bash
# 1. Verify (do NOT re-flip) the fork-PR approval policy stays strict.
gh api repos/evoila/meho/actions/permissions/fork-pr-contributor-approval
#   expect: {"approval_policy":"all_external_contributors"}

# 2. Restrict the internal runner groups so a fork that rewrites
#    `runs-on` back to the pool still cannot use it (org admin).
gh api orgs/evoila/actions/runner-groups          # find the group id(s)
#    then, per group, restrict visibility to selected repos AND restrict
#    to selected workflows (fill in <id> and the trusted workflow refs):
gh api -X PATCH orgs/evoila/actions/runner-groups/<id> \
  -F visibility=selected -F restricted_to_workflows=true \
  -f 'selected_workflows[]=evoila/meho/.github/workflows/ci.yml@refs/heads/main' \
  -f 'selected_workflows[]=evoila/meho/.github/workflows/image.yml@refs/heads/main'
#   (add each workflow that legitimately uses the internal pool)

# 3. Before enabling pr-smoke, create the rke2-ci environment WITH
#    required reviewers so the secret-bearing pull_request_target run
#    gates on a human (replace <reviewer-user-id>):
gh api -X PUT repos/evoila/meho/environments/rke2-ci \
  -F 'reviewers[][type]=User' -F 'reviewers[][id]=<reviewer-user-id>'
#   keep vars.RKE2_SMOKE_ENABLED=false until this exists.

# 4. AC5 routing verification (infra): confirm the CI runner cluster has
#    no network route or credentials to the automation cluster. Record
#    the result; do not assume reachability.
```

## Test plan

- [x] `actionlint` on all 5 changed workflows — clean (repo-wide run
  shows only pre-existing findings in untouched files).
- [x] `yaml.safe_load` parses all 5 workflows.
- [x] `pytest tests/test_ci_fork_runner_isolation.py` — 17 passed, 3
  skipped (push-only / workflow_run workflows).
- [x] `ruff check` / `ruff format --check` / `mypy` on the new test —
  clean.
- [x] `.claude/hooks/code-quality.py --diff` — exit 0.

The diff adds no importable Python module (only a self-contained
workflow-parsing test, run directly above), so the full backend unit
lane adds no signal for this change; CI runs it on the PR regardless.

## Out of scope

- The VPN / management-plane lockdown program (#234, #248, #249, #250).
- Fixing the CI→automation routing itself (AC5 asks to verify, not fix).
- Action SHA-pinning / `allowed_actions` tightening (`sha_pinning_required`
  is false) — that is #155's domain, not runner-execution-trust.
- Adjacent finding (untouched files): `ci.yml` uses
  `meho-runners-ci-heavy`, which is absent from `.github/actionlint.yaml`;
  `cli-release.yml` / `runner-smoke.yml` carry pre-existing shellcheck
  nits. Recorded, not changed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#268
