### PR TITLE
feat(connectors): vmware_rest Supervisor (WCP) enable/disable/status composites

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -90,6 +90,11 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
 from meho_backplane.connectors.vmware_rest.composites._register import (
     register_vmware_composite_operations,
 )
+from meho_backplane.connectors.vmware_rest.composites._supervisor import (
+    supervisor_disable_composite,
+    supervisor_enable_composite,
+    supervisor_status_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     cluster_patch_composite,
@@ -154,6 +159,9 @@ __all__ = [
     "performance_summary_composite",
     "register_vmware_composite_operations",
     "service_control_composite",
+    "supervisor_disable_composite",
+    "supervisor_enable_composite",
+    "supervisor_status_composite",
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from meho_backplane.connectors.vmware_rest.composites import _host, _write
+from meho_backplane.connectors.vmware_rest.composites import _host, _supervisor, _write
 
 #: Connector the vmware-rest composites dispatch against. The composites are
 #: registered for vCenter 9.0 (``vmware-rest-9.0``); the discovery surface
@@ -80,6 +80,8 @@ _GOVERNED_SUBOP_MANIFEST: Final[dict[str, tuple[str, ...]]] = {
     "vmware.composite.host.datastore_mount_nfs": _host._VIM_SUB_OPS_HOST_DATASTORE_MOUNT_NFS,
     "vmware.composite.host.disk_mark_flash": _host._VIM_SUB_OPS_HOST_DISK_MARK_FLASH,
     "vmware.composite.host.service_control": _host._VIM_SUB_OPS_HOST_SERVICE_CONTROL,
+    "vmware.composite.supervisor.enable": _supervisor._SUB_OPS_SUPERVISOR_ENABLE,
+    "vmware.composite.supervisor.disable": _supervisor._SUB_OPS_SUPERVISOR_DISABLE,
 }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -85,6 +85,11 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._supervisor import (
+    supervisor_disable_composite,
+    supervisor_enable_composite,
+    supervisor_status_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     cluster_patch_composite,
@@ -156,6 +161,12 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     NETWORK_PORTGROUP_SECURITY_SET_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
     PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+    SUPERVISOR_DISABLE_PARAMETER_SCHEMA,
+    SUPERVISOR_DISABLE_RESPONSE_SCHEMA,
+    SUPERVISOR_ENABLE_PARAMETER_SCHEMA,
+    SUPERVISOR_ENABLE_RESPONSE_SCHEMA,
+    SUPERVISOR_STATUS_PARAMETER_SCHEMA,
+    SUPERVISOR_STATUS_RESPONSE_SCHEMA,
     VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA,
     VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA,
     VM_CLONE_PARAMETER_SCHEMA,
@@ -341,6 +352,24 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "guest', 'what does the guest think its network is?', 'drop this config "
         "file into the guest', or 'run Install-WindowsFeature inside the guest'. "
         "Requires VMware Tools in the guest."
+    ),
+    "namespace_management": (
+        "Use for governed vSphere Supervisor (Workload Control Plane / WCP) "
+        "lifecycle on a cluster -- the governed replacement for out-of-band "
+        "'govc'/'kubectl-vsphere' enablement. Writes (dangerous / "
+        "approval-required): enable the Supervisor on a single compute cluster "
+        "(supervisor.enable -- takes the nested EnableOnComputeClusterSpec: "
+        "control_plane + workloads with a network stack the composite validates, "
+        "VSPHERE+VSPHERE_FOUNDATION for the VDS + Foundation LB model or NSX_VPC "
+        "for NSX VPC), and disable/tear it down (supervisor.disable). Both are "
+        "asynchronous -- they return immediately and you poll for convergence. "
+        "Read (safe): supervisor.status -- read a cluster's config_status "
+        "(CONFIGURING -> RUNNING / ERROR) + kubernetes_status (READY) shaped so a "
+        "runbook OperationCallVerify step or a Sensor can poll ready==true. The "
+        "right group for 'stand up Kubernetes on this cluster', 'tear the "
+        "Supervisor down', or 'has the Supervisor come up yet?'. Pair with "
+        "'storage' for the SPBM policy id the enable spec needs and 'networking' "
+        "for the workload / management network context."
     ),
 }
 
@@ -1430,6 +1459,82 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
                 "OperationResult verbatim (awaiting_approval / denied)."
             ),
         },
+    ),
+    # ----------------------------------------------------------------
+    # namespace-management -- Supervisor (WCP) lifecycle (#3281).
+    # 2 dangerous / approval-required writes + 1 safe status read.
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.supervisor.enable",
+        handler=supervisor_enable_composite,
+        summary="Enable a vSphere Supervisor (WCP) on a single compute cluster.",
+        description=(
+            "Enables the vSphere Supervisor on a cluster via "
+            "POST /vcenter/namespace-management/supervisors/{cluster}"
+            "?action=enable_on_compute_cluster (the current 9.x path; the "
+            "clusters/{cluster}?action=enable form is deprecated as of vSphere "
+            "9.0). Takes the nested EnableOnComputeClusterSpec (name + "
+            "control_plane + workloads + optional zone). Validates the spec "
+            "server-side -- the control-plane essentials (management network + "
+            "SPBM storage policy) and the workload network stack -- and refuses "
+            "an unknown network_type / edge provider loudly "
+            "(status='unknown_network_provider') before any write. The VDS + "
+            "Foundation LB model is network_type=VSPHERE + edge "
+            "provider=VSPHERE_FOUNDATION (no separate NSX edge cluster); NSX VPC "
+            "is NSX_VPC/NSX_VPC. Asynchronous: returns the new Supervisor id "
+            "immediately (status='enabling') and does NOT block on the 30-60 min "
+            "convergence -- poll vmware.composite.supervisor.status. Governed "
+            "replacement for out-of-band 'govc'/'kubectl-vsphere' enablement."
+        ),
+        parameter_schema=SUPERVISOR_ENABLE_PARAMETER_SCHEMA,
+        response_schema=SUPERVISOR_ENABLE_RESPONSE_SCHEMA,
+        group_key="namespace_management",
+        tags=["composite", "write", "namespace-management", "supervisor", "wcp"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.supervisor.disable",
+        handler=supervisor_disable_composite,
+        summary="Disable / tear down the vSphere Supervisor on a cluster.",
+        description=(
+            "Tears the Supervisor down via "
+            "POST /vcenter/namespace-management/clusters/{cluster}?action=disable "
+            "(DELETE clusters/{cluster} 404s -- the action form is the documented "
+            "teardown). No request body; removes the control-plane VMs and worker "
+            "nodes but leaves the cluster's networking / zone intact for a fresh "
+            "re-enable. Asynchronous: returns status='disabling' immediately "
+            "-- poll vmware.composite.supervisor.status (config_status moves "
+            "through 'REMOVING'). Governed replacement for out-of-band teardown."
+        ),
+        parameter_schema=SUPERVISOR_DISABLE_PARAMETER_SCHEMA,
+        response_schema=SUPERVISOR_DISABLE_RESPONSE_SCHEMA,
+        group_key="namespace_management",
+        tags=["composite", "write", "namespace-management", "supervisor", "wcp"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.supervisor.status",
+        handler=supervisor_status_composite,
+        summary="Read a cluster's Supervisor config + kubernetes status (poll-friendly).",
+        description=(
+            "Reads GET /vcenter/namespace-management/clusters/{cluster} and "
+            "reshapes Clusters.Info into a compact, inline-pollable envelope: the "
+            "scalar config_status (CONFIGURING/REMOVING/RUNNING/ERROR) + "
+            "kubernetes_status (READY/WARNING/ERROR) + a derived ready flag stay "
+            "top-level so a runbook OperationCallVerify step or a Sensor assertion "
+            "can poll config_status=='RUNNING' / ready==true directly. The "
+            "messages + conditions arrays are capped inline (messages_limit). "
+            "Read-only -- never mutates cluster state. The status op enable/disable "
+            "hand the caller for the asynchronous convergence poll."
+        ),
+        parameter_schema=SUPERVISOR_STATUS_PARAMETER_SCHEMA,
+        response_schema=SUPERVISOR_STATUS_RESPONSE_SCHEMA,
+        group_key="namespace_management",
+        tags=["composite", "read-only", "namespace-management", "supervisor", "wcp"],
+        safety_level="safe",
+        requires_approval=False,
     ),
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_supervisor.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_supervisor.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Namespace-management ``vmware.composite.supervisor.*`` handlers (#3281).
+
+Governed Supervisor (Workload Control Plane / WCP) lifecycle on the
+``vmware_rest`` connector. Before this module the connector had
+namespace-management **reads** only; enabling / disabling a Supervisor ran
+out-of-band (``govc`` / ``kubectl-vsphere``) and escaped the backplane's
+policy / audit / approval path. The three composites here close that gap:
+
+* ``vmware.composite.supervisor.enable`` --
+  ``POST /vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster``
+  (the current single-compute-cluster path; the ``clusters/{cluster}?action=enable``
+  form is **deprecated as of vSphere 9.0** and is not used). Takes the
+  nested ``EnableOnComputeClusterSpec`` body (``name`` / ``control_plane`` /
+  ``workloads`` / optional ``zone``). ``safety_level="dangerous"`` +
+  ``requires_approval=True``.
+* ``vmware.composite.supervisor.disable`` --
+  ``POST /vcenter/namespace-management/clusters/{cluster}?action=disable``
+  (``DELETE clusters/{cluster}`` 404s -- the action form is the documented
+  teardown). No request body. ``safety_level="dangerous"`` +
+  ``requires_approval=True``.
+* ``vmware.composite.supervisor.status`` --
+  ``GET /vcenter/namespace-management/clusters/{cluster}`` -->
+  ``config_status`` (``CONFIGURING`` -> ``RUNNING`` / ``ERROR``) +
+  ``kubernetes_status`` (``READY`` / ``WARNING`` / ``ERROR``) + messages.
+  Shaped so a runbook ``OperationCallVerify`` step or a Sensor assertion
+  can poll ``config_status == "RUNNING"`` / ``ready == true`` inline (the
+  scalars stay top-level, never buried in a set-shaped handle).
+  ``safety_level="safe"`` + ``requires_approval=False``.
+
+Generic-vs-typed
+----------------
+
+The three namespace-management paths are present in the pinned
+``vcenter.yaml`` and land as ingested ``endpoint_descriptor`` rows, and
+``vmware_rest`` is a **real** connector (it overrides
+:meth:`~...connector.VmwareRestConnector.mount_op_path`), so an unstaged
+generic ingested row dispatches through ``httpx`` -- it is not an
+``unreplaced_auto_shim`` dead end. Generic dispatch is therefore
+*mechanically* possible. It is nonetheless insufficient for a governed
+enable: the body is a deeply nested, provider-discriminated spec
+(``workloads.network.network_type`` x ``workloads.edge.provider``), the
+enable is asynchronous (returns the Supervisor id immediately; readiness
+is a separate 30-60 min poll), and the task requires the composite to
+**refuse an unknown network provider loudly** -- none of which a raw
+pass-through row can do. So enable / disable are typed composites that
+own the spec validation + the readiness contract, and ``status`` is the
+poll op they hand the runbook / Sensor. This matches the #3281 scope
+("typed composite -- expected outcome").
+
+Async readiness (non-blocking)
+------------------------------
+
+``enable`` deliberately does **not** block the dispatcher polling for the
+30-60 min ``CONFIGURING`` -> ``RUNNING`` transition. It returns
+``status="enabling"`` with the new Supervisor id and points the caller at
+``vmware.composite.supervisor.status``; a runbook step / Sensor drives the
+poll on its own cadence.
+
+Governance seam
+---------------
+
+The two writes ride the same #2254 governed REST sub-op seam the other
+REST write composites use
+(:func:`~meho_backplane.connectors.vmware_rest.composites._write._write_sub_op`
+-> :func:`~meho_backplane.operations.composite.enforce_subop_policy` ->
+``_post_json``): the top-level composite's own ``dangerous`` /
+``requires_approval=True`` posture parks for human approval at dispatch,
+and the governed child POST re-applies policy (allowlist / grant) under
+the shared ``dangerous`` / ``requires_approval=False`` sub-op posture. The
+``status`` read rides the un-gated read sub-op seam
+(:func:`~...composites._write._read_sub_op`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    _read_sub_op,
+    _unwrap_value,
+    _write_sub_op,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+__all__ = [
+    "supervisor_disable_composite",
+    "supervisor_enable_composite",
+    "supervisor_status_composite",
+]
+
+
+# Canonical ``METHOD:/path`` op_ids -- byte-for-byte the strings the ingest
+# parser emits from the pinned ``vcenter.yaml`` (the ``?action=<verb>`` query
+# rides on the path key, and the ``{cluster}`` path var is a
+# ClusterComputeResource moid). These are the governance op_ids fed to
+# ``enforce_subop_policy`` via ``_write_sub_op`` and the read seam via
+# ``_read_sub_op``; the spec-shelf reconcile lane
+# (``tests/acceptance/test_supervisor_op_id_reconcile.py``) asserts each
+# resolves against the canonical pinned spec.
+_OP_ENABLE_ON_COMPUTE_CLUSTER: Final = (
+    "POST:/vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster"
+)
+_OP_DISABLE: Final = "POST:/vcenter/namespace-management/clusters/{cluster}?action=disable"
+_OP_GET_CLUSTER: Final = "GET:/vcenter/namespace-management/clusters/{cluster}"
+
+#: REST governed-child manifests (parallel to ``_write._SUB_OPS_*``). Referenced
+#: by :mod:`._governed_subops` so the discovery surface publishes each write
+#: composite's grant set, and asserted by the reconcile lane.
+_SUB_OPS_SUPERVISOR_ENABLE: tuple[str, ...] = (_OP_ENABLE_ON_COMPUTE_CLUSTER,)
+_SUB_OPS_SUPERVISOR_DISABLE: tuple[str, ...] = (_OP_DISABLE,)
+
+#: Authoritative 9.x ``Supervisors.Networks.Workload.NetworkType`` enum -- the
+#: workload network stack. VDS + Foundation LB is ``VSPHERE``; the NSX VPC
+#: model is ``NSX_VPC``; classic NSX-T is ``NSXT``.
+_ALLOWED_NETWORK_TYPES: Final[frozenset[str]] = frozenset({"VSPHERE", "NSXT", "NSX_VPC"})
+
+#: Authoritative 9.x ``Networks.Edges.EdgeProvider`` enum -- who provides edge
+#: (load-balancer) services. VDS + Foundation LB is ``VSPHERE_FOUNDATION`` (no
+#: separate NSX edge cluster required); the NSX models are ``NSX`` / ``NSX_VPC``
+#: / ``NSX_ADVANCED``; ``HAPROXY`` is deprecated as of vSphere 9.0.
+_ALLOWED_EDGE_PROVIDERS: Final[frozenset[str]] = frozenset(
+    {"VSPHERE_FOUNDATION", "NSX", "NSX_VPC", "NSX_ADVANCED", "HAPROXY"}
+)
+
+#: Config-status values that mean the enable has converged.
+_CONFIG_STATUS_RUNNING: Final = "RUNNING"
+_KUBERNETES_STATUS_READY: Final = "READY"
+
+#: Default cap on the ``messages`` / ``conditions`` arrays the status op
+#: returns inline. During ``CONFIGURING`` the conditions array can grow; the
+#: cap keeps the response small + inline-pollable (the scalars stay top-level).
+_STATUS_MESSAGES_DEFAULT_CAP: Final = 25
+
+
+def _validate_network_provider(workloads: Any) -> dict[str, Any] | None:
+    """Refuse an unknown network stack loudly; return a refusal envelope or ``None``.
+
+    Reads ``workloads.network.network_type`` and ``workloads.edge.provider``
+    and checks each against the authoritative 9.x enums
+    (:data:`_ALLOWED_NETWORK_TYPES` / :data:`_ALLOWED_EDGE_PROVIDERS`). An
+    unknown value -- or a missing network / edge object -- returns a
+    structured ``status="unknown_network_provider"`` /
+    ``status="invalid_spec"`` envelope naming the offending value and the
+    allowed set, so the composite fails closed *before* dispatching the
+    enable POST rather than letting vCenter reject an opaque body. Returns
+    ``None`` when both are recognised.
+    """
+    if not isinstance(workloads, dict):
+        return {
+            "status": "invalid_spec",
+            "guidance": "workloads must be an object with 'network' and 'edge'",
+        }
+    network = workloads.get("network")
+    edge = workloads.get("edge")
+    if not isinstance(network, dict) or not isinstance(edge, dict):
+        return {
+            "status": "invalid_spec",
+            "guidance": "workloads.network and workloads.edge are both required objects",
+        }
+    network_type = network.get("network_type")
+    provider = edge.get("provider")
+    if network_type not in _ALLOWED_NETWORK_TYPES:
+        return {
+            "status": "unknown_network_provider",
+            "network_type": network_type if isinstance(network_type, str) else None,
+            "guidance": (
+                f"workloads.network.network_type {network_type!r} is not a known "
+                f"vSphere 9.x network stack; allowed: {sorted(_ALLOWED_NETWORK_TYPES)} "
+                "(VSPHERE = VDS + Foundation LB, NSX_VPC = NSX VPC, NSXT = classic NSX-T)"
+            ),
+        }
+    if provider not in _ALLOWED_EDGE_PROVIDERS:
+        return {
+            "status": "unknown_network_provider",
+            "network_type": network_type,
+            "edge_provider": provider if isinstance(provider, str) else None,
+            "guidance": (
+                f"workloads.edge.provider {provider!r} is not a known edge provider; "
+                f"allowed: {sorted(_ALLOWED_EDGE_PROVIDERS)} (VSPHERE_FOUNDATION pairs "
+                "with the VSPHERE network stack for the VDS + Foundation LB model)"
+            ),
+        }
+    return None
+
+
+def _validate_control_plane(control_plane: Any) -> dict[str, Any] | None:
+    """Refuse a control-plane spec missing its load-bearing fields.
+
+    The ``enable_on_compute_cluster`` body requires a ``control_plane`` with
+    a management ``network`` and a ``storage_policy`` (the Supervisor API
+    server's SPBM policy -- load-bearing on NFS, where there is no default
+    policy). A missing field returns ``status="invalid_spec"``; otherwise
+    ``None``.
+    """
+    if not isinstance(control_plane, dict):
+        return {
+            "status": "invalid_spec",
+            "guidance": "control_plane must be an object with 'network' and 'storage_policy'",
+        }
+    if not isinstance(control_plane.get("network"), dict):
+        return {
+            "status": "invalid_spec",
+            "guidance": "control_plane.network is a required object (management network)",
+        }
+    if not control_plane.get("storage_policy"):
+        return {
+            "status": "invalid_spec",
+            "guidance": (
+                "control_plane.storage_policy is required (the Supervisor API-server "
+                "SPBM policy id); on NFS there is no default policy"
+            ),
+        }
+    return None
+
+
+async def supervisor_enable_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Enable a Supervisor on a single vSphere cluster (async; returns immediately).
+
+    Op-id: ``vmware.composite.supervisor.enable``. Validates the nested
+    ``EnableOnComputeClusterSpec`` server-side -- the network stack
+    (:func:`_validate_network_provider`, refuses an unknown
+    ``network_type`` / edge ``provider`` loudly) and the control-plane
+    essentials (:func:`_validate_control_plane`) -- then issues
+    ``POST /vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster``
+    through the governed REST write seam. A parked/denied gate returns the
+    :class:`OperationResult` verbatim and no enable fires. On success the
+    200 body is the new Supervisor id (a bare string); the composite returns
+    ``status="enabling"`` with that id and does **not** block on the
+    30-60 min ``CONFIGURING`` -> ``RUNNING`` convergence -- the caller polls
+    ``vmware.composite.supervisor.status``. A vim/REST fault
+    (``AlreadyExists`` when the cluster already has a Supervisor,
+    ``UnableToAllocateResource`` when the cluster is unlicensed) propagates
+    as a transport error the dispatcher wraps ``connector_error``.
+    """
+    cluster = params["cluster"]
+    workloads = params["workloads"]
+    control_plane = params["control_plane"]
+
+    refusal = _validate_control_plane(control_plane) or _validate_network_provider(workloads)
+    if refusal is not None:
+        return {"supervisor": None, "cluster": cluster, **refusal}
+
+    sub_op_params: dict[str, Any] = {
+        "cluster": cluster,
+        "name": params["name"],
+        "control_plane": control_plane,
+        "workloads": workloads,
+    }
+    zone = params.get("zone")
+    if zone is not None:
+        sub_op_params["zone"] = zone
+
+    gate, payload = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_ENABLE_ON_COMPUTE_CLUSTER,
+        sub_op_params,
+    )
+    if gate is not None:
+        return gate
+
+    supervisor = _unwrap_value(payload)
+    supervisor_id = supervisor if isinstance(supervisor, str) and supervisor else None
+    return {
+        "status": "enabling",
+        "cluster": cluster,
+        "supervisor": supervisor_id,
+        "network_type": workloads["network"]["network_type"],
+        "edge_provider": workloads["edge"]["provider"],
+        "guidance": (
+            "Supervisor enablement started (asynchronous). Poll "
+            "vmware.composite.supervisor.status with this cluster until "
+            "config_status == 'RUNNING' and kubernetes_status == 'READY' "
+            "(typically 30-60 min); config_status == 'ERROR' needs operator "
+            "intervention."
+        ),
+    }
+
+
+async def supervisor_disable_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Disable (tear down) the Supervisor on a vSphere cluster (async).
+
+    Op-id: ``vmware.composite.supervisor.disable``. Issues
+    ``POST /vcenter/namespace-management/clusters/{cluster}?action=disable``
+    through the governed REST write seam (``DELETE clusters/{cluster}``
+    404s -- the action form is the documented teardown). The call takes no
+    body and returns 204; the composite returns ``status="disabling"`` and
+    does not block on the removal converging -- the caller polls
+    ``vmware.composite.supervisor.status`` (``config_status`` moves through
+    ``REMOVING``). A parked/denied gate returns the :class:`OperationResult`
+    verbatim and no teardown fires.
+    """
+    cluster = params["cluster"]
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_DISABLE,
+        {"cluster": cluster},
+    )
+    if gate is not None:
+        return gate
+    return {
+        "status": "disabling",
+        "cluster": cluster,
+        "guidance": (
+            "Supervisor teardown started (asynchronous). Poll "
+            "vmware.composite.supervisor.status with this cluster; "
+            "config_status moves through 'REMOVING'. Teardown removes the "
+            "control-plane VMs and worker nodes but leaves the cluster's "
+            "networking / zone intact for a fresh re-enable."
+        ),
+    }
+
+
+def _project_messages(items: Any, cap: int) -> tuple[list[dict[str, Any]], int]:
+    """Cap + project a messages / conditions array; return ``(capped, total)``.
+
+    Keeps the array small + inline (the status op stays pollable without a
+    JSONFlux handle). Non-dict rows are dropped; ``total`` is the uncapped
+    count so a caller sees the true size even when the list is truncated.
+    """
+    if not isinstance(items, list):
+        return [], 0
+    rows = [row for row in items if isinstance(row, dict)]
+    return rows[:cap], len(rows)
+
+
+async def supervisor_status_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """Read a cluster's Supervisor config + kubernetes status (poll-friendly).
+
+    Op-id: ``vmware.composite.supervisor.status``. Issues
+    ``GET /vcenter/namespace-management/clusters/{cluster}`` (un-gated read)
+    and reshapes ``Clusters.Info`` into a compact, inline-pollable envelope:
+    the scalar ``config_status`` (``CONFIGURING`` / ``REMOVING`` /
+    ``RUNNING`` / ``ERROR``) and ``kubernetes_status`` (``READY`` /
+    ``WARNING`` / ``ERROR``) stay top-level so a runbook
+    ``OperationCallVerify`` step or a Sensor assertion can read
+    ``config_status == 'RUNNING'`` / ``ready == true`` directly -- never
+    behind a set-shaped handle. The (potentially long during
+    ``CONFIGURING``) ``messages`` + ``conditions`` arrays are capped inline
+    to :data:`_STATUS_MESSAGES_DEFAULT_CAP` (override with
+    ``messages_limit``); ``message_count`` / ``condition_count`` carry the
+    uncapped sizes. Read-only -- never mutates cluster state. A vCenter 400
+    (the cluster has no Supervisor enabled) propagates as a transport error
+    the dispatcher wraps ``connector_error``.
+    """
+    cluster = params["cluster"]
+    cap = params.get("messages_limit", _STATUS_MESSAGES_DEFAULT_CAP)
+
+    info = _unwrap_value(
+        await _read_sub_op(connector, target, operator, _OP_GET_CLUSTER, {"cluster": cluster})
+    )
+    info = info if isinstance(info, dict) else {}
+    config_status = info.get("config_status")
+    kubernetes_status = info.get("kubernetes_status")
+    messages, message_count = _project_messages(info.get("messages"), cap)
+    conditions, condition_count = _project_messages(info.get("conditions"), cap)
+    return {
+        "cluster": cluster,
+        "config_status": config_status if isinstance(config_status, str) else None,
+        "kubernetes_status": kubernetes_status if isinstance(kubernetes_status, str) else None,
+        "ready": config_status == _CONFIG_STATUS_RUNNING
+        and kubernetes_status == _KUBERNETES_STATUS_READY,
+        "messages": messages,
+        "conditions": conditions,
+        "message_count": message_count,
+        "condition_count": condition_count,
+    }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1131,9 +1131,56 @@ async def _vm_destroy_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
-#: op_id → builder for the 26 write composites. Module-level so the
+async def _supervisor_enable_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``supervisor.enable`` — echo the cluster + network stack (no I/O).
+
+    Enabling a Supervisor stands up an entire Kubernetes control plane on a
+    cluster; the reviewer must see *which* cluster and *which* network stack
+    (the VDS + Foundation LB vs NSX VPC decision) they are approving. Echoes
+    the cluster moid, Supervisor name, control-plane sizing (size + count),
+    and the workload ``network_type`` + edge ``provider`` -- all from params,
+    no resolution read. Declines (``None``) on malformed params (the handler
+    does the full spec validation + loud provider refusal).
+    """
+    cluster = ctx.params.get("cluster")
+    name = ctx.params.get("name")
+    control_plane = ctx.params.get("control_plane")
+    workloads = ctx.params.get("workloads")
+    if not isinstance(cluster, str) or not isinstance(name, str):
+        return None
+    if not isinstance(control_plane, dict) or not isinstance(workloads, dict):
+        return None
+    network = workloads.get("network")
+    edge = workloads.get("edge")
+    return {
+        "cluster": cluster,
+        "name": name,
+        "size": control_plane.get("size"),
+        "count": control_plane.get("count"),
+        "network_type": network.get("network_type") if isinstance(network, dict) else None,
+        "edge_provider": edge.get("provider") if isinstance(edge, dict) else None,
+    }
+
+
+async def _supervisor_disable_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``supervisor.disable`` — echo the cluster being torn down (no I/O).
+
+    Teardown removes the Supervisor's control-plane VMs + worker nodes; the
+    reviewer must see which cluster. The ``irreversibility`` marker flags
+    that the Kubernetes instance is destroyed (the cluster networking / zone
+    survive for a fresh re-enable). Declines (``None``) on a malformed param.
+    """
+    cluster = ctx.params.get("cluster")
+    if not isinstance(cluster, str):
+        return None
+    return {"cluster": cluster, "irreversibility": "kubernetes-instance-destroyed"}
+
+
+#: op_id → builder for the write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
+    "vmware.composite.supervisor.enable": _supervisor_enable_preview,
+    "vmware.composite.supervisor.disable": _supervisor_disable_preview,
     "vmware.composite.vm.guest.file.write": _guest_file_write_preview,
     "vmware.composite.vm.guest.program.run": _guest_program_run_preview,
     "vmware.composite.vm.create": _vm_create_preview,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -88,6 +88,12 @@ __all__ = [
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
     "PERFORMANCE_SUMMARY_RESPONSE_SCHEMA",
+    "SUPERVISOR_DISABLE_PARAMETER_SCHEMA",
+    "SUPERVISOR_DISABLE_RESPONSE_SCHEMA",
+    "SUPERVISOR_ENABLE_PARAMETER_SCHEMA",
+    "SUPERVISOR_ENABLE_RESPONSE_SCHEMA",
+    "SUPERVISOR_STATUS_PARAMETER_SCHEMA",
+    "SUPERVISOR_STATUS_RESPONSE_SCHEMA",
     "VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA",
     "VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA",
     "VM_CLONE_PARAMETER_SCHEMA",
@@ -4461,4 +4467,285 @@ GUEST_PROGRAM_RUN_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm", "process_manager_moid", "program_path", "pid", "wait"],
+}
+
+
+# ---------------------------------------------------------------------------
+# namespace-management -- Supervisor (WCP) enable / disable / status (#3281)
+# ---------------------------------------------------------------------------
+
+
+#: ``vmware.composite.supervisor.enable`` parameter schema. The nested
+#: ``control_plane`` / ``workloads`` objects are the vendor
+#: ``EnableOnComputeClusterSpec`` sub-objects passed through to the enable POST
+#: body verbatim, so they keep ``additionalProperties: True`` (the full vendor
+#: spec -- LB config, DNS/NTP, image sync, CIDRs -- flows through unmodified).
+#: The schema pins the *structural* essentials (management network + control-
+#: plane storage policy, workload network_type + edge provider); the handler
+#: enforces the network-stack enums with a loud structured refusal
+#: (``unknown_network_provider``), so a bad provider fails closed in the
+#: composite rather than as an opaque vCenter 400.
+SUPERVISOR_ENABLE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "ClusterComputeResource moid (``domain-cN``) of the vSphere cluster to "
+                "enable the Supervisor on. Rides the ``{cluster}`` path segment of "
+                "``POST /vcenter/namespace-management/supervisors/{cluster}"
+                "?action=enable_on_compute_cluster`` (the current 9.x path; the "
+                "``clusters/{cluster}?action=enable`` form is deprecated as of vSphere 9.0)."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "User-friendly Supervisor name (EnableOnComputeClusterSpec.name).",
+        },
+        "control_plane": {
+            "type": "object",
+            "required": ["network", "storage_policy"],
+            "properties": {
+                "network": {
+                    "type": "object",
+                    "description": (
+                        "Management network for the control plane (Networks.Management."
+                        "Network): backing portgroup + IP management (gateway in CIDR "
+                        "form, 5-address node range) + DNS/NTP services."
+                    ),
+                },
+                "storage_policy": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "SPBM policy id backing the Supervisor Kubernetes API server "
+                        "(SpsStorageProfile). Required -- on NFS there is no default "
+                        "policy; pass the tag-based NFS policy id."
+                    ),
+                },
+                "size": {
+                    "type": "string",
+                    "description": (
+                        "Control-plane sizing hint (TINY/SMALL/MEDIUM/LARGE). Optional; "
+                        "defaults to SMALL. TINY = 8 GB per CP VM."
+                    ),
+                },
+                "count": {
+                    "type": "integer",
+                    "enum": [1, 3],
+                    "description": "Number of control-plane VMs (1 or 3). Optional; defaults to 3.",
+                },
+            },
+            "additionalProperties": True,
+            "description": (
+                "EnableOnComputeClusterSpec.control_plane -- passed through to the "
+                "enable body. Requires a management ``network`` and a ``storage_policy``."
+            ),
+        },
+        "workloads": {
+            "type": "object",
+            "required": ["network", "edge"],
+            "properties": {
+                "network": {
+                    "type": "object",
+                    "required": ["network_type"],
+                    "properties": {
+                        "network_type": {
+                            "type": "string",
+                            "description": (
+                                "Workload network stack (Supervisors.Networks.Workload."
+                                "NetworkType). One of VSPHERE (VDS + Foundation LB), "
+                                "NSX_VPC (NSX VPC), NSXT (classic NSX-T). An unknown "
+                                "value is refused loudly by the composite "
+                                "(status='unknown_network_provider')."
+                            ),
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+                "edge": {
+                    "type": "object",
+                    "required": ["provider"],
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Edge (load-balancer) provider (Networks.Edges."
+                                "EdgeProvider). One of VSPHERE_FOUNDATION (pairs with the "
+                                "VSPHERE stack -- no separate NSX edge cluster required), "
+                                "NSX / NSX_VPC / NSX_ADVANCED, or the deprecated HAPROXY. "
+                                "An unknown value is refused loudly by the composite."
+                            ),
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+            },
+            "additionalProperties": True,
+            "description": (
+                "EnableOnComputeClusterSpec.workloads -- passed through to the enable "
+                "body. Requires a workload ``network`` (with ``network_type``) and an "
+                "``edge`` (with ``provider``); ``storage`` (ephemeral/image policies) is "
+                "optional and defaults from the control plane when omitted."
+            ),
+        },
+        "zone": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional pre-existing consumption fault-domain Zone id. Omitted -> a "
+                "zone is auto-created from the cluster's managed-object id."
+            ),
+        },
+    },
+    "required": ["cluster", "name", "control_plane", "workloads"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.supervisor.enable`` response schema.
+SUPERVISOR_ENABLE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["enabling", "unknown_network_provider", "invalid_spec"],
+            "description": (
+                "``'enabling'`` -- the enable POST was accepted (asynchronous; poll "
+                "``vmware.composite.supervisor.status``). ``'unknown_network_provider'`` "
+                "-- workloads.network.network_type or workloads.edge.provider is not a "
+                "known 9.x value (refused before any write). ``'invalid_spec'`` -- a "
+                "required control_plane / workloads sub-field was missing (refused before "
+                "any write)."
+            ),
+        },
+        "cluster": {"type": "string", "description": "Input cluster moid."},
+        "supervisor": {
+            "type": ["string", "null"],
+            "description": (
+                "New Supervisor id returned by the enable POST; ``null`` on any refusal."
+            ),
+        },
+        "network_type": {
+            "type": ["string", "null"],
+            "description": "Echoed workload network_type on success / provider refusal.",
+        },
+        "edge_provider": {
+            "type": ["string", "null"],
+            "description": "Echoed edge provider on success.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "cluster", "supervisor"],
+}
+
+
+#: ``vmware.composite.supervisor.disable`` parameter schema.
+SUPERVISOR_DISABLE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "ClusterComputeResource moid of the Supervisor-enabled cluster to tear "
+                "down. Rides ``POST /vcenter/namespace-management/clusters/{cluster}"
+                "?action=disable`` (``DELETE clusters/{cluster}`` 404s)."
+            ),
+        },
+    },
+    "required": ["cluster"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.supervisor.disable`` response schema.
+SUPERVISOR_DISABLE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["disabling"],
+            "description": (
+                "``'disabling'`` -- the disable POST was accepted (asynchronous; poll "
+                "``vmware.composite.supervisor.status``, config_status moves through "
+                "'REMOVING')."
+            ),
+        },
+        "cluster": {"type": "string", "description": "Input cluster moid."},
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "cluster"],
+}
+
+
+#: ``vmware.composite.supervisor.status`` parameter schema.
+SUPERVISOR_STATUS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "ClusterComputeResource moid to read Supervisor status for "
+                "(``GET /vcenter/namespace-management/clusters/{cluster}``)."
+            ),
+        },
+        "messages_limit": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Optional cap on the inline ``messages`` / ``conditions`` arrays "
+                "(default 25). ``message_count`` / ``condition_count`` always carry the "
+                "uncapped sizes."
+            ),
+        },
+    },
+    "required": ["cluster"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.supervisor.status`` response schema. Shaped for inline
+#: polling: the scalar ``config_status`` / ``kubernetes_status`` / ``ready``
+#: stay top-level so a runbook OperationCallVerify step or a Sensor assertion
+#: reads them without a JSONFlux handle.
+SUPERVISOR_STATUS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {"type": "string", "description": "Input cluster moid."},
+        "config_status": {
+            "type": ["string", "null"],
+            "description": (
+                "Clusters.ConfigStatus: CONFIGURING / REMOVING / RUNNING / ERROR. "
+                "``null`` when absent from the vCenter payload."
+            ),
+        },
+        "kubernetes_status": {
+            "type": ["string", "null"],
+            "description": "Clusters.KubernetesStatus: READY / WARNING / ERROR; else null.",
+        },
+        "ready": {
+            "type": "boolean",
+            "description": (
+                "True iff config_status == 'RUNNING' AND kubernetes_status == 'READY' -- "
+                "the single poll predicate a runbook / Sensor waits on."
+            ),
+        },
+        "messages": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Capped Clusters.Message rows (severity + details).",
+        },
+        "conditions": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Capped Clusters.Condition rows (type / status / severity).",
+        },
+        "message_count": {"type": "integer", "description": "Uncapped message count."},
+        "condition_count": {"type": "integer", "description": "Uncapped condition count."},
+    },
+    "required": ["cluster", "config_status", "kubernetes_status", "ready"],
 }

--- a/backend/tests/acceptance/test_supervisor_op_id_reconcile.py
+++ b/backend/tests/acceptance/test_supervisor_op_id_reconcile.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Build-time guard: the Supervisor (WCP) composite op_ids resolve in the spec.
+
+#3281. The ``vmware.composite.supervisor.*`` composites in
+:mod:`~meho_backplane.connectors.vmware_rest.composites._supervisor` dispatch
+three canonical ``METHOD:/path`` op_ids against the vCenter
+namespace-management surface:
+
+* enable  -- ``POST:/vcenter/namespace-management/supervisors/{cluster}``
+  ``?action=enable_on_compute_cluster``
+* disable -- ``POST:/vcenter/namespace-management/clusters/{cluster}?action=disable``
+* status  -- ``GET:/vcenter/namespace-management/clusters/{cluster}``
+
+Both writes ride the governed REST sub-op seam (``_write_sub_op`` ->
+``enforce_subop_policy`` -> ``_post_json``); the status read rides the read
+seam (``_read_sub_op``). Each op_id must be byte-for-byte the string the
+ingest parser emits from the pinned ``vcenter.yaml``, or the sub-op would
+mount a path vCenter does not serve.
+
+Two tiers mirror the ``network.portgroup.audit`` reconcile guard
+(:mod:`tests.acceptance.test_portgroup_audit_op_id_reconcile`):
+
+* an **always-on** test pinning the constant *strings* so a drift (e.g. a
+  respelt ``?action=`` verb, or a slip back to the deprecated
+  ``clusters/{cluster}?action=enable`` form) is caught even in the sandbox
+  where the vendor spec is unavailable;
+* a **spec-backed** test that parses the canonical pinned ``vcenter.yaml``
+  through the real :func:`parse_openapi` and asserts each op_id is emitted --
+  it skips when the spec shelf is unconfigured and runs in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.connectors.vmware_rest.composites import _supervisor
+from meho_backplane.operations.ingest import parse_openapi
+from tests.acceptance._vcenter_spec import (
+    VCENTER_SPEC_REASON,
+    resolve_vcenter_yaml,
+)
+
+
+def test_supervisor_op_id_constants_are_the_reconciled_rest_keys() -> None:
+    """Pin the exact op_id constants (sandbox-safe, always runs).
+
+    Freezes the ``METHOD:/path`` keys the REST Automation ingest produces so
+    a regression to the deprecated 7.x ``clusters/{cluster}?action=enable``
+    form, or a drift in the ``?action=`` verb / ``{cluster}`` path var, goes
+    red even without the spec shelf.
+    """
+    assert _supervisor._OP_ENABLE_ON_COMPUTE_CLUSTER == (
+        "POST:/vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster"
+    )
+    assert (
+        _supervisor._OP_DISABLE
+        == "POST:/vcenter/namespace-management/clusters/{cluster}?action=disable"
+    )
+    assert _supervisor._OP_GET_CLUSTER == "GET:/vcenter/namespace-management/clusters/{cluster}"
+    # The governed-subop manifests reference exactly those write op_ids.
+    assert _supervisor._SUB_OPS_SUPERVISOR_ENABLE == (_supervisor._OP_ENABLE_ON_COMPUTE_CLUSTER,)
+    assert _supervisor._SUB_OPS_SUPERVISOR_DISABLE == (_supervisor._OP_DISABLE,)
+
+
+def test_supervisor_op_ids_resolve_against_pinned_vcenter_spec() -> None:
+    """Every Supervisor composite op_id is emitted by parsing the pinned vcenter.yaml.
+
+    Parser op_ids are byte-for-byte the strings written to
+    ``endpoint_descriptor.op_id`` and the strings the governed sub-op seam +
+    the read seam mount, so parser coverage == dispatch resolution for these
+    composites. Skips when the spec shelf is unconfigured (sandbox); CI wires
+    the env vars and runs it for real.
+    """
+    spec_path = resolve_vcenter_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+
+    spec_text = spec_path.read_text(encoding="utf-8")
+    rows = parse_openapi(
+        f"file://{spec_path}",
+        spec_source="spec:vcenter.yaml",
+        content=spec_text,
+    )
+    ingested_op_ids = {row.op_id for row in rows}
+
+    required = {
+        _supervisor._OP_ENABLE_ON_COMPUTE_CLUSTER,
+        _supervisor._OP_DISABLE,
+        _supervisor._OP_GET_CLUSTER,
+    }
+    missing = required - ingested_op_ids
+    assert not missing, (
+        "vmware.composite.supervisor.* declares op_ids the vcenter.yaml ingest "
+        f"does not emit: {sorted(missing)}. Either a constant drifted from the "
+        "METHOD:/path form the parser produces, or the pinned spec revision no "
+        "longer exposes the namespace-management resource under that key "
+        "(re-check against the vSphere Automation REST API)."
+    )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -71,6 +71,8 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.env.read",
     "vmware.composite.vm.guest.net.show",
     "vmware.composite.vm.guest.file.read",
+    # Supervisor (WCP) status read (#3281).
+    "vmware.composite.supervisor.status",
 )
 
 
@@ -103,6 +105,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.file.read": (
         "meho_backplane.connectors.vmware_rest.composites._guest.guest_file_read_composite"
     ),
+    "vmware.composite.supervisor.status": (
+        "meho_backplane.connectors.vmware_rest.composites._supervisor.supervisor_status_composite"
+    ),
 }
 
 
@@ -116,6 +121,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.env.read": "guest_ops",
     "vmware.composite.vm.guest.net.show": "guest_ops",
     "vmware.composite.vm.guest.file.read": "guest_ops",
+    "vmware.composite.supervisor.status": "namespace_management",
 }
 
 
@@ -212,7 +218,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # network.portgroup.security.set + the content-library import
     # vm.import_from_library #3229). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 38
+    assert stub_embedding_service.encode_one.call_count == 41
 
 
 @pytest.mark.asyncio
@@ -475,11 +481,12 @@ async def test_register_vmware_composite_operations_is_idempotent(
     vm.guest.program.run #3255 + the destructive-tier vm.destroy #3198 + the
     #3091 vim distributed-portgroup writes network.portgroup.create +
     network.portgroup.security.set + the content-library import
-    vm.import_from_library #3229).
+    vm.import_from_library #3229 + the Supervisor writes supervisor.enable +
+    supervisor.disable + the supervisor.status read #3281).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 38
+    assert first_count == 41
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -497,7 +504,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 9
+    assert len(rows) == 10
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_supervisor.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_supervisor.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Handler + schema tests for the Supervisor (WCP) composites (#3281).
+
+Covers the three ``vmware.composite.supervisor.*`` composites in
+:mod:`~meho_backplane.connectors.vmware_rest.composites._supervisor`:
+``enable`` / ``disable`` (dangerous, approval-gated writes) and ``status``
+(safe read). Two concerns:
+
+* **Handler behaviour** with a stubbed gate (``_GateRecorder``) and a
+  recording connector double: the enable happy path (spec flows to the
+  ``enable_on_compute_cluster`` POST body, Supervisor id returned, async
+  ``enabling`` status, no blocking poll), the **loud** server-side refusals
+  (unknown network stack / edge provider / missing control-plane essentials
+  never reach the wire), the parked-gate short-circuit, the disable path,
+  and the poll-friendly status reshaping (scalar ``config_status`` /
+  ``kubernetes_status`` / ``ready`` inline, capped message arrays).
+* **Parameter-schema conformance**: the registered JSON Schema accepts a
+  well-formed enable/disable/status payload and rejects unknown top-level
+  keys + missing required fields, so a malformed ``params`` is caught by the
+  dispatcher's Draft202012Validator before the handler runs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites import _supervisor, _write
+from meho_backplane.connectors.vmware_rest.composites._supervisor import (
+    supervisor_disable_composite,
+    supervisor_enable_composite,
+    supervisor_status_composite,
+)
+from meho_backplane.connectors.vmware_rest.composites.schemas import (
+    SUPERVISOR_DISABLE_PARAMETER_SCHEMA,
+    SUPERVISOR_ENABLE_PARAMETER_SCHEMA,
+    SUPERVISOR_STATUS_PARAMETER_SCHEMA,
+)
+
+_ENABLE_OP_ID = (
+    "POST:/vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster"
+)
+_DISABLE_OP_ID = "POST:/vcenter/namespace-management/clusters/{cluster}?action=disable"
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="agent-supervisor-composite",
+        name="Supervisor Composite Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-0000000032a1"),
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.AGENT,
+    )
+
+
+class _GateRecorder:
+    """Recording stub for :func:`enforce_subop_policy` (auto-execute by default)."""
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {
+                "op_id": op_id,
+                "connector_id": connector_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
+                "params": dict(params),
+            }
+        )
+        return self._gate_for.get(op_id)
+
+    @property
+    def gated_op_ids(self) -> list[str]:
+        return [c["op_id"] for c in self.calls]
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    """Install a default (auto-execute) gate recorder on the ``_write`` module.
+
+    The supervisor writes route through ``_write._write_sub_op``, which
+    resolves ``enforce_subop_policy`` in the ``_write`` namespace.
+    """
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+class _RecordingConnector:
+    """Recording connector double serving the status read + recording writes."""
+
+    def __init__(
+        self,
+        *,
+        enable_result: Any = "supervisor-42",
+        status_info: dict[str, Any] | None = None,
+    ) -> None:
+        self._enable_result = enable_result
+        self._status_info = status_info or {}
+        self.writes: list[dict[str, Any]] = []
+        self.gets: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        del target, operator
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return query or None
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        del target, operator, params
+        self.gets.append(path)
+        return self._status_info
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        timeout: Any = None,
+    ) -> Any:
+        del target, operator, timeout
+        self.writes.append({"path": path, "verb": verb, "json": json})
+        if path.endswith("?action=enable_on_compute_cluster"):
+            return self._enable_result
+        return None
+
+
+def _valid_enable_params(
+    *, network_type: str = "VSPHERE", provider: str = "VSPHERE_FOUNDATION"
+) -> dict[str, Any]:
+    return {
+        "cluster": "domain-c8",
+        "name": "envision-supervisor",
+        "control_plane": {
+            "network": {"backing": {"network": "dvportgroup-30"}},
+            "storage_policy": "nfs-policy-1",
+            "size": "TINY",
+            "count": 3,
+        },
+        "workloads": {
+            "network": {"network_type": network_type},
+            "edge": {
+                "provider": provider,
+                "load_balancer_address_ranges": [{"address": "10.0.0.10", "count": 16}],
+            },
+            "storage": {
+                "ephemeral_storage_policy": "nfs-policy-1",
+                "image_storage_policy": "nfs-policy-1",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# enable
+# ---------------------------------------------------------------------------
+
+
+async def test_enable_happy_path_dispatches_spec_body(gate: _GateRecorder) -> None:
+    connector = _RecordingConnector(enable_result="supervisor-42")
+    result = await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=_valid_enable_params(),
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result == {
+        "status": "enabling",
+        "cluster": "domain-c8",
+        "supervisor": "supervisor-42",
+        "network_type": "VSPHERE",
+        "edge_provider": "VSPHERE_FOUNDATION",
+        "guidance": result["guidance"],  # type: ignore[index]
+    }
+    # Gate ran against the canonical enable op_id with the composite posture.
+    assert gate.gated_op_ids == [_ENABLE_OP_ID]
+    assert gate.calls[0]["safety_level"] == "dangerous"
+    # Exactly one write reached the wire: the enable POST with the nested body
+    # (cluster is the path var; zone omitted).
+    assert len(connector.writes) == 1
+    write = connector.writes[0]
+    expected_path = "/api" + _ENABLE_OP_ID.split(":", 1)[1].replace("{cluster}", "domain-c8")
+    assert write["path"] == expected_path
+    assert write["verb"] == "POST"
+    assert set(write["json"]) == {"name", "control_plane", "workloads"}
+    assert "cluster" not in write["json"]
+    assert write["json"]["workloads"]["edge"]["provider"] == "VSPHERE_FOUNDATION"
+
+
+async def test_enable_nsx_vpc_stack_is_accepted(gate: _GateRecorder) -> None:
+    connector = _RecordingConnector()
+    result = await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=_valid_enable_params(network_type="NSX_VPC", provider="NSX_VPC"),
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["status"] == "enabling"
+    assert result["network_type"] == "NSX_VPC"
+    assert len(connector.writes) == 1
+
+
+async def test_enable_zone_flows_into_body_when_present(gate: _GateRecorder) -> None:
+    connector = _RecordingConnector()
+    params = _valid_enable_params()
+    params["zone"] = "zone-1"
+    await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=params,
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert connector.writes[0]["json"]["zone"] == "zone-1"
+
+
+@pytest.mark.parametrize(
+    ("network_type", "provider"),
+    [
+        ("VSPHERE_NETWORK", "VSPHERE_FOUNDATION"),  # deprecated flat-spec term, not 9.x
+        ("VSPHERE", "AVI"),  # AVI is a post-enable derived provider, not an input
+        ("bogus", "VSPHERE_FOUNDATION"),
+    ],
+)
+async def test_enable_refuses_unknown_network_provider_loudly(
+    gate: _GateRecorder, network_type: str, provider: str
+) -> None:
+    connector = _RecordingConnector()
+    result = await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=_valid_enable_params(network_type=network_type, provider=provider),
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["status"] == "unknown_network_provider"
+    assert result["supervisor"] is None
+    assert result["guidance"]
+    # Fail-closed: nothing reached the wire and the gate was never consulted.
+    assert connector.writes == []
+    assert gate.calls == []
+
+
+async def test_enable_refuses_missing_control_plane_storage_policy(gate: _GateRecorder) -> None:
+    connector = _RecordingConnector()
+    params = _valid_enable_params()
+    del params["control_plane"]["storage_policy"]
+    result = await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=params,
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["status"] == "invalid_spec"
+    assert connector.writes == []
+    assert gate.calls == []
+
+
+async def test_enable_parked_gate_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    parked = OperationResult(
+        status="awaiting_approval", op_id="vmware.composite.supervisor.enable", duration_ms=0
+    )
+    recorder = _GateRecorder(gate_for={_ENABLE_OP_ID: parked})
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    connector = _RecordingConnector()
+    result = await supervisor_enable_composite(
+        operator=_operator(),
+        target=object(),
+        params=_valid_enable_params(),
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result is parked
+    assert connector.writes == []
+
+
+# ---------------------------------------------------------------------------
+# disable
+# ---------------------------------------------------------------------------
+
+
+async def test_disable_happy_path(gate: _GateRecorder) -> None:
+    connector = _RecordingConnector()
+    result = await supervisor_disable_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["status"] == "disabling"
+    assert result["cluster"] == "domain-c8"
+    assert gate.gated_op_ids == [_DISABLE_OP_ID]
+    assert len(connector.writes) == 1
+    write = connector.writes[0]
+    assert write["path"] == "/api/vcenter/namespace-management/clusters/domain-c8?action=disable"
+    # No request body on disable.
+    assert write["json"] is None
+
+
+async def test_disable_parked_gate_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    parked = OperationResult(
+        status="awaiting_approval", op_id="vmware.composite.supervisor.disable", duration_ms=0
+    )
+    recorder = _GateRecorder(gate_for={_DISABLE_OP_ID: parked})
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    connector = _RecordingConnector()
+    result = await supervisor_disable_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result is parked
+    assert connector.writes == []
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+async def test_status_running_ready_is_pollable_inline() -> None:
+    connector = _RecordingConnector(
+        status_info={
+            "config_status": "RUNNING",
+            "kubernetes_status": "READY",
+            "messages": [],
+            "conditions": [{"type": "InfrastructureInitialized", "status": "TRUE"}],
+        }
+    )
+    result = await supervisor_status_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["config_status"] == "RUNNING"
+    assert result["kubernetes_status"] == "READY"
+    assert result["ready"] is True
+    assert result["condition_count"] == 1
+    assert connector.gets == ["/api/vcenter/namespace-management/clusters/domain-c8"]
+
+
+async def test_status_configuring_is_not_ready() -> None:
+    connector = _RecordingConnector(
+        status_info={"config_status": "CONFIGURING", "kubernetes_status": "ERROR"}
+    )
+    result = await supervisor_status_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["ready"] is False
+    assert result["messages"] == []
+    assert result["message_count"] == 0
+
+
+async def test_status_caps_message_arrays_but_reports_true_count() -> None:
+    conditions = [{"type": f"c{i}"} for i in range(40)]
+    connector = _RecordingConnector(
+        status_info={
+            "config_status": "CONFIGURING",
+            "kubernetes_status": "WARNING",
+            "conditions": conditions,
+        }
+    )
+    result = await supervisor_status_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8", "messages_limit": 5},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert len(result["conditions"]) == 5
+    assert result["condition_count"] == 40
+
+
+async def test_status_handles_absent_status_fields() -> None:
+    connector = _RecordingConnector(status_info={})
+    result = await supervisor_status_composite(
+        operator=_operator(),
+        target=object(),
+        params={"cluster": "domain-c8"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert result["config_status"] is None
+    assert result["kubernetes_status"] is None
+    assert result["ready"] is False
+
+
+# ---------------------------------------------------------------------------
+# parameter-schema conformance
+# ---------------------------------------------------------------------------
+
+
+def test_enable_schema_accepts_valid_and_rejects_unknown_key() -> None:
+    validator = Draft202012Validator(SUPERVISOR_ENABLE_PARAMETER_SCHEMA)
+    validator.validate(_valid_enable_params())
+    bad = _valid_enable_params()
+    bad["network_provider"] = "VSPHERE_NETWORK"  # deprecated flat-spec key not on the surface
+    assert list(validator.iter_errors(bad))
+
+
+def test_enable_schema_requires_control_plane_and_workloads() -> None:
+    validator = Draft202012Validator(SUPERVISOR_ENABLE_PARAMETER_SCHEMA)
+    missing = {"cluster": "domain-c8", "name": "x"}
+    assert list(validator.iter_errors(missing))
+    no_provider = _valid_enable_params()
+    del no_provider["workloads"]["edge"]["provider"]
+    assert list(validator.iter_errors(no_provider))
+
+
+def test_disable_schema_requires_cluster_only() -> None:
+    validator = Draft202012Validator(SUPERVISOR_DISABLE_PARAMETER_SCHEMA)
+    validator.validate({"cluster": "domain-c8"})
+    assert list(validator.iter_errors({"cluster": "domain-c8", "extra": 1}))
+    assert list(validator.iter_errors({}))
+
+
+def test_status_schema_accepts_optional_limit() -> None:
+    validator = Draft202012Validator(SUPERVISOR_STATUS_PARAMETER_SCHEMA)
+    validator.validate({"cluster": "domain-c8"})
+    validator.validate({"cluster": "domain-c8", "messages_limit": 10})
+    assert list(validator.iter_errors({"cluster": "domain-c8", "messages_limit": -1}))
+
+
+def test_governed_subop_manifest_references_supervisor_writes() -> None:
+    assert _supervisor._SUB_OPS_SUPERVISOR_ENABLE == (_ENABLE_OP_ID,)
+    assert _supervisor._SUB_OPS_SUPERVISOR_DISABLE == (_DISABLE_OP_ID,)

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -98,6 +98,8 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.host.service_control",
         "vmware.composite.vm.guest.file.write",
         "vmware.composite.vm.guest.program.run",
+        "vmware.composite.supervisor.enable",
+        "vmware.composite.supervisor.disable",
     }
 )
 
@@ -309,14 +311,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 26 write composites register a builder (criterion 4)
+# Wiring — all 28 preview-carrying write composites register a builder (criterion 4)
 # ===========================================================================
 
 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 26
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 28
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -72,7 +72,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 29 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 31 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893 + WSFC/FCI vm.disk.attach / #3256,
 # the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
@@ -81,8 +81,9 @@ from meho_backplane.settings import get_settings
 # GOSC composites guest.customization_spec.create + vm.customize / #2892,
 # the destructive-tier vm.destroy / #3198, the vim distributed-portgroup
 # writes network.portgroup.create + network.portgroup.security.set / #3091,
-# the content-library import vm.import_from_library / #3229, and the
-# guest-ops writes vm.guest.file.write / #3100 + vm.guest.program.run / #3255).
+# the content-library import vm.import_from_library / #3229, the
+# guest-ops writes vm.guest.file.write / #3100 + vm.guest.program.run / #3255,
+# and the Supervisor (WCP) writes supervisor.enable + supervisor.disable / #3281).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -114,6 +115,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     # Guest-ops channel writes (#3100 / #3255).
     "vmware.composite.vm.guest.file.write",
     "vmware.composite.vm.guest.program.run",
+    # Supervisor (WCP) namespace-management writes (#3281).
+    "vmware.composite.supervisor.enable",
+    "vmware.composite.supervisor.disable",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -131,9 +135,12 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.env.read",
     "vmware.composite.vm.guest.net.show",
     "vmware.composite.vm.guest.file.read",
+    # Supervisor (WCP) status read (#3281).
+    "vmware.composite.supervisor.status",
 )
 
-# 38 total -- 9 read (T5 / #508 + 4 guest-ops reads / #3100) + 29 write
+# 41 total -- 10 read (T5 / #508 + 4 guest-ops reads / #3100 + the
+# supervisor status read / #3281) + 31 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -142,7 +149,8 @@ _READ_OP_IDS: tuple[str, ...] = (
 # network.portgroup.create + network.portgroup.security.set + the
 # content-library import vm.import_from_library / #3229 + the guest-ops
 # program-exec write vm.guest.program.run / #3255 + the WSFC/FCI shared-attach
-# vm.disk.attach / #3256).
+# vm.disk.attach / #3256 + the Supervisor writes supervisor.enable +
+# supervisor.disable / #3281).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -236,6 +244,12 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.program.run": (
         "meho_backplane.connectors.vmware_rest.composites._guest.guest_program_run_composite"
     ),
+    "vmware.composite.supervisor.enable": (
+        "meho_backplane.connectors.vmware_rest.composites._supervisor.supervisor_enable_composite"
+    ),
+    "vmware.composite.supervisor.disable": (
+        "meho_backplane.connectors.vmware_rest.composites._supervisor.supervisor_disable_composite"
+    ),
 }
 
 
@@ -269,6 +283,8 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.host.service_control": "host",
     "vmware.composite.vm.guest.file.write": "guest_ops",
     "vmware.composite.vm.guest.program.run": "guest_ops",
+    "vmware.composite.supervisor.enable": "namespace_management",
+    "vmware.composite.supervisor.disable": "namespace_management",
 }
 
 
@@ -348,7 +364,8 @@ async def test_full_registration_produces_thirty_three_composite_rows(
     vm.guest.file.write #3100 + vm.guest.program.run #3255 + destructive-tier
     vm.destroy #3198 + #3091 portgroup writes network.portgroup.create /
     network.portgroup.security.set + content-library import
-    vm.import_from_library #3229) = 38 rows. DoD bar."""
+    vm.import_from_library #3229 + Supervisor writes supervisor.enable /
+    supervisor.disable #3281) = 41 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -362,7 +379,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 38
+    assert len(rows) == 41
 
 
 @pytest.mark.asyncio
@@ -689,14 +706,14 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 38 rows total, embedding called 38x once."""
+    """Running the registrar twice -> 41 rows total, embedding called 41x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 38
+    assert first_count == 41
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 38.
+    # pipeline; the row count stays at 41.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -710,7 +727,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 38
+    assert len(rows) == 41
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -89,6 +89,7 @@ _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
         "host",
         "guest",
         "guest_ops",
+        "namespace_management",
     }
 )
 _BIND9_GROUPS: Final[frozenset[str]] = frozenset({"identity", "zone", "record", "config"})

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,11 +8,12 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 38 hand-authored composites
-that orchestrate cross-spec workflows: 9 read composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 41 hand-authored composites
+that orchestrate cross-spec workflows: 10 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`; plus the four guest-operations reads `#3100`) and 29 write
+in `#2258`; plus the four guest-operations reads `#3100` and the
+Supervisor status read `#3281`) and 31 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893` + the WSFC/FCI shared-attach
@@ -27,10 +28,13 @@ the three host-domain writes `host.datastore_mount_nfs` /
 `host.disk_mark_flash` / `host.service_control` / `#3182`, the two vim
 distributed-portgroup writes `network.portgroup.create` +
 `network.portgroup.security.set` / `#3091`, the content-library import
-`vm.import_from_library` / `#3229`, plus the two governed
+`vm.import_from_library` / `#3229`, the two governed
 guest-operations writes `vm.guest.file.write` / `#3100` +
 `vm.guest.program.run` / `#3255` (see
-`connectors-vmware-rest-guest-ops.md`)). The
+`connectors-vmware-rest-guest-ops.md`), plus the two Supervisor (WCP)
+namespace-management writes `supervisor.enable` + `supervisor.disable`
+/ `#3281` (see the **Supervisor (WCP) namespace-management composites**
+subsection under Control flow)). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -268,10 +272,23 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   safety model live in `connectors-vmware-rest-guest-ops.md`; the freeform
   in-guest program-exec tier `StartProgramInGuest` #3100 deferred is now
   lifted as `guest.program.run` (#3255).
+- **Supervisor (WCP) namespace-management composites** (`#3281`, group
+  `namespace_management`, `composites/_supervisor.py`) — the governed
+  replacement for out-of-band `govc` / `kubectl-vsphere` Supervisor
+  enablement. Two `dangerous` / approval-gated writes,
+  `supervisor_enable_composite`
+  (`POST:/vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster`,
+  the current 9.x path — the `clusters/{cluster}?action=enable` form is
+  deprecated as of vSphere 9.0) and `supervisor_disable_composite`
+  (`POST:/vcenter/namespace-management/clusters/{cluster}?action=disable`),
+  plus one `safe` read, `supervisor_status_composite`
+  (`GET:/vcenter/namespace-management/clusters/{cluster}`). See the
+  **Supervisor (WCP) namespace-management composites** subsection under
+  Control flow.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 37
-  `_CompositeSpec` rows (9 read + 24 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 41
+  `_CompositeSpec` rows (10 read + 31 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -1603,6 +1620,72 @@ gate as every other write composite (there is no `caution` tier in this
 connector; only `vm.destroy` is `destructive`). Neither composite registers a
 park-time preview builder (matching `vm.import_from_library`); the read-back
 `previous` / `observed` rows in the response are the verification surface.
+
+### Supervisor (WCP) namespace-management composites (`supervisor.enable` / `supervisor.disable` / `supervisor.status`, #3281)
+
+`composites/_supervisor.py` (group `namespace_management`) governs vSphere
+Supervisor (Workload Control Plane) lifecycle on a cluster — the governed
+replacement for out-of-band `govc` / `kubectl-vsphere` enablement. Three ops:
+
+**`supervisor.enable`** (`dangerous` / `requires_approval=True`) issues
+`POST:/vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster`
+— the current 9.x path. The 7.x `clusters/{cluster}?action=enable` form is
+**deprecated as of vSphere 9.0** and is not used. The body is the nested
+`EnableOnComputeClusterSpec` (`name` + `control_plane` + `workloads` +
+optional `zone`), passed as the **top-level** POST body verbatim (the
+top-level-`*Spec` envelope convention documented above — never wrapped in
+`{"spec": {...}}`); `{cluster}` is the only path var, so the composite's
+`params` carry `cluster` plus the spec sub-objects and `_split_sub_op` lifts
+the remainder into the body. The handler validates the spec **server-side
+before any write**: `control_plane` must carry a management `network` and a
+`storage_policy` (on NFS there is no default SPBM policy), and the workload
+network stack — `workloads.network.network_type` (`VSPHERE` / `NSXT` /
+`NSX_VPC`) paired with `workloads.edge.provider` (`VSPHERE_FOUNDATION` / `NSX`
+/ `NSX_VPC` / `NSX_ADVANCED` / `HAPROXY`) — is checked against the
+authoritative 9.x enums and an unknown value is **refused loudly**
+(`status='unknown_network_provider'`, nothing reaches the wire, the gate is
+never consulted). The VDS + Foundation LB model is `VSPHERE` +
+`VSPHERE_FOUNDATION` (no separate NSX edge cluster required); the NSX VPC
+model is `NSX_VPC` + `NSX_VPC`. Enable is **asynchronous**: vCenter returns
+the new Supervisor id immediately (the handler returns
+`status='enabling'`), and the composite deliberately does **not** block the
+dispatcher polling the 30–60 min `CONFIGURING` → `RUNNING` convergence —
+readiness is the separate `supervisor.status` op.
+
+**`supervisor.disable`** (`dangerous` / `requires_approval=True`) issues
+`POST:/vcenter/namespace-management/clusters/{cluster}?action=disable`
+(`DELETE clusters/{cluster}` 404s — the action form is the documented
+teardown). No request body; removes the control-plane VMs + worker nodes but
+leaves the cluster's networking / zone intact for a fresh re-enable.
+Asynchronous (`status='disabling'`; poll `supervisor.status`, `config_status`
+moves through `REMOVING`).
+
+Both writes ride the standard governed REST sub-op seam
+(`_write._write_sub_op` → `enforce_subop_policy` → `_post_json`): the
+top-level composite's own `dangerous` / `requires_approval=True` posture pops
+the human approval park at dispatch, and the governed child POST re-applies
+policy under the shared `dangerous` / `requires_approval=False` sub-op posture
+(`_governed_subops._GOVERNED_SUBOP_MANIFEST` publishes each write's grant set).
+Both register echo-only park-time preview builders (`_write_preview`) — enable
+echoes cluster / name / size / count / network stack, disable echoes the
+cluster + an irreversibility marker.
+
+**`supervisor.status`** (`safe` / `requires_approval=False`) reads
+`GET:/vcenter/namespace-management/clusters/{cluster}` and reshapes
+`Clusters.Info` into a **poll-friendly, inline** envelope: the scalar
+`config_status` (`CONFIGURING` / `REMOVING` / `RUNNING` / `ERROR`),
+`kubernetes_status` (`READY` / `WARNING` / `ERROR`), and a derived `ready`
+flag (`RUNNING` AND `READY`) stay top-level so a runbook `OperationCallVerify`
+step or a Sensor assertion can poll `ready == true` / `config_status ==
+'RUNNING'` **directly**, never behind a JSONFlux handle. The `messages` +
+`conditions` arrays (which can grow during `CONFIGURING`) are capped inline
+(`messages_limit`, default 25); `message_count` / `condition_count` carry the
+uncapped sizes.
+
+The three op_ids are byte-for-byte the strings the ingest parser emits from
+the pinned `vcenter.yaml`; the reconcile guard
+`tests/acceptance/test_supervisor_op_id_reconcile.py` pins them (always-on
+string test + spec-backed parse).
 
 ### Read-composite best-effort enrichment (`datastore.usage`, #1908)
 


### PR DESCRIPTION
## Summary

Adds governed vSphere **Supervisor (Workload Control Plane)** lifecycle to the `vmware_rest` connector in a new `namespace_management` operation group, so enable / disable / status stop escaping the backplane's policy / audit / approval path (they run out-of-band via `govc` / `kubectl-vsphere` today):

- **`vmware.composite.supervisor.enable`** (`dangerous`, `requires_approval=True`) — `POST /vcenter/namespace-management/supervisors/{cluster}?action=enable_on_compute_cluster` (the current 9.x path; the `clusters/{cluster}?action=enable` form is **deprecated as of vSphere 9.0** and is not used). Takes the nested `EnableOnComputeClusterSpec` (`name` + `control_plane` + `workloads` + optional `zone`) as the top-level POST body, validated server-side; an unknown workload `network_type` / edge `provider` is **refused loudly** (`status='unknown_network_provider'`, nothing reaches the wire).
- **`vmware.composite.supervisor.disable`** (`dangerous`, `requires_approval=True`) — `POST /vcenter/namespace-management/clusters/{cluster}?action=disable` (`DELETE` 404s).
- **`vmware.composite.supervisor.status`** (`safe`) — `GET /vcenter/namespace-management/clusters/{cluster}`, reshaped so scalar `config_status` / `kubernetes_status` / derived `ready` stay top-level for a runbook `OperationCallVerify` step or a Sensor to poll inline (never behind a JSONFlux handle); the `messages` / `conditions` arrays are capped inline.

enable/disable are **asynchronous** (return immediately) — readiness is the `status` op, so the dispatcher never blocks on the 30–60 min convergence. Both writes ride the standard governed REST sub-op seam (`_write_sub_op` → `enforce_subop_policy` → `_post_json`) and register echo-only park-time preview builders. VDS + Foundation LB is `network_type=VSPHERE` + `edge.provider=VSPHERE_FOUNDATION` (no separate NSX edge cluster); NSX VPC (`NSX_VPC`/`NSX_VPC`) remains expressible.

### Generic-unstage spike result (typed composite chosen — matches #3281's expected outcome)

`vmware_rest` is a **real** connector (it overrides `mount_op_path`), so an unstaged ingested namespace-management enable POST would dispatch via `httpx` — it is **not** an `unreplaced_auto_shim` dead end, so generic dispatch is *mechanically* possible. It is nonetheless insufficient: it cannot (a) refuse an unknown network provider loudly, (b) shape the async readiness poll (`config_status` scalar) for a runbook/Sensor, or (c) safely carry the deeply nested, provider-discriminated `EnableOnComputeClusterSpec`. So the enable/disable are typed composites and `status` is the poll op they hand the runbook. (Note: the current `enable_on_compute_cluster` body is the **nested** `EnableOnComputeClusterSpec` — `control_plane` / `workloads` — not the flat deprecated `Clusters.EnableSpec`; the loud provider check validates `workloads.network.network_type` ∈ {VSPHERE, NSXT, NSX_VPC} and `workloads.edge.provider` ∈ {VSPHERE_FOUNDATION, NSX, NSX_VPC, NSX_ADVANCED, HAPROXY}.)

**No new MCP tools** — composites are ops dispatched via `call_operation`; the default agent surface and `docs/codebase/mcp.md` are unchanged (the generated `docs-site/reference/*.md` regen produced no diff).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on all touched files
- [x] `mypy src/meho_backplane/connectors/vmware_rest/composites/` — clean (10 files)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (1 warning: enable handler 69 lines, under the 100-line block threshold)
- [x] New handler + schema unit tests — `tests/test_connectors_vmware_rest_composites_supervisor.py` (19 tests: enable happy path + spec-body dispatch, NSX_VPC accepted, zone flows through, loud `unknown_network_provider` / `invalid_spec` refusals never reach the wire, parked-gate short-circuit, disable, poll-friendly status reshaping + caps, parameter-schema conformance)
- [x] Reconcile lane — `tests/acceptance/test_supervisor_op_id_reconcile.py`: always-on string-pin of the three op_ids + spec-backed parse (skips in sandbox, **verified passing** against the pinned `vcenter.yaml` — all three op_ids are byte-for-byte the ingest parser's output)
- [x] Registration guards updated + green — `test_connectors_vmware_rest_composites_register.py`, `..._write_register.py` (41 total: 10 read + 31 write), `..._write_preview.py` (28 preview builders), `test_typed_connectors_metadata.py` (`namespace_management` group), `test_governed_subops.py` (derives from the manifest)
- [x] Targeted suite (`-k "vmware_rest or governed_subop or composite or mcp_surface or typed_connectors_metadata or supervisor"`) — 1213 passed, 42 skipped
- [x] `docs/codebase/connectors-vmware-rest.md` updated (Overview counts + a dedicated Supervisor composites subsection)

## Changelog (batched separately — not in this PR per merge-queue policy)

```
### Added
- vmware_rest: governed vSphere Supervisor (WCP) lifecycle — `vmware.composite.supervisor.enable` / `.disable` (approval-gated) + `.status` (poll-friendly) in the new `namespace_management` operation group (#3281).
```

## Out of scope / adjacent findings

- Follow-on Supervisor prerequisites tracked elsewhere in the Envision program (NFS SPBM tag-policy create, vSphere-namespace create, subscribed content-library create, guest-cluster kubeconfig read) — not this task.
- `_supervisor.py::supervisor_enable_composite` is 69 lines (code-quality warn threshold 60, block 100) — mostly docstring + the response envelope; left as-is (under the block bar).

Closes #3281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
