### PR TITLE
feat(connectors): kubernetes — governed guest-cluster kubeconfig secret-data read to a Vault ref (#3496)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -99,6 +99,13 @@ _CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
         # collapse to aggregate-only, on top of the op's requires_approval
         # gate and the connector-boundary secret scrub.
         "sddc.credential.list",
+        # The governed guest-cluster kubeconfig read (#3496). Reads a Secret's
+        # data value on a k8s / vSphere-Supervisor target and stages it to a
+        # tenant-scoped Vault secret_ref (returning only the ref, never the
+        # value). Classified credential_read — same posture as the SDDC read —
+        # so audit + broadcast collapse to aggregate-only on top of its
+        # requires_approval gate; the result is value-free by construction.
+        "k8s.secret.read_to_ref",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -1479,6 +1479,19 @@ class KubernetesConnector(Connector):
 
         return await k8s_job_create(self, target, operator, params)
 
+    async def k8s_secret_read_to_ref(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.secret.read_to_ref`` (#3496)."""
+        from meho_backplane.connectors.kubernetes.ops_secret_read import (
+            k8s_secret_read_to_ref,
+        )
+
+        return await k8s_secret_read_to_ref(self, target, operator, params)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`KUBERNETES_OPS` into ``endpoint_descriptor``.

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -183,7 +183,9 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
     + ``STORAGE_OPS`` (#2830 storage: ``k8s.storageclass.list`` /
     ``k8s.persistentvolume.list`` / ``k8s.persistentvolumeclaim.list``)
     + ``CUSTOM_RESOURCE_OPS`` (#2830 generic CR reads: ``k8s.crd.list``
-    / ``k8s.cr.list`` / ``k8s.cr.info``) + ``k8s.logs`` (T5).
+    / ``k8s.cr.list`` / ``k8s.cr.info``) + ``k8s.logs`` (T5) +
+    ``k8s.exec`` + the write ops + ``SECRET_READ_OPS`` (#3496 governed
+    guest-cluster kubeconfig read: ``k8s.secret.read_to_ref``).
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -208,6 +210,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         K8S_LOGS_RESPONSE_SCHEMA,
     )
     from meho_backplane.connectors.kubernetes.ops_network import NETWORK_OPS
+    from meho_backplane.connectors.kubernetes.ops_secret_read import SECRET_READ_OPS
     from meho_backplane.connectors.kubernetes.ops_storage import STORAGE_OPS
     from meho_backplane.connectors.kubernetes.ops_workload import WORKLOAD_OPS
     from meho_backplane.connectors.kubernetes.ops_write_meta import (
@@ -259,6 +262,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         _exec_op(),
         *WRITE_CAUTION_OPS,
         *WRITE_DANGEROUS_OPS,
+        *SECRET_READ_OPS,
     )
 
 

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_secret_read.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_secret_read.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed, audit-classified guest-cluster kubeconfig read (#3496).
+
+``k8s.secret.read_to_ref`` reads one named Secret's ``data`` key on a
+k8s / vSphere-Supervisor target and stages the decoded value into a Vault
+``secret_ref`` under the caller's tenant scope, returning **only** the
+``secret_ref`` + provenance metadata. The value never enters the op
+result, so it never lands in an agent transcript.
+
+Why this op exists
+==================
+
+The shipped WCP SSO auth mode (#2905) establishes only the top-level
+Supervisor context; it deliberately does not open guest-cluster
+sub-sessions (``wcp.py``). A VKS guest cluster is therefore registered
+from its Cluster-API-generated ``<cluster>-kubeconfig`` Secret in the
+Supervisor namespace (the admin client-cert kubeconfig, stored under the
+``value`` data key). But the k8s connector had ``k8s.secret.create`` and
+no **data-returning** Secret read — Secret ``data`` is clamped on
+broadcast — so extracting that kubeconfig meant an out-of-band
+``kubectl get secret … -o jsonpath``, escaping audit / policy / approval.
+This op closes that gap **through the backplane**.
+
+The no-transit design (contrast with the issue's ``read_data`` sketch)
+==================================================================
+
+The issue (#3496) sketched a ``read_data`` op that returns the decoded
+kubeconfig to the approval-gated caller (redacted only in
+audit/broadcast transcripts). This op is the stronger ``read_to_ref``
+shape: it borrows the secret broker's core invariant
+(``connectors/secret``) — the value is read inside the backplane and
+written straight to a Vault ``secret_ref``; the caller receives only the
+ref. So the kubeconfig never reaches the ``call_operation`` result / the
+model-API transcript at all, not merely the audit row. The round-trip
+the issue calls for (stage → register a ``product=k8s`` target →
+``k8s.node.list``) is served directly: this op *is* the staging step,
+and it writes under the field name the k8s kubeconfig loader
+(:func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`)
+reads (``kubeconfig`` by default), so a freshly-created ``product=k8s``
+target whose ``secret_ref`` is the returned path authenticates out of
+the box.
+
+Governance posture (mirrors ``sddc.credential.list``, #2306)
+============================================================
+
+* ``safety_level="caution"`` + ``requires_approval=True`` — the policy
+  gate parks an ordinary dispatch for operator approval; the read never
+  runs unapproved.
+* ``op_id`` is pinned in
+  :data:`meho_backplane.broadcast.events._CREDENTIAL_READ_OPS`, so
+  ``classify_op`` returns ``credential_read`` and the audit + broadcast
+  rows collapse to aggregate-only.
+* the result is value-free **by construction** (only the ref + a
+  SHA-256 + byte length, like the secret broker's ``SecretMaterial``
+  provenance), so even the connector-boundary ``credential_read``
+  response scrub (#2467) and the defensive Tier-1 engine have no secret
+  to strip.
+
+Tenant scope (no duplicated logic)
+==================================
+
+The destination path is derived with
+:func:`~meho_backplane.connectors.vault.tenant_paths.tenant_secret_ref`
+— the same helper ``POST /api/v1/targets`` uses to default an omitted
+``secret_ref`` (#1723) — so the returned ref is exactly what a later
+``targets create --name <register_as>`` (secret_ref omitted) reads, and
+is inside the operator's tenant subtree by construction. The write goes
+through the ``vault.kv.put`` handler
+(:func:`~meho_backplane.connectors.vault.ops.vault_kv_put`), which runs
+:func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`
+before any Vault round-trip — so the same default-on guard the
+``api/v1/targets.py`` write-time ``secret_ref`` gate mirrors is enforced
+here as defense-in-depth, without re-implementing the check (that gate
+itself raises ``HTTPException`` and is FastAPI-coupled, so the
+connector-appropriate reuse is the shared guard it wraps).
+
+Supervisor case: no server rewrite (corpus-verified)
+====================================================
+
+A VKS guest kubeconfig's ``clusters[].cluster.server`` already points at
+the guest cluster's own LoadBalancer API-server VIP and is used as-is —
+so **no** server-address rewrite is needed here (corpus:
+``vsphere-supervisor-services-and-standalone-components.pdf``,
+``VCFB1443LV-kubernetes-101-and-the-iaas-control-plane-on-vmware-cloud-fo.pdf``).
+The op stages the kubeconfig verbatim.
+
+References
+----------
+* Task: #3496. Related: #2905 (WCP SSO auth), meho-automation#181
+  (the blueprint that stages the kubeconfig + registers the guest target).
+* Secret-broker no-transit invariant: ``connectors/secret`` (#1577).
+* ``credential_read`` classification: ``broadcast/events.py`` (#2306, #2467).
+* k8s Secret API:
+  https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+from kubernetes_asyncio import client
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+
+__all__ = [
+    "DEFAULT_KUBECONFIG_DATA_KEY",
+    "DEFAULT_STAGE_FIELD",
+    "SECRET_READ_OPS",
+    "KubernetesSecretDataError",
+    "k8s_secret_read_to_ref",
+]
+
+#: The Secret ``data`` key a Cluster-API-generated ``<cluster>-kubeconfig``
+#: Secret stores the admin kubeconfig under (corpus-verified for VKS /
+#: vSphere Supervisor; the upstream Cluster API ``KubeconfigDataName``
+#: constant is likewise ``"value"``).
+DEFAULT_KUBECONFIG_DATA_KEY = "value"
+
+#: The field name the staged value is written under in the destination
+#: Vault secret. The k8s kubeconfig loader
+#: (:func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`)
+#: reads the ``kubeconfig`` field, so a ``product=k8s`` target created
+#: against the returned ``secret_ref`` authenticates without any extra
+#: staging step.
+DEFAULT_STAGE_FIELD = "kubeconfig"
+
+
+class KubernetesSecretDataError(ValueError):
+    """The requested Secret ``data`` key is absent or not decodable.
+
+    Raised when the named Secret carries no ``data`` map, the requested
+    key is missing, or its value is not valid base64 / UTF-8. The message
+    names the Secret + key (never the value). Subclasses :class:`ValueError`
+    so the dispatcher's ``connector_error`` envelope tags
+    ``extras.exception_class="KubernetesSecretDataError"``, matching the
+    sibling ``k8s.secret.create`` error shapes.
+    """
+
+
+def _decode_secret_value(
+    data: dict[str, str] | None, *, name: str, namespace: str, key: str
+) -> str:
+    """Return the UTF-8-decoded value of ``data[key]`` from a Secret.
+
+    ``V1Secret.data`` values are base64-encoded strings. A missing map,
+    a missing key, or a value that is not valid base64 / UTF-8 raises
+    :class:`KubernetesSecretDataError` naming the Secret + key but never
+    the value.
+    """
+    if not data or key not in data:
+        available = sorted(data) if data else []
+        raise KubernetesSecretDataError(
+            f"Secret {namespace}/{name} has no data key {key!r} "
+            f"(present keys: {available}). Pass data_key to name the key that "
+            f"holds the kubeconfig (a Cluster-API guest kubeconfig uses 'value')."
+        )
+    try:
+        return base64.b64decode(data[key], validate=True).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError) as exc:
+        raise KubernetesSecretDataError(
+            f"Secret {namespace}/{name} data key {key!r} is not valid "
+            f"base64-encoded UTF-8 ({type(exc).__name__})"
+        ) from exc
+
+
+async def k8s_secret_read_to_ref(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.secret.read_to_ref`` — stage a Secret value to a Vault ref.
+
+    Reads ``data[data_key]`` from the named Secret on *target* (a
+    Supervisor / k8s cluster), decodes it, and writes it to a Vault
+    ``secret_ref`` derived for the caller's tenant via
+    :func:`~meho_backplane.connectors.vault.tenant_paths.tenant_secret_ref`.
+    The write rides the ``vault.kv.put`` handler so the tenant-scope guard
+    runs under the operator's own Vault identity. Returns only the
+    ``secret_ref`` + provenance (SHA-256, byte length) — never the value.
+    """
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    data_key: str = params.get("data_key") or DEFAULT_KUBECONFIG_DATA_KEY
+    register_as: str = params["register_as"]
+    field: str = params.get("field") or DEFAULT_STAGE_FIELD
+
+    # Lazy imports: keep this metadata/handler module free of import-time
+    # coupling to the vault connector + settings (it is imported while the
+    # kubernetes op tuple is built at module load); the handler only runs
+    # at dispatch, long after every connector module is imported.
+    from meho_backplane.connectors._shared.vault_creds import DEFAULT_KV_MOUNT
+    from meho_backplane.connectors.vault.ops import vault_kv_put
+    from meho_backplane.connectors.vault.tenant_paths import tenant_secret_ref
+
+    api_client = await connector._get_api_client(target, operator)
+    core_v1 = client.CoreV1Api(api_client)
+    secret = await core_v1.read_namespaced_secret(name=name, namespace=namespace)
+    value = _decode_secret_value(secret.data, name=name, namespace=namespace, key=data_key)
+
+    dest_ref = tenant_secret_ref(operator.tenant_id, register_as)
+    # vault_kv_put runs enforce_tenant_scope (#1643) under the operator's
+    # identity before the Vault round-trip; dest_ref is inside the tenant
+    # subtree by construction, so this is defense-in-depth, not the gate.
+    await vault_kv_put(
+        operator,
+        None,
+        {"mount": DEFAULT_KV_MOUNT, "path": dest_ref, "data": {field: value}},
+    )
+
+    value_bytes = value.encode("utf-8")
+    return {
+        "secret_ref": dest_ref,
+        "field": field,
+        "registered_as": register_as,
+        "name": name,
+        "namespace": namespace,
+        "data_key": data_key,
+        "value_sha256": hashlib.sha256(value_bytes).hexdigest(),
+        "length": len(value_bytes),
+    }
+
+
+_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Exact Secret name on the source target — e.g. the "
+                "'<cluster>-kubeconfig' Secret a VKS guest cluster publishes."
+            ),
+        },
+        "namespace": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Namespace the Secret lives in (the Supervisor namespace for VKS).",
+        },
+        "data_key": {
+            "type": "string",
+            "minLength": 1,
+            "default": DEFAULT_KUBECONFIG_DATA_KEY,
+            "description": (
+                "The Secret 'data' key holding the kubeconfig. Defaults to 'value' "
+                "(the Cluster-API guest-kubeconfig convention)."
+            ),
+        },
+        "register_as": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 253,
+            "description": (
+                "The target name the guest cluster will be registered under. The "
+                "destination Vault path is derived as tenants/<tenant_id>/<register_as> "
+                "— exactly what 'targets create --name <register_as>' (secret_ref "
+                "omitted) reads, so the staged kubeconfig round-trips into that target."
+            ),
+        },
+        "field": {
+            "type": "string",
+            "minLength": 1,
+            "default": DEFAULT_STAGE_FIELD,
+            "description": (
+                "The field name the value is written under in the destination Vault "
+                "secret. Defaults to 'kubeconfig' — the field the k8s kubeconfig "
+                "loader reads, so a product=k8s target on the returned secret_ref "
+                "authenticates as-is."
+            ),
+        },
+    },
+    "required": ["name", "namespace", "register_as"],
+    "additionalProperties": False,
+}
+
+
+_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "secret_ref": {"type": "string"},
+        "field": {"type": "string"},
+        "registered_as": {"type": "string"},
+        "name": {"type": "string"},
+        "namespace": {"type": "string"},
+        "data_key": {"type": "string"},
+        "value_sha256": {"type": "string"},
+        "length": {"type": "integer"},
+    },
+    "required": [
+        "secret_ref",
+        "field",
+        "registered_as",
+        "name",
+        "namespace",
+        "data_key",
+        "value_sha256",
+        "length",
+    ],
+    "additionalProperties": False,
+}
+
+
+_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Register a VKS / vSphere-Supervisor guest cluster as a second k8s "
+        "target WITHOUT ever putting its kubeconfig in your context. Reads the "
+        "'<cluster>-kubeconfig' Secret on the Supervisor target and stages the "
+        "decoded kubeconfig to a Vault secret_ref under your tenant; the value "
+        "is NEVER returned. Then create a product=k8s target named <register_as> "
+        "(secret_ref omitted — it defaults to the returned path). Approval-gated; "
+        "audit + broadcast collapse to aggregate-only (credential_read)."
+    ),
+    "parameter_hints": {
+        "name": "The source Secret name (e.g. 'my-cluster-kubeconfig').",
+        "namespace": "The Supervisor namespace the guest cluster lives in.",
+        "data_key": "Which data key holds the kubeconfig; defaults to 'value'.",
+        "register_as": "The guest target name; the Vault path is derived from it.",
+        "field": "Destination Vault field; defaults to 'kubeconfig' (loader-ready).",
+    },
+    "output_shape": (
+        "{secret_ref, field, registered_as, name, namespace, data_key, "
+        "value_sha256, length} — the kubeconfig itself is NEVER in the result; "
+        "only its SHA-256 + byte length as provenance."
+    ),
+}
+
+
+SECRET_READ_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.secret.read_to_ref",
+        handler_attr="k8s_secret_read_to_ref",
+        summary="Stage a Secret value to a tenant-scoped Vault secret_ref; return only the ref.",
+        description=(
+            "Reads ``data[data_key]`` (default 'value') from the named Secret "
+            "on a k8s / vSphere-Supervisor target, decodes it, and writes it to "
+            "a Vault ``secret_ref`` derived for the caller's tenant "
+            "(tenants/<tenant_id>/<register_as>) via the ``vault.kv.put`` "
+            "handler (which enforces the tenant-scope guard). Returns ONLY the "
+            "secret_ref + provenance (SHA-256, byte length) — the value never "
+            "enters the result, so a guest-cluster kubeconfig can be registered "
+            "as a second k8s target without the kubeconfig ever reaching an "
+            "agent transcript. Purpose-built for extracting a VKS guest "
+            "cluster's '<cluster>-kubeconfig' Secret from the Supervisor "
+            "namespace. Classified credential_read (audit + broadcast collapse "
+            "to aggregate-only) and requires approval."
+        ),
+        parameter_schema=_PARAMETER_SCHEMA,
+        response_schema=_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("read", "secret", "credential", "kubeconfig", "caution"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -170,6 +170,10 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "k8s.job.create",
     # G3.14-T2 exec op (websocket pod-exec, approval-gated).
     "k8s.exec",
+    # #3496 governed guest-cluster kubeconfig read (credential_read,
+    # approval-gated): reads a Secret's data value and stages it to a
+    # tenant-scoped Vault secret_ref.
+    "k8s.secret.read_to_ref",
 )
 
 

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -180,10 +180,13 @@ class TestClassifyOp:
             # SDDC Manager's typed GET /v1/credentials read (#2306) — the
             # nested-infra credential inventory (system of record).
             ("sddc.credential.list", "credential_read"),
+            # The governed guest-cluster kubeconfig read (#3496) — reads a
+            # Secret's data value and stages it to a tenant-scoped Vault ref.
+            ("k8s.secret.read_to_ref", "credential_read"),
         ],
     )
     def test_credential_read_allowlist(self, op_id: str, expected: str) -> None:
-        """Exact-match allowlist — decision #3 names these; #2306 adds the SDDC read."""
+        """Exact-match allowlist — decision #3 names these; #2306/#3496 add the SDDC + k8s reads."""
         assert classify_op(op_id) == expected
 
     @pytest.mark.parametrize(

--- a/backend/tests/test_connectors_k8s_secret_read.py
+++ b/backend/tests/test_connectors_k8s_secret_read.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the governed guest-kubeconfig read ``k8s.secret.read_to_ref`` (#3496).
+
+Proves the no-transit contract: the op reads a Secret's ``data`` value on
+a k8s / Supervisor target, stages it to a tenant-scoped Vault
+``secret_ref`` under the operator's identity, and returns **only** the
+ref + provenance — the kubeconfig never enters the op result (the leak
+vector the ``read_to_ref`` shape closes over the issue's ``read_data``
+sketch), the op params, or a broadcast payload.
+
+The kubernetes API and Vault are stubbed at their boundaries (the
+in-process Vault fake + a mocked ``CoreV1Api``) so the suite runs in the
+secret-free unit lane with no Docker and no real secret. The canary
+kubeconfig strings are the leak sentinels the no-leak assertions grep
+against.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import (
+    classify_op,
+    redact_payload,
+    scrub_secret_named_values,
+)
+from meho_backplane.connectors.kubernetes import (
+    KUBERNETES_OPS,
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes.ops_secret_read import (
+    DEFAULT_KUBECONFIG_DATA_KEY,
+    DEFAULT_STAGE_FIELD,
+    SECRET_READ_OPS,
+    KubernetesSecretDataError,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary kubeconfig — asserted to NEVER appear in the result / params.
+# The server VIP + bearer token are the load-bearing secret fields.
+# ---------------------------------------------------------------------------
+
+_CANARY_SERVER = "https://guest-vip.envision.test.invalid:6443"
+_CANARY_TOKEN = "guest-admin-client-cert-canary-MUST-NOT-LEAK"
+_CANARY_KUBECONFIG = f"""apiVersion: v1
+kind: Config
+current-context: guest
+contexts:
+- name: guest
+  context: {{cluster: guest, user: admin}}
+clusters:
+- name: guest
+  cluster:
+    server: {_CANARY_SERVER}
+users:
+- name: admin
+  user:
+    token: {_CANARY_TOKEN}
+"""
+_CANARY_B64 = base64.b64encode(_CANARY_KUBECONFIG.encode("utf-8")).decode("ascii")
+
+_TENANT_ID = UUID("00000000-0000-0000-0000-00000000a0a0")
+_EXPECTED_REF = f"tenants/{_TENANT_ID}/envision-guest"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_connectors_k8s_write.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_kubernetes_registry() -> Iterator[None]:
+    clear_registry()
+    register_connector("k8s", KubernetesConnector)
+    register_connector_v2(product="k8s", version="1.x", impl_id="k8s", cls=KubernetesConnector)
+    yield
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    id: object = field(default_factory=uuid4)
+    tenant_id: object = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET = _StubTarget(
+    name="envision-supervisor",
+    host="supervisor.envision.test.invalid",
+    port=6443,
+    secret_ref="k8s/envision-supervisor",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://supervisor.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-read-to-ref-test",
+        name="Read-To-Ref Test Operator",
+        email=None,
+        raw_jwt="op.read-to-ref.jwt",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _patch_kubeconfig() -> Any:
+    return patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        return_value=MagicMock(close=AsyncMock()),
+    )
+
+
+def _core_v1_patch() -> Any:
+    return patch("meho_backplane.connectors.kubernetes.ops_secret_read.client.CoreV1Api")
+
+
+def _secret_with(data: dict[str, str]) -> MagicMock:
+    """A stand-in ``V1Secret`` whose ``.data`` is *data* (base64 values)."""
+    return MagicMock(data=data)
+
+
+# ---------------------------------------------------------------------------
+# Registration + schema surface
+# ---------------------------------------------------------------------------
+
+
+def test_registered_with_caution_and_approval() -> None:
+    by_id = {op.op_id: op for op in KUBERNETES_OPS}
+    assert "k8s.secret.read_to_ref" in by_id, "op not registered in KUBERNETES_OPS"
+    op = by_id["k8s.secret.read_to_ref"]
+    assert op.safety_level == "caution"
+    assert op.requires_approval is True
+
+
+def test_handler_attr_resolves_on_connector() -> None:
+    op = SECRET_READ_OPS[0]
+    assert getattr(KubernetesConnector, op.handler_attr, None) is not None
+
+
+def test_schema_shape_and_defaults() -> None:
+    op = SECRET_READ_OPS[0]
+    props = op.parameter_schema["properties"]
+    assert {"name", "namespace", "data_key", "register_as", "field"} <= set(props)
+    assert op.parameter_schema["required"] == ["name", "namespace", "register_as"]
+    assert op.parameter_schema["additionalProperties"] is False
+    assert props["data_key"]["default"] == DEFAULT_KUBECONFIG_DATA_KEY == "value"
+    assert props["field"]["default"] == DEFAULT_STAGE_FIELD == "kubeconfig"
+
+
+# ---------------------------------------------------------------------------
+# Classification — credential_read, aggregate-only broadcast
+# ---------------------------------------------------------------------------
+
+
+def test_classifies_credential_read_and_collapses_broadcast() -> None:
+    """The op classifies credential_read; its broadcast payload is aggregate-only."""
+    assert classify_op("k8s.secret.read_to_ref") == "credential_read"
+    raw = {"params": {"name": "guest-kubeconfig", "namespace": "envision-ns", "register_as": "g"}}
+    payload = redact_payload("credential_read", raw, "ok")
+    assert payload == {"op_class": "credential_read", "result_status": "ok"}
+
+
+def test_result_fields_survive_the_credential_read_scrub() -> None:
+    """The #2467 credential_read response scrub must NOT redact the returned ref.
+
+    The op's whole value is the secret_ref it hands back; if the key-name
+    scrub collapsed it the caller could never register the target.
+    """
+    result = {
+        "secret_ref": _EXPECTED_REF,
+        "field": "kubeconfig",
+        "registered_as": "envision-guest",
+        "name": "guest-kubeconfig",
+        "namespace": "envision-ns",
+        "data_key": "value",
+        "value_sha256": "deadbeef",
+        "length": 42,
+    }
+    scrubbed, found = scrub_secret_named_values(result)
+    assert found is False
+    assert scrubbed["secret_ref"] == _EXPECTED_REF
+    assert scrubbed["field"] == "kubeconfig"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — read Secret, stage to a tenant-scoped Vault ref
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reads_secret_and_stages_to_tenant_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = install_fake_client(monkeypatch)
+    conn = _make_connector()
+    operator = _make_operator()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.read_namespaced_secret = AsyncMock(
+            return_value=_secret_with({"value": _CANARY_B64})
+        )
+        result = await conn.k8s_secret_read_to_ref(
+            operator=operator,
+            target=_TARGET,
+            params={
+                "name": "envision-guest-kubeconfig",
+                "namespace": "envision-ns",
+                "register_as": "envision-guest",
+            },
+        )
+
+    # Result is only the ref + provenance — the derived path is tenant-scoped
+    # and matches what `targets create --name envision-guest` (secret_ref
+    # omitted) reads.
+    assert result["secret_ref"] == _EXPECTED_REF
+    assert result["field"] == "kubeconfig"
+    assert result["registered_as"] == "envision-guest"
+    assert result["data_key"] == "value"
+    assert result["length"] == len(_CANARY_KUBECONFIG.encode("utf-8"))
+    assert result["value_sha256"] == hashlib.sha256(_CANARY_KUBECONFIG.encode()).hexdigest()
+
+    # The decoded kubeconfig reached Vault (the point) — under the operator's
+    # own JWT, at the derived tenant path, on the default 'secret' mount.
+    put = fake.secrets.kv.v2.put_calls[-1]
+    assert put["path"] == _EXPECTED_REF
+    assert put["mount_point"] == "secret"
+    assert put["secret"] == {"kubeconfig": _CANARY_KUBECONFIG}
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+
+
+@pytest.mark.asyncio
+async def test_result_envelope_carries_no_secret_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The redaction contract: no kubeconfig bytes in the op result envelope."""
+    install_fake_client(monkeypatch)
+    conn = _make_connector()
+    params = {
+        "name": "envision-guest-kubeconfig",
+        "namespace": "envision-ns",
+        "register_as": "envision-guest",
+    }
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.read_namespaced_secret = AsyncMock(
+            return_value=_secret_with({"value": _CANARY_B64})
+        )
+        result = await conn.k8s_secret_read_to_ref(
+            operator=_make_operator(), target=_TARGET, params=params
+        )
+
+    blob = str(result)
+    assert _CANARY_TOKEN not in blob, "bearer token leaked into the op result"
+    assert _CANARY_SERVER not in blob, "server VIP leaked into the op result"
+    assert _CANARY_KUBECONFIG not in blob, "raw kubeconfig leaked into the op result"
+    assert _CANARY_B64 not in blob, "base64 kubeconfig leaked into the op result"
+    # The value never entered the op params either (only the ref does).
+    assert _CANARY_TOKEN not in str(params)
+    # Provenance is present so an approver/audit can correlate.
+    assert result["value_sha256"] and result["length"] > 0
+
+
+@pytest.mark.asyncio
+async def test_custom_data_key_and_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = install_fake_client(monkeypatch)
+    conn = _make_connector()
+    payload = base64.b64encode(b"a-different-kubeconfig-blob").decode("ascii")
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.read_namespaced_secret = AsyncMock(
+            return_value=_secret_with({"admin.conf": payload})
+        )
+        result = await conn.k8s_secret_read_to_ref(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "s",
+                "namespace": "ns",
+                "register_as": "envision-guest",
+                "data_key": "admin.conf",
+                "field": "kubeconfig",
+            },
+        )
+    assert result["data_key"] == "admin.conf"
+    assert fake.secrets.kv.v2.put_calls[-1]["secret"] == {
+        "kubeconfig": "a-different-kubeconfig-blob"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Error paths — value never leaks, nothing is written on failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_data_key_raises_and_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.read_namespaced_secret = AsyncMock(
+            return_value=_secret_with({"other-key": _CANARY_B64})
+        )
+        with pytest.raises(KubernetesSecretDataError) as excinfo:
+            await conn.k8s_secret_read_to_ref(
+                operator=_make_operator(),
+                target=_TARGET,
+                params={
+                    "name": "envision-guest-kubeconfig",
+                    "namespace": "envision-ns",
+                    "register_as": "envision-guest",
+                },
+            )
+    # Error names the missing key, never the value; no Vault write happened.
+    assert "value" in str(excinfo.value)
+    assert _CANARY_B64 not in str(excinfo.value)
+    assert fake.secrets.kv.v2.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_base64_raises_and_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.read_namespaced_secret = AsyncMock(
+            return_value=_secret_with({"value": "!!! not base64 !!!"})
+        )
+        with pytest.raises(KubernetesSecretDataError):
+            await conn.k8s_secret_read_to_ref(
+                operator=_make_operator(),
+                target=_TARGET,
+                params={
+                    "name": "envision-guest-kubeconfig",
+                    "namespace": "envision-ns",
+                    "register_as": "envision-guest",
+                },
+            )
+    assert fake.secrets.kv.v2.put_calls == []

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -326,6 +326,7 @@ real operator through the same loader.
 | `k8s.cr.info`          | safe   | Generic single CR read over `CustomObjectsApi.get_namespaced_custom_object()` / `get_cluster_custom_object()`. Single-object projection (metadata + bounded `spec_excerpt`), not a rows envelope. Requires `group`/`version`/`plural`/`name`. (`ops_customresource.py`) |
 | `k8s.logs`             | safe   | `CoreV1Api.read_namespaced_pod_log()` non-streaming -- tail / container / since / previous + 1 MiB cap. |
 | `k8s.exec`             | **dangerous** (`requires_approval=True`) | `CoreV1Api.connect_get_namespaced_pod_exec()` over the `WsApiClient` websocket transport -- bounded argv command-and-capture: stdout / stderr demuxed from the `v4.channel.k8s.io` channels + exit code parsed from the channel-3 status frame, per-stream 1 MiB cap, bounded timeout. Interactive `-it` deferred. |
+| `k8s.secret.read_to_ref` | **caution** (`requires_approval=True`) | `CoreV1Api.read_namespaced_secret()` -- reads one Secret's `data[data_key]` (default `value`), decodes it, and stages the value to a **tenant-scoped Vault `secret_ref`** via `vault.kv.put`; returns **only** the ref + provenance (SHA-256 / byte length), never the value. Classified `credential_read` (audit + broadcast aggregate-only). The governed VKS guest-kubeconfig read (`ops_secret_read.py`, #3496). |
 
 ### `k8s.exec` -- websocket command-and-capture (`ops_exec.py`)
 
@@ -465,6 +466,75 @@ apply. Note: the dispatcher / approval-queue substrate has **no per-op
 auto-populated into the approval row at queue time today; the dry-run is
 expressible + returned by the op, and queue-time auto-population is a
 follow-up that needs a dispatcher hook.
+
+### Governed guest-cluster kubeconfig read -- `k8s.secret.read_to_ref` (#3496)
+
+The `ops_secret_read.py` op closes the one gap the write surface left:
+there was `k8s.secret.create` but **no data-returning Secret read**
+(Secret `data` is clamped on broadcast). Extracting a credential from a
+Secret therefore meant an out-of-band `kubectl get secret … -o
+jsonpath`, escaping audit / policy / approval. The motivating case is
+registering a **VKS guest cluster** as a second `product=k8s` target: the
+shipped WCP SSO auth mode (#2905) reaches only the Supervisor, so a guest
+cluster is registered from its Cluster-API-generated
+`<cluster>-kubeconfig` Secret (the admin client-cert kubeconfig, stored
+under the `value` data key) in the Supervisor namespace.
+
+**No-transit shape (not the issue's `read_data` sketch).** The op does
+**not** return the decoded kubeconfig to the caller. Borrowing the secret
+broker's core invariant (`connectors/secret`, #1577), it reads the value
+inside the backplane and writes it straight to a Vault `secret_ref`,
+returning only `{secret_ref, field, registered_as, name, namespace,
+data_key, value_sha256, length}`. So the kubeconfig never reaches the
+`call_operation` result / the agent transcript at all -- not merely the
+audit row. This is a deliberate hardening of #3496's `read_data` sketch
+(which returned the value to the approval-gated caller); the round-trip
+the issue asks for is served directly, because the op **is** the staging
+step.
+
+**Round-trip.** The destination path is derived with
+`tenant_secret_ref(operator.tenant_id, register_as)`
+(`connectors/vault/tenant_paths.py`) -- the same helper `POST
+/api/v1/targets` uses to default an omitted `secret_ref` (#1723) -- and
+the value is written under the `field` name the kubeconfig loader reads
+(`kubeconfig` by default, see `load_kubeconfig_from_vault`). So the demo
+flow is: `call_operation k8s.secret.read_to_ref … register_as=<guest>`
+-> `meho targets create --name <guest> --product k8s --host <guest-VIP>
+--port 6443` (secret_ref omitted; it defaults to the returned path) ->
+`k8s.node.list` against the guest works.
+
+**Governance (mirrors `sddc.credential.list`).** Three layers: (1)
+`safety_level="caution"` + `requires_approval=True` (the policy gate
+parks an unapproved dispatch); (2) the op-id is pinned in
+`broadcast.events._CREDENTIAL_READ_OPS`, so `classify_op` returns
+`credential_read` and audit + broadcast rows collapse to aggregate-only;
+(3) the result is value-free **by construction** (only the ref + a
+SHA-256 + byte length), so the connector-boundary `credential_read`
+response scrub (#2467) and the defensive Tier-1 engine have no secret to
+strip.
+
+**Tenant scope, not duplicated.** The write rides the `vault.kv.put`
+handler, which runs `enforce_tenant_scope`
+(`connectors/vault/tenant_scope.py`) under the operator's own Vault
+identity before any round-trip -- the same default-on guard the
+`api/v1/targets.py` write-time `secret_ref` gate mirrors, enforced here
+without re-implementing it (that gate raises `HTTPException` and is
+FastAPI-coupled, so the connector-appropriate reuse is the shared guard
+it wraps). The derived path is inside the operator's tenant subtree by
+construction.
+
+**Supervisor case: no server rewrite (corpus-verified).** A VKS guest
+kubeconfig's `clusters[].cluster.server` already points at the guest
+cluster's own LoadBalancer API-server VIP and is used as-is, so **no**
+server-address rewrite is performed -- the op stages the kubeconfig
+verbatim (corpus:
+`vsphere-supervisor-services-and-standalone-components.pdf`,
+`VCFB1443LV-kubernetes-101-and-the-iaas-control-plane-on-vmware-cloud-fo.pdf`).
+
+A missing `data_key`, or a value that is not valid base64 / UTF-8, raises
+`KubernetesSecretDataError` naming the Secret + key (never the value);
+the error surfaces through the dispatcher's `connector_error` envelope,
+and nothing is written to Vault on failure.
 
 ### Shared list-op request shape (`ops_listparams.py`)
 


### PR DESCRIPTION
## Summary

- Adds **`k8s.secret.read_to_ref`** to the kubernetes connector: a governed, audit-classified read of one Secret's `data` value on a k8s / vSphere-Supervisor target that stages the decoded value to a **tenant-scoped Vault `secret_ref`** and returns **only** the ref + provenance — the value never enters the op result, so a VKS guest cluster's `<cluster>-kubeconfig` can be registered as a second `product=k8s` target **through the backplane** without the kubeconfig ever landing in an agent transcript.
- `safety_level="caution"`, `requires_approval=True`, classified `credential_read` (pinned in `broadcast.events._CREDENTIAL_READ_OPS`) so audit + broadcast collapse to aggregate-only — the same three-layer gating as `sddc.credential.list`.
- Reuses existing tenant-scope machinery with **no duplication**: the destination path is derived with `tenant_secret_ref` (the helper `POST /api/v1/targets` uses to default an omitted `secret_ref`, #1723), and the write rides the `vault.kv.put` handler, which runs `enforce_tenant_scope` under the operator's own Vault identity — the same default-on guard the `api/v1/targets.py` write-time `secret_ref` gate mirrors.
- **Corpus-verified** (VMware doc corpus): the VKS guest kubeconfig's `clusters[].cluster.server` is the guest API-server LoadBalancer VIP and is used as-is — **no** server-address rewrite is performed; the op stages the kubeconfig verbatim.

### Design note — a hardening of the issue's `read_data` sketch

#3496 sketched a `read_data` op returning the decoded kubeconfig to the approval-gated caller (redacted only in audit/broadcast transcripts). This PR implements the stronger **`read_to_ref`** shape, borrowing the secret broker's no-transit invariant (`connectors/secret`): the value is written straight to a Vault `secret_ref` and **never returned**, so the kubeconfig never reaches the `call_operation` result / model-API transcript at all — not merely the audit row. The round-trip the issue calls for is served directly, because this op *is* the staging step: it writes under the `kubeconfig` field the k8s kubeconfig loader reads, so a `product=k8s` target created on the returned ref (secret_ref omitted → derived to the same path) authenticates as-is.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean on touched files (the sole error, `net/icmp.py` `MSG_ERRQUEUE`, is a pre-existing macOS-only quirk unrelated to this change; Linux CI is clean)
- [x] `pytest tests/test_connectors_k8s_secret_read.py` — new unit suite: registration/schema/defaults, `credential_read` classification + aggregate-only broadcast, happy-path stage-to-tenant-ref (value reaches Vault under the operator JWT at the derived path; result carries only the ref), **redaction test proving no secret bytes in the result envelope**, custom `data_key`/`field`, and missing-key + invalid-base64 error paths (value never leaked, nothing written on failure).
- [x] `pytest tests/test_broadcast_events.py tests/test_broadcast_classifier_coverage.py` — classifier allowlist (added the op) + the secret-param coverage sweep.
- [x] `pytest tests/integration/test_connectors_k8s_e2e.py` — updated the `EXPECTED_OP_IDS` registration snapshot; both drift/known-op-count assertions pass.
- [x] `pytest tests/test_reference_docs_drift.py` + regen — `docs-site/reference/connectors.md` / `mcp-tools.md` unchanged (op is behind the meta-tools, not a new MCP tool; connectors.md is a per-connector inventory).

## Docs / snapshots

- Updated `docs/codebase/connectors-kubernetes.md`: a new op-surface row plus a dedicated subsection (no-transit design, round-trip, governance posture, tenant scope, and the no-server-rewrite finding).
- `docs-site/reference/connectors.md` + `mcp-tools.md`: regenerated, **no change**.
- CLI OpenAPI snapshot: **no change** — no CLI verb / REST route added. CLI + MCP parity is automatic via `search_operations` / `call_operation`.

## Out of scope

- The live "register the guest target → `k8s.node.list` succeeds against the guest cluster" leg runs at the demo (no live-lab access in this run); the staging leg is unit-proven.
- **No CHANGELOG edit in this PR** (per the coordination protocol — CHANGELOG lands in the release roll-up). Changelog line:
  - `**kubernetes connector**: governed guest-cluster kubeconfig read `k8s.secret.read_to_ref` — reads a Secret's data value on a k8s/Supervisor target and stages it to a tenant-scoped Vault `secret_ref` (returns only the ref, never the value), so a VKS guest cluster can be registered as a second k8s target through the backplane. Classified `credential_read`, `requires_approval`. (#3496)`

Closes #3496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
