### PR TITLE
feat(connectors): governed resource-pool create/delete + VM-Host affinity rule in vmware-rest

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
@@ -74,6 +74,13 @@ _GOVERNED_SUBOP_MANIFEST: Final[dict[str, tuple[str, ...]]] = {
         _write._SUB_OPS_CLUSTER_PATCH + _write._VIM_SUB_OPS_CLUSTER_PATCH
     ),
     "vmware.composite.cluster.drs_rule.create": _write._VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE,
+    "vmware.composite.cluster.drs_vm_host_rule.create": (
+        _write._VIM_SUB_OPS_CLUSTER_DRS_VM_HOST_RULE_CREATE
+    ),
+    "vmware.composite.resource_pool.create": (
+        _write._SUB_OPS_RESOURCE_POOL_CREATE + _write._VIM_SUB_OPS_RESOURCE_POOL_CREATE
+    ),
+    "vmware.composite.resource_pool.delete": _write._SUB_OPS_RESOURCE_POOL_DELETE,
     "vmware.composite.folder.create": _write._VIM_SUB_OPS_FOLDER_CREATE,
     "vmware.composite.vm.resize": _write._SUB_OPS_VM_RESIZE,
     "vmware.composite.vm.nic.repoint": _write._SUB_OPS_VM_NIC_REPOINT,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -51,6 +51,11 @@ at the call site; the helper would default to those values anyway). The
 ``safety_level="destructive"`` op (still ``requires_approval=True``) — the
 governed-delete tier (decision
 ``docs/decisions/governed-delete-operations.md``).
+The #3505 governed-allocation writes add the first two ``caution`` rows —
+``resource_pool.create`` and the VM-Host affinity
+``cluster.drs_vm_host_rule.create`` — plus one more ``dangerous`` row,
+``resource_pool.delete`` (a reparent, not a destroy); all three still
+``requires_approval=True``.
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
 ``requires_approval`` so the policy posture is implied by the row,
 not by global state.
@@ -97,6 +102,7 @@ from meho_backplane.connectors.vmware_rest.composites._supervisor import (
 )
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
+    cluster_drs_vm_host_rule_create_composite,
     cluster_patch_composite,
     folder_create_composite,
     guest_customization_spec_create_composite,
@@ -104,6 +110,8 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_evacuate_composite,
     network_portgroup_create_composite,
     network_portgroup_security_set_composite,
+    resource_pool_create_composite,
+    resource_pool_delete_composite,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
@@ -126,6 +134,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
     CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA,
     CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA,
+    CLUSTER_DRS_VM_HOST_RULE_CREATE_PARAMETER_SCHEMA,
+    CLUSTER_DRS_VM_HOST_RULE_CREATE_RESPONSE_SCHEMA,
     CLUSTER_PATCH_PARAMETER_SCHEMA,
     CLUSTER_PATCH_RESPONSE_SCHEMA,
     DATASTORE_USAGE_PARAMETER_SCHEMA,
@@ -166,6 +176,10 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     NETWORK_PORTGROUP_SECURITY_SET_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
     PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+    RESOURCE_POOL_CREATE_PARAMETER_SCHEMA,
+    RESOURCE_POOL_CREATE_RESPONSE_SCHEMA,
+    RESOURCE_POOL_DELETE_PARAMETER_SCHEMA,
+    RESOURCE_POOL_DELETE_RESPONSE_SCHEMA,
     STORAGE_POLICY_CREATE_PARAMETER_SCHEMA,
     STORAGE_POLICY_CREATE_RESPONSE_SCHEMA,
     STORAGE_POLICY_DELETE_PARAMETER_SCHEMA,
@@ -240,11 +254,18 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "cluster": (
         "Use for cluster-level reads and orchestrated cluster ops "
         "that aggregate across hosts: DRS state + active "
-        "recommendations (read), and sequential cluster patch (write, "
-        "approval-gated). The right group when the question is "
-        "'what is DRS suggesting?' or 'patch every host in this "
-        "cluster in order'. Pair with the 'host' group when the "
-        "follow-up drills into one host's lifecycle (evacuate, "
+        "recommendations (read); sequential cluster patch (write, "
+        "approval-gated); the two DRS-rule writes — a VM-VM affinity / "
+        "anti-affinity rule by explicit VM list (drs_rule.create) and a "
+        "VM-Host rule pinning a VM group onto an (anti-)affine host group "
+        "(drs_vm_host_rule.create); and the governed resource-pool "
+        "allocation writes (resource_pool.create under a parent pool or a "
+        "cluster's root pool, and resource_pool.delete with a "
+        "refuse-then-force guard). The right group when the question is "
+        "'what is DRS suggesting?', 'patch every host in this cluster in "
+        "order', 'pin these VMs to these hosts', or 'carve out / tear down "
+        "a resource pool for this estate'. Pair with the 'host' group when "
+        "the follow-up drills into one host's lifecycle (evacuate, "
         "maintenance), and with 'vm' when DRS recommendations need "
         "to translate into actual VM migrations."
     ),
@@ -1013,6 +1034,77 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         requires_approval=True,
     ),
     _CompositeSpec(
+        op_id="vmware.composite.cluster.drs_vm_host_rule.create",
+        handler=cluster_drs_vm_host_rule_create_composite,
+        summary="Add a DRS VM-Host affinity rule (VM group + host group + run-on rule).",
+        description=(
+            "Pins the VMs of a named VM group onto (affine) or away from "
+            "(anti-affine) the hosts of a named host group — a VM-Host DRS "
+            "rule (ClusterVmHostRuleInfo), the placement primitive that binds "
+            "an estate's nested ESXi to a chosen subset of a cluster's hosts. "
+            "A sibling of cluster.drs_rule.create (which is VM-VM only, by "
+            "explicit VM list) that leaves that op's contract unchanged. No "
+            "REST path exists, so one vim "
+            "ClusterComputeResource.ReconfigureComputeResource_Task carries "
+            "both a ClusterConfigSpecEx.groupSpec delta (adds the VM + host "
+            "groups) and a rulesSpec delta (adds the rule), polled to a "
+            "terminal state. VM + host names resolve to MoRefs scoped to the "
+            "cluster; rule + group names are the idempotence keys "
+            "(status='rule_exists' / 'group_exists' before any write). "
+            "'mandatory' picks a 'must' vs a 'should' rule."
+        ),
+        parameter_schema=CLUSTER_DRS_VM_HOST_RULE_CREATE_PARAMETER_SCHEMA,
+        response_schema=CLUSTER_DRS_VM_HOST_RULE_CREATE_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "write", "cluster", "drs", "vi-json"],
+        safety_level="caution",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.resource_pool.create",
+        handler=resource_pool_create_composite,
+        summary="Create a resource pool under a parent pool or a cluster's root pool.",
+        description=(
+            "Creates a resource pool via the REST POST /vcenter/resource-pool "
+            "(Vcenter.ResourcePool.CreateSpec: name + parent + optional cpu / "
+            "memory allocation) and returns the new pool moid — the governed "
+            "allocation step a nested-lab estate is built on. Parent selection "
+            "is either an explicit 'parent' ResourcePool moid (nesting) or a "
+            "'cluster' moid whose root resource pool is resolved for you "
+            "(ClusterComputeResource.resourcePool) — the estate convenience, "
+            "since operators have a cluster, not a root-pool moid. Read-back "
+            "confirms the new pool lists under the resolved parent. Equivalent "
+            "of 'govc pool.create'."
+        ),
+        parameter_schema=RESOURCE_POOL_CREATE_PARAMETER_SCHEMA,
+        response_schema=RESOURCE_POOL_CREATE_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "write", "cluster", "resource-pool"],
+        safety_level="caution",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.resource_pool.delete",
+        handler=resource_pool_delete_composite,
+        summary="Delete a resource pool; refuse a non-empty pool unless force.",
+        description=(
+            "Deletes a resource pool via the REST DELETE "
+            "/vcenter/resource-pool/{resourcePool}, which reparents the pool's "
+            "child pools + VMs up to its parent (it does not destroy them). A "
+            "non-empty pool is refused (status='not_empty') unless force=true "
+            "is passed; the delete then read-backs through the listing to "
+            "confirm the pool is absent (status='deleted'). safety_level="
+            "'dangerous' — the reparent, not a destroy. Equivalent of 'govc "
+            "pool.destroy'."
+        ),
+        parameter_schema=RESOURCE_POOL_DELETE_PARAMETER_SCHEMA,
+        response_schema=RESOURCE_POOL_DELETE_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "write", "cluster", "resource-pool"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
         op_id="vmware.composite.folder.create",
         handler=folder_create_composite,
         summary="Create a VM folder under a named parent (synchronous vim CreateFolder).",
@@ -1634,9 +1726,11 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 38 composites total -- 9 read (T5 / #508 + the 4 guest-ops
-    reads / #3100) + 29 write (T6 / #509 + the destructive-tier
-    ``vm.destroy`` / #3198,
+    Scope: 41 composites total -- 9 read (T5 / #508 + the 4 guest-ops
+    reads / #3100) + 32 write (T6 / #509 + the destructive-tier
+    ``vm.destroy`` / #3198, the governed resource-pool allocation writes
+    ``resource_pool.create`` / ``resource_pool.delete`` + the VM-Host
+    affinity ``cluster.drs_vm_host_rule.create`` / #3505,
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893 + the WSFC/FCI shared-attach
     ``vm.disk.attach`` / #3256, the folder-template

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "cluster_drs_rule_create_composite",
+    "cluster_drs_vm_host_rule_create_composite",
     "cluster_patch_composite",
     "folder_create_composite",
     "guest_customization_spec_create_composite",
@@ -125,6 +126,8 @@ __all__ = [
     "host_evacuate_composite",
     "network_portgroup_create_composite",
     "network_portgroup_security_set_composite",
+    "resource_pool_create_composite",
+    "resource_pool_delete_composite",
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",
@@ -285,6 +288,15 @@ _OP_GET_DATASTORE = "GET:/vcenter/datastore/{datastore}"
 _OP_LIST_DATACENTERS = "GET:/vcenter/datacenter"
 _OP_LIST_RESOURCE_POOLS = "GET:/vcenter/resource-pool"
 _OP_LIST_DATASTORES = "GET:/vcenter/datastore"
+# REST resource-pool write ops (#3505). The pinned 9.0 vcenter.yaml serves a
+# real ``POST:/vcenter/resource-pool`` (``Vcenter.ResourcePool.CreateSpec``:
+# name + parent ResourcePool moid + optional cpu/memory allocation, returns
+# the new pool moid) and ``DELETE:/vcenter/resource-pool/{resourcePool}``
+# (reparents children up to the parent). Both ride the direct-session REST
+# write seam (:func:`_write_sub_op`), so the composites work on a fresh boot
+# with zero catalog ingest like every other vmware-rest write.
+_OP_CREATE_RESOURCE_POOL = "POST:/vcenter/resource-pool"
+_OP_DELETE_RESOURCE_POOL = "DELETE:/vcenter/resource-pool/{resourcePool}"
 # REST Disk.Info read — the disk-grow park-time preview reads label +
 # current capacity (bytes) off this; the disk id is the vim device key.
 _OP_GET_VM_DISK = "GET:/vcenter/vm/{vm}/hardware/disk/{disk}"
@@ -671,7 +683,25 @@ _CLUSTER_CONFIG_SPEC_EX_TYPE = "ClusterConfigSpecEx"
 _CLUSTER_RULE_SPEC_TYPE = "ClusterRuleSpec"
 _CLUSTER_AFFINITY_RULE_TYPE = "ClusterAffinityRuleSpec"
 _CLUSTER_ANTI_AFFINITY_RULE_TYPE = "ClusterAntiAffinityRuleSpec"
+# VM-Host affinity rule types (#3505). A VM-Host rule pins a VM *group* onto
+# an (anti-)affine host *group* — a different shape from the VM-VM affinity /
+# anti-affinity rules above (which take an explicit VM list). The single
+# ``ReconfigureComputeResource_Task`` carries both a ``ClusterConfigSpecEx``
+# ``groupSpec`` delta (adds the ``ClusterVmGroup`` + ``ClusterHostGroup``) and
+# a ``rulesSpec`` delta (adds the ``ClusterVmHostRuleInfo`` referencing those
+# groups by name). All four are pinned vi-json.yaml DataObjects (spec-verified).
+_CLUSTER_VM_HOST_RULE_INFO_TYPE = "ClusterVmHostRuleInfo"
+_CLUSTER_VM_GROUP_TYPE = "ClusterVmGroup"
+_CLUSTER_HOST_GROUP_TYPE = "ClusterHostGroup"
+_CLUSTER_GROUP_SPEC_TYPE = "ClusterGroupSpec"
 _CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
+# ``ClusterComputeResource.configurationEx.group`` — the array of existing
+# ``ClusterGroupInfo`` (VM + host) groups; read for the VM-Host rule's
+# group-name collision check. The root resource pool of a cluster is read off
+# ``ClusterComputeResource.resourcePool`` (a single MoRef) for the #3505
+# resource-pool create's ``cluster`` convenience parent resolution.
+_PROP_CONFIGURATION_EX_GROUP = "configurationEx.group"
+_PROP_CLUSTER_RESOURCE_POOL = "resourcePool"
 # Property path the collision / idempotence read queries on the cluster:
 # ``ClusterComputeResource.configurationEx`` is a ``ClusterConfigInfoEx``
 # whose ``rule`` array holds the existing ``ClusterRuleInfo`` rules
@@ -706,6 +736,17 @@ _VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE: tuple[str, ...] = (
     _OP_RECONFIGURE_COMPUTE_RESOURCE_TASK,
 )
 _VIM_SUB_OPS_FOLDER_CREATE: tuple[str, ...] = (_OP_CREATE_FOLDER,)
+# cluster.drs_vm_host_rule.create (#3505): same vim shape as drs_rule.create —
+# a ``RetrievePropertiesEx`` read (existing rule + group names, collision
+# check) then one ``ReconfigureComputeResource_Task`` carrying the groupSpec +
+# rulesSpec delta. The VM / host name→moref resolution reads ride the REST
+# session (``GET:/vcenter/vm`` / ``GET:/vcenter/host``), not manifested here —
+# mirroring drs_rule.create, whose VM-list resolution read is likewise not in
+# a ``_SUB_OPS_*`` tuple.
+_VIM_SUB_OPS_CLUSTER_DRS_VM_HOST_RULE_CREATE: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIGURE_COMPUTE_RESOURCE_TASK,
+)
 
 # vim (VI-JSON) op_ids for the #2970 real-spec repoints. The pinned
 # ``vcenter.yaml`` serves NO REST path for VM snapshots, host maintenance
@@ -1058,6 +1099,30 @@ _SUB_OPS_CLUSTER_PATCH: tuple[str, ...] = (
     _OP_HOST_SOFTWARE_APPLY,
     _OP_GET_TASK,
 )
+# resource_pool.create (#3505): the synchronous REST create write + the
+# read-back list (``filter.parent_resource_pools`` confirms the new pool is
+# under the resolved parent). Both vcenter.yaml-served REST paths, so they
+# reconcile through the generic ``_SUB_OPS_*`` sweep. The optional
+# cluster→root-RP resolution vim read is the separate
+# ``_VIM_SUB_OPS_RESOURCE_POOL_CREATE`` lane.
+_SUB_OPS_RESOURCE_POOL_CREATE: tuple[str, ...] = (
+    _OP_CREATE_RESOURCE_POOL,
+    _OP_LIST_RESOURCE_POOLS,
+)
+# resource_pool.delete (#3505): the emptiness reads (child pools via
+# ``filter.parent_resource_pools`` + child VMs via ``filter.resource_pools``),
+# the delete write, and the read-back list (absent = deleted). All
+# vcenter.yaml-served REST paths.
+_SUB_OPS_RESOURCE_POOL_DELETE: tuple[str, ...] = (
+    _OP_LIST_RESOURCE_POOLS,
+    _OP_LIST_VMS,
+    _OP_DELETE_RESOURCE_POOL,
+)
+# resource_pool.create's optional ``cluster`` convenience resolves the
+# cluster's root resource pool via a ``RetrievePropertiesEx`` read of
+# ``ClusterComputeResource.resourcePool`` — a vim read, so it lives in the
+# vi-json lane (mirroring the drs_rule reads).
+_VIM_SUB_OPS_RESOURCE_POOL_CREATE: tuple[str, ...] = (_OP_RETRIEVE_PROPERTIES,)
 _SUB_OPS_VM_RESIZE: tuple[str, ...] = (
     _OP_GET_VM,
     _OP_UPDATE_VM_CPU,
@@ -6068,6 +6133,598 @@ async def folder_create_composite(
         "folder": new_folder_moid,
         "guidance": None,
     }
+
+
+# ===========================================================================
+# resource_pool.create / .delete (REST Vcenter.ResourcePool_create / _delete
+# — #3505)
+# ===========================================================================
+#
+# The pinned 9.0 vcenter.yaml serves a real ``POST:/vcenter/resource-pool``
+# and ``DELETE:/vcenter/resource-pool/{resourcePool}`` (the issue body's
+# "GET-only" claim predates this spec revision — spec-verified against
+# ``vcenter.yaml`` L40601 + L40925). Both ride the direct-session REST write
+# seam, so — unlike the vim-shaped drs_rule / folder writes — no vmomi is
+# needed for the mutation itself. A thin composite (rather than curating the
+# raw ingested rows) is the right shape because the raw ``CreateSpec.parent``
+# is a bare ``ResourcePool`` moid: operators think in clusters, so the
+# composite resolves a cluster's *root* resource pool for them, refuse-then-
+# ``force`` guards a non-empty delete, and both read back through the listing.
+
+
+def _build_resource_allocation(alloc: Any) -> dict[str, Any] | None:
+    """Map an operator cpu/memory allocation onto ``ResourceAllocationCreateSpec``.
+
+    Passes through only the CreateSpec-recognised keys (``reservation`` /
+    ``expandable_reservation`` / ``limit`` and a nested ``shares`` with its
+    ``level`` + optional custom ``shares`` count); a ``None`` / non-dict input
+    yields ``None`` so the create body omits the allocation entirely and
+    vCenter applies its documented default. The keys sit flat on the ``/api``
+    body (no ``spec`` envelope — the #2973 flat-body rule).
+    """
+    if not isinstance(alloc, dict):
+        return None
+    out: dict[str, Any] = {}
+    for key in ("reservation", "expandable_reservation", "limit"):
+        if alloc.get(key) is not None:
+            out[key] = alloc[key]
+    shares = alloc.get("shares")
+    if isinstance(shares, dict) and shares.get("level") is not None:
+        shares_out: dict[str, Any] = {"level": shares["level"]}
+        if shares.get("shares") is not None:
+            shares_out["shares"] = shares["shares"]
+        out["shares"] = shares_out
+    return out or None
+
+
+async def _resolve_cluster_root_resource_pool(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    cluster_moid: str,
+) -> str | None:
+    """Resolve a cluster's *root* resource pool moid via a vim property read.
+
+    Reads ``ClusterComputeResource.resourcePool`` (a single MoRef) through the
+    shared ``RetrievePropertiesEx`` seam — the deterministic, non-localised
+    way to name the pool a new child nests under (the plain REST listing has
+    no "which one is root" marker). Returns the moid, or ``None`` when the
+    property is unreadable or not a MoRef (the caller surfaces a structured
+    ``cluster_root_pool_unresolved`` status).
+    """
+    retrieve = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_single_prop_retrieve_params(
+            _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, cluster_moid, _PROP_CLUSTER_RESOURCE_POOL
+        ),
+    )
+    return _moref_value(_extract_single_prop(retrieve, _PROP_CLUSTER_RESOURCE_POOL))
+
+
+async def _list_child_resource_pool_ids(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    parent_moid: str,
+) -> list[str]:
+    """Child resource-pool moids of *parent_moid* via ``filter.parent_resource_pools``."""
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_RESOURCE_POOLS,
+        {"filter.parent_resource_pools": [parent_moid]},
+    )
+    rows = _unwrap_value(listing)
+    if not isinstance(rows, list):
+        return []
+    return [
+        r["resource_pool"]
+        for r in rows
+        if isinstance(r, dict) and isinstance(r.get("resource_pool"), str)
+    ]
+
+
+async def _resource_pool_present(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    resource_pool_moid: str,
+) -> bool:
+    """``True`` when a pool with *resource_pool_moid* still lists (read-back seam).
+
+    Uses ``GET:/vcenter/resource-pool?filter.resource_pools=<moid>`` rather
+    than a direct ``GET .../{id}`` so an absent pool is an *empty list* — no
+    404-exception path to disambiguate from a transport fault. Shared by the
+    create read-back (expect present under the parent) and the delete
+    read-back (expect absent).
+    """
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_RESOURCE_POOLS,
+        {"filter.resource_pools": [resource_pool_moid]},
+    )
+    rows = _unwrap_value(listing)
+    if not isinstance(rows, list):
+        return False
+    return any(isinstance(r, dict) and r.get("resource_pool") == resource_pool_moid for r in rows)
+
+
+async def resource_pool_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Create a resource pool under a parent pool or a cluster's root pool.
+
+    Op-id: ``vmware.composite.resource_pool.create``. Issues the synchronous
+    REST ``POST:/vcenter/resource-pool`` (``Vcenter.ResourcePool.CreateSpec``)
+    through the governed :func:`_write_sub_op` seam and returns the new pool
+    moid.
+
+    Parent selection (exactly one, enforced by the schema): ``parent`` is a
+    ``ResourcePool`` moid used verbatim (nesting under an existing pool);
+    ``cluster`` is a ``ClusterComputeResource`` moid whose *root* resource
+    pool is resolved (:func:`_resolve_cluster_root_resource_pool`) and used as
+    the parent — the estate-allocation convenience (the operator has a cluster,
+    not a root-pool moid). A ``cluster`` that yields no root pool returns
+    ``status='cluster_root_pool_unresolved'`` before any write.
+
+    Read-back: lists ``filter.parent_resource_pools=<parent>`` and confirms
+    the new moid is present under the resolved parent
+    (``verified_under_parent``). ``safety_level='caution'`` /
+    ``requires_approval=True``.
+    """
+    name = params["name"]
+    parent_param = params.get("parent")
+    cluster_param = params.get("cluster")
+
+    if isinstance(parent_param, str) and parent_param:
+        parent_moid = parent_param
+        parent_source = "resource_pool"
+    elif isinstance(cluster_param, str) and cluster_param:
+        parent_source = "cluster"
+        resolved_parent = await _resolve_cluster_root_resource_pool(
+            connector, target, operator, cluster_moid=cluster_param
+        )
+        if resolved_parent is None:
+            return {
+                "status": "cluster_root_pool_unresolved",
+                "name": name,
+                "parent": None,
+                "parent_source": parent_source,
+                "cluster": cluster_param,
+                "resource_pool": None,
+                "verified_under_parent": False,
+                "guidance": (
+                    f"could not resolve the root resource pool of cluster {cluster_param!r} "
+                    "(ClusterComputeResource.resourcePool was unreadable); pass an explicit "
+                    "'parent' resource-pool moid instead"
+                ),
+            }
+        parent_moid = resolved_parent
+    else:
+        return {
+            "status": "no_parent",
+            "name": name,
+            "parent": None,
+            "parent_source": None,
+            "cluster": None,
+            "resource_pool": None,
+            "verified_under_parent": False,
+            "guidance": "exactly one of 'parent' (a resource-pool moid) or 'cluster' is required",
+        }
+
+    body: dict[str, Any] = {"name": name, "parent": parent_moid}
+    cpu_alloc = _build_resource_allocation(params.get("cpu_allocation"))
+    if cpu_alloc is not None:
+        body["cpu_allocation"] = cpu_alloc
+    memory_alloc = _build_resource_allocation(params.get("memory_allocation"))
+    if memory_alloc is not None:
+        body["memory_allocation"] = memory_alloc
+
+    gate, create_payload = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_CREATE_RESOURCE_POOL,
+        params=body,
+    )
+    if gate is not None:
+        return gate
+
+    new_moid = _unwrap_value(create_payload)
+    new_moid = new_moid if isinstance(new_moid, str) else None
+    verified = False
+    if new_moid is not None:
+        verified = new_moid in await _list_child_resource_pool_ids(
+            connector, target, operator, parent_moid=parent_moid
+        )
+    return {
+        "status": "created",
+        "name": name,
+        "parent": parent_moid,
+        "parent_source": parent_source,
+        "cluster": cluster_param if parent_source == "cluster" else None,
+        "resource_pool": new_moid,
+        "verified_under_parent": verified,
+        "guidance": None,
+    }
+
+
+async def resource_pool_delete_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Delete a resource pool; refuse a non-empty pool unless ``force``.
+
+    Op-id: ``vmware.composite.resource_pool.delete``. The REST
+    ``DELETE:/vcenter/resource-pool/{resourcePool}`` **reparents** the pool's
+    child pools and VMs up to its parent rather than destroying them, so this
+    is ``safety_level='dangerous'`` (not ``destructive``) /
+    ``requires_approval=True``.
+
+    Refuse-then-``force``: the child pools (``filter.parent_resource_pools``)
+    and child VMs (``filter.resource_pools``) are counted first; a non-empty
+    pool returns ``status='not_empty'`` with the counts and no write unless
+    ``force=true`` is passed (the operator acknowledging the reparent). The
+    delete then read-backs through the listing — an absent pool
+    (``verified_absent``) confirms ``status='deleted'``.
+    """
+    pool_moid = params["resource_pool"]
+    force = bool(params.get("force", False))
+
+    child_pool_ids = await _list_child_resource_pool_ids(
+        connector, target, operator, parent_moid=pool_moid
+    )
+    child_vms = await _resolve_vm_list(
+        connector=connector,
+        target=target,
+        operator=operator,
+        filter_dict={"resource_pools": [pool_moid]},
+    )
+    child_pool_count = len(child_pool_ids)
+    child_vm_count = len(child_vms)
+
+    if (child_pool_count or child_vm_count) and not force:
+        return {
+            "status": "not_empty",
+            "resource_pool": pool_moid,
+            "forced": False,
+            "child_pool_count": child_pool_count,
+            "child_vm_count": child_vm_count,
+            "verified_absent": False,
+            "guidance": (
+                f"resource pool {pool_moid!r} is not empty ({child_pool_count} child pool(s), "
+                f"{child_vm_count} VM(s)); pass force=true to delete it — the delete reparents "
+                "the children up to the parent pool, it does not destroy them"
+            ),
+        }
+
+    gate, _payload = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_DELETE_RESOURCE_POOL,
+        params={"resourcePool": pool_moid},
+    )
+    if gate is not None:
+        return gate
+
+    still_present = await _resource_pool_present(
+        connector, target, operator, resource_pool_moid=pool_moid
+    )
+    return {
+        "status": "deleted" if not still_present else "delete_unverified",
+        "resource_pool": pool_moid,
+        "forced": force,
+        "child_pool_count": child_pool_count,
+        "child_vm_count": child_vm_count,
+        "verified_absent": not still_present,
+        "guidance": (
+            None
+            if not still_present
+            else (
+                f"the DELETE returned but resource pool {pool_moid!r} still lists; re-read the "
+                "pool or retry — the delete may still settle in the background"
+            )
+        ),
+    }
+
+
+# ===========================================================================
+# cluster.drs_vm_host_rule.create (vim ClusterVmHostRuleInfo — #3505)
+# ===========================================================================
+#
+# A VM-Host affinity rule pins a VM *group* onto an (anti-)affine host
+# *group* — a different shape from ``cluster.drs_rule.create`` (VM-VM, by
+# explicit VM list), so it ships as a **sibling** op that leaves the existing
+# op's contract byte-for-byte unchanged. One ``ReconfigureComputeResource_Task``
+# carries both the ``groupSpec`` delta (adds the ClusterVmGroup + ClusterHostGroup)
+# and the ``rulesSpec`` delta (adds the ClusterVmHostRuleInfo referencing those
+# groups). Rides the same governed vmomi seam + task poll as drs_rule.create.
+
+
+def _extract_cluster_group_names(retrieve_result: Any) -> set[str]:
+    """Pull the existing DRS group names off a ``RetrievePropertiesEx`` result.
+
+    The host / VM group names share one flat namespace with each other (a
+    ``ClusterGroupInfo.name`` is unique within the cluster), read off
+    ``configurationEx.group`` — the collision check for the VM-Host rule's two
+    new groups. Mirrors :func:`_extract_cluster_rule_names`.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    names: set[str] = set()
+    if not isinstance(objects, list):
+        return names
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if not isinstance(prop, dict) or prop.get("name") != _PROP_CONFIGURATION_EX_GROUP:
+                continue
+            groups = unwrap_vim_value(prop.get("val"))
+            for group in groups if isinstance(groups, list) else []:
+                if isinstance(group, dict) and isinstance(group.get("name"), str):
+                    names.add(group["name"])
+    return names
+
+
+async def _resolve_named_hosts_in_cluster(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    cluster_moid: str,
+    host_names: list[str],
+) -> list[dict[str, Any]]:
+    """Resolve host display names to ``[{host, name}]`` rows scoped to the cluster.
+
+    One read-only ``GET:/vcenter/host`` filtered by both ``names`` and
+    ``clusters`` — a VM-Host rule is cluster-local, so scoping the resolution
+    to the cluster disambiguates same-named hosts elsewhere and drops any name
+    that does not name a host in this cluster (the host analogue of
+    :func:`_resolve_drs_rule_vms`).
+    """
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_HOSTS,
+        {"filter.names": host_names, "filter.clusters": [cluster_moid]},
+    )
+    entries = _unwrap_value(listing)
+    rows = [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    resolved: list[dict[str, Any]] = []
+    for row in rows:
+        moid = row.get("host")
+        if isinstance(moid, str):
+            name = row.get("name")
+            resolved.append({"host": moid, "name": name if isinstance(name, str) else None})
+    return resolved
+
+
+async def cluster_drs_vm_host_rule_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Add a DRS VM-Host affinity rule (VM group + host group + run-on rule).
+
+    Op-id: ``vmware.composite.cluster.drs_vm_host_rule.create``. Pins the VMs
+    of a named VM group onto (``affine=true``) or away from
+    (``affine=false``) the hosts of a named host group. No REST path exists,
+    so the add rides one vim
+    ``ClusterComputeResource.ReconfigureComputeResource_Task`` carrying a
+    ``ClusterConfigSpecEx`` with a ``groupSpec`` delta (adds the ClusterVmGroup
+    + ClusterHostGroup, ``operation='add'``) and a ``rulesSpec`` delta (adds
+    the ClusterVmHostRuleInfo, ``operation='add'``, ``modify=true``).
+
+    Flow:
+
+    1. Resolve the VM + host names to MoRefs, scoped to the cluster (*reads*,
+       un-gated). Zero VMs → ``status='insufficient_vms'``; zero hosts →
+       ``status='insufficient_hosts'`` (both before any write).
+    2. Read the cluster's existing rule + group names
+       (``configurationEx.rule`` / ``.group``) for the collision check: a
+       duplicate rule name → ``status='rule_exists'``; a duplicate VM- or
+       host-group name → ``status='group_exists'``.
+    3. Issue the single ``ReconfigureComputeResource_Task`` through the
+       governed :func:`_write_vmomi_sub_op` seam (a parked/denied gate returns
+       the :class:`OperationResult` verbatim) and poll it to terminal.
+       ``safety_level='caution'`` / ``requires_approval=True``.
+    """
+    cluster_moid = params["cluster"]
+    rule_name = params["rule_name"]
+    vm_group_name = params["vm_group_name"]
+    host_group_name = params["host_group_name"]
+    affine = bool(params.get("affine", True))
+    mandatory = bool(params.get("mandatory", False))
+    enabled = bool(params.get("enabled", True))
+    vm_names = [n for n in (params.get("vms") or []) if isinstance(n, str)]
+    host_names = [n for n in (params.get("hosts") or []) if isinstance(n, str)]
+
+    resolved_vms = await _resolve_drs_rule_vms(
+        connector=connector,
+        target=target,
+        operator=operator,
+        cluster_moid=cluster_moid,
+        vm_names=vm_names,
+    )
+    resolved_hosts = await _resolve_named_hosts_in_cluster(
+        connector=connector,
+        target=target,
+        operator=operator,
+        cluster_moid=cluster_moid,
+        host_names=host_names,
+    )
+
+    def _envelope(status: str, *, task: str | None, guidance: str | None) -> dict[str, Any]:
+        return {
+            "status": status,
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "vm_group_name": vm_group_name,
+            "host_group_name": host_group_name,
+            "affine": affine,
+            "mandatory": mandatory,
+            "enabled": enabled,
+            "task": task,
+            "resolved_vms": resolved_vms,
+            "resolved_hosts": resolved_hosts,
+            "guidance": guidance,
+        }
+
+    if not resolved_vms:
+        return _envelope(
+            "insufficient_vms",
+            task=None,
+            guidance=(
+                f"none of the {len(vm_names)} requested VM name(s) resolved to a VM in cluster "
+                f"{cluster_moid!r}; a VM-Host rule needs at least one VM in its group"
+            ),
+        )
+    if not resolved_hosts:
+        return _envelope(
+            "insufficient_hosts",
+            task=None,
+            guidance=(
+                f"none of the {len(host_names)} requested host name(s) resolved to a host in "
+                f"cluster {cluster_moid!r}; a VM-Host rule needs at least one host in its group"
+            ),
+        )
+
+    existing = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=retrieve_properties_body(
+            _CLUSTER_COMPUTE_RESOURCE_MO_TYPE,
+            [cluster_moid],
+            [_PROP_CONFIGURATION_EX_RULE, _PROP_CONFIGURATION_EX_GROUP],
+        ),
+    )
+    if rule_name in _extract_cluster_rule_names(existing):
+        return _envelope(
+            "rule_exists",
+            task=None,
+            guidance=(
+                f"a DRS rule named {rule_name!r} already exists on cluster {cluster_moid!r}; "
+                "rule names are the idempotence key — pick a new name or remove the existing rule"
+            ),
+        )
+    existing_groups = _extract_cluster_group_names(existing)
+    clash = {vm_group_name, host_group_name} & existing_groups
+    if clash:
+        return _envelope(
+            "group_exists",
+            task=None,
+            guidance=(
+                f"DRS group name(s) {sorted(clash)!r} already exist on cluster {cluster_moid!r}; "
+                "group names are unique within a cluster — pick new group names"
+            ),
+        )
+
+    host_group_key = "affineHostGroupName" if affine else "antiAffineHostGroupName"
+    reconfig_spec = {
+        "spec": {
+            _VMOMI_TYPE_NAME_KEY: _CLUSTER_CONFIG_SPEC_EX_TYPE,
+            "groupSpec": [
+                {
+                    _VMOMI_TYPE_NAME_KEY: _CLUSTER_GROUP_SPEC_TYPE,
+                    "operation": "add",
+                    "info": {
+                        _VMOMI_TYPE_NAME_KEY: _CLUSTER_VM_GROUP_TYPE,
+                        "name": vm_group_name,
+                        "vm": [
+                            vim_moref(_VIRTUAL_MACHINE_MO_TYPE, row["vm"]) for row in resolved_vms
+                        ],
+                    },
+                },
+                {
+                    _VMOMI_TYPE_NAME_KEY: _CLUSTER_GROUP_SPEC_TYPE,
+                    "operation": "add",
+                    "info": {
+                        _VMOMI_TYPE_NAME_KEY: _CLUSTER_HOST_GROUP_TYPE,
+                        "name": host_group_name,
+                        "host": [
+                            vim_moref(_HOST_SYSTEM_MO_TYPE, row["host"]) for row in resolved_hosts
+                        ],
+                    },
+                },
+            ],
+            "rulesSpec": [
+                {
+                    _VMOMI_TYPE_NAME_KEY: _CLUSTER_RULE_SPEC_TYPE,
+                    "operation": "add",
+                    "info": {
+                        _VMOMI_TYPE_NAME_KEY: _CLUSTER_VM_HOST_RULE_INFO_TYPE,
+                        "name": rule_name,
+                        "enabled": enabled,
+                        "mandatory": mandatory,
+                        "vmGroupName": vm_group_name,
+                        host_group_key: host_group_name,
+                    },
+                }
+            ],
+        },
+        "modify": True,
+    }
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_RECONFIGURE_COMPUTE_RESOURCE_TASK,
+        vmomi_path=f"/ClusterComputeResource/{cluster_moid}/ReconfigureComputeResource_Task",
+        body=reconfig_spec,
+        params={
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "vm_group_name": vm_group_name,
+            "host_group_name": host_group_name,
+        },
+    )
+    if gate is not None:
+        return gate
+
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_DRS_RULE_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == TASK_STATE_ERROR:
+        raise RuntimeError(
+            f"cluster.drs_vm_host_rule.create: ReconfigureComputeResource_Task on cluster "
+            f"{cluster_moid!r} faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return _envelope(
+            "timeout",
+            task=outcome.task,
+            guidance=(
+                f"ReconfigureComputeResource_Task {outcome.task} did not reach a terminal state "
+                f"within {int(_DRS_RULE_TASK_TIMEOUT_SECONDS)}s; poll the task or re-read the "
+                "cluster's DRS rules — the rule add may still complete in the background"
+            ),
+        )
+    return _envelope("created", task=outcome.task, guidance=None)
 
 
 # ===========================================================================

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -15,13 +15,17 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires 26 of the 29 write composites onto the per-op preview hook
+This wires 29 of the 32 write composites onto the per-op preview hook
 shipped by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
-helpers, never the mutating sub-ops. (The three most recent write ops —
+helpers, never the mutating sub-ops. (Three write ops —
 ``network.portgroup.create`` / ``network.portgroup.security.set`` /
 ``vm.import_from_library`` — carry no bespoke builder yet and fall back to
-the identifier-only default.)
+the identifier-only default.) The #3505 governed-allocation writes add three
+builders: ``resource_pool.create`` (param echo: name + parent / cluster +
+allocations), ``resource_pool.delete`` (live-read: child pool + VM counts the
+delete reparents), and ``cluster.drs_vm_host_rule.create`` (live-read: the
+resolved VM + host group sets).
 
 ========================  ====================================================
 ``vmware.composite.*``    preview stored in ``proposed_effect["preview"]``
@@ -163,6 +167,7 @@ from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
 )
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
+    _list_child_resource_pool_ids,
     _read_cdrom,
     _read_ethernet_nic,
     _read_sub_op,
@@ -172,6 +177,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     _resolve_cluster_name,
     _resolve_disk_info,
     _resolve_distributed_portgroup,
+    _resolve_named_hosts_in_cluster,
     _resolve_vm_list,
     _resolve_vm_name,
 )
@@ -694,6 +700,132 @@ async def _folder_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     if not isinstance(parent_folder, str) or not isinstance(folder_name, str):
         return None
     return {"parent_folder": parent_folder, "new_folder_name": folder_name}
+
+
+async def _resource_pool_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``resource_pool.create`` — echo the pool name + parent selector (no I/O).
+
+    Param echo (the ``folder.create`` precedent): the params fully name the
+    blast radius — one new pool under one parent (an explicit ``parent`` moid
+    or the root pool of a ``cluster``), plus any cpu / memory allocation. The
+    cluster→root-pool resolution and the POST write stay the handler's job.
+    """
+    name = ctx.params.get("name")
+    if not isinstance(name, str):
+        return None
+    effect: dict[str, Any] = {
+        "name": name,
+        "parent": ctx.params.get("parent"),
+        "cluster": ctx.params.get("cluster"),
+    }
+    for key in ("cpu_allocation", "memory_allocation"):
+        alloc = ctx.params.get(key)
+        if isinstance(alloc, dict):
+            effect[key] = alloc
+    return effect
+
+
+async def _resource_pool_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``resource_pool.delete`` — count the children the delete reparents.
+
+    The blast radius the approver signs off is which pool and how many child
+    pools + VMs get reparented up to the parent. Best-effort resolves the two
+    child counts (child pools via :func:`._write._list_child_resource_pool_ids`,
+    child VMs via :func:`._write._resolve_vm_list`); a resolution fault leaves
+    the count ``None`` rather than sinking the preview. The DELETE never fires
+    here. Declines without a resolved connector or a missing moid.
+    """
+    resource_pool = ctx.params.get("resource_pool")
+    if not isinstance(resource_pool, str) or ctx.connector_instance is None:
+        return None
+    try:
+        child_pool_ids = await _list_child_resource_pool_ids(
+            ctx.connector_instance,  # type: ignore[arg-type]
+            ctx.target,
+            ctx.operator,
+            parent_moid=resource_pool,
+        )
+        child_pool_count: int | None = len(child_pool_ids)
+    except httpx.HTTPError:
+        child_pool_count = None
+    try:
+        child_vms = await _resolve_vm_list(
+            connector=ctx.connector_instance,  # type: ignore[arg-type]
+            target=ctx.target,
+            operator=ctx.operator,
+            filter_dict={"resource_pools": [resource_pool]},
+        )
+        child_vm_count: int | None = len(child_vms)
+    except httpx.HTTPError:
+        child_vm_count = None
+    return {
+        "resource_pool": resource_pool,
+        "force": bool(ctx.params.get("force", False)),
+        "child_pool_count": child_pool_count,
+        "child_vm_count": child_vm_count,
+    }
+
+
+async def _cluster_drs_vm_host_rule_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``cluster.drs_vm_host_rule.create`` — resolve the VM + host groups.
+
+    The fan-out blast-radius pattern (like ``cluster.drs_rule.create``):
+    resolves the VM group's VM names and the host group's host names to the
+    same MoRef sets the approved write references — both scoped to the cluster
+    — capped at :data:`_PREVIEW_RESOLVED_CAP` with the uncapped ``total_*``
+    counts, plus the best-effort cluster display name. The reconfigure write
+    never fires here. Declines without a resolved connector or on malformed
+    params.
+    """
+    cluster = ctx.params.get("cluster")
+    rule_name = ctx.params.get("rule_name")
+    vm_group_name = ctx.params.get("vm_group_name")
+    host_group_name = ctx.params.get("host_group_name")
+    if (
+        not isinstance(cluster, str)
+        or not isinstance(rule_name, str)
+        or not isinstance(vm_group_name, str)
+        or not isinstance(host_group_name, str)
+        or ctx.connector_instance is None
+    ):
+        return None
+    vm_names = [n for n in (ctx.params.get("vms") or []) if isinstance(n, str)]
+    host_names = [n for n in (ctx.params.get("hosts") or []) if isinstance(n, str)]
+    vm_rows = await _resolve_vm_list(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        filter_dict={"names": vm_names, "clusters": [cluster]},
+    )
+    host_rows = await _resolve_named_hosts_in_cluster(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        cluster_moid=cluster,
+        host_names=host_names,
+    )
+    cluster_name = await _resolve_cluster_name(
+        ctx.connector_instance,  # type: ignore[arg-type]
+        ctx.target,
+        ctx.operator,
+        cluster=cluster,
+    )
+    vm_resolution = _capped_resolution(vm_rows, _vm_identity)
+    host_resolution = _capped_resolution(host_rows, _host_identity)
+    return {
+        "cluster": cluster,
+        "cluster_name": cluster_name,
+        "rule_name": rule_name,
+        "vm_group_name": vm_group_name,
+        "host_group_name": host_group_name,
+        "affine": bool(ctx.params.get("affine", True)),
+        "mandatory": bool(ctx.params.get("mandatory", False)),
+        "enabled": bool(ctx.params.get("enabled", True)),
+        "resolved_vms": vm_resolution["resolved"],
+        "total_vms": vm_resolution["total_resolved"],
+        "resolved_hosts": host_resolution["resolved"],
+        "total_hosts": host_resolution["total_resolved"],
+    }
 
 
 async def _vm_resize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
@@ -1268,6 +1400,9 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.host.detach_from_vds": _host_detach_from_vds_preview,
     "vmware.composite.cluster.patch": _cluster_patch_preview,
     "vmware.composite.cluster.drs_rule.create": _cluster_drs_rule_create_preview,
+    "vmware.composite.cluster.drs_vm_host_rule.create": _cluster_drs_vm_host_rule_create_preview,
+    "vmware.composite.resource_pool.create": _resource_pool_create_preview,
+    "vmware.composite.resource_pool.delete": _resource_pool_delete_preview,
     "vmware.composite.folder.create": _folder_create_preview,
     "vmware.composite.guest.customization_spec.create": _guest_customization_spec_create_preview,
     "vmware.composite.vm.customize": _vm_customize_preview,
@@ -1280,9 +1415,9 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 26 write-composite park-time preview builders. Import-time.
+    """Wire the 33 write-composite park-time preview builders. Import-time.
 
-    The 9 read composites register no builder — they are
+    The 11 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be
     dead code.
     """

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -53,6 +53,8 @@ __all__ = [
     "CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA",
     "CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA",
     "CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA",
+    "CLUSTER_DRS_VM_HOST_RULE_CREATE_PARAMETER_SCHEMA",
+    "CLUSTER_DRS_VM_HOST_RULE_CREATE_RESPONSE_SCHEMA",
     "CLUSTER_PATCH_PARAMETER_SCHEMA",
     "CLUSTER_PATCH_RESPONSE_SCHEMA",
     "DATASTORE_USAGE_MAX_VM_NAMES",
@@ -88,6 +90,10 @@ __all__ = [
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
     "PERFORMANCE_SUMMARY_RESPONSE_SCHEMA",
+    "RESOURCE_POOL_CREATE_PARAMETER_SCHEMA",
+    "RESOURCE_POOL_CREATE_RESPONSE_SCHEMA",
+    "RESOURCE_POOL_DELETE_PARAMETER_SCHEMA",
+    "RESOURCE_POOL_DELETE_RESPONSE_SCHEMA",
     "SUPERVISOR_DISABLE_PARAMETER_SCHEMA",
     "SUPERVISOR_DISABLE_RESPONSE_SCHEMA",
     "SUPERVISOR_ENABLE_PARAMETER_SCHEMA",
@@ -1478,6 +1484,207 @@ CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
 }
 
 
+#: ``vmware.composite.cluster.drs_vm_host_rule.create`` parameter schema.
+#:
+#: A VM-Host affinity rule (``ClusterVmHostRuleInfo``) pins the VMs of a named
+#: VM group onto (``affine=true``) or away from (``affine=false``) the hosts of
+#: a named host group. A **sibling** of ``cluster.drs_rule.create`` (whose
+#: contract stays unchanged), because a VM-Host rule needs a host group + VM
+#: group, not the VM-VM explicit list. VM + host names resolve to MoRefs scoped
+#: to the cluster; rule + group names are the idempotence keys.
+CLUSTER_DRS_VM_HOST_RULE_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ClusterComputeResource moid the rule is added to (e.g. 'domain-c1').",
+        },
+        "rule_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name of the new VM-Host rule. Rule names are an idempotence key — a name "
+                "already present returns ``status='rule_exists'`` before any write."
+            ),
+        },
+        "vm_group_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name of the ClusterVmGroup to create for the rule's VMs. Group names are "
+                "unique within a cluster — a clash returns ``status='group_exists'``."
+            ),
+        },
+        "host_group_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name of the ClusterHostGroup to create for the rule's hosts. Group names are "
+                "unique within a cluster — a clash returns ``status='group_exists'``."
+            ),
+        },
+        "vms": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1,
+            "description": (
+                "Display names of the VMs in the VM group. Resolved to MoRefs scoped to the "
+                "cluster; none resolving → ``status='insufficient_vms'``."
+            ),
+        },
+        "hosts": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1,
+            "description": (
+                "Display names of the hosts in the host group. Resolved to MoRefs scoped to the "
+                "cluster; none resolving → ``status='insufficient_hosts'``."
+            ),
+        },
+        "affine": {
+            "type": "boolean",
+            "default": True,
+            "description": (
+                "``true`` (default) makes the host group the *affine* group (VMs run on those "
+                "hosts); ``false`` makes it the *anti-affine* group (VMs avoid those hosts)."
+            ),
+        },
+        "mandatory": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "``true`` = a 'must' rule (DRS never violates it, even for HA/maintenance); "
+                "``false`` (default) = a 'should' rule (a soft preference DRS may relax)."
+            ),
+        },
+        "enabled": {
+            "type": "boolean",
+            "default": True,
+            "description": "Whether the rule is enabled on creation. Defaults to true.",
+        },
+    },
+    "required": ["cluster", "rule_name", "vm_group_name", "host_group_name", "vms", "hosts"],
+    "additionalProperties": False,
+}
+
+
+#: Nested ``cpu_allocation`` / ``memory_allocation`` sub-schema for the
+#: resource-pool create (``Vcenter.ResourcePool.ResourceAllocationCreateSpec``).
+#: All optional — an omitted allocation uses vCenter's documented default.
+_RESOURCE_ALLOCATION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "reservation": {
+            "type": "integer",
+            "description": (
+                "Guaranteed resource (MHz for CPU, MB for memory). Default 0 when omitted."
+            ),
+        },
+        "expandable_reservation": {
+            "type": "boolean",
+            "description": (
+                "Whether the reservation can grow into the parent's unreserved resources. "
+                "Default true when omitted."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                "Utilisation ceiling (MHz for CPU, MB for memory); -1 = unbounded. Default -1."
+            ),
+        },
+        "shares": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": ["LOW", "NORMAL", "HIGH", "CUSTOM"],
+                    "description": "Shares level; CUSTOM uses the numeric ``shares`` count.",
+                },
+                "shares": {
+                    "type": "integer",
+                    "description": "Custom shares count; only used when ``level`` is CUSTOM.",
+                },
+            },
+            "required": ["level"],
+            "additionalProperties": False,
+            "description": "Relative-weight shares under contention. Default NORMAL when omitted.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.resource_pool.create`` parameter schema.
+#:
+#: Create a resource pool via the REST ``POST:/vcenter/resource-pool``
+#: (``Vcenter.ResourcePool.CreateSpec``). Exactly one parent selector:
+#: ``parent`` (a ResourcePool moid, used verbatim) or ``cluster`` (a
+#: ClusterComputeResource moid whose *root* resource pool is resolved as the
+#: parent — the estate-allocation convenience).
+RESOURCE_POOL_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the new resource pool.",
+        },
+        "parent": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Parent ResourcePool moid the new pool nests under (e.g. 'resgroup-42'). "
+                "Mutually exclusive with ``cluster``."
+            ),
+        },
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "ClusterComputeResource moid (e.g. 'domain-c1') whose root resource pool "
+                "becomes the parent — resolved via ClusterComputeResource.resourcePool. "
+                "Mutually exclusive with ``parent``."
+            ),
+        },
+        "cpu_allocation": _RESOURCE_ALLOCATION_SCHEMA,
+        "memory_allocation": _RESOURCE_ALLOCATION_SCHEMA,
+    },
+    "required": ["name"],
+    "oneOf": [{"required": ["parent"]}, {"required": ["cluster"]}],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.resource_pool.delete`` parameter schema.
+#:
+#: Delete a resource pool via the REST
+#: ``DELETE:/vcenter/resource-pool/{resourcePool}``, which reparents the pool's
+#: child pools + VMs up to its parent (it does not destroy them). A non-empty
+#: pool is refused unless ``force=true``.
+RESOURCE_POOL_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "resource_pool": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ResourcePool moid to delete (e.g. 'resgroup-42').",
+        },
+        "force": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Delete even when the pool has child pools / VMs (they are reparented up to the "
+                "parent). Without it, a non-empty pool returns ``status='not_empty'``."
+            ),
+        },
+    },
+    "required": ["resource_pool"],
+    "additionalProperties": False,
+}
+
+
 #: ``vmware.composite.folder.create`` parameter schema.
 #:
 #: Create a VM folder under a named parent via the **synchronous** vim
@@ -2367,6 +2574,184 @@ CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "cluster", "rule_name", "rule_type"],
+}
+
+
+#: ``vmware.composite.cluster.drs_vm_host_rule.create`` response schema.
+CLUSTER_DRS_VM_HOST_RULE_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "created",
+                "rule_exists",
+                "group_exists",
+                "insufficient_vms",
+                "insufficient_hosts",
+                "timeout",
+            ],
+            "description": (
+                "``'created'`` — the ReconfigureComputeResource_Task add reached terminal "
+                "success; ``'rule_exists'`` / ``'group_exists'`` — the rule or a group name is "
+                "already present (idempotence keys; refused before any write); "
+                "``'insufficient_vms'`` / ``'insufficient_hosts'`` — none of the requested VM / "
+                "host names resolved in the cluster (refused before any write); ``'timeout'`` — "
+                "the reconfigure task did not reach a terminal state within the poll bound."
+            ),
+        },
+        "cluster": {"type": "string", "description": "ClusterComputeResource moid."},
+        "rule_name": {"type": "string", "description": "Name of the rule."},
+        "vm_group_name": {"type": "string", "description": "Name of the created VM group."},
+        "host_group_name": {"type": "string", "description": "Name of the created host group."},
+        "affine": {
+            "type": "boolean",
+            "description": (
+                "Whether the host group is the affine (true) or anti-affine (false) group."
+            ),
+        },
+        "mandatory": {
+            "type": "boolean",
+            "description": "Whether the rule is a 'must' (true) or 'should' (false) rule.",
+        },
+        "enabled": {"type": "boolean", "description": "Whether the rule was created enabled."},
+        "task": {
+            "type": ["string", "null"],
+            "description": (
+                "ReconfigureComputeResource_Task moid — present once the write was issued "
+                "(``created`` / ``timeout``); ``null`` on the pre-write refusals."
+            ),
+        },
+        "resolved_vms": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "vm": {"type": "string"},
+                    "name": {"type": ["string", "null"]},
+                },
+            },
+            "description": (
+                "The ``[{vm, name}]`` MoRefs placed in the VM group, resolved from names."
+            ),
+        },
+        "resolved_hosts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "host": {"type": "string"},
+                    "name": {"type": ["string", "null"]},
+                },
+            },
+            "description": (
+                "The ``[{host, name}]`` MoRefs placed in the host group, resolved from names."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``created`` status; ``null`` on success."
+            ),
+        },
+    },
+    "required": ["status", "cluster", "rule_name", "vm_group_name", "host_group_name"],
+}
+
+
+#: ``vmware.composite.resource_pool.create`` response schema.
+RESOURCE_POOL_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["created", "cluster_root_pool_unresolved", "no_parent"],
+            "description": (
+                "``'created'`` — the POST returned the new pool moid; "
+                "``'cluster_root_pool_unresolved'`` — the ``cluster`` convenience could not read "
+                "the cluster's root resource pool (pass an explicit ``parent``); ``'no_parent'`` "
+                "— neither ``parent`` nor ``cluster`` was supplied."
+            ),
+        },
+        "name": {"type": "string", "description": "The requested pool name."},
+        "parent": {
+            "type": ["string", "null"],
+            "description": "Resolved parent ResourcePool moid; ``null`` on a resolution refusal.",
+        },
+        "parent_source": {
+            "type": ["string", "null"],
+            "description": (
+                "Whether the parent came from ``parent`` (verbatim) or ``cluster`` "
+                "(root-pool resolution)."
+            ),
+        },
+        "cluster": {
+            "type": ["string", "null"],
+            "description": (
+                "The cluster moid, when the parent was resolved from a cluster; else ``null``."
+            ),
+        },
+        "resource_pool": {
+            "type": ["string", "null"],
+            "description": "The new pool's moid on success; ``null`` on a refusal.",
+        },
+        "verified_under_parent": {
+            "type": "boolean",
+            "description": (
+                "Read-back result: whether the new pool lists under the resolved parent "
+                "(``filter.parent_resource_pools``)."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``created`` status; ``null`` on success."
+            ),
+        },
+    },
+    "required": ["status", "name"],
+}
+
+
+#: ``vmware.composite.resource_pool.delete`` response schema.
+RESOURCE_POOL_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["deleted", "not_empty", "delete_unverified"],
+            "description": (
+                "``'deleted'`` — the DELETE returned and the read-back confirmed the pool is "
+                "absent; ``'not_empty'`` — the pool has child pools / VMs and ``force`` was not "
+                "set (no write); ``'delete_unverified'`` — the DELETE returned but the pool "
+                "still lists on read-back."
+            ),
+        },
+        "resource_pool": {"type": "string", "description": "The ResourcePool moid targeted."},
+        "forced": {
+            "type": "boolean",
+            "description": "Whether ``force`` was set (i.e. a non-empty pool was deleted).",
+        },
+        "child_pool_count": {
+            "type": "integer",
+            "description": "Number of child resource pools counted before the delete.",
+        },
+        "child_vm_count": {
+            "type": "integer",
+            "description": "Number of child VMs counted before the delete.",
+        },
+        "verified_absent": {
+            "type": "boolean",
+            "description": "Read-back result: whether the pool no longer lists.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``deleted`` status; ``null`` on success."
+            ),
+        },
+    },
+    "required": ["status", "resource_pool"],
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -134,11 +134,12 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Fifteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
+    Seventeen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
     writes, the #2891 hardware trio, the two GOSC composites / #2892, the
-    OVF/OVA content-library deploy / #2909, plus the typed HttpNfcLease import
+    OVF/OVA content-library deploy / #2909, the typed HttpNfcLease import
     / #3229 — whose REST sub-ops ride the content-library find + download-session
-    actions, all served by the pinned vcenter.yaml).
+    actions — and the #3505 governed-allocation resource-pool create + delete,
+    all served by the pinned vcenter.yaml).
     ``vm.snapshot.revert`` no longer appears: both of its sub-ops moved to
     the vim surface in #2970 (the pinned vcenter.yaml serves no snapshot
     REST resource), so its manifest lives in
@@ -153,6 +154,8 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_GUEST_CUSTOMIZATION_SPEC_CREATE",
         "_SUB_OPS_HOST_DETACH_FROM_VDS",
         "_SUB_OPS_HOST_EVACUATE",
+        "_SUB_OPS_RESOURCE_POOL_CREATE",
+        "_SUB_OPS_RESOURCE_POOL_DELETE",
         "_SUB_OPS_VM_CLONE",
         "_SUB_OPS_VM_CREATE",
         "_SUB_OPS_VM_CUSTOMIZE",
@@ -201,6 +204,23 @@ def test_vm_import_from_library_sub_op_manifest_is_expected() -> None:
         "POST:/content/library/item/download-session/{downloadSessionId}?action=keep-alive",
         "POST:/content/library/item/download-session/{downloadSessionId}?action=cancel",
         "POST:/vcenter/vm/{vm}/power?action=start",
+    }
+
+
+def test_resource_pool_create_sub_op_manifest_is_expected() -> None:
+    """Pin the #3505 resource_pool.create REST manifest (create write + read-back list)."""
+    assert set(_write._SUB_OPS_RESOURCE_POOL_CREATE) == {
+        "POST:/vcenter/resource-pool",
+        "GET:/vcenter/resource-pool",
+    }
+
+
+def test_resource_pool_delete_sub_op_manifest_is_expected() -> None:
+    """Pin the #3505 resource_pool.delete REST manifest (emptiness reads + delete write)."""
+    assert set(_write._SUB_OPS_RESOURCE_POOL_DELETE) == {
+        "GET:/vcenter/resource-pool",
+        "GET:/vcenter/vm",
+        "DELETE:/vcenter/resource-pool/{resourcePool}",
     }
 
 
@@ -733,6 +753,21 @@ def test_folder_create_vi_json_sub_op_manifest_is_the_expected_single() -> None:
     """Pin the folder.create vi-json manifest — one synchronous CreateFolder, no poll."""
     assert set(_write._VIM_SUB_OPS_FOLDER_CREATE) == {
         "POST:/Folder/{moId}/CreateFolder",
+    }
+
+
+def test_cluster_drs_vm_host_rule_create_vi_json_manifest_is_the_expected_pair() -> None:
+    """Pin the #3505 VM-Host rule vi-json manifest — same shape as drs_rule.create."""
+    assert set(_write._VIM_SUB_OPS_CLUSTER_DRS_VM_HOST_RULE_CREATE) == {
+        "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+
+
+def test_resource_pool_create_vi_json_manifest_is_the_expected_single() -> None:
+    """Pin the #3505 resource_pool.create vi-json manifest — the cluster root-pool read."""
+    assert set(_write._VIM_SUB_OPS_RESOURCE_POOL_CREATE) == {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
     }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -209,9 +209,11 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 41 total: 10 reads
+    # Embedding service called once per composite -- 47 total: 11 reads
     # (T5 #508's 5 + the 4 guest-ops reads #3100 + storage_policy.list
-    # #3494) + 31 writes (T6 #509 +
+    # #3494) + 36 writes (T6 #509 +
+    # the #3505 resource_pool.create / .delete + cluster.drs_vm_host_rule.create +
+    # the #3494 storage_policy.create / .delete +
     # single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     # WSFC/FCI shared-attach vm.disk.attach #3256 +
     # folder-template vm.clone_from_template #2894 + vim cluster/inventory
@@ -226,7 +228,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # network.portgroup.security.set + the content-library import
     # vm.import_from_library #3229). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 44
+    assert stub_embedding_service.encode_one.call_count == 47
 
 
 @pytest.mark.asyncio
@@ -477,8 +479,9 @@ async def test_register_vmware_composite_operations_is_idempotent(
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (10 reads incl. the 4 guest-ops
-    reads #3100 + 29 writes / T6 + single-VM vm.power #2301 + mutating
+    persist after the combined registrar (11 reads incl. the 4 guest-ops
+    reads #3100 + 36 writes / T6 + the #3505 governed-allocation writes +
+    the #3494 storage_policy.create / .delete + single-VM vm.power #2301 + mutating
     VI-JSON vm.disk.grow #2893 + WSFC/FCI vm.disk.attach #3256 +
     folder-template vm.clone_from_template
     #2894 + vim cluster/inventory writes cluster.drs_rule.create +
@@ -494,7 +497,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 44
+    assert first_count == 47
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -56,6 +56,7 @@ from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
+    cluster_drs_vm_host_rule_create_composite,
     cluster_patch_composite,
     folder_create_composite,
     guest_customization_spec_create_composite,
@@ -63,6 +64,8 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_evacuate_composite,
     network_portgroup_create_composite,
     network_portgroup_security_set_composite,
+    resource_pool_create_composite,
+    resource_pool_delete_composite,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
@@ -5688,6 +5691,619 @@ async def test_folder_create_body_reaches_the_wire_respx(
         assert body == {"name": "cluster-nodes"}
     finally:
         await connector.aclose()
+
+
+# ===========================================================================
+# resource_pool.create / .delete + cluster.drs_vm_host_rule.create (#3505)
+# ===========================================================================
+
+
+def _host_row(host: str, name: str) -> dict[str, Any]:
+    """A host listing row as ``GET:/vcenter/host`` returns it (moid + display name)."""
+    return {"host": host, "name": name}
+
+
+class _ResourcePoolConnector:
+    """Recording double for resource_pool.create / .delete REST + the cluster vim read.
+
+    ``_get_json`` on ``/vcenter/resource-pool`` discriminates on the bare
+    FilterSpec key (``parent_resource_pools`` → child pools / read-back under
+    parent; ``resource_pools`` → the delete read-back present check); on
+    ``/vcenter/vm`` it serves the child-VM listing. ``_post_json`` serves the
+    ``POST`` create (returns the new moid) and the ``DELETE``. ``_post_vmomi_json``
+    serves the ``ClusterComputeResource.resourcePool`` root-pool read.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(
+        self,
+        *,
+        created_moid: str = "resgroup-new",
+        root_pool: str | None = "resgroup-root",
+        child_vms: list[dict[str, Any]] | None = None,
+        present_after_delete: bool = False,
+        list_under_parent: list[str] | None = None,
+    ) -> None:
+        self.created_moid = created_moid
+        self.root_pool = root_pool
+        self.child_vms = child_vms or []
+        self.present_after_delete = present_after_delete
+        # What a ``parent_resource_pools`` listing returns — the create
+        # read-back (child pools under the new pool's parent, defaults to the
+        # freshly-created pool so verified_under_parent is True) and the delete
+        # emptiness check (child pools under the pool being deleted) share this.
+        self.list_under_parent = [created_moid] if list_under_parent is None else list_under_parent
+        self.rest_calls: list[dict[str, Any]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.rest_calls.append({"method": "GET", "path": path, "params": params})
+        query = params or {}
+        if path.endswith("/vcenter/vm"):
+            return {"value": self.child_vms}
+        if path.endswith("/vcenter/resource-pool"):
+            if "parent_resource_pools" in query:
+                return {"value": [{"resource_pool": rp} for rp in self.list_under_parent]}
+            if "resource_pools" in query:
+                present = self.present_after_delete
+                return {"value": [{"resource_pool": query["resource_pools"][0]}] if present else []}
+        raise AssertionError(f"unexpected GET {path!r} params={params!r}")
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
+    ) -> Any:
+        self.rest_calls.append({"method": verb, "path": path, "body": json})
+        if verb == "POST":
+            return self.created_moid
+        if verb == "DELETE":
+            return None
+        raise AssertionError(f"unexpected {verb} {path!r}")
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        # The only vmomi read: ClusterComputeResource.resourcePool.
+        val = (
+            {"_typeName": "ManagedObjectReference", "type": "ResourcePool", "value": self.root_pool}
+            if self.root_pool is not None
+            else None
+        )
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                    "propSet": [{"name": "resourcePool", "val": val}] if val is not None else [],
+                }
+            ]
+        }
+
+    def _last_create_body(self) -> Any:
+        return next(c["body"] for c in self.rest_calls if c.get("method") == "POST" and "body" in c)
+
+
+class _VmHostRuleConnector:
+    """Recording double for cluster.drs_vm_host_rule.create REST reads + vim writes."""
+
+    _MOUNT = "/api"
+
+    def __init__(
+        self,
+        *,
+        vms: list[dict[str, Any]] | None = None,
+        hosts: list[dict[str, Any]] | None = None,
+        existing_rules: list[dict[str, Any]] | None = None,
+        existing_groups: list[dict[str, Any]] | None = None,
+        task_state: str = "success",
+        task_error: str | None = None,
+        reconfig_task: str = "task-vmhost-1",
+    ) -> None:
+        self.vms = [_vm_row("vm-7", "esxi-nested-01")] if vms is None else vms
+        self.hosts = [_host_row("host-3", "esx-dc19-a")] if hosts is None else hosts
+        self.existing_rules = existing_rules or []
+        self.existing_groups = existing_groups or []
+        self.task_state = task_state
+        self.task_error = task_error
+        self.reconfig_task = reconfig_task
+        self.rest_calls: list[tuple[str, Any]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.rest_calls.append((path, params))
+        if path.endswith("/vcenter/host"):
+            return {"value": self.hosts}
+        if path.endswith("/vcenter/vm"):
+            return {"value": self.vms}
+        raise AssertionError(f"unexpected GET {path!r}")
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/ReconfigureComputeResource_Task"):
+            return {"type": "Task", "value": self.reconfig_task}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "ClusterComputeResource":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                        "propSet": [
+                            {
+                                "name": "configurationEx.rule",
+                                "val": {
+                                    "_typeName": "ArrayOfClusterRuleInfo",
+                                    "_value": self.existing_rules,
+                                },
+                            },
+                            {
+                                "name": "configurationEx.group",
+                                "val": {
+                                    "_typeName": "ArrayOfClusterGroupInfo",
+                                    "_value": self.existing_groups,
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        if spec_type == "Task":
+            info: dict[str, Any] = {"state": self.task_state}
+            if self.task_error is not None:
+                info["error"] = {"localizedMessage": self.task_error}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": self.reconfig_task},
+                        "propSet": [{"name": "info", "val": info}],
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+
+    @property
+    def reconfig_bodies(self) -> list[Any]:
+        return [
+            body
+            for path, body in self.vmomi_calls
+            if path.endswith("/ReconfigureComputeResource_Task")
+        ]
+
+
+# --- resource_pool.create ---
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_create_under_cluster_resolves_root_pool(gate: _GateRecorder) -> None:
+    """cluster convenience: resolve root RP -> gated POST -> read-back under parent."""
+    conn = _ResourcePoolConnector()
+    out = await resource_pool_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "name": "estate-rp",
+            "cluster": "domain-c1",
+            "cpu_allocation": {"reservation": 4000, "shares": {"level": "HIGH"}},
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["resource_pool"] == "resgroup-new"
+    assert out["parent"] == "resgroup-root"
+    assert out["parent_source"] == "cluster"
+    assert out["cluster"] == "domain-c1"
+    assert out["verified_under_parent"] is True
+    # The create POST was gated with its REST op_id + the flat CreateSpec body.
+    assert gate.gated_op_ids == ["POST:/vcenter/resource-pool"]
+    assert gate.calls[0]["safety_level"] == "dangerous"
+    assert gate.calls[0]["requires_approval"] is False
+    body = conn._last_create_body()
+    assert body["name"] == "estate-rp"
+    assert body["parent"] == "resgroup-root"
+    assert body["cpu_allocation"] == {"reservation": 4000, "shares": {"level": "HIGH"}}
+    assert "memory_allocation" not in body
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_create_under_explicit_parent_skips_cluster_read(
+    gate: _GateRecorder,
+) -> None:
+    """An explicit parent moid is used verbatim; no cluster vmomi read fires."""
+    conn = _ResourcePoolConnector(list_under_parent=["resgroup-new"])
+    out = await resource_pool_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "child-rp", "parent": "resgroup-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["parent"] == "resgroup-42"
+    assert out["parent_source"] == "resource_pool"
+    assert out["cluster"] is None
+    assert conn.vmomi_calls == []
+    assert conn._last_create_body()["parent"] == "resgroup-42"
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_create_no_parent_refused_before_write(gate: _GateRecorder) -> None:
+    """Neither parent nor cluster -> status=no_parent; no gate, no write."""
+    conn = _ResourcePoolConnector()
+    out = await resource_pool_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "orphan"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "no_parent"
+    assert gate.calls == []
+    assert conn.rest_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_create_unresolved_cluster_root_refused(gate: _GateRecorder) -> None:
+    """A cluster whose root pool cannot be read -> status=cluster_root_pool_unresolved."""
+    conn = _ResourcePoolConnector(root_pool=None)
+    out = await resource_pool_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "estate-rp", "cluster": "domain-c1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "cluster_root_pool_unresolved"
+    assert gate.calls == []
+    # No create POST fired (only the failed vmomi read).
+    assert all(c.get("method") != "POST" for c in conn.rest_calls)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_create_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the create POST returns the OperationResult verbatim; no write."""
+    op_id = "POST:/vcenter/resource-pool"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _ResourcePoolConnector()
+    out = await resource_pool_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "estate-rp", "parent": "resgroup-42"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert all(c.get("method") != "POST" for c in conn.rest_calls)
+
+
+# --- resource_pool.delete ---
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_empty_pool_deletes_and_verifies_absent(
+    gate: _GateRecorder,
+) -> None:
+    """Empty pool: gated DELETE -> read-back absent -> status=deleted."""
+    conn = _ResourcePoolConnector(present_after_delete=False, list_under_parent=[])
+    out = await resource_pool_delete_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-9"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "deleted"
+    assert out["verified_absent"] is True
+    assert out["child_pool_count"] == 0
+    assert out["child_vm_count"] == 0
+    assert gate.gated_op_ids == ["DELETE:/vcenter/resource-pool/{resourcePool}"]
+    assert gate.calls[0]["params"]["resourcePool"] == "resgroup-9"
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_non_empty_refused_without_force(gate: _GateRecorder) -> None:
+    """A non-empty pool without force -> status=not_empty; no gate, no delete."""
+    conn = _ResourcePoolConnector(
+        list_under_parent=["resgroup-child"], child_vms=[_vm_row("vm-1", "a")]
+    )
+    out = await resource_pool_delete_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-9"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "not_empty"
+    assert out["child_pool_count"] == 1
+    assert out["child_vm_count"] == 1
+    assert gate.calls == []
+    assert all(c.get("method") != "DELETE" for c in conn.rest_calls)
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_non_empty_with_force_deletes(gate: _GateRecorder) -> None:
+    """force=true deletes a non-empty pool (children are reparented) and verifies absent."""
+    conn = _ResourcePoolConnector(
+        list_under_parent=["resgroup-child"], child_vms=[_vm_row("vm-1", "a")]
+    )
+    out = await resource_pool_delete_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-9", "force": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "deleted"
+    assert out["forced"] is True
+    assert out["child_pool_count"] == 1
+    assert out["child_vm_count"] == 1
+    assert gate.gated_op_ids == ["DELETE:/vcenter/resource-pool/{resourcePool}"]
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_unverified_when_still_present(gate: _GateRecorder) -> None:
+    """DELETE returns but the pool still lists -> status=delete_unverified."""
+    conn = _ResourcePoolConnector(present_after_delete=True, list_under_parent=[])
+    out = await resource_pool_delete_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-9"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "delete_unverified"
+    assert out["verified_absent"] is False
+
+
+@pytest.mark.asyncio
+async def test_resource_pool_delete_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the DELETE returns the OperationResult verbatim; no delete."""
+    op_id = "DELETE:/vcenter/resource-pool/{resourcePool}"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _ResourcePoolConnector(list_under_parent=[])
+    out = await resource_pool_delete_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-9"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert all(c.get("method") != "DELETE" for c in conn.rest_calls)
+
+
+# --- cluster.drs_vm_host_rule.create ---
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_happy_path_adds_groups_and_rule(gate: _GateRecorder) -> None:
+    """Resolve VMs+hosts -> gated reconfigure (groupSpec + rulesSpec) -> poll -> created."""
+    conn = _VmHostRuleConnector()
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "nested-esxi",
+            "host_group_name": "gold-hosts",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["esx-dc19-a"],
+            "affine": True,
+            "mandatory": True,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["task"] == "task-vmhost-1"
+    assert out["resolved_vms"] == [{"vm": "vm-7", "name": "esxi-nested-01"}]
+    assert out["resolved_hosts"] == [{"host": "host-3", "name": "esx-dc19-a"}]
+    assert gate.gated_op_ids == [
+        "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+    ]
+    body = conn.reconfig_bodies[0]
+    assert body["modify"] is True
+    assert body["spec"]["_typeName"] == "ClusterConfigSpecEx"
+    group_spec = body["spec"]["groupSpec"]
+    assert [g["info"]["_typeName"] for g in group_spec] == ["ClusterVmGroup", "ClusterHostGroup"]
+    assert group_spec[0]["operation"] == "add"
+    assert group_spec[0]["info"]["name"] == "nested-esxi"
+    assert group_spec[0]["info"]["vm"] == [
+        {"_typeName": "ManagedObjectReference", "type": "VirtualMachine", "value": "vm-7"}
+    ]
+    assert group_spec[1]["info"]["name"] == "gold-hosts"
+    assert group_spec[1]["info"]["host"] == [
+        {"_typeName": "ManagedObjectReference", "type": "HostSystem", "value": "host-3"}
+    ]
+    rule_info = body["spec"]["rulesSpec"][0]["info"]
+    assert rule_info["_typeName"] == "ClusterVmHostRuleInfo"
+    assert rule_info["name"] == "pin-nested"
+    assert rule_info["mandatory"] is True
+    assert rule_info["vmGroupName"] == "nested-esxi"
+    assert rule_info["affineHostGroupName"] == "gold-hosts"
+    assert "antiAffineHostGroupName" not in rule_info
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_anti_affine_uses_anti_affine_group(
+    gate: _GateRecorder,
+) -> None:
+    """affine=false routes the host group into ``antiAffineHostGroupName``."""
+    conn = _VmHostRuleConnector()
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-off",
+            "vm_group_name": "vg",
+            "host_group_name": "hg",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["esx-dc19-a"],
+            "affine": False,
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    rule_info = conn.reconfig_bodies[0]["spec"]["rulesSpec"][0]["info"]
+    assert rule_info["antiAffineHostGroupName"] == "hg"
+    assert "affineHostGroupName" not in rule_info
+    # mandatory defaults to False (a 'should' rule).
+    assert rule_info["mandatory"] is False
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_rule_name_collision_refused(gate: _GateRecorder) -> None:
+    """An existing rule of the same name -> status=rule_exists; no write, no gate."""
+    conn = _VmHostRuleConnector(existing_rules=[{"name": "pin-nested", "key": 1}])
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "vg",
+            "host_group_name": "hg",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["esx-dc19-a"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "rule_exists"
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_group_name_collision_refused(gate: _GateRecorder) -> None:
+    """An existing group of the same name -> status=group_exists; no write, no gate."""
+    conn = _VmHostRuleConnector(existing_groups=[{"name": "gold-hosts", "userCreated": True}])
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "nested-esxi",
+            "host_group_name": "gold-hosts",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["esx-dc19-a"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "group_exists"
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_insufficient_vms_refused(gate: _GateRecorder) -> None:
+    """No VM name resolves -> status=insufficient_vms; no write, no gate."""
+    conn = _VmHostRuleConnector(vms=[])
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "vg",
+            "host_group_name": "hg",
+            "vms": ["missing"],
+            "hosts": ["esx-dc19-a"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "insufficient_vms"
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_insufficient_hosts_refused(gate: _GateRecorder) -> None:
+    """No host name resolves -> status=insufficient_hosts; no write, no gate."""
+    conn = _VmHostRuleConnector(hosts=[])
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "vg",
+            "host_group_name": "hg",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["missing"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "insufficient_hosts"
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_host_rule_create_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the reconfigure returns the OperationResult verbatim; no write."""
+    op_id = "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _VmHostRuleConnector()
+    out = await cluster_drs_vm_host_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "pin-nested",
+            "vm_group_name": "vg",
+            "host_group_name": "hg",
+            "vms": ["esxi-nested-01"],
+            "hosts": ["esx-dc19-a"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert conn.reconfig_bodies == []
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
@@ -67,6 +67,9 @@ _EXPECTED_REST_WRITE_OP_IDS = {
     "PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}",
     "POST:/vcenter/guest/customization-specs",
     "PUT:/vcenter/vm/{vm}/guest/customization",
+    # #3505 governed resource-pool create (a flat CreateSpec body — the DELETE
+    # counterpart is a path-only op excluded by the POST/PATCH/PUT collector).
+    "POST:/vcenter/resource-pool",
 }
 
 # The bodies #2973 flattened from the ``/rest`` ``{"spec": {...}}`` envelope to
@@ -231,6 +234,11 @@ _EMITTED_VIM_TYPE_NAMES: set[str] = {
     _write._CLUSTER_RULE_SPEC_TYPE,
     _write._CLUSTER_AFFINITY_RULE_TYPE,
     _write._CLUSTER_ANTI_AFFINITY_RULE_TYPE,
+    # #3505 VM-Host affinity rule DataObjects.
+    _write._CLUSTER_VM_HOST_RULE_INFO_TYPE,
+    _write._CLUSTER_VM_GROUP_TYPE,
+    _write._CLUSTER_HOST_GROUP_TYPE,
+    _write._CLUSTER_GROUP_SPEC_TYPE,
     # Typed HttpNfcLease OVF import (#3229) -- the CreateImportSpec cisp +
     # its network / property mapping DataObjects.
     ovf_import_control.OVF_CREATE_IMPORT_SPEC_PARAMS_TYPE,

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -90,6 +90,9 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.host.detach_from_vds",
         "vmware.composite.cluster.patch",
         "vmware.composite.cluster.drs_rule.create",
+        "vmware.composite.cluster.drs_vm_host_rule.create",
+        "vmware.composite.resource_pool.create",
+        "vmware.composite.resource_pool.delete",
         "vmware.composite.folder.create",
         "vmware.composite.guest.customization_spec.create",
         "vmware.composite.vm.customize",
@@ -320,7 +323,7 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 30
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 33
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -375,6 +378,18 @@ async def test_live_read_builders_decline_without_a_connector_instance() -> None
         (
             _write_preview._vm_device_cdrom_preview,
             {"vm": "vm-1", "cdrom": "16000", "action": "remove"},
+        ),
+        (_write_preview._resource_pool_delete_preview, {"resource_pool": "resgroup-9"}),
+        (
+            _write_preview._cluster_drs_vm_host_rule_create_preview,
+            {
+                "cluster": "domain-c1",
+                "rule_name": "pin-nested",
+                "vm_group_name": "nested-esxi",
+                "host_group_name": "gold-hosts",
+                "vms": ["esxi-nested-01"],
+                "hosts": ["esx-dc19-a"],
+            },
         ),
     ):
         assert await builder(_make_preview_ctx(params, connector_instance=None)) is None
@@ -732,6 +747,89 @@ async def test_vm_customize_preview_declines_on_malformed() -> None:
     assert await _write_preview._cluster_patch_preview(_make_preview_ctx({})) is None
     assert await _write_preview._folder_create_preview(_make_preview_ctx({})) is None
     assert await _write_preview._cluster_drs_rule_create_preview(_make_preview_ctx({})) is None
+    # #3505: resource_pool.create declines without a name; the two live-read
+    # #3505 builders decline without a resolved connector / required params.
+    assert await _write_preview._resource_pool_create_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._resource_pool_delete_preview(_make_preview_ctx({})) is None
+    assert (
+        await _write_preview._cluster_drs_vm_host_rule_create_preview(_make_preview_ctx({})) is None
+    )
+
+
+async def test_resource_pool_create_preview_echoes_params() -> None:
+    """#3505: resource_pool.create is a param echo (no I/O) naming the pool + parent."""
+    preview = await _write_preview._resource_pool_create_preview(
+        _make_preview_ctx(
+            {
+                "name": "estate-rp",
+                "cluster": "domain-c1",
+                "cpu_allocation": {"reservation": 4000, "shares": {"level": "HIGH"}},
+            }
+        )
+    )
+    assert preview == {
+        "name": "estate-rp",
+        "parent": None,
+        "cluster": "domain-c1",
+        "cpu_allocation": {"reservation": 4000, "shares": {"level": "HIGH"}},
+    }
+
+
+async def test_resource_pool_delete_preview_counts_reparented_children() -> None:
+    """#3505: resource_pool.delete previews the child pool + VM counts the delete reparents."""
+    recorder = _RecordingConnector()
+    recorder.responses["/vcenter/resource-pool"] = {
+        "value": [{"resource_pool": "resgroup-child-1"}]
+    }
+    recorder.responses["/vcenter/vm"] = {
+        "value": [{"vm": "vm-1", "name": "a"}, {"vm": "vm-2", "name": "b"}]
+    }
+    preview = await _write_preview._resource_pool_delete_preview(
+        _make_preview_ctx(
+            {"resource_pool": "resgroup-9", "force": True}, connector_instance=recorder
+        )
+    )
+    assert preview == {
+        "resource_pool": "resgroup-9",
+        "force": True,
+        "child_pool_count": 1,
+        "child_vm_count": 2,
+    }
+
+
+async def test_cluster_drs_vm_host_rule_create_preview_resolves_groups() -> None:
+    """#3505: the VM-Host rule preview resolves the VM + host group member sets."""
+    recorder = _RecordingConnector()
+    recorder.responses["/vcenter/vm"] = {"value": [{"vm": "vm-7", "name": "esxi-nested-01"}]}
+    recorder.responses["/vcenter/host"] = {"value": [{"host": "host-3", "name": "esx-dc19-a"}]}
+    recorder.responses["/vcenter/cluster/domain-c1"] = {"value": {"name": "cluster3"}}
+    preview = await _write_preview._cluster_drs_vm_host_rule_create_preview(
+        _make_preview_ctx(
+            {
+                "cluster": "domain-c1",
+                "rule_name": "pin-nested",
+                "vm_group_name": "nested-esxi",
+                "host_group_name": "gold-hosts",
+                "vms": ["esxi-nested-01"],
+                "hosts": ["esx-dc19-a"],
+                "affine": True,
+                "mandatory": True,
+            },
+            connector_instance=recorder,
+        )
+    )
+    assert preview is not None
+    assert preview["cluster"] == "domain-c1"
+    assert preview["cluster_name"] == "cluster3"
+    assert preview["rule_name"] == "pin-nested"
+    assert preview["vm_group_name"] == "nested-esxi"
+    assert preview["host_group_name"] == "gold-hosts"
+    assert preview["affine"] is True
+    assert preview["mandatory"] is True
+    assert preview["resolved_vms"] == [{"vm": "vm-7", "name": "esxi-nested-01"}]
+    assert preview["total_vms"] == 1
+    assert preview["resolved_hosts"] == [{"host": "host-3", "name": "esx-dc19-a"}]
+    assert preview["total_hosts"] == 1
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 29 vmware-rest write composites.
+"""Registration tests for the 32 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -10,7 +10,7 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 28 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 32 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``requires_approval=True``, and
   ``safety_level="dangerous"`` (T4's defaults intentionally inherited) —
   except the destructive-tier ``vm.destroy`` / #3198, which is
@@ -20,7 +20,7 @@ and the GOSC composites ``guest.customization_spec.create`` /
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
   ``guest`` / ``networking`` per the canary's stub-LLM taxonomy.
 * Combined with the 9 read composites (#508's 5 + the 4 guest-ops
-  reads / #3100), the registrar produces **37 rows** total. (The former
+  reads / #3100), the registrar produces **41 rows** total. (The former
   host.network_uplinks / host.vsan_health reads were re-shipped as typed
   ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
@@ -72,7 +72,9 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 31 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 34 write composites (T6 / #509, single-VM vm.power / #2301, the #3505
+# governed-allocation writes resource_pool.create / .delete +
+# cluster.drs_vm_host_rule.create, the
 # mutating VI-JSON vm.disk.grow / #2893 + WSFC/FCI vm.disk.attach / #3256,
 # the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
@@ -106,6 +108,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.security.set",
     "vmware.composite.cluster.patch",
     "vmware.composite.cluster.drs_rule.create",
+    "vmware.composite.cluster.drs_vm_host_rule.create",
+    "vmware.composite.resource_pool.create",
+    "vmware.composite.resource_pool.delete",
     "vmware.composite.folder.create",
     "vmware.composite.guest.customization_spec.create",
     "vmware.composite.vm.customize",
@@ -144,8 +149,8 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.storage_policy.list",
 )
 
-# 44 total -- 11 read (T5 / #508 + 4 guest-ops reads / #3100 + the
-# supervisor status read / #3281 + storage_policy.list / #3494) + 33 write
+# 47 total -- 11 read (T5 / #508 + 4 guest-ops reads / #3100 + the
+# supervisor status read / #3281 + storage_policy.list / #3494) + 36 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -156,7 +161,8 @@ _READ_OP_IDS: tuple[str, ...] = (
 # program-exec write vm.guest.program.run / #3255 + the WSFC/FCI shared-attach
 # vm.disk.attach / #3256 + the Supervisor writes supervisor.enable +
 # supervisor.disable / #3281 + the storage-policy writes storage_policy.create
-# + storage_policy.delete / #3494).
+# + storage_policy.delete / #3494 + the #3505 governed-allocation writes
+# resource_pool.create + resource_pool.delete + cluster.drs_vm_host_rule.create).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -215,6 +221,16 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.cluster.drs_rule.create": (
         "meho_backplane.connectors.vmware_rest.composites._write.cluster_drs_rule_create_composite"
+    ),
+    "vmware.composite.cluster.drs_vm_host_rule.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write."
+        "cluster_drs_vm_host_rule_create_composite"
+    ),
+    "vmware.composite.resource_pool.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write.resource_pool_create_composite"
+    ),
+    "vmware.composite.resource_pool.delete": (
+        "meho_backplane.connectors.vmware_rest.composites._write.resource_pool_delete_composite"
     ),
     "vmware.composite.folder.create": (
         "meho_backplane.connectors.vmware_rest.composites._write.folder_create_composite"
@@ -289,6 +305,9 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.network.portgroup.security.set": "networking",
     "vmware.composite.cluster.patch": "cluster",
     "vmware.composite.cluster.drs_rule.create": "cluster",
+    "vmware.composite.cluster.drs_vm_host_rule.create": "cluster",
+    "vmware.composite.resource_pool.create": "cluster",
+    "vmware.composite.resource_pool.delete": "cluster",
     "vmware.composite.folder.create": "vm",
     "vmware.composite.guest.customization_spec.create": "guest",
     "vmware.composite.vm.customize": "guest",
@@ -352,7 +371,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 async def test_register_vmware_composite_operations_inserts_all_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 29 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 32 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -395,23 +414,27 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 44
+    assert len(rows) == 47
 
 
 @pytest.mark.asyncio
 async def test_every_write_composite_row_uses_dangerous_requires_approval(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Each write row carries T4's defaults: dangerous + requires_approval=True.
+    """Each write row is approval-gated at its declared safety tier.
 
     Load-bearing: write composites should pop the approval queue on
     every dispatch. A misconfigured read-override would silently
     permit unauthenticated mutation; pinning the policy here means CI
     catches a regression before lifespan-startup.
 
-    The one exception is the destructive-tier ``vm.destroy`` (#3198): it is
-    ``safety_level="destructive"`` (a strictly harder tier than
-    ``dangerous``), still ``requires_approval=True``.
+    Tiers other than the ``dangerous`` default: the destructive-tier
+    ``vm.destroy`` (#3198) is ``safety_level="destructive"`` (a strictly
+    harder tier); the #3505 governed-allocation writes
+    ``resource_pool.create`` and the VM-Host affinity
+    ``cluster.drs_vm_host_rule.create`` are ``caution`` (a softer tier —
+    an allocation carve-out / a placement hint, not a mutation of running
+    state). All rows stay ``requires_approval=True``.
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
@@ -425,16 +448,24 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 29 write rows before iterating —
+    # Prove the query actually returned all 32 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
+    caution_ops = {
+        "vmware.composite.resource_pool.create",
+        "vmware.composite.cluster.drs_vm_host_rule.create",
+        "vmware.composite.storage_policy.create",
+    }
     for row in rows:
-        _non_dangerous_levels = {
-            "vmware.composite.vm.destroy": "destructive",
-            "vmware.composite.storage_policy.create": "caution",
-            "vmware.composite.storage_policy.delete": "destructive",
-        }
-        expected_level = _non_dangerous_levels.get(row.op_id, "dangerous")
+        if row.op_id in (
+            "vmware.composite.vm.destroy",
+            "vmware.composite.storage_policy.delete",
+        ):
+            expected_level = "destructive"
+        elif row.op_id in caution_ops:
+            expected_level = "caution"
+        else:
+            expected_level = "dangerous"
         assert row.safety_level == expected_level, (
             f"{row.op_id}: expected {expected_level}, got {row.safety_level!r}"
         )
@@ -496,9 +527,13 @@ async def test_write_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_write_composites_land_in_vm_host_cluster_groups(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Group distribution: 12 in ``vm`` (11 ``vm.*`` + ``folder.create``),
-    2 ``host.*`` in ``host``, 2 ``cluster.*`` in ``cluster``, 2 GOSC in ``guest``,
-    2 portgroup writes in ``networking``.
+    """Group distribution: ``vm.*`` + ``folder.create`` in ``vm``, the
+    ``host.*`` writes in ``host``, the ``cluster.*`` writes + the two
+    ``resource_pool.*`` allocation writes in ``cluster`` (5: patch,
+    drs_rule.create, drs_vm_host_rule.create, resource_pool.create,
+    resource_pool.delete), the GOSC + guest-ops writes in ``guest`` /
+    ``guest_ops``, and the two portgroup writes in ``networking``. Asserted
+    per-op against :data:`_EXPECTED_GROUP_KEY_BY_OP`.
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
@@ -739,7 +774,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
     """Running the registrar twice -> 41 rows total, embedding called 41x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 44
+    assert first_count == 47
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
@@ -757,7 +792,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 44
+    assert len(rows) == 47
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,12 +8,12 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 44 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 47 hand-authored composites
 that orchestrate cross-spec workflows: 11 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
 in `#2258`; plus the four guest-operations reads `#3100` and the
-Supervisor status read `#3281` + the storage-policy list read `#3494`) and 33 write
+Supervisor status read `#3281` + the storage-policy list read `#3494`) and 36 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 governed NFS tag-based SPBM `storage_policy.create` (caution) +
 `storage_policy.delete` (destructive) / `#3494`, the
@@ -21,7 +21,10 @@ single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893` + the WSFC/FCI shared-attach
 `vm.disk.attach` / `#3256`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
-`cluster.drs_rule.create` + `folder.create` / `#2895`, the `#2891`
+`cluster.drs_rule.create` + `folder.create` / `#2895`, the governed
+resource-pool allocation writes `resource_pool.create` (`caution`) +
+`resource_pool.delete` (`dangerous`) and the VM-Host affinity
+`cluster.drs_vm_host_rule.create` (`caution`) / `#3505`, the `#2891`
 post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
 `vm.device.cdrom`, the two guest-customization (GOSC) composites
 `guest.customization_spec.create` + `vm.customize` / `#2892`, the
@@ -91,7 +94,7 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   cluster-wide `overall_health` colour plus the health-test `groups`
   list. It is likewise best-effort (a failed health-service read nulls
   `groups` / `overall_health` with a `read_note`).
-- **Write composites** (`composites/_write.py`) — eighteen module-level
+- **Write composites** (`composites/_write.py`) — the module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_deploy_from_library_composite`, `vm_import_from_library_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
@@ -102,7 +105,25 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `network_portgroup_create_composite`,
   `network_portgroup_security_set_composite`,
   `cluster_patch_composite`, `guest_customization_spec_create_composite`,
-  `vm_customize_composite`). The `vm_resize` / `vm_nic_repoint` /
+  `vm_customize_composite`, and the `#3505` governed-allocation writes
+  `resource_pool_create_composite` / `resource_pool_delete_composite` /
+  `cluster_drs_vm_host_rule_create_composite`). The `resource_pool.create`
+  handler issues the REST `POST:/vcenter/resource-pool` through the same
+  governed `_write_sub_op` seam the other REST writes use, resolving the
+  parent either from an explicit `parent` moid or (the estate convenience)
+  from a `cluster` moid whose root resource pool it reads via one vim
+  `RetrievePropertiesEx` of `ClusterComputeResource.resourcePool`;
+  `resource_pool.delete` counts the pool's child pools + VMs first and
+  refuses (`not_empty`) a populated pool unless `force=true` (the REST
+  `DELETE` reparents children up to the parent). The VM-Host affinity
+  `cluster.drs_vm_host_rule.create` is a **sibling** of
+  `cluster.drs_rule.create` (which stays VM-VM only, contract unchanged):
+  one `ReconfigureComputeResource_Task` carries a `ClusterConfigSpecEx`
+  `groupSpec` delta (adds a `ClusterVmGroup` + `ClusterHostGroup`) plus a
+  `rulesSpec` delta (adds a `ClusterVmHostRuleInfo` referencing those groups
+  by name, with a `mandatory` must/should flag), riding the governed
+  `_write_vmomi_sub_op` seam + `poll_vim_task` like the VM-VM rule. The
+  `vm_resize` / `vm_nic_repoint` /
   `vm_device_cdrom` trio (`#2891`) is the post-clone hardware reconfigure
   trio — see the **Hardware write composites** subsection under Control
   flow. Since
@@ -289,8 +310,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   Control flow.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 41
-  `_CompositeSpec` rows (11 read + 33 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 47
+  `_CompositeSpec` rows (11 read + 36 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -459,11 +480,14 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
-   queued registrar and upserts: the 32 `vmware.composite.*` rows with
+   queued registrar and upserts: the 41 `vmware.composite.*` rows with
    `source_kind="composite"` (9 reads with `safety_level="safe"` +
-   `requires_approval=False`; 23 writes with `safety_level="dangerous"`
-   + `requires_approval=True`, and the destructive-tier `vm.destroy` with
-   `safety_level="destructive"` + `requires_approval=True` / `#3198`),
+   `requires_approval=False`; 29 writes with `safety_level="dangerous"`
+   + `requires_approval=True`; the two #3505 governed-allocation writes
+   `resource_pool.create` + `cluster.drs_vm_host_rule.create` with
+   `safety_level="caution"` + `requires_approval=True`; and the
+   destructive-tier `vm.destroy` with `safety_level="destructive"` +
+   `requires_approval=True` / `#3198`),
    plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
@@ -713,7 +737,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 38 composites (9 reads + 29 writes) land as `source_kind="composite"`
+The 44 composites (10 reads + 34 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -903,6 +927,9 @@ enum) are:
 | `host.detach_from_vds` | `detached`, `incomplete`, `timeout` (the detach is the vim `ReconfigureDvs_Task` host-member remove, polled, #2970) |
 | `cluster.patch` | `completed`, `stopped` (per-host vim maintenance `*_Task`s + the vLCM `software?action=apply&vmw-task=true` cis task, every task polled before the next step, #2970) |
 | `cluster.drs_rule.create` | `created`, `rule_exists`, `insufficient_vms`, `timeout` (idempotent on rule name — a duplicate `rule_exists` is refused before any write; `insufficient_vms` when fewer than two named VMs resolve to the cluster; `timeout` when the `ReconfigureComputeResource_Task` poll gives up) |
+| `cluster.drs_vm_host_rule.create` | `created`, `rule_exists`, `group_exists`, `insufficient_vms`, `insufficient_hosts`, `timeout` (#3505 VM-Host rule; rule + group names are idempotence keys refused before any write; `insufficient_*` when no VM / host name resolves in the cluster; `timeout` when the `ReconfigureComputeResource_Task` poll gives up) |
+| `resource_pool.create` | `created`, `cluster_root_pool_unresolved`, `no_parent` (#3505; the REST `POST:/vcenter/resource-pool` create — `cluster_root_pool_unresolved` when the `cluster` convenience cannot read the cluster's root pool, `no_parent` when neither `parent` nor `cluster` is given, both before any write; read-back confirms the pool under the resolved parent) |
+| `resource_pool.delete` | `deleted`, `not_empty`, `delete_unverified` (#3505; `not_empty` refuses a pool with child pools / VMs unless `force=true` — the REST `DELETE` reparents children up to the parent; `delete_unverified` when the read-back still lists the pool) |
 | `folder.create` | `created`, `parent_not_found`, `ambiguous_parent` (synchronous `CreateFolder` — the resolution refusals are structured, not raw vim faults) |
 | `network.portgroup.create` | `created`, `invalid_vlan_spec`, `timeout` (vim `CreateDVPortgroup_Task` polled, #3091; `invalid_vlan_spec` refuses a trunk+access clash before any write; `timeout` when the poll gives up; a task *fault* — e.g. `DuplicateName` — raises `connector_error`. The `created` envelope carries a read-back `observed` = `{name, vlan}` off the new portgroup's `config`. The trunk / access VLAN specs are `InheritablePolicy` subtypes, so each wire body carries `inherited: false` — without it vCenter defaults `inherited: true` and drops the `vlanId`, silently creating an untagged (VLAN 0) portgroup, #3356) |
 | `network.portgroup.security.set` | `updated`, `no_change_requested`, `timeout` (vim `ReconfigureDVPortgroup_Task` polled, #3091; `no_change_requested` refuses when none of the three booleans is supplied, before any read/write; `timeout` when the poll gives up; a task *fault* raises `connector_error`. Carries `previous` (pre-write security triple) + `observed` (post-write triple) read-backs) |


### PR DESCRIPTION
## Summary

Adds three governed `vmware-rest-9.0` composites that close the two lab-estate allocation steps with no governed path today (`Closes #3505`):

- **`vmware.composite.resource_pool.create`** (`caution` + `requires_approval`) — issues the REST `POST:/vcenter/resource-pool` (`Vcenter.ResourcePool.CreateSpec`) through the direct-session `_write_sub_op` seam and returns the new pool moid. Parent resolves from an explicit `parent` (a ResourcePool moid) or — the estate convenience — a `cluster` moid whose **root** resource pool is read via one vim `RetrievePropertiesEx` of `ClusterComputeResource.resourcePool`. Read-back lists `filter.parent_resource_pools` and confirms the new pool under the resolved parent.
- **`vmware.composite.resource_pool.delete`** (`dangerous` + `requires_approval`) — the REST `DELETE:/vcenter/resource-pool/{resourcePool}` reparents child pools + VMs up to the parent (not a destroy), so `dangerous`, not `destructive`. Counts children first and refuses `not_empty` unless `force=true`; read-back verifies the pool is absent.
- **`vmware.composite.cluster.drs_vm_host_rule.create`** (`caution` + `requires_approval`) — a DRS **VM-Host** affinity rule (host group + VM group + should/must-run-on `ClusterVmHostRuleInfo`) via one `ReconfigureComputeResource_Task` carrying a `groupSpec` + `rulesSpec` delta. Shipped as a **sibling** op so `cluster.drs_rule.create` (VM-VM only) keeps its contract byte-for-byte.

**Delivery shape (documented per the brief):** thin composites over the REST/vim seams the connector already uses — **not** curated ingested rows. The connector's whole write surface is direct-session composites that work on a fresh boot with zero catalog ingest; curating the raw `POST`/`DELETE` rows would require a full vCenter catalog ingest to dispatch and reintroduce the path Goal #2247 migrated away from. And the raw `CreateSpec.parent` is a bare ResourcePool moid — operators have a cluster, so the composite does the `cluster → root pool` resolution the raw row cannot express. The pinned 9.0 `vcenter.yaml` does serve the create/delete REST paths (L40925 / L40654); the issue body's "GET-only" note predates that spec revision.

Preview parity, governed-subop discovery (`_governed_subops`), and the spec-shelf reconcile lanes are wired for all three. **No new MCP tools** (dispatched via `call_operation`); **no new CLI verbs/routes** (so `docs-site/reference/connectors.md` and the CLI OpenAPI snapshot regenerate to a no-op — verified).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (connector + tests)
- [x] `mypy src/meho_backplane/connectors/vmware_rest/` — clean (28 files)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (warn-level function-size only, matching the existing composites)
- [x] Handler units (`test_...composites_write.py`) — create (cluster/explicit-parent/no_parent/unresolved/gate), delete (empty→deleted, non-empty refuse, force, unverified, gate), VM-Host rule (created affine/anti-affine, rule_exists, group_exists, insufficient_vms/hosts, gate): **18 new, all green**
- [x] Preview shape + decline (`..._write_preview.py`) — param-echo create, child-count delete, group-resolve VM-Host; `_WRITE_COMPOSITE_OP_IDS` 26→29
- [x] Registration (`..._write_register.py` / `..._register.py`) — 38→41 rows, per-op safety-level map (2 `caution`, 1 `destructive`, rest `dangerous`), group-key = `cluster`
- [x] Reconcile lanes (`..._l2_ingest_reconcile.py` / `..._write_body_reconcile.py`) — `_SUB_OPS_*` / `_VIM_SUB_OPS_*` manifest pins, `_EXPECTED_REST_WRITE_OP_IDS` + `_EMITTED_VIM_TYPE_NAMES` for the 4 VM-Host DataObjects
- [x] Full vmware-rest composite suite — **384 passed, 21 skipped** (shelf-gated); governed-subops + MCP surface conformance green

## Changelog

`Added — vmware-rest: governed resource-pool create/delete (`vmware.composite.resource_pool.create` / `.delete`) and a DRS VM-Host affinity rule (`vmware.composite.cluster.drs_vm_host_rule.create`), the last two lab-estate allocation steps with no governed path (#3505).`

(CHANGELOG.md intentionally not edited in this PR — entry text provided here per repo merge-train convention.)

## Out of scope / notes

- Live-lab validation of the three ops against a real vCenter is deferred (no live-lab access from this run).
- Pre-existing warn-level function-size warnings in `_write.py` (e.g. `host_evacuate_composite`, `vm_nic_repoint_composite`) are unchanged adjacent findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
