### PR TITLE
fix(docs): screen the corpus backend.ref endpoint and stop replaying the caller's JWT (S02)

### DIFF
--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -74,6 +74,7 @@ from meho_backplane.docs_collections import (
     DocCollectionConflictError,
     DocCollectionCreate,
     DocCollectionCreateResponse,
+    DocCollectionEndpointError,
     DocCollectionGlobalError,
     DocCollectionNotDisabledError,
     DocCollectionSummary,
@@ -253,6 +254,11 @@ async def create_doc_collection_endpoint(
     try:
         row = await create_doc_collection(session, operator, body)
     except DocCollectionBackendTypeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=exc.detail,
+        ) from exc
+    except DocCollectionEndpointError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=exc.detail,

--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -7,11 +7,35 @@ The ``search_docs`` add-on (Initiative #1518) routes vendor-document
 queries through the backplane to an **external** corpus service the ops
 team runs, rather than ingesting the corpus into MEHO's own substrate.
 This module is the one place that federation happens: a thin async
-``httpx`` client that POSTs a search request to ``settings.corpus_url``
-carrying ``Authorization: Bearer <operator.raw_jwt>`` — so the corpus's
-own audit log sees the operator identity, exactly as
-:func:`~meho_backplane.auth.vault.vault_client_for_operator` forwards the
-operator JWT to Vault's OIDC auth.
+``httpx`` client that POSTs a search request to a screened ``https``
+corpus URL carrying a **deployment-configured** corpus service credential
+(``settings.corpus_service_token``).
+
+The caller's raw inbound operator JWT is **never** forwarded
+(evoila-bosnia/meho-internal#290). The corpus URL is read from a
+tenant-configurable ``backend.ref`` (the ``meho-docs`` add-on's
+per-collection endpoint), so replaying the operator's Vault-capable
+bearer to it let a ``tenant_admin`` capture that credential (a
+credential-capture + SSRF path). Two controls close it here:
+
+* **Destination screen.** Every corpus dial requires the ``https``
+  scheme and screens the resolved host through the shared target SSRF
+  guard (:func:`~meho_backplane.targets.ssrf_guard.assert_public_destination_async`),
+  so a corpus URL cannot be pointed at ``http://``, loopback, RFC 1918
+  space, or ``169.254.169.254``. On-prem corpora on private space are
+  opted back in via ``MEHO_TARGET_SSRF_ALLOWLIST`` (the same allowlist
+  the connector target-dial guard reads).
+* **Configured downstream credential.** The bearer presented to the
+  corpus is ``settings.corpus_service_token`` — a dedicated, corpus-scoped
+  service credential owned by the deployment, not the operator's inbound
+  bearer. An empty setting sends no ``Authorization`` header (a corpus
+  that requires auth then fails closed) rather than falling back to the
+  operator JWT.
+
+The tradeoff of no longer forwarding the operator JWT: the corpus's own
+audit log now attributes the call to the service principal, not the
+operator. MEHO's central ``audit_log`` (bound from the JWT the operator
+presented to the backplane) is unaffected.
 
 Fail-closed by construction. The corpus being unconfigured
 (``corpus_url`` unset), unreachable (network / timeout), or returning a
@@ -59,13 +83,19 @@ from pydantic import (
 )
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.settings import get_settings
+from meho_backplane.settings import Settings, get_settings
+from meho_backplane.targets.ssrf_guard import (
+    TargetDestinationBlockedError,
+    assert_public_destination_async,
+)
 
 __all__ = [
     "CorpusChunk",
+    "CorpusEndpointBlockedError",
     "CorpusSearchResponse",
     "CorpusStatusResponse",
     "CorpusUnavailable",
+    "corpus_endpoint_host",
     "corpus_status",
     "derive_status_url",
     "search_corpus",
@@ -90,6 +120,68 @@ class CorpusUnavailable(RuntimeError):  # noqa: N818 -- "Unavailable" reads bett
     def __init__(self, message: str, *, status: int | None = None) -> None:
         self.status = status
         super().__init__(message)
+
+
+class CorpusEndpointBlockedError(TargetDestinationBlockedError):
+    """A corpus endpoint URL is not an allowed ``https`` public destination.
+
+    Subclasses :class:`~meho_backplane.targets.ssrf_guard.TargetDestinationBlockedError`
+    (itself a :class:`ValueError`) so a single ``except`` at each
+    enforcement point catches both the scheme rejection raised here and the
+    non-public-address rejection the shared SSRF host guard raises — the
+    create path renders one 422, the dial path one :class:`CorpusUnavailable`.
+    """
+
+
+def corpus_endpoint_host(url: str) -> str:
+    """Return the host to SSRF-screen for a corpus *url*, requiring ``https``.
+
+    Parses *url* and returns the host component the transport will dial.
+    Rejects — with :class:`CorpusEndpointBlockedError` — any URL whose
+    scheme is not ``https`` or that names no host, so a corpus endpoint can
+    never be a plaintext (`http://`) or structurally-degenerate destination.
+    The returned host is what the caller passes to
+    :func:`~meho_backplane.targets.ssrf_guard.assert_public_destination_async`;
+    keeping the parse here (not in the guard) leaves the guard a
+    host-screening primitive shared verbatim with the connector target dial.
+    """
+    parts = urlsplit(url)
+    host = parts.hostname
+    if parts.scheme != "https" or not host:
+        raise CorpusEndpointBlockedError("corpus endpoint must be an https:// URL naming a host")
+    return host
+
+
+async def _screen_corpus_dial(url: str) -> None:
+    """Fail closed unless *url* is an ``https`` public corpus destination.
+
+    The connect-time enforcement point for both the search and the
+    readiness dial: requires ``https`` + a public host (allowlist-aware)
+    and maps any rejection onto :class:`CorpusUnavailable` so the consuming
+    route renders a 503. The message never echoes the resolved address (no
+    internal-topology oracle — the guard's posture).
+    """
+    try:
+        host = corpus_endpoint_host(url)
+        await assert_public_destination_async(host)
+    except TargetDestinationBlockedError as exc:
+        _log.warning("corpus_endpoint_blocked")
+        raise CorpusUnavailable(
+            "corpus endpoint is not an allowed https public destination"
+        ) from exc
+
+
+def _corpus_auth_headers(settings: Settings) -> dict[str, str]:
+    """Build the corpus ``Authorization`` header from the configured token.
+
+    Presents ``settings.corpus_service_token`` as a Bearer credential — the
+    deployment-owned, corpus-scoped service token, never the caller's
+    operator JWT (#290). An empty setting sends **no** header, so a corpus
+    that requires auth fails closed (401 → :class:`CorpusUnavailable`)
+    rather than the operator bearer being forwarded to it.
+    """
+    token = settings.corpus_service_token
+    return {"Authorization": f"Bearer {token}"} if token else {}
 
 
 def _parse_2xx_body[ModelT: BaseModel](
@@ -254,11 +346,12 @@ async def search_corpus(
     corpus_url: str | None = None,
     audience: str | None = None,
 ) -> CorpusSearchResponse:
-    """Search the external corpus as *operator*, returning cited chunks.
+    """Search the external corpus, returning cited chunks.
 
-    POSTs a JSON search request to *corpus_url* with
-    ``Authorization: Bearer <operator.raw_jwt>`` so the corpus
-    authenticates and audits the call as the operator. The request is
+    Screens *corpus_url* (``https`` + a public host, allowlist-aware) and
+    POSTs a JSON search request to it carrying the deployment-configured
+    corpus service credential (``settings.corpus_service_token``) — the
+    caller's raw operator JWT is **never** forwarded (#290). The request is
     bounded by ``settings.corpus_timeout_seconds`` across connect / read
     / write so a slow or hung corpus raises rather than blocking the
     event loop. *audience* (RFC 8707), when set, is forwarded as the
@@ -266,7 +359,11 @@ async def search_corpus(
     token to itself.
 
     Args:
-        operator: The verified operator whose JWT is forwarded.
+        operator: The verified operator. Retained for the
+            :class:`~meho_backplane.docs_search.backends.base.SearchBackend`
+            seam and central-audit context; it is **not** used to
+            authenticate to the corpus (the operator JWT is no longer
+            forwarded, #290).
         query: The free-text search query.
         metadata_filters: Optional binary ``{key: scalar}`` narrowing
             (e.g. ``{"product": "vmware", "version": "9.0"}``). The
@@ -285,17 +382,18 @@ async def search_corpus(
             forwards no audience.
 
     Raises:
-        CorpusUnavailable: when *corpus_url* is unset (unconfigured),
-            the corpus is unreachable / times out, or it returns a
-            non-2xx status. The upstream status is carried on the
-            exception (``status``) for non-2xx responses; the raw
-            response body is never included.
+        CorpusUnavailable: when *corpus_url* is unset (unconfigured), is
+            not an allowed ``https`` public destination, the corpus is
+            unreachable / times out, or it returns a non-2xx status. The
+            upstream status is carried on the exception (``status``) for
+            non-2xx responses; the raw response body is never included.
     """
     settings = get_settings()
     resolved_url = corpus_url if corpus_url is not None else settings.corpus_url
     if not resolved_url:
         # Fail-closed: an unconfigured corpus is unavailable, not empty.
         raise CorpusUnavailable("corpus_url is not configured")
+    await _screen_corpus_dial(resolved_url)
     resolved_audience = audience if audience is not None else settings.corpus_audience
 
     # MEHO.Knowledge's ``/search`` reads ``top_k`` for the hit cap and
@@ -308,7 +406,7 @@ async def search_corpus(
     if resolved_audience:
         payload["audience"] = resolved_audience
 
-    headers = {"Authorization": f"Bearer {operator.raw_jwt}"}
+    headers = _corpus_auth_headers(settings)
     timeout = httpx.Timeout(settings.corpus_timeout_seconds)
 
     try:
@@ -316,8 +414,8 @@ async def search_corpus(
             response = await client.post(resolved_url, json=payload, headers=headers)
     except httpx.HTTPError as exc:
         # ConnectError / TimeoutException / any transport failure — the
-        # corpus is unreachable. Log the cause by type (never the JWT or
-        # the query body) and fail closed.
+        # corpus is unreachable. Log the cause by type (never the service
+        # credential or the query body) and fail closed.
         _log.warning("corpus_unreachable", error=type(exc).__name__)
         raise CorpusUnavailable(f"corpus unreachable: {type(exc).__name__}") from exc
 
@@ -397,18 +495,22 @@ async def corpus_status(
     corpus_url: str | None = None,
     audience: str | None = None,
 ) -> CorpusStatusResponse:
-    """Read the external corpus's readiness as *operator* (T6 #1555).
+    """Read the external corpus's readiness (T6 #1555).
 
-    GETs the corpus readiness endpoint (:func:`derive_status_url` of the
-    search URL) with ``Authorization: Bearer <operator.raw_jwt>`` so the
-    corpus authenticates and audits the probe as the operator — the same
-    forward-the-JWT contract as :func:`search_corpus`. Bounded by
+    Screens the corpus URL (``https`` + a public host, allowlist-aware),
+    then GETs the corpus readiness endpoint (:func:`derive_status_url` of
+    the search URL) carrying the deployment-configured corpus service
+    credential (``settings.corpus_service_token``) — the caller's operator
+    JWT is **never** forwarded (#290), the same downstream-credential
+    contract as :func:`search_corpus`. Bounded by
     ``settings.corpus_timeout_seconds``; every fail-closed branch
     collapses to one :class:`CorpusUnavailable` so the probe route never
     persists a partial / stale liveness snapshot.
 
     Args:
-        operator: The verified operator whose JWT is forwarded.
+        operator: The verified operator. Retained for the backend-probe
+            seam and audit context; not used to authenticate to the corpus
+            (the operator JWT is no longer forwarded, #290).
         corpus_url: The corpus *search* endpoint (the readiness URL is
             derived from it). ``None`` falls back to ``settings.corpus_url``
             — the legacy single-collection deploy. The ``corpus-http``
@@ -419,23 +521,24 @@ async def corpus_status(
             empty string forwards none.
 
     Raises:
-        CorpusUnavailable: when *corpus_url* is unset (unconfigured), the
-            corpus is unreachable / times out, returns a non-2xx status,
-            or returns a body that does not match
-            :class:`CorpusStatusResponse`. The upstream status rides on
-            the exception (``status``) for non-2xx; the raw body is never
-            attached.
+        CorpusUnavailable: when *corpus_url* is unset (unconfigured), is
+            not an allowed ``https`` public destination, the corpus is
+            unreachable / times out, returns a non-2xx status, or returns
+            a body that does not match :class:`CorpusStatusResponse`. The
+            upstream status rides on the exception (``status``) for
+            non-2xx; the raw body is never attached.
     """
     settings = get_settings()
     resolved_url = corpus_url if corpus_url is not None else settings.corpus_url
     if not resolved_url:
         # Fail-closed: an unconfigured corpus has no readiness to report.
         raise CorpusUnavailable("corpus_url is not configured")
+    await _screen_corpus_dial(resolved_url)
     status_url = derive_status_url(resolved_url)
     resolved_audience = audience if audience is not None else settings.corpus_audience
 
     params = {"audience": resolved_audience} if resolved_audience else None
-    headers = {"Authorization": f"Bearer {operator.raw_jwt}"}
+    headers = _corpus_auth_headers(settings)
     timeout = httpx.Timeout(settings.corpus_timeout_seconds)
 
     try:

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -83,6 +83,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
 import ssl
 from typing import Any
 
@@ -124,6 +125,30 @@ class SsrfBlockedError(httpx.ConnectError):
     dispatcher plumbing. Explicitly excluded from :func:`_retryable`:
     the rejection is deterministic policy, not a transient network
     failure, so retrying would only re-run the DNS lookup.
+    """
+
+
+class ResponseTooLargeError(Exception):
+    """Dispatch refused: a vendor response body exceeded the byte cap.
+
+    Raised by :func:`_read_capped_json_response` when a vendor response —
+    declared via ``Content-Length`` or measured while streaming — exceeds
+    :data:`_MAX_RESPONSE_BYTES`, *before* the body (or its parsed object
+    graph) is materialised. The shared generic-connector transport
+    otherwise buffers every vendor response fully into memory, so a single
+    oversized body — from a compromised/malicious appliance, a MITM on a
+    ``verify_tls=false`` channel, or a pathologically large legitimate
+    listing — could exhaust the single-replica pod's heap and OOM-kill it
+    (evoila-bosnia/meho-internal#297).
+
+    A plain :class:`Exception` (not an :class:`httpx.HTTPError`): it is a
+    policy rejection, not a transport fault, so it flattens through the
+    dispatcher's generic ``except Exception`` arm into the structured
+    ``connector_error`` shape carrying this message. Being outside the
+    ``httpx.ConnectError`` / ``httpx.HTTPStatusError`` families, it is
+    automatically excluded from :func:`_retryable` (a deterministic
+    over-cap verdict never resolves on replay), with no explicit exclusion
+    needed.
     """
 
 
@@ -304,6 +329,133 @@ def json_payload_or_empty(resp: httpx.Response) -> dict[str, Any]:
     if resp.status_code == httpx.codes.NO_CONTENT or not resp.content:
         return {}
     return resp.json()  # type: ignore[no-any-return]
+
+
+#: Default ceiling on a single vendor response body the shared dispatch
+#: transport will buffer, in bytes (100 MiB). Large enough for any realistic
+#: JSON listing — full vCenter inventory / event pulls are single-digit to
+#: low-tens of MiB, and set-shaped results are reduced to a handle *after*
+#: parse (JSONFlux, dispatcher step 8) — while bounding a multi-GB transfer
+#: from a compromised/malicious appliance, a ``verify_tls=false`` MITM, or a
+#: pathological legitimate listing that would otherwise OOM the
+#: single-replica pod (evoila-bosnia/meho-internal#297). Mirrors the
+#: streamed byte-cap idiom the spec-fetch (``openapi._MAX_SPEC_BYTES``) and
+#: event-ingest (``events_ingest._read_capped_body``) paths already enforce;
+#: this closes the same gap on the outbound-dispatch path.
+_DEFAULT_MAX_RESPONSE_BYTES = 100 * 1024 * 1024
+
+
+def _resolve_max_response_bytes() -> int:
+    """Resolve the response-body cap, honouring an operator env override.
+
+    ``MEHO_CONNECTOR_MAX_RESPONSE_BYTES`` (a positive integer byte count)
+    tunes the cap per deployment — a tighter-memory pod can lower it. An
+    unset, non-integer, or non-positive value falls back to
+    :data:`_DEFAULT_MAX_RESPONSE_BYTES` so a typo never silently disables
+    the guard.
+    """
+    raw = os.environ.get("MEHO_CONNECTOR_MAX_RESPONSE_BYTES")
+    if raw is None:
+        return _DEFAULT_MAX_RESPONSE_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_RESPONSE_BYTES
+    return value if value > 0 else _DEFAULT_MAX_RESPONSE_BYTES
+
+
+#: Resolved once at import; the streaming guard reads the module global by
+#: name at call time, so a test (or a reload after an env change) can rebind
+#: it to a small value without allocating a real over-cap body.
+_MAX_RESPONSE_BYTES = _resolve_max_response_bytes()
+
+
+def _reject_oversize_content_length(resp: httpx.Response) -> None:
+    """Fast-reject a response whose declared ``Content-Length`` exceeds the cap.
+
+    Fires before a single body byte is read, so an honest oversized
+    response costs nothing to refuse. A missing header falls through to the
+    streaming running-total guard (the real backstop against an absent,
+    understated, or content-encoded length); a malformed header is likewise
+    left to that guard rather than trusted.
+    """
+    declared = resp.headers.get("content-length")
+    if declared is None:
+        return
+    try:
+        length = int(declared)
+    except ValueError:
+        return
+    if length > _MAX_RESPONSE_BYTES:
+        raise ResponseTooLargeError(
+            f"vendor response Content-Length {length} exceeds the "
+            f"{_MAX_RESPONSE_BYTES}-byte response-body cap"
+        )
+
+
+async def _read_capped_json_response(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    extensions: dict[str, Any] | None = None,
+    timeout: Any = httpx.USE_CLIENT_DEFAULT,
+) -> httpx.Response:
+    """Issue the request with a streamed, byte-capped read of the response.
+
+    Shared success-path front for :meth:`HttpConnector._request_json` and
+    :meth:`HttpConnector._post_json`. The default non-streaming
+    ``client.request(...)`` buffers the whole vendor body into memory before
+    the caller can inspect its size; this streams instead
+    (:meth:`httpx.AsyncClient.stream` -> the pooled
+    :class:`_SameOriginRedirectClient`'s ``send`` override, so the
+    same-origin redirect and destination-pinning transport behaviour is
+    unchanged) and enforces a two-part cap: a ``Content-Length`` fast-reject
+    up front, then a running byte total across
+    :meth:`~httpx.Response.aiter_bytes` chunks that aborts the moment the
+    body would exceed :data:`_MAX_RESPONSE_BYTES`. At most the cap (plus one
+    trailing chunk) is ever held in memory, and an over-cap body raises
+    :exc:`ResponseTooLargeError` before :func:`json_payload_or_empty` can
+    parse it.
+
+    An under-cap body is joined and re-materialised into a fully-read
+    :class:`httpx.Response` carrying the original status, headers, request,
+    and extensions, so every downstream step — the flight-recorder span,
+    ``raise_for_status``, and ``json_payload_or_empty`` — sees a response
+    byte-identical to the non-streamed path.
+    """
+    async with client.stream(
+        method,
+        path,
+        params=params,
+        json=json,
+        data=data,
+        headers=headers,
+        extensions=extensions,
+        timeout=timeout,
+    ) as resp:
+        _reject_oversize_content_length(resp)
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes():
+            total += len(chunk)
+            if total > _MAX_RESPONSE_BYTES:
+                raise ResponseTooLargeError(
+                    f"vendor response body exceeded the "
+                    f"{_MAX_RESPONSE_BYTES}-byte response-body cap"
+                )
+            chunks.append(chunk)
+        return httpx.Response(
+            status_code=resp.status_code,
+            headers=resp.headers,
+            content=b"".join(chunks),
+            request=resp.request,
+            extensions=resp.extensions,
+        )
 
 
 # Hard cap on the same-origin redirect chain followed by
@@ -766,7 +918,8 @@ class HttpConnector(Connector):
         # span is recorded before ``raise_for_status`` so a vendor 4xx/5xx is
         # captured too.
         _fr_start = flight_recorder_capture.span_start()
-        resp = await client.request(
+        resp = await _read_capped_json_response(
+            client,
             method,
             path,
             params=params,
@@ -873,7 +1026,8 @@ class HttpConnector(Connector):
         # its matching content-type; a hard-excluded (login / token / DELETE)
         # op has its body dropped by the redaction engine's family rules.
         _fr_start = flight_recorder_capture.span_start()
-        resp = await client.request(
+        resp = await _read_capped_json_response(
+            client,
             verb,
             path,
             params=params,

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -34,6 +34,7 @@ from meho_backplane.docs_collections.schemas import (
 from meho_backplane.docs_collections.service import (
     DocCollectionBackendTypeError,
     DocCollectionConflictError,
+    DocCollectionEndpointError,
     DocCollectionGlobalError,
     DocCollectionNotDisabledError,
     create_doc_collection,
@@ -48,6 +49,7 @@ __all__ = [
     "DocCollectionConflictError",
     "DocCollectionCreate",
     "DocCollectionCreateResponse",
+    "DocCollectionEndpointError",
     "DocCollectionGlobalError",
     "DocCollectionNotDisabledError",
     "DocCollectionNotFoundError",

--- a/backend/src/meho_backplane/docs_collections/service.py
+++ b/backend/src/meho_backplane/docs_collections/service.py
@@ -42,6 +42,7 @@ import structlog
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.auth.corpus import corpus_endpoint_host
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.models import DocCollection as DocCollectionORM
 from meho_backplane.docs_collections.lifecycle import (
@@ -53,11 +54,17 @@ from meho_backplane.docs_collections.lifecycle import (
 )
 from meho_backplane.docs_collections.schemas import DocCollectionCreate
 from meho_backplane.docs_search.backends import BackendReadiness, resolve_backend
+from meho_backplane.docs_search.backends.corpus_http import CORPUS_HTTP_BACKEND_TYPE
 from meho_backplane.docs_search.backends.registry import all_backends
+from meho_backplane.targets.ssrf_guard import (
+    TargetDestinationBlockedError,
+    assert_public_destination_async,
+)
 
 __all__ = [
     "DocCollectionBackendTypeError",
     "DocCollectionConflictError",
+    "DocCollectionEndpointError",
     "DocCollectionGlobalError",
     "DocCollectionNotDisabledError",
     "create_doc_collection",
@@ -126,6 +133,62 @@ class DocCollectionConflictError(Exception):
         super().__init__(f"doc collection {collection_key!r} already exists in the {scope} scope")
 
 
+class DocCollectionEndpointError(Exception):
+    """The ``backend.ref`` corpus endpoint is not an allowed destination.
+
+    A ``corpus-http`` collection's ``backend.ref["endpoint"]`` (alias
+    ``url``) is the URL the federation transport later dials with a
+    credential attached. Left unscreened, a ``tenant_admin`` could point it
+    at ``http://``, loopback, RFC 1918 space, or ``169.254.169.254`` (cloud
+    metadata) — a credential-capture + SSRF path
+    (evoila-bosnia/meho-internal#290). The create rejects a non-``https`` or
+    non-public endpoint here so it never persists, mirroring the
+    ``create_target`` SSRF screen. Carries a structured 422 ``detail`` (a
+    stable ``kind`` + a human ``message``); it never echoes any resolved
+    address, so the error is not an internal-DNS oracle.
+    """
+
+    def __init__(self, endpoint: str, reason: str) -> None:
+        self.endpoint = endpoint
+        self.detail: dict[str, object] = {
+            "kind": "endpoint_not_allowed",
+            "endpoint": endpoint,
+            "message": (
+                f"backend.ref endpoint {endpoint!r} is not allowed: {reason}. "
+                f"The corpus endpoint must be an https:// URL that resolves to "
+                f"a public address; an on-prem corpus on private space is opted "
+                f"in via MEHO_TARGET_SSRF_ALLOWLIST."
+            ),
+        }
+        super().__init__(self.detail["message"])
+
+
+async def _screen_backend_endpoint(body: DocCollectionCreate) -> None:
+    """Reject a ``corpus-http`` create whose endpoint is non-public / non-https.
+
+    Extracts the corpus endpoint from ``backend.ref`` (the ``endpoint`` key,
+    alias ``url``) and screens it with the shared target SSRF guard —
+    ``https`` scheme + a public, allowlist-aware host — the same
+    :func:`~meho_backplane.targets.ssrf_guard.assert_public_destination_async`
+    the connector target dial uses. Absent endpoint (the legacy global
+    ``settings.corpus_url`` deploy) is nothing to screen here; that global is
+    deployment-owned and screened at dial time. Only ``corpus-http`` names a
+    dialed URL, so the screen is scoped to that backend type.
+    """
+    if body.backend.type != CORPUS_HTTP_BACKEND_TYPE:
+        return
+    ref = body.backend.ref
+    raw = ref.get("endpoint") or ref.get("url")
+    endpoint = raw.strip() if isinstance(raw, str) else None
+    if not endpoint:
+        return
+    try:
+        host = corpus_endpoint_host(endpoint)
+        await assert_public_destination_async(host)
+    except TargetDestinationBlockedError as exc:
+        raise DocCollectionEndpointError(endpoint, str(exc)) from exc
+
+
 async def create_doc_collection(
     session: AsyncSession,
     operator: Operator,
@@ -164,6 +227,9 @@ async def create_doc_collection(
             the front maps it to 422.
         DocCollectionConflictError: a collection with this ``collection_key``
             already exists in the operator's scope; the front maps it to 409.
+        DocCollectionEndpointError: the ``corpus-http`` ``backend.ref``
+            endpoint is not an ``https`` public destination; the front maps
+            it to 422.
     """
     # Bind the canonical op_id up-front so a persisted audit row is
     # filterable by ``op_id="meho.docs.*"`` even if the insert raises
@@ -184,6 +250,11 @@ async def create_doc_collection(
     valid_types = sorted(all_backends())
     if valid_types and body.backend.type not in valid_types:
         raise DocCollectionBackendTypeError(body.backend.type, valid_types)
+
+    # Screen the corpus endpoint BEFORE the insert so a non-https / non-public
+    # destination is rejected at create (a structured 422), never persisted
+    # and never dialed with a credential (#290).
+    await _screen_backend_endpoint(body)
 
     now = datetime.now(UTC)
     row = DocCollectionORM(

--- a/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
@@ -52,6 +52,7 @@ from meho_backplane.docs_collections import (
     DocCollectionBackendTypeError,
     DocCollectionConflictError,
     DocCollectionCreate,
+    DocCollectionEndpointError,
     create_doc_collection,
     project_doc_collection,
 )
@@ -228,6 +229,8 @@ async def _create_doc_collections_handler(
                 # built off attributes still attached to the live session.
                 created = project_doc_collection(row)
         except DocCollectionBackendTypeError as exc:
+            raise McpInvalidParamsError(str(exc), data=exc.detail) from exc
+        except DocCollectionEndpointError as exc:
             raise McpInvalidParamsError(str(exc), data=exc.detail) from exc
         except DocCollectionConflictError as exc:
             raise McpInvalidParamsError(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1710,8 +1710,20 @@ class Settings(BaseModel):
     #: at the T3 route) rather than returning a silent empty result.
     corpus_url: str = ""
     #: Optional RFC 8707 resource indicator (``aud``) the corpus binds
-    #: the forwarded token to. Empty ("") forwards no audience.
+    #: the downstream token to. Empty ("") forwards no audience.
     corpus_audience: str = ""
+    #: Deployment-configured bearer credential the corpus federation
+    #: client (:func:`~meho_backplane.auth.corpus.search_corpus`) presents
+    #: to the corpus. This is a dedicated, corpus-scoped service credential
+    #: owned by the deployment — NOT the caller's inbound operator JWT.
+    #: Replaying the operator's raw bearer to a tenant-configurable corpus
+    #: URL leaked a Vault-capable credential to an attacker-controlled sink
+    #: (evoila-bosnia/meho-internal#290), so the operator JWT is never
+    #: forwarded. Empty ("") sends no ``Authorization`` header — a corpus
+    #: that requires auth then fails closed (401 → ``CorpusUnavailable`` →
+    #: 503) rather than receiving the operator bearer. ``repr=False`` keeps
+    #: the secret out of ``Settings`` reprs / structured logs.
+    corpus_service_token: str = Field(default="", repr=False)
     #: Bound on the corpus HTTP request (connect / read / write), in
     #: seconds. A slow corpus raises ``CorpusUnavailable`` rather than
     #: blocking the event loop.
@@ -2376,6 +2388,7 @@ def get_settings() -> Settings:
         ),
         corpus_url=os.environ.get("CORPUS_URL", "").strip(),
         corpus_audience=os.environ.get("CORPUS_AUDIENCE", "").strip(),
+        corpus_service_token=os.environ.get("CORPUS_SERVICE_TOKEN", "").strip(),
         corpus_timeout_seconds=float(
             os.environ.get("CORPUS_TIMEOUT_SECONDS", "10.0"),
         ),

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -74,12 +74,16 @@ from cryptography.x509.oid import NameOID
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors._shared.pinned_transport import _PinnedAsyncBackend
 from meho_backplane.connectors.adapters import HttpConnector
+from meho_backplane.connectors.adapters import http as http_adapter
 from meho_backplane.connectors.adapters.http import HttpConnector as _HttpConnectorDirect
 from meho_backplane.connectors.adapters.http import (
+    ResponseTooLargeError,
     SsrfBlockedError,
     _build_ca_pinned_ssl_context,
     _ca_pin_digest,
     _effective_scheme,
+    _resolve_max_response_bytes,
+    _retryable,
     _same_origin,
     _SameOriginRedirectClient,
 )
@@ -609,6 +613,207 @@ async def test_request_json_204_no_content_returns_empty_payload() -> None:
         )
 
     assert result == {}
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Response-body byte cap — reject oversize before buffer+parse
+# (evoila-bosnia/meho-internal#297)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_max_response_bytes_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cap honours a positive env override and fails safe on garbage."""
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "4096")
+    assert _resolve_max_response_bytes() == 4096
+
+    # Non-integer and non-positive values fall back to the default, so a
+    # typo never silently disables the guard.
+    default = http_adapter._DEFAULT_MAX_RESPONSE_BYTES
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "not-a-number")
+    assert _resolve_max_response_bytes() == default
+    monkeypatch.setenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", "0")
+    assert _resolve_max_response_bytes() == default
+    monkeypatch.delenv("MEHO_CONNECTOR_MAX_RESPONSE_BYTES", raising=False)
+    assert _resolve_max_response_bytes() == default
+
+
+def test_oversize_error_is_connector_error_shaped_and_not_retryable() -> None:
+    """The cap error flattens to ``connector_error`` and is never retried.
+
+    It is a plain :class:`Exception` — outside the ``httpx.ConnectError`` /
+    ``httpx.HTTPStatusError`` families the dispatcher special-cases — so it
+    falls through to the generic ``except Exception`` arm that builds the
+    structured ``connector_error`` envelope. Being outside those families
+    also keeps it out of :func:`_retryable`, so a deterministic over-cap
+    verdict does not burn the idempotent-path tenacity budget.
+    """
+    err = ResponseTooLargeError("too big")
+    assert not isinstance(err, (httpx.ConnectError, httpx.HTTPStatusError))
+    assert _retryable(err) is False
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_oversize_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GET body over the cap is rejected before it is ever ``resp.json()``-parsed.
+
+    The body is deliberately **invalid** JSON: if the transport buffered and
+    parsed it (the pre-#297 behaviour), the call would surface a
+    :exc:`json.JSONDecodeError`, not :exc:`ResponseTooLargeError`. Asserting
+    the cap error is raised proves the body was refused before the parse.
+    Here the over-cap size is declared via ``Content-Length``, so the
+    fast-reject arm fires.
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize_invalid_json = b"{ not valid json " + b"x" * 4096
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.get("/api/inventory").respond(
+            200,
+            content=oversize_invalid_json,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError) as exc_info:
+            await conn._request_json(
+                target, "GET", "/api/inventory", operator=_make_operator("tok")
+            )
+
+    assert "cap" in str(exc_info.value)
+    assert "Content-Length" in str(exc_info.value)
+    assert route.called
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_oversize_response_without_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversize body with no ``Content-Length`` is caught by the streamed total.
+
+    An absent (or understated / content-encoded) length header cannot smuggle
+    an oversize body past the guard: the running byte total across
+    ``aiter_bytes`` chunks aborts once the cap is exceeded, before the whole
+    body is buffered.
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize = b'{"items": "' + b"y" * 4096 + b'"}'
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        # A ``ByteStream`` response has no ``Content-Length`` header, so the
+        # fast-reject arm is skipped and the streaming running-total guard is
+        # the one exercised here.
+        mock.get("/api/events").respond(
+            200,
+            stream=httpx.ByteStream(oversize),
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError) as exc_info:
+            await conn._request_json(target, "GET", "/api/events", operator=_make_operator("tok"))
+
+    assert "Content-Length" not in str(exc_info.value)
+    assert "cap" in str(exc_info.value)
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_oversize_response_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The idempotent path does not retry an over-cap rejection — exactly one call.
+
+    The cap verdict is deterministic, so — like the 4xx and SSRF-block arms —
+    it must not consume the tenacity retry budget (which would re-transfer the
+    oversize body three more times).
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.get("/api/inventory").respond(
+            200,
+            content=b"x" * 4096,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError):
+            await conn._request_json(
+                target, "GET", "/api/inventory", operator=_make_operator("tok")
+            )
+
+    assert route.call_count == 1
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_under_cap_returns_parsed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An under-cap JSON response parses to its payload unchanged (regression guard)."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.get("/api/items").respond(200, json={"items": [1, 2, 3]})
+        result = await conn._request_json(
+            target, "GET", "/api/items", operator=_make_operator("tok")
+        )
+
+    assert result == {"items": [1, 2, 3]}
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_rejects_oversize_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-idempotent path enforces the same cap as ``_request_json``."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    oversize_invalid_json = b"{ not valid json " + b"z" * 4096
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.post("/api/sessions").respond(
+            200,
+            content=oversize_invalid_json,
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(ResponseTooLargeError):
+            await conn._post_json(
+                target,
+                "/api/sessions",
+                operator=_make_operator("tok"),
+                json={"provider": "Local"},
+            )
+
+    assert route.called
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_under_cap_returns_parsed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An under-cap non-idempotent response parses unchanged (regression guard)."""
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.post("/api/widget").respond(200, json={"value": "vm-42"})
+        result = await conn._post_json(
+            target, "/api/widget", operator=_make_operator("tok"), json={"n": 1}
+        )
+
+    assert result == {"value": "vm-42"}
     await conn.aclose()
 
 

--- a/backend/tests/test_corpus_client.py
+++ b/backend/tests/test_corpus_client.py
@@ -35,6 +35,10 @@ from meho_backplane.settings import Settings, get_settings
 
 _CORPUS_URL = "https://corpus.test/search"
 _JWT = "header.payload.signature-secret"
+#: The deployment-configured corpus service credential (#290) — the bearer
+#: the transport presents to the corpus, distinct from the operator JWT
+#: (which is never forwarded).
+_SERVICE_TOKEN = "corpus-service-token-distinct-from-jwt"
 
 
 def _make_operator(jwt: str = _JWT) -> Operator:
@@ -111,9 +115,11 @@ def _patch_async_client(
 
 
 @pytest.mark.asyncio
-async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The client POSTs to corpus_url with Authorization: Bearer <raw_jwt>."""
-    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+async def test_forwards_configured_service_token_and_posts_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client POSTs with the configured corpus service token, not the JWT (#290)."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_service_token=_SERVICE_TOKEN)
     captured: list[httpx.Request] = []
     # MEHO.Knowledge's actual /search wire shape (#1732): a ``results``
     # envelope of chunks whose text/source-link fields are ``text`` /
@@ -153,7 +159,10 @@ async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPat
     sent = captured[0]
     assert sent.method == "POST"
     assert str(sent.url) == _CORPUS_URL
-    assert sent.headers["Authorization"] == f"Bearer {_JWT}"
+    # The deployment-configured service token is the bearer — never the
+    # caller's operator JWT (#290).
+    assert sent.headers["Authorization"] == f"Bearer {_SERVICE_TOKEN}"
+    assert _JWT not in sent.headers.get("Authorization", "")
     import json
 
     body = json.loads(sent.content.decode())
@@ -161,6 +170,69 @@ async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPat
     # The corpus reads ``top_k``, not ``limit`` (#1732).
     assert body["top_k"] == 5
     assert "limit" not in body
+
+
+@pytest.mark.asyncio
+async def test_operator_jwt_is_never_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller's raw operator JWT never rides the corpus request (#290).
+
+    The credential-capture leg: replaying ``operator.raw_jwt`` to a
+    tenant-configurable corpus URL leaked a Vault-capable bearer. The
+    transport must present only the deployment-configured service token.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_service_token=_SERVICE_TOKEN)
+    captured: list[httpx.Request] = []
+    transport = _transport_capturing(captured, httpx.Response(200, json={"chunks": []}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    secret_jwt = "eyJ.super-secret-vault-capable.bearer"
+    await search_corpus(_make_operator(jwt=secret_jwt), "q")
+
+    # The operator JWT appears nowhere in the outbound request — not the
+    # Authorization header, not any other header.
+    assert secret_jwt not in repr(dict(captured[0].headers))
+    assert captured[0].headers["Authorization"] == f"Bearer {_SERVICE_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_no_service_token_sends_no_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset service token sends no Authorization header (never the JWT, #290)."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_service_token="")
+    captured: list[httpx.Request] = []
+    transport = _transport_capturing(captured, httpx.Response(200, json={"chunks": []}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    await search_corpus(_make_operator(), "q")
+
+    assert "Authorization" not in captured[0].headers
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://corpus.test/search",  # plaintext scheme
+        "https://127.0.0.1/search",  # loopback
+        "https://169.254.169.254/search",  # cloud metadata
+        "https://[::1]/search",  # IPv6 loopback
+    ],
+)
+@pytest.mark.asyncio
+async def test_search_screens_endpoint_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, bad_url: str
+) -> None:
+    """A non-https / non-public corpus endpoint fails closed before any dial (#290).
+
+    No transport is patched: the destination screen must reject the URL
+    before the client is built, so a bug that skips the screen would try a
+    real dial (and, for the IP literals, reach loopback / metadata). The
+    error message is the screen's, distinguishing it from a connect error.
+    """
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    _pin_settings(monkeypatch, corpus_url=bad_url)
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await search_corpus(_make_operator(), "q")
+    assert "not an allowed https public destination" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -569,8 +641,10 @@ async def test_unrecognized_envelope_fails_loud_not_zero(
 
 
 @pytest.mark.asyncio
-async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The forwarded operator JWT must not appear in any structlog event.
+async def test_operator_jwt_and_service_token_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither the operator JWT nor the corpus service token appears in logs (#290).
 
     Capture surface (#1254 pattern, see ``docs/codebase/backend.md``): we
     bind a private :class:`structlog.testing.LogCapture` onto a
@@ -586,7 +660,7 @@ async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> No
     process-local and contextvar-free, so it is immune to any concurrent
     ``configure`` regardless of xdist scheduling.
     """
-    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_service_token=_SERVICE_TOKEN)
     transport = _transport_capturing([], httpx.Response(503, text="down"))
     _patch_async_client(monkeypatch, transport, [])
 
@@ -618,8 +692,9 @@ async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> No
     logs = capture.entries
     serialised = repr(logs)
     assert _JWT not in serialised
+    assert _SERVICE_TOKEN not in serialised
     # The failure is still observable by status — this canary fails loudly
-    # if the capture ever misses, so the JWT-absence check above cannot
+    # if the capture ever misses, so the secret-absence checks above cannot
     # pass vacuously against an empty list.
     assert any(event.get("status") == 503 for event in logs)
 
@@ -649,8 +724,8 @@ def test_derive_status_url(search_url: str, expected: str) -> None:
 async def test_corpus_status_gets_status_url_with_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """corpus_status GETs the derived /readyz URL forwarding the operator JWT."""
-    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    """corpus_status GETs the derived /readyz URL with the service token (#290)."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_service_token=_SERVICE_TOKEN)
     captured: list[httpx.Request] = []
     response = httpx.Response(
         200,
@@ -671,7 +746,9 @@ async def test_corpus_status_gets_status_url_with_bearer(
     assert len(captured) == 1
     assert captured[0].method == "GET"
     assert str(captured[0].url) == derive_status_url(_CORPUS_URL)
-    assert captured[0].headers["Authorization"] == f"Bearer {_JWT}"
+    # The configured service token, not the operator JWT (#290).
+    assert captured[0].headers["Authorization"] == f"Bearer {_SERVICE_TOKEN}"
+    assert _JWT not in captured[0].headers.get("Authorization", "")
 
 
 @pytest.mark.asyncio
@@ -714,6 +791,19 @@ async def test_corpus_status_unconfigured_raises(monkeypatch: pytest.MonkeyPatch
     _pin_settings(monkeypatch, corpus_url="")
     with pytest.raises(CorpusUnavailable):
         await corpus_status(_make_operator())
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_screens_endpoint_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The readiness dial screens the endpoint the same way search does (#290)."""
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    _pin_settings(monkeypatch, corpus_url="https://169.254.169.254/v1/search")
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await corpus_status(_make_operator())
+    assert "not an allowed https public destination" in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_doc_collections_create.py
+++ b/backend/tests/test_doc_collections_create.py
@@ -236,6 +236,78 @@ def test_unknown_backend_type_is_422_listing_registered_types(client: TestClient
 
 
 # ---------------------------------------------------------------------------
+# SSRF: a non-https / non-public corpus endpoint → 422 (never persisted, #290)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_endpoint",
+    [
+        "http://corpus.internal/v1/search",  # plaintext scheme
+        "https://127.0.0.1/v1/search",  # loopback
+        "https://169.254.169.254/latest/meta-data",  # cloud metadata
+        "https://10.0.0.5/v1/search",  # RFC 1918
+    ],
+)
+def test_non_public_corpus_endpoint_is_rejected_at_create(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, bad_endpoint: str
+) -> None:
+    """A tenant_admin cannot register a collection pointing at an internal / http host.
+
+    The credential-capture + SSRF path (#290): the ``backend.ref`` endpoint
+    is later dialed with a credential, so a non-https or private/link-local/
+    metadata destination is refused at create — a structured 422 — and the
+    row is never persisted.
+    """
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    key = make_rsa_keypair("kid-A")
+    body = _valid_body(backend={"type": "corpus-http", "ref": {"endpoint": bad_endpoint}})
+    resp = _post(client, key, _admin_token(key), body)
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["kind"] == "endpoint_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_rejected_endpoint_persists_no_row(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A create rejected on its endpoint writes no ``doc_collections`` row (#290)."""
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    key = make_rsa_keypair("kid-A")
+    body = _valid_body(
+        collection_key="ssrf-probe",
+        backend={"type": "corpus-http", "ref": {"endpoint": "https://169.254.169.254/x"}},
+    )
+    resp = _post(client, key, _admin_token(key), body)
+    assert resp.status_code == 422, resp.text
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(DocCollectionORM).where(DocCollectionORM.collection_key == "ssrf-probe")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+def test_url_alias_endpoint_is_also_screened(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ``url`` alias for the endpoint is screened, not just ``endpoint`` (#290)."""
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    key = make_rsa_keypair("kid-A")
+    body = _valid_body(backend={"type": "corpus-http", "ref": {"url": "https://127.0.0.1/s"}})
+    resp = _post(client, key, _admin_token(key), body)
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["kind"] == "endpoint_not_allowed"
+
+
+# ---------------------------------------------------------------------------
 # Conflict: duplicate key in the same scope → 409 (not an opaque 500)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_docs_backends_router.py
+++ b/backend/tests/test_docs_backends_router.py
@@ -59,6 +59,9 @@ from meho_backplane.settings import Settings, get_settings
 
 _JWT = "header.payload.signature-secret"
 _CORPUS_URL = "https://corpus.test/search"
+#: Deployment-configured corpus service credential (#290) — the bearer the
+#: adapter presents, never the caller's operator JWT.
+_SERVICE_TOKEN = "corpus-service-token-distinct-from-jwt"
 
 
 def _make_operator(jwt: str = _JWT) -> Operator:
@@ -295,12 +298,17 @@ def test_blank_backend_type_is_unroutable() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_adapter_forwards_jwt_and_uses_backend_ref_endpoint(
+async def test_adapter_uses_service_token_and_backend_ref_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC2: the adapter forwards the JWT and POSTs to the ref's endpoint."""
+    """AC2: the adapter presents the configured service token (never the JWT, #290)
+    and POSTs to the ref's endpoint."""
     # Legacy global is a different URL; the ref must win.
-    _pin_settings(monkeypatch, corpus_url="https://legacy.test/search")
+    _pin_settings(
+        monkeypatch,
+        corpus_url="https://legacy.test/search",
+        corpus_service_token=_SERVICE_TOKEN,
+    )
     captured: list[httpx.Request] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
@@ -320,7 +328,9 @@ async def test_adapter_forwards_jwt_and_uses_backend_ref_endpoint(
 
     sent = captured[0]
     assert str(sent.url) == _CORPUS_URL  # ref endpoint, not the legacy global
-    assert sent.headers["Authorization"] == f"Bearer {_JWT}"
+    # The deployment-configured service token is the bearer, not the JWT (#290).
+    assert sent.headers["Authorization"] == f"Bearer {_SERVICE_TOKEN}"
+    assert _JWT not in sent.headers.get("Authorization", "")
     import json
 
     body = json.loads(sent.content.decode())

--- a/backend/tests/test_mcp_tools_doc_collections_create.py
+++ b/backend/tests/test_mcp_tools_doc_collections_create.py
@@ -271,6 +271,26 @@ def test_unknown_backend_type_is_invalid_params(
     [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
     indirect=True,
 )
+def test_non_public_endpoint_is_invalid_params(
+    admin_client: tuple[TestClient, Operator],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-https / non-public corpus endpoint → INVALID_PARAMS (MCP analogue of 422, #290)."""
+    monkeypatch.delenv("MEHO_TARGET_SSRF_ALLOWLIST", raising=False)
+    client, _op = admin_client
+    body = _call_create(
+        client,
+        _valid_args(backend={"type": "corpus-http", "ref": {"endpoint": "https://127.0.0.1/s"}}),
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert body["error"]["data"]["kind"] == "endpoint_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
 def test_duplicate_key_is_invalid_params(
     admin_client: tuple[TestClient, Operator],
     seeded_operator_tenant: None,  # noqa: F811

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -359,6 +359,18 @@ The service primitive
   a structured `422` whose detail enumerates the registered types (the
   `create_target` unknown-product shape). This moves the failure forward
   from a deferred probe/search-time `503` to create time.
+- **`backend.ref` corpus endpoint SSRF-screened (#290)** — for a
+  `corpus-http` collection the `backend.ref["endpoint"]` (alias `url`) is
+  the URL later dialed with a credential, so it is screened at create:
+  `https` scheme + a public, allowlist-aware host, via the shared target
+  SSRF guard (`assert_public_destination_async` — the same
+  `MEHO_TARGET_SSRF_ALLOWLIST`-aware guard the connector target dial uses).
+  A non-`https` or private/link-local/metadata endpoint raises
+  `DocCollectionEndpointError` → `422` (`kind="endpoint_not_allowed"`) and
+  is never persisted, closing a credential-capture + SSRF path a
+  `tenant_admin` could otherwise open. Absent endpoint (the legacy global
+  `settings.corpus_url` deploy) is nothing to screen here; that global is
+  deployment-owned and screened again at dial time.
 - **Server-derived fields** — `id` / `created_at` / `updated_at` are
   generated; `status` defaults to `provisioning` (a follow-up `probe`
   promotes it); the probe-written liveness stays `NULL`.
@@ -376,7 +388,8 @@ Three fronts forward to the same primitive:
   (`DocCollectionCreateResponse`, #1756; see
   [The `create → probe → ready` flow](#the-create--probe--ready-flow-1756)),
   `tenant_admin`-gated (parity with the lifecycle routes). The route maps
-  the two service exceptions to `422` / `409`.
+  the service exceptions to `422` (unknown backend type / rejected
+  endpoint) / `409` (conflict).
 - **MCP** — the `create_doc_collections` write-class tool
   (`meho_backplane.mcp.tools.doc_collections_create`), `tenant_admin` +
   `required_capability="meho-docs"`. The exceptions map to JSON-RPC

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -7,8 +7,9 @@
 `search_knowledge` — which read MEHO's own Postgres+pgvector substrate
 (see [retrieval.md](retrieval.md)) — `search_docs` does **not** ingest
 the vendor corpus. It proxies each query through the backplane to the
-**external** corpus service the ops team runs, forwarding the operator's
-JWT so the corpus authenticates and audits the call as the operator.
+**external** corpus service the ops team runs, presenting a
+deployment-configured corpus service credential (never the caller's
+operator JWT — see the SSRF + credential note below, #290).
 
 Routing through the backplane (rather than letting clients hit the
 corpus directly) is what buys three properties in one place:
@@ -16,8 +17,9 @@ corpus directly) is what buys three properties in one place:
 - **Central audit.** Every query lands one `audit_log` row under the
   named op `meho.docs.search`, so `query_audit` / who-touched surface
   it (the raw query is hashed, never stored).
-- **JWT federation handled once.** The operator JWT forwarding lives in
-  the T2 client, not in every consumer.
+- **Downstream federation handled once.** The screened-`https` dial and
+  the corpus service credential live in the T2 client, not in every
+  consumer.
 - **Mandatory collection scope + per-collection entitlement enforced
   centrally.** A docs query without a `collection` is rejected —
   fail-closed — and a tenant may only search collections it holds the
@@ -63,9 +65,11 @@ every face (no `collections` fan-out field).
 
 ### `search_corpus(...)` (`meho_backplane.auth.corpus`, T2 #1520)
 
-The transport. An async `httpx` client that POSTs a search request to a
-corpus URL carrying `Authorization: Bearer <operator.raw_jwt>`, bounded
-by `settings.corpus_timeout_seconds`. The URL and RFC 8707 audience are
+The transport. An async `httpx` client that screens the corpus URL
+(`https` + a public, allowlist-aware host) and then POSTs a search
+request to it carrying the deployment-configured corpus service
+credential (`settings.corpus_service_token`), bounded by
+`settings.corpus_timeout_seconds`. The URL and RFC 8707 audience are
 optional overrides (`corpus_url=` / `audience=`); `None` falls back to
 the global `settings.corpus_url` / `settings.corpus_audience` — the
 seam the `corpus-http` backend uses to pass a per-collection endpoint
@@ -91,6 +95,27 @@ non-2xx, or malformed-response corpus all collapse to one typed
 `CorpusUnavailable`. The exception carries the upstream HTTP status (when
 the failure was a non-2xx response) but **never** the response body — a
 corpus error page cannot leak through.
+
+**Destination screen + downstream credential (#290).** The corpus URL is
+read from a *tenant-configurable* `backend.ref`, so two controls stop a
+`tenant_admin` from turning it into a credential-capture + SSRF sink:
+
+- Every dial (search **and** the `corpus_status` readiness probe) requires
+  the `https` scheme and screens the resolved host through the shared
+  target SSRF guard (`assert_public_destination_async`, the same guard the
+  connector target dial uses), so a corpus endpoint cannot be pointed at
+  `http://`, loopback, RFC 1918 space, or `169.254.169.254`. An on-prem
+  corpus on private space is opted in via `MEHO_TARGET_SSRF_ALLOWLIST`. The
+  same endpoint is also screened at collection **create** time
+  (`docs_collections.service`) so a bad endpoint is a 422, never persisted.
+- The bearer presented to the corpus is `settings.corpus_service_token` —
+  a deployment-owned, corpus-scoped service credential, **not** the
+  caller's inbound operator JWT. Replaying the operator's Vault-capable
+  bearer to the tenant-configurable URL was the capture vector; the JWT is
+  no longer forwarded. An empty token sends no `Authorization` header (a
+  corpus requiring auth then fails closed). Tradeoff: the corpus's own
+  audit attributes the call to the service principal, not the operator;
+  MEHO's central `audit_log` is unaffected.
 
 ### Backend-agnostic search router (`meho_backplane.docs_search.backends`, T2 #1551)
 


### PR DESCRIPTION
## Summary

Closes a credential-capture + SSRF path in the `meho-docs` add-on (security review S02). The corpus URL was read verbatim from a **tenant-configurable** `backend.ref["endpoint"]` and POSTed to carrying the caller's own operator bearer, with no scheme/host/allowlist/SSRF screen. A `tenant_admin` could point a collection's corpus endpoint at an internal host (`127.0.0.1`, RFC 1918, `169.254.169.254`) and capture the operator's Vault-capable JWT.

Two controls, one focused change:

- **Screen the corpus endpoint** — `https` scheme + a public, allowlist-aware host via the shared target SSRF guard (`assert_public_destination_async`, the same guard the connector target dial uses per #275) — at collection **create** (`docs_collections.service`) **and** at every corpus **dial** (`auth.corpus.search_corpus` + `corpus_status`). A non-`https`/private/link-local/metadata endpoint is a structured **422** at create (never persisted) and a fail-closed `CorpusUnavailable` at dial. On-prem corpora on private space are opted in via `MEHO_TARGET_SSRF_ALLOWLIST`.
- **Stop replaying the operator JWT.** The bearer presented to the corpus is now a deployment-configured, corpus-scoped service credential (`settings.corpus_service_token`, env `CORPUS_SERVICE_TOKEN`). The raw operator JWT is never forwarded; an empty token sends no `Authorization` header (fail closed). Tradeoff: the corpus's own audit now attributes to the service principal, not the operator — MEHO's central `audit_log` is unaffected.

## Relationship to work already on main

- **#275 (F13, PR #3437)** — landed the pinned SSRF transport + `screen_and_resolve`/`assert_public_destination(_async)` guard on `main`. This PR **reuses that guard** for the docs-corpus path rather than adding a second SSRF check (per the orchestrator constraint). None of this task's acceptance criteria were already satisfied on main: the guard primitive existed, but the docs-corpus path called it **nowhere** and carried the raw-JWT prong #275 does not.
- **#297 (PR #3459, response-byte-cap)** — merged into this branch at branch time (`git merge origin/fix/297-connector-response-byte-cap`) so this PR carries its `connectors/adapters/http.py` hunk and cannot conflict; base stays `main`. Unrelated to these acceptance criteria.

## Test plan

- [x] `ruff check` / `ruff format --check` (whole `src/` + `tests/`) — clean
- [x] `mypy src/meho_backplane/` — clean on all changed modules (one pre-existing macOS-only false positive in the untouched `connectors/net/icmp.py`, `socket.MSG_ERRQUEUE` is Linux-only)
- [x] **AC1** `grep -n assert_public_destination …/docs_collections/service.py …/auth/corpus.py` → hits in both
- [x] **AC2** non-`https` / `127.0.0.1` / `169.254.169.254` / RFC 1918 endpoints rejected at create — new negative tests in `test_doc_collections_create.py` (+ MCP parity in `test_mcp_tools_doc_collections_create.py`)
- [x] **AC3** `grep -n operator.raw_jwt …/auth/corpus.py` → empty; the configured downstream credential is asserted in `test_corpus_client.py` (and the JWT is proven never-forwarded)
- [x] **AC4** `pytest tests/test_targets_ssrf_guard.py` — unchanged, passes
- [x] **AC5** `pytest tests/test_corpus_client.py tests/test_doc_collections_create.py` — passes
- [x] Issue verification set (`test_targets_ssrf_guard`, `test_corpus_client`, `test_doc_collections_create`, `test_mcp_tools_doc_collections_create`) — 129 passed
- [x] Full backend unit lane (`pytest -n auto`) — 15534 passed; the 7 environment-only failures are all in modules this PR does not touch (raw-ICMP traceroute, DNS nameserver query, live mssql/mongodb drivers, DBOS async ingest, helm-chart env, a timing-sensitive topology perf test); 4 pass serially (xdist contention) and none import the changed modules.

## Out of scope

- Broader redesign of the `meho-docs:<key>` entitlement model / endpoint-shadowing beyond the endpoint screen (per the issue).
- The connector target-dial SSRF TOCTOU (#275, already on main).
- Rotation/revocation of any already-forwarded operator tokens (incident response, not a code change).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#290
