### PR TITLE
docs(deploy): state the 2026-09-06 hardening baseline across install guidelines

### DIFF
--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -82,6 +82,32 @@ request.
     kubectl -n meho logs deploy/meho --tail=50
     ```
 
+### Security baseline these values carry
+
+`values-rdc-example.yaml` ships the hardened posture as its default; the
+inline comments mark each control. When you copy it, keep these at their
+secure state (each is stated once, in full, on the published docs site's
+[deployment-shapes baseline table](https://evoila.github.io/meho/latest/deployment-shapes/#the-hardening-baseline-every-production-shape-inherits)):
+
+- **`networkPolicy.enabled: true`** — default-deny network isolation is
+  the baseline for any multi-tenant / production install; `false` is a
+  first-install-only convenience and a documented downgrade.
+- **`config.forwardedAllowIps` narrowed to the ingress controller's
+  source** (a `/32`), not the whole pod CIDR — over-wide trust lets any
+  in-cluster workload forge the client address.
+- **`VAULT_KV_TENANT_SCOPE_PREFIX` left at its default**
+  (`secret/tenants/{tenant_id}/`) — the per-tenant credential guard is on
+  by default; emptying it is a documented downgrade for single-tenant /
+  mid-migration only.
+- **`config.approvalAllowSelfApproval` left at `"false"`** — four-eyes
+  enforced; `"true"` is an audited emergency break-glass only.
+- **Deploy by digest + verify signature** — pin `image.digest`
+  (`sha256:…`) and `cosign verify` it before rollout, beyond the immutable
+  `image.tag`.
+- **Realm mappers** — on a shared public client derive `tenant_role` from
+  group membership; never hardcode a privileged `tenant_role` (see the
+  auth-onramp section below).
+
 ## ESO sync patterns
 
 The MEHO chart references operator-provisioned Kubernetes Secrets *by
@@ -818,6 +844,19 @@ tenant/role on the user (group attribute, custom user-attribute,
 identity-provider mapping) can swap these for `oidc-usermodel-*`
 mappers — keep the **claim names** identical (`tenant_id`,
 `tenant_role`) because that's what the backplane validates against.
+
+> **Security baseline — no hardcoded privileged `tenant_role` on a
+> shared client.** A hardcoded-claim mapper is safe only on a
+> **single-identity** client (the dogfood lab, where one operator
+> authenticates). On any **shared, multi-user** public client, do **not**
+> hardcode a privileged `tenant_role` such as `tenant_admin`: every user
+> who can authenticate through that client would inherit it, and the
+> backplane correctly trusts the signed claim. Derive `tenant_role` from
+> controlled **group or user membership** (`oidc-usermodel-*` /
+> group-membership mappers), fail closed when no assignment exists, and
+> restrict which realm users may use the client. Keep service-account
+> claim issuance on separate confidential clients. Cryptographically valid
+> JWTs do not correct an over-privileged identity-provider mapper.
 
 Validator-side errors at the decode stage are made specific by
 [#797](https://github.com/evoila/meho/issues/797) (G0.9.1-T12) and

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -35,6 +35,16 @@ image:
   # install.sh injects this via `--set image.tag=...` so the example file
   # leaves it as the schema's reject-empty trigger.
   tag: "<REPLACE: sha-<40-char-git-sha> or v0.1.0>"
+  # SECURITY BASELINE (deploy by digest + verify signature). Beyond the
+  # immutable tag, the production baseline is to pin `digest` to the exact
+  # content-addressed, scanned + cosign-signed digest the image pipeline
+  # promoted — a digest can never be re-pointed the way a tag can. When set
+  # the Deployment (and the byte-identical migration Job) render
+  # `repository@digest`; `tag` stays as the human-readable label. Verify it
+  # with `cosign verify ghcr.io/evoila/meho@<digest>` against the keyless
+  # workflow identity before rollout (ideally enforced at admission). See
+  # docs-site install/index.md § Step 7 and the repo README verify recipes.
+  # digest: "sha256:<64-hex from the release>"
   pullPolicy: IfNotPresent
 
 # RDC GHCR pulls are anonymous (public package). No pullSecret needed.
@@ -135,12 +145,18 @@ config:
   databasePoolTimeout: "30.0"
   # Reverse-proxy trust list (Issue #730, RDC Signal #3). uvicorn's
   # default `127.0.0.1` fails-closed in-cluster — the Ingress
-  # controller's pod IP is never the loopback. The rke2-infra RDC
-  # cluster runs the default pod CIDR; pin to the ingress controller's
-  # pod-CIDR slice if you've subnetted it tighter. See
-  # `docs/cross-repo/reverse-proxy-contract.md` for the per-cluster
-  # recommended values and the diagnostic walk.
-  forwardedAllowIps: "10.42.0.0/16"
+  # controller's pod IP is never the loopback.
+  # SECURITY BASELINE (narrow forwarded-header trust). Trust `X-Forwarded-*`
+  # ONLY from the ingress controller's own source address — a `/32` or the
+  # tightest slice you have subnetted the controller onto — NOT the whole
+  # pod CIDR. The wide `10.42.0.0/16` below is the lab convenience value; on
+  # a shared or multi-tenant cluster it lets any in-cluster workload forge
+  # the client address, so narrow it. Recover the controller address with
+  #   kubectl get endpoints <ingress-controller> -n <ns> \
+  #     -o jsonpath='{.subsets[].addresses[].ip}'
+  # See `docs/cross-repo/reverse-proxy-contract.md` for per-cluster values
+  # and docs-site install/tls-ingress.md § Reverse-proxy trust.
+  forwardedAllowIps: "10.42.0.0/16"   # REPLACE: narrow to the controller /32
   # Target-destination SSRF allowlist (v0.20.0, PR #2191). The default-
   # deny guard refuses to register or dial a target on non-public space,
   # but the RDC lab registers on-prem appliances on RFC 1918 ranges as a
@@ -150,6 +166,14 @@ config:
   # Leave `""` on a chassis-only lab that dials no private-range targets.
   # See `docs/codebase/target-ssrf-guard.md`.
   targetSsrfAllowlist: "10.0.0.0/8,192.168.0.0/16"
+  # SECURITY BASELINE (self-approval off). `approvalAllowSelfApproval`
+  # defaults to "false" (four-eyes enforced: the requester of a gated write
+  # may not approve it). This example leaves the secure default in place by
+  # not setting it. Set "true" ONLY as an audited, posture-wide emergency
+  # break-glass — it never reaches a dangerous/destructive op, and the
+  # endorsed single-operator answer is the agent-requester pattern instead.
+  # See docs-site guides/approvals-and-break-glass.md.
+  # approvalAllowSelfApproval: "false"
 
 postgres:
   # Cluster-internal Postgres on rke2-infra (per Goal #11 cross-repo deps).
@@ -238,6 +262,13 @@ connectors:
   enabled: []
 
 networkPolicy:
+  # SECURITY BASELINE (default-deny network isolation ON). `enabled: true`
+  # is the baseline for any multi-tenant or production install — it renders
+  # a default-deny ingress+egress policy and makes the schema REQUIRE the
+  # three egress CIDRs below (it refuses to ship a wide subnet by accident).
+  # `enabled: false` is a first-install-only convenience and a documented
+  # downgrade past bring-up. The broadcast subchart renders its own ingress
+  # NetworkPolicy + Valkey auth alongside.
   enabled: true
   # rke2-infra labels the controller namespace `ingress-nginx`.
   ingressControllerNamespace: ingress-nginx
@@ -318,6 +349,17 @@ extraVolumeMounts:
     readOnly: true
 
 extraEnv:
+  # SECURITY BASELINE (Vault per-tenant credential scope ON). The backend
+  # setting VAULT_KV_TENANT_SCOPE_PREFIX defaults to
+  # `secret/tenants/{tenant_id}/` — the cross-tenant credential guard is on
+  # out of the box, so this example does NOT override it (the secure default
+  # carries). Setting `VAULT_KV_TENANT_SCOPE_PREFIX=""` here would turn the
+  # guard OFF and is a DOCUMENTED DOWNGRADE — valid only mid-migration (while
+  # a tenant's secrets are relocated under the prefix) or on a genuinely
+  # single-tenant install. Never empty it on a multi-tenant deploy.
+  # See docs-site install/credential-backends.md.
+  # - name: VAULT_KV_TENANT_SCOPE_PREFIX
+  #   value: "secret/tenants/{tenant_id}/"   # default; shown for reference only
   - name: SSL_CERT_FILE
     # Python's `ssl` module honours `SSL_CERT_FILE` as a CA bundle
     # path (see CPython `ssl.get_default_verify_paths()`). This routes

--- a/docs-site/deployment-shapes.md
+++ b/docs-site/deployment-shapes.md
@@ -93,6 +93,31 @@ instead, row by row in the cold-start checklist.
 — the MCP-audience row for the example, the rest of the table for what
 surfaces later.)
 
+### The hardening baseline every production shape inherits
+
+The chart ships secure defaults, but a handful of controls decide
+whether a deployment is a real boundary between mutually-untrusted
+tenants or only a convenience. State the baseline once, here, so every
+shape below inherits it; the per-shape sections call out only where a
+control is load-bearing or where the setting differs.
+
+| Control | Baseline (secure default or must-set) | Where it lives |
+|---|---|---|
+| **Network isolation** | `networkPolicy.enabled: true` (default-deny ingress + egress) is the baseline for any multi-tenant or production install. Enabling it makes the schema *require* the three egress CIDRs, so it refuses to ship a wide subnet by accident. Staging it off is a first-install convenience only, and a documented downgrade for anything past bring-up. | [`install/index.md` § Step 6](install/index.md#step-6-write-your-values-file) `networkPolicy` block |
+| **Tenant credential scope** | `VAULT_KV_TENANT_SCOPE_PREFIX` defaults to `secret/tenants/{tenant_id}/` — on by default, so one tenant can never read another's Vault credentials. Keep it set on any multi-tenant deploy; emptying it (`VAULT_KV_TENANT_SCOPE_PREFIX=""`) removes the cross-tenant guard and is a documented downgrade, valid only mid-migration or on a genuinely single-tenant install. | [`install/credential-backends.md`](install/credential-backends.md#vault) |
+| **Reverse-proxy trust** | `config.forwardedAllowIps` names *only* the reverse proxy / ingress controller the backplane should trust `X-Forwarded-*` from — narrow it to the controller's source address, not the whole pod CIDR. Over-wide trust lets any in-cluster workload forge the client address. | [`install/tls-ingress.md` § Reverse-proxy trust](install/tls-ingress.md#reverse-proxy-trust-forwardedallowips) |
+| **Self-approval** | `config.approvalAllowSelfApproval` defaults to `"false"` — four-eyes is enforced and the requester of a gated write may not approve it. Leave it off; `"true"` is an audited emergency break-glass that never reaches a `dangerous`/`destructive` operation. | [`guides/approvals-and-break-glass.md`](guides/approvals-and-break-glass.md) |
+| **Realm claim mappers** | On a shared, multi-user public client, derive `tenant_role` from group or user membership — never install a hardcoded privileged `tenant_role` (e.g. `tenant_admin`) mapper that every user authenticating through that client inherits. A hardcoded claim is acceptable only on a single-identity lab client. | [`install/keycloak-realm.md`](install/keycloak-realm.md) |
+| **Outbound peer authentication** | No verification-disabled defaults on credential-bearing outbound paths. The SSH connector verifies the target host key fail-closed (an unpinned target is refused until its `known_hosts` line is provisioned on the secret); SMTP validates its TLS peer; bootstrap scripts trust a real CA rather than `curl -k`. Per-target opt-outs (`known_hosts_insecure`, `verify_tls: false`) are loud, audited, and never the default. | [`install/tls-ingress.md` § Outbound peer authentication](install/tls-ingress.md#outbound-peer-authentication-for-credential-bearing-connections) |
+| **CI / fork-PR isolation** | Untrusted pull-request code runs on disposable GitHub-hosted runners, never the internal `meho-runners-ci` pool, and the repository's fork-PR approval policy is `all_external_contributors` (a maintainer must approve any external fork run). Signing and deployment identities are separated from PR-triggered jobs. | [`docs/RELEASING.md` § Supply-chain and CI baseline](https://github.com/evoila/meho/blob/main/docs/RELEASING.md) |
+| **Deploy by digest + verify signature** | Pin `image.digest` (`sha256:…`) so the Deployment renders the exact content-addressed, scanned, cosign-signed digest the pipeline promoted, and `cosign verify` it (against the keyless workflow identity) before `helm upgrade` — ideally enforced at admission. The pipeline's quarantine → scan → promote ordering guarantees a promoted digest was scanned first. | [`install/index.md` § Step 7](install/index.md#step-7-install-the-chart), [repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures) |
+| **Automation API placement** | When the automation add-on is deployed alongside the backplane, expose `/ui`-only at the ingress; its REST `/api` stays cluster-internal and is never ingress-exposed. | Per-shape notes below |
+
+Every control above is stated as the *secure* state — the deployment
+inherits the hardened posture without an operator having to reconstruct
+it. Where a shape empties or widens one of these on purpose, name it in
+the values file as a documented downgrade, not a silent default.
+
 ---
 
 ## Flat LAN

--- a/docs-site/guides/approvals-and-break-glass.md
+++ b/docs-site/guides/approvals-and-break-glass.md
@@ -7,6 +7,18 @@ execute when you call it. It **parks** in an approval queue and returns
 `awaiting_approval`, and a second person has to approve it before it
 runs. That is the four-eyes rule, and it is on by default.
 
+!!! note "Baseline: self-approval is off by default"
+
+    `config.approvalAllowSelfApproval` defaults to **`"false"`**
+    (`APPROVAL_ALLOW_SELF_APPROVAL=false`) — the secure baseline. With it
+    off, the identity that requested a gated write can never approve it,
+    and `GET /ready` reports `approval_queue.effective_posture:
+    "four_eyes_enforced"`. Leave it off. Setting it `"true"` is a
+    posture-wide, audited emergency break-glass (covered in Option 2 below)
+    that still never reaches a `dangerous` or `destructive` operation. The
+    endorsed single-operator answer is the agent-requester pattern, not the
+    flag.
+
 This guide is about the case the rule does not obviously cover: **you
 are the only operator.** A solo deploy still has to be able to make
 gated writes, so MEHO ships two ways for one person to clear the queue

--- a/docs-site/install/credential-backends.md
+++ b/docs-site/install/credential-backends.md
@@ -43,6 +43,20 @@ for MEHO to find — the
 [Vault tenant-scope guide](https://github.com/evoila/meho/blob/main/docs/codebase/connectors-vault-tenant-scope.md)
 has the path shapes.
 
+!!! warning "Baseline: keep `VAULT_KV_TENANT_SCOPE_PREFIX` set on any multi-tenant deploy"
+
+    The per-tenant prefix is the setting `VAULT_KV_TENANT_SCOPE_PREFIX`,
+    which **defaults to `secret/tenants/{tenant_id}/`** — the cross-tenant
+    credential guard is on out of the box, and this is the secure baseline.
+    Emptying it (`VAULT_KV_TENANT_SCOPE_PREFIX=""`) turns the guard off:
+    schemeless references then resolve unscoped and the Vault
+    target-registration guard becomes a no-op. That is a **documented
+    downgrade**, valid only mid-migration (while a tenant's secrets are
+    being relocated under the prefix) or on a genuinely single-tenant
+    install. Never empty it on a multi-tenant deployment. It is a backend
+    env var, so a deploy that must set it does so through the chart's
+    `extraEnv`; the default carries the secure posture with no override.
+
 ### Google Secret Manager
 
 - `config.credentialBackend: gsm`, plus `gsm.enabled: true` and

--- a/docs-site/install/index.md
+++ b/docs-site/install/index.md
@@ -227,6 +227,19 @@ networkPolicy:
   keycloakCIDR: "10.0.3.0/24"   # REPLACE
 ```
 
+!!! warning "Baseline: `networkPolicy.enabled: true` for any multi-tenant or production install"
+
+    Staging `networkPolicy.enabled: false` above is a first-install
+    convenience — it keeps a bring-up from failing on a CIDR typo before the
+    backplane is even green. The **secure baseline is default-deny network
+    isolation on** (`enabled: true`), and leaving it off past bring-up is a
+    documented downgrade, not a default. Turning it on makes the schema
+    *require* the three egress CIDRs, so it refuses to ship a wide subnet by
+    accident — replace the placeholder CIDRs above with the real addresses
+    your Postgres / Vault / Keycloak resolve to, set `enabled: true`, and
+    re-run the same `helm upgrade` from Step 7. The broadcast subchart
+    renders its own ingress NetworkPolicy and Valkey auth alongside.
+
 For a **Google Secret Manager** deploy, replace the `vault` block and
 `config.vaultAddr` with the GSM fields — the exact delta is on the
 [credential backends](credential-backends.md#helm-values-per-backend)
@@ -258,6 +271,28 @@ helm upgrade --install meho oci://ghcr.io/evoila/meho-chart \
 Pin `--version <chart-version>` in production (discover versions with
 `helm show chart oci://ghcr.io/evoila/meho-chart`); without it Helm
 uses the latest published chart.
+
+!!! tip "Baseline: deploy by digest and verify the signature"
+
+    Beyond pinning an immutable `image.tag`, the production baseline is to
+    **deploy by digest and verify the signature before rollout**. Set
+    `image.digest` (`sha256:…`) so the Deployment (and the byte-identical
+    migration Job) render `repository@digest` — the exact, content-addressed
+    digest the image pipeline scanned, promoted, and cosign-signed; a digest
+    can never be re-pointed the way a tag can. `cosign verify` that digest
+    against the keyless workflow identity before `helm upgrade`:
+
+    ```bash
+    DIGEST=sha256:<the digest you are pinning>
+    cosign verify "ghcr.io/evoila/meho@${DIGEST}" \
+      --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@.*$' \
+      --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+    ```
+
+    Ideally the same check is enforced at admission (a Sigstore
+    policy-controller / Kyverno image-verification rule). The full
+    verification recipes — image, chart, and CLI — are in the
+    [repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures).
 
 What happens, in order:
 

--- a/docs-site/install/tls-ingress.md
+++ b/docs-site/install/tls-ingress.md
@@ -60,6 +60,34 @@ internal CA adds — trusting it on each operator workstation — and the
 per-client trust picture are in
 [Connect clients](../clients/index.md).
 
+## Reverse-proxy trust (`forwardedAllowIps`)
+
+The backplane sits behind your ingress controller, so it reads the real
+client address from the `X-Forwarded-*` headers the proxy sets — but it
+must only *trust* those headers from the proxy itself. That trust list
+is `config.forwardedAllowIps`, and the **baseline is to narrow it to the
+reverse proxy / ingress controller's own source address**, never the
+whole pod CIDR:
+
+```yaml
+config:
+  # Trust forwarded headers ONLY from the ingress controller's address.
+  # Recover it from the controller's Service/Endpoints rather than
+  # trusting the whole pod network:
+  #   kubectl get endpoints <ingress-controller> -n <ns> \
+  #     -o jsonpath='{.subsets[].addresses[].ip}'
+  forwardedAllowIps: "10.0.4.11/32"   # the controller's address, not 10.0.0.0/16
+```
+
+uvicorn's default (`127.0.0.1`) fails closed in-cluster — the controller
+pod is never loopback — so a value has to be set. The wrong fix is to
+open it to the entire pod network: any workload that can reach the
+backplane could then forge the client address the audit log and any
+address-based policy record. Scope it to the controller's address (a
+`/32`, or the tightest slice you have subnetted the controller onto).
+The per-cluster recommended values and the diagnostic walk are in
+[`docs/cross-repo/reverse-proxy-contract.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/reverse-proxy-contract.md).
+
 ## Your workstation: OS trust store
 
 Skip this section if the backplane and Keycloak present
@@ -195,6 +223,39 @@ The API and `targets.yaml` recipes for pinning and the opt-out live
 with the targets documentation in the
 [values-examples deep-dive](https://github.com/evoila/meho/blob/main/deploy/values-examples/README.md#connector-dispatch-against-self-signed--internal-ca-targets),
 and will be promoted into the *Do real work* section's target guide.
+
+## Outbound peer authentication for credential-bearing connections
+
+TLS on the ingress protects traffic *into* the backplane. The same
+discipline applies to every credential-bearing connection the backplane
+makes *outward* — and the **baseline is that none of these paths ships a
+verification-disabled default**. Each fails closed and authenticates its
+peer before a secret is offered:
+
+- **SSH host-key verification.** The SSH connector verifies the target's
+  host key fail-closed. A target whose resolved secret carries no
+  `known_hosts` entry is refused before the connection opens — so a
+  password can never be disclosed to an impostor host by default. Provision
+  the target's host key as an OpenSSH `known_hosts`-format line on the
+  target's secret (`<host-pattern> <keytype> <base64>`); an unexpected key
+  then aborts key exchange before authentication. A per-target
+  `known_hosts_insecure` escape hatch restores the old no-verification
+  behaviour for one target, logging a loud warning on every connect — opt-in,
+  per-target, never the default, and mirroring the `verify_tls: false`
+  target posture above.
+- **SMTP TLS verification.** The mail transport builds a validating TLS
+  context (`CERT_REQUIRED` with hostname checking on) for both the
+  implicit-TLS (port 465) and STARTTLS paths, so mail contents and SMTP
+  credentials are not exposed to an active intermediary. Point it at your
+  internal CA the same way the backplane's other outbound TLS is trusted
+  (the CA-bundle section above).
+- **Bootstrap CA trust.** Identity-bootstrap scripts that post an admin
+  credential must verify the endpoint's certificate against a real CA
+  bundle rather than running `curl -k` — provision the CA, and prefer a
+  bounded provisioning identity over a master-admin credential.
+
+Fail closed on the wrong name, an untrusted chain, or an unexpected SSH
+key; treat the per-target opt-outs as audited, temporary exceptions.
 
 ## Back to the trail
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,6 +30,37 @@ on tags — a tag always publishes). `cli-release.yml` is **tag-only**: a
 main push never cuts a release. Docs versions are cut **per minor** — a
 patch tag republishes its minor's docs in place.
 
+## Supply-chain and CI baseline
+
+A release is only as trustworthy as the pipeline that built it. Two
+supply-chain controls are baselines, not per-release choices — they hold
+across every cut:
+
+- **Build → quarantine → scan → promote → deploy by digest, and verify
+  the signature.** `image.yml` builds to a quarantine digest, runs the
+  required scans, and only then promotes and cosign-signs the **approved
+  digest** — so a failing scan can never leave a publishable release
+  candidate advertised as approved. The deploy side completes the chain:
+  pin the chart's `image.digest` (`sha256:…`, the content-addressed digest
+  the pipeline promoted) rather than deploying a mutable tag, and
+  `cosign verify` that digest against the keyless workflow identity before
+  `helm upgrade` — ideally enforced at admission (a Sigstore
+  policy-controller / Kyverno rule). CLI tarballs carry `SHA256SUMS` plus
+  cosign signatures for the same reason. Full recipes:
+  [`docs/codebase/devops.md` § Image reference / Verifying provenance](codebase/devops.md)
+  and the [repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures).
+
+- **Untrusted PR code never runs on the internal runner pool.** The
+  repository's fork-PR approval policy is **`all_external_contributors`**
+  (a maintainer must "Approve and run" any external fork PR before any
+  workflow runs), and every job that checks out and executes PR-controlled
+  code routes fork PRs to a **disposable GitHub-hosted runner**, never the
+  internal `meho-runners-ci` pool — with signing, deployment, and build-cache
+  identities kept off the PR-triggered path. Org-level runner-group access
+  restricts which workflows may schedule the internal pool as the durable
+  backstop a PR cannot edit. The full enforcement map is in
+  [`docs/codebase/devops.md` § Untrusted pull-request isolation](codebase/devops.md).
+
 ## Versioning
 
 [SemVer](https://semver.org). The version lives **only in the git tag** —


### PR DESCRIPTION
Part of evoila-bosnia/meho-internal#285 (NOT Closes — the lab-repo arm is deferred; see below).

## What this does

States each deployment-level hardening control as a **baseline** — a secure default or an explicit must-set — in the public deployment guidelines and example values, so a new deployment inherits the hardened posture without an operator reconstructing it. **Control-only wording**: no finding narratives, no F-ids, no CVE ids, no exploit preconditions (embargo, AC5).

## Controls and where each landed (AC2)

| Control | Baseline | Files |
|---|---|---|
| Network isolation | `networkPolicy.enabled: true` default-deny is the multi-tenant/production baseline; off = documented downgrade; broadcast subchart policy noted | `docs-site/install/index.md` (Step 6 block), `docs-site/deployment-shapes.md`, `deploy/values-examples/values-rdc-example.yaml` |
| Tenant credential scope | `VAULT_KV_TENANT_SCOPE_PREFIX` default `secret/tenants/{tenant_id}/` (on); emptying = documented downgrade | `docs-site/install/credential-backends.md`, `values-rdc-example.yaml`, `deploy/values-examples/README.md` |
| Reverse-proxy trust | `config.forwardedAllowIps` narrowed to the ingress-controller source, not the pod CIDR | `docs-site/install/tls-ingress.md` (new § Reverse-proxy trust), `values-rdc-example.yaml` |
| Self-approval | `config.approvalAllowSelfApproval` default `"false"` (four-eyes) | `docs-site/guides/approvals-and-break-glass.md`, `values-rdc-example.yaml` |
| No hardcoded tenant-role mappers | derive `tenant_role` from group membership on shared public clients | `deploy/values-examples/README.md` (auth-onramp), `deployment-shapes.md` |
| SSH host key / known_hosts | fail-closed host-key verification via `known_hosts`; SMTP TLS; bootstrap CA; no verification-disabled defaults | `docs-site/install/tls-ingress.md` (new § Outbound peer authentication) |
| Fork-PR runner isolation | disposable runners + `all_external_contributors` | `docs/RELEASING.md` (new § Supply-chain and CI baseline), `deployment-shapes.md` |
| Image digest / cosign signature | pin `image.digest` + `cosign verify` before rollout; `SHA256SUMS`; quarantine→scan→promote | `docs-site/install/index.md` (Step 7 + Step 9), `docs/RELEASING.md`, `deployment-shapes.md`, `values-rdc-example.yaml` |
| /ui-only + cluster-internal API | automation add-on `/ui-only` ingress, REST `/api` cluster-internal | `docs-site/deployment-shapes.md` |

`docs-site/deployment-shapes.md` carries the consolidated **hardening baseline** table (all nine) that the shape sections and the example values cross-link to.

## Verification

AC4 — `mkdocs build --strict` from the docs-site config dir:

```
$ mkdocs build --strict
INFO - Documentation built in 0.86 seconds     # exit 0, no link/anchor warnings
```

AC5 — embargo grep over `docs-site` returns nothing review-derived:

```
$ grep -rEn "F0[0-9]|F1[0-6]|CVE-|exploit precondition" docs-site
   (no output)
$ grep -rEn "F0[0-9]|F1[0-6]|CVE-|exploit" docs-site
   (no output)
```

Every owned control is grep-findable in its file (spot-checked per file above).

## Deferred (lab arm)

The lab-repo arm — `rdc-hetzner-dc/manifests/meho/README.md` cross-links and the `values-rdc.yaml` deviation notes (AC3) — is **deferred by the orchestrator until the lab applies finish**. No lab PR is opened here.

## Grounding

Setting names are taken from `evoila/meho` main as it stands today — the chart `values.schema.json` (`networkPolicy`, `forwardedAllowIps`, `approvalAllowSelfApproval`, `image.digest`), backend settings (`VAULT_KV_TENANT_SCOPE_PREFIX`), the SSH connector (`known_hosts` fail-closed, #3467), and `docs/codebase/devops.md` (`all_external_contributors`, digest/cosign). No names invented.
