### PR TITLE
docs(changelog): cut v0.34.0 — roll [Unreleased] into [0.34.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-09-08
+
 ### Fixed
 
 - `pfsense.mgmt_flow.summary` honours the `pfctl -ss` direction arrow when splitting server/client, so operator-initiated flows are no longer reported as unexpected sources (#3471).


### PR DESCRIPTION
## Cut v0.34.0

Rolls the `## [Unreleased]` CHANGELOG section into `## [0.34.0] - 2026-09-08`
and leaves a fresh empty `[Unreleased]`. Base commit: `7436bd9d` (PR #3488).
Previous tag: `v0.33.5` (`3e164a7c`). Classified **minor** (0.33.5 → 0.34.0)
per the agreed minor-before-1.0 policy — this cut ships the 2026-09-06
security-review wave as new hardening behaviour.

**Version files untouched** (rule 2) — version lives only in the tag. Chart
`version`/`appVersion` are calver-bumped by `chart.yml` at publish, the CLI
bakes `{{.Tag}}`, `backend/pyproject.toml` stays `0.1.0-dev`, and the CLI
OpenAPI snapshot's `info.version` is the static `0.1.0-dev` (not release-
derived). Diff is **CHANGELOG.md only** — a clean 2-line insert.

### What ships in v0.34.0

The 2026-09-06 security-review programme (`evoila-bosnia/meho-internal`
Goal #262) — ~34 entries. Highlights:

- **Fixed** — `pfsense.mgmt_flow.summary` honours the `pfctl -ss` direction
  arrow so operator-initiated flows are no longer misreported as unexpected
  sources (#3471 / PR #3474).
- **Security** — auth/JWKS unknown-`kid` refetch bound (#3484); write-class
  dispatch fails closed on audit-commit failure (#3485); `audit_log`
  append-only enforced at the datastore (#3435) + bounded `raw_payload`
  retention age-off (#3464); connector-dispatch SSRF address-pinning (#3437)
  and response-body cap (#3459); passive-only kubeconfig schema (#3443) and
  `holodeck.k8s.exec` kubectl allowlist (#3448); transactional approval
  decisions with a decision-time deadline (#3441); untrusted fork-PR CI jobs
  isolated from internal runners (#3477) and pr-smoke buildx cache scoped off
  the signed-release cache (#3475); image pipeline gates on trivy and promotes
  only the scanned digest (#3460); plus ingest param-rejection, SSRF path
  hardening, tenant-scoped secret broker, per-(tenant,principal) scheduler
  Vault paths, OAuth-callback browser-binding, k8s client-cache keying,
  untrusted-text envelopes, preamble band neutralisation, sensor-runner
  re-gating, CLI echo suppression, RKE2 argv scrubbing, mcp-remote lockfile
  pinning, `qs` bump, broadcast subchart NetworkPolicy + Valkey auth, and the
  REST human-only-guard docs.

### Completeness audit (mandatory — rule 4)

`git log v0.33.5..origin/main` = 38 commits. Audit (`tr -d '#' | sort -u`):

```
comm -23 shipped cited  →  262  3469  3473  3474  3487  3488
```

Resolution — **zero genuine misses, zero bullets added**:

- **#262** — the security-review Initiative/Goal parent ref cited across the
  changelog-batch commit subjects, not a PR needing a bullet.
- **#3469 / #3473 / #3487** — the security-wave `[Unreleased]`-assembly
  CHANGELOG batch PRs themselves (CHANGELOG.md-only, self-referential); they
  already carried the wave entries — correctly no bullet.
- **#3474** — PR for issue **#3471**; bullet present (cites #3471), same
  issue-vs-PR-number reconciliation the runbook calls out.
- **#3488** — docs-only (docs-site install guides + deploy values READMEs +
  `docs/RELEASING.md`); documents the already-shipped hardening baseline, no
  user-visible code change → correctly no bullet.

Every substantive code PR since v0.33.5 already carried a bullet.

### Migrations / upgrade-notes (RELEASING.md §3 + §6b)

**No new migrations since v0.33.5** — alembic head stays `0099`
(`0098`/`0099` shipped in v0.33.5). No `docs/deploying.md` upgrade-notes row
is required this cut, and the §6b rollback drill is not exercised (no
migration).

### Release-body path-freshness gate

`scripts/release/check_release_body_paths.py` against `cli/api/openapi.json`:
**PASS (exit 0)** — 0 cited API paths (the entries cite module paths and
JSONPath expressions, not `/api/v*` routes).

### Pre-flight

Base `7436bd9d` is current `origin/main` HEAD. The tagged-commit main-CI
green check is the **Phase 3 tag gate** (the `v*` tag publishes whatever main
is), owned by the release owner — not a Phase-2 blocker for this PR.

Do **not** merge/tag/deploy from this PR — release owner drives Phases 3+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
