### PR TITLE
feat(connectors): SDDC Manager 9.1 shelf + curated workload-domain write ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,7 @@ jobs:
             docs/proxmox-8.4
             docs/rabbitmq-4.3
             docs/sddc-manager-9.0
+            docs/sddc-manager-9.1
             docs/vcenter-9.0
             docs/vcf-automation-9.0
             docs/vcf-operations-9.0
@@ -521,6 +522,7 @@ jobs:
             spec-shelf/docs/rabbitmq-4.3/http-api-index.md \
             spec-shelf/docs/rabbitmq-4.3/rabbit_shovel_mgmt_shovels.erl \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
+            spec-shelf/docs/sddc-manager-9.1/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
             spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
@@ -531,7 +533,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/ + spec-shelf/docs/sddc-manager-9.1/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -1478,6 +1480,7 @@ jobs:
             docs/proxmox-8.4
             docs/rabbitmq-4.3
             docs/sddc-manager-9.0
+            docs/sddc-manager-9.1
             docs/vcenter-9.0
             docs/vcf-automation-9.0
             docs/vcf-operations-9.0
@@ -1504,6 +1507,7 @@ jobs:
             spec-shelf/docs/rabbitmq-4.3/http-api-index.md \
             spec-shelf/docs/rabbitmq-4.3/rabbit_shovel_mgmt_shovels.erl \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
+            spec-shelf/docs/sddc-manager-9.1/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
             spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
@@ -1514,7 +1518,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/ + spec-shelf/docs/sddc-manager-9.1/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-unit-shard's login step — the

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -250,6 +250,27 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # aggregate-only; the park-time bespoke preview echoes only program
         # identity + argument byte size + env-var NAMES, never any value.
         "linux.script.run",
+        # #3497 — the governed SDDC Manager host-commission write pair. Both
+        # take the same ``{"spec": [<HostCommissionSpec>, ...]}`` params, and
+        # each spec item declares a ``password`` (the ESXi host root password
+        # POSTed to /v1/hosts/validations resp. /v1/hosts). ``password`` is a
+        # secret-*named* key the runtime ``scrub_broadcast_params`` key-scrub
+        # would catch, but the classifier-coverage lint (meho-internal #151)
+        # requires every op *declaring* a secret-shaped param to be statically
+        # pinned to a ``credential_*`` class so its broadcast collapses to
+        # aggregate-only, not merely field-redacted. ``.validate`` is not even
+        # a ``.write`` suffix (it would fall through to ``other``) and
+        # ``.commission`` would classify plain ``write`` — either would ship
+        # the host passwords on the feed. Pinning both collapses the params
+        # dict to aggregate-only. The sibling domain writes
+        # (``sddc.domain.validate`` / ``sddc.domain.create``) carry their
+        # passwords inside an open-``additionalProperties`` DomainCreationSpec
+        # (no *declared* secret prop), so the lint does not flag them; the
+        # runtime scrub catches their nested ``*password*`` keys and collapses
+        # the broadcast, exactly the two-layer split that pins ``vault.kv.put``
+        # statically while leaving its generic ``data`` container to the scrub.
+        "sddc.host.validate",
+        "sddc.host.commission",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -26,10 +26,16 @@ because this module has already registered the hand-rolled class. Until then,
 this module is the only registration path.
 
 Operations span two surfaces. The audited 12-read lab-audit set (#2306),
-extended with the network-pool pre-flight reads (#2837), ships as
-first-class **typed** ops in :mod:`.typed_ops` / :mod:`.typed_reads`
-(``source_kind="typed"``), dispatchable on a fresh boot with zero catalog
-ingest. The three non-audited reads (release, domain detail, bundles) and
+extended with the network-pool pre-flight reads (#2837) and the curated
+workload-domain **write** path (#3497 — network-pool create, host
+validate/commission, domain validate/create, plus the ``sddc.task.get``
+build poll), ships as first-class **typed** ops in :mod:`.typed_ops` /
+:mod:`.typed_reads` / :mod:`.typed_writes` (``source_kind="typed"``),
+dispatchable on a fresh boot with zero catalog ingest. The write ops carry
+``requires_approval=True`` at the ``caution`` / ``dangerous`` tier so the
+dispatcher parks each for approval; the create calls are ``202``-async and
+the caller polls ``sddc.task.get`` / ``sddc.domain.status`` to a terminal
+state. The three non-audited reads (release, domain detail, bundles) and
 the wider VCF API catalog arrive via G0.7 spec ingestion
 against the ``endpoint_descriptor`` table and stay browsable as
 profiled-dispatch breadth, enable-able through the generic review flow
@@ -52,6 +58,14 @@ from meho_backplane.connectors.sddc_manager.typed_ops import (
     SDDC_TYPED_OPS,
     SddcTypedOp,
     register_sddc_typed_operations,
+)
+from meho_backplane.connectors.sddc_manager.typed_writes import (
+    SDDC_DOMAIN_CREATE_OP_ID,
+    SDDC_DOMAIN_VALIDATE_OP_ID,
+    SDDC_HOST_COMMISSION_OP_ID,
+    SDDC_HOST_VALIDATE_OP_ID,
+    SDDC_NETWORK_POOL_CREATE_OP_ID,
+    TYPED_WRITE_DECLARED_OP_IDS,
 )
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
@@ -95,11 +109,17 @@ register_typed_op_registrar(register_sddc_typed_operations)
 
 __all__ = [
     "SDDC_CONNECTOR_ID",
+    "SDDC_DOMAIN_CREATE_OP_ID",
+    "SDDC_DOMAIN_VALIDATE_OP_ID",
     "SDDC_EXECUTION_PROFILE",
+    "SDDC_HOST_COMMISSION_OP_ID",
+    "SDDC_HOST_VALIDATE_OP_ID",
     "SDDC_IMPL_ID",
+    "SDDC_NETWORK_POOL_CREATE_OP_ID",
     "SDDC_PRODUCT",
     "SDDC_TYPED_OPS",
     "SDDC_VERSION",
+    "TYPED_WRITE_DECLARED_OP_IDS",
     "SddcCredentialsLoader",
     "SddcManagerConnector",
     "SddcTargetLike",

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -1,5 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: connector-class aggregation. This file is the one
+# SddcManagerConnector class — auth + session + fingerprint + probe + dispatch
+# shim + the thin bound-method shims for every typed op. The dispatcher's
+# import_handler walk resolves each typed handler as module.ClassName.method,
+# so the shims MUST be methods on this single class and cannot be split to
+# another module. The #3497 WLD-write shims (task_get / network_pool_create /
+# host_validate / host_commission / domain_validate / domain_create) pushed the
+# pre-existing 688-line file past the 600-line soft limit; the op bodies
+# themselves live in typed_reads.py / typed_writes.py.
 
 """SddcManagerConnector — hand-rolled HttpConnector subclass for SDDC Manager 9.0.
 
@@ -669,6 +678,56 @@ class SddcManagerConnector(HttpConnector):
         from meho_backplane.connectors.sddc_manager.typed_reads import sddc_license_list_impl
 
         return await sddc_license_list_impl(self, operator, target, params)
+
+    async def task_get(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.task.get`` shim (#3497) — the WLD-build task poll."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_task_get_impl
+
+        return await sddc_task_get_impl(self, operator, target, params)
+
+    async def network_pool_create(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.network_pool.create`` shim (#3497)."""
+        from meho_backplane.connectors.sddc_manager.typed_writes import (
+            sddc_network_pool_create_impl,
+        )
+
+        return await sddc_network_pool_create_impl(self, operator, target, params)
+
+    async def host_validate(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.host.validate`` shim (#3497)."""
+        from meho_backplane.connectors.sddc_manager.typed_writes import sddc_host_validate_impl
+
+        return await sddc_host_validate_impl(self, operator, target, params)
+
+    async def host_commission(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.host.commission`` shim (#3497)."""
+        from meho_backplane.connectors.sddc_manager.typed_writes import sddc_host_commission_impl
+
+        return await sddc_host_commission_impl(self, operator, target, params)
+
+    async def domain_validate(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.domain.validate`` shim (#3497)."""
+        from meho_backplane.connectors.sddc_manager.typed_writes import sddc_domain_validate_impl
+
+        return await sddc_domain_validate_impl(self, operator, target, params)
+
+    async def domain_create(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.domain.create`` shim (#3497) — dangerous, approval-gated."""
+        from meho_backplane.connectors.sddc_manager.typed_writes import sddc_domain_create_impl
+
+        return await sddc_domain_create_impl(self, operator, target, params)
 
     async def aclose(self) -> None:
         """Clear cached session tokens + credentials, then tear down the httpx pool.

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -1197,8 +1197,9 @@ _DOMAIN_CREATE = SddcTypedOp(
         "governed workload-domain build. The build runs for hours on the "
         "appliance; poll sddc.task.get (and sddc.domain.status once the domain "
         "object exists) to ACTIVE. safety_level=dangerous + requires_approval "
-        "-- the dispatcher parks for approval first and the park-time preview "
-        "scrubs the spec's plaintext passwords."
+        "-- the dispatcher parks for approval first, and the reviewer context "
+        "shows op/target/subject identity only (never the spec body), so the "
+        "spec's plaintext passwords never reach the approver."
     ),
     parameter_schema=_domain_spec_parameter_schema("/v1/domains"),
     response_schema={"type": "object", "additionalProperties": True},

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -59,9 +59,13 @@ mapped to the **existing** safety_level/policy mechanism:
 * the handler additionally scrubs secret-keyed values at the connector
   boundary (:func:`~meho_backplane.connectors.sddc_manager.typed_reads._redact_secrets`).
 
-The write surface (none wanted for SDDC), the session/auth itself
-(#2290), and the profiled ingested dispatch (#2271) are out of this
-task's scope.
+The curated workload-domain **write** surface (#3497) — network-pool
+create, host validate/commission, domain validate/create, plus the
+``sddc.task.get`` build poll — ships alongside the reads as typed ops in
+:mod:`.typed_writes` (bodies) and this module (metadata), each
+approval-gated at the ``caution`` / ``dangerous`` tier and dispatched via
+:meth:`HttpConnector._post_json`. The session/auth itself (#2290) and the
+profiled ingested dispatch (#2271) remain out of scope.
 """
 
 from __future__ import annotations
@@ -70,6 +74,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
+
+from meho_backplane.connectors.sddc_manager.typed_writes import (
+    SDDC_DOMAIN_CREATE_OP_ID,
+    SDDC_DOMAIN_VALIDATE_OP_ID,
+    SDDC_HOST_COMMISSION_OP_ID,
+    SDDC_HOST_VALIDATE_OP_ID,
+    SDDC_NETWORK_POOL_CREATE_OP_ID,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.retrieval.embedding import EmbeddingService
@@ -90,6 +102,7 @@ _GROUP_INVENTORY = "sddc-inventory"
 _GROUP_PLATFORM = "sddc-platform"
 _GROUP_TASKS = "sddc-tasks-typed"
 _GROUP_CREDENTIALS = "sddc-credentials"
+_GROUP_LIFECYCLE = "sddc-lifecycle"
 
 
 @dataclass(frozen=True)
@@ -162,6 +175,21 @@ SDDC_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "never their passwords. The group an operator reaches for during a "
         "nested-infra credential audit or outage."
     ),
+    _GROUP_LIFECYCLE: (
+        "Use to BUILD a VCF workload domain through the backplane -- the "
+        "curated, approval-gated write path (#3497): create the network pool "
+        "the domain draws from (sddc.network_pool.create), validate then "
+        "commission the ESXi hosts (sddc.host.validate / sddc.host.commission), "
+        "and validate then create the domain itself "
+        "(sddc.domain.validate / sddc.domain.create). The mutating steps are "
+        "dangerous + require operator approval; the validations are "
+        "non-mutating pre-flights. Each create is 202-async -- keep the "
+        "returned task id and poll sddc.task.get (and sddc.domain.status) to a "
+        "terminal state. Sequencing (validate -> create -> poll) is the "
+        "caller's job. For an NFS-principal domain the DomainCreationSpec uses "
+        "computeSpec.clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume, "
+        "never vsanDatastoreSpec."
+    ),
 }
 
 
@@ -182,12 +210,211 @@ def _instructions(
     when_to_use: str,
     output_shape: str,
     parameter_hints: dict[str, str] | None = None,
+    result_scalars: tuple[str, ...] | None = None,
+    result_digest: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build the per-op ``llm_instructions`` blob with the canonical keys."""
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    ``result_scalars`` / ``result_digest`` are the JSONFlux reduction hints
+    (#3084 / #3122): on the WLD-build poll ops the vendor ``Task`` /
+    ``Validation`` carries a large set-shaped field (``subTasks[]`` /
+    ``validationChecks[]``), so ``result_scalars`` names the scalar siblings
+    (``id`` / ``status``) that survive the reduction on the inline summary and
+    ``result_digest`` names the collection to reduce (SDDC's ``Task`` carries
+    three list fields — ``subTasks`` / ``errors`` / ``resources`` — so the hint
+    is what makes the reducer reduce ``subTasks`` instead of passing the whole
+    document through the multi-list detail-object exemption).
+    """
     blob: dict[str, Any] = {"when_to_use": when_to_use, "output_shape": output_shape}
     if parameter_hints is not None:
         blob["parameter_hints"] = parameter_hints
+    if result_scalars is not None:
+        blob["result_scalars"] = {"keys": list(result_scalars)}
+    if result_digest is not None:
+        blob["result_digest"] = dict(result_digest)
     return blob
+
+
+# ---------------------------------------------------------------------------
+# JSONFlux reduction hints for the WLD write/poll ops (#3497)
+# ---------------------------------------------------------------------------
+
+#: ``Task`` scalars that must survive a ``subTasks[]`` reduction (#3084):
+#: ``id`` is the poll key for ``sddc.task.get``; ``status`` carries the
+#: lifecycle state; the rest identify the task. Field names pinned by the
+#: ``sddc-manager-9.1`` OpenAPI (``components.schemas.Task``).
+_TASK_RESULT_SCALARS: tuple[str, ...] = ("id", "name", "status", "type", "creationTimestamp")
+
+#: ``Task`` row-digest hint (#3122). A live workload-domain build's ``Task``
+#: carries a large ``subTasks[]`` AND populated ``errors[]`` / ``resources[]``
+#: — three list fields, so the reducer's dict-of-arrays detail-object
+#: exemption would pass the whole document through UNREDUCED. This hint names
+#: ``subTasks`` as THE collection to reduce and drives the inline digest:
+#: per-``status`` counts, the ``name`` of every IN_PROGRESS/PENDING sub-task,
+#: and every FAILED sub-task preserved whole. Status values pinned by the
+#: ``sddc-manager-9.1`` OpenAPI (``components.schemas.SubTask.status``:
+#: PENDING / IN_PROGRESS / SUCCESSFUL / FAILED / SKIPPED / NOT_APPLICABLE).
+_TASK_RESULT_DIGEST: dict[str, Any] = {
+    "collection": "subTasks",
+    "status_field": "status",
+    "name_field": "name",
+    "active_states": ["IN_PROGRESS", "PENDING"],
+    "failed_states": ["FAILED"],
+}
+
+#: ``Validation`` scalars that must survive a ``validationChecks[]`` reduction
+#: (#3084): ``id`` is the poll key; ``executionStatus`` / ``resultStatus``
+#: carry the lifecycle + verdict; ``description`` names the run. Field names
+#: pinned by the ``sddc-manager-9.1`` OpenAPI (``components.schemas.Validation``).
+_VALIDATION_RESULT_SCALARS: tuple[str, ...] = (
+    "id",
+    "description",
+    "executionStatus",
+    "resultStatus",
+)
+
+
+# ---------------------------------------------------------------------------
+# WLD write parameter schemas (#3497)
+# ---------------------------------------------------------------------------
+
+#: The ``{"id": <task id>}`` parameter schema of ``sddc.task.get``.
+_TASK_GET_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The task id returned by a host-commission or domain-create.",
+        },
+    },
+    "required": ["id"],
+    "additionalProperties": False,
+}
+
+#: The ``{"spec": <NetworkPool>}`` parameter schema of ``sddc.network_pool.create``.
+#: The vendor ``NetworkPool`` requires ``name`` + ``networks``; the body is
+#: otherwise passed through verbatim (``additionalProperties`` open) so the
+#: full vendor shape reaches the wire without this connector re-modelling it.
+_NETWORK_POOL_CREATE_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "spec": {
+            "type": "object",
+            "description": (
+                "A vendor NetworkPool. For an NFS-principal workload domain the "
+                "networks[] must carry the vMotion and NFS networks the hosts "
+                "draw from; POSTed verbatim to /v1/network-pools."
+            ),
+            "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "networks": {"type": "array", "items": {"type": "object"}},
+            },
+            "required": ["name", "networks"],
+            "additionalProperties": True,
+        },
+    },
+    "required": ["spec"],
+    "additionalProperties": False,
+}
+
+#: The ``{"spec": [<HostCommissionSpec>, ...]}`` parameter schema shared by
+#: ``sddc.host.validate`` and ``sddc.host.commission``. The vendor endpoint
+#: takes a JSON **array** of ``HostCommissionSpec`` (required ``fqdn`` /
+#: ``username`` / ``password`` / ``storageType`` / ``networkPoolId``).
+_HOST_COMMISSION_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "spec": {
+            "type": "array",
+            "minItems": 1,
+            "description": (
+                "A JSON array of vendor HostCommissionSpec objects; POSTed "
+                "verbatim. storageType='NFS' for the Envision NFS-principal "
+                "estate."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "fqdn": {"type": "string", "minLength": 1},
+                    "username": {"type": "string", "minLength": 1},
+                    "password": {"type": "string", "minLength": 1},
+                    "storageType": {"type": "string", "minLength": 1},
+                    "networkPoolId": {"type": "string", "minLength": 1},
+                },
+                "required": ["fqdn", "username", "password", "storageType", "networkPoolId"],
+                "additionalProperties": True,
+            },
+        },
+    },
+    "required": ["spec"],
+    "additionalProperties": False,
+}
+
+
+def _domain_spec_parameter_schema(posted_to: str) -> dict[str, Any]:
+    """The ``{"spec": <DomainCreationSpec>}`` schema shared by the domain ops.
+
+    The body is passed through verbatim (``additionalProperties`` open) so the
+    full vendor ``DomainCreationSpec`` reaches the wire without this connector
+    re-modelling every field — but the **NFS datastore sub-shape** is modelled
+    so a well-formed NFS spec validates while a malformed ``nasVolume`` (the
+    common trap the field notes warn about — reusing a vSAN-shaped spec and
+    swapping only the datastore) is rejected before dispatch. ``nfsDatastoreSpecs``
+    stays optional (a vSAN or VMFS domain is a valid spec too); when present, each
+    entry must carry a ``nasVolume`` with ``serverName`` / ``path`` / ``readOnly``.
+    """
+    nas_volume = {
+        "type": "object",
+        "properties": {
+            "serverName": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "path": {"type": "string", "minLength": 1},
+            "readOnly": {"type": "boolean"},
+        },
+        "required": ["serverName", "path", "readOnly"],
+        "additionalProperties": True,
+    }
+    nfs_datastore_spec = {
+        "type": "object",
+        "properties": {"nasVolume": nas_volume},
+        "required": ["nasVolume"],
+        "additionalProperties": True,
+    }
+    datastore_spec = {
+        "type": "object",
+        "properties": {
+            "nfsDatastoreSpecs": {"type": "array", "items": nfs_datastore_spec},
+        },
+        "additionalProperties": True,
+    }
+    cluster_spec = {
+        "type": "object",
+        "properties": {"datastoreSpec": datastore_spec},
+        "additionalProperties": True,
+    }
+    compute_spec = {
+        "type": "object",
+        "properties": {"clusterSpecs": {"type": "array", "items": cluster_spec}},
+        "additionalProperties": True,
+    }
+    return {
+        "type": "object",
+        "properties": {
+            "spec": {
+                "type": "object",
+                "description": (
+                    "A vendor DomainCreationSpec. NFS-principal shape: "
+                    "computeSpec.clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[]."
+                    "nasVolume (never vsanDatastoreSpec). POSTed verbatim to "
+                    f"{posted_to}."
+                ),
+                "properties": {"computeSpec": compute_spec},
+                "additionalProperties": True,
+            },
+        },
+        "required": ["spec"],
+        "additionalProperties": False,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -754,10 +981,261 @@ _LICENSE_LIST = SddcTypedOp(
 )
 
 
+# ---------------------------------------------------------------------------
+# sddc.task.get — WLD-build task poll (#3497)
+# ---------------------------------------------------------------------------
+
+_TASK_GET = SddcTypedOp(
+    op_id="sddc.task.get",
+    handler_attr="task_get",
+    summary="Read one VCF workflow task by id (the WLD-build poll).",
+    description=(
+        "Reads one VCF workflow task via GET /v1/tasks/{id} -- the poll a "
+        "caller runs against the Task a host-commission or domain-create "
+        "returned (both are 202-async). The object's top-level status carries "
+        "the PENDING / IN_PROGRESS / SUCCESSFUL / FAILED lifecycle state, and "
+        "subTasks[] the per-stage progress; on a live workload-domain build "
+        "subTasks[] reduces to a JSONFlux handle while id / status / name stay "
+        "top-level. Requires a task id from sddc.host.commission / "
+        "sddc.domain.create. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_TASK_GET_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_TASKS,
+    tags=("read-only", "sddc", "vcf", "task", "lifecycle"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a task id to poll a host-commission or domain-create to "
+            "a terminal status; read subTasks for per-stage progress."
+        ),
+        output_shape=(
+            "{id, name, status, type, creationTimestamp, subTasks: [...], "
+            "errors: [...]}. When subTasks[] reduces to a JSONFlux handle, "
+            "id / name / status stay top-level with a per-status digest inline."
+        ),
+        parameter_hints={"id": "The task id from sddc.host.commission / sddc.domain.create."},
+        result_scalars=_TASK_RESULT_SCALARS,
+        result_digest=_TASK_RESULT_DIGEST,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.network_pool.create — WLD write (#3497)
+# ---------------------------------------------------------------------------
+
+_NETWORK_POOL_CREATE = SddcTypedOp(
+    op_id=SDDC_NETWORK_POOL_CREATE_OP_ID,
+    handler_attr="network_pool_create",
+    summary="Create the network pool a workload domain draws from.",
+    description=(
+        "Creates a VCF network pool via POST /v1/network-pools -- step 1 of "
+        "the governed workload-domain build. For an NFS-principal domain the "
+        "spec's networks[] must carry the vMotion and NFS networks the hosts "
+        "draw from. safety_level=caution + requires_approval -- the dispatcher "
+        "parks the call for approval before it runs. Returns the created pool."
+    ),
+    parameter_schema=_NETWORK_POOL_CREATE_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_LIFECYCLE,
+    tags=("write", "sddc", "vcf", "network-pool", "lifecycle"),
+    safety_level="caution",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a NetworkPool spec to create the pool a new workload "
+            "domain's hosts will draw from. Parks for approval first."
+        ),
+        output_shape="{id, name, networks: [...]} (the created NetworkPool).",
+        parameter_hints={
+            "spec": (
+                "The NetworkPool body: name + networks[] (VMOTION + NFS for an "
+                "NFS-principal domain, each with vlanId / subnet / gateway / "
+                "ipPools[])."
+            ),
+        },
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.host.validate — WLD write pre-flight (#3497)
+# ---------------------------------------------------------------------------
+
+_HOST_VALIDATE = SddcTypedOp(
+    op_id=SDDC_HOST_VALIDATE_OP_ID,
+    handler_attr="host_validate",
+    summary="Validate a host-commission spec (non-mutating pre-flight).",
+    description=(
+        "Submits a JSON array of HostCommissionSpec to POST /v1/hosts/"
+        "validations -- the vendor's non-mutating pre-flight before "
+        "sddc.host.commission. Returns the Validation to poll (202); check its "
+        "resultStatus before commissioning. Mutates no estate. "
+        "safety_level=caution, no approval."
+    ),
+    parameter_schema=_HOST_COMMISSION_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_LIFECYCLE,
+    tags=("write", "sddc", "vcf", "host", "validation", "lifecycle"),
+    safety_level="caution",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with the array of HostCommissionSpec to dry-run-validate the "
+            "hosts before committing to sddc.host.commission."
+        ),
+        output_shape=(
+            "{id, description, executionStatus, resultStatus, "
+            "validationChecks: [...]}. Poll to a terminal executionStatus."
+        ),
+        parameter_hints={
+            "spec": "The array of HostCommissionSpec (storageType=NFS for the estate).",
+        },
+        result_scalars=_VALIDATION_RESULT_SCALARS,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.host.commission — WLD write (estate mutation) (#3497)
+# ---------------------------------------------------------------------------
+
+_HOST_COMMISSION = SddcTypedOp(
+    op_id=SDDC_HOST_COMMISSION_OP_ID,
+    handler_attr="host_commission",
+    summary="Commission ESXi hosts into the free pool (estate mutation).",
+    description=(
+        "Submits the array of HostCommissionSpec (validated first via "
+        "sddc.host.validate) to POST /v1/hosts and returns the Task to poll "
+        "(202-async) -- step 2 of the governed workload-domain build, moving "
+        "ESXi hosts into the free pool. safety_level=dangerous + "
+        "requires_approval -- the dispatcher parks for approval first; poll "
+        "sddc.task.get with the returned id to a terminal status."
+    ),
+    parameter_schema=_HOST_COMMISSION_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_LIFECYCLE,
+    tags=("write", "sddc", "vcf", "host", "commission", "dangerous"),
+    safety_level="dangerous",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with the validated array of HostCommissionSpec to add the "
+            "hosts. Parks for approval first; poll sddc.task.get to terminal."
+        ),
+        output_shape=(
+            "{id, name, status, subTasks: [...]} (a Task). Keep the id and "
+            "poll sddc.task.get; when subTasks[] reduces to a JSONFlux handle, "
+            "id / status stay top-level."
+        ),
+        parameter_hints={"spec": "The validated array of HostCommissionSpec."},
+        result_scalars=_TASK_RESULT_SCALARS,
+        result_digest=_TASK_RESULT_DIGEST,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.domain.validate — WLD write pre-flight (#3497)
+# ---------------------------------------------------------------------------
+
+_DOMAIN_VALIDATE = SddcTypedOp(
+    op_id=SDDC_DOMAIN_VALIDATE_OP_ID,
+    handler_attr="domain_validate",
+    summary="Validate a DomainCreationSpec (non-mutating pre-flight).",
+    description=(
+        "Submits a DomainCreationSpec to POST /v1/domains/validations -- the "
+        "vendor's non-mutating pre-flight before sddc.domain.create. Returns "
+        "the Validation to poll; run it to a passing resultStatus first "
+        "because the DomainCreationSpec is trap-rich (NFS-vs-vSAN datastore "
+        "shape, clusterImageId). Mutates no estate. safety_level=caution, no "
+        "approval."
+    ),
+    parameter_schema=_domain_spec_parameter_schema("/v1/domains/validations"),
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_LIFECYCLE,
+    tags=("write", "sddc", "vcf", "domain", "validation", "lifecycle"),
+    safety_level="caution",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a DomainCreationSpec to dry-run-validate the domain "
+            "before committing to sddc.domain.create."
+        ),
+        output_shape=(
+            "{id, description, executionStatus, resultStatus, "
+            "validationChecks: [...]}. Poll to a terminal executionStatus and "
+            "read resultStatus."
+        ),
+        parameter_hints={
+            "spec": (
+                "The DomainCreationSpec. NFS-principal: computeSpec."
+                "clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume "
+                "(serverName[] / path / readOnly), never vsanDatastoreSpec."
+            ),
+        },
+        result_scalars=_VALIDATION_RESULT_SCALARS,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.domain.create — WLD write (estate mutation) (#3497)
+# ---------------------------------------------------------------------------
+
+_DOMAIN_CREATE = SddcTypedOp(
+    op_id=SDDC_DOMAIN_CREATE_OP_ID,
+    handler_attr="domain_create",
+    summary="Create a VCF workload domain (202-async build).",
+    description=(
+        "Submits an NFS-shaped DomainCreationSpec (validated first via "
+        "sddc.domain.validate) to POST /v1/domains and returns the Task the "
+        "moment the build is accepted (202-async) -- the final step of the "
+        "governed workload-domain build. The build runs for hours on the "
+        "appliance; poll sddc.task.get (and sddc.domain.status once the domain "
+        "object exists) to ACTIVE. safety_level=dangerous + requires_approval "
+        "-- the dispatcher parks for approval first and the park-time preview "
+        "scrubs the spec's plaintext passwords."
+    ),
+    parameter_schema=_domain_spec_parameter_schema("/v1/domains"),
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_LIFECYCLE,
+    tags=("write", "sddc", "vcf", "domain", "create", "dangerous"),
+    safety_level="dangerous",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a validated NFS-shaped DomainCreationSpec to build the "
+            "workload domain. Parks for approval first; poll sddc.task.get to "
+            "terminal, then sddc.domain.status to ACTIVE."
+        ),
+        output_shape=(
+            "{id, name, status, subTasks: [...]} (a Task). Keep the id and "
+            "poll sddc.task.get; when subTasks[] reduces to a JSONFlux handle, "
+            "id / status stay top-level with a per-status digest inline."
+        ),
+        parameter_hints={
+            "spec": (
+                "The DomainCreationSpec. NFS-principal: computeSpec."
+                "clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume "
+                "(serverName[] / path / readOnly), never vsanDatastoreSpec."
+            ),
+        },
+        result_scalars=_TASK_RESULT_SCALARS,
+        result_digest=_TASK_RESULT_DIGEST,
+    ),
+)
+
+
 #: The typed ops :class:`SddcManagerConnector` registers at lifespan
-#: startup -- the audited 12-read set (#2306) plus the network-pool
-#: pre-flight reads (#2837). Ordered inventory -> credentials -> tasks ->
-#: platform to match the operator's typical path.
+#: startup -- the audited 12-read set (#2306), the network-pool pre-flight
+#: reads (#2837), and the curated workload-domain write path (#3497:
+#: network-pool create, host validate/commission, domain validate/create,
+#: plus the task poll). Ordered inventory -> credentials -> tasks -> platform
+#: -> lifecycle to match the operator's typical path.
 SDDC_TYPED_OPS: tuple[SddcTypedOp, ...] = (
     _DOMAIN_LIST,
     _DOMAIN_STATUS,
@@ -769,10 +1247,16 @@ SDDC_TYPED_OPS: tuple[SddcTypedOp, ...] = (
     _NETWORK_POOL_GET,
     _CREDENTIAL_LIST,
     _TASK_LIST,
+    _TASK_GET,
     _SYSTEM_INFO,
     _VCF_SERVICE_LIST,
     _MANAGER_LIST,
     _LICENSE_LIST,
+    _NETWORK_POOL_CREATE,
+    _HOST_VALIDATE,
+    _HOST_COMMISSION,
+    _DOMAIN_VALIDATE,
+    _DOMAIN_CREATE,
 )
 
 

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
@@ -92,6 +92,7 @@ __all__ = [
     "sddc_network_pool_list_impl",
     "sddc_nsxt_cluster_list_impl",
     "sddc_system_info_impl",
+    "sddc_task_get_impl",
     "sddc_task_list_impl",
     "sddc_vcenter_list_impl",
     "sddc_vcf_service_list_impl",
@@ -111,6 +112,7 @@ _VCENTERS_PATH = "/v1/vcenters"
 _NSXT_CLUSTERS_PATH = "/v1/nsxt-clusters"
 _CREDENTIALS_PATH = "/v1/credentials"
 _TASKS_PATH = "/v1/tasks"
+_TASK_GET_PATH = "/v1/tasks/{id}"
 _SYSTEM_PATH = "/v1/system"
 _VCF_SERVICES_PATH = "/v1/vcf-services"
 _SDDC_MANAGERS_PATH = "/v1/sddc-managers"
@@ -388,6 +390,29 @@ async def sddc_task_list_impl(
     """
     query = _optional_query(params, ("status",))
     return await connector._get_json(target, _TASKS_PATH, operator=operator, params=query)
+
+
+async def sddc_task_get_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.task.get`` -- ``GET /v1/tasks/{id}``.
+
+    Reads one VCF workflow task by id -- the poll a caller runs against the
+    ``Task`` a host-commission or domain-create returned (both are ``202``
+    async). The returned object's top-level ``status`` carries the
+    PENDING / IN_PROGRESS / SUCCESSFUL / FAILED / ... lifecycle state, and its
+    ``subTasks[]`` the per-stage progress; on a live workload-domain build the
+    sub-task list runs to hundreds of rows, so the op's ``result_scalars`` /
+    ``result_digest`` hints keep ``id`` / ``status`` / ``name`` top-level while
+    ``subTasks[]`` reduces to a JSONFlux handle. Requires a task ``id`` from
+    ``sddc.host.commission`` / ``sddc.domain.create``.
+    """
+    task_id = params["id"]
+    path = _TASK_GET_PATH.format(id=task_id)
+    return await connector._get_json(target, path, operator=operator)
 
 
 async def sddc_system_info_impl(

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_writes.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_writes.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) workload-domain write implementations for the connector.
+
+The curated SDDC Manager workload-domain (WLD) lifecycle *submit* primitives
+(#3497). #368 shipped the connector read-only and deferred writes; this module
+lands the four-step governed build path an operator (or the deploy-automation
+add-on) drives to stand a workload domain up **through the backplane**:
+
+1. ``sddc.network_pool.create`` -- ``POST /v1/network-pools`` with a
+   ``NetworkPool`` carrying the vMotion + **NFS** networks the domain draws
+   from. ``safety_level="caution"`` + ``requires_approval=True``.
+2. ``sddc.host.validate`` -- ``POST /v1/hosts/validations`` with the list of
+   ``HostCommissionSpec`` (``storageType="NFS"``); a non-mutating pre-flight
+   returning the vendor ``Validation`` to poll. ``safety_level="caution"``,
+   no approval.
+3. ``sddc.host.commission`` -- ``POST /v1/hosts`` with the same list; the
+   estate mutation that adds the hosts. ``safety_level="dangerous"`` +
+   ``requires_approval=True``; returns the ``Task`` to poll.
+4. ``sddc.domain.validate`` -- ``POST /v1/domains/validations`` with the
+   ``DomainCreationSpec`` (NFS shape:
+   ``computeSpec.clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume``,
+   never ``vsanDatastoreSpec``); a non-mutating pre-flight. ``caution``, no
+   approval.
+5. ``sddc.domain.create`` -- ``POST /v1/domains`` with the same spec; the
+   ``202``-async domain build. ``safety_level="dangerous"`` +
+   ``requires_approval=True``; returns the ``Task`` to poll.
+
+The create calls are natively asynchronous -- each returns its tracking
+``Task`` in seconds and the multi-hour build runs on the appliance -- so every
+call here is short, the standard park -> approve -> resume machinery governs
+each write as-is, and no long-blocking loop lives in this module. Sequencing
+(validate -> create -> poll ``sddc.task.get`` / ``sddc.domain.status`` to
+``ACTIVE``) is the caller's responsibility (runbook / automation add-on), not
+the dispatcher's. There is deliberately **no** bulk enable path: each write is
+a distinct approval-gated typed op.
+
+The optional NSX edge-cluster create/validate ops are out of scope: the
+Envision estate's Supervisor path is VDS + Foundation LB, so no edge cluster
+is needed (issue #3497 lists them for completeness only).
+
+Each write is issued directly on the connector's own authenticated token
+session via :meth:`HttpConnector._post_json`. A raw ``401`` (SDDC Manager's
+expired-token signal) propagates as :class:`httpx.HTTPStatusError` up to the
+dispatcher's #2067 recovery arm, which evicts the cached session token via the
+connector's public :meth:`SddcManagerConnector.invalidate_session` hook and
+re-dispatches once. That single re-dispatch is safe even for these
+non-idempotent POSTs: a ``401`` means the request was rejected at auth
+*before* the appliance processed it, so the first attempt had no effect --
+the same argument :mod:`meho_backplane.connectors.vcf_installer.typed_writes`
+documents.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from meho_backplane.connectors.sddc_manager.session import SddcTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+
+__all__ = [
+    "SDDC_DOMAIN_CREATE_OP_ID",
+    "SDDC_DOMAIN_VALIDATE_OP_ID",
+    "SDDC_HOST_COMMISSION_OP_ID",
+    "SDDC_HOST_VALIDATE_OP_ID",
+    "SDDC_NETWORK_POOL_CREATE_OP_ID",
+    "TYPED_WRITE_DECLARED_OP_IDS",
+    "sddc_domain_create_impl",
+    "sddc_domain_validate_impl",
+    "sddc_host_commission_impl",
+    "sddc_host_validate_impl",
+    "sddc_network_pool_create_impl",
+]
+
+#: ``sddc.network_pool.create`` -- create the network pool a WLD draws from.
+SDDC_NETWORK_POOL_CREATE_OP_ID: Final[str] = "sddc.network_pool.create"
+#: ``sddc.host.validate`` -- pre-flight a host-commission spec (non-mutating).
+SDDC_HOST_VALIDATE_OP_ID: Final[str] = "sddc.host.validate"
+#: ``sddc.host.commission`` -- add ESXi hosts to the free pool (estate mutation).
+SDDC_HOST_COMMISSION_OP_ID: Final[str] = "sddc.host.commission"
+#: ``sddc.domain.validate`` -- pre-flight a DomainCreationSpec (non-mutating).
+SDDC_DOMAIN_VALIDATE_OP_ID: Final[str] = "sddc.domain.validate"
+#: ``sddc.domain.create`` -- create the workload domain (202-async build).
+SDDC_DOMAIN_CREATE_OP_ID: Final[str] = "sddc.domain.create"
+
+# --- Hand-coded wire paths — the spec-reconcile lane's introspection source
+# (module constants introspected by value, the #2944 pattern). ---
+#: ``POST`` — create a network pool (the vendor ``createNetworkPool``).
+_NETWORK_POOLS_PATH = "/v1/network-pools"
+#: ``POST`` — validate a host-commission spec (``validateHostCommissionSpec``).
+_HOSTS_VALIDATIONS_PATH = "/v1/hosts/validations"
+#: ``POST`` — commission hosts (the vendor ``commissionHosts``).
+_HOSTS_PATH = "/v1/hosts"
+#: ``POST`` — validate a DomainCreationSpec (``validateDomainCreationSpec``).
+_DOMAINS_VALIDATIONS_PATH = "/v1/domains/validations"
+#: ``POST`` — create a workload domain (the vendor ``createDomain``).
+_DOMAINS_PATH = "/v1/domains"
+
+#: The exact ``METHOD:/path`` set these WLD write primitives hand-code. The
+#: 9.1 reconcile lane
+#: (:mod:`tests.test_connectors_sddc_manager_91_spec_reconcile`) asserts each
+#: is served by the pinned ``sddc-manager-9.1`` OpenAPI, and pins this set so
+#: it can't go vacuous. Reads stay guarded against ``sddc-manager-9.0`` by the
+#: sibling lane.
+TYPED_WRITE_DECLARED_OP_IDS: frozenset[str] = frozenset(
+    {
+        f"POST:{_NETWORK_POOLS_PATH}",
+        f"POST:{_HOSTS_VALIDATIONS_PATH}",
+        f"POST:{_HOSTS_PATH}",
+        f"POST:{_DOMAINS_VALIDATIONS_PATH}",
+        f"POST:{_DOMAINS_PATH}",
+    }
+)
+
+
+async def sddc_network_pool_create_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.network_pool.create`` -- ``POST /v1/network-pools``.
+
+    Submits ``params["spec"]`` (a vendor ``NetworkPool`` — ``name`` plus the
+    ``networks[]`` the domain's hosts draw from, which for an NFS-principal
+    workload domain must include the vMotion and NFS networks) verbatim and
+    returns the created pool (``201``). ``requires_approval=True``: the
+    dispatcher parks the call for approval before this handler runs.
+    """
+    return await connector._post_json(
+        target, _NETWORK_POOLS_PATH, operator=operator, json=params["spec"]
+    )
+
+
+async def sddc_host_validate_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.host.validate`` -- ``POST /v1/hosts/validations``.
+
+    Submits ``params["spec"]`` (a JSON array of vendor ``HostCommissionSpec``,
+    each with ``fqdn`` / ``username`` / ``password`` / ``networkPoolId`` and
+    ``storageType`` — ``NFS`` for the Envision estate) and returns the vendor
+    ``Validation`` (``202`` with ``executionStatus="IN_PROGRESS"`` and the
+    ``id`` to poll via ``sddc.task.get`` — validations resolve to a task).
+    Mutates no estate; ``safety_level="caution"``, no approval.
+    """
+    return await connector._post_json(
+        target, _HOSTS_VALIDATIONS_PATH, operator=operator, json=params["spec"]
+    )
+
+
+async def sddc_host_commission_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.host.commission`` -- ``POST /v1/hosts``.
+
+    Submits ``params["spec"]`` (the same array of ``HostCommissionSpec``,
+    validated first via ``sddc.host.validate``) and returns the vendor
+    ``Task`` the moment the commission is accepted (``202``); poll
+    ``sddc.task.get`` with the returned ``id`` to a terminal ``status``. The
+    estate mutation that moves ESXi hosts into the free pool —
+    ``safety_level="dangerous"`` + ``requires_approval=True``, so the
+    dispatcher has already parked and an approver already resumed by the time
+    this handler runs.
+    """
+    return await connector._post_json(target, _HOSTS_PATH, operator=operator, json=params["spec"])
+
+
+async def sddc_domain_validate_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.domain.validate`` -- ``POST /v1/domains/validations``.
+
+    Submits ``params["spec"]`` (a vendor ``DomainCreationSpec``) for a
+    non-mutating pre-flight and returns the vendor ``Validation`` to poll. Run
+    this to a passing ``resultStatus`` before ``sddc.domain.create`` — the
+    ``DomainCreationSpec`` is trap-rich (NFS-vs-vSAN datastore shape,
+    ``clusterImageId``), and the validation is the vendor's own answer to
+    "will this build". Mutates no estate; ``safety_level="caution"``, no
+    approval.
+    """
+    return await connector._post_json(
+        target, _DOMAINS_VALIDATIONS_PATH, operator=operator, json=params["spec"]
+    )
+
+
+async def sddc_domain_create_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.domain.create`` -- ``POST /v1/domains``.
+
+    Submits ``params["spec"]`` (an NFS-shaped ``DomainCreationSpec`` —
+    ``computeSpec.clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume``,
+    not ``vsanDatastoreSpec``) verbatim and returns the vendor ``Task`` the
+    moment the build is accepted (``202``); the domain build itself runs for
+    hours on the appliance — poll ``sddc.task.get`` with the returned ``id``
+    (and ``sddc.domain.status`` once the domain object exists) to ``ACTIVE``.
+    The estate mutation — ``safety_level="dangerous"`` + ``requires_approval``,
+    so the dispatcher has already parked and an approver already resumed by
+    the time this handler runs; the park-time preview scrubs the spec's
+    plaintext passwords at the connector-boundary redaction layer.
+    """
+    return await connector._post_json(target, _DOMAINS_PATH, operator=operator, json=params["spec"])

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_writes.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_writes.py
@@ -213,7 +213,9 @@ async def sddc_domain_create_impl(
     (and ``sddc.domain.status`` once the domain object exists) to ``ACTIVE``.
     The estate mutation — ``safety_level="dangerous"`` + ``requires_approval``,
     so the dispatcher has already parked and an approver already resumed by
-    the time this handler runs; the park-time preview scrubs the spec's
-    plaintext passwords at the connector-boundary redaction layer.
+    the time this handler runs. The reviewer context surfaces the op + target
+    + subject identity only, never the hidden ``params`` body
+    (:func:`~meho_backplane.operations.approval_context.resolve_reviewer_context`),
+    so the spec's plaintext passwords never reach the approver.
     """
     return await connector._post_json(target, _DOMAINS_PATH, operator=operator, json=params["spec"])

--- a/backend/tests/test_connectors_sddc_manager_91_spec_reconcile.py
+++ b/backend/tests/test_connectors_sddc_manager_91_spec_reconcile.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""sddc-manager **9.1** write-path real-spec reconcile lane (#3497) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the connector's curated
+workload-domain **write** ops dispatch is served by the pinned
+``sddc-manager-9.1`` spec on the shelf (``vmware/vcf-api-specs``' OpenAPI
+3.0.1 document at ``@3949fc33`` — Apache-2.0, provenance in the shelf's
+``MANIFEST.md``). Parse-only set compare — no DB, no embeddings, no
+containers — so it lives in the required unit sweep per
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when the
+shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+Why a **second, 9.1** lane rather than folding the writes into the 9.0
+lane. A 9.1 target resolves to the same ``sddc-rest-9.0`` connector (range
+``>=9.0,<10.0``; no path was removed 9.0 → 9.1, so 9.0-era call sites keep
+resolving), and the Envision estate the write path is authored for runs
+9.1. The reads stay guarded against ``sddc-manager-9.0`` by the sibling
+lane (:mod:`tests.test_connectors_sddc_manager_spec_reconcile`); the new
+write path constants are guarded here against the pinned 9.1 spec. The
+declared set is introspected from the connector's live constants (the
+#2944 pattern — never a hardcoded mirror):
+
+* :mod:`~meho_backplane.connectors.sddc_manager.typed_writes` — the WLD
+  submit primitives' ``TYPED_WRITE_DECLARED_OP_IDS`` (``POST /v1/network-pools``,
+  ``POST /v1/hosts/validations``, ``POST /v1/hosts``,
+  ``POST /v1/domains/validations``, ``POST /v1/domains``), each carrying its
+  own HTTP method.
+
+A red lane here is the guard surfacing a real finding (a fictional or
+renamed write path), not harness noise.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.sddc_manager import typed_writes as _typed_writes
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "sddc-manager-9.1"
+_SPEC_FILE = "sddc-manager-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the WLD write ops dispatch."""
+    return set(_typed_writes.TYPED_WRITE_DECLARED_OP_IDS)
+
+
+def test_typed_write_declared_op_ids_are_pinned() -> None:
+    """Guard: the WLD write declared set can't go vacuous.
+
+    Pinning the exact ``METHOD:/path`` set means dropping or renaming a write
+    path constant can't silently shrink the reconciled set to a passing subset.
+    """
+    assert (
+        frozenset(
+            {
+                "POST:/v1/network-pools",
+                "POST:/v1/hosts/validations",
+                "POST:/v1/hosts",
+                "POST:/v1/domains/validations",
+                "POST:/v1/domains",
+            }
+        )
+        == _typed_writes.TYPED_WRITE_DECLARED_OP_IDS
+    )
+
+
+def test_declared_write_op_ids_are_served_by_the_pinned_91_spec() -> None:
+    """Every hand-coded write op_id is served by the pinned sddc-manager-9.1 spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/backend/tests/test_connectors_sddc_manager_spec_reconcile.py
+++ b/backend/tests/test_connectors_sddc_manager_spec_reconcile.py
@@ -16,10 +16,14 @@ The declared set is introspected from the connector's live constants
 (the #2944 pattern — never a hardcoded mirror), across the three
 surfaces that hand-code a path:
 
-* :mod:`~meho_backplane.connectors.sddc_manager.typed_reads` — the 14
-  ``_*_PATH`` module constants. Every typed read dispatches through
+* :mod:`~meho_backplane.connectors.sddc_manager.typed_reads` — the 15
+  ``_*_PATH`` module constants (the audited reads plus the ``sddc.task.get``
+  build poll added in #3497). Every typed read dispatches through
   :meth:`HttpConnector._get_json` (a GET-only seam that delegates to
-  ``_request_json(target, "GET", ...)``), so each declares ``GET:``.
+  ``_request_json(target, "GET", ...)``), so each declares ``GET:``. The
+  curated WLD **write** paths (#3497) are guarded separately against the
+  pinned ``sddc-manager-9.1`` spec by
+  :mod:`tests.test_connectors_sddc_manager_91_spec_reconcile`.
 * :mod:`~meho_backplane.connectors.sddc_manager.connector` — the token
   mint ``_SESSION_CREATE_PATH`` (``POST /v1/tokens``, sourced from the
   ``session_login_token`` scheme spec). The connector's bespoke
@@ -90,6 +94,7 @@ def test_typed_read_path_constants_are_all_discovered() -> None:
         "_SDDC_MANAGERS_PATH",
         "_SYSTEM_PATH",
         "_TASKS_PATH",
+        "_TASK_GET_PATH",
         "_VCENTERS_PATH",
         "_VCF_SERVICES_PATH",
     ]

--- a/backend/tests/test_connectors_sddc_manager_typed_reads.py
+++ b/backend/tests/test_connectors_sddc_manager_typed_reads.py
@@ -558,6 +558,9 @@ async def test_registered_ops_are_visible_to_search_operations(
     assert expected <= found, f"missing from search: {expected - found}"
 
 
+#: The read subset of the typed-op table — the #2306 audited reads, the
+#: #2837 network-pool pre-flight reads, and the #3497 ``sddc.task.get`` build
+#: poll. Every op here is ``safe`` / no-approval / ``read-only``.
 _EXPECTED_OP_IDS = {
     "sddc.domain.list",
     "sddc.domain.status",
@@ -569,15 +572,27 @@ _EXPECTED_OP_IDS = {
     "sddc.network_pool.get",
     "sddc.credential.list",
     "sddc.task.list",
+    "sddc.task.get",
     "sddc.system.info",
     "sddc.vcf_service.list",
     "sddc.manager.list",
     "sddc.license.list",
 }
 
+#: The curated workload-domain write ops added in #3497. Approval-gated at
+#: the ``caution`` / ``dangerous`` tier; guarded separately in
+#: :mod:`tests.test_connectors_sddc_manager_writes`.
+_EXPECTED_WRITE_OP_IDS = {
+    "sddc.network_pool.create",
+    "sddc.host.validate",
+    "sddc.host.commission",
+    "sddc.domain.validate",
+    "sddc.domain.create",
+}
 
-def test_typed_ops_table_is_exactly_the_audited_read_set() -> None:
-    assert {op.op_id for op in SDDC_TYPED_OPS} == _EXPECTED_OP_IDS
+
+def test_typed_ops_table_is_exactly_the_read_set_plus_curated_writes() -> None:
+    assert {op.op_id for op in SDDC_TYPED_OPS} == _EXPECTED_OP_IDS | _EXPECTED_WRITE_OP_IDS
 
 
 @pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS - {_CREDENTIAL_OP_ID}))
@@ -602,10 +617,22 @@ def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) ->
     assert op.parameter_schema.get("additionalProperties") is False
 
 
-def test_no_write_or_mutating_op_is_registered() -> None:
-    """Read-only Task: no create/write op ships (SDDC writes are out of scope)."""
+def test_only_the_curated_write_ops_are_mutating() -> None:
+    """The read subset stays read-only; the only write ops are the #3497 WLD set.
+
+    The pre-#3497 invariant was "no write op ships"; #3497 lands the curated
+    workload-domain write path, so the guard flips: every ``read-only``-tagged
+    op is ``safe`` / no-approval, and every mutating op (``write`` tag) is one
+    of the expected #3497 write ops (registration-shape detail asserted in
+    :mod:`tests.test_connectors_sddc_manager_writes`).
+    """
     for op in SDDC_TYPED_OPS:
-        assert not any(
-            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
-        )
-        assert "write" not in op.tags
+        if "write" in op.tags:
+            assert op.op_id in _EXPECTED_WRITE_OP_IDS, op.op_id
+        elif op.op_id == _CREDENTIAL_OP_ID:
+            # The one read gated as a credential-read (caution + approval).
+            assert op.safety_level == "caution"
+            assert op.requires_approval is True
+        else:
+            assert op.safety_level == "safe", op.op_id
+            assert op.requires_approval is False, op.op_id

--- a/backend/tests/test_connectors_sddc_manager_writes.py
+++ b/backend/tests/test_connectors_sddc_manager_writes.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the SDDC Manager curated workload-domain write ops (#3497).
+
+Coverage matrix (per Task #3497 acceptance criteria):
+
+* **Registration shape.** The five WLD write ops carry the correct
+  ``safety_level`` (network-pool create + validations ``caution``; host
+  commission + domain create ``dangerous``), the mutating ones carry
+  ``requires_approval=True`` (validations do not), each is grouped under
+  ``sddc-lifecycle``, tagged ``write``, and its ``handler_attr`` resolves to
+  a real bound method on the connector (the dispatcher's ``import_handler``
+  contract). ``sddc.task.get`` is ``safe`` / no-approval and carries the
+  JSONFlux ``result_scalars`` + ``result_digest`` hints.
+* **Approval park (AC: approval-gated).** ``sddc.domain.create`` and
+  ``sddc.host.commission`` are not dispatchable without the elevated policy
+  path: with ``requires_approval`` set, dispatch parks at
+  ``status="awaiting_approval"`` and the vendor endpoint is never hit.
+* **Dispatch (AC: dispatchable + park-for-approval + audit).** The
+  non-approval validation ops dispatch through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked SDDC
+  Manager on the post-#2290 token session and return ``status="ok"``.
+  ``sddc.task.get`` dispatches read-only and interpolates the task id.
+* **Approved-path wire shape.** Called directly (the handler that runs once
+  an operator approves), each write POSTs its vendor path with the caller's
+  ``spec`` as the JSON body (a single object for network-pool / domain, a
+  JSON array for host commission).
+* **NFS-shaped DomainCreationSpec validates (AC).** The domain ops'
+  parameter schema accepts a well-formed NFS-principal
+  ``DomainCreationSpec`` (``...datastoreSpec.nfsDatastoreSpecs[].nasVolume``)
+  and rejects a malformed ``nasVolume`` (the vSAN-reuse trap) and a missing
+  ``spec``.
+
+Mirrors :mod:`tests.test_connectors_sddc_manager_typed_reads` for the
+dispatch lifecycle + embedding stub + SDDC token-session mock.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.sddc_manager import (
+    SDDC_CONNECTOR_ID,
+    SDDC_DOMAIN_CREATE_OP_ID,
+    SDDC_DOMAIN_VALIDATE_OP_ID,
+    SDDC_HOST_COMMISSION_OP_ID,
+    SDDC_HOST_VALIDATE_OP_ID,
+    SDDC_IMPL_ID,
+    SDDC_NETWORK_POOL_CREATE_OP_ID,
+    SDDC_PRODUCT,
+    SDDC_TYPED_OPS,
+    SDDC_VERSION,
+    SddcManagerConnector,
+    register_sddc_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations._validate import validate_params
+from meho_backplane.settings import get_settings
+
+_SDDC_HOST = "sddc-writes.test.invalid"
+_SDDC_BASE_URL = f"https://{_SDDC_HOST}"
+_TOKEN_PATH = "/v1/tokens"
+_ACCESS_TOKEN = "writes-access-token"
+
+_WRITE_OP_IDS = frozenset(
+    {
+        SDDC_NETWORK_POOL_CREATE_OP_ID,
+        SDDC_HOST_VALIDATE_OP_ID,
+        SDDC_HOST_COMMISSION_OP_ID,
+        SDDC_DOMAIN_VALIDATE_OP_ID,
+        SDDC_DOMAIN_CREATE_OP_ID,
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=SDDC_PRODUCT,
+        version=SDDC_VERSION,
+        impl_id=SDDC_IMPL_ID,
+        cls=SddcManagerConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _SddcWriteTarget:
+    """Target satisfying both ``SddcTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = SDDC_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": SDDC_VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000d0")
+        self.name = "sddc-writes"
+        self.host = _SDDC_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-writes/sddc-writes"
+        self.auth_model = "shared_service_account"
+        self.sso_realm = "vsphere.local"
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-writes-sddc",
+        name="SDDC Writes Operator",
+        email=None,
+        raw_jwt="op.writes.sddc.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000d4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _sddc_credentials_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    return {"username": "sddc-writes-svc", "password": "sddc-writes-pw"}
+
+
+async def _register_and_resolve(_stub_embedding: AsyncMock) -> SddcManagerConnector:
+    await register_sddc_typed_operations()
+    instance = get_or_create_connector_instance(SddcManagerConnector)
+    instance._credentials_loader = _sddc_credentials_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Canonical NFS-principal DomainCreationSpec (the Envision estate shape)
+# ---------------------------------------------------------------------------
+
+#: A well-formed NFS-principal DomainCreationSpec: the datastore carries
+#: ``nfsDatastoreSpecs[].nasVolume`` (serverName[] / path / readOnly), NOT
+#: ``vsanDatastoreSpec`` (the trap the field notes warn about — reusing a
+#: vSAN spec and swapping only the datastore).
+_NFS_DOMAIN_SPEC: dict[str, Any] = {
+    "domainName": "wld-envision-01",
+    "vcenterSpec": {"name": "wld-vc01", "networkDetailsSpec": {}},
+    "computeSpec": {
+        "clusterSpecs": [
+            {
+                "name": "wld-cl01",
+                "hostSpecs": [{"id": "host-1"}, {"id": "host-2"}],
+                "datastoreSpec": {
+                    "nfsDatastoreSpecs": [
+                        {
+                            "datastoreName": "wld-nfs01",
+                            "nasVolume": {
+                                "serverName": ["10.6.7.10"],
+                                "path": "/exports/wld01",
+                                "readOnly": False,
+                            },
+                        }
+                    ]
+                },
+                "networkSpec": {},
+            }
+        ]
+    },
+}
+
+
+def _domain_ops() -> list[Any]:
+    return [
+        o
+        for o in SDDC_TYPED_OPS
+        if o.op_id in (SDDC_DOMAIN_CREATE_OP_ID, SDDC_DOMAIN_VALIDATE_OP_ID)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Registration shape
+# ---------------------------------------------------------------------------
+
+
+def test_write_ops_registration_shape() -> None:
+    """The five WLD write ops carry the correct safety/approval/group/tag shape."""
+    by_id = {o.op_id: o for o in SDDC_TYPED_OPS}
+    expected = {
+        SDDC_NETWORK_POOL_CREATE_OP_ID: ("caution", True),
+        SDDC_HOST_VALIDATE_OP_ID: ("caution", False),
+        SDDC_HOST_COMMISSION_OP_ID: ("dangerous", True),
+        SDDC_DOMAIN_VALIDATE_OP_ID: ("caution", False),
+        SDDC_DOMAIN_CREATE_OP_ID: ("dangerous", True),
+    }
+    for op_id, (safety, approval) in expected.items():
+        op = by_id[op_id]
+        assert op.safety_level == safety, op_id
+        assert op.requires_approval is approval, op_id
+        assert op.group_key == "sddc-lifecycle", op_id
+        assert "write" in op.tags, op_id
+        assert op.llm_instructions and op.llm_instructions["when_to_use"], op_id
+
+
+def test_write_op_handlers_resolve_to_connector_bound_methods() -> None:
+    """Every write op's handler_attr names a real async method (dispatcher binds it)."""
+    for op in SDDC_TYPED_OPS:
+        if op.op_id in _WRITE_OP_IDS or op.op_id == "sddc.task.get":
+            handler = getattr(SddcManagerConnector, op.handler_attr, None)
+            assert handler is not None, op.op_id
+            assert callable(handler), op.op_id
+
+
+def test_task_get_registration_shape() -> None:
+    """sddc.task.get is a safe read carrying the JSONFlux reduction hints."""
+    op = next(o for o in SDDC_TYPED_OPS if o.op_id == "sddc.task.get")
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert op.group_key == "sddc-tasks-typed"
+    instr = op.llm_instructions
+    assert instr is not None
+    assert instr["result_scalars"]["keys"] == ["id", "name", "status", "type", "creationTimestamp"]
+    assert instr["result_digest"]["collection"] == "subTasks"
+    assert "FAILED" in instr["result_digest"]["failed_states"]
+
+
+def test_validation_ops_carry_result_scalars() -> None:
+    """The validation ops keep the Validation poll keys on a reduced result."""
+    for op_id in (SDDC_HOST_VALIDATE_OP_ID, SDDC_DOMAIN_VALIDATE_OP_ID):
+        op = next(o for o in SDDC_TYPED_OPS if o.op_id == op_id)
+        assert op.llm_instructions is not None
+        assert op.llm_instructions["result_scalars"]["keys"] == [
+            "id",
+            "description",
+            "executionStatus",
+            "resultStatus",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# NFS-shaped DomainCreationSpec validates (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_nfs_shaped_domain_spec_validates() -> None:
+    """A well-formed NFS-principal DomainCreationSpec passes the domain ops' schema."""
+    for op in _domain_ops():
+        errors = list(validate_params(op.parameter_schema, {"spec": _NFS_DOMAIN_SPEC}))
+        assert errors == [], (op.op_id, errors)
+
+
+def test_malformed_nfs_nas_volume_is_rejected() -> None:
+    """An NFS spec whose nasVolume drops the required `path` fails validation.
+
+    Guards the vSAN-reuse trap: the schema meaningfully checks the NFS
+    sub-shape rather than waving any object through.
+    """
+    bad_spec = {
+        "domainName": "wld-bad",
+        "vcenterSpec": {"name": "vc"},
+        "computeSpec": {
+            "clusterSpecs": [
+                {
+                    "datastoreSpec": {
+                        "nfsDatastoreSpecs": [
+                            {"nasVolume": {"serverName": ["10.6.7.10"], "readOnly": False}}
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+    for op in _domain_ops():
+        errors = list(validate_params(op.parameter_schema, {"spec": bad_spec}))
+        assert errors, op.op_id
+
+
+def test_domain_ops_require_spec() -> None:
+    """A missing `spec` param fails validation for both domain ops."""
+    for op in _domain_ops():
+        errors = list(validate_params(op.parameter_schema, {}))
+        assert errors, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Approval park — the mutating writes are not dispatchable without approval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op_id", "path", "spec"),
+    [
+        (SDDC_DOMAIN_CREATE_OP_ID, "/v1/domains", _NFS_DOMAIN_SPEC),
+        (
+            SDDC_HOST_COMMISSION_OP_ID,
+            "/v1/hosts",
+            [
+                {
+                    "fqdn": "esxi-1.wld.test",
+                    "username": "root",
+                    "password": "pw",
+                    "storageType": "NFS",
+                    "networkPoolId": "np-01",
+                }
+            ],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_mutating_write_parks_for_approval(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+    spec: Any,
+) -> None:
+    """A dangerous + requires_approval write parks; the vendor endpoint isn't hit."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        write_route = mock.post(path).respond(202, json={"id": "task-x", "status": "IN_PROGRESS"})
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id=op_id,
+            target=_SddcWriteTarget(),
+            params={"spec": spec},
+        )
+
+    assert result.status == "awaiting_approval", result
+    assert not write_route.called
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — the non-approval validation ops + the task poll
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_domain_validate_dispatches(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """sddc.domain.validate (caution, no approval) POSTs the spec and returns ok."""
+    await _register_and_resolve(_stub_embedding)
+    validation = {"id": "val-1", "executionStatus": "IN_PROGRESS", "resultStatus": "UNKNOWN"}
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.post("/v1/domains/validations").respond(202, json=validation)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id=SDDC_DOMAIN_VALIDATE_OP_ID,
+            target=_SddcWriteTarget(),
+            params={"spec": _NFS_DOMAIN_SPEC},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == validation
+    assert route.called and route.call_count == 1
+    assert route.calls[0].request.headers.get("authorization") == f"Bearer {_ACCESS_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_task_get_dispatches_and_builds_path_from_id(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """sddc.task.get (safe) interpolates the task id and returns the Task."""
+    await _register_and_resolve(_stub_embedding)
+    task = {"id": "task-42", "name": "Commission Hosts", "status": "IN_PROGRESS", "subTasks": []}
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.get("/v1/tasks/task-42").respond(200, json=task)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id="sddc.task.get",
+            target=_SddcWriteTarget(),
+            params={"id": "task-42"},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == task
+    assert route.called and route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Approved-path wire shape — the handler that runs once an operator approves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_network_pool_create_posts_spec_as_object_body(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The approved network-pool create POSTs the NetworkPool spec as the JSON body."""
+    instance = await _register_and_resolve(_stub_embedding)
+    pool = {"name": "wld-np01", "networks": [{"type": "VMOTION"}, {"type": "NFS"}]}
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.post("/v1/network-pools").respond(201, json={"id": "np-9", **pool})
+        result = await instance.network_pool_create(
+            _make_operator(), _SddcWriteTarget(), {"spec": pool}
+        )
+
+    assert result["id"] == "np-9"
+    assert route.called
+    import json as _json
+
+    assert _json.loads(route.calls[0].request.content) == pool
+
+
+@pytest.mark.asyncio
+async def test_host_commission_posts_spec_as_array_body(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The approved host commission POSTs the HostCommissionSpec **array** verbatim."""
+    instance = await _register_and_resolve(_stub_embedding)
+    hosts = [
+        {
+            "fqdn": "esxi-1.wld.test",
+            "username": "root",
+            "password": "pw1",
+            "storageType": "NFS",
+            "networkPoolId": "np-01",
+        },
+        {
+            "fqdn": "esxi-2.wld.test",
+            "username": "root",
+            "password": "pw2",
+            "storageType": "NFS",
+            "networkPoolId": "np-01",
+        },
+    ]
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.post("/v1/hosts").respond(202, json={"id": "task-hc", "status": "IN_PROGRESS"})
+        result = await instance.host_commission(
+            _make_operator(), _SddcWriteTarget(), {"spec": hosts}
+        )
+
+    assert result["id"] == "task-hc"
+    assert route.called
+    import json as _json
+
+    body = _json.loads(route.calls[0].request.content)
+    assert isinstance(body, list) and len(body) == 2
+    assert body[0]["fqdn"] == "esxi-1.wld.test"
+
+
+@pytest.mark.asyncio
+async def test_domain_create_posts_nfs_spec_as_object_body(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The approved domain create POSTs the NFS-shaped DomainCreationSpec verbatim."""
+    instance = await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.post("/v1/domains").respond(
+            202, json={"id": "task-dc", "status": "IN_PROGRESS"}
+        )
+        result = await instance.domain_create(
+            _make_operator(), _SddcWriteTarget(), {"spec": _NFS_DOMAIN_SPEC}
+        )
+
+    assert result["id"] == "task-dc"
+    assert route.called
+    import json as _json
+
+    body = _json.loads(route.calls[0].request.content)
+    nfs = body["computeSpec"]["clusterSpecs"][0]["datastoreSpec"]["nfsDatastoreSpecs"][0]
+    assert nfs["nasVolume"]["path"] == "/exports/wld01"

--- a/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
@@ -105,6 +105,7 @@ var typedOpCLICoverage = map[string]string{
 	"sddc.cluster.list":      "cluster list",
 	"sddc.host.list":         "host list",
 	"sddc.task.list":         "workflow list",
+	"sddc.task.get":          "", // agent surface only (the #3497 WLD-write poll primitive: agents/automation poll a single Task by id; workflow list covers the list surface, no per-id get verb — the sddc.domain.status precedent)
 	"sddc.credential.list":   "", // agent surface only
 	"sddc.license.list":      "", // agent surface only
 	"sddc.nsxt_cluster.list": "", // agent surface only

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -10,6 +10,11 @@ shim. G3.5-T5 (#617) added spec ingestion + ingested read enablement. #2290
 rebuilt the auth on the profile-derived `session_login_token` token session
 (`POST /v1/tokens` → Bearer; the appliance rejects HTTP Basic). G3.5-T6 (#618)
 shipped the CLI verb tree (`meho sddc-manager …`) + recorded-fixture E2E test.
+#3497 lands the curated workload-domain **write** surface (network-pool create,
+host validate/commission, domain validate/create, plus a `task.get` poll) as
+approval-gated typed ops — the first writes on this connector; a 9.1 target
+resolves to this same connector (range `>=9.0,<10.0`), and the write paths are
+guarded against a pinned `sddc-manager-9.1` shelf spec.
 
 #2306 converted the audited 12-read lab-audit set to first-class **typed** ops
 (`source_kind="typed"`, `typed_ops.py` / `typed_reads.py`) that dispatch on a
@@ -172,6 +177,7 @@ dispatcher's #2067 recovery arm, which calls the connector's public
 | `sddc.network_pool.get` | `sddc-inventory` | `GET /v1/network-pools/{id}` |
 | `sddc.credential.list` | `sddc-credentials` | `GET /v1/credentials` |
 | `sddc.task.list` | `sddc-tasks-typed` | `GET /v1/tasks` |
+| `sddc.task.get` | `sddc-tasks-typed` | `GET /v1/tasks/{id}` |
 | `sddc.system.info` | `sddc-platform` | `GET /v1/system` |
 | `sddc.vcf_service.list` | `sddc-platform` | `GET /v1/vcf-services` |
 | `sddc.manager.list` | `sddc-platform` | `GET /v1/sddc-managers` |
@@ -226,9 +232,88 @@ The hand-curated ingested-enable apparatus (the `core_ops.py` module with its
 `classify_sddc_op` / `apply_sddc_core_curation` helpers) was retired in #2358
 (T7 of #2266); read enablement is now generic, with no per-product curation code.
 
-Lifecycle-write ops (`workflow start`, `domain create`, `cluster expand`,
-`host commission`) remain `staged` (never enabled) per Initiative #368 v0.2
-scope.
+The curated workload-domain **write** ops (`network-pool create`, host
+`validate` / `commission`, domain `validate` / `create`) ship as first-class
+**typed** ops (#3497 — see the write-surface section below), enabled at boot
+and approval-gated, not as staged ingested rows. Other lifecycle-write ops
+(`workflow start`, `cluster expand`, edge-cluster create) remain out of the
+curated surface: they are browsable as profiled-dispatch breadth from a
+full-catalog ingest and enable-able through the generic review flow
+(`ReviewService.edit_op`), never bulk-enabled (writes are default-deny).
+
+## `typed_writes.py` — curated workload-domain write surface (#3497)
+
+#368 shipped the connector read-only and deferred writes; #3497 lands the
+curated **workload-domain (WLD) build** path as first-class typed ops
+(`source_kind="typed"`), so a workload domain can be stood up **through the
+backplane** on the governed dispatch path. The bodies live in
+`typed_writes.py`; the metadata + JSONFlux hints in `typed_ops.py`; thin
+bound-method shims on `SddcManagerConnector` (`network_pool_create`,
+`host_validate`, `host_commission`, `domain_validate`, `domain_create`, plus
+the `task_get` poll in `typed_reads.py`) expose them so the dispatcher's
+`import_handler` walk recovers each callable from its `module.ClassName.method`
+`handler_ref`. Each write issues one `HttpConnector._post_json(...)` on the
+token session (the generic non-idempotent seam that honours the declared verb,
+carries the JSON body, and records the flight-recorder vendor span); a raw
+`401` rides the dispatcher's #2067 session-recovery arm exactly as the reads do.
+
+| op_id | verb + path | safety_level | requires_approval |
+|---|---|---|---|
+| `sddc.network_pool.create` | `POST /v1/network-pools` | `caution` | yes |
+| `sddc.host.validate` | `POST /v1/hosts/validations` | `caution` | no |
+| `sddc.host.commission` | `POST /v1/hosts` | `dangerous` | yes |
+| `sddc.domain.validate` | `POST /v1/domains/validations` | `caution` | no |
+| `sddc.domain.create` | `POST /v1/domains` | `dangerous` | yes |
+| `sddc.task.get` | `GET /v1/tasks/{id}` | `safe` | no |
+
+All six are grouped under `sddc-lifecycle` (the writes) / `sddc-tasks-typed`
+(`task.get`) and dispatch through `call_operation` (MCP) or `meho sddc-manager
+operation call <op_id> --params @spec.json` (CLI) — **no new MCP tool and no new
+CLI verb** (CLAUDE.md postulate 5; the generic `operation call` verb carries the
+body). No `enable_writes` bulk path exists by design; each mutating op is a
+distinct approval-gated typed op that the dispatcher **parks** for approval
+before the handler runs. The park-time reviewer context runs the parked spec
+through the connector-boundary redaction engine, so a `DomainCreationSpec`'s or
+`HostCommissionSpec`'s plaintext passwords never reach the approver.
+
+**The governed WLD build sequence** (the caller's responsibility — runbook or
+the meho-automation add-on — not the dispatcher's): `network_pool.create` →
+`host.validate` → `host.commission` → `domain.validate` → `domain.create`. The
+create calls are `202`-async (they return a `Task` in seconds while the build
+runs for hours on the appliance); poll `sddc.task.get` with the returned task id
+and `sddc.domain.status` once the domain object exists, to a terminal state.
+
+**NFS-principal shape.** For the Envision estate (and any NFS-principal domain)
+the `DomainCreationSpec` uses
+`computeSpec.clusterSpecs[].datastoreSpec.nfsDatastoreSpecs[].nasVolume`
+(`NasVolumeSpec`: `serverName[]` / `path` / `readOnly`) — **not**
+`vsanDatastoreSpec`. The domain ops' parameter schema models this NFS sub-shape
+so a well-formed NFS spec validates while a malformed `nasVolume` (the common
+trap of reusing a vSAN spec and swapping only the datastore) is rejected before
+dispatch; the schema stays permissive elsewhere so the full vendor
+`DomainCreationSpec` reaches the wire verbatim. Host commission and validation
+take a JSON **array** of `HostCommissionSpec` (`storageType="NFS"` for the
+estate).
+
+**JSONFlux.** The `Task` and `Validation` responses are set-shaped (a live
+build's `Task.subTasks[]` runs to hundreds of rows). `task.get` /
+`host.commission` / `domain.create` carry a `result_scalars` hint (keep `id` /
+`name` / `status` top-level) plus a `result_digest` hint naming `subTasks` as
+the collection to reduce (the `Task` carries three list fields — `subTasks` /
+`errors` / `resources` — so without the hint the reducer's multi-list
+detail-object exemption would pass the whole document through unreduced); the
+validation ops keep the `id` / `executionStatus` / `resultStatus` poll keys.
+
+**Spec-reconcile lane (#3497).** The hand-coded write `METHOD:/path` set
+(`typed_writes.TYPED_WRITE_DECLARED_OP_IDS`) is asserted against the pinned
+**`sddc-manager-9.1`** shelf spec by
+[`backend/tests/test_connectors_sddc_manager_91_spec_reconcile.py`](../../backend/tests/test_connectors_sddc_manager_91_spec_reconcile.py).
+A 9.1 target resolves to this same `sddc-rest-9.0` connector (range
+`>=9.0,<10.0`; no path was removed 9.0 → 9.1), so the reads stay guarded against
+`sddc-manager-9.0` (the #2982 lane) and the new writes against `sddc-manager-9.1`
+(the estate version). Provenance + CI wiring:
+[`docs/decisions/vendor-spec-ci-provisioning.md`](../decisions/vendor-spec-ci-provisioning.md)
+(the sddc-manager-9.1 extension).
 
 ## CLI verbs (`cli/internal/cmd/sddc-manager/`)
 
@@ -309,6 +394,8 @@ host-commissioning IP-capacity pre-flight; `--json` emits the full envelope.
   (skeleton); [G3.5-T5 #617](https://github.com/evoila/meho/issues/617)
   (spec ingestion + read ops); [G3.5-T6 #618](https://github.com/evoila/meho/issues/618)
   (CLI verbs + E2E + this doc update).
+  [#3497](https://github.com/evoila/meho/issues/3497) (curated
+  workload-domain write surface + `sddc-manager-9.1` reconcile lane).
 - Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
 - Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
 - Operator onboarding: [`docs/cross-repo/sddc-manager-onboarding.md`](../cross-repo/sddc-manager-onboarding.md) — wrapper-flip recipe.

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -272,9 +272,14 @@ operation call <op_id> --params @spec.json` (CLI) — **no new MCP tool and no n
 CLI verb** (CLAUDE.md postulate 5; the generic `operation call` verb carries the
 body). No `enable_writes` bulk path exists by design; each mutating op is a
 distinct approval-gated typed op that the dispatcher **parks** for approval
-before the handler runs. The park-time reviewer context runs the parked spec
-through the connector-boundary redaction engine, so a `DomainCreationSpec`'s or
-`HostCommissionSpec`'s plaintext passwords never reach the approver.
+before the handler runs. The reviewer context
+(`resolve_reviewer_context`) surfaces the op + target + subject identity only —
+never the hidden `params` body — so a `DomainCreationSpec`'s or
+`HostCommissionSpec`'s plaintext passwords never reach the approver (the
+connector-boundary redaction engine is the backstop on any identity field that
+resolves). A custom park-time blast-radius preview builder (the vcf-installer
+`bringup` shape) is a possible future enhancement, not required at the
+`dangerous` tier.
 
 **The governed WLD build sequence** (the caller's responsibility — runbook or
 the meho-automation add-on — not the dispatcher's): `network_pool.create` →

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -226,6 +226,35 @@ OSS-licensed-spec form in
 [`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
 extension mechanics.
 
+### Extension: sddc-manager / sddc-manager-9.1 (#3497)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/sddc-manager-9.1/` directory (`sddc-manager-openapi.json`, OpenAPI
+3.0.1, `info.version 9.1.0.0`, ~1.8 MB, 320 paths) for the **9.1**
+sddc-manager write-path reconcile lane
+(`backend/tests/test_connectors_sddc_manager_91_spec_reconcile.py`),
+under the identical ephemeral-use conditions recorded above (sparse
+read-only checkout, workspace destroyed at job end, never committed,
+never in artifacts or logs, secret withheld from fork PRs and the
+Dependabot store). No vendor-license attestation is needed for this
+extension: the spec is published by VMware in the **public, Apache-2.0**
+[`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs/blob/3949fc33339fc5ea1b77eadb258f1cf49aa88e26/specifications/sddc-manager/sddc-manager-openapi.json)
+repo (pinned at `3949fc33`, retrieved 2026-08-20 — matching the VCF 9.1
+estate the curated workload-domain write ops are authored for) — the
+provenance note of record is the shelf's `sddc-manager-9.1/MANIFEST.md`,
+per the OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics (the sibling `sddc-manager-9.0` OSS precedent above).
+The **9.0** lane (#2982) is retained unchanged — a 9.1 target resolves to
+the same `sddc-rest-9.0` connector (range `>=9.0,<10.0`; no path was
+removed 9.0 → 9.1), so the connector's read paths stay guarded against
+`sddc-manager-9.0` while the new write paths are guarded against
+`sddc-manager-9.1`. **Sequencing:** the spec already ships on the shelf
+(consumer-repo PRs #2602 / #2608), so this extension arms with **no new
+consumer-repo PR** — this repo change adds only the sparse-checkout
+widening (`docs/sddc-manager-9.1` in both Python jobs' checkout list +
+fail-loud verify step) and the lane.
+
 ### Signoff extension — NSX (nsx-9.0, 2026-08-18, #2981 / PR #3007)
 
 The nsx spec-reconcile lane


### PR DESCRIPTION
## Summary

- Lands the curated **workload-domain (WLD) write path** on the `sddc-rest-9.0`
  connector as first-class **typed** ops so an NFS-principal workload domain can
  be built end-to-end **through the backplane** (the Envision dogfooding story):
  `sddc.network_pool.create`, `sddc.host.validate` / `sddc.host.commission`,
  `sddc.domain.validate` / `sddc.domain.create`, plus a `sddc.task.get`
  JSONFlux poll. #368 shipped this connector read-only and deferred writes; the
  bundled ingest spec is GET-only, so nothing existed to build a WLD in a
  default deployment.
- Every mutating write ships **`requires_approval=True`** at the correct safety
  tier — network-pool create + validations `caution`, host commission + domain
  create `dangerous` — and dispatches via `HttpConnector._post_json` on the same
  generic httpx path with standard **park-for-approval + synchronous audit**. No
  bulk enable path (writes are default-deny by design). The nested NFS
  `DomainCreationSpec` rides as a single JSON body param; the domain ops'
  parameter schema models the NFS sub-shape
  (`...datastoreSpec.nfsDatastoreSpecs[].nasVolume`) so a well-formed NFS spec
  validates and the vSAN-reuse trap is rejected pre-dispatch.
- Adds the **SDDC Manager 9.1** spec to the CI vendor shelf (already committed
  on the consumer shelf via #2602/#2608 — OSS Apache-2.0
  `vmware/vcf-api-specs@3949fc33`) + a **9.1 write-path reconcile lane**. A 9.1
  target resolves to this same connector (range `>=9.0,<10.0`; no path removed
  9.0→9.1), so **9.0 is not touched**: reads stay guarded against
  `sddc-manager-9.0` (the #2982 lane), the new write paths against
  `sddc-manager-9.1`. CI sparse-checkout widened in both Python jobs + verify
  step; signoff extension recorded.

### Design note (generic vs typed — the issue leaves it to the implementer)

Typed ops, not staged generic descriptors: they ship registered + enabled +
approval-gated with per-op safety at boot (no runtime ingest+`edit_op` dance
the automation pack would otherwise pay), are unit-testable, and their
hand-coded write paths reconcile against the pinned 9.1 spec (the reason the
shelf entry is added). Generic-bundled-spec would ship *staged* (not
"enabled"), carry heavy blast radius on the shipped-spec provenance record /
parity test / catalog counts, and could not bake per-op safety. Sequencing
(validate → create → poll to terminal) is the caller's responsibility.
Edge-cluster create/validate is out of scope: the Supervisor path is VDS +
Foundation LB, so no NSX edge cluster is needed.

## Changelog line (not committed here per repo train discipline)

- **Added** — SDDC Manager: curated workload-domain write ops
  (`sddc.network_pool.create`, `sddc.host.validate`/`.commission`,
  `sddc.domain.validate`/`.create`) + `sddc.task.get` poll, approval-gated typed
  ops on the generic dispatch path; SDDC Manager **9.1** spec on the CI vendor
  shelf + write-path spec-reconcile lane (reads stay pinned to 9.0). (#3497)

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/sddc_manager/` — clean
- [x] `code-quality.py --diff` — 0 blockers (3 warnings, under limits)
- [x] New `tests/test_connectors_sddc_manager_writes.py` — registration shape
  (safety/approval/group/tag), handler_attr resolves to bound methods, approval
  **park** for the dangerous writes (endpoint not hit), validation-op + task-poll
  dispatch, approved-path wire shape (object body vs array body), and the
  **NFS-shaped `DomainCreationSpec` validates** / malformed `nasVolume` rejected
- [x] New `tests/test_connectors_sddc_manager_91_spec_reconcile.py` — armed
  against the real shelf: the write paths are served by `sddc-manager-9.1`; the
  declared set is pinned so it can't go vacuous
- [x] `tests/test_connectors_sddc_manager_spec_reconcile.py` (9.0 lane) extended
  with the `task.get` read path — still green against 9.0
- [x] Full sddc + flight-recorder typed-span guard + all `test_operations_*` +
  reference-docs drift + catalog ingest — **1048 passed, 1 skipped**
- [x] `docs/codebase/connectors-sddc-manager.md` updated (writes no longer out
  of scope); `docs-site/reference/connectors.md` verified unchanged (drift guard)

## Out of scope

- NSX edge-cluster create/validate ops (optional; VDS + Foundation LB path).
- The live-instance ingest of the full 9.1 catalog + the runbook/automation
  sequencing that drives these ops — meho-automation, not this backplane change.
- No new MCP tool, no new CLI verb (CLAUDE.md postulate 5; parity via
  `call_operation` / the existing `meho sddc-manager operation call`).

Closes #3497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
