### PR TITLE
fix(auth): fail-close service-token classification for the #3152 park (#299)

### DIFF
--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -671,14 +671,22 @@ def _is_service_account_token(claims: Any, settings: Settings) -> bool:
     marker** of a service-account token, not a fuzzy heuristic.
 
     Fail-closed by construction (this is the policy path): the function
-    returns ``True`` **only** on a positive prefix match, so a token whose
-    shape we cannot positively identify falls through to the ``user``
-    default in :func:`_extract_principal_kind`. A false negative is safe —
-    the #3152 grants gate is fail-open into the human approval flow — but a
-    false positive would silently upgrade an ordinary user into the
-    unattended-dispatch surface, so the marker must be a positive signal
-    only. An empty configured prefix disables the marker (every token stays
-    ``user`` unless it carries an explicit ``principal_kind`` claim).
+    returns ``True`` **only** on a positive prefix match, so a token this
+    marker cannot identify falls through in :func:`_extract_principal_kind`
+    to the marker-independent :func:`_is_client_credentials_token` shape
+    test (security review S11), and only then to the ``user`` default. That
+    backstop matters: a prefix-marker false negative is safe **only**
+    because the shape test catches the client-credentials token it missed —
+    on its own it is *not* safe, because for a mutating ``caution`` /
+    ``dangerous`` op the #3152 gate auto-executes a ``user``-classified
+    principal instead of parking it (only ``requires_approval`` and the
+    ``destructive`` tier park for a ``user``). A false positive, conversely,
+    would silently upgrade an ordinary user into the unattended-dispatch
+    surface, so this marker must stay a positive prefix signal only. An
+    empty configured prefix disables *this* marker; the shape test still
+    classifies a real client-credentials token as ``service``, while an
+    ordinary user stays ``user`` unless it carries an explicit
+    ``principal_kind`` claim.
 
     Both the claim name (``JWT_SERVICE_ACCOUNT_USERNAME_CLAIM``) and the
     prefix (``JWT_SERVICE_ACCOUNT_USERNAME_PREFIX``) are configurable so a
@@ -691,6 +699,50 @@ def _is_service_account_token(claims: Any, settings: Settings) -> bool:
         return False
     username = claims.get(settings.jwt_service_account_username_claim)
     return isinstance(username, str) and username.startswith(prefix)
+
+
+#: Claims Keycloak stamps on a token minted from an *interactive* user
+#: session (authorization-code / direct-access grants) and never on a pure
+#: ``client_credentials`` token, which creates no user session. Their
+#: absence — paired with a positive client-identity claim — positively marks
+#: a non-interactive service token (standard OIDC / RFC 9068 claim names, not
+#: realm-configurable, so they are fixed here rather than in Settings).
+_INTERACTIVE_SESSION_CLAIMS: tuple[str, ...] = ("auth_time", "session_state", "sid")
+
+
+def _is_client_credentials_token(claims: Any) -> bool:
+    """Positively identify a non-interactive client-credentials token by *shape*.
+
+    Fail-close backstop for the #3152 gate (security review S11). The #3178
+    username-prefix marker (:func:`_is_service_account_token`) is the
+    *preferred* service-account signal, but it is disabled outright by an
+    empty ``JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`` and silent when a realm
+    omits or renames the ``preferred_username`` mapper — leaving a
+    client-credentials principal to default to ``user`` and auto-execute the
+    mutating ``caution`` / ``dangerous`` ops a ``service`` classification
+    would park.
+
+    This marker keys on the token shape instead, independent of the username
+    mapper: an OAuth2 ``client_credentials`` grant carries a client-identity
+    claim (``azp`` — the authorized party — or the RFC 9068 ``client_id``)
+    but no interactive user session, so it never carries the session claims
+    Keycloak stamps on an authorization-code / direct-grant token
+    (:data:`_INTERACTIVE_SESSION_CLAIMS`). A positive client-identity claim
+    together with the absence of **every** interactive-session claim is a
+    positive signal of a non-interactive service token.
+
+    Fail-closed by construction: it returns ``True`` only on that positive
+    shape. An interactive human token always carries a session claim, so it
+    is never upgraded — the human-``user`` default-allow is preserved. A
+    degenerate token with no client-identity claim stays ``user`` too (the
+    absence of session claims alone never upgrades).
+    """
+    has_client_identity = any(
+        isinstance(claims.get(name), str) and claims.get(name) for name in ("azp", "client_id")
+    )
+    if not has_client_identity:
+        return False
+    return not any(claims.get(name) is not None for name in _INTERACTIVE_SESSION_CLAIMS)
 
 
 def _extract_client_id(claims: Any, settings: Settings) -> str | None:
@@ -735,16 +787,22 @@ def _extract_principal_kind(claims: Any, settings: Settings) -> PrincipalKind:
     custom kind needs the enum widened first — exactly like an out-of-enum
     ``tenant_role``.
 
-    When the claim is **absent**, the classification is inferred (#3178):
-    an IdP service-account (client-credentials) token — positively
-    identified by :func:`_is_service_account_token` — resolves to
-    ``service`` so the #3152 standing-grants gate evaluates it, and any
-    other token falls back to the pre-G11.2 human-``user`` default (which
-    keeps every existing human-operator token working without a Keycloak
-    mapper update). The inference runs **only** for the absent-claim case
-    and only *upgrades* on a positive marker, so it never overrides an
-    explicit claim and never downgrades — the fail-closed direction for the
-    policy path.
+    When the claim is **absent**, the classification is inferred (#3178,
+    security review S11): an IdP service-account (client-credentials) token
+    resolves to ``service`` so the #3152 standing-grants gate evaluates it,
+    and any other token falls back to the pre-G11.2 human-``user`` default
+    (which keeps every existing human-operator token working without a
+    Keycloak mapper update). Two positive markers are consulted, either
+    sufficient: the #3178 username-prefix marker
+    (:func:`_is_service_account_token`), and — because that marker is
+    disabled by an empty prefix and silent when the ``preferred_username``
+    mapper is absent or renamed — the marker-independent token-shape test
+    (:func:`_is_client_credentials_token`, S11) that classifies a
+    client-credentials token by its ``azp`` / ``client_id`` claim and the
+    absence of interactive-session claims. The inference runs **only** for
+    the absent-claim case and only *upgrades* on a positive marker, so it
+    never overrides an explicit claim and never downgrades — the fail-closed
+    direction for the policy path.
 
     The claim name is configurable via ``JWT_PRINCIPAL_KIND_CLAIM_NAME``
     (default ``principal_kind``) in :class:`~meho_backplane.settings.Settings`
@@ -757,8 +815,11 @@ def _extract_principal_kind(claims: Any, settings: Settings) -> PrincipalKind:
         # Claim absent. An explicit Keycloak ``principal_kind`` mapper is
         # the canonical way to set this, but a client-credentials client
         # often lacks it — so positively test for a service-account token
-        # before defaulting to the legacy human-``user`` fallback (#3178).
-        if _is_service_account_token(claims, settings):
+        # before defaulting to the legacy human-``user`` fallback. Either
+        # the #3178 username-prefix marker or the marker-independent
+        # token-shape test (S11, correct when the prefix is cleared or the
+        # ``preferred_username`` mapper is absent/renamed) is sufficient.
+        if _is_service_account_token(claims, settings) or _is_client_credentials_token(claims):
             return PrincipalKind.SERVICE
         return PrincipalKind.USER
     try:

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -112,9 +112,20 @@ def _split_ingested_params(
     Algorithm: walk ``parameter_schema["properties"]``; for each
     property, read the ``x-meho-param-loc`` extension (default
     ``"query"`` -- the most common OpenAPI shape) and route the
-    matching params dict entry to the corresponding bucket. Params
-    not declared in the schema fall through to the **body** bucket --
-    the OpenAPI convention for free-form request bodies.
+    matching params dict entry to the corresponding bucket. A param
+    absent from ``properties`` has no ``x-meho-param-loc`` to read, so it
+    takes that same ``"query"`` default and routes to the **query**
+    bucket.
+
+    On the dispatch path such undeclared params never reach this splitter:
+    the dispatcher validates an ingested op against a schema with
+    ``additionalProperties: false`` (built in by the ingester since #293,
+    and applied as a backstop by
+    :func:`~meho_backplane.operations._validate.ingested_schema_for_validation`
+    for descriptors ingested before that fix), so an undeclared name is
+    already rejected as ``invalid_params`` upstream. The ``"query"``
+    default therefore only ever fires here for a caller that resolves
+    buckets without that gate (the read-only request preview).
 
     The four buckets are returned even when empty so the caller's
     request-building branch can pass them positionally without

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -49,6 +49,7 @@ _log = structlog.get_logger(__name__)
 __all__ = [
     "InvalidOpSchemaError",
     "compute_params_hash",
+    "ingested_schema_for_validation",
     "policy_gate",
     "validate_params",
 ]
@@ -141,6 +142,41 @@ def validate_params(
         missing_ref = f"#{pointer}" if pointer.startswith("/") else pointer
         raise InvalidOpSchemaError(missing_ref) from exc
     return out
+
+
+def ingested_schema_for_validation(parameter_schema: dict[str, Any]) -> dict[str, Any]:
+    """Return *parameter_schema* strengthened to reject undeclared params.
+
+    Fail-closed dispatch backstop (#293 / security review S05) for
+    ``source_kind='ingested'`` descriptors. The OpenAPI ingester now emits
+    ``additionalProperties: false`` on every built schema
+    (:func:`~meho_backplane.operations.ingest.openapi._build_parameter_schema`),
+    but a descriptor persisted before that fix carries no such clause, so
+    :func:`validate_params` -- JSON Schema 2020-12, which defaults
+    ``additionalProperties`` to ``true`` -- would accept a param the op
+    never declared and let the dispatcher forward it verbatim onto the
+    vendor query string. Applying the clause at the dispatch seam closes
+    that window for already-ingested connectors without a re-ingest, and
+    produces the *same* ``invalid_params`` error shape (``validator ==
+    "additionalProperties"``) a freshly-ingested strict descriptor does.
+
+    A no-op when the schema already declares ``additionalProperties`` (a
+    post-fix descriptor, or one an operator deliberately widened) or is
+    not an object schema with declared ``properties`` (an empty ``{}``
+    descriptor stays permissive, matching :func:`validate_params`). The
+    returned mapping is a shallow copy -- the stored descriptor's JSON
+    column is never mutated, and the nested ``properties`` /
+    ``components`` are shared by reference (``additionalProperties: false``
+    constrains only the top-level instance keys, so nested body/object
+    fields stay unconstrained).
+    """
+    if not isinstance(parameter_schema, dict):
+        return parameter_schema
+    if "properties" not in parameter_schema:
+        return parameter_schema
+    if "additionalProperties" in parameter_schema:
+        return parameter_schema
+    return {**parameter_schema, "additionalProperties": False}
 
 
 def _is_mutating(descriptor: EndpointDescriptor) -> bool:

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -331,6 +331,7 @@ from meho_backplane.operations._request_preview import (
 from meho_backplane.operations._validate import (
     InvalidOpSchemaError,
     compute_params_hash,
+    ingested_schema_for_validation,
     policy_gate,
     validate_params,
 )
@@ -2385,8 +2386,18 @@ async def dispatch(
         return result_unknown_op(op_id, known_op_count, _elapsed_ms(started))
 
     # --- Step 3: parameter_schema validation ------------------------------
+    # #293 (security review S05): for an ingested (generic-connector) op,
+    # validate against a schema that forbids undeclared params. Freshly
+    # ingested descriptors already carry ``additionalProperties: false``
+    # (openapi._build_parameter_schema); this backstop applies the same
+    # clause to descriptors ingested before that fix, so an undeclared
+    # param is rejected as ``invalid_params`` here rather than defaulting
+    # onto the vendor query string in ``_split_ingested_params``.
+    schema_to_validate = descriptor.parameter_schema
+    if descriptor.source_kind == "ingested":
+        schema_to_validate = ingested_schema_for_validation(descriptor.parameter_schema)
     try:
-        validation_errors = validate_params(descriptor.parameter_schema, params)
+        validation_errors = validate_params(schema_to_validate, params)
     except InvalidOpSchemaError as exc:
         # #3095: the stored schema itself is broken (dangling $ref) --
         # the descriptor is at fault, not the caller. Structured error

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -1181,6 +1181,7 @@ def _safety_level_for(method: str) -> SafetyLevel:
     return "safe"
 
 
+# code-quality-allow: function-size - pre-existing spec builder; #293 adds one key
 def _build_parameter_schema(
     *,
     path: str,
@@ -1226,7 +1227,9 @@ def _build_parameter_schema(
     dispatcher uses ``x-meho-param-loc == "body"`` to recover the
     payload regardless of property name. Operations with no params
     at all get the empty-but-valid ``{"type": "object", "properties":
-    {}}``.
+    {}, "additionalProperties": false}``. The ``additionalProperties:
+    false`` clause (#293) makes ``validate_params`` reject any param the
+    op did not declare instead of defaulting it onto the vendor query.
 
     Nested ``$ref`` strings inside the inlined schemas are preserved
     verbatim, and the components they transitively reference are
@@ -1273,7 +1276,13 @@ def _build_parameter_schema(
         if body_property["required"]:
             required.append("body")
 
-    schema: dict[str, object] = {"type": "object", "properties": properties}
+    # #293 (S05): ``additionalProperties: false`` fails closed on any param
+    # the op never declared (else it defaults onto the vendor query string).
+    schema: dict[str, object] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     _attach_component_closure(

--- a/backend/tests/test_auth_principal_kind.py
+++ b/backend/tests/test_auth_principal_kind.py
@@ -313,7 +313,12 @@ def test_custom_service_account_username_claim(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_empty_prefix_disables_marker(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An empty configured prefix disables the marker — a service account stays ``user``."""
+    """An empty prefix disables the username marker.
+
+    A token carrying only the service-account username (and none of the
+    client-credentials shape markers the S11 backstop keys on — no ``azp`` /
+    ``client_id``) then stays ``user``.
+    """
     monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "")
     key = _make_key("kid-empty-prefix")
     token = _mint(
@@ -322,6 +327,89 @@ def test_empty_prefix_disables_marker(monkeypatch: pytest.MonkeyPatch) -> None:
         extra_claims={"preferred_username": "service-account-deploy-bot"},
     )
     assert _classify(token, key, monkeypatch=monkeypatch) == "user"
+
+
+# ---------------------------------------------------------------------------
+# Marker-independent client-credentials shape classification (security review S11)
+# ---------------------------------------------------------------------------
+#
+# The #3178 username-prefix marker is disabled by an empty
+# JWT_SERVICE_ACCOUNT_USERNAME_PREFIX and silent when a realm omits or
+# renames the preferred_username mapper. A client-credentials token must
+# still classify as ``service`` in those configs — otherwise it defaults to
+# ``user`` and auto-executes the mutating caution/dangerous ops the #3152
+# gate would park (the S11 fail-open). The fail-close backstop keys on the
+# token *shape*: a client-identity claim (``azp`` / ``client_id``) with none
+# of the interactive-session claims (``auth_time`` / ``session_state`` /
+# ``sid``) a human authorization-code / direct-grant token carries.
+
+
+def test_client_credentials_shape_classifies_service_empty_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty prefix + client-credentials shape (``azp``, no session claims) → ``service``."""
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "")
+    key = _make_key("kid-ccred-empty-prefix")
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={
+            "azp": "deploy-bot",
+            "client_id": "deploy-bot",
+            # Prefix disabled: the #3178 username marker cannot fire, so the
+            # shape test alone must classify this as a service token.
+            "preferred_username": "service-account-deploy-bot",
+        },
+    )
+    assert _classify(token, key, monkeypatch=monkeypatch) == "service"
+
+
+def test_client_credentials_shape_classifies_service_absent_username() -> None:
+    """No username claim at all + ``azp``, no session claims → ``service``.
+
+    Default settings (prefix enabled) but the realm omits the
+    ``preferred_username`` mapper, so the #3178 marker is silent; the
+    shape test still resolves ``service``.
+    """
+    key = _make_key("kid-ccred-no-username")
+    token = _mint(key, principal_kind=None, extra_claims={"azp": "deploy-bot"})
+    assert _classify(token, key) == "service"
+
+
+def test_client_credentials_shape_via_client_id_only() -> None:
+    """RFC 9068 ``client_id`` (no ``azp``), no session claims → ``service``."""
+    key = _make_key("kid-ccred-client-id")
+    token = _mint(key, principal_kind=None, extra_claims={"client_id": "deploy-bot"})
+    assert _classify(token, key) == "service"
+
+
+@pytest.mark.parametrize("session_claim", ["auth_time", "session_state", "sid"])
+def test_interactive_token_with_session_claim_stays_user(session_claim: str) -> None:
+    """A token with a client id but an interactive-session claim stays ``user``.
+
+    An authorization-code / direct-grant human token carries ``azp`` (the
+    client it logged into) *and* a user-session claim. The shape test must
+    not upgrade it — the human-``user`` default-allow is preserved.
+    """
+    key = _make_key(f"kid-interactive-{session_claim}")
+    value: Any = 1700000000 if session_claim == "auth_time" else "sess-xyz"
+    token = _mint(
+        key,
+        principal_kind=None,
+        extra_claims={"azp": "meho-cli", "preferred_username": "alice", session_claim: value},
+    )
+    assert _classify(token, key) == "user"
+
+
+def test_explicit_user_claim_overrides_client_credentials_shape() -> None:
+    """An explicit ``principal_kind=user`` wins over the shape inference."""
+    key = _make_key("kid-explicit-user-ccred")
+    token = _mint(
+        key,
+        principal_kind="user",
+        extra_claims={"azp": "deploy-bot", "client_id": "deploy-bot"},
+    )
+    assert _classify(token, key) == "user"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -487,6 +487,85 @@ async def test_dispatch_returns_invalid_params_when_schema_violated(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_ingested_rejects_undeclared_param(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#293 (S05): an undeclared param on an ingested op -> ``invalid_params``.
+
+    Regression for the generic-connector query-injection gap: an ingested
+    descriptor persisted *before* the ingester emitted
+    ``additionalProperties: false`` carries a permissive schema, so a param
+    the op never declared used to pass validation and get forwarded onto
+    the vendor query string. The dispatcher now validates ingested ops
+    against a strict schema, so the additive key is rejected here -- before
+    any connector is resolved or vendor request built. The descriptor is
+    deliberately built WITHOUT ``additionalProperties`` to prove the
+    dispatch-seam backstop, not just the freshly-ingested strict schema.
+    """
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import EndpointDescriptor
+
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product="demo",
+        version="1.0",
+        impl_id="demo-rest",
+        op_id="GET:/api/things",
+        source_kind="ingested",
+        method="GET",
+        path="/api/things",
+        handler_ref=None,
+        summary="List things",
+        description="Pre-#293 ingested op with a permissive schema.",
+        tags=[],
+        # No ``additionalProperties`` clause -- the pre-fix persisted shape.
+        parameter_schema={
+            "type": "object",
+            "properties": {"filter": {"type": "string", "x-meho-param-loc": "query"}},
+        },
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=stub_embedding_service.encode_one.return_value,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+    operator = _make_operator()
+    target = _FakeTarget(product="demo", version="1.0")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="demo-rest-1.0",
+        op_id="GET:/api/things",
+        target=target,
+        # ``filter`` is declared; ``cascade`` is not -- the injected switch.
+        params={"filter": "name=foo", "cascade": "true"},
+    )
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras["error_code"] == "invalid_params"
+    validation = result.extras["validation_errors"]
+    assert isinstance(validation, list)
+    assert any(err["validator"] == "additionalProperties" for err in validation)
+    # No vendor request was built -- the reject is a pre-dispatch fault, so
+    # no broadcast event fires for a would-be call.
+    assert captured_events == []
+
+
+@pytest.mark.asyncio
 async def test_dispatch_returns_invalid_op_schema_for_poisoned_descriptor(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -2292,7 +2292,62 @@ def test_parse_schema_without_nested_refs_gains_no_components_key() -> None:
                 "x-meho-param-loc": "body",
             }
         },
+        # #293: the top-level ingested schema fails closed on undeclared params.
+        "additionalProperties": False,
     }
+
+
+def test_build_parameter_schema_fails_closed_on_undeclared_params() -> None:
+    """AC (#293 / S05): every built ingested schema carries ``additionalProperties: false``.
+
+    JSON Schema 2020-12 defaults ``additionalProperties`` to ``true``, so
+    without the clause a param the op never declared passes
+    ``validate_params`` and the dispatcher forwards it verbatim onto the
+    vendor query string. The ingester now emits the clause on every
+    built ``parameter_schema`` so the generic-connector dispatch surface
+    is confined to its declared params.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
+
+    # Every ingested op's built schema fails closed on additive keys.
+    for proto in rows:
+        assert proto.parameter_schema["additionalProperties"] is False, proto.op_id
+
+    # The clause is load-bearing: a strict validator over the built schema
+    # rejects an undeclared param with an ``additionalProperties`` error,
+    # while a declared param validates clean at the additive-key layer.
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    validator = Draft202012Validator(list_pets.parameter_schema)
+    undeclared = [
+        err
+        for err in validator.iter_errors({"undeclared_switch": "on"})
+        if err.validator == "additionalProperties"
+    ]
+    assert undeclared, "undeclared param must raise an additionalProperties error"
+    declared_only = [
+        err
+        for err in validator.iter_errors({"limit": 5})
+        if err.validator == "additionalProperties"
+    ]
+    assert declared_only == []
+
+
+def test_response_schema_is_not_strict_additional_properties() -> None:
+    """Only the top-level *parameter* schema fails closed -- responses stay open.
+
+    ``additionalProperties: false`` on a response schema would make the
+    JSONFlux reducer choke on any vendor field the spec under-declares;
+    #293 hardens the request contract only, so ``response_schema`` never
+    gains the clause.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
+    page = _by_op_id(rows)["GET:/pets"].response_schema
+    assert page is not None
+    assert "additionalProperties" not in page
 
 
 def test_parse_response_schema_is_deliberately_not_bundled() -> None:

--- a/backend/tests/test_service_principal_grant_gate.py
+++ b/backend/tests/test_service_principal_grant_gate.py
@@ -189,6 +189,50 @@ async def test_service_principal_safe_read_auto_executes() -> None:
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_client_credentials_shape_principal_parks_caution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client-credentials token classified via the S11 shape test parks a caution op.
+
+    Ties the auth-layer classification (:func:`_extract_principal_kind`) to
+    the dispatch consequence: with the #3178 username-prefix marker disabled
+    (empty prefix), a client-credentials token — ``azp`` present, no
+    interactive-session claim — classifies ``service`` on the
+    marker-independent shape test, so a mutating ``caution`` op it dispatches
+    parks for a human decision instead of auto-executing (the S11 fail-open
+    this Task closes). Before the fix the same token defaulted to ``user``
+    and this op auto-executed (``enforce_subop_policy`` returning ``None``).
+    """
+    from meho_backplane.auth.jwt import _extract_principal_kind
+
+    monkeypatch.setenv("JWT_SERVICE_ACCOUNT_USERNAME_PREFIX", "")
+    get_settings.cache_clear()
+    settings = get_settings()
+    claims = {
+        "azp": "deploy-bot",
+        "client_id": "deploy-bot",
+        # Prefix disabled: the #3178 username marker cannot fire on this
+        # username, so only the shape test can classify it as a service token.
+        "preferred_username": "service-account-deploy-bot",
+    }
+    kind = _extract_principal_kind(claims, settings)
+    assert kind is PrincipalKind.SERVICE
+
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=kind),
+        connector_id=_CONNECTOR,
+        op_id=_OP,
+        safety_level="caution",
+        requires_approval=False,
+        target=None,
+        params=_PARAMS,
+    )
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    assert not await _grant_use_rows()
+
+
 # ---------------------------------------------------------------------------
 # standing grant clears the gate + records grant-use audit (#3151)
 # ---------------------------------------------------------------------------

--- a/docs/codebase/service-principal-grants.md
+++ b/docs/codebase/service-principal-grants.md
@@ -52,15 +52,29 @@ always wins, but a Keycloak client-credentials client often carries **no**
 such claim (no `principal_kind` mapper), which historically fell back to
 the `user` default and left this whole gate — and any standing grants —
 silently inert. `_extract_principal_kind` therefore infers `service` for
-the **absent-claim** case when the token is positively identified as an IdP
-service account: its username claim (default `preferred_username`,
-`JWT_SERVICE_ACCOUNT_USERNAME_CLAIM`) bears Keycloak's reserved
-`service-account-<clientId>` prefix (default `service-account-`,
-`JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`). Fail-closed for the policy path:
-only a positive marker *upgrades*; any unrecognised shape stays `user`. As
-a residual-drift signal, `_non_agent_verdict` emits a WARN
-(`policy_gate_grant_holder_classified_non_service`) whenever a **parking**
-non-service principal still holds ≥1 live grant.
+the **absent-claim** case on either of two positive markers:
+
+1. **Username-prefix marker (#3178).** The token's username claim (default
+   `preferred_username`, `JWT_SERVICE_ACCOUNT_USERNAME_CLAIM`) bears
+   Keycloak's reserved `service-account-<clientId>` prefix (default
+   `service-account-`, `JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`).
+2. **Token-shape marker (security review S11, `_is_client_credentials_token`).**
+   Independent of the username mapper: the token carries a client-identity
+   claim (`azp` or the RFC 9068 `client_id`) and **none** of the
+   interactive-session claims (`auth_time` / `session_state` / `sid`) that
+   Keycloak stamps on an authorization-code / direct-grant token. This
+   backstops marker 1 for a realm that clears the prefix
+   (`JWT_SERVICE_ACCOUNT_USERNAME_PREFIX=""`) or omits/renames the
+   `preferred_username` mapper — the config-dependent fail-open S11 closed
+   (a false negative on marker 1 alone would have let a client-credentials
+   principal auto-execute a mutating `caution`/`dangerous` op).
+
+Fail-closed for the policy path: only a positive marker *upgrades*; any
+unrecognised shape stays `user`, and an interactive human token (which
+always carries a session claim) is never upgraded, so the `user`
+default-allow is preserved. As a residual-drift signal, `_non_agent_verdict`
+emits a WARN (`policy_gate_grant_holder_classified_non_service`) whenever a
+**parking** non-service principal still holds ≥1 live grant.
 
 **"Mutating" is grounded in existing descriptor fields** (no new column,
 `_is_mutating`): an ingested op is read-class iff its HTTP `method` ∈

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -458,7 +458,7 @@ Frozen Pydantic v2 model. One per operation. Maps 1:1 to a subset of
 | `summary` | `summary` | Verbatim from spec |
 | `description` | `description` | Verbatim from spec |
 | `tags` | `tags` | Spec tags + optional `spec:<source>` marker |
-| `parameter_schema` | `parameter_schema` | Flattened JSON Schema 2020-12 with `x-meho-param-loc` |
+| `parameter_schema` | `parameter_schema` | Flattened JSON Schema 2020-12 with `x-meho-param-loc`; `additionalProperties: false` (#293) |
 | `response_schema` | `response_schema` | Success-response schema or `None` |
 | `safety_level` | `safety_level` | HTTP-verb heuristic, operator-overridable at review |
 | `requires_approval` | `requires_approval` | Always `False` at parse time |
@@ -1816,6 +1816,21 @@ defect class out:
   refusal (extras carry `missing_ref` + re-ingest remediation) —
   covering rows persisted by pre-#3095 ingests until they are
   re-ingested.
+
+Undeclared params fail closed too (#293 / security review S05).
+`_build_parameter_schema` emits `additionalProperties: false` on every
+built object, so `validate_params` rejects a param the op never declared
+as `invalid_params` rather than letting it default onto the vendor query
+string (`_split_ingested_params` routes an undeclared name to the `query`
+bucket). For descriptors ingested before that clause existed, the
+dispatcher applies the same strictness at the Step-3 validation seam —
+`ingested_schema_for_validation` (`operations/_validate.py`), scoped to
+`source_kind='ingested'` — so the fail-closed posture covers persisted
+rows without a re-ingest and yields the same `additionalProperties`
+error shape a freshly-ingested strict descriptor does. Typed/composite
+ops already carry the clause; `response_schema` deliberately does not
+(the JSONFlux reducer must tolerate vendor fields the spec
+under-declares).
 
 ### Repairing pre-#3095 rows (#3102)
 


### PR DESCRIPTION
## Summary

- **Fail-closes the #3152 caution/dangerous park for an unclassifiable client-credentials principal** (security review S11). A token with no `principal_kind` claim defaulted to `USER` in `auth/jwt.py::_extract_principal_kind` whenever the #3178 username-prefix marker could not fire — an empty `JWT_SERVICE_ACCOUNT_USERNAME_PREFIX`, or a realm that omits/renames the `preferred_username` mapper. `USER` skips the `elif is_service:` branch of `operations/_validate.py::_non_agent_verdict`, so a mutating `caution`/`dangerous` op the principal dispatched auto-executed instead of parking (config-dependent fail-open).
- **New marker-independent positive detector** `_is_client_credentials_token`: keys on the token *shape* (a client-identity claim `azp` or the RFC 9068 `client_id`, together with the absence of every interactive-session claim `auth_time`/`session_state`/`sid` Keycloak stamps on an authorization-code / direct-grant token). `_extract_principal_kind` consults it as a second positive marker in the absent-claim case, so such a token now classifies `SERVICE` and its mutating caution/dangerous ops park.
- **Human `USER` default-allow unchanged**: the detector fires only on a positive shape, and an interactive human token always carries a session claim, so it is never upgraded. An explicit `principal_kind` claim still always wins.
- **Docstring corrected**: `_is_service_account_token` no longer claims an absent-claim false negative is unconditionally safe for the #3152 gate — it now names the mutating caution/dangerous auto-execute consequence and the shape-test backstop.

## Already on main

None of the acceptance criteria were satisfied on `origin/main` before this PR — the classifier still defaulted an unclassifiable client-credentials token to `USER`. Containment PRs #3423/#3427 addressed a different finding (F05) and did not touch this path; #298 (S10 settings) and the in-queue #293 (S05) are unrelated to principal-kind classification.

This branch was cut from `origin/main` and immediately merged `origin/fix/293-ingested-params-additional-properties` per the orchestrator's coordination note (#293 shares the validate/dispatch code path and is still in the merge queue), so this PR carries #3466's hunks and cannot conflict. Base stays `main`.

## Test plan

- [x] `ruff check src/meho_backplane/auth/jwt.py src/meho_backplane/operations/_validate.py` — clean
- [x] `ruff format --check` (touched files) — clean
- [x] `mypy src/meho_backplane/auth/jwt.py` — Success, no issues
- [x] **AC1** — `test_client_credentials_shape_classifies_service_empty_prefix` / `_absent_username` / `_via_client_id_only` in `tests/test_auth_principal_kind.py` assert a client-credentials token (no `principal_kind`, empty prefix or absent username) resolves to `PrincipalKind.SERVICE`
- [x] **AC2** — `test_client_credentials_shape_principal_parks_caution` in `tests/test_service_principal_grant_gate.py`: the classified-`SERVICE` token on a mutating `caution` op with `requires_approval=False` parks (`enforce_subop_policy` returns `awaiting_approval`, not AUTO_EXECUTE)
- [x] **AC3** — `pytest tests/test_service_principal_grant_gate.py -k test_user_principal_caution_mutation_auto_executes -q` — 1 passed (human default-allow preserved)
- [x] **AC4** — `grep -n "false negative is safe" src/meho_backplane/auth/jwt.py` returns corrected text naming the caution/dangerous exception
- [x] **AC5** — `ruff check && mypy && pytest tests/test_service_principal_grant_gate.py tests/test_auth_principal_kind.py -q` — all pass (64 passed)
- [x] Full backend unit lane (all `tests/test_*.py` less integration/migrations, xdist) — green
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope

- The explicit-`principal_kind`-mapper path (already fail-closed), the destructive tier and `requires_approval=True` ops (#3183/#3198), the `_agent_verdict` branch, and the human-`USER` interactive default-allow — all untouched.
- Pre-existing `code-quality` warnings on `auth/jwt.py` (oversized file; `_extract_principal_kind` is 62 lines, docstring-driven) — not introduced by this change and left as-is per surgical-change discipline.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#299
