### PR TITLE
feat(connectors): vmware_rest SUBSCRIBED content-library create/sync + status/items reads

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -278,6 +278,16 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # statically while leaving its generic ``data`` container to the scrub.
         "sddc.host.validate",
         "sddc.host.commission",
+        # #3495 — the SUBSCRIBED content-library create composite. Its
+        # ``password`` param (BASIC-auth to the publisher) IS a secret-named
+        # key the scrub would catch, but ``username`` / ``ssl_thumbprint`` are
+        # not, and pinning the whole op collapses its params to aggregate-only
+        # rather than relying on per-key scrubbing — matching the GOSC-create /
+        # guest-ops precedent. The park-time bespoke preview echoes only the
+        # non-secret identity fields (name / subscription URL / datastore /
+        # auth method / sync mode). The sibling reads (status / items.list) and
+        # the sync write carry no credential and are NOT pinned.
+        "vmware.composite.content_library.subscribed.create",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -80,6 +80,12 @@ from meho_backplane.connectors.vmware_rest.composites._host import (
     disk_mark_flash_composite,
     service_control_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._library import (
+    content_library_subscribed_create_composite,
+    content_library_subscribed_items_list_composite,
+    content_library_subscribed_status_composite,
+    content_library_subscribed_sync_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -144,6 +150,10 @@ __all__ = [
     "cluster_drs_recommendations_composite",
     "cluster_drs_rule_create_composite",
     "cluster_patch_composite",
+    "content_library_subscribed_create_composite",
+    "content_library_subscribed_items_list_composite",
+    "content_library_subscribed_status_composite",
+    "content_library_subscribed_sync_composite",
     "datastore_mount_nfs_composite",
     "datastore_usage_composite",
     "disk_mark_flash_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_governed_subops.py
@@ -32,6 +32,7 @@ from typing import Final
 
 from meho_backplane.connectors.vmware_rest.composites import (
     _host,
+    _library,
     _storage_policy,
     _supervisor,
     _write,
@@ -96,6 +97,14 @@ _GOVERNED_SUBOP_MANIFEST: Final[dict[str, tuple[str, ...]]] = {
     "vmware.composite.supervisor.disable": _supervisor._SUB_OPS_SUPERVISOR_DISABLE,
     "vmware.composite.storage_policy.create": _storage_policy._SUB_OPS_STORAGE_POLICY_CREATE,
     "vmware.composite.storage_policy.delete": _storage_policy._SUB_OPS_STORAGE_POLICY_DELETE,
+    # #3495 content-library SUBSCRIBED writes (the two reads auto-execute for
+    # a service principal and need no grant, so they are not listed here).
+    "vmware.composite.content_library.subscribed.create": (
+        _library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_CREATE
+    ),
+    "vmware.composite.content_library.subscribed.sync": (
+        _library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_SYNC
+    ),
 }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_library.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_library.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Content-library **subscribed**-library composites (#3495).
+
+The four ``vmware.composite.content_library.subscribed.*`` composites that
+let an operator create and drive a **SUBSCRIBED** content library through the
+backplane -- the governed source for a vSphere Supervisor's Tanzu Kubernetes
+release (TKr / VKr) images.
+
+Why this exists: on Supervisor enable, ``wcpsvc`` auto-creates a SUBSCRIBED
+"Kubernetes Service Content Library" pointed at the fleet offline-depot
+content-gateway, which cannot serve the ``VKR`` component on a VCF-Installer
+fleet, so activation hangs ``CONFIGURING``. The governed path is to
+**pre-create** a SUBSCRIBED library subscribed straight to the upstream VMware
+TKr repo (``https://wp-content.vmware.com/v2/latest/lib.json``) and assign it
+as the Supervisor's TKr library via the enable spec's
+``default_kubernetes_service_content_library`` field (#3281). This module is
+that pre-create + sync + status/items read surface.
+
+Delivery shape -- **thin typed composites**, not the generic-ingested row.
+The subscribe body carries a ``subscription_info.password`` (BASIC auth) plus
+an ``ssl_thumbprint``, so the op needs credential hygiene (broadcast
+aggregate-only via the ``_CREDENTIAL_WRITE_OPS`` pin, a park-time preview that
+never echoes the secret, ``params_hash``-only audit) that a raw ingested row
+cannot carry; and the connector's governed ops must dispatch on a fresh boot
+with **zero catalog ingest** (a generic row requires a runtime spec-ingest +
+``edit_op`` enable), which composites satisfy and ingested rows do not. The
+issue permits a typed composite "if the subscribe body ... needs it" -- it
+does. The naming nests under the sibling #3331 LOCAL-library family
+(``content_library.create``) via the ``subscribed`` infix, so the two do not
+collide.
+
+Each handler rides the **same** direct-session seam the #2909 /
+``vm.deploy_from_library`` content-library composite established: the resolve
+reads go through :func:`._write._read_sub_op` /
+:func:`._write._find_content_library_ids` (un-gated), and the two writes
+(create / sync) through :func:`._write._write_sub_op`, which re-applies the
+:func:`~meho_backplane.operations.composite.enforce_subop_policy` gate per
+governed write -- so the direct path keeps property 3 of #508's four
+``dispatch_child`` guarantees. The create / sync composites are registered
+``caution`` + ``requires_approval=True`` (the issue's "write" tier: a write
+that always needs an approval decision, but not the ``dangerous`` /
+destructive intrinsic-risk of a VM/host mutation); the status / items reads
+are ``safe`` + ``requires_approval=False``.
+
+Sub-op manifests (``_SUB_OPS_*``) are the canonical path lists the
+spec-reconcile lane (``test_connectors_vmware_rest_library_reconcile.py``)
+pins against the pinned ``vcenter.yaml`` so no fictional path drifts in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+import httpx
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    _OP_FIND_LIBRARY,
+    _OP_FIND_LIBRARY_ITEM,
+    _OP_LIST_DATASTORES,
+    _find_content_library_ids,
+    _read_sub_op,
+    _unwrap_value,
+    _write_sub_op,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+# ---------------------------------------------------------------------------
+# Sub-op path manifests (reconcile-lane pinning; #3495).
+#
+# Every op_id is a well-formed ``METHOD:/path`` the pinned vcenter.yaml
+# ingest emits -- the reconcile lane sweeps these and fails on any path the
+# real spec does not serve (the "no fictional-path drift" AC). The two write
+# composites' manifests are also the grant-discovery source fed into
+# ``_GOVERNED_SUBOP_MANIFEST`` (#3349); the read composites need no grant.
+# ---------------------------------------------------------------------------
+
+#: ``content_library.subscribed.create`` -- resolve the datastore backing by
+#: name, then POST the subscribed-library create.
+_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_CREATE: Final[tuple[str, ...]] = (
+    _OP_LIST_DATASTORES,
+    "POST:/content/subscribed-library",
+)
+
+#: ``content_library.subscribed.sync`` -- resolve a ``library_name`` to its
+#: id (un-gated find), then force the sync.
+_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_SYNC: Final[tuple[str, ...]] = (
+    _OP_FIND_LIBRARY,
+    "POST:/content/subscribed-library/{libraryId}?action=sync",
+)
+
+#: ``content_library.subscribed.status`` -- resolve a ``library_name``, then
+#: read the LibraryModel back.
+_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_STATUS: Final[tuple[str, ...]] = (
+    _OP_FIND_LIBRARY,
+    "GET:/content/subscribed-library/{libraryId}",
+)
+
+#: ``content_library.subscribed.items.list`` -- resolve a ``library_name``,
+#: find every item id in the library, then read each item's metadata.
+_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST: Final[tuple[str, ...]] = (
+    _OP_FIND_LIBRARY,
+    _OP_FIND_LIBRARY_ITEM,
+    "GET:/content/library/item/{libraryItemId}",
+)
+
+_OP_CREATE_SUBSCRIBED_LIBRARY = "POST:/content/subscribed-library"
+_OP_SYNC_SUBSCRIBED_LIBRARY = "POST:/content/subscribed-library/{libraryId}?action=sync"
+_OP_GET_SUBSCRIBED_LIBRARY = "GET:/content/subscribed-library/{libraryId}"
+_OP_GET_LIBRARY_ITEM = "GET:/content/library/item/{libraryItemId}"
+
+#: Cap on the item rows surfaced inline before the JSONFlux reducer spills to
+#: a handle. The reducer's own 50-row / 4 KB threshold is the real gate; this
+#: is a defensive ceiling so a pathologically large library never materialises
+#: an unbounded intermediate list in the handler.
+_ITEMS_HARD_CAP: Final[int] = 500
+
+
+def _issue(category: str, severity: str, message: str) -> dict[str, Any]:
+    """Build one structured issue entry for a failure envelope."""
+    return {"category": category, "severity": severity, "message": message}
+
+
+async def _resolve_datastore_id(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    name: str,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve a datastore display name to its moid via ``GET:/vcenter/datastore``.
+
+    Returns ``(datastore_id, None)`` on a unique match, or ``(None, envelope)``
+    with a terminal ``datastore_not_found`` / ``ambiguous_datastore`` response
+    dict. The listing forwards ``filter.names`` (exact match); ambiguity is
+    refused so the operator re-dispatches by an unambiguous name.
+    """
+    listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_DATASTORES, {"filter.names": [name]}
+    )
+    entries = _unwrap_value(listing)
+    ids = [
+        entry["datastore"]
+        for entry in (entries if isinstance(entries, list) else [])
+        if isinstance(entry, dict) and isinstance(entry.get("datastore"), str)
+    ]
+    if not ids:
+        return None, {
+            "status": "datastore_not_found",
+            "library_id": None,
+            "issues": [_issue("input", "error", f"datastore {name!r} matched no datastore")],
+        }
+    if len(ids) > 1:
+        return None, {
+            "status": "ambiguous_datastore",
+            "library_id": None,
+            "candidates": ids,
+            "issues": [
+                _issue("input", "error", f"datastore {name!r} matched {len(ids)} datastores")
+            ],
+        }
+    return ids[0], None
+
+
+async def _resolve_library_id(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    params: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve the target library id from ``library_id`` or ``library_name``.
+
+    ``library_id`` (an id) short-circuits; otherwise ``library_name`` is
+    resolved via ``Content.Library_find`` (``POST:/content/library?action=find``).
+    Returns ``(library_id, None)`` on success or ``(None, envelope)`` with a
+    terminal ``invalid_reference`` / ``library_not_found`` /
+    ``ambiguous_library`` response dict. Shared by the sync / status / items
+    composites.
+    """
+    passthrough = params.get("library_id")
+    if isinstance(passthrough, str) and passthrough:
+        return passthrough, None
+
+    library_name = params.get("library_name")
+    if not isinstance(library_name, str) or not library_name:
+        return None, {
+            "status": "invalid_reference",
+            "library_id": None,
+            "issues": [
+                _issue("input", "error", "supply library_id (id) or library_name to identify")
+            ],
+        }
+
+    library_ids = await _find_content_library_ids(
+        connector, target, operator, op_id=_OP_FIND_LIBRARY, spec={"name": library_name}
+    )
+    if not library_ids:
+        return None, {
+            "status": "library_not_found",
+            "library_id": None,
+            "issues": [_issue("input", "error", f"library {library_name!r} matched no library")],
+        }
+    if len(library_ids) > 1:
+        return None, {
+            "status": "ambiguous_library",
+            "library_id": None,
+            "candidates": library_ids,
+            "issues": [
+                _issue(
+                    "input",
+                    "error",
+                    f"library {library_name!r} matched {len(library_ids)} libraries",
+                )
+            ],
+        }
+    return library_ids[0], None
+
+
+def _build_subscription_info(params: dict[str, Any]) -> dict[str, Any]:
+    """Assemble the ``Content.Library.SubscriptionInfo`` body from *params*.
+
+    ``authentication_method`` / ``automatic_sync_enabled`` / ``on_demand`` /
+    ``subscription_url`` are the four the create requires; ``user_name`` /
+    ``password`` are sent only for ``BASIC`` auth, and ``ssl_thumbprint`` only
+    when supplied. The password rides the request body (and the durable
+    ``ApprovalRequest.params``) but never a preview / broadcast / audit-hash
+    surface -- see the module docstring.
+    """
+    auth_method = params.get("authentication_method") or "NONE"
+    info: dict[str, Any] = {
+        "authentication_method": auth_method,
+        "automatic_sync_enabled": bool(params.get("automatic_sync_enabled", False)),
+        "on_demand": bool(params.get("on_demand", True)),
+        "subscription_url": params["subscription_url"],
+    }
+    if auth_method == "BASIC":
+        username = params.get("username")
+        if isinstance(username, str):
+            info["user_name"] = username
+        password = params.get("password")
+        if isinstance(password, str) and password:
+            info["password"] = password
+    ssl_thumbprint = params.get("ssl_thumbprint")
+    if isinstance(ssl_thumbprint, str) and ssl_thumbprint:
+        info["ssl_thumbprint"] = ssl_thumbprint
+    return info
+
+
+async def content_library_subscribed_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Create a SUBSCRIBED content library subscribed to a remote publisher.
+
+    Op-id: ``vmware.composite.content_library.subscribed.create``.
+
+    Sub-ops (direct session):
+
+    1. ``GET:/vcenter/datastore`` -- resolve the ``datastore`` name to a moid
+       for the mandatory ``storage_backings`` entry (load-bearing: a
+       no/ambiguous match returns ``datastore_not_found`` /
+       ``ambiguous_datastore`` before any write).
+    2. ``POST:/content/subscribed-library`` -- the governed create (through
+       :func:`._write._write_sub_op`), body = ``Content.LibraryModel`` with a
+       ``DATASTORE`` storage backing and the assembled
+       ``Content.Library.SubscriptionInfo``. Returns the new library id (a
+       bare string on the modern ``/api`` surface).
+
+    The create is asynchronous on the vCenter side: it returns immediately and
+    the Content Library Service synchronises to the remote source in the
+    background (metadata only when ``on_demand`` is true). Poll readiness with
+    ``content_library.subscribed.status`` (``last_sync_time``) /
+    ``content_library.subscribed.items.list``.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"status": "created", "library_id": <id>, "name": ...,
+        "subscription_url": ..., "datastore_id": ..., "on_demand": ...,
+        "automatic_sync_enabled": ...}`` on success; a terminal
+        ``datastore_not_found`` / ``ambiguous_datastore`` / ``create_error``
+        envelope (``library_id=None``) otherwise. May instead return an
+        ``awaiting_approval`` / ``denied`` :class:`OperationResult` from the
+        write governance seam.
+    """
+    datastore_name = params["datastore"]
+    datastore_id, ds_err = await _resolve_datastore_id(connector, target, operator, datastore_name)
+    if ds_err is not None:
+        return ds_err
+
+    body: dict[str, Any] = {
+        "name": params["name"],
+        "storage_backings": [{"type": "DATASTORE", "datastore_id": datastore_id}],
+        "subscription_info": _build_subscription_info(params),
+    }
+    description = params.get("description")
+    if isinstance(description, str) and description:
+        body["description"] = description
+
+    try:
+        gate, payload = await _write_sub_op(
+            connector, target, operator, _OP_CREATE_SUBSCRIBED_LIBRARY, body
+        )
+    except httpx.HTTPError as exc:
+        return {
+            "status": "create_error",
+            "library_id": None,
+            "issues": [_issue("connector", "error", f"subscribed-library create failed: {exc}")],
+        }
+    if gate is not None:
+        return gate
+
+    library_id = _unwrap_value(payload)
+    if not isinstance(library_id, str) or not library_id:
+        return {
+            "status": "create_error",
+            "library_id": None,
+            "issues": [
+                _issue(
+                    "connector",
+                    "error",
+                    f"create returned no library id (got {type(library_id).__name__})",
+                )
+            ],
+        }
+    subscription_info = body["subscription_info"]
+    return {
+        "status": "created",
+        "library_id": library_id,
+        "name": params["name"],
+        "subscription_url": subscription_info["subscription_url"],
+        "datastore_id": datastore_id,
+        "on_demand": subscription_info["on_demand"],
+        "automatic_sync_enabled": subscription_info["automatic_sync_enabled"],
+    }
+
+
+async def content_library_subscribed_sync_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Force synchronisation of a SUBSCRIBED content library.
+
+    Op-id: ``vmware.composite.content_library.subscribed.sync``.
+
+    Sub-ops (direct session):
+
+    1. ``POST:/content/library?action=find`` -- resolve a ``library_name`` to
+       its id (skipped when ``library_id`` is supplied; un-gated read).
+    2. ``POST:/content/subscribed-library/{libraryId}?action=sync`` -- the
+       governed sync trigger (through :func:`._write._write_sub_op`).
+
+    The sync respects the library's ``on_demand`` setting and is asynchronous:
+    it returns immediately (HTTP 204) and does not wait for the content to
+    land. Calling it on a library already synchronising is a no-op vCenter-side.
+    Confirm completion with ``content_library.subscribed.status``
+    (``last_sync_time``) / ``content_library.subscribed.items.list``.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"status": "sync_triggered", "library_id": <id>}`` on success; a
+        terminal ``invalid_reference`` / ``library_not_found`` /
+        ``ambiguous_library`` / ``sync_error`` envelope otherwise. May instead
+        return an ``awaiting_approval`` / ``denied`` :class:`OperationResult`.
+    """
+    library_id, resolve_err = await _resolve_library_id(connector, target, operator, params)
+    if resolve_err is not None:
+        return resolve_err
+
+    try:
+        gate, _ = await _write_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_SYNC_SUBSCRIBED_LIBRARY,
+            {"libraryId": library_id},
+        )
+    except httpx.HTTPError as exc:
+        return {
+            "status": "sync_error",
+            "library_id": library_id,
+            "issues": [_issue("connector", "error", f"subscribed-library sync failed: {exc}")],
+        }
+    if gate is not None:
+        return gate
+
+    return {"status": "sync_triggered", "library_id": library_id}
+
+
+async def content_library_subscribed_status_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """Read a SUBSCRIBED content library's model + subscription state.
+
+    Op-id: ``vmware.composite.content_library.subscribed.status``.
+
+    Sub-ops (direct session, un-gated reads):
+
+    1. ``POST:/content/library?action=find`` -- resolve a ``library_name``
+       (skipped when ``library_id`` is supplied).
+    2. ``GET:/content/subscribed-library/{libraryId}`` -- read the
+       ``Content.LibraryModel`` back.
+
+    The readiness signal for the enable flow: ``last_sync_time`` is populated
+    once the first sync completes. The API contract omits the subscription
+    ``password`` from the GET response, so this read carries no secret.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"status": "ok", "library_id": ..., "name": ..., "type": ...,
+        "subscription_url": ..., "automatic_sync_enabled": ...,
+        "on_demand": ..., "last_sync_time": ..., "description": ...,
+        "storage_backings": [...]}`` on success; a terminal
+        ``invalid_reference`` / ``library_not_found`` / ``ambiguous_library``
+        envelope otherwise.
+    """
+    library_id, resolve_err = await _resolve_library_id(connector, target, operator, params)
+    if resolve_err is not None:
+        return resolve_err
+
+    detail = await _read_sub_op(
+        connector, target, operator, _OP_GET_SUBSCRIBED_LIBRARY, {"libraryId": library_id}
+    )
+    model = _unwrap_value(detail)
+    if not isinstance(model, dict):
+        return {
+            "status": "read_error",
+            "library_id": library_id,
+            "issues": [
+                _issue(
+                    "connector",
+                    "error",
+                    f"library read returned {type(model).__name__}, expected object",
+                )
+            ],
+        }
+    subscription_info = model.get("subscription_info")
+    subscription_info = subscription_info if isinstance(subscription_info, dict) else {}
+    return {
+        "status": "ok",
+        "library_id": library_id,
+        "name": model.get("name"),
+        "type": model.get("type"),
+        "subscription_url": subscription_info.get("subscription_url"),
+        "authentication_method": subscription_info.get("authentication_method"),
+        "automatic_sync_enabled": subscription_info.get("automatic_sync_enabled"),
+        "on_demand": subscription_info.get("on_demand"),
+        "last_sync_time": model.get("last_sync_time"),
+        "description": model.get("description"),
+        "storage_backings": model.get("storage_backings"),
+    }
+
+
+async def content_library_subscribed_items_list_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any]:
+    """List the items (synchronised TKr images) in a SUBSCRIBED library.
+
+    Op-id: ``vmware.composite.content_library.subscribed.items.list``.
+
+    Sub-ops (direct session, un-gated reads):
+
+    1. ``POST:/content/library?action=find`` -- resolve a ``library_name``
+       (skipped when ``library_id`` is supplied).
+    2. ``POST:/content/library/item?action=find`` -- every item id scoped to
+       the library.
+    3. ``GET:/content/library/item/{libraryItemId}`` -- per-item metadata.
+
+    The set-shaped ``items`` list is JSONFlux-reduced automatically by the
+    dispatcher once it crosses the 50-row / 4 KB threshold (a handle the
+    caller drills into with ``result_query``); each row carries the TKr-triage
+    fields (``name`` = the TKr version, ``cached`` = whether the image content
+    is downloaded).
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"library_id": ..., "item_count": N, "items": [{"id", "name",
+        "type", "version", "cached", "size", "last_sync_time"}, ...]}`` on
+        success; a terminal ``invalid_reference`` / ``library_not_found`` /
+        ``ambiguous_library`` envelope otherwise.
+    """
+    library_id, resolve_err = await _resolve_library_id(connector, target, operator, params)
+    if resolve_err is not None:
+        return resolve_err
+
+    item_ids = await _find_content_library_ids(
+        connector, target, operator, op_id=_OP_FIND_LIBRARY_ITEM, spec={"library_id": library_id}
+    )
+    items: list[dict[str, Any]] = []
+    for item_id in item_ids[:_ITEMS_HARD_CAP]:
+        detail = await _read_sub_op(
+            connector, target, operator, _OP_GET_LIBRARY_ITEM, {"libraryItemId": item_id}
+        )
+        model = _unwrap_value(detail)
+        if not isinstance(model, dict):
+            continue
+        items.append(
+            {
+                "id": model.get("id", item_id),
+                "name": model.get("name"),
+                "type": model.get("type"),
+                "version": model.get("version"),
+                "cached": model.get("cached"),
+                "size": model.get("size"),
+                "last_sync_time": model.get("last_sync_time"),
+            }
+        )
+    return {"library_id": library_id, "item_count": len(items), "items": items}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -83,6 +83,12 @@ from meho_backplane.connectors.vmware_rest.composites._host import (
     disk_mark_flash_composite,
     service_control_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._library import (
+    content_library_subscribed_create_composite,
+    content_library_subscribed_items_list_composite,
+    content_library_subscribed_status_composite,
+    content_library_subscribed_sync_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -138,6 +144,14 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     CLUSTER_DRS_VM_HOST_RULE_CREATE_RESPONSE_SCHEMA,
     CLUSTER_PATCH_PARAMETER_SCHEMA,
     CLUSTER_PATCH_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_CREATE_PARAMETER_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_PARAMETER_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_STATUS_PARAMETER_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_STATUS_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_SYNC_PARAMETER_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_SYNC_RESPONSE_SCHEMA,
     DATASTORE_USAGE_PARAMETER_SCHEMA,
     DATASTORE_USAGE_RESPONSE_SCHEMA,
     EVENT_TAIL_PARAMETER_SCHEMA,
@@ -402,6 +416,24 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Supervisor down', or 'has the Supervisor come up yet?'. Pair with "
         "'storage' for the SPBM policy id the enable spec needs and 'networking' "
         "for the workload / management network context."
+    ),
+    "content_library": (
+        "Use for the governed SUBSCRIBED content-library surface -- create a "
+        "content library subscribed to a remote publisher, force / confirm its "
+        "synchronisation, and list its items. The right group for standing up "
+        "the Tanzu Kubernetes release (TKr / VKr) image source a vSphere "
+        "Supervisor needs: pre-create a SUBSCRIBED library pointed at the "
+        "upstream VMware repo (subscribed.create, approval-gated, returns the "
+        "library id #3281's Supervisor enable spec consumes as "
+        "default_kubernetes_service_content_library), trigger a sync "
+        "(subscribed.sync, approval-gated, asynchronous), and read readiness "
+        "back -- subscribed.status (last_sync_time) and subscribed.items.list "
+        "(the synchronised TKr versions, JSONFlux-reduced). The right group for "
+        "'create the TKr content library', 'sync the Kubernetes release "
+        "library', or 'which TKr images are available?'. Distinct from the "
+        "content-library *item* deploy/import (the 'vm' group's "
+        "deploy_from_library / import_from_library) -- this group is the "
+        "library-container lifecycle, not the VM deploy."
     ),
 }
 
@@ -1709,6 +1741,95 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         tags=["composite", "write", "storage", "policy", "spbm", "destroy", "destructive"],
         safety_level="destructive",
         requires_approval=True,
+    ),
+    # Content-library SUBSCRIBED-library composites (#3495) -- the
+    # governed TKr/VKr image source for a vSphere Supervisor. Two
+    # caution + approval writes (create / sync) and two safe reads
+    # (status / items.list). Naming nests under the sibling #3331
+    # LOCAL-library family via the ``subscribed`` infix.
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.content_library.subscribed.create",
+        handler=content_library_subscribed_create_composite,
+        summary="Create a SUBSCRIBED content library (e.g. the Supervisor TKr/VKr image source).",
+        description=(
+            "Resolves the ``datastore`` name to a moid, then POSTs a "
+            "``Content.LibraryModel`` to POST:/content/subscribed-library with a "
+            "DATASTORE storage backing and a subscription to the given publisher "
+            "URL (e.g. https://wp-content.vmware.com/v2/latest/lib.json for the "
+            "upstream VMware Tanzu Kubernetes release repo). Returns the new "
+            "library id — the value #3281's Supervisor enable spec consumes as "
+            "``default_kubernetes_service_content_library``. The create is "
+            "asynchronous vCenter-side (metadata syncs in the background; item "
+            "content lazily when ``on_demand``). The optional BASIC-auth "
+            "``password`` is kept off every preview / broadcast / audit-hash "
+            "surface. Approval-gated (caution)."
+        ),
+        parameter_schema=CONTENT_LIBRARY_SUBSCRIBED_CREATE_PARAMETER_SCHEMA,
+        response_schema=CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA,
+        group_key="content_library",
+        tags=["composite", "content-library", "subscribed", "tkr", "vks"],
+        safety_level="caution",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.content_library.subscribed.sync",
+        handler=content_library_subscribed_sync_composite,
+        summary="Force synchronisation of a SUBSCRIBED content library.",
+        description=(
+            "Resolves ``library_id`` / ``library_name``, then forces a sync via "
+            "POST:/content/subscribed-library/{libraryId}?action=sync. "
+            "Asynchronous: returns as soon as the sync is accepted (a no-op if "
+            "one is already running); it respects the library's ``on_demand`` "
+            "setting. Confirm completion with content_library.subscribed.status "
+            "(last_sync_time) / .items.list. Approval-gated (caution)."
+        ),
+        parameter_schema=CONTENT_LIBRARY_SUBSCRIBED_SYNC_PARAMETER_SCHEMA,
+        response_schema=CONTENT_LIBRARY_SUBSCRIBED_SYNC_RESPONSE_SCHEMA,
+        group_key="content_library",
+        tags=["composite", "content-library", "subscribed", "sync"],
+        safety_level="caution",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.content_library.subscribed.status",
+        handler=content_library_subscribed_status_composite,
+        summary="Read a SUBSCRIBED content library's model + subscription state.",
+        description=(
+            "Resolves ``library_id`` / ``library_name``, then reads the "
+            "Content.LibraryModel via GET:/content/subscribed-library/{libraryId}. "
+            "Surfaces name / type / subscription URL / sync mode and "
+            "``last_sync_time`` — the readiness signal, populated once the first "
+            "metadata sync completes. The API omits the subscription password "
+            "from the GET response, so this read carries no secret. Read-only."
+        ),
+        parameter_schema=CONTENT_LIBRARY_SUBSCRIBED_STATUS_PARAMETER_SCHEMA,
+        response_schema=CONTENT_LIBRARY_SUBSCRIBED_STATUS_RESPONSE_SCHEMA,
+        group_key="content_library",
+        tags=["composite", "read-only", "content-library", "subscribed"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.content_library.subscribed.items.list",
+        handler=content_library_subscribed_items_list_composite,
+        summary="List the items (synchronised TKr images) in a SUBSCRIBED library.",
+        description=(
+            "Resolves ``library_id`` / ``library_name``, finds every item id "
+            "scoped to the library via POST:/content/library/item?action=find, "
+            "then reads each item's metadata. Each row carries the TKr-triage "
+            "fields — ``name`` (the TKr version), ``type``, ``version``, "
+            "``cached`` (whether the multi-GB image content is downloaded), "
+            "``size``, ``last_sync_time``. The set-shaped ``items`` list is "
+            "JSONFlux-reduced automatically once it crosses the dispatcher's "
+            "50-row / 4 KB threshold (drill in with result_query). Read-only."
+        ),
+        parameter_schema=CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_PARAMETER_SCHEMA,
+        response_schema=CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA,
+        group_key="content_library",
+        tags=["composite", "read-only", "content-library", "subscribed", "tkr"],
+        safety_level="safe",
+        requires_approval=False,
     ),
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1377,6 +1377,56 @@ async def _storage_policy_delete_preview(ctx: PreviewContext) -> dict[str, Any] 
 
 #: op_id → builder for the write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
+async def _content_library_subscribed_create_preview(
+    ctx: PreviewContext,
+) -> dict[str, Any] | None:
+    """Preview ``content_library.subscribed.create`` — non-secret fields only (no I/O).
+
+    Secret hygiene (#3495): echoes the library identity + subscription shape
+    the reviewer needs to decide (name, publisher URL, backing datastore,
+    auth method, sync mode, whether an SSL thumbprint was pinned) but **never**
+    the ``password`` / ``username`` — so no credential can reach the durable
+    ``proposed_effect`` row through this path by construction. The broadcast
+    ``_CREDENTIAL_WRITE_OPS`` pin and the ``params_hash``-only audit are the
+    other two surfaces; this builder is the park-time one.
+    """
+    name = ctx.params.get("name")
+    subscription_url = ctx.params.get("subscription_url")
+    datastore = ctx.params.get("datastore")
+    if not isinstance(name, str) or not isinstance(subscription_url, str):
+        return None
+    return {
+        "name": name,
+        "subscription_url": subscription_url,
+        "datastore": datastore if isinstance(datastore, str) else None,
+        "authentication_method": ctx.params.get("authentication_method") or "NONE",
+        "automatic_sync_enabled": bool(ctx.params.get("automatic_sync_enabled", False)),
+        "on_demand": bool(ctx.params.get("on_demand", True)),
+        "ssl_thumbprint_pinned": bool(ctx.params.get("ssl_thumbprint")),
+    }
+
+
+async def _content_library_subscribed_sync_preview(
+    ctx: PreviewContext,
+) -> dict[str, Any] | None:
+    """Preview ``content_library.subscribed.sync`` — the library reference only.
+
+    Echoes whichever reference the caller supplied (``library_id`` or
+    ``library_name``) so the reviewer sees which library the forced sync
+    targets. No I/O, no secret (the sync op carries no credential).
+    """
+    library_id = ctx.params.get("library_id")
+    library_name = ctx.params.get("library_name")
+    if not (isinstance(library_id, str) and library_id) and not (
+        isinstance(library_name, str) and library_name
+    ):
+        return None
+    return {
+        "library_id": library_id if isinstance(library_id, str) else None,
+        "library_name": library_name if isinstance(library_name, str) else None,
+    }
+
+
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.supervisor.enable": _supervisor_enable_preview,
     "vmware.composite.supervisor.disable": _supervisor_disable_preview,
@@ -1411,13 +1461,17 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.host.service_control": _host_service_control_preview,
     "vmware.composite.storage_policy.create": _storage_policy_create_preview,
     "vmware.composite.storage_policy.delete": _storage_policy_delete_preview,
+    "vmware.composite.content_library.subscribed.create": (
+        _content_library_subscribed_create_preview
+    ),
+    "vmware.composite.content_library.subscribed.sync": _content_library_subscribed_sync_preview,
 }
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 33 write-composite park-time preview builders. Import-time.
+    """Wire the 35 write-composite park-time preview builders. Import-time.
 
-    The 11 read composites register no builder — they are
+    The 13 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be
     dead code.
     """

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -5335,3 +5335,464 @@ STORAGE_POLICY_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
     "required": ["status", "policy_id"],
     "additionalProperties": True,
 }
+
+
+# ===========================================================================
+# Content-library SUBSCRIBED-library composites (#3495)
+# ===========================================================================
+
+
+#: ``vmware.composite.content_library.subscribed.create`` parameter schema.
+#:
+#: Create a SUBSCRIBED content library subscribed to a remote publisher (the
+#: TKr/VKr image source for a vSphere Supervisor). The subscription
+#: ``password`` may be secret; it rides the request body but never a preview /
+#: broadcast / audit-hash surface (the op is pinned into
+#: ``_CREDENTIAL_WRITE_OPS`` and carries a bespoke identity-only preview).
+CONTENT_LIBRARY_SUBSCRIBED_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name for the new subscribed library "
+                "(``Content.LibraryModel.name``). Names need not be unique."
+            ),
+        },
+        "subscription_url": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Publisher endpoint URL serving the library metadata "
+                "(``Content.Library.SubscriptionInfo.subscription_url``), e.g. "
+                "``https://wp-content.vmware.com/v2/latest/lib.json`` for the "
+                "upstream VMware Tanzu Kubernetes release (TKr/VKr) repo."
+            ),
+        },
+        "datastore": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the datastore backing the library "
+                "(``Content.Library.StorageBacking`` of type ``DATASTORE``), "
+                "resolved to a moid via ``GET:/vcenter/datastore`` "
+                "(``filter.names``, exact match). A name matching no datastore "
+                "returns ``status='datastore_not_found'``, more than one "
+                "``status='ambiguous_datastore'`` — no library is created. A "
+                "storage backing is required even for an on-demand subscribed "
+                "library (only item metadata syncs, but the backing is still "
+                "mandatory)."
+            ),
+        },
+        "on_demand": {
+            "type": "boolean",
+            "default": True,
+            "description": (
+                "When true (default), only item **metadata** synchronises; each "
+                "item's content (files) is pulled on first use. Recommended for "
+                "a TKr library — the ~3 GB-per-release image content then pulls "
+                "lazily at guest-cluster-create time rather than all up front. "
+                "When false, all content synchronises in advance."
+            ),
+        },
+        "automatic_sync_enabled": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Whether the library participates in automatic (periodic) "
+                "synchronisation. The subscription stays active either way; "
+                "with this false, sync happens only via an explicit "
+                "``content_library.subscribed.sync``. Automatic sync also "
+                "requires the global content-library automatic-sync option to "
+                "be enabled."
+            ),
+        },
+        "authentication_method": {
+            "type": "string",
+            "enum": ["NONE", "BASIC"],
+            "default": "NONE",
+            "description": (
+                "How the subscribed library authenticates to the publisher. "
+                "``NONE`` for a public endpoint (the VMware TKr repo); ``BASIC`` "
+                "for HTTP Basic, in which case ``username`` / ``password`` are "
+                "sent."
+            ),
+        },
+        "username": {
+            "type": "string",
+            "description": (
+                "Username for ``BASIC`` authentication "
+                "(``Content.Library.SubscriptionInfo.user_name``). Ignored when "
+                "``authentication_method`` is ``NONE``."
+            ),
+        },
+        "password": {
+            "type": "string",
+            "description": (
+                "Password for ``BASIC`` authentication "
+                "(``Content.Library.SubscriptionInfo.password``). Secret: kept "
+                "off every preview / broadcast / audit-hash surface. Ignored "
+                "when ``authentication_method`` is ``NONE``."
+            ),
+        },
+        "ssl_thumbprint": {
+            "type": "string",
+            "description": (
+                "Optional SHA-1 thumbprint of the publisher's SSL certificate "
+                "(``Content.Library.SubscriptionInfo.ssl_thumbprint``). When "
+                "set, the certificate is pinned to this thumbprint instead of "
+                "the normal chain validation."
+            ),
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional human-readable library description.",
+        },
+    },
+    "required": ["name", "subscription_url", "datastore"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.content_library.subscribed.create`` response schema.
+CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "created",
+                "datastore_not_found",
+                "ambiguous_datastore",
+                "create_error",
+            ],
+            "description": (
+                "``'created'`` — the subscribed library was created and its id "
+                "returned (the background sync to the publisher has begun); "
+                "``'datastore_not_found'`` / ``'ambiguous_datastore'`` — the "
+                "``datastore`` name matched zero / many datastores (no library "
+                "created); ``'create_error'`` — the create call itself faulted, "
+                "surfaced as a structured message under ``issues`` rather than a "
+                "raw vendor error."
+            ),
+        },
+        "library_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Identifier of the newly created subscribed library "
+                "(``com.vmware.content.Library``) — the id #3281's enable spec "
+                "consumes as ``default_kubernetes_service_content_library``. "
+                "``null`` unless ``status='created'``."
+            ),
+        },
+        "name": {"type": ["string", "null"], "description": "Echo of the library name."},
+        "subscription_url": {
+            "type": ["string", "null"],
+            "description": "Echo of the publisher subscription URL.",
+        },
+        "datastore_id": {
+            "type": ["string", "null"],
+            "description": "Resolved datastore moid used for the storage backing.",
+        },
+        "on_demand": {
+            "type": ["boolean", "null"],
+            "description": "Echo of the effective on-demand sync mode.",
+        },
+        "automatic_sync_enabled": {
+            "type": ["boolean", "null"],
+            "description": "Echo of the effective automatic-sync setting.",
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Datastore moids that matched on ``ambiguous_datastore``.",
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Structured issue entries on a non-``created`` status.",
+        },
+    },
+    "required": ["status", "library_id"],
+}
+
+
+#: ``vmware.composite.content_library.subscribed.sync`` parameter schema.
+CONTENT_LIBRARY_SUBSCRIBED_SYNC_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "library_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Subscribed-library id to synchronise. Supply this **or** "
+                "``library_name``; ``library_id`` wins when both are present."
+            ),
+        },
+        "library_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Library display name, resolved to an id via "
+                "``POST:/content/library?action=find``. A name matching no "
+                "library returns ``status='library_not_found'``, more than one "
+                "``status='ambiguous_library'``. Ignored when ``library_id`` is "
+                "given."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.content_library.subscribed.sync`` response schema.
+CONTENT_LIBRARY_SUBSCRIBED_SYNC_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "sync_triggered",
+                "invalid_reference",
+                "library_not_found",
+                "ambiguous_library",
+                "sync_error",
+            ],
+            "description": (
+                "``'sync_triggered'`` — the forced synchronisation was accepted "
+                "(asynchronous: it does not wait for content to land, and is a "
+                "no-op if a sync is already in progress); ``'invalid_reference'`` "
+                "— neither ``library_id`` nor ``library_name`` was supplied; "
+                "``'library_not_found'`` / ``'ambiguous_library'`` — the "
+                "``library_name`` lookup matched zero / many libraries; "
+                "``'sync_error'`` — the sync call itself faulted."
+            ),
+        },
+        "library_id": {
+            "type": ["string", "null"],
+            "description": "The resolved library id the sync targeted.",
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Library ids that matched on ``ambiguous_library``.",
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Structured issue entries on a non-``sync_triggered`` status.",
+        },
+    },
+    "required": ["status", "library_id"],
+}
+
+
+#: ``vmware.composite.content_library.subscribed.status`` parameter schema.
+CONTENT_LIBRARY_SUBSCRIBED_STATUS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "library_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Subscribed-library id to read. Supply this **or** "
+                "``library_name``; ``library_id`` wins when both are present."
+            ),
+        },
+        "library_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Library display name, resolved to an id via "
+                "``POST:/content/library?action=find`` (see the sync op's "
+                "``library_name`` for the not-found / ambiguous semantics). "
+                "Ignored when ``library_id`` is given."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.content_library.subscribed.status`` response schema.
+CONTENT_LIBRARY_SUBSCRIBED_STATUS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "invalid_reference",
+                "library_not_found",
+                "ambiguous_library",
+                "read_error",
+            ],
+            "description": (
+                "``'ok'`` — the library model was read; ``'invalid_reference'`` / "
+                "``'library_not_found'`` / ``'ambiguous_library'`` — reference "
+                "resolution failures (see the sync op); ``'read_error'`` — the "
+                "GET returned a non-object payload."
+            ),
+        },
+        "library_id": {"type": ["string", "null"], "description": "The resolved library id."},
+        "name": {"type": ["string", "null"], "description": "Library display name."},
+        "type": {
+            "type": ["string", "null"],
+            "description": "Library type (``SUBSCRIBED`` for a subscribed library).",
+        },
+        "subscription_url": {
+            "type": ["string", "null"],
+            "description": "Publisher subscription URL (no secret in the GET response).",
+        },
+        "authentication_method": {
+            "type": ["string", "null"],
+            "description": "Subscription authentication method (``NONE`` / ``BASIC``).",
+        },
+        "automatic_sync_enabled": {
+            "type": ["boolean", "null"],
+            "description": "Whether automatic synchronisation is enabled.",
+        },
+        "on_demand": {
+            "type": ["boolean", "null"],
+            "description": "Whether the library synchronises item content on demand.",
+        },
+        "last_sync_time": {
+            "type": ["string", "null"],
+            "description": (
+                "ISO-8601 timestamp of the last successful synchronisation — the "
+                "readiness signal: populated once the first metadata sync "
+                "completes. ``null`` before the first sync."
+            ),
+        },
+        "description": {
+            "type": ["string", "null"],
+            "description": "Library description, if any.",
+        },
+        "storage_backings": {
+            "type": ["array", "null"],
+            "items": {"type": "object"},
+            "description": "The library's storage backings (as returned by vCenter).",
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Library ids that matched on ``ambiguous_library``.",
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Structured issue entries on a non-``ok`` status.",
+        },
+    },
+    "required": ["status", "library_id"],
+}
+
+
+#: ``vmware.composite.content_library.subscribed.items.list`` parameter schema.
+CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "library_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Subscribed-library id whose items to list. Supply this **or** "
+                "``library_name``; ``library_id`` wins when both are present."
+            ),
+        },
+        "library_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Library display name, resolved to an id via "
+                "``POST:/content/library?action=find`` (see the sync op for the "
+                "not-found / ambiguous semantics). Ignored when ``library_id`` "
+                "is given."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.content_library.subscribed.items.list`` response schema.
+#:
+#: The ``items`` collection is JSONFlux-reduced automatically once it crosses
+#: the dispatcher's 50-row / 4 KB threshold (drill in with ``result_query``).
+CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "invalid_reference",
+                "library_not_found",
+                "ambiguous_library",
+            ],
+            "description": (
+                "Present only on a reference-resolution failure; a successful "
+                "listing omits ``status`` and returns ``library_id`` + "
+                "``item_count`` + ``items``."
+            ),
+        },
+        "library_id": {"type": ["string", "null"], "description": "The resolved library id."},
+        "item_count": {
+            "type": "integer",
+            "description": "Number of items read from the library.",
+        },
+        "items": {
+            "type": "array",
+            "description": (
+                "One row per library item. For a TKr library each row's "
+                "``name`` is a Tanzu Kubernetes release version and ``cached`` "
+                "indicates whether the (multi-GB) image content is downloaded."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Library item id."},
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "Item name (the TKr version for a TKr item).",
+                    },
+                    "type": {
+                        "type": ["string", "null"],
+                        "description": "Item type (e.g. ``ovf``, ``vm-template``).",
+                    },
+                    "version": {
+                        "type": ["string", "null"],
+                        "description": "Item metadata version.",
+                    },
+                    "cached": {
+                        "type": ["boolean", "null"],
+                        "description": "Whether the item's content is synchronised locally.",
+                    },
+                    "size": {
+                        "type": ["integer", "null"],
+                        "description": "Aggregate size of the item's files in bytes, if reported.",
+                    },
+                    "last_sync_time": {
+                        "type": ["string", "null"],
+                        "description": "ISO-8601 timestamp of the item's last sync.",
+                    },
+                },
+                "required": ["id"],
+            },
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Library ids that matched on ``ambiguous_library``.",
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Structured issue entries on a reference-resolution failure.",
+        },
+    },
+    "required": ["library_id"],
+}

--- a/backend/tests/test_connectors_vmware_rest_composites_library.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_library.py
@@ -1,0 +1,620 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the SUBSCRIBED content-library composites (#3495).
+
+The four ``vmware.composite.content_library.subscribed.*`` handlers dispatch
+their sub-ops directly on the connector session (``_get_json`` / ``_post_json``
+mounted through ``mount_op_path``), and the two writes (create / sync) route
+through the #2254 ``enforce_subop_policy`` seam via ``_write._write_sub_op``.
+These tests stub the connector session with a recording double and stub the
+policy seam with a recorder, asserting:
+
+* the create builds the right ``Content.LibraryModel`` body (DATASTORE storage
+  backing + subscription_info), resolves the datastore by name, and returns
+  the new library id;
+* BASIC auth threads ``user_name`` / ``password`` into subscription_info while
+  ``NONE`` (the default) sends neither;
+* sync / status / items.list resolve ``library_id`` / ``library_name`` and
+  refuse ambiguity before any action;
+* the two writes are gated (``dangerous`` / ``requires_approval=False`` at the
+  sub-op seam — the top-level ``caution`` + approval posture is proven in
+  ``test_connectors_vmware_rest_composites_register`` /
+  ``_write_register``) and short-circuit verbatim on a parked gate;
+* the reads are never gated;
+* the create's park-time preview + broadcast classification keep the
+  subscription ``password`` off the governed surfaces (secret hygiene);
+* each handler's payload validates against its registered response schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+from jsonschema import Draft202012Validator
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import _CREDENTIAL_WRITE_OPS, classify_op
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites import _library, _write
+from meho_backplane.connectors.vmware_rest.composites._library import (
+    content_library_subscribed_create_composite,
+    content_library_subscribed_items_list_composite,
+    content_library_subscribed_status_composite,
+    content_library_subscribed_sync_composite,
+)
+from meho_backplane.connectors.vmware_rest.composites._write_preview import (
+    _content_library_subscribed_create_preview,
+)
+from meho_backplane.connectors.vmware_rest.composites.schemas import (
+    CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_STATUS_RESPONSE_SCHEMA,
+    CONTENT_LIBRARY_SUBSCRIBED_SYNC_RESPONSE_SCHEMA,
+)
+from meho_backplane.operations._preview import PreviewContext
+
+_CREATE_OP = "POST:/content/subscribed-library"
+_CREATE_PATH = "/api/content/subscribed-library"
+_SYNC_OP = "POST:/content/subscribed-library/{libraryId}?action=sync"
+_FIND_LIBRARY_PATH = "/api/content/library?action=find"
+_FIND_ITEM_PATH = "/api/content/library/item?action=find"
+_DATASTORE_PATH = "/api/vcenter/datastore"
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-subscribed-library",
+        name="Subscribed Library Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a1"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _RecordingConnector:
+    """Stub connector session: records sub-calls, serves canned JSON by path."""
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        del target, operator
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return query
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: dict[str, Any] | None = None
+    ) -> Any:
+        del target, operator
+        self.calls.append({"method": "GET", "path": path, "query": params, "body": None})
+        return self._serve(path)
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        timeout: Any = httpx.USE_CLIENT_DEFAULT,
+    ) -> Any:
+        del target, operator, data, extra_headers, timeout
+        self.calls.append({"method": verb, "path": path, "query": None, "body": json})
+        return self._serve(path)
+
+    def _serve(self, path: str) -> Any:
+        payload = self._responses[path]
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+
+class _GateRecorder:
+    """Recording stub for ``enforce_subop_policy``; returns a canned verdict."""
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        connector_id: str,
+        op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
+        params: dict[str, Any],
+    ) -> OperationResult | None:
+        self.calls.append(
+            {
+                "op_id": op_id,
+                "connector_id": connector_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
+                "params": dict(params),
+            }
+        )
+        return self._gate_for.get(op_id)
+
+    @property
+    def gated_op_ids(self) -> list[str]:
+        return [c["op_id"] for c in self.calls]
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+def _install_gate(monkeypatch: pytest.MonkeyPatch, recorder: _GateRecorder) -> _GateRecorder:
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+def _awaiting(op_id: str) -> OperationResult:
+    return OperationResult(
+        status="awaiting_approval",
+        op_id=op_id,
+        result=None,
+        duration_ms=1.0,
+        extras={"approval_request_id": "00000000-0000-0000-0000-0000000000aa"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_happy_path_resolves_datastore_and_builds_model_body(
+    gate: _GateRecorder,
+) -> None:
+    conn = _RecordingConnector(
+        {
+            _DATASTORE_PATH: [{"datastore": "datastore-42", "name": "nfs-lab"}],
+            _CREATE_PATH: "lib-new-1",
+        }
+    )
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "name": "vkr-lib",
+            "subscription_url": "https://wp-content.vmware.com/v2/latest/lib.json",
+            "datastore": "nfs-lab",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "created"
+    assert out["library_id"] == "lib-new-1"
+    assert out["datastore_id"] == "datastore-42"
+    assert out["on_demand"] is True  # default
+    assert out["automatic_sync_enabled"] is False  # default
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA).validate(out)
+
+    # Datastore resolve (GET) then create (POST) in order.
+    assert [c["path"] for c in conn.calls] == [_DATASTORE_PATH, _CREATE_PATH]
+    body = conn.calls[1]["body"]
+    assert body["name"] == "vkr-lib"
+    assert body["storage_backings"] == [{"type": "DATASTORE", "datastore_id": "datastore-42"}]
+    info = body["subscription_info"]
+    assert info["subscription_url"] == "https://wp-content.vmware.com/v2/latest/lib.json"
+    assert info["authentication_method"] == "NONE"
+    assert info["on_demand"] is True
+    assert info["automatic_sync_enabled"] is False
+    # NONE auth sends no credential.
+    assert "password" not in info
+    assert "user_name" not in info
+
+    # Only the create POST is gated; the datastore read is not.
+    assert gate.gated_op_ids == [_CREATE_OP]
+    assert gate.calls[0]["safety_level"] == "dangerous"
+    assert gate.calls[0]["requires_approval"] is False
+
+
+async def test_create_basic_auth_threads_username_and_password(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        {
+            _DATASTORE_PATH: [{"datastore": "ds-1", "name": "ds"}],
+            _CREATE_PATH: "lib-2",
+        }
+    )
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "name": "priv",
+            "subscription_url": "https://host/lib.json",
+            "datastore": "ds",
+            "authentication_method": "BASIC",
+            "username": "svc",
+            "password": "s3cret",
+            "on_demand": False,
+            "automatic_sync_enabled": True,
+            "ssl_thumbprint": "AA:BB",
+            "description": "private mirror",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "created"
+    body = conn.calls[1]["body"]
+    info = body["subscription_info"]
+    assert info["authentication_method"] == "BASIC"
+    assert info["user_name"] == "svc"
+    assert info["password"] == "s3cret"
+    assert info["ssl_thumbprint"] == "AA:BB"
+    assert info["on_demand"] is False
+    assert info["automatic_sync_enabled"] is True
+    assert body["description"] == "private mirror"
+
+
+async def test_create_datastore_not_found_refuses_before_write(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({_DATASTORE_PATH: []})
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "x", "subscription_url": "https://h/lib.json", "datastore": "gone"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "datastore_not_found"
+    assert out["library_id"] is None
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA).validate(out)
+    # No create POST, no gate.
+    assert [c["path"] for c in conn.calls] == [_DATASTORE_PATH]
+    assert gate.calls == []
+
+
+async def test_create_ambiguous_datastore_refuses_with_candidates(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        {
+            _DATASTORE_PATH: [
+                {"datastore": "ds-a", "name": "dup"},
+                {"datastore": "ds-b", "name": "dup"},
+            ]
+        }
+    )
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "x", "subscription_url": "https://h/lib.json", "datastore": "dup"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous_datastore"
+    assert set(out["candidates"]) == {"ds-a", "ds-b"}
+    assert gate.calls == []
+
+
+async def test_create_gate_short_circuits_before_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_gate(monkeypatch, _GateRecorder(gate_for={_CREATE_OP: _awaiting(_CREATE_OP)}))
+    conn = _RecordingConnector({_DATASTORE_PATH: [{"datastore": "ds-1", "name": "ds"}]})
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "x", "subscription_url": "https://h/lib.json", "datastore": "ds"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    # Datastore resolved, but the create POST never reached the wire.
+    assert [c["path"] for c in conn.calls] == [_DATASTORE_PATH]
+
+
+async def test_create_http_fault_surfaces_create_error(gate: _GateRecorder) -> None:
+    fault = httpx.HTTPStatusError(
+        "boom",
+        request=httpx.Request("POST", "https://vc/api/content/subscribed-library"),
+        response=httpx.Response(500),
+    )
+    conn = _RecordingConnector(
+        {_DATASTORE_PATH: [{"datastore": "ds-1", "name": "ds"}], _CREATE_PATH: fault}
+    )
+    out = await content_library_subscribed_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "x", "subscription_url": "https://h/lib.json", "datastore": "ds"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "create_error"
+    assert out["library_id"] is None
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_CREATE_RESPONSE_SCHEMA).validate(out)
+
+
+# ---------------------------------------------------------------------------
+# sync
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_by_library_id_triggers_and_gates(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({"/api/content/subscribed-library/lib-1?action=sync": None})
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_id": "lib-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out == {"status": "sync_triggered", "library_id": "lib-1"}
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_SYNC_RESPONSE_SCHEMA).validate(out)
+    # No name resolution when library_id is given; only the sync POST is gated.
+    assert [c["path"] for c in conn.calls] == ["/api/content/subscribed-library/lib-1?action=sync"]
+    assert gate.gated_op_ids == [_SYNC_OP]
+    assert gate.calls[0]["params"] == {"libraryId": "lib-1"}
+
+
+async def test_sync_by_library_name_resolves_then_syncs(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        {
+            _FIND_LIBRARY_PATH: ["lib-9"],
+            "/api/content/subscribed-library/lib-9?action=sync": None,
+        }
+    )
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_name": "vkr-lib"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "sync_triggered"
+    assert out["library_id"] == "lib-9"
+    assert [c["path"] for c in conn.calls] == [
+        _FIND_LIBRARY_PATH,
+        "/api/content/subscribed-library/lib-9?action=sync",
+    ]
+    # The find is un-gated; only the sync write hits the seam.
+    assert gate.gated_op_ids == [_SYNC_OP]
+
+
+async def test_sync_invalid_reference_when_neither_supplied(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({})
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "invalid_reference"
+    assert conn.calls == []
+    assert gate.calls == []
+
+
+async def test_sync_library_not_found(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({_FIND_LIBRARY_PATH: []})
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_name": "nope"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "library_not_found"
+    assert gate.calls == []
+
+
+async def test_sync_ambiguous_library(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({_FIND_LIBRARY_PATH: ["a", "b"]})
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_name": "dup"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous_library"
+    assert set(out["candidates"]) == {"a", "b"}
+    assert gate.calls == []
+
+
+async def test_sync_gate_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_gate(monkeypatch, _GateRecorder(gate_for={_SYNC_OP: _awaiting(_SYNC_OP)}))
+    conn = _RecordingConnector({})
+    out = await content_library_subscribed_sync_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_id": "lib-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert conn.calls == []  # sync POST never issued
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+async def test_status_reads_model_without_secret(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        {
+            "/api/content/subscribed-library/lib-1": {
+                "name": "vkr-lib",
+                "type": "SUBSCRIBED",
+                "last_sync_time": "2026-09-08T10:00:00Z",
+                "description": "TKr source",
+                "storage_backings": [{"type": "DATASTORE", "datastore_id": "ds-1"}],
+                "subscription_info": {
+                    "subscription_url": "https://wp-content.vmware.com/v2/latest/lib.json",
+                    "authentication_method": "NONE",
+                    "automatic_sync_enabled": False,
+                    "on_demand": True,
+                },
+            }
+        }
+    )
+    out = await content_library_subscribed_status_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_id": "lib-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ok"
+    assert out["library_id"] == "lib-1"
+    assert out["name"] == "vkr-lib"
+    assert out["type"] == "SUBSCRIBED"
+    assert out["last_sync_time"] == "2026-09-08T10:00:00Z"
+    assert out["subscription_url"] == "https://wp-content.vmware.com/v2/latest/lib.json"
+    assert out["on_demand"] is True
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_STATUS_RESPONSE_SCHEMA).validate(out)
+    # Reads are never gated.
+    assert gate.calls == []
+
+
+async def test_status_invalid_reference(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({})
+    out = await content_library_subscribed_status_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "invalid_reference"
+    assert conn.calls == []
+
+
+# ---------------------------------------------------------------------------
+# items.list
+# ---------------------------------------------------------------------------
+
+
+async def test_items_list_returns_tkr_rows(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector(
+        {
+            _FIND_ITEM_PATH: ["item-1", "item-2"],
+            "/api/content/library/item/item-1": {
+                "id": "item-1",
+                "name": "v1.33.6---vmware.1-fips-vkr.2",
+                "type": "vmtx",
+                "version": "3",
+                "cached": True,
+                "size": 3221225472,
+                "last_sync_time": "2026-09-08T09:00:00Z",
+            },
+            "/api/content/library/item/item-2": {
+                "id": "item-2",
+                "name": "v1.32.4---vmware.1-vkr.1",
+                "type": "vmtx",
+                "version": "1",
+                "cached": False,
+                "size": None,
+                "last_sync_time": None,
+            },
+        }
+    )
+    out = await content_library_subscribed_items_list_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_id": "lib-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["library_id"] == "lib-1"
+    assert out["item_count"] == 2
+    names = {row["name"] for row in out["items"]}
+    assert names == {"v1.33.6---vmware.1-fips-vkr.2", "v1.32.4---vmware.1-vkr.1"}
+    assert out["items"][0]["cached"] is True
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA).validate(out)
+    # find (POST, un-gated) + one GET per item; no write gate.
+    assert conn.calls[0]["path"] == _FIND_ITEM_PATH
+    assert gate.calls == []
+
+
+async def test_items_list_empty_library(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({_FIND_ITEM_PATH: []})
+    out = await content_library_subscribed_items_list_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_id": "lib-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["item_count"] == 0
+    assert out["items"] == []
+    Draft202012Validator(CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST_RESPONSE_SCHEMA).validate(out)
+
+
+async def test_items_list_ambiguous_library_refuses(gate: _GateRecorder) -> None:
+    conn = _RecordingConnector({_FIND_LIBRARY_PATH: ["a", "b"]})
+    out = await content_library_subscribed_items_list_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_name": "dup"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous_library"
+    # Refused at resolution; the item find never ran.
+    assert [c["path"] for c in conn.calls] == [_FIND_LIBRARY_PATH]
+
+
+# ---------------------------------------------------------------------------
+# Secret hygiene
+# ---------------------------------------------------------------------------
+
+
+async def test_create_preview_echoes_identity_only_never_the_password() -> None:
+    ctx = PreviewContext(
+        descriptor=object(),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "name": "vkr-lib",
+            "subscription_url": "https://wp-content.vmware.com/v2/latest/lib.json",
+            "datastore": "nfs-lab",
+            "authentication_method": "BASIC",
+            "username": "svc",
+            "password": "s3cret",
+            "ssl_thumbprint": "AA:BB",
+        },
+    )
+    preview = await _content_library_subscribed_create_preview(ctx)
+    assert preview is not None
+    # The reviewer sees the blast radius...
+    assert preview["name"] == "vkr-lib"
+    assert preview["subscription_url"] == "https://wp-content.vmware.com/v2/latest/lib.json"
+    assert preview["datastore"] == "nfs-lab"
+    assert preview["authentication_method"] == "BASIC"
+    assert preview["ssl_thumbprint_pinned"] is True
+    # ...but never the credential material.
+    flat = repr(preview)
+    assert "s3cret" not in flat
+    assert "svc" not in flat
+    assert "password" not in preview
+    assert "username" not in preview
+
+
+def test_create_op_is_pinned_credential_write() -> None:
+    """The create op broadcasts aggregate-only (its params carry a password)."""
+    assert "vmware.composite.content_library.subscribed.create" in _CREDENTIAL_WRITE_OPS
+    assert classify_op("vmware.composite.content_library.subscribed.create") == "credential_write"
+    # The sync / reads carry no secret and are not pinned.
+    assert "vmware.composite.content_library.subscribed.sync" not in _CREDENTIAL_WRITE_OPS
+
+
+def test_governed_subop_manifest_lists_the_two_writes() -> None:
+    from meho_backplane.connectors.vmware_rest.composites._governed_subops import (
+        _GOVERNED_SUBOP_MANIFEST,
+    )
+
+    assert (
+        _GOVERNED_SUBOP_MANIFEST["vmware.composite.content_library.subscribed.create"]
+        == _library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_CREATE
+    )
+    assert (
+        _GOVERNED_SUBOP_MANIFEST["vmware.composite.content_library.subscribed.sync"]
+        == _library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_SYNC
+    )
+    # The reads auto-execute and are not in the grant-discovery manifest.
+    assert "vmware.composite.content_library.subscribed.status" not in _GOVERNED_SUBOP_MANIFEST

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -75,6 +75,9 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.supervisor.status",
     # Storage-policy list read (#3494).
     "vmware.composite.storage_policy.list",
+    # Content-library SUBSCRIBED reads (#3495).
+    "vmware.composite.content_library.subscribed.status",
+    "vmware.composite.content_library.subscribed.items.list",
 )
 
 
@@ -114,6 +117,14 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
         "meho_backplane.connectors.vmware_rest.composites._storage_policy."
         "storage_policy_list_composite"
     ),
+    "vmware.composite.content_library.subscribed.status": (
+        "meho_backplane.connectors.vmware_rest.composites._library."
+        "content_library_subscribed_status_composite"
+    ),
+    "vmware.composite.content_library.subscribed.items.list": (
+        "meho_backplane.connectors.vmware_rest.composites._library."
+        "content_library_subscribed_items_list_composite"
+    ),
 }
 
 
@@ -129,6 +140,8 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.guest.file.read": "guest_ops",
     "vmware.composite.supervisor.status": "namespace_management",
     "vmware.composite.storage_policy.list": "storage",
+    "vmware.composite.content_library.subscribed.status": "content_library",
+    "vmware.composite.content_library.subscribed.items.list": "content_library",
 }
 
 
@@ -228,7 +241,7 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
     # network.portgroup.security.set + the content-library import
     # vm.import_from_library #3229). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 47
+    assert stub_embedding_service.encode_one.call_count == 51
 
 
 @pytest.mark.asyncio
@@ -497,7 +510,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 47
+    assert first_count == 51
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -515,7 +528,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 11
+    assert len(rows) == 13
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -105,6 +105,11 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.supervisor.disable",
         "vmware.composite.storage_policy.create",
         "vmware.composite.storage_policy.delete",
+        # Content-library SUBSCRIBED writes (#3495): caution + approval, so
+        # they park and carry a bespoke park-time preview builder (create's is
+        # secret-hygienic — it never echoes the subscription password).
+        "vmware.composite.content_library.subscribed.create",
+        "vmware.composite.content_library.subscribed.sync",
     }
 )
 
@@ -316,14 +321,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 28 preview-carrying write composites register a builder (criterion 4)
+# Wiring — all 35 preview-carrying write composites register a builder (criterion 4)
 # ===========================================================================
 
 
 def test_all_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 33
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 35
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -147,10 +147,24 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.supervisor.status",
     # Storage-policy list read (#3494).
     "vmware.composite.storage_policy.list",
+    # Content-library SUBSCRIBED reads (#3495).
+    "vmware.composite.content_library.subscribed.status",
+    "vmware.composite.content_library.subscribed.items.list",
 )
 
-# 47 total -- 11 read (T5 / #508 + 4 guest-ops reads / #3100 + the
-# supervisor status read / #3281 + storage_policy.list / #3494) + 36 write
+# 2 caution + approval writes (#3495) -- the SUBSCRIBED content-library
+# create / sync. These are ``caution`` (a write that always needs an approval
+# decision, but not the ``dangerous`` intrinsic-risk of a VM/host mutation),
+# so they are deliberately NOT in ``_WRITE_OP_IDS`` (whose rows are asserted
+# ``dangerous``); they land in ``_ALL_OP_IDS`` via this bucket instead.
+_CAUTION_OP_IDS: tuple[str, ...] = (
+    "vmware.composite.content_library.subscribed.create",
+    "vmware.composite.content_library.subscribed.sync",
+)
+
+# 51 total -- 13 read (T5 / #508 + 4 guest-ops reads / #3100 + the
+# supervisor status read / #3281 + storage_policy.list / #3494 + 2 SUBSCRIBED
+# content-library reads / #3495) + 2 caution content-library writes / #3495 + 36 write
 # (T6 / #509 + vm.power / #2301 + vm.disk.grow / #2893 +
 # vm.clone_from_template / #2894 + vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
@@ -163,7 +177,7 @@ _READ_OP_IDS: tuple[str, ...] = (
 # supervisor.disable / #3281 + the storage-policy writes storage_policy.create
 # + storage_policy.delete / #3494 + the #3505 governed-allocation writes
 # resource_pool.create + resource_pool.delete + cluster.drs_vm_host_rule.create).
-_ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
+_ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _CAUTION_OP_IDS + _WRITE_OP_IDS
 
 
 _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
@@ -400,7 +414,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
     vm.destroy #3198 + #3091 portgroup writes network.portgroup.create /
     network.portgroup.security.set + content-library import
     vm.import_from_library #3229 + Supervisor writes supervisor.enable /
-    supervisor.disable #3281) = 41 rows. DoD bar."""
+    supervisor.disable #3281 + SUBSCRIBED content-library reads/writes #3495) = 45 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -414,7 +428,7 @@ async def test_full_registration_produces_thirty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 47
+    assert len(rows) == 51
 
 
 @pytest.mark.asyncio
@@ -771,14 +785,14 @@ async def test_write_composite_tags_include_composite_and_write(
 async def test_register_vmware_composite_operations_is_idempotent_across_thirty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 41 rows total, embedding called 41x once."""
+    """Running the registrar twice -> 45 rows total, embedding called 45x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 47
+    assert first_count == 51
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 41.
+    # pipeline; the row count stays at 45.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -792,7 +806,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirty_
             .scalars()
             .all()
         )
-    assert len(rows) == 47
+    assert len(rows) == 51
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_library_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_library_reconcile.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Spec-reconcile lane for the SUBSCRIBED content-library composites (#3495).
+
+The four ``content_library.subscribed.*`` composites declare the raw-REST
+sub-op paths they dispatch into via ``_SUB_OPS_*`` tuples in
+:mod:`meho_backplane.connectors.vmware_rest.composites._library`. This lane
+pins those tuples against the real vCenter 9.0 OpenAPI:
+
+* :func:`test_library_sub_op_tuples_are_all_discovered` guards the
+  introspection (every ``_SUB_OPS_*`` constant is found) so a rename can't
+  silently drop a manifest from the sweep;
+* :func:`test_library_sub_ops_resolve_to_an_ingested_op_id_from_fixture`
+  parses a vCenter-shaped fixture synthesised from the declared op_ids
+  through the real :func:`parse_openapi` and asserts every op_id round-trips
+  — the always-runs proof (no spec-shelf needed) that each is a well-formed
+  ``METHOD:/path`` the ingest pipeline emits;
+* :func:`test_library_sub_ops_resolve_against_pinned_vcenter_spec` parses the
+  operator's pinned ``vcenter.yaml`` (skipped when the spec-shelf is
+  unconfigured — CI wires it) and asserts every op_id is a **real** path the
+  9.0 spec serves — the "no fictional-path drift" acceptance criterion.
+
+The reads' GET paths sit in the manifests too (not just the writes), so the
+whole subscribed-library surface — create / sync / status / items.list — is
+reconciled here.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.vmware_rest.composites import _library
+from meho_backplane.operations.ingest import parse_openapi
+from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vcenter_yaml
+
+# Public IP the mock getaddrinfo returns so the ingest SSRF guard passes
+# without real DNS (the guard is a correctness property, not a test concern).
+_PUBLIC_TEST_IP = "93.184.216.34"
+_GETADDRINFO_PATCH = patch(
+    "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+    return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_PUBLIC_TEST_IP, 443))],
+)
+
+
+def _required_sub_op_ids() -> set[str]:
+    """Union of every ``_SUB_OPS_*`` op_id across the subscribed-library composites."""
+    raw: set[str] = set()
+    for name in dir(_library):
+        if not name.startswith("_SUB_OPS_"):
+            continue
+        raw.update(getattr(_library, name))
+    return raw
+
+
+def _build_vcenter_fixture(required_op_ids: set[str]) -> dict[str, Any]:
+    """Synthesise an OpenAPI doc whose paths reproduce *required_op_ids*.
+
+    Splits each ``METHOD:/path`` op_id into a (path-key, verb) pair and
+    assembles the ``paths`` object the way vCenter keys these endpoints — the
+    ``?action=<verb>`` verb rides in the path key, never as a parameter.
+    """
+    paths: dict[str, dict[str, Any]] = {}
+    for op_id in sorted(required_op_ids):
+        method, _, path_key = op_id.partition(":")
+        assert path_key, f"malformed op_id without path: {op_id!r}"
+        path_item = paths.setdefault(path_key, {})
+        path_item[method.lower()] = {
+            "summary": f"synthetic op for {op_id}",
+            "responses": {"200": {"description": "ok"}},
+        }
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "vcenter", "version": "9.0.0.0"},
+        "paths": paths,
+    }
+
+
+def test_library_sub_op_tuples_are_all_discovered() -> None:
+    """Guard: the introspection finds every subscribed-library sub-op tuple."""
+    tuple_names = sorted(n for n in dir(_library) if n.startswith("_SUB_OPS_"))
+    assert tuple_names == [
+        "_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_CREATE",
+        "_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST",
+        "_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_STATUS",
+        "_SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_SYNC",
+    ]
+
+
+def test_subscribed_library_manifests_are_expected() -> None:
+    """The declared sub-op paths are exactly the create/sync/status/items set."""
+    assert set(_library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_CREATE) == {
+        "GET:/vcenter/datastore",
+        "POST:/content/subscribed-library",
+    }
+    assert set(_library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_SYNC) == {
+        "POST:/content/library?action=find",
+        "POST:/content/subscribed-library/{libraryId}?action=sync",
+    }
+    assert set(_library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_STATUS) == {
+        "POST:/content/library?action=find",
+        "GET:/content/subscribed-library/{libraryId}",
+    }
+    assert set(_library._SUB_OPS_CONTENT_LIBRARY_SUBSCRIBED_ITEMS_LIST) == {
+        "POST:/content/library?action=find",
+        "POST:/content/library/item?action=find",
+        "GET:/content/library/item/{libraryItemId}",
+    }
+
+
+def test_library_sub_ops_resolve_to_an_ingested_op_id_from_fixture() -> None:
+    """Every op_id round-trips through the real parser from a vCenter-shaped spec."""
+    required = _required_sub_op_ids()
+    assert required, "introspection found no sub-op_ids -- wiring broke"
+
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vcenter.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vcenter.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+
+    missing = required - ingested_op_ids
+    assert not missing, (
+        "subscribed-library composites declare sub-op_ids the ingest pipeline "
+        f"does not emit: {sorted(missing)} — a _SUB_OPS_* tuple drifted from the "
+        "METHOD:/path form the parser produces."
+    )
+
+
+def test_library_sub_ops_resolve_against_pinned_vcenter_spec() -> None:
+    """Every subscribed-library sub-op path is a real ``vcenter.yaml`` 9.0 path.
+
+    The definitive #3495 grounding: parse the canonical pinned ``vcenter.yaml``
+    through the real :func:`parse_openapi` and assert every declared op_id is
+    in the emitted descriptor set — real path existence for the
+    ``/content/subscribed-library`` create + sync, the subscribed-library GET,
+    the content-library / item find actions, the per-item GET, and the
+    datastore-resolve read. Skips when the spec-shelf is unconfigured (the
+    canary's convention), so CI — where the env vars are wired — is the
+    operator-visible signal.
+    """
+    spec_path = resolve_vcenter_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    required = _required_sub_op_ids()
+    spec_text = spec_path.read_text(encoding="utf-8")
+    rows = parse_openapi(f"file://{spec_path}", spec_source="spec:vcenter.yaml", content=spec_text)
+    ingested_op_ids = {row.op_id for row in rows}
+    missing = required - ingested_op_ids
+    assert not missing, (
+        "subscribed-library composites declare REST sub-op_ids the real "
+        f"vcenter.yaml ingest does not emit: {sorted(missing)} — re-check the "
+        "/content/subscribed-library + content-library find/item paths against "
+        "the pinned 9.0 spec."
+    )

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -90,6 +90,7 @@ _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
         "guest",
         "guest_ops",
         "namespace_management",
+        "content_library",
     }
 )
 _BIND9_GROUPS: Final[frozenset[str]] = frozenset({"identity", "zone", "record", "config"})

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,12 +8,14 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 47 hand-authored composites
-that orchestrate cross-spec workflows: 11 read composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 51 hand-authored composites
+that orchestrate cross-spec workflows: 13 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
 in `#2258`; plus the four guest-operations reads `#3100` and the
-Supervisor status read `#3281` + the storage-policy list read `#3494`) and 36 write
+Supervisor status read `#3281` + the storage-policy list read `#3494` +
+the two SUBSCRIBED content-library reads `content_library.subscribed.status` +
+`content_library.subscribed.items.list` / `#3495`) and 38 write
 composites (G3.1-T6 / `#509`, incl. the destructive-tier `vm.destroy` / `#3198`, the
 governed NFS tag-based SPBM `storage_policy.create` (caution) +
 `storage_policy.delete` (destructive) / `#3494`, the
@@ -39,7 +41,10 @@ guest-operations writes `vm.guest.file.write` / `#3100` +
 `connectors-vmware-rest-guest-ops.md`), plus the two Supervisor (WCP)
 namespace-management writes `supervisor.enable` + `supervisor.disable`
 / `#3281` (see the **Supervisor (WCP) namespace-management composites**
-subsection under Control flow)). The
+subsection under Control flow), and the two SUBSCRIBED content-library
+caution writes `content_library.subscribed.create` +
+`content_library.subscribed.sync` / `#3495` (see the **Content-library
+SUBSCRIBED composites** subsection)). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -308,10 +313,51 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (`GET:/vcenter/namespace-management/clusters/{cluster}`). See the
   **Supervisor (WCP) namespace-management composites** subsection under
   Control flow.
+- **Content-library SUBSCRIBED composites** (`composites/_library.py`,
+  `#3495`, group `content_library`) — four
+  `vmware.composite.content_library.subscribed.*` composites that create and
+  drive a **SUBSCRIBED** content library through the backplane: the governed
+  source for a vSphere Supervisor's Tanzu Kubernetes release (TKr / VKr)
+  images. On Supervisor enable, `wcpsvc` otherwise auto-creates a subscribed
+  library pointed at the fleet offline-depot content-gateway, which cannot
+  serve the `VKR` component on a VCF-Installer fleet → activation hangs
+  `CONFIGURING`; the governed path is to **pre-create** a subscribed library
+  subscribed straight to the upstream VMware repo
+  (`https://wp-content.vmware.com/v2/latest/lib.json`) and assign it as the
+  Supervisor's TKr library via `#3281`'s enable spec
+  `default_kubernetes_service_content_library` field. Two writes —
+  `subscribed.create` (`POST:/content/subscribed-library`, resolves the
+  `datastore` name to a `DATASTORE` storage backing, returns the new library
+  id) and `subscribed.sync`
+  (`POST:/content/subscribed-library/{libraryId}?action=sync`, respects
+  `on_demand`, asynchronous) — registered **`caution` + `requires_approval=True`**
+  (the issue's "write" tier: a write that always needs an approval decision,
+  but not the `dangerous` intrinsic-risk of a VM/host mutation, and the first
+  `caution` composites on this connector). Two reads — `subscribed.status`
+  (`GET:/content/subscribed-library/{libraryId}`, surfaces `last_sync_time`,
+  the readiness signal) and `subscribed.items.list`
+  (item ids via `POST:/content/library/item?action=find`, then per-item
+  `GET:/content/library/item/{libraryItemId}`, JSONFlux-reduced) — registered
+  `safe`. Both writes ride the same `_write._write_sub_op` governance seam the
+  other write composites use (`dangerous` / `requires_approval=False` sub-op
+  posture) and both reads use `_write._read_sub_op` /
+  `_find_content_library_ids` (un-gated). **Delivery shape — thin typed
+  composites, not the generic-ingested row:** the subscribe body carries a
+  `subscription_info.password` (BASIC auth) needing credential hygiene the raw
+  ingested row cannot provide (broadcast aggregate-only via the
+  `_CREDENTIAL_WRITE_OPS` pin on `subscribed.create`, a park-time preview that
+  echoes identity fields only — never the password / username, `params_hash`-only
+  audit), and the connector's governed ops must dispatch on a fresh boot with
+  zero catalog ingest (a generic row requires a runtime spec-ingest +
+  `edit_op` enable). The naming nests under the sibling `#3331` LOCAL-library
+  family (`content_library.create`) via the `subscribed` infix, so the two do
+  not collide. `_SUB_OPS_*` manifests are reconciled against the pinned
+  `vcenter.yaml` by `test_connectors_vmware_rest_library_reconcile.py`.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 47
-  `_CompositeSpec` rows (11 read + 36 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 51
+  `_CompositeSpec` rows (13 read + 36 dangerous/destructive writes + 2
+  caution content-library subscribed writes); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -737,7 +783,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 44 composites (10 reads + 34 writes) land as `source_kind="composite"`
+The 51 composites (13 reads + 38 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -804,7 +850,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 38 composites are hand-authored aggregators the connector ships as
+The 42 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the


### PR DESCRIPTION
## Summary

- Adds four governed `vmware.composite.content_library.subscribed.*` composites so a vSphere Supervisor's Tanzu Kubernetes release (TKr/VKr) image library can be created, synced and inspected **through the backplane** — closing the one library shape the connector could not create. Feeds #3281 (Supervisor enable consumes the returned id as `default_kubernetes_service_content_library`) and the Envision 2026 dogfooding build.
- **`subscribed.create`** (`caution` + `requires_approval`) — `POST /content/subscribed-library` with a `DATASTORE` storage backing + `subscription_info`; resolves the `datastore` name to a moid; returns the new library id. **`subscribed.sync`** (`caution` + `requires_approval`) — force sync, respects `on_demand`, async. **`subscribed.status`** (`safe`) — reads the LibraryModel (`last_sync_time` = readiness). **`subscribed.items.list`** (`safe`) — enumerates items (TKr versions), JSONFlux-reduced.
- **Delivery shape = thin typed composites** (new `composites/_library.py`), not the generic-ingested row: the subscribe body carries a BASIC-auth `password` needing credential hygiene (broadcast `_CREDENTIAL_WRITE_OPS` pin on create, a park-time preview echoing identity fields only, `params_hash`-only audit) a raw ingested row cannot provide, and governed ops must dispatch on a fresh boot with zero catalog ingest. Both writes ride the existing `_write._write_sub_op` governance seam; both reads use the un-gated resolve helpers. Naming nests under the sibling **#3331** LOCAL-library family via the `subscribed` infix — no collision.
- **"write" → `caution`**: the codebase's `SafetyLevel` enum is `safe|caution|dangerous|destructive` (no `write` tier), so the issue's `safety_level=write` maps to `caution` — the first `caution` composites on this connector.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (5 touched source files)
- [x] `.claude/hooks/code-quality.py --diff` — pass
- [x] New unit lane `test_connectors_vmware_rest_composites_library.py` (20 tests): create body/datastore-resolve/BASIC-auth/refusals/gate-short-circuit/HTTP-fault, sync/status/items.list happy + resolution failures, secret-hygiene (preview omits password/username; create pinned `credential_write`), governed-subop manifest.
- [x] New reconcile lane `test_connectors_vmware_rest_library_reconcile.py` — every `_SUB_OPS_*` path resolves against a synthesized fixture (always runs) **and** against the pinned real `vcenter.yaml` (proved locally with the spec-shelf; skips without it, runs in CI) — no fictional-path drift.
- [x] Registrar/preview/broadcast count + coverage gates updated and green: `composites_register` (42 total, 11 reads), `composites_write_register` (42 total, new `_CAUTION_OP_IDS` bucket), `composites_write_preview` (28 builders), `broadcast_classifier_coverage`, `governed_subops`, `reference_docs_drift`.
- [x] Broad sweep `-k "vmware_rest_composites or vmware_rest_library or broadcast or governed_subop"` — 1148 passed, 29 skipped, 0 failed.
- [x] No new MCP tools (composites dispatch under `call_operation`); `docs-site/reference/{connectors,mcp-tools}.md` and `cli/api/openapi.json` regenerated → no drift.
- [x] `docs/codebase/connectors-vmware-rest.md` updated (new composites subsection + counts).

## Changelog

`### Added` — vmware-rest: governed SUBSCRIBED content-library create/sync + status/items composites (`content_library.subscribed.*`) — the TKr/VKr image source for a vSphere Supervisor (#3495).

## Out of scope

- The **LOCAL**-library create/delete + item upload/delete ops are #3331 (a distinct API surface); this PR adds only the SUBSCRIBED path and reconciles naming with it.
- No delete/evict verb for a subscribed library (not needed by the enable flow; can be added later if teardown symmetry demands it).

Closes #3495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
