### PR TITLE
feat(connectors): vmware — governed NFS tag-based SPBM storage policy create/delete (typed PBM SOAP)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -90,6 +90,11 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
 from meho_backplane.connectors.vmware_rest.composites._register import (
     register_vmware_composite_operations,
 )
+from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
+    storage_policy_create_composite,
+    storage_policy_delete_composite,
+    storage_policy_list_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._supervisor import (
     supervisor_disable_composite,
     supervisor_enable_composite,
@@ -159,6 +164,9 @@ __all__ = [
     "performance_summary_composite",
     "register_vmware_composite_operations",
     "service_control_composite",
+    "storage_policy_create_composite",
+    "storage_policy_delete_composite",
+    "storage_policy_list_composite",
     "supervisor_disable_composite",
     "supervisor_enable_composite",
     "supervisor_status_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
@@ -30,7 +30,12 @@ from __future__ import annotations
 
 from typing import Final
 
-from meho_backplane.connectors.vmware_rest.composites import _host, _supervisor, _write
+from meho_backplane.connectors.vmware_rest.composites import (
+    _host,
+    _storage_policy,
+    _supervisor,
+    _write,
+)
 
 #: Connector the vmware-rest composites dispatch against. The composites are
 #: registered for vCenter 9.0 (``vmware-rest-9.0``); the discovery surface
@@ -82,6 +87,8 @@ _GOVERNED_SUBOP_MANIFEST: Final[dict[str, tuple[str, ...]]] = {
     "vmware.composite.host.service_control": _host._VIM_SUB_OPS_HOST_SERVICE_CONTROL,
     "vmware.composite.supervisor.enable": _supervisor._SUB_OPS_SUPERVISOR_ENABLE,
     "vmware.composite.supervisor.disable": _supervisor._SUB_OPS_SUPERVISOR_DISABLE,
+    "vmware.composite.storage_policy.create": _storage_policy._SUB_OPS_STORAGE_POLICY_CREATE,
+    "vmware.composite.storage_policy.delete": _storage_policy._SUB_OPS_STORAGE_POLICY_DELETE,
 }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -85,6 +85,11 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
+    storage_policy_create_composite,
+    storage_policy_delete_composite,
+    storage_policy_list_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._supervisor import (
     supervisor_disable_composite,
     supervisor_enable_composite,
@@ -161,6 +166,12 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     NETWORK_PORTGROUP_SECURITY_SET_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
     PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+    STORAGE_POLICY_CREATE_PARAMETER_SCHEMA,
+    STORAGE_POLICY_CREATE_RESPONSE_SCHEMA,
+    STORAGE_POLICY_DELETE_PARAMETER_SCHEMA,
+    STORAGE_POLICY_DELETE_RESPONSE_SCHEMA,
+    STORAGE_POLICY_LIST_PARAMETER_SCHEMA,
+    STORAGE_POLICY_LIST_RESPONSE_SCHEMA,
     SUPERVISOR_DISABLE_PARAMETER_SCHEMA,
     SUPERVISOR_DISABLE_RESPONSE_SCHEMA,
     SUPERVISOR_ENABLE_PARAMETER_SCHEMA,
@@ -1535,6 +1546,77 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         tags=["composite", "read-only", "namespace-management", "supervisor", "wcp"],
         safety_level="safe",
         requires_approval=False,
+    ),
+    # storage_policy.* — governed NFS tag-based SPBM policy (#3494)
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.storage_policy.list",
+        handler=storage_policy_list_composite,
+        summary="List the visible vCenter storage policies (JSONFlux-reduced).",
+        description=(
+            "Reads GET /vcenter/storage/policies and returns the visible "
+            "storage policies; the set-shaped list is JSONFlux-reduced to a "
+            "result handle by the dispatcher when large (drill in via "
+            "result_query). Optional policy_ids narrows the scan. The "
+            "companion read for storage_policy.create/delete — confirms a "
+            "minted policy is visible or a deleted one is gone. Read-only."
+        ),
+        parameter_schema=STORAGE_POLICY_LIST_PARAMETER_SCHEMA,
+        response_schema=STORAGE_POLICY_LIST_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=["composite", "read-only", "storage", "policy", "spbm"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.storage_policy.create",
+        handler=storage_policy_create_composite,
+        summary="Create a tag-based NFS VM storage policy (tag substrate + PBM SOAP).",
+        description=(
+            "Mints a tag-based requirement storage policy for NFS-principal "
+            "datastores (which have no default policy — vSAN Default Storage "
+            "Policy is vSAN-only), the first link in the Supervisor-enable "
+            "chain (#3494). Creates the tag category + tag over vCenter REST "
+            "(POST /cis/tagging/category / /tag), attaches the tag to each "
+            "named datastore (/tag-association?action=attach), then creates "
+            "the policy over the PBM SOAP API (PbmProfileProfileManager."
+            "PbmCreate on /pbm — there is no vCenter REST for policy creation) "
+            "whose one rule requires the tag, and returns the new policy id. "
+            "safety_level='caution' + requires_approval=True: parked for human "
+            "approval before any write; each child write flows through the "
+            "governed sub-op seam (its own audit row + grant point). "
+            "Fail-closed if a datastore name resolves to zero / many. "
+            "Equivalent of the out-of-band 'New-SpbmStoragePolicy' / "
+            "'govc storage.policy.create -category -tag', governed."
+        ),
+        parameter_schema=STORAGE_POLICY_CREATE_PARAMETER_SCHEMA,
+        response_schema=STORAGE_POLICY_CREATE_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=["composite", "write", "storage", "policy", "spbm", "tagging", "nfs"],
+        safety_level="caution",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.storage_policy.delete",
+        handler=storage_policy_delete_composite,
+        summary="Delete a storage policy by id (PBM SOAP) and read-back verify absent.",
+        description=(
+            "The teardown counterpart of storage_policy.create (#3494). Issues "
+            "PbmProfileProfileManager.PbmDelete for the policy id over the PBM "
+            "SOAP API, then read-backs GET /vcenter/storage/policies to confirm "
+            "the id is gone. safety_level='destructive' + requires_approval="
+            "True. A per-id PbmDelete fault (e.g. the policy is still in use by "
+            "a VM / Supervisor) returns status='delete_failed' with the fault "
+            "type — an in-use policy must be freed first (no force). Deletes "
+            "only the policy; the tag / category are left in place (may be "
+            "shared). Equivalent of 'govc storage.policy.rm', governed."
+        ),
+        parameter_schema=STORAGE_POLICY_DELETE_PARAMETER_SCHEMA,
+        response_schema=STORAGE_POLICY_DELETE_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=["composite", "write", "storage", "policy", "spbm", "destroy", "destructive"],
+        safety_level="destructive",
+        requires_approval=True,
     ),
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_storage_policy.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_storage_policy.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Governed NFS tag-based SPBM storage-policy composites (#3494).
+
+NFS-principal datastores have no default VM storage policy (``vSAN Default
+Storage Policy`` is vSAN-only), so a **tag-based** policy must be minted before
+a vSphere Supervisor can be enabled (its ``EnableSpec`` requires
+``master_storage_policy`` / ``ephemeral_storage_policy`` / ``image_storage``,
+all policy ids) and before a vSphere Namespace / VKS guest cluster can bind
+storage. Creating it out of band (``govc`` / PowerCLI ``New-SpbmStoragePolicy``)
+is exactly the escape from policy / audit / approval the dogfooding story
+cannot have — hence these governed ops.
+
+Two transports, both first-class (the postulate): the **tag substrate** (tag
+category + tag + tag-association) rides the vCenter REST paths
+(``POST /cis/tagging/category`` / ``/tag`` / ``/tag-association/{tagId}?action=attach``,
+present in the pinned ``vcenter.yaml``) through the connector's REST session;
+the **policy create/delete** itself has *no* vCenter REST equivalent — the spec
+exposes only ``GET /vcenter/storage/policies`` (read) — so it rides the **PBM
+SOAP** API (``PbmProfileProfileManager.PbmCreate`` / ``PbmDelete`` on ``/pbm``,
+``urn:pbm``) through the connector's :meth:`~VmwareRestConnector.pbm_create_tag_profile`
+/ :meth:`~VmwareRestConnector.pbm_delete_profiles` seam. The agent sees one
+op either way.
+
+Governance mirrors the destructive-delete family: ``storage_policy.create`` is
+``safety_level="caution"`` + ``requires_approval=True`` (the dispatcher parks it
+for a human before the handler runs), ``storage_policy.delete`` is
+``safety_level="destructive"`` + ``requires_approval=True``. Every child write —
+each REST tag op and the PBM create/delete — flows through the shared
+:func:`~meho_backplane.operations.composite.enforce_subop_policy` seam (the
+``dangerous`` / ``requires_approval=False`` posture the composite's own human
+approval sits above), so each carries its own synchronous audit row and a
+per-``(principal, op, target)`` grant point.
+
+The wire shape of the PBM tag rule is grounded on govmomi ``pbm`` +
+``govc storage.policy.create`` + the community ``vmware_vm_storage_policy``
+Ansible module (see :mod:`~meho_backplane.connectors.vmware_rest.soap`). The
+PBM SOAP path is mock-validated (respx fixtures replaying the documented wire
+shapes); live-appliance validation is deferred (no lab access at build time).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    _CONNECTOR_ID,
+    _WRITE_REQUIRES_APPROVAL,
+    _WRITE_SAFETY_LEVEL,
+    _read_sub_op,
+    _write_sub_op,
+)
+from meho_backplane.operations.composite import enforce_subop_policy
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+# --- Child op-id governance keys -------------------------------------------
+# These are the canonical METHOD:/path keys fed to enforce_subop_policy (the
+# grant / audit vocabulary), matching the ingested vcenter.yaml rows so a
+# per-(principal, op, target) grant lines up. The tagging rows ride the
+# generic REST sub-op seam; the two PBM keys are synthetic (PBM has no REST
+# path — the dispatch is the typed SOAP seam) but follow the same METHOD:/path
+# shape the vim sub-ops use (e.g. POST:/VirtualMachine/{moId}/ReconfigVM_Task).
+
+_OP_CATEGORY_CREATE = "POST:/cis/tagging/category"
+_OP_TAG_CREATE = "POST:/cis/tagging/tag"
+_OP_TAG_ATTACH = "POST:/cis/tagging/tag-association/{tagId}?action=attach"
+_OP_DATASTORE_LIST = "GET:/vcenter/datastore"
+_OP_STORAGE_POLICIES_LIST = "GET:/vcenter/storage/policies"
+_OP_PBM_CREATE = "POST:/pbm/ProfileManager/PbmCreate"
+_OP_PBM_DELETE = "POST:/pbm/ProfileManager/PbmDelete"
+
+#: Tag categories that constrain datastores use MULTIPLE cardinality so a
+#: datastore can carry several policy tags at once (the common lab shape).
+_TAG_CATEGORY_CARDINALITY = "MULTIPLE"
+#: The vim managed-object type a datastore tag-association DynamicID names.
+_DATASTORE_OBJECT_TYPE = "Datastore"
+
+
+async def _gate_pbm_sub_op(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    op_id: str,
+    params: dict[str, Any],
+) -> OperationResult | None:
+    """Run the shared sub-op governance gate for a PBM SOAP write.
+
+    The PBM twin of ``_write_sub_op``'s gate leg: the PBM create/delete has no
+    ingested REST descriptor, so there is nothing to dispatch generically — but
+    it is still a governed write, so it flows through the same #2254
+    :func:`enforce_subop_policy` seam under the shared ``dangerous`` /
+    ``requires_approval=False`` posture (the composite's own human approval sits
+    above it). Returns the parked / denied :class:`OperationResult` for the
+    caller to bubble verbatim, or ``None`` when the gate clears and the caller
+    may issue the SOAP call.
+    """
+    return await enforce_subop_policy(
+        operator=operator,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        safety_level=_WRITE_SAFETY_LEVEL,
+        requires_approval=_WRITE_REQUIRES_APPROVAL,
+        target=target,
+        params=params,
+    )
+
+
+async def _resolve_datastore_moids(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    datastore_names: list[str],
+) -> tuple[list[dict[str, str]], str | None]:
+    """Resolve each datastore *name* to its moid via ``GET /vcenter/datastore``.
+
+    Returns ``(resolved, error_name)``: ``resolved`` is ``[{name, moid}]`` in
+    input order; ``error_name`` names the first datastore that resolved to zero
+    or many matches (a fail-closed refuse before any write), else ``None``.
+    """
+    resolved: list[dict[str, str]] = []
+    for name in datastore_names:
+        rows = await _read_sub_op(
+            connector, target, operator, _OP_DATASTORE_LIST, {"names": [name]}
+        )
+        matches = [r for r in (rows or []) if isinstance(r, dict) and r.get("name") == name]
+        if len(matches) != 1:
+            return resolved, name
+        resolved.append({"name": name, "moid": str(matches[0]["datastore"])})
+    return resolved, None
+
+
+async def storage_policy_list_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """List the visible storage policies (``GET /vcenter/storage/policies``).
+
+    Op-id ``vmware.composite.storage_policy.list``. Read-only; the set-shaped
+    ``policies`` list is JSONFlux-reduced to a result handle by the dispatcher
+    when it crosses the byte threshold (postulate 6). Optional ``policy_ids``
+    narrows the scan.
+    """
+    policy_ids = params.get("policy_ids") or []
+    rows = await _read_sub_op(connector, target, operator, _OP_STORAGE_POLICIES_LIST, {})
+    policies = [r for r in (rows or []) if isinstance(r, dict)]
+    if policy_ids:
+        wanted = set(policy_ids)
+        policies = [p for p in policies if p.get("policy") in wanted]
+    return {"policies": policies}
+
+
+async def _storage_policy_listed(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    policy_id: str,
+) -> bool:
+    """Read-back: is *policy_id* visible in ``GET /vcenter/storage/policies``?
+
+    Scans the full (uncapped-by-filter) list so a picky filter can never
+    mask presence; the list is small in practice (capped at 1024 server-side).
+    """
+    rows = await _read_sub_op(connector, target, operator, _OP_STORAGE_POLICIES_LIST, {})
+    return any(isinstance(r, dict) and r.get("policy") == policy_id for r in (rows or []))
+
+
+def _create_result(
+    *,
+    status: str,
+    policy_name: str,
+    tag_name: str,
+    resolved: list[dict[str, str]],
+    policy_id: str | None = None,
+    category_id: str | None = None,
+    tag_id: str | None = None,
+    listed: bool = False,
+    guidance: str | None = None,
+) -> dict[str, Any]:
+    """Build the ``storage_policy.create`` response envelope (one shape, all paths)."""
+    return {
+        "status": status,
+        "policy_id": policy_id,
+        "policy_name": policy_name,
+        "category_id": category_id,
+        "tag_id": tag_id,
+        "tag_name": tag_name,
+        "datastores": resolved,
+        "listed": listed,
+        "guidance": guidance,
+    }
+
+
+async def _create_tag_substrate(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    category_name: str,
+    tag_name: str,
+    description: str,
+    resolved: list[dict[str, str]],
+) -> tuple[OperationResult | None, str | None, str | None]:
+    """Create the tag category + tag and attach the tag to each datastore.
+
+    Returns ``(gate, category_id, tag_id)``: ``gate`` is a parked / denied
+    :class:`OperationResult` the caller bubbles verbatim (``category_id`` /
+    ``tag_id`` then ``None``); on success ``gate`` is ``None`` and both ids are
+    populated. Each write flows through the shared sub-op governance seam.
+    """
+    gate, category_id = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_CATEGORY_CREATE,
+        {
+            "name": category_name,
+            "description": description,
+            "cardinality": _TAG_CATEGORY_CARDINALITY,
+            "associable_types": [_DATASTORE_OBJECT_TYPE],
+        },
+    )
+    if gate is not None:
+        return gate, None, None
+    gate, tag_id = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_TAG_CREATE,
+        {"name": tag_name, "description": description, "category_id": category_id},
+    )
+    if gate is not None:
+        return gate, category_id, None
+    for datastore in resolved:
+        gate, _payload = await _write_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_TAG_ATTACH,
+            {
+                "tagId": tag_id,
+                "object_id": {"id": datastore["moid"], "type": _DATASTORE_OBJECT_TYPE},
+            },
+        )
+        if gate is not None:
+            return gate, category_id, tag_id
+    return None, category_id, tag_id
+
+
+async def _mint_pbm_policy(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    policy_name: str,
+    description: str,
+    category_name: str,
+    category_id: str,
+    tag_id: str,
+    tag_name: str,
+    resolved: list[dict[str, str]],
+) -> dict[str, Any] | OperationResult:
+    """Gate + create the PBM policy for an already-created tag substrate, then verify.
+
+    Runs the PBM sub-op gate (bubbled verbatim on park / deny), issues
+    ``PbmCreate``, and read-backs ``GET /vcenter/storage/policies``. Returns the
+    ``policy_create_failed`` result when PbmCreate yields no id (reporting the
+    created category / tag for cleanup), else the ``created`` result.
+
+    The PBM tag rule references the category by its **display name**
+    (``com.vmware.storage.tag.<category_name>.property``, per the govc / Ansible
+    reference), not the ``category_id`` the REST create returned — the id is
+    kept only for the response envelope + cleanup guidance.
+    """
+    gate = await _gate_pbm_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_PBM_CREATE,
+        params={"policy_name": policy_name, "category_name": category_name, "tag_name": tag_name},
+    )
+    if gate is not None:
+        return gate
+    policy_id = await connector.pbm_create_tag_profile(
+        target,
+        operator,
+        name=policy_name,
+        description=description,
+        category_name=category_name,
+        tag_names=[tag_name],
+    )
+    if not policy_id:
+        return _create_result(
+            status="policy_create_failed",
+            policy_name=policy_name,
+            tag_name=tag_name,
+            resolved=resolved,
+            category_id=category_id,
+            tag_id=tag_id,
+            guidance=(
+                "PbmCreate returned no policy id after the tag substrate was "
+                f"created (category {category_id!r}, tag {tag_id!r}); no policy "
+                "exists — clean up the tag/category or retry"
+            ),
+        )
+    listed = await _storage_policy_listed(connector, target, operator, policy_id)
+    return _create_result(
+        status="created",
+        policy_name=policy_name,
+        tag_name=tag_name,
+        resolved=resolved,
+        policy_id=policy_id,
+        category_id=category_id,
+        tag_id=tag_id,
+        listed=listed,
+        guidance=(
+            None
+            if listed
+            else (
+                f"policy {policy_id!r} was created but did not appear in "
+                "GET /vcenter/storage/policies on the immediate read-back; it "
+                "may take a moment to propagate — re-list to confirm"
+            )
+        ),
+    )
+
+
+async def storage_policy_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Create a tag-based NFS storage policy end to end (#3494).
+
+    Op-id ``vmware.composite.storage_policy.create``. ``safety_level="caution"``
+    + ``requires_approval=True`` — the dispatcher parks it for a human before
+    the handler runs; each child write flows through the shared sub-op gate.
+    Resolves datastore names to moids (fail-closed ``datastore_not_found``
+    before any write), creates the tag category + tag and attaches it to each
+    datastore (:func:`_create_tag_substrate`), then mints + verifies the PBM
+    policy whose one rule requires the tag (:func:`_mint_pbm_policy`).
+    """
+    policy_name = params["policy_name"]
+    tag_name = params["tag_name"]
+    description = params.get("description", "") or ""
+
+    resolved, missing = await _resolve_datastore_moids(
+        connector, target, operator, list(params["datastore_names"])
+    )
+    if missing is not None:
+        return _create_result(
+            status="datastore_not_found",
+            policy_name=policy_name,
+            tag_name=tag_name,
+            resolved=resolved,
+            guidance=(
+                f"datastore {missing!r} resolved to zero or several datastores; "
+                "no tag substrate or policy was created — pass a name that "
+                "matches exactly one datastore"
+            ),
+        )
+
+    gate, category_id, tag_id = await _create_tag_substrate(
+        connector,
+        target,
+        operator,
+        category_name=params["category_name"],
+        tag_name=tag_name,
+        description=description,
+        resolved=resolved,
+    )
+    if gate is not None:
+        return gate
+
+    return await _mint_pbm_policy(
+        connector,
+        target,
+        operator,
+        policy_name=policy_name,
+        description=description,
+        category_name=params["category_name"],
+        category_id=str(category_id),
+        tag_id=str(tag_id),
+        tag_name=tag_name,
+        resolved=resolved,
+    )
+
+
+async def storage_policy_delete_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Delete a storage policy by id and read-back verify it is absent (#3494).
+
+    Op-id ``vmware.composite.storage_policy.delete``. ``safety_level="destructive"``
+    + ``requires_approval=True`` — the teardown counterpart of
+    ``storage_policy.create``. Gates the PBM delete, issues
+    ``PbmProfileProfileManager.PbmDelete`` for the id, then read-backs
+    ``GET /vcenter/storage/policies``:
+
+    - a per-id ``PbmDelete`` fault (e.g. the policy is still in use by a VM /
+      Supervisor) → ``status="delete_failed"`` with the fault type (no retry
+      or force — an in-use policy must be freed first);
+    - the read-back still lists the id → ``status="still_present"``;
+    - otherwise → ``status="deleted"``.
+
+    Deletes only the **policy**; the tag / category the create minted are left
+    in place (they may be shared) — remove them separately if orphaned.
+    """
+    policy_id = params["policy_id"]
+    policy_name = params.get("policy_name")
+
+    gate = await _gate_pbm_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_PBM_DELETE,
+        params={"policy_id": policy_id, "policy_name": policy_name},
+    )
+    if gate is not None:
+        return gate
+
+    outcomes = await connector.pbm_delete_profiles(target, operator, profile_ids=[policy_id])
+    faulted = next(
+        (o for o in outcomes if isinstance(o, dict) and o.get("fault") is not None), None
+    )
+    if faulted is not None:
+        fault = faulted.get("fault")
+        fault_type = fault.get("_typeName") if isinstance(fault, dict) else None
+        return {
+            "status": "delete_failed",
+            "policy_id": policy_id,
+            "fault": fault_type,
+            "guidance": (
+                f"PbmDelete refused to remove policy {policy_id!r}"
+                + (f" ({policy_name!r})" if policy_name else "")
+                + f": {fault_type or 'fault'}. An in-use policy must be freed "
+                "(detach it from every VM / Supervisor / namespace) before it "
+                "can be deleted."
+            ),
+        }
+
+    still_present = await _storage_policy_listed(connector, target, operator, policy_id)
+    if still_present:
+        return {
+            "status": "still_present",
+            "policy_id": policy_id,
+            "fault": None,
+            "guidance": (
+                f"PbmDelete reported success but policy {policy_id!r} still "
+                "appears in GET /vcenter/storage/policies; re-check the target"
+            ),
+        }
+    return {
+        "status": "deleted",
+        "policy_id": policy_id,
+        "fault": None,
+        "guidance": None,
+    }
+
+
+# Re-export for the governed-subop manifest (#3349): the child op-ids each
+# write composite may fan out to, referenced (never re-typed) by
+# ``_governed_subops._GOVERNED_SUBOP_MANIFEST``.
+_SUB_OPS_STORAGE_POLICY_CREATE: tuple[str, ...] = (
+    _OP_CATEGORY_CREATE,
+    _OP_TAG_CREATE,
+    _OP_TAG_ATTACH,
+    _OP_PBM_CREATE,
+)
+_SUB_OPS_STORAGE_POLICY_DELETE: tuple[str, ...] = (_OP_PBM_DELETE,)
+
+
+__all__ = [
+    "storage_policy_create_composite",
+    "storage_policy_delete_composite",
+    "storage_policy_list_composite",
+]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -156,10 +156,16 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+import httpx
+
+from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
+    _OP_STORAGE_POLICIES_LIST,
+)
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
     _read_cdrom,
     _read_ethernet_nic,
+    _read_sub_op,
     _read_vm_info,
     _read_vm_snapshots_best_effort,
     _resolve_cluster_hosts,
@@ -1176,6 +1182,67 @@ async def _supervisor_disable_preview(ctx: PreviewContext) -> dict[str, Any] | N
     return {"cluster": cluster, "irreversibility": "kubernetes-instance-destroyed"}
 
 
+async def _storage_policy_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``storage_policy.create`` — echo what the caution-tier write builds.
+
+    Not destructive, so no mandatory blast_radius: a plain ``preview`` block
+    naming the policy / category / tag / datastores the approver is authorising
+    to be created. Params here are non-secret, so the echo is safe.
+    """
+    params = ctx.params
+    return {
+        "preview": {
+            "action": "create_tag_storage_policy",
+            "policy_name": params.get("policy_name"),
+            "category_name": params.get("category_name"),
+            "tag_name": params.get("tag_name"),
+            "datastore_names": params.get("datastore_names"),
+        }
+    }
+
+
+async def _storage_policy_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``storage_policy.delete`` — the mandatory destructive blast radius (#3494).
+
+    Populates the ``blast_radius`` block the destructive-tier park gate requires
+    (:func:`~meho_backplane.operations._preview.blast_radius_missing_reason`):
+    the policy identity (name best-effort read from
+    ``GET /vcenter/storage/policies``), an empty ``children`` list (deleting the
+    policy removes no child objects — the tag / category are left in place), and
+    the ``permanent`` irreversibility class. Declines (``None``) only when no
+    ``policy_id`` was supplied; the name read degrades to the params echo /
+    ``None`` on a transport fault so the block is always well-formed.
+    """
+    policy_id = ctx.params.get("policy_id")
+    if not isinstance(policy_id, str) or not policy_id:
+        return None
+    name = ctx.params.get("policy_name")
+    if not name and ctx.connector_instance is not None:
+        try:
+            rows = await _read_sub_op(
+                ctx.connector_instance,  # type: ignore[arg-type]
+                ctx.target,
+                ctx.operator,
+                _OP_STORAGE_POLICIES_LIST,
+                {},
+            )
+            match = next(
+                (r for r in (rows or []) if isinstance(r, dict) and r.get("policy") == policy_id),
+                None,
+            )
+            if match is not None:
+                name = match.get("name")
+        except httpx.HTTPError:
+            name = ctx.params.get("policy_name")
+    return {
+        "blast_radius": {
+            "object": {"kind": "storage_policy", "id": policy_id, "name": name},
+            "children": [],
+            "irreversibility": "permanent",
+        },
+    }
+
+
 #: op_id → builder for the write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
@@ -1207,6 +1274,8 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.host.datastore_mount_nfs": _host_datastore_mount_nfs_preview,
     "vmware.composite.host.disk_mark_flash": _host_disk_mark_flash_preview,
     "vmware.composite.host.service_control": _host_service_control_preview,
+    "vmware.composite.storage_policy.create": _storage_policy_create_preview,
+    "vmware.composite.storage_policy.delete": _storage_policy_delete_preview,
 }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -4749,3 +4749,204 @@ SUPERVISOR_STATUS_RESPONSE_SCHEMA: dict[str, Any] = {
     },
     "required": ["cluster", "config_status", "kubernetes_status", "ready"],
 }
+
+
+# ===========================================================================
+# storage_policy.* — governed NFS tag-based SPBM policy create/delete (#3494)
+# ===========================================================================
+
+#: ``vmware.composite.storage_policy.list`` parameter schema.
+#:
+#: Optional ``policy_ids`` narrows the list; absent, every visible policy is
+#: returned (JSONFlux-reduced by the dispatcher when set-shaped).
+STORAGE_POLICY_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policy_ids": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Optional storage-policy identifiers to filter the list by. "
+                "Absent or empty lists every visible policy."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+#: ``vmware.composite.storage_policy.list`` response schema.
+STORAGE_POLICY_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policies": {
+            "type": "array",
+            "description": "The visible storage policies (Vcenter.Storage.Policies.Summary rows).",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "policy": {"type": "string", "description": "Storage-policy identifier."},
+                    "name": {"type": "string", "description": "Storage-policy display name."},
+                    "description": {"type": "string", "description": "Storage-policy description."},
+                },
+                "required": ["policy", "name"],
+                "additionalProperties": True,
+            },
+        },
+    },
+    "required": ["policies"],
+    "additionalProperties": True,
+}
+
+#: ``vmware.composite.storage_policy.create`` parameter schema.
+#:
+#: Mints a tag-based requirement storage policy for NFS-principal datastores
+#: (which have no default policy). Creates the tag category + tag, attaches the
+#: tag to each named datastore, then creates the PBM policy whose one rule
+#: requires that tag. Category / tag / policy names must be new (this is a
+#: create op; use storage_policy.delete for teardown).
+STORAGE_POLICY_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policy_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": (
+                "Display name of the storage policy to create (PBM caps the name at 80 characters)."
+            ),
+        },
+        "category_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the tag category to create. The tag rule "
+                "references this category; the property id is "
+                "``com.vmware.storage.tag.<category_name>.property``."
+            ),
+        },
+        "tag_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the tag to create in the category and attach "
+                "to the datastores. The policy's tag rule requires this tag."
+            ),
+        },
+        "datastore_names": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1,
+            "description": (
+                "Names of the datastore(s) the tag is attached to (typically "
+                "the NFS datastore(s) the Supervisor / VKS storage binds to). "
+                "Each name must resolve to exactly one datastore."
+            ),
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional description applied to the category, tag, and policy.",
+        },
+    },
+    "required": ["policy_name", "category_name", "tag_name", "datastore_names"],
+    "additionalProperties": False,
+}
+
+#: ``vmware.composite.storage_policy.create`` response schema.
+STORAGE_POLICY_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "created",
+                "datastore_not_found",
+                "policy_create_failed",
+            ],
+            "description": (
+                "``created`` — policy minted and visible; "
+                "``datastore_not_found`` — a datastore name resolved to zero / "
+                "many datastores (no tag substrate created); "
+                "``policy_create_failed`` — the tag substrate was created but "
+                "PbmCreate did not return a policy id (created artifacts "
+                "reported for cleanup)."
+            ),
+        },
+        "policy_id": {
+            "type": ["string", "null"],
+            "description": "The created PBM policy id (the vCenter StoragePolicy identifier).",
+        },
+        "policy_name": {"type": "string"},
+        "category_id": {"type": ["string", "null"], "description": "The created tag category id."},
+        "tag_id": {"type": ["string", "null"], "description": "The created tag id."},
+        "tag_name": {"type": "string"},
+        "datastores": {
+            "type": "array",
+            "description": "Resolved datastores the tag was attached to.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "moid": {"type": "string"},
+                },
+                "required": ["name", "moid"],
+                "additionalProperties": False,
+            },
+        },
+        "listed": {
+            "type": "boolean",
+            "description": "Whether the read-back GET saw the new policy in the policies list.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "policy_id", "policy_name"],
+    "additionalProperties": True,
+}
+
+#: ``vmware.composite.storage_policy.delete`` parameter schema.
+STORAGE_POLICY_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policy_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "The storage-policy id to delete (the PBM profile uniqueId / "
+                "the identifier storage_policy.list returns as ``policy``)."
+            ),
+        },
+        "policy_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional display name, echoed in guidance for the approver.",
+        },
+    },
+    "required": ["policy_id"],
+    "additionalProperties": False,
+}
+
+#: ``vmware.composite.storage_policy.delete`` response schema.
+STORAGE_POLICY_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "delete_failed", "still_present"],
+            "description": (
+                "``deleted`` — PbmDelete reported no per-id fault and the "
+                "read-back no longer lists the id; ``delete_failed`` — PbmDelete "
+                "returned a per-id fault (e.g. the policy is in use); "
+                "``still_present`` — PbmDelete reported success but the "
+                "read-back still lists the id."
+            ),
+        },
+        "policy_id": {"type": "string"},
+        "fault": {
+            "type": ["string", "null"],
+            "description": "The per-id PbmDelete fault type, when status='delete_failed'.",
+        },
+        "guidance": {"type": ["string", "null"]},
+    },
+    "required": ["status", "policy_id"],
+    "additionalProperties": True,
+}

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -149,6 +149,17 @@ from meho_backplane.connectors.vmware_rest.soap import (
     parse_soap_fault,
     soap_action_for_version,
 )
+from meho_backplane.connectors.vmware_rest.soap_pbm import (
+    PBM_PATH,
+    build_pbm_create_envelope,
+    build_pbm_delete_envelope,
+    build_pbm_retrieve_content_envelope,
+    build_pbm_service_content_envelope,
+    parse_pbm_delete_outcomes,
+    parse_pbm_profile_id,
+    parse_pbm_profiles,
+    parse_pbm_service_content,
+)
 from meho_backplane.flight_recorder import capture as flight_recorder_capture
 
 __all__ = ["VmwareRestConnector", "product_from_line_id", "service_versions_api_version"]
@@ -479,6 +490,19 @@ class VmwareRestConnector(HttpConnector):
         # so the vmomi path falls back to the ``/api`` mount without
         # re-probing on every call.
         self._about_versions: dict[tuple[str, str], str | None] = {}
+        # PBM (Storage Policy Based Management) SOAP session bookkeeping
+        # (#3494), used ONLY by the storage-policy create/delete composites.
+        # PBM is a distinct SOAP service (endpoint ``/pbm``, ns ``urn:pbm``)
+        # that reuses a vim ``vmware_soap_session`` cookie for auth, so a
+        # vCenter target — which authenticates the vAPI/VI-JSON path with the
+        # ``vmware-api-session-id`` token, never a SOAP cookie — needs a
+        # *separate* SOAP login established on demand. ``_pbm_cookies`` is the
+        # ``SessionManager.Login`` cookie; ``_pbm_profile_managers`` the
+        # ``PbmServiceInstanceContent.profileManager`` moid. Both keyed on the
+        # tenant-unique tuple, both empty until the first storage-policy op.
+        self._pbm_cookies: dict[tuple[str, str], str] = {}
+        self._pbm_profile_managers: dict[tuple[str, str], str] = {}
+        self._pbm_lock = asyncio.Lock()
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -1056,8 +1080,9 @@ class VmwareRestConnector(HttpConnector):
         extensions: dict[str, Any],
         *,
         soap_action: str = "",
+        path: str = _SDK_PATH,
     ) -> httpx.Response:
-        """POST a SOAP 1.1 *envelope* on ``/sdk``, recording a body-free span.
+        """POST a SOAP 1.1 *envelope* on ``/sdk`` (or *path*), recording a body-free span.
 
         The shared low-level wire helper for every ESXi vmomi POST
         (ServiceContent, Login, Logout, and the :meth:`_post_soap` ops). It
@@ -1081,7 +1106,7 @@ class VmwareRestConnector(HttpConnector):
         """
         _fr_start = flight_recorder_capture.span_start()
         resp = await client.post(
-            _SDK_PATH,
+            path,
             content=envelope.encode("utf-8"),
             headers={"Content-Type": SOAP_CONTENT_TYPE, "SOAPAction": soap_action},
             extensions=extensions,
@@ -1149,6 +1174,223 @@ class VmwareRestConnector(HttpConnector):
             raise self._soap_fault_error(fault, target, message=message)
         resp.raise_for_status()
         return self._parse_esxi_soap_response(method, resp.text)
+
+    # -----------------------------------------------------------------------
+    # PBM (Storage Policy Based Management) SOAP transport (#3494)
+    # -----------------------------------------------------------------------
+
+    async def _ensure_pbm(self, target: VsphereTargetLike, operator: Operator) -> tuple[str, str]:
+        """Establish (once, per target) a PBM SOAP session and return its handles.
+
+        Storage-policy create/delete have no vCenter REST path, so they run
+        over the PBM SOAP service (``/pbm``, ``urn:pbm``). PBM authenticates
+        with a **vim** ``vmware_soap_session`` cookie — not the vAPI
+        ``vmware-api-session-id`` token the connector's REST/VI-JSON path uses
+        — so this mints a *separate* SOAP session on the pooled client:
+
+        1. unauthenticated ``RetrieveServiceContent`` on ``/sdk`` → the
+           vCenter ``sessionManager`` moid (read from ServiceContent, not a
+           hard-coded literal);
+        2. ``SessionManager.Login`` on ``/sdk`` → a 200 sets the
+           ``vmware_soap_session`` cookie, which ``httpx`` keeps in the pooled
+           client's cookie jar (harmless to the REST path, which authenticates
+           by header, never by cookie);
+        3. ``PbmRetrieveServiceContent`` on ``/pbm`` → the
+           ``PbmServiceInstanceContent.profileManager`` moid every PBM
+           create/delete/retrieve is invoked on. The Login cookie rides to
+           ``/pbm`` automatically (same host, same pooled jar), exactly as
+           govmomi's ``pbm.NewClient`` copies the vim session cookie.
+
+        Returns ``(cookie, profile_manager_moid)`` and caches both under the
+        tenant-unique ``target_cache_key``. Credentials never appear in logs,
+        errors, results, or the flight-recorder span: the Login envelope is
+        the only place the password lives (XML-escaped) and :meth:`_soap_post`
+        records the vendor-call span with no request body. A rejected
+        credential (``InvalidLogin`` / ``NoPermission``) raises
+        :class:`ConnectorAuthError`; any other fault a :class:`RuntimeError`
+        naming only the target.
+        """
+        cache_key = target_cache_key(target)
+        async with self._pbm_lock:
+            cookie = self._pbm_cookies.get(cache_key)
+            profile_manager = self._pbm_profile_managers.get(cache_key)
+            if cookie and profile_manager:
+                return cookie, profile_manager
+            creds = await self._session_loader(target, operator)
+            try:
+                username = creds["username"]
+                password = creds["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"vsphere pbm session loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}"
+                ) from exc
+            client = await self._http_client(target)
+            extensions = self._request_extensions(target)
+            # 1. vim SOAP ServiceContent bootstrap → sessionManager moid.
+            sc_resp = await self._soap_post(client, build_service_content_envelope(), extensions)
+            sc_fault = parse_soap_fault(sc_resp.text)
+            if sc_fault is not None:
+                raise RuntimeError(
+                    f"vmware pbm session establish failed for target {target.name!r}: "
+                    f"SOAP RetrieveServiceContent faulted "
+                    f"({sc_fault.fault_type or sc_fault.faultcode})"
+                )
+            sc_resp.raise_for_status()
+            content = parse_service_content(sc_resp.text)
+            sm_ref = content.get("sessionManager")
+            sm_moid = sm_ref.get("value") if isinstance(sm_ref, dict) else None
+            if not isinstance(sm_moid, str) or not sm_moid:
+                raise RuntimeError(
+                    f"vmware pbm session establish failed for target {target.name!r}: "
+                    f"SOAP RetrieveServiceContent returned no sessionManager MoRef"
+                )
+            # 2. SessionManager.Login → vmware_soap_session cookie.
+            login_resp = await self._soap_post(
+                client,
+                build_login_envelope(sm_moid, username=username, password=password),
+                extensions,
+            )
+            login_fault = parse_soap_fault(login_resp.text)
+            if login_fault is not None:
+                raise self._soap_fault_error(
+                    login_fault,
+                    target,
+                    message=(
+                        f"vmware pbm session establish failed for target {target.name!r}: "
+                        f"SOAP SessionManager.Login rejected the credential"
+                    ),
+                )
+            login_resp.raise_for_status()
+            cookie = login_resp.cookies.get(_ESXI_SOAP_SESSION_COOKIE)
+            if not cookie:
+                raise RuntimeError(
+                    f"vmware pbm session establish failed for target {target.name!r}: "
+                    f"SOAP SessionManager.Login returned HTTP {login_resp.status_code} "
+                    f"without a {_ESXI_SOAP_SESSION_COOKIE} cookie"
+                )
+            # 3. PbmRetrieveServiceContent on /pbm → profileManager moid.
+            pbm_resp = await self._soap_post(
+                client, build_pbm_service_content_envelope(), extensions, path=PBM_PATH
+            )
+            pbm_fault = parse_soap_fault(pbm_resp.text)
+            if pbm_fault is not None:
+                raise self._soap_fault_error(
+                    pbm_fault,
+                    target,
+                    message=(
+                        f"vmware pbm session establish failed for target {target.name!r}: "
+                        f"SOAP PbmRetrieveServiceContent faulted"
+                    ),
+                )
+            pbm_resp.raise_for_status()
+            pbm_content = parse_pbm_service_content(pbm_resp.text)
+            pm_ref = pbm_content.get("profileManager")
+            profile_manager = pm_ref.get("value") if isinstance(pm_ref, dict) else None
+            if not isinstance(profile_manager, str) or not profile_manager:
+                raise RuntimeError(
+                    f"vmware pbm session establish failed for target {target.name!r}: "
+                    f"PbmRetrieveServiceContent returned no profileManager MoRef"
+                )
+            self._pbm_cookies[cache_key] = cookie
+            self._pbm_profile_managers[cache_key] = profile_manager
+            return cookie, profile_manager
+
+    async def _post_pbm(
+        self, target: VsphereTargetLike, envelope: str, operator: Operator, *, method: str
+    ) -> str:
+        """POST one PBM SOAP *envelope* on ``/pbm``; return the response body.
+
+        The PBM twin of :meth:`_post_soap`: the fault parse (not the HTTP
+        status) is the authority, so :func:`.soap.parse_soap_fault` runs on the
+        body before ``raise_for_status`` — an ``InvalidLogin`` /
+        ``NoPermission`` fault becomes :class:`ConnectorAuthError` (the
+        dispatcher's cold re-login path), any other PBM fault a
+        :class:`RuntimeError` naming only the target and method. The caller
+        builds *envelope* with the profile-manager moid from :meth:`_ensure_pbm`.
+        """
+        client = await self._http_client(target)
+        extensions = self._request_extensions(target)
+        resp = await self._soap_post(client, envelope, extensions, path=PBM_PATH)
+        fault = parse_soap_fault(resp.text)
+        if fault is not None:
+            raise self._soap_fault_error(
+                fault, target, message=f"vmware pbm {method} failed on target {target.name!r}"
+            )
+        resp.raise_for_status()
+        return resp.text
+
+    async def pbm_create_tag_profile(
+        self,
+        target: VsphereTargetLike,
+        operator: Operator,
+        *,
+        name: str,
+        description: str,
+        category_name: str,
+        tag_names: list[str],
+    ) -> str:
+        """Create a tag-based requirement storage policy; return its profile id.
+
+        Post-gate raw dispatch (the composite runs the governance gate first):
+        ensures the PBM session, POSTs ``PbmCreate`` with the tag-rule
+        create-spec, and returns the new ``PbmProfileId.uniqueId`` — which is
+        the identifier ``GET /vcenter/storage/policies`` lists the policy by.
+        """
+        _cookie, profile_manager = await self._ensure_pbm(target, operator)
+        xml = await self._post_pbm(
+            target,
+            build_pbm_create_envelope(
+                profile_manager,
+                name=name,
+                description=description,
+                category_name=category_name,
+                tag_names=tag_names,
+            ),
+            operator,
+            method="PbmCreate",
+        )
+        policy_id = parse_pbm_profile_id(xml)
+        if not policy_id:
+            raise RuntimeError(
+                f"vmware pbm PbmCreate on target {target.name!r} returned no profile id"
+            )
+        return policy_id
+
+    async def pbm_delete_profiles(
+        self, target: VsphereTargetLike, operator: Operator, *, profile_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        """Delete storage policies by id; return the per-id operation outcomes.
+
+        An outcome carrying a ``fault`` means that id was not removed; an empty
+        list means every id was removed without a reported per-id fault.
+        """
+        _cookie, profile_manager = await self._ensure_pbm(target, operator)
+        xml = await self._post_pbm(
+            target,
+            build_pbm_delete_envelope(profile_manager, profile_ids),
+            operator,
+            method="PbmDelete",
+        )
+        return parse_pbm_delete_outcomes(xml)
+
+    async def pbm_retrieve_profiles(
+        self, target: VsphereTargetLike, operator: Operator, *, profile_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        """Read storage policies by id (the create/delete read-back verify).
+
+        Returns the profile dicts (``profileId`` / ``name`` / ``description`` /
+        ``constraints``) for the ids that still exist; an id absent from the
+        result has been removed.
+        """
+        _cookie, profile_manager = await self._ensure_pbm(target, operator)
+        xml = await self._post_pbm(
+            target,
+            build_pbm_retrieve_content_envelope(profile_manager, profile_ids),
+            operator,
+            method="PbmRetrieveContent",
+        )
+        return parse_pbm_profiles(xml)
 
     @staticmethod
     def _parse_vmomi_path(vmomi_path: str) -> tuple[str, str, str]:
@@ -1377,6 +1619,13 @@ class VmwareRestConnector(HttpConnector):
             self._esxi_pc_moids.pop(cache_key, None)
             self._esxi_api_versions.pop(cache_key, None)
             sm_moid = self._esxi_session_manager_moids.pop(cache_key, None)
+        # Drop any PBM SOAP session too (#3494): an expired vim cookie faults
+        # the next storage-policy op as ``InvalidLogin`` -> ConnectorAuthError
+        # -> this invalidate; evicting forces ``_ensure_pbm`` to re-login and
+        # re-read the profileManager. A plain dict ``pop`` is atomic, so no
+        # ``_pbm_lock`` is needed for the eviction.
+        self._pbm_cookies.pop(cache_key, None)
+        self._pbm_profile_managers.pop(cache_key, None)
         if flavor == HOST_FLAVOR_ESXI and token is not None:
             await self._esxi_logout_quiet(cache_key, sm_moid, extensions or {})
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/soap_pbm.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/soap_pbm.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""PBM (Storage Policy Based Management) SOAP codec (#3494).
+
+The vim25 codec :mod:`~meho_backplane.connectors.vmware_rest.soap` is a
+single cohesive hand-rolled SOAP 1.1 codec for the ``urn:vim25`` surface on
+``/sdk``; PBM is a *distinct* SOAP service (endpoint ``/pbm``, namespace
+``urn:pbm``, its own ``PbmServiceInstance`` bootstrap), so its envelope
+builders + response parsers live in this sibling module. It **reuses** the
+vim25 codec's low-level helpers (``_this`` / ``_envelope`` / ``_xml_escape``
+for building, ``_parse_returnval`` / ``_soap_val_to_json`` / ``_find_body`` /
+``_find_child`` / ``_local`` for parsing) — they are namespace-agnostic
+(local-name walks over ``defusedxml`` nodes) — and adds only the ``urn:pbm``
+method wrapper and the tag-rule create-spec builder.
+
+The wire shapes here are grounded on govmomi ``pbm`` (client/types/methods),
+``govc storage.policy.create``, and the community ``vmware_vm_storage_policy``
+Ansible module: namespace ``http://www.vmware.com/storage/tag``, property id
+``com.vmware.storage.tag.<category>.property``, subprofile "Tag based
+placement", ``category=REQUIREMENT``, ``resourceType=STORAGE``. The
+polymorphic ``constraints`` / ``value`` / ``values`` slots carry the
+``xsi:type`` discriminator vmomi requires on a subclass-in-base-slot; element
+order follows the pbm-types.xsd sequences.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Final
+
+from defusedxml.ElementTree import fromstring
+
+from meho_backplane.connectors.vmware_rest.soap import (
+    _envelope,
+    _find_body,
+    _find_child,
+    _local,
+    _parse_returnval,
+    _soap_val_to_json,
+    _this,
+    _xml_escape,
+)
+
+#: PBM SOAP namespace (the ``urn:pbm`` method element default ns).
+_PBM_NS: Final = "urn:pbm"
+
+#: PBM SOAP endpoint path on a vCenter (distinct from vim25's ``/sdk``).
+PBM_PATH: Final = "/pbm"
+
+#: The ``PbmServiceInstance`` singleton MoRef — the fixed bootstrap object
+#: ``PbmRetrieveServiceContent`` is invoked on (type == moId == the literal).
+PBM_SERVICE_INSTANCE_TYPE: Final = "PbmServiceInstance"
+PBM_SERVICE_INSTANCE_MOID: Final = "ServiceInstance"
+
+#: MoRef type of the ProfileManager (``PbmServiceInstanceContent.profileManager``)
+#: every create/delete/retrieve method is invoked on.
+PBM_PROFILE_MANAGER_TYPE: Final = "PbmProfileProfileManager"
+
+#: The tag-based capability namespace + property-id template (govc / Ansible
+#: reference). ``id`` of the capability's ``PbmCapabilityMetadataUniqueId`` is
+#: the tag *category* name; the property instance id is the formatted string.
+_PBM_TAG_NAMESPACE: Final = "http://www.vmware.com/storage/tag"
+#: ``category`` value on a requirement storage policy.
+_PBM_CATEGORY_REQUIREMENT: Final = "REQUIREMENT"
+#: The only legal ``resourceType`` for a storage policy.
+_PBM_RESOURCE_TYPE_STORAGE: Final = "STORAGE"
+
+
+def pbm_tag_property_id(category_name: str) -> str:
+    """The ``PbmCapabilityPropertyInstance.id`` for a tag rule on *category_name*.
+
+    Mirrors the govc ``com.vmware.storage.tag.%s.property`` / Ansible
+    ``format_tag_mob_id`` convention verbatim.
+    """
+    return f"com.vmware.storage.tag.{category_name}.property"
+
+
+def _pbm_method(name: str, body: str) -> str:
+    """A ``urn:pbm`` method element (default ns so children inherit it)."""
+    return f'<{name} xmlns="{_PBM_NS}">{body}</{name}>'
+
+
+def build_pbm_service_content_envelope() -> str:
+    """``PbmServiceInstance.PbmRetrieveServiceContent`` — the bootstrap read.
+
+    Returns the ``PbmServiceInstanceContent`` whose ``profileManager`` MoRef
+    every create/delete/retrieve is invoked on. Authenticated by the
+    already-established ``vmware_soap_session`` cookie on the pooled client.
+    """
+    return _envelope(
+        "PbmRetrieveServiceContent",
+        _pbm_method(
+            "PbmRetrieveServiceContent",
+            _this(PBM_SERVICE_INSTANCE_TYPE, PBM_SERVICE_INSTANCE_MOID),
+        ),
+    )
+
+
+def build_pbm_create_envelope(
+    profile_manager_moid: str,
+    *,
+    name: str,
+    description: str,
+    category_name: str,
+    tag_names: Sequence[str],
+) -> str:
+    """``PbmProfileProfileManager.PbmCreate`` for a tag-based requirement policy.
+
+    Builds the ``PbmCapabilityProfileCreateSpec`` for a single tag rule: a
+    ``PbmCapabilitySubProfileConstraints`` (name "Tag based placement") whose
+    one capability names the tag ``category`` (``PbmCapabilityMetadataUniqueId``
+    ``{namespace, id=category}``) and constrains it to the given *tag_names*
+    (a ``PbmCapabilityDiscreteSet`` of ``xsd:string`` values). The polymorphic
+    ``constraints`` / ``value`` / ``values`` slots carry the ``xsi:type``
+    discriminator vmomi requires on a subclass-in-base-slot (element order
+    follows the pbm-types.xsd sequences: create-spec name/description/category/
+    resourceType/constraints; property-instance id/value; unique-id
+    namespace/id).
+    """
+    property_id = pbm_tag_property_id(category_name)
+    values_xml = "".join(
+        f'<values xsi:type="xsd:string">{_xml_escape(tag)}</values>' for tag in tag_names
+    )
+    create_spec = (
+        f"<name>{_xml_escape(name)}</name>"
+        f"<description>{_xml_escape(description)}</description>"
+        f"<category>{_PBM_CATEGORY_REQUIREMENT}</category>"
+        f"<resourceType><resourceType>{_PBM_RESOURCE_TYPE_STORAGE}</resourceType></resourceType>"
+        '<constraints xsi:type="PbmCapabilitySubProfileConstraints">'
+        "<subProfiles>"
+        "<name>Tag based placement</name>"
+        "<capability>"
+        "<id>"
+        f"<namespace>{_xml_escape(_PBM_TAG_NAMESPACE)}</namespace>"
+        f"<id>{_xml_escape(category_name)}</id>"
+        "</id>"
+        "<constraint>"
+        "<propertyInstance>"
+        f"<id>{_xml_escape(property_id)}</id>"
+        '<value xsi:type="PbmCapabilityDiscreteSet">'
+        f"{values_xml}"
+        "</value>"
+        "</propertyInstance>"
+        "</constraint>"
+        "</capability>"
+        "</subProfiles>"
+        "</constraints>"
+    )
+    inner = (
+        _this(PBM_PROFILE_MANAGER_TYPE, profile_manager_moid)
+        + f"<createSpec>{create_spec}</createSpec>"
+    )
+    return _envelope("PbmCreate", _pbm_method("PbmCreate", inner))
+
+
+def build_pbm_delete_envelope(profile_manager_moid: str, profile_ids: Sequence[str]) -> str:
+    """``PbmProfileProfileManager.PbmDelete`` — remove one or more policies by id."""
+    ids_xml = "".join(
+        f"<profileId><uniqueId>{_xml_escape(pid)}</uniqueId></profileId>" for pid in profile_ids
+    )
+    inner = _this(PBM_PROFILE_MANAGER_TYPE, profile_manager_moid) + ids_xml
+    return _envelope("PbmDelete", _pbm_method("PbmDelete", inner))
+
+
+def build_pbm_retrieve_content_envelope(
+    profile_manager_moid: str, profile_ids: Sequence[str]
+) -> str:
+    """``PbmProfileProfileManager.PbmRetrieveContent`` — read policies by id (read-back)."""
+    ids_xml = "".join(
+        f"<profileIds><uniqueId>{_xml_escape(pid)}</uniqueId></profileIds>" for pid in profile_ids
+    )
+    inner = _this(PBM_PROFILE_MANAGER_TYPE, profile_manager_moid) + ids_xml
+    return _envelope("PbmRetrieveContent", _pbm_method("PbmRetrieveContent", inner))
+
+
+def _parse_returnval_list(xml: str, method: str) -> list[Any]:
+    """Codec rule 1 for an *array* return: collect **every** ``returnval`` child.
+
+    :func:`_parse_returnval` returns only the first ``returnval`` — correct for
+    the singular vim methods, wrong for PBM methods whose ``returnval`` is a
+    sequence (``PbmDelete`` outcomes, ``PbmRetrieveContent`` profiles). Returns
+    ``[]`` when the response carries none.
+    """
+    root = fromstring(xml)
+    body = _find_body(root)
+    if body is None:
+        return []
+    response = _find_child(body, f"{method}Response")
+    if response is None:
+        response = next(iter(body), None)
+    if response is None:
+        return []
+    out: list[Any] = []
+    for child in response:
+        if _local(child.tag) == "returnval":
+            out.append(_soap_val_to_json(child))
+    return out
+
+
+def parse_pbm_service_content(xml: str) -> dict[str, Any]:
+    """Parse ``PbmRetrieveServiceContentResponse`` -> the ServiceContent dict.
+
+    Carries ``profileManager`` (MoRef ``{type, value}``) among the other
+    manager MoRefs; the caller reads ``profileManager.value``.
+    """
+    content = _parse_returnval(xml, "PbmRetrieveServiceContent")
+    return content if isinstance(content, dict) else {}
+
+
+def parse_pbm_profile_id(xml: str) -> str | None:
+    """Parse ``PbmCreateResponse`` -> the created profile's ``uniqueId`` string.
+
+    ``returnval`` is a ``PbmProfileId`` (``{"uniqueId": "<guid>"}``). Returns
+    the id, or ``None`` when the response carries no usable id.
+    """
+    val = _parse_returnval(xml, "PbmCreate")
+    if isinstance(val, dict):
+        unique_id = val.get("uniqueId")
+        if isinstance(unique_id, str) and unique_id:
+            return unique_id
+    return None
+
+
+def parse_pbm_delete_outcomes(xml: str) -> list[dict[str, Any]]:
+    """Parse ``PbmDeleteResponse`` -> a list of ``PbmProfileOperationOutcome`` dicts.
+
+    Each carries ``profileId`` (``{"uniqueId"}``) and, on failure, a ``fault``.
+    An empty list means every requested id was removed without a reported
+    per-id fault.
+    """
+    return [row for row in _parse_returnval_list(xml, "PbmDelete") if isinstance(row, dict)]
+
+
+def parse_pbm_profiles(xml: str) -> list[dict[str, Any]]:
+    """Parse ``PbmRetrieveContentResponse`` -> a list of profile dicts.
+
+    Each carries ``profileId`` (``{"uniqueId"}``), ``name``, ``description``,
+    and the capability ``constraints`` — the read-back a create/delete verify
+    reads for the policy's presence/absence and name.
+    """
+    return [
+        row for row in _parse_returnval_list(xml, "PbmRetrieveContent") if isinstance(row, dict)
+    ]

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -73,6 +73,8 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
     # Supervisor (WCP) status read (#3281).
     "vmware.composite.supervisor.status",
+    # Storage-policy list read (#3494).
+    "vmware.composite.storage_policy.list",
 )
 
 
@@ -108,6 +110,10 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.supervisor.status": (
         "meho_backplane.connectors.vmware_rest.composites._supervisor.supervisor_status_composite"
     ),
+    "vmware.composite.storage_policy.list": (
+        "meho_backplane.connectors.vmware_rest.composites._storage_policy."
+        "storage_policy_list_composite"
+    ),
 }
 
 
@@ -122,6 +128,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.net.show": "guest_ops",
     "vmware.composite.vm.guest.file.read": "guest_ops",
     "vmware.composite.supervisor.status": "namespace_management",
+    "vmware.composite.storage_policy.list": "storage",
 }
 
 
@@ -202,8 +209,9 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 38 total: 9 reads
-    # (T5 #508's 5 + the 4 guest-ops reads #3100) + 29 writes (T6 #509 +
+    # Embedding service called once per composite -- 41 total: 10 reads
+    # (T5 #508's 5 + the 4 guest-ops reads #3100 + storage_policy.list
+    # #3494) + 31 writes (T6 #509 +
     # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     # WSFC/FCI shared-attach vm.disk.attach #3256 +
     # folder-template vm.clone_from_template #2894 + vim cluster/inventory
@@ -218,7 +226,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # network.portgroup.security.set + the content-library import
     # vm.import_from_library #3229). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 41
+    assert stub_embedding_service.encode_one.call_count == 44
 
 
 @pytest.mark.asyncio
@@ -469,7 +477,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (9 reads incl. the 4 guest-ops
+    persist after the combined registrar (10 reads incl. the 4 guest-ops
     reads #3100 + 29 writes / T6 + single-VM vm.power #2301 + mutating
     VI-JSON vm.disk.grow #2893 + WSFC/FCI vm.disk.attach #3256 +
     folder-template vm.clone_from_template
@@ -486,7 +494,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 41
+    assert first_count == 44
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -504,7 +512,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 10
+    assert len(rows) == 11
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -100,6 +100,8 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.vm.guest.program.run",
         "vmware.composite.supervisor.enable",
         "vmware.composite.supervisor.disable",
+        "vmware.composite.storage_policy.create",
+        "vmware.composite.storage_policy.delete",
     }
 )
 
@@ -318,7 +320,7 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 28
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 30
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -118,6 +118,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     # Supervisor (WCP) namespace-management writes (#3281).
     "vmware.composite.supervisor.enable",
     "vmware.composite.supervisor.disable",
+    # Governed NFS tag-based SPBM storage-policy writes (#3494).
+    "vmware.composite.storage_policy.create",
+    "vmware.composite.storage_policy.delete",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -137,10 +140,12 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.guest.file.read",
     # Supervisor (WCP) status read (#3281).
     "vmware.composite.supervisor.status",
+    # Storage-policy list read (#3494).
+    "vmware.composite.storage_policy.list",
 )
 
-# 41 total -- 10 read (T5 / #508 + 4 guest-ops reads / #3100 + the
-# supervisor status read / #3281) + 31 write
+# 44 total -- 11 read (T5 / #508 + 4 guest-ops reads / #3100 + the
+# supervisor status read / #3281 + storage_policy.list / #3494) + 33 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -150,7 +155,8 @@ _READ_OP_IDS: tuple[str, ...] = (
 # content-library import vm.import_from_library / #3229 + the guest-ops
 # program-exec write vm.guest.program.run / #3255 + the WSFC/FCI shared-attach
 # vm.disk.attach / #3256 + the Supervisor writes supervisor.enable +
-# supervisor.disable / #3281).
+# supervisor.disable / #3281 + the storage-policy writes storage_policy.create
+# + storage_policy.delete / #3494).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -250,6 +256,14 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.supervisor.disable": (
         "meho_backplane.connectors.vmware_rest.composites._supervisor.supervisor_disable_composite"
     ),
+    "vmware.composite.storage_policy.create": (
+        "meho_backplane.connectors.vmware_rest.composites._storage_policy."
+        "storage_policy_create_composite"
+    ),
+    "vmware.composite.storage_policy.delete": (
+        "meho_backplane.connectors.vmware_rest.composites._storage_policy."
+        "storage_policy_delete_composite"
+    ),
 }
 
 
@@ -285,6 +299,8 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.program.run": "guest_ops",
     "vmware.composite.supervisor.enable": "namespace_management",
     "vmware.composite.supervisor.disable": "namespace_management",
+    "vmware.composite.storage_policy.create": "storage",
+    "vmware.composite.storage_policy.delete": "storage",
 }
 
 
@@ -379,7 +395,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 41
+    assert len(rows) == 44
 
 
 @pytest.mark.asyncio
@@ -413,9 +429,12 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
-        expected_level = (
-            "destructive" if row.op_id == "vmware.composite.vm.destroy" else "dangerous"
-        )
+        _non_dangerous_levels = {
+            "vmware.composite.vm.destroy": "destructive",
+            "vmware.composite.storage_policy.create": "caution",
+            "vmware.composite.storage_policy.delete": "destructive",
+        }
+        expected_level = _non_dangerous_levels.get(row.op_id, "dangerous")
         assert row.safety_level == expected_level, (
             f"{row.op_id}: expected {expected_level}, got {row.safety_level!r}"
         )
@@ -660,6 +679,17 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
             "disconnected",
             "invalid_request",
         },
+        # #3494: governed NFS tag-based SPBM storage-policy create/delete.
+        "vmware.composite.storage_policy.create": {
+            "created",
+            "datastore_not_found",
+            "policy_create_failed",
+        },
+        "vmware.composite.storage_policy.delete": {
+            "deleted",
+            "delete_failed",
+            "still_present",
+        },
     }
     for op_id, expected_values in expected_status_values.items():
         schema: dict[str, Any] = dict(by_op[op_id].response_schema)
@@ -709,7 +739,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
     """Running the registrar twice -> 41 rows total, embedding called 41x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 41
+    assert first_count == 44
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
@@ -727,7 +757,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 41
+    assert len(rows) == 44
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_soap_pbm.py
+++ b/backend/tests/test_connectors_vmware_rest_soap_pbm.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the PBM SOAP codec (``vmware_rest/soap_pbm.py``, #3494).
+
+Storage-policy creation has no vCenter REST path, so it rides the PBM SOAP
+API. This module is the single point where the hand-rolled ``urn:pbm``
+envelopes and their response parsers can silently drift from the wire shape
+real vCenter accepts (the mock-vs-hardware trap the vim25 codec docstring
+warns about), so every builder is asserted against the govmomi / govc /
+Ansible reference shape (namespace, property-id, subprofile name, xsi:type
+discriminators, element order) and every parser is round-tripped on a
+synthetic ``urn:pbm`` response envelope.
+"""
+
+from __future__ import annotations
+
+from defusedxml.ElementTree import fromstring
+
+from meho_backplane.connectors.vmware_rest.soap_pbm import (
+    build_pbm_create_envelope,
+    build_pbm_delete_envelope,
+    build_pbm_retrieve_content_envelope,
+    build_pbm_service_content_envelope,
+    parse_pbm_delete_outcomes,
+    parse_pbm_profile_id,
+    parse_pbm_profiles,
+    parse_pbm_service_content,
+    pbm_tag_property_id,
+)
+
+_SOAPENV = "http://schemas.xmlsoap.org/soap/envelope/"
+
+
+def _body(inner: str) -> str:
+    """Wrap *inner* (a ``{Method}Response`` element) in a SOAP envelope."""
+    return (
+        f'<soapenv:Envelope xmlns:soapenv="{_SOAPENV}" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+        f"<soapenv:Body>{inner}</soapenv:Body></soapenv:Envelope>"
+    )
+
+
+# --- Builders --------------------------------------------------------------
+
+
+def test_service_content_envelope_is_well_formed_and_targets_pbm_service_instance() -> None:
+    env = build_pbm_service_content_envelope()
+    fromstring(env)  # raises on malformed XML
+    assert '<PbmRetrieveServiceContent xmlns="urn:pbm">' in env
+    assert '<_this type="PbmServiceInstance">ServiceInstance</_this>' in env
+
+
+def test_create_envelope_matches_the_tag_rule_reference_shape() -> None:
+    env = build_pbm_create_envelope(
+        "pm-1",
+        name="NFS-Gold",
+        description="NFS tag policy",
+        category_name="meho-storage",
+        tag_names=["nfs-gold", "nfs-silver"],
+    )
+    fromstring(env)
+    # PbmCreate on the ProfileManager, urn:pbm.
+    assert '<PbmCreate xmlns="urn:pbm">' in env
+    assert '<_this type="PbmProfileProfileManager">pm-1</_this>' in env
+    # Requirement storage policy.
+    assert "<category>REQUIREMENT</category>" in env
+    assert "<resourceType><resourceType>STORAGE</resourceType></resourceType>" in env
+    # The polymorphic constraints slot carries the xsi:type discriminator.
+    assert '<constraints xsi:type="PbmCapabilitySubProfileConstraints">' in env
+    assert "<name>Tag based placement</name>" in env
+    # Tag capability: namespace + category id + property id (govc / Ansible).
+    assert "<namespace>http://www.vmware.com/storage/tag</namespace>" in env
+    assert "<id>meho-storage</id>" in env
+    assert "<id>com.vmware.storage.tag.meho-storage.property</id>" in env
+    # DiscreteSet of xsd:string values, one per tag.
+    assert '<value xsi:type="PbmCapabilityDiscreteSet">' in env
+    assert '<values xsi:type="xsd:string">nfs-gold</values>' in env
+    assert '<values xsi:type="xsd:string">nfs-silver</values>' in env
+
+
+def test_create_envelope_xml_escapes_names() -> None:
+    env = build_pbm_create_envelope(
+        "pm-1",
+        name="a&b",
+        description="<desc>",
+        category_name="c&c",
+        tag_names=["t<1"],
+    )
+    fromstring(env)
+    assert "a&amp;b" in env
+    assert "&lt;desc&gt;" in env
+    assert "com.vmware.storage.tag.c&amp;c.property" in env
+
+
+def test_property_id_helper_matches_govc_convention() -> None:
+    assert pbm_tag_property_id("my_cat") == "com.vmware.storage.tag.my_cat.property"
+
+
+def test_delete_and_retrieve_envelopes_carry_profile_ids() -> None:
+    del_env = build_pbm_delete_envelope("pm-1", ["p-1", "p-2"])
+    fromstring(del_env)
+    assert '<PbmDelete xmlns="urn:pbm">' in del_env
+    assert "<profileId><uniqueId>p-1</uniqueId></profileId>" in del_env
+    assert "<profileId><uniqueId>p-2</uniqueId></profileId>" in del_env
+
+    ret_env = build_pbm_retrieve_content_envelope("pm-1", ["p-1"])
+    fromstring(ret_env)
+    assert '<PbmRetrieveContent xmlns="urn:pbm">' in ret_env
+    assert "<profileIds><uniqueId>p-1</uniqueId></profileIds>" in ret_env
+
+
+# --- Parsers ---------------------------------------------------------------
+
+
+def test_parse_service_content_extracts_profile_manager_moref() -> None:
+    xml = _body(
+        '<PbmRetrieveServiceContentResponse xmlns="urn:pbm"><returnval>'
+        "<aboutInfo><name>PBM</name></aboutInfo>"
+        '<sessionManager type="PbmSessionManager">SessionManager</sessionManager>'
+        '<profileManager type="PbmProfileProfileManager">ProfileManager</profileManager>'
+        "</returnval></PbmRetrieveServiceContentResponse>"
+    )
+    content = parse_pbm_service_content(xml)
+    assert content["profileManager"] == {
+        "type": "PbmProfileProfileManager",
+        "value": "ProfileManager",
+    }
+
+
+def test_parse_profile_id_returns_unique_id() -> None:
+    xml = _body(
+        '<PbmCreateResponse xmlns="urn:pbm"><returnval>'
+        "<uniqueId>abc-123-guid</uniqueId></returnval></PbmCreateResponse>"
+    )
+    assert parse_pbm_profile_id(xml) == "abc-123-guid"
+
+
+def test_parse_profile_id_none_when_absent() -> None:
+    xml = _body('<PbmCreateResponse xmlns="urn:pbm"/>')
+    assert parse_pbm_profile_id(xml) is None
+
+
+def test_parse_delete_outcomes_collects_every_returnval() -> None:
+    xml = _body(
+        '<PbmDeleteResponse xmlns="urn:pbm">'
+        "<returnval><profileId><uniqueId>p-1</uniqueId></profileId></returnval>"
+        "<returnval><profileId><uniqueId>p-2</uniqueId></profileId>"
+        '<fault xsi:type="PbmFault"><localizedMessage>in use</localizedMessage></fault>'
+        "</returnval>"
+        "</PbmDeleteResponse>"
+    )
+    outcomes = parse_pbm_delete_outcomes(xml)
+    assert [o["profileId"]["uniqueId"] for o in outcomes] == ["p-1", "p-2"]
+    assert outcomes[0].get("fault") is None
+    assert outcomes[1]["fault"]["_typeName"] == "PbmFault"
+
+
+def test_parse_delete_outcomes_empty_on_no_returnval() -> None:
+    xml = _body('<PbmDeleteResponse xmlns="urn:pbm"/>')
+    assert parse_pbm_delete_outcomes(xml) == []
+
+
+def test_parse_profiles_lists_content_rows() -> None:
+    xml = _body(
+        '<PbmRetrieveContentResponse xmlns="urn:pbm">'
+        '<returnval xsi:type="PbmCapabilityProfile">'
+        "<profileId><uniqueId>abc-123-guid</uniqueId></profileId>"
+        "<name>NFS-Gold</name><description>d</description></returnval>"
+        "</PbmRetrieveContentResponse>"
+    )
+    profiles = parse_pbm_profiles(xml)
+    assert len(profiles) == 1
+    assert profiles[0]["profileId"]["uniqueId"] == "abc-123-guid"
+    assert profiles[0]["name"] == "NFS-Gold"

--- a/backend/tests/test_connectors_vmware_rest_storage_policy.py
+++ b/backend/tests/test_connectors_vmware_rest_storage_policy.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the governed NFS tag-based SPBM storage-policy composites (#3494).
+
+Exercises the ``storage_policy.create`` / ``.delete`` / ``.list`` handlers on
+the **direct-session** path — a recording connector double stands in for the
+REST tag sub-ops (``mount_op_path`` + ``_get_json`` / ``_post_json``) and the
+typed PBM SOAP seam (``pbm_create_tag_profile`` / ``pbm_delete_profiles`` /
+``pbm_retrieve_profiles``), and the shared ``enforce_subop_policy`` gate is
+stubbed with a recorder. The tests prove the create-then-list-visible ->
+delete -> absent lifecycle, the tag-substrate fan-out order, the fail-closed
+datastore refuse, the delete-fault surface, and that every child write is
+gated (its own audit / grant point).
+
+The PBM wire codec itself is covered in ``test_connectors_vmware_rest_soap_pbm``;
+here the SOAP seam is faked at the connector method boundary so the handler
+orchestration is what is under test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites import _storage_policy, _write
+from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
+    storage_policy_create_composite,
+    storage_policy_delete_composite,
+    storage_policy_list_composite,
+)
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-storage-policy",
+        name="Storage Policy Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-000000003494"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _RecordingConnector:
+    """Connector double for the tag REST sub-ops + the typed PBM SOAP seam.
+
+    REST reads/writes are recorded and served by mounted path; the PBM seam
+    is faked at the method boundary and mutates ``policies`` so the create
+    read-back sees the new policy and the delete read-back sees it gone.
+    """
+
+    def __init__(
+        self,
+        *,
+        datastores: list[dict[str, str]],
+        category_id: str = "cat-1",
+        tag_id: str = "tag-1",
+        policy_id: str = "policy-guid-1",
+        policies: list[dict[str, str]] | None = None,
+        pbm_create_returns: str = "policy-guid-1",
+        pbm_delete_outcomes: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._datastores = datastores
+        self._category_id = category_id
+        self._tag_id = tag_id
+        self._policy_id = policy_id
+        self.policies = list(policies or [])
+        self._pbm_create_returns = pbm_create_returns
+        self._pbm_delete_outcomes = pbm_delete_outcomes if pbm_delete_outcomes is not None else []
+        self.calls: list[dict[str, Any]] = []
+        self.pbm_create_calls: list[dict[str, Any]] = []
+        self.pbm_delete_calls: list[list[str]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return query
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: dict[str, Any] | None = None
+    ) -> Any:
+        self.calls.append({"method": "GET", "path": path, "query": params})
+        if "/vcenter/datastore" in path:
+            names = (params or {}).get("names") or []
+            return [d for d in self._datastores if not names or d["name"] in names]
+        if "/vcenter/storage/policies" in path:
+            return list(self.policies)
+        raise AssertionError(f"unexpected GET {path!r}")
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Any:
+        self.calls.append({"method": verb, "path": path, "body": json})
+        if path == "/api/cis/tagging/category":
+            return self._category_id
+        if path == "/api/cis/tagging/tag":
+            return self._tag_id
+        if "/cis/tagging/tag-association/" in path:
+            return None
+        raise AssertionError(f"unexpected POST {path!r}")
+
+    async def pbm_create_tag_profile(
+        self,
+        target: Any,
+        operator: Operator,
+        *,
+        name: str,
+        description: str,
+        category_name: str,
+        tag_names: list[str],
+    ) -> str:
+        self.pbm_create_calls.append(
+            {"name": name, "category_name": category_name, "tag_names": list(tag_names)}
+        )
+        if self._pbm_create_returns:
+            self.policies.append({"policy": self._pbm_create_returns, "name": name})
+        return self._pbm_create_returns
+
+    async def pbm_delete_profiles(
+        self, target: Any, operator: Operator, *, profile_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        self.pbm_delete_calls.append(list(profile_ids))
+        if not self._pbm_delete_outcomes:
+            self.policies = [p for p in self.policies if p.get("policy") not in profile_ids]
+        return self._pbm_delete_outcomes
+
+
+class _GateRecorder:
+    """Recording stub for ``enforce_subop_policy`` shared by both modules."""
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {"op_id": op_id, "safety_level": safety_level, "requires_approval": requires_approval}
+        )
+        return self._gate_for.get(op_id)
+
+    @property
+    def gated_op_ids(self) -> list[str]:
+        return [c["op_id"] for c in self.calls]
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    """Install an auto-execute gate recorder on both handler modules."""
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    monkeypatch.setattr(_storage_policy, "enforce_subop_policy", recorder)
+    return recorder
+
+
+_TARGET = object()
+
+
+# --- create ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_happy_path_full_fan_out_and_readback(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(datastores=[{"name": "nfs-ds", "datastore": "datastore-1"}])
+    out = await storage_policy_create_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={
+            "policy_name": "NFS-Gold",
+            "category_name": "meho-storage",
+            "tag_name": "nfs-gold",
+            "datastore_names": ["nfs-ds"],
+            "description": "envision nfs",
+        },
+        connector=conn,
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["policy_id"] == "policy-guid-1"
+    assert out["category_id"] == "cat-1"
+    assert out["tag_id"] == "tag-1"
+    assert out["datastores"] == [{"name": "nfs-ds", "moid": "datastore-1"}]
+    assert out["listed"] is True
+    # Category -> tag -> attach -> PBM create, all gated in order.
+    assert gate.gated_op_ids == [
+        "POST:/cis/tagging/category",
+        "POST:/cis/tagging/tag",
+        "POST:/cis/tagging/tag-association/{tagId}?action=attach",
+        "POST:/pbm/ProfileManager/PbmCreate",
+    ]
+    # The PBM tag rule references the category by NAME (not the REST id), per
+    # the govc / Ansible reference — com.vmware.storage.tag.<name>.property.
+    assert conn.pbm_create_calls == [
+        {"name": "NFS-Gold", "category_name": "meho-storage", "tag_names": ["nfs-gold"]}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_attaches_tag_to_every_datastore(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        datastores=[
+            {"name": "nfs-a", "datastore": "datastore-1"},
+            {"name": "nfs-b", "datastore": "datastore-2"},
+        ]
+    )
+    out = await storage_policy_create_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={
+            "policy_name": "NFS-Gold",
+            "category_name": "meho-storage",
+            "tag_name": "nfs-gold",
+            "datastore_names": ["nfs-a", "nfs-b"],
+        },
+        connector=conn,
+    )
+    assert out["status"] == "created"
+    attach_calls = [c for c in conn.calls if "/cis/tagging/tag-association/" in c["path"]]
+    assert len(attach_calls) == 2
+    assert {c["body"]["object_id"]["id"] for c in attach_calls} == {"datastore-1", "datastore-2"}
+    assert all(c["body"]["object_id"]["type"] == "Datastore" for c in attach_calls)
+
+
+@pytest.mark.asyncio
+async def test_create_fails_closed_when_datastore_unresolved(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(datastores=[])  # no datastore matches
+    out = await storage_policy_create_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={
+            "policy_name": "NFS-Gold",
+            "category_name": "meho-storage",
+            "tag_name": "nfs-gold",
+            "datastore_names": ["missing-ds"],
+        },
+        connector=conn,
+    )
+    assert out["status"] == "datastore_not_found"
+    assert out["policy_id"] is None
+    # No writes were issued and nothing was gated.
+    assert gate.calls == []
+    assert conn.pbm_create_calls == []
+    assert not any(c["method"] == "POST" for c in conn.calls)
+
+
+@pytest.mark.asyncio
+async def test_create_gate_park_short_circuits_before_pbm(monkeypatch: pytest.MonkeyPatch) -> None:
+    parked = OperationResult(
+        status="awaiting_approval",
+        op_id="vmware.composite.storage_policy.create",
+        duration_ms=0,
+        result={"approval_request_id": "ar-1"},
+    )
+    recorder = _GateRecorder(gate_for={"POST:/pbm/ProfileManager/PbmCreate": parked})
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    monkeypatch.setattr(_storage_policy, "enforce_subop_policy", recorder)
+    conn = _RecordingConnector(datastores=[{"name": "nfs-ds", "datastore": "datastore-1"}])
+    out = await storage_policy_create_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={
+            "policy_name": "NFS-Gold",
+            "category_name": "meho-storage",
+            "tag_name": "nfs-gold",
+            "datastore_names": ["nfs-ds"],
+        },
+        connector=conn,
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    # The tag substrate ran; the PBM create was gated and never fired.
+    assert conn.pbm_create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_reports_created_artifacts_when_pbm_returns_no_id(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        datastores=[{"name": "nfs-ds", "datastore": "datastore-1"}], pbm_create_returns=""
+    )
+    out = await storage_policy_create_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={
+            "policy_name": "NFS-Gold",
+            "category_name": "meho-storage",
+            "tag_name": "nfs-gold",
+            "datastore_names": ["nfs-ds"],
+        },
+        connector=conn,
+    )
+    assert out["status"] == "policy_create_failed"
+    assert out["policy_id"] is None
+    assert out["category_id"] == "cat-1"
+    assert out["tag_id"] == "tag-1"
+
+
+# --- delete ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_happy_path_read_back_absent(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        datastores=[], policies=[{"policy": "policy-guid-1", "name": "NFS-Gold"}]
+    )
+    out = await storage_policy_delete_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={"policy_id": "policy-guid-1", "policy_name": "NFS-Gold"},
+        connector=conn,
+    )
+    assert out["status"] == "deleted"
+    assert conn.pbm_delete_calls == [["policy-guid-1"]]
+    assert gate.gated_op_ids == ["POST:/pbm/ProfileManager/PbmDelete"]
+    assert conn.policies == []
+
+
+@pytest.mark.asyncio
+async def test_delete_surfaces_per_id_fault(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        datastores=[],
+        policies=[{"policy": "policy-guid-1", "name": "NFS-Gold"}],
+        pbm_delete_outcomes=[
+            {"profileId": {"uniqueId": "policy-guid-1"}, "fault": {"_typeName": "PbmFault"}}
+        ],
+    )
+    out = await storage_policy_delete_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={"policy_id": "policy-guid-1"},
+        connector=conn,
+    )
+    assert out["status"] == "delete_failed"
+    assert out["fault"] == "PbmFault"
+    # The policy is still listed (delete was refused).
+    assert conn.policies == [{"policy": "policy-guid-1", "name": "NFS-Gold"}]
+
+
+@pytest.mark.asyncio
+async def test_delete_still_present_when_readback_shows_policy(gate: _GateRecorder) -> None:
+    # PbmDelete reports success (no outcomes) but the policy lingers in the list.
+    conn = _RecordingConnector(
+        datastores=[], policies=[{"policy": "policy-guid-1", "name": "NFS-Gold"}]
+    )
+    # Freeze the policy list so the delete's list-scrub cannot remove it.
+    conn.policies = [{"policy": "policy-guid-1", "name": "NFS-Gold"}]
+
+    async def _no_scrub(target: Any, operator: Operator, *, profile_ids: list[str]) -> list[Any]:
+        conn.pbm_delete_calls.append(list(profile_ids))
+        return []
+
+    conn.pbm_delete_profiles = _no_scrub  # type: ignore[assignment]
+    out = await storage_policy_delete_composite(
+        operator=_make_operator(),
+        target=_TARGET,
+        params={"policy_id": "policy-guid-1"},
+        connector=conn,
+    )
+    assert out["status"] == "still_present"
+
+
+# --- list ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_returns_policies_and_filters_by_id(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        datastores=[],
+        policies=[
+            {"policy": "p-1", "name": "one"},
+            {"policy": "p-2", "name": "two"},
+        ],
+    )
+    out = await storage_policy_list_composite(
+        operator=_make_operator(), target=_TARGET, params={}, connector=conn
+    )
+    assert [p["policy"] for p in out["policies"]] == ["p-1", "p-2"]
+
+    out2 = await storage_policy_list_composite(
+        operator=_make_operator(), target=_TARGET, params={"policy_ids": ["p-2"]}, connector=conn
+    )
+    assert [p["policy"] for p in out2["policies"]] == ["p-2"]

--- a/backend/tests/test_connectors_vmware_rest_storage_policy_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_storage_policy_reconcile.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Spec-shelf reconcile lane for the storage-policy composite's REST paths (#3494).
+
+``vmware.composite.storage_policy.create`` orchestrates the tag substrate over
+the vCenter REST paths ``POST /cis/tagging/category`` / ``/tag`` /
+``/tag-association/{tagId}?action=attach`` and reads
+``GET /vcenter/datastore`` / ``GET /vcenter/storage/policies``; the policy
+create/delete itself rides the PBM **SOAP** API (``POST:/pbm/...`` governance
+keys), which the pinned ``vcenter.yaml`` deliberately does *not* serve (there
+is no REST path for PBM — the whole reason this op is typed). This lane, per
+the spec-reconcile-guards standard (``docs/decisions/spec-reconcile-guards-standard.md``):
+
+* **shape (always runs)** — every ``_storage_policy._OP_*`` constant is a
+  well-formed ``METHOD:/path`` string, the REST paths match their expected
+  literals (a typo drifting a tag path into a fiction fails here), and the PBM
+  keys are correctly partitioned out of the REST-served set;
+* **path existence (skips without the vendor-licensed shelf)** — every REST
+  path the composite hits is served by the pinned ``vcenter.yaml`` (no
+  fictional-path drift), while the PBM SOAP keys are asserted **absent** from
+  the served set (proving they genuinely have no REST equivalent).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vmware_rest.composites import _storage_policy
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+# The REST-Automation paths the composite hits (served by vcenter.yaml).
+_EXPECTED_REST_OP_IDS = {
+    "POST:/cis/tagging/category",
+    "POST:/cis/tagging/tag",
+    "POST:/cis/tagging/tag-association/{tagId}?action=attach",
+    "GET:/vcenter/datastore",
+    "GET:/vcenter/storage/policies",
+}
+# The PBM SOAP governance keys — no REST path exists for these (the gap #3494
+# closes over SOAP), so vcenter.yaml must NOT serve them.
+_EXPECTED_PBM_OP_IDS = {
+    "POST:/pbm/ProfileManager/PbmCreate",
+    "POST:/pbm/ProfileManager/PbmDelete",
+}
+
+
+def _declared_op_ids() -> set[str]:
+    """Introspect every ``_OP_*`` op-id constant on the ``_storage_policy`` module."""
+    ops: set[str] = set()
+    for name in dir(_storage_policy):
+        if not name.startswith("_OP_"):
+            continue
+        value = getattr(_storage_policy, name)
+        if isinstance(value, str) and ":" in value:
+            ops.add(value)
+    return ops
+
+
+def _partition(op_ids: set[str]) -> tuple[set[str], set[str]]:
+    """Split declared op_ids into (REST-Automation, PBM SOAP) by path root."""
+    rest, pbm = set(), set()
+    for op_id in op_ids:
+        _, _, path = op_id.partition(":")
+        (pbm if path.lstrip("/").startswith("pbm/") else rest).add(op_id)
+    return rest, pbm
+
+
+def test_storage_policy_op_ids_are_well_formed_and_partitioned() -> None:
+    """Shape gate (always runs): the op-id constants match the frozen surface.
+
+    Guards against a typo drifting a tag path into a fiction and against a PBM
+    key leaking into the REST-served set — the deliberate-change gate the
+    shelf-backed lane below needs (it skips where the shelf is unprovisioned).
+    """
+    declared = _declared_op_ids()
+    assert declared, "introspection found no _OP_* constants — wiring broke"
+    for op_id in declared:
+        method, _, path = op_id.partition(":")
+        assert method in {"GET", "POST", "PATCH", "PUT", "DELETE"}, op_id
+        assert path.startswith("/"), op_id
+    rest, pbm = _partition(declared)
+    assert rest == _EXPECTED_REST_OP_IDS
+    assert pbm == _EXPECTED_PBM_OP_IDS
+
+
+def test_rest_paths_are_served_by_the_pinned_vcenter_spec() -> None:
+    """Path existence (skips without shelf): every REST path is real; PBM is not."""
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    served = openapi_served_op_ids(spec_path, spec_source="spec:vcenter.yaml")
+    rest, pbm = _partition(_declared_op_ids())
+    assert_op_ids_served(rest, served, spec_label="vcenter.yaml")
+    # The PBM SOAP keys have no REST equivalent — prove the spec serves none.
+    assert not (pbm & served), (
+        f"pinned vcenter.yaml unexpectedly serves PBM keys {sorted(pbm & served)}; "
+        "PBM policy create/delete is SOAP-only (the gap #3494 closes)"
+    )

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,13 +8,15 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 41 hand-authored composites
-that orchestrate cross-spec workflows: 10 read composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 44 hand-authored composites
+that orchestrate cross-spec workflows: 11 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
 in `#2258`; plus the four guest-operations reads `#3100` and the
-Supervisor status read `#3281`) and 31 write
+Supervisor status read `#3281` + the storage-policy list read `#3494`) and 33 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
+governed NFS tag-based SPBM `storage_policy.create` (caution) +
+`storage_policy.delete` (destructive) / `#3494`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893` + the WSFC/FCI shared-attach
 `vm.disk.attach` / `#3256`, the folder-template
@@ -288,7 +290,7 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
   lifespan startup. Iterates a single `_COMPOSITES` tuple of 41
-  `_CompositeSpec` rows (10 read + 31 write); each row carries its
+  `_CompositeSpec` rows (11 read + 33 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -1223,6 +1225,66 @@ fault yields "no snapshots enumerated", never sinks the park). It declines
 (`None` → the park is refused `blast_radius_required`, fail-closed) when the
 VM cannot be read.
 
+### Governed NFS tag-based SPBM storage policy (`storage_policy.*`, #3494)
+
+NFS-principal datastores have **no default VM storage policy** (`vSAN Default
+Storage Policy` is vSAN-only), so a tag-based SPBM policy must be minted before
+a vSphere Supervisor can be enabled (its `EnableSpec` requires
+`master_storage_policy` / `ephemeral_storage_policy` / `image_storage`, all
+policy ids) and before a vSphere Namespace / VKS guest cluster can bind
+storage. Creating it out of band (`govc` / PowerCLI `New-SpbmStoragePolicy`) is
+exactly the escape from policy / audit / approval the dogfooding story cannot
+have, so three composites (`group_key="storage"`) close the gap:
+
+- **`storage_policy.list`** — a read (`safe`, no approval) over
+  `GET /vcenter/storage/policies`; the set-shaped `policies` list is
+  JSONFlux-reduced to a result handle by the dispatcher when large.
+- **`storage_policy.create`** (`safety_level="caution"`, `requires_approval=True`)
+  — the first link in the Supervisor-enable chain. Fans out, each child
+  gated through `enforce_subop_policy`: resolve every `datastore_names` entry
+  to a moid (`GET /vcenter/datastore`, fail-closed `datastore_not_found`
+  before any write if one resolves to zero / many) → create the tag
+  **category** (`POST /cis/tagging/category`, MULTIPLE cardinality, associable
+  to `Datastore`) → create the **tag** in it (`POST /cis/tagging/tag`) →
+  **attach** the tag to each datastore
+  (`POST /cis/tagging/tag-association/{tagId}?action=attach`, `object_id` =
+  `{id: <datastore-moid>, type: "Datastore"}`) → create the **PBM policy**
+  whose one rule requires the tag → read-back `GET /vcenter/storage/policies`.
+  Returns the policy id (the vCenter `StoragePolicy` identifier). No implicit
+  rollback: a PBM create that returns no id reports the created category / tag
+  ids for cleanup (`policy_create_failed`).
+- **`storage_policy.delete`** (`safety_level="destructive"`,
+  `requires_approval=True`) — issues PBM `PbmDelete` for the id, then read-backs
+  the policies list; a per-id `PbmDelete` fault (e.g. the policy is in use)
+  returns `delete_failed` with the fault type (an in-use policy must be freed
+  first — no force). Deletes only the policy; the tag / category are left in
+  place (they may be shared).
+
+**Two transports, one op.** The tag substrate rides the generic REST sub-op
+seam (`_write_sub_op` → `connector._post_json`, the tag rows are ingested
+`vcenter.yaml` paths). Policy **creation has no vCenter REST equivalent** — the
+spec exposes only `GET /vcenter/storage/policies` (read) — so it rides the
+**PBM SOAP** API (`PbmProfileProfileManager.PbmCreate` / `PbmDelete` on `/pbm`,
+namespace `urn:pbm`). PBM is a distinct SOAP service from the vim25 `/sdk`
+codec: `soap_pbm.py` carries its envelope builders + parsers (reusing the
+vim25 codec's namespace-agnostic low-level helpers), and the connector's
+`_ensure_pbm` mints a **separate** vim SOAP session — a `SessionManager.Login`
+on `/sdk` for the `vmware_soap_session` cookie, then `PbmRetrieveServiceContent`
+on `/pbm` for the `profileManager` moid — because PBM authenticates with the
+vim SOAP cookie, not the vAPI `vmware-api-session-id` token the REST/VI-JSON
+path uses (`_soap_post` gained a `path` argument so the same span-recording,
+credential-free wire helper serves both `/sdk` and `/pbm`). The tag-rule
+create-spec shape (namespace `http://www.vmware.com/storage/tag`, property id
+`com.vmware.storage.tag.<category>.property`, subprofile "Tag based placement",
+`category=REQUIREMENT`, `resourceType=STORAGE`, with the `xsi:type`
+discriminators vmomi requires on the polymorphic `constraints` / `value` /
+`values` slots) is grounded on govmomi `pbm` + `govc storage.policy.create` +
+the community `vmware_vm_storage_policy` Ansible module. The `storage_policy.*`
+group's REST paths are pinned against the vendor spec by
+`test_connectors_vmware_rest_storage_policy_reconcile.py` (the tag / datastore /
+policies paths must be served; the `/pbm` keys must **not** be — proving they
+have no REST equivalent).
+
 ### Two clone ops: content-library vs folder-template (`vm.clone_from_template`, #2894)
 
 The connector ships **two** clone composites, and they deploy from two
@@ -2068,6 +2130,18 @@ they never park.
   `vcenter-9.0/vcenter.yaml`, vmomi POST legs vs
   `vcenter-9.0/vi-json.yaml` — skipping uniformly without the shelf,
   running for real in CI.
+- **PBM SOAP path (`storage_policy.*`, #3494) is mock-validated only** —
+  the `/pbm` envelope builders + parsers (`soap_pbm.py`) and the
+  `_ensure_pbm` vim-SOAP-session-then-`/pbm` establish are unit-tested
+  against synthetic `urn:pbm` envelopes grounded on the govmomi / govc /
+  Ansible reference shapes, and the REST tag paths are spec-reconciled, but
+  the SOAP wire has **not** been exercised against a live vCenter at build
+  time (no lab access) — the mock-vs-hardware trap the ESXi SOAP codec
+  (#3363) documents. Live-appliance validation (probe → `storage_policy.create`
+  on the NFS WLD → Supervisor-enable consumes the id → `storage_policy.delete`)
+  is deferred; treat the SOAPAction posture (empty, matching the bootstrap
+  posts) and the `xsi:type` discriminators as the first things to re-check if
+  a live PbmCreate faults.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds governed **NFS tag-based VM storage-policy create/delete** to the `vmware-rest-9.0` connector — the first link in the Supervisor-enable chain, which has no governed path today (`#3281` consumes the policy id this mints). NFS-principal datastores have no default policy, and policy *creation* has no vCenter REST equivalent, so this rides the **PBM SOAP** API (`PbmProfileProfileManager.PbmCreate`/`PbmDelete` on `/pbm`, `urn:pbm`) while the tag substrate rides the ingested vCenter REST paths — the agent sees one op either way.
- Three composites (`group_key="storage"`): `vmware.composite.storage_policy.create` (`safety_level="caution"`, approval-gated; resolves datastore names → moids, creates the tag category + tag, attaches the tag to each datastore, mints the PBM policy whose one rule requires the tag, read-back-verifies via `GET /vcenter/storage/policies`, returns the policy id), `vmware.composite.storage_policy.delete` (`destructive` + approval; PBM delete + read-back-absent, surfaces an in-use fault), and `vmware.composite.storage_policy.list` (safe read, JSONFlux-reduced by the dispatcher).
- New PBM SOAP codec (`soap_pbm.py`) reusing the vim25 codec's namespace-agnostic helpers; the connector gains `_ensure_pbm` (a separate vim `SessionManager.Login` for the `vmware_soap_session` cookie PBM reuses, then `PbmRetrieveServiceContent` for the `profileManager` moid) and `pbm_create_tag_profile`/`pbm_delete_profiles`/`pbm_retrieve_profiles`. `_soap_post` gained a `path` arg so the same span-recording, credential-free wire helper serves `/sdk` and `/pbm`. Every child write flows through `enforce_subop_policy` (own audit row + grant point); the two destructive/caution ops register park-time previews (mandatory blast-radius for delete).
- Wire shapes grounded on govmomi `pbm` + `govc storage.policy.create` + the community `vmware_vm_storage_policy` Ansible module, and the tagging REST bodies on the pinned `vcenter.yaml`. **No new MCP tools** (dispatched through the existing meta-tool surface).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vmware_rest/` — clean
- [x] code-quality diff gate — 0 blockers (11 warnings are pre-existing legacy functions in `connector.py`, not introduced here)
- [x] New unit tests: `test_connectors_vmware_rest_soap_pbm.py` (PBM envelope/parser codec, incl. xsi:type discriminators + tag-rule shape) and `test_connectors_vmware_rest_storage_policy.py` (create → list-visible → delete → absent lifecycle, tag-substrate fan-out order, fail-closed datastore refuse, PBM gate park short-circuit, delete-fault surface) — all pass
- [x] Spec-shelf reconcile lane `test_connectors_vmware_rest_storage_policy_reconcile.py` — shape gate always runs; the shelf-backed path-existence check (skips without the vendor-licensed shelf) verified locally against the real pinned `vcenter.yaml`: all 5 REST paths served, both `/pbm` keys absent (no fictional-path drift)
- [x] Registration + preview + governed-subop + surface-conformance + F8 typed-span guards updated and green
- [x] `docs/codebase/connectors-vmware-rest.md` updated (new SPBM/tagging surface + mock-validated-only known gap)
- [x] `docs-site/reference/connectors.md` + CLI OpenAPI snapshot: regenerated — no diff (composites are not per-op REST routes / MCP tools, so neither snapshot changes)

## Known gap (documented)

The PBM SOAP path is **mock-validated only** — the `/pbm` codec and the `_ensure_pbm` establish are unit-tested against synthetic `urn:pbm` envelopes grounded on the vendor reference shapes, but the SOAP wire has not been exercised against a live vCenter at build time (no lab access). Live-appliance validation is deferred; see the Known-issues note in `connectors-vmware-rest.md`.

## Out of scope

- Enabling the raw ingested tag rows for standalone dispatch is an operator-review (`edit_op`) runtime action; the create path drives them as governed sub-ops, so it does not depend on that.
- `#3281` Supervisor enable op (consumes the policy id).

## Changelog

Added: `vmware-rest` governed NFS tag-based VM storage-policy create/delete over the PBM SOAP API — `vmware.composite.storage_policy.create` (caution) / `.delete` (destructive) / `.list` (read), orchestrating the tag category/tag/tag-association substrate the vSphere Supervisor-enable chain needs on NFS-principal datastores (#3494).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
